### PR TITLE
Fix grey screen when opening neurons page in Safari

### DIFF
--- a/js-agent/src/canisters/governance/ResponseConverters.ts
+++ b/js-agent/src/canisters/governance/ResponseConverters.ts
@@ -68,13 +68,12 @@ export default class ResponseConverters {
     }
 
     public toArrayOfNeuronInfo = (response: ListNeuronsResponse, principal: Principal) : Array<NeuronInfo> => {
-        // NOTE: Safari's implementation of `Map` doesn't support bigint keys.
-        // The ids are therefore encoded as strings for compatibility with Safari.
-        const map = new Map(response.full_neurons.map(n => [n.id[0].id.toString(), n]));
         const principalString = principal.toString();
 
         return response.neuron_infos.map(([id, neuronInfo]) =>
-            this.toNeuronInfo(id, principalString, neuronInfo, map.get(id.toString())));
+            this.toNeuronInfo(id, principalString, neuronInfo, response.full_neurons.find(neuron =>
+                neuron.id.length > 0 && neuron.id[0].id === id
+            )));
     }
 
     private toNeuronInfo(neuronId: bigint, principalString: string, neuronInfo: RawNeuronInfo, rawNeuron?: RawNeuron): NeuronInfo {


### PR DESCRIPTION
Safari's implementation of [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) apparently doesn't `bigint` keys. This lead to a problem when we were populating the neurons tab in Safari where neurons weren't found when they were expected to be found, causing an exception to be thrown and a grey screen to appear. The grey screen is what flutter renders when a widget throws an exception.

From Safari's console:
```
> m = new Map([[1n, 2]])
< Map {1n => 2} (1)
> m.get(1n)
< undefined
```