### PR TITLE
Update `ICPSource` to not store ICPs as doubles.

### DIFF
--- a/dfinity_wallet/lib/data/account.dart
+++ b/dfinity_wallet/lib/data/account.dart
@@ -2,20 +2,23 @@ import 'package:dfinity_wallet/data/data.dart';
 import 'package:dfinity_wallet/data/transaction.dart';
 import 'package:observable/observable.dart';
 import 'package:dartx/dartx.dart';
+import 'icp.dart';
 import 'icp_source.dart';
-
 
 class Account extends DfinityEntity with ICPSource {
   String name;
-  String accountIdentifier;
+  final String accountIdentifier;
   final bool primary;
-  late String balance;
+  String balance;
+  late ICP icpBalance;
   List<Transaction> transactions;
   int? subAccountId;
   bool hardwareWallet;
 
   Account(this.name, this.accountIdentifier, this.primary, this.balance,
-      this.subAccountId, this.transactions, this.hardwareWallet);
+      this.subAccountId, this.transactions, this.hardwareWallet) {
+    this.icpBalance = ICP.fromString(this.balance);
+  }
 
   Account.create({required this.name,
     required this.accountIdentifier,
@@ -23,7 +26,9 @@ class Account extends DfinityEntity with ICPSource {
     required this.subAccountId,
     required this.balance,
     required this.transactions,
-    required this.hardwareWallet});
+    required this.hardwareWallet}) {
+    this.icpBalance = ICP.fromString(this.balance);
+  }
 
   @override
   String get identifier => accountIdentifier;

--- a/dfinity_wallet/lib/data/icp.dart
+++ b/dfinity_wallet/lib/data/icp.dart
@@ -48,4 +48,10 @@ class ICP {
     final icpDouble = this._e8s / _e8sPerICP;
     return NumberFormat("###,##0.00######", locale).format(icpDouble);
   }
+
+  // This is temporary until all ICP uses are migrated to use this type
+  // instead of a double.
+  double asDouble() {
+    return this._e8s / _e8sPerICP;
+  }
 }

--- a/dfinity_wallet/lib/data/icp_source.dart
+++ b/dfinity_wallet/lib/data/icp_source.dart
@@ -1,12 +1,13 @@
 import 'package:dfinity_wallet/dfinity.dart';
 import 'package:intl/intl.dart';
 
+import 'icp.dart';
+
 abstract class ICPSource {
   String get address;
   int? get subAccountId;
   ICPSourceType get type;
-  String get balance;
-  double get icpBalance => balance.toBigInt.toICPT;
+  ICP get icpBalance;
 }
 
 const E8S_PER_ICP = 100000000;

--- a/dfinity_wallet/lib/data/neuron.dart
+++ b/dfinity_wallet/lib/data/neuron.dart
@@ -4,10 +4,10 @@ import 'package:dfinity_wallet/data/proposal.dart';
 import 'package:dfinity_wallet/data/vote.dart';
 import 'dfinity_entity.dart';
 import 'followee.dart';
+import 'icp.dart';
 import 'neuron_state.dart';
 import 'package:core/extensions.dart';
 import 'package:dartx/dartx.dart';
-
 
 class Neuron extends DfinityEntity with ICPSource {
   late String id;
@@ -52,9 +52,10 @@ class Neuron extends DfinityEntity with ICPSource {
   BigInt get stake => cachedNeuronStakeDoms.toBigInt - neuronFeesDoms.toBigInt;
 
   @override
-  String get balance => stake.toString();
+  ICP get icpBalance => ICP.fromString(stake.toString());
 
-  DateTime get whenDissolvedTimestamp => whenDissolvedTimestampSeconds.secondsToDateTime();
+  DateTime get whenDissolvedTimestamp =>
+      whenDissolvedTimestampSeconds.secondsToDateTime();
 
   Duration get durationRemaining => whenDissolvedTimestamp.difference(DateTime.now());
 
@@ -65,7 +66,3 @@ class Neuron extends DfinityEntity with ICPSource {
   @override
   ICPSourceType get type => ICPSourceType.NEURON;
 }
-
-
-
-

--- a/dfinity_wallet/lib/ui/canisters/cycles_input_widget.dart
+++ b/dfinity_wallet/lib/ui/canisters/cycles_input_widget.dart
@@ -31,7 +31,8 @@ class _CycleInputWidgetState extends State<CycleInputWidget> {
 
     icpField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.source.icpBalance, 2)
+          StringFieldValidation.insufficientFunds(
+              widget.source.icpBalance.asDouble(), 2)
         ],
         inputType: TextInputType.number,
         inputFormatters: <TextInputFormatter>[ FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')) ]

--- a/dfinity_wallet/lib/ui/neurons/stake_neuron_page.dart
+++ b/dfinity_wallet/lib/ui/neurons/stake_neuron_page.dart
@@ -25,7 +25,8 @@ class _StakeNeuronPageState extends State<StakeNeuronPage> {
   void initState() {
     amountField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.source.icpBalance, 2),
+          StringFieldValidation.insufficientFunds(
+              widget.source.icpBalance.asDouble(), 2),
           StringFieldValidation("Minimum amount: 1 ICP", (e) => (e.toDoubleOrNull() ?? 0) < 1),
         ],
         inputFormatters: <TextInputFormatter>[ FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')) ],

--- a/dfinity_wallet/lib/ui/transaction/canister/topup_canister_page.dart
+++ b/dfinity_wallet/lib/ui/transaction/canister/topup_canister_page.dart
@@ -27,7 +27,8 @@ class _TopUpCanisterPageState extends State<TopUpCanisterPage> {
     super.initState();
     amountField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.source.icpBalance, 2)
+          StringFieldValidation.insufficientFunds(
+              widget.source.icpBalance.asDouble(), 2)
         ],
         inputType: TextInputType.number,
         inputFormatters: <TextInputFormatter>[

--- a/dfinity_wallet/lib/ui/transaction/wallet/confirm_transactions_widget.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/confirm_transactions_widget.dart
@@ -80,7 +80,7 @@ class _ConfirmTransactionWidgetState extends State<ConfirmTransactionWidget> {
                         return context.icApi.disburse(
                             neuronId: BigInt.parse(widget.source.address),
                             // this is intentional. send all of them.
-                            doms: widget.source.icpBalance.toE8s,
+                            doms: widget.source.icpBalance.asE8s(),
                             toAccountId: widget.destination);
                       });
 

--- a/dfinity_wallet/lib/ui/transaction/wallet/enter_amount_page.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/enter_amount_page.dart
@@ -1,3 +1,4 @@
+import 'package:dfinity_wallet/data/icp.dart';
 import 'package:dfinity_wallet/data/icp_source.dart';
 import 'package:dfinity_wallet/dfinity.dart';
 import 'package:dfinity_wallet/ui/_components/form_utils.dart';
@@ -32,7 +33,8 @@ class _EnterAmountPageState extends State<EnterAmountPage> {
 
     amountField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.source.icpBalance, 1),
+          StringFieldValidation.insufficientFunds(
+              widget.source.icpBalance.asDouble(), 1),
           StringFieldValidation.greaterThanZero()
         ],
         inputType: TextInputType.number,
@@ -108,7 +110,7 @@ class _EnterAmountPageState extends State<EnterAmountPage> {
                 child: ValidFieldsSubmitButton(
                   child: Text("Review Transaction"),
                   onPressed: () async {
-                    var amount = amountField.currentValue.toDouble();
+                    var amount = ICP.fromString(amountField.currentValue);
                     WizardOverlay.of(context).pushPage(
                         "Review Transaction",
                         ConfirmTransactionWidget(

--- a/dfinity_wallet/lib/ui/transaction/wallet/select_destination_wallet_page.dart
+++ b/dfinity_wallet/lib/ui/transaction/wallet/select_destination_wallet_page.dart
@@ -63,7 +63,8 @@ class _SelectDestinationAccountPageState
                                     ConfirmTransactionWidget(
                                       // if we're disbursing, no fee?
                                       fee: 0,
-                                      amount: widget.source.icpBalance,
+                                      amount:
+                                          widget.source.icpBalance.asDouble(),
                                       source: widget.source,
                                       destination: address,
                                       subAccountId: widget.source.subAccountId,
@@ -118,7 +119,8 @@ class _SelectDestinationAccountPageState
                                               ConfirmTransactionWidget(
                                                 fee: 0,
                                                 amount:
-                                                    widget.source.icpBalance,
+                                                    widget.source.icpBalance
+                                                    .asDouble(),
                                                 source: widget.source,
                                                 destination:
                                                     e.accountIdentifier,

--- a/dfinity_wallet/lib/ui/wallet/accounts_tab_widget.dart
+++ b/dfinity_wallet/lib/ui/wallet/accounts_tab_widget.dart
@@ -66,7 +66,8 @@ class _AccountsTabWidgetState extends State<AccountsTabWidget> {
                                   ),
                                   BalanceDisplayWidget(
                                       amount: wallets
-                                          .sumBy((element) => element.icpBalance),
+                                          .sumBy((element) =>
+                                          element.icpBalance.asDouble()),
                                       amountSize: 40,
                                       icpLabelSize: 20),
                                 ],


### PR DESCRIPTION
This is another PR towards not using doubles for ICP values. `ICPSource`
represented the balance as a string `balance` along with a helper method
`icpBalance` that parses this string and returns it as a double.

This PR replaces the `balance` string and `icpBalance` method with an
`icpBalance` of type ICP. In follow-up PRs further uses of doubles for
ICP will be removed.