### PR TITLE
feat: disburse all icp from neuron, skip amount screen

### DIFF
--- a/dfinity_wallet/lib/ic_api/web/web_ic_api.dart
+++ b/dfinity_wallet/lib/ic_api/web/web_ic_api.dart
@@ -140,7 +140,7 @@ class PlatformICApi extends AbstractPlatformICApi {
     final res = await promiseToFuture(serviceApi!.disburse(
         DisperseNeuronRequest(
             neuronId: neuronId.toJS,
-            amount: doms.toJS,
+            amount: null,
             toAccountId: toAccountId)));
     await fetchNeuron(neuronId: neuronId);
     balanceSyncService?.syncBalances();

--- a/dfinity_wallet/lib/ui/transaction/wallet/confirm_transactions_widget.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/confirm_transactions_widget.dart
@@ -47,7 +47,7 @@ class _ConfirmTransactionWidgetState extends State<ConfirmTransactionWidget> {
               origin: widget.origin,
               destination: widget.destination,
               // surfacing fee as part of total
-              amount: (widget.amount + TRANSACTION_FEE_ICP),
+              amount: (widget.amount),
             ),
             Expanded(child: Container()),
             SizedBox(
@@ -68,7 +68,7 @@ class _ConfirmTransactionWidgetState extends State<ConfirmTransactionWidget> {
                       WizardOverlay.of(context).replacePage(
                           "Transaction Completed!",
                           TransactionDoneWidget(
-                            amount: widget.amount+TRANSACTION_FEE_ICP,
+                            amount: widget.amount,
                             origin: widget.origin,
                             destination: widget.destination,
                           ));
@@ -76,7 +76,8 @@ class _ConfirmTransactionWidgetState extends State<ConfirmTransactionWidget> {
                       await context.performLoading(() async {
                         return context.icApi.disburse(
                             neuronId: BigInt.parse(widget.origin.address),
-                            doms: widget.amount.toE8s,
+                            // this is intentional. send all of them.
+                            doms: widget.origin.icpBalance.toE8s,
                             toAccountId: widget.destination);
                       });
                       WizardOverlay.of(context).replacePage(

--- a/dfinity_wallet/lib/ui/transaction/wallet/enter_amount_page.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/enter_amount_page.dart
@@ -35,13 +35,14 @@ class _EnterAmountPageState extends State<EnterAmountPage> {
 
     amountField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.origin.icpBalance)
+          StringFieldValidation.insufficientFunds(widget.origin.icpBalance),StringFieldValidation.nonZero()
         ],
         inputType: TextInputType.number);
   }
 
   @override
   Widget build(BuildContext context) {
+    var isNeuron = widget.origin.type == ICPSourceType.NEURON;
     return SizedBox.expand(
       child: Padding(
         padding: const EdgeInsets.all(32.0),
@@ -80,6 +81,17 @@ class _EnterAmountPageState extends State<EnterAmountPage> {
                   Text(widget.destinationAccountIdentifier,
                       style: context.textTheme.bodyText1),
                   TallFormDivider(),
+                  isNeuron
+                ? Row()
+                : Row(
+                    children: [
+                      Text("Transaction Fee",
+                          style: context.textTheme.headline4),
+                      TallFormDivider(),
+                      Text(TRANSACTION_FEE_ICP.toString() + " ICP",
+                          style: context.textTheme.bodyText1),
+                    ],
+                  )
                 ],
               ),
             ),
@@ -90,10 +102,11 @@ class _EnterAmountPageState extends State<EnterAmountPage> {
                 child: ValidFieldsSubmitButton(
                   child: Text("Review Transaction"),
                   onPressed: () async {
+                    var amount = amountField.currentValue.toDouble()+TRANSACTION_FEE_ICP;
                     WizardOverlay.of(context).pushPage(
                         "Review Transaction",
                         ConfirmTransactionWidget(
-                          amount: amountField.currentValue.toDouble(),
+                          amount: amount,
                           origin: widget.origin,
                           destination: widget.destinationAccountIdentifier,
                           subAccountId: widget.subAccountId,

--- a/dfinity_wallet/lib/ui/transaction/wallet/select_wallet_page.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/select_wallet_page.dart
@@ -2,6 +2,7 @@ import 'package:dfinity_wallet/data/icp_source.dart';
 import 'package:dfinity_wallet/ui/_components/form_utils.dart';
 import 'package:dfinity_wallet/ui/_components/valid_fields_submit_button.dart';
 import 'package:dfinity_wallet/ui/transaction/canister/topup_canister_page.dart';
+import 'package:dfinity_wallet/ui/transaction/wallet/confirm_transactions_widget.dart';
 import 'package:dfinity_wallet/ui/transaction/wallet/enter_amount_page.dart';
 import '../../../dfinity.dart';
 import '../wizard_overlay.dart';
@@ -48,20 +49,32 @@ class _SelectDestinationAccountPageState
                             child: Padding(
                               padding: const EdgeInsets.all(24.0),
                               child: Text(
-                                "Send",
+                                "Continue",
                                 style: context.textTheme.subtitle1,
                               ),
                             ),
                             fields: [addressField],
                             onPressed: () {
                               final address = addressField.currentValue;
-                              WizardOverlay.of(context).pushPage(
-                                  "Enter ICP Amount",
-                                  EnterAmountPage(
-                                    origin: widget.source,
-                                    destinationAccountIdentifier: address,
-                                    subAccountId: widget.source.subAccountId,
-                                  ));
+
+                              if (widget.source.type == ICPSourceType.NEURON) {
+                                WizardOverlay.of(context).pushPage(
+                                    "Review Transaction",
+                                    ConfirmTransactionWidget(
+                                      amount: widget.source.icpBalance,
+                                      origin: widget.source,
+                                      destination: address,
+                                      subAccountId: widget.source.subAccountId,
+                                    ));
+                              } else {
+                                WizardOverlay.of(context).pushPage(
+                                    "Enter ICP Amount",
+                                    EnterAmountPage(
+                                      origin: widget.source,
+                                      destinationAccountIdentifier: address,
+                                      subAccountId: widget.source.subAccountId,
+                                    ));
+                              }
                             },
                           ),
                         ),
@@ -73,44 +86,61 @@ class _SelectDestinationAccountPageState
             ),
             if(context.boxes.accounts.values.length >= 1)
               Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        "My Accounts",
-                        style: context.textTheme.headline3,
-                      ),
-                      SmallFormDivider(),
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Container(
-                          decoration: ShapeDecoration(
-                              shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(8),
-                                  side: BorderSide(
-                                      width: 2, color: AppColors.gray800))),
-                          child: Column(
-                            children: context.boxes.accounts.values
-                                .filter((element) => element != widget.source)
-                                .mapToList((e) => _AccountRow(
-                                    account: e,
-                                    onPressed: () {
-                                      WizardOverlay.of(context).pushPage(
-                                          "Enter ICP Amount",
-                                          EnterAmountPage(
-                                            origin: widget.source,
-                                            destinationAccountIdentifier: e.accountIdentifier,
-                                            subAccountId: widget.source.subAccountId,
-                                          ));
-                                    })),
-                          ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          "My Accounts",
+                          style: context.textTheme.headline3,
                         ),
-                      )
-                    ]),
+                        SmallFormDivider(),
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Container(
+                            decoration: ShapeDecoration(
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(8),
+                                    side: BorderSide(
+                                        width: 2, color: AppColors.gray800))),
+                            child: Column(
+                              children: context.boxes.accounts.values
+                                  .filter((element) => element != widget.source)
+                                  .mapToList((e) => _AccountRow(
+                                      account: e,
+                                      onPressed: () {
+                                        if (widget.source.type ==
+                                            ICPSourceType.NEURON) {
+                                          WizardOverlay.of(context).pushPage(
+                                              "Review Transaction",
+                                              ConfirmTransactionWidget(
+                                                amount:
+                                                    widget.source.icpBalance,
+                                                origin: widget.source,
+                                                destination:
+                                                    e.accountIdentifier,
+                                                subAccountId:
+                                                    widget.source.subAccountId,
+                                              ));
+                                        } else {
+                                          WizardOverlay.of(context).pushPage(
+                                              "Enter ICP Amount",
+                                              EnterAmountPage(
+                                                origin: widget.source,
+                                                destinationAccountIdentifier:
+                                                    e.accountIdentifier,
+                                                subAccountId:
+                                                    widget.source.subAccountId,
+                                              ));
+                                        }
+                                      })),
+                            ),
+                          ),
+                        )
+                      ]),
+                ),
               ),
-            ),
           ],
         ),
       ),
@@ -161,7 +191,8 @@ class _AccountRow extends StatelessWidget {
           ),
           BalanceDisplayWidget(
               amount: account.balance.toBigInt.toICPT,
-              amountSize: 30, icpLabelSize: 20)
+              amountSize: 30,
+              icpLabelSize: 20)
         ],
       ),
     );

--- a/dfinity_wallet/lib/ui/transaction/wallet/transaction_details_widget.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/transaction_details_widget.dart
@@ -16,7 +16,8 @@ class TransactionDetailsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var transactionFeeICPMsg = TRANSACTION_FEE_ICP.toString() + " ICP";
+    var isNeuron = origin.type == ICPSourceType.NEURON;
+
     return Container(
         child: Center(
       child: IntrinsicWidth(
@@ -40,9 +41,18 @@ class TransactionDetailsWidget extends StatelessWidget {
             VerySmallFormDivider(),
             Text(destination, style: context.textTheme.bodyText1),
             TallFormDivider(),
-            Text("Transaction Fee", style: context.textTheme.headline4),
-            VerySmallFormDivider(),
-            Text(transactionFeeICPMsg, style: context.textTheme.bodyText1),
+            // display transaction fee only if it is not a neuron
+            isNeuron
+                ? Row()
+                : Row(
+                    children: [
+                      Text("Transaction Fee",
+                          style: context.textTheme.headline4),
+                      VerySmallFormDivider(),
+                      Text(TRANSACTION_FEE_ICP.toString() + " ICP",
+                          style: context.textTheme.bodyText1),
+                    ],
+                  ),
             VerySmallFormDivider()
           ],
         ),

--- a/js-agent/src/canisters/governance/model.ts
+++ b/js-agent/src/canisters/governance/model.ts
@@ -335,7 +335,7 @@ export interface SplitRequest {
 export interface DisburseRequest {
     neuronId: NeuronId,
     toAccountId: AccountIdentifier,
-    amount: E8s,
+    amount?: E8s,
 }
 
 export interface DisburseToNeuronRequest {


### PR DESCRIPTION
OK, so this looks a little un-DRY because it is. I threw an `if/else` in a few places to:
a) don't add or show a transaction fee for neuron activities
b) send "null" to disbursal to get all ICP

Needs a lot of manual testing as I am new to dart/flutter.