### PR TITLE
Make 'transactions_to_be_processed_queue' more generic

### DIFF
--- a/canisters/nns_ui/nns_ui.did
+++ b/canisters/nns_ui/nns_ui.did
@@ -199,8 +199,9 @@ type Stats =
         latest_transaction_timestamp_nanos: nat64;
         latest_transaction_block_height: BlockHeight;
         seconds_since_last_ledger_sync: nat64;
-        neuron_accounts_count: nat64;
-        neurons_refreshed_count: nat64;
+        neurons_created_count: nat64;
+        neurons_topped_up_count: nat64;
+        transactions_to_process_queue_length: nat32;
     };
 
 type HeaderField =

--- a/canisters/nns_ui/src/periodic_tasks_runner.rs
+++ b/canisters/nns_ui/src/periodic_tasks_runner.rs
@@ -1,0 +1,79 @@
+use crate::canisters::governance::{self, ClaimOrRefreshNeuronFromAccount, claim_or_refresh_neuron_from_account_response};
+use crate::ledger_sync;
+use crate::state::STATE;
+use crate::transaction_store::TransactionToBeProcessed;
+use dfn_core::api::PrincipalId;
+use ledger_canister::Memo;
+
+const PRUNE_TRANSACTIONS_COUNT: u32 = 1000;
+
+pub async fn run_periodic_tasks() {
+    ledger_sync::sync_transactions().await;
+
+    let maybe_transaction_to_process = STATE.write().unwrap().transactions_store.try_take_next_transaction_to_process();
+    if let Some(transaction_to_process) = maybe_transaction_to_process {
+        match transaction_to_process {
+            TransactionToBeProcessed::StakeNeuron(principal, memo) => {
+                stake_neuron(principal, memo).await;
+            },
+            TransactionToBeProcessed::TopUpNeuron(principal, memo) => {
+                top_up_neuron(principal, memo).await;
+            },
+        }
+    }
+
+    if should_prune_transactions() {
+        let store = &mut STATE.write().unwrap().transactions_store;
+        store.prune_transactions(PRUNE_TRANSACTIONS_COUNT);
+    }
+}
+
+async fn stake_neuron(principal: PrincipalId, memo: Memo) {
+    claim_or_refresh_neuron(principal, memo, false).await;
+}
+
+async fn top_up_neuron(principal: PrincipalId, memo: Memo) {
+    claim_or_refresh_neuron(principal, memo, true).await;
+}
+
+async fn claim_or_refresh_neuron(principal: PrincipalId, memo: Memo, is_top_up: bool) {
+    let request = ClaimOrRefreshNeuronFromAccount {
+        controller: Some(principal),
+        memo: memo.0
+    };
+
+    match governance::claim_or_refresh_neuron_from_account(request).await {
+        Ok(response) => match response.result {
+            Some(claim_or_refresh_neuron_from_account_response::Result::NeuronId(neuron_id)) => {
+                if is_top_up {
+                    STATE.write().unwrap().transactions_store.mark_neuron_topped_up();
+                } else {
+                    STATE.write().unwrap().transactions_store.mark_neuron_created(&principal, memo, neuron_id.into());
+                }
+            },
+            _ => {
+                // TODO NU-76 Handle any errors returned by the claim_or_refresh_neuron method
+            }
+        },
+        Err(_) => {
+            // TODO NU-76 Handle any errors returned by the claim_or_refresh_neuron method
+        }
+    }
+}
+
+fn should_prune_transactions() -> bool {
+    #[cfg(target_arch = "wasm32")]
+        {
+            const MEMORY_LIMIT_BYTES: u32 = 1024 * 1024 * 1024; // 1GB
+            let memory_usage_bytes = (core::arch::wasm32::memory_size(0) * 65536) as u32;
+            memory_usage_bytes > MEMORY_LIMIT_BYTES
+        }
+
+    #[cfg(not(target_arch = "wasm32"))]
+        {
+            const TRANSACTIONS_COUNT_LIMIT: u32 = 1_000_000;
+            let store = &mut STATE.write().unwrap().transactions_store;
+            let transactions_count = store.get_transactions_count();
+            transactions_count > TRANSACTIONS_COUNT_LIMIT
+        }
+}

--- a/dfinity_wallet/lib/ui/neurons/stake_neuron_page.dart
+++ b/dfinity_wallet/lib/ui/neurons/stake_neuron_page.dart
@@ -29,7 +29,7 @@ class _StakeNeuronPageState extends State<StakeNeuronPage> {
     super.initState();
     amountField = ValidatedTextField("Amount",
         validations: [
-          StringFieldValidation.insufficientFunds(widget.source.balance, 2),
+          StringFieldValidation.insufficientFunds(widget.source.balance, 1),
           StringFieldValidation(
               "Minimum amount: 1 ICP", (e) => (e.toDoubleOrNull() ?? 0) < 1),
         ],
@@ -76,7 +76,7 @@ class _StakeNeuronPageState extends State<StakeNeuronPage> {
                           // fee is doubled as it is a SEND and NOTIFY
                           Text(
                               (ICP.fromE8s(
-                                          BigInt.from(TRANSACTION_FEE_E8S * 2)))
+                                          BigInt.from(TRANSACTION_FEE_E8S)))
                                       .asString(myLocale.languageCode) +
                                   " ICP",
                               style: Responsive.isDesktop(context) |

--- a/js-agent/src/canisters/createNeuron.ts
+++ b/js-agent/src/canisters/createNeuron.ts
@@ -47,8 +47,6 @@ export default async function(
                 memo: nonce
             });
 
-            console.log(status);
-
             if ("Created" in status) {
                 return status.Created;
             } else if ("NotFound" in status) {


### PR DESCRIPTION
By making the functionality around the 'transactions_to_be_processed_queue' more generic we can easily add 'create canister' and 'top-up canister' without having to change the layout of stable memory.

If the previous version were to go live we would have to do the whole dance around handling different stable memory formats in pre_upgrade and post_upgrade during the next release so by making this change now we are able to keep things simple.