### PR TITLE
[NU-69] Support for multiple controllers

### DIFF
--- a/dfinity_wallet/lib/ic_api/platform_ic_api.dart
+++ b/dfinity_wallet/lib/ic_api/platform_ic_api.dart
@@ -92,7 +92,8 @@ abstract class AbstractPlatformICApi {
 
   Future<void> getCanister(String canisterId);
 
-  Future<void> changeCanisterController(String canisterId, String newController);
+  Future<void> changeCanisterControllers(
+      String canisterId, List<String> newControllers);
 
   Future<void> test();
 

--- a/dfinity_wallet/lib/ic_api/web/web_ic_api.dart
+++ b/dfinity_wallet/lib/ic_api/web/web_ic_api.dart
@@ -121,8 +121,8 @@ class PlatformICApi extends AbstractPlatformICApi {
   @override
   Future<void> retryStakeNeuronNotification(
       {required BigInt blockHeight,
-        required BigInt nonce,
-        int? fromSubAccount}) async {
+      required BigInt nonce,
+      int? fromSubAccount}) async {
     await promiseToFuture(serviceApi!.retryStakeNeuronNotification(RetryStakeNeuronNotificationRequest(
         blockHeight: blockHeight.toJS, nonce: nonce.toJS, fromSubAccountId: fromSubAccount)));
     await neuronSyncService!.fetchNeurons();
@@ -313,7 +313,8 @@ class PlatformICApi extends AbstractPlatformICApi {
     final response = [...res];
     final canisterIds = response.mapToList((e) {
       final id = e.canisterId.toString();
-      hiveBoxes.canisters[id] = Canister(name: e.name, publicKey: id, userIsController: null);
+      hiveBoxes.canisters[id] =
+          Canister(name: e.name, publicKey: id, userIsController: null);
       return id;
     });
 
@@ -363,13 +364,12 @@ class PlatformICApi extends AbstractPlatformICApi {
   }
 
   @override
-  Future<void> changeCanisterController(
-      String canisterId, String newController) async {
+  Future<void> changeCanisterControllers(
+      String canisterId, List<String> newControllers) async {
     final settings = UpdateSettingsRequest(
         canisterId: canisterId,
-        settings: UpdateCanisterSettings(controllers: [newController]));
-    final res =
-        await promiseToFuture(serviceApi!.updateCanisterSettings(settings));
+        settings: UpdateCanisterSettings(controllers: newControllers));
+    await promiseToFuture(serviceApi!.updateCanisterSettings(settings));
     await getCanister(canisterId);
     hiveBoxes.canisters.notifyChange();
   }

--- a/dfinity_wallet/lib/ui/canisters/canister_detail_widget.dart
+++ b/dfinity_wallet/lib/ui/canisters/canister_detail_widget.dart
@@ -36,14 +36,17 @@ class _CanisterDetailWidgetState extends State<CanisterDetailWidget> {
             child: TextButton(
                 onPressed: () {
                   OverlayBaseWidget.show(
-                      context, ConfirmDialog(
-                    title: 'Confirm Detach',
-                    description: "This will remove the canister from your account, it does not change the controller.\n\If you control the canister, ensure you have it's identifier stored securely",
-                    onConfirm: () async {
-                      await context.callUpdate(() => context.icApi.detachCanister(widget.canister.identifier));
-                      context.nav.replace(CanistersTabPage);
-                    },
-                  ));
+                      context,
+                      ConfirmDialog(
+                        title: 'Confirm Detach',
+                        description:
+                            "This will remove the canister from your account, it does not change the controller.\n\If you control the canister, ensure you have it's identifier stored securely",
+                        onConfirm: () async {
+                          await context.callUpdate(() => context.icApi
+                              .detachCanister(widget.canister.identifier));
+                          context.nav.replace(CanistersTabPage);
+                        },
+                      ));
                 },
                 child: Text(
                   "Detach",
@@ -207,43 +210,46 @@ class _CanisterDetailWidgetState extends State<CanisterDetailWidget> {
   }
 
   Card buildControllerCard(BuildContext context, Canister canister) {
+    final children = [
+      [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(
+            "Controllers",
+            style: context.textTheme.headline3,
+          ),
+        )
+      ],
+      canister.controllers.map((controller) => Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SelectableText(
+              controller,
+              style: context.textTheme.subtitle2,
+            ))),
+      [
+        Align(
+          alignment: Alignment.bottomRight,
+          child: ElevatedButton(
+              onPressed: () {
+                OverlayBaseWidget.show(
+                    context,
+                    ChangeCanisterControllerWidget(
+                      canister: canister,
+                    ));
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text("Change Controllers"),
+              )),
+        ),
+      ]
+    ].expand((e) => e).toList();
+
     return Card(
         child: Padding(
       padding: const EdgeInsets.all(16.0),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Text(
-              "Controller",
-              style: context.textTheme.headline3,
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: SelectableText(
-              canister.controllers?.getOrNull(0) ?? "",
-              style: context.textTheme.subtitle2,
-            ),
-          ),
-          Align(
-            alignment: Alignment.bottomRight,
-            child: ElevatedButton(
-                onPressed: () {
-                  OverlayBaseWidget.show(
-                      context,
-                      ChangeCanisterControllerWidget(
-                        canister: canister,
-                      ));
-                },
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text("Change Controller"),
-                )),
-          )
-        ],
-      ),
+          crossAxisAlignment: CrossAxisAlignment.start, children: children),
     ));
   }
 }


### PR DESCRIPTION
This PR adds support for multiple controllers in the UI. A user can now:

* See multiple controllers per canister.
* Set/modify multiple controllers.

Due to inexperience with Flutter, I did the bare minimum to make this functional. The UI is far less than ideal and needs to be polished, ideally by someone who has some experience with Flutter's UI elements.

Error handling is still missing, but that will come in a follow-up PR.

<img width="785" alt="Screen Shot 2021-06-01 at 13 49 45" src="https://user-images.githubusercontent.com/208628/120319284-22ab1680-c2e1-11eb-89a3-242768143801.png">
<img width="628" alt="Screen Shot 2021-06-01 at 13 50 02" src="https://user-images.githubusercontent.com/208628/120319303-28086100-c2e1-11eb-9ba8-453d785464f1.png">
<img width="636" alt="Screen Shot 2021-06-01 at 13 50 46" src="https://user-images.githubusercontent.com/208628/120319314-2b035180-c2e1-11eb-9726-c20a97597cc3.png">
<img width="619" alt="Screen Shot 2021-06-01 at 13 51 01" src="https://user-images.githubusercontent.com/208628/120319330-2dfe4200-c2e1-11eb-9e1d-5403e2e4fb12.png">
