### PR TITLE
Handle 'Top-up Neuron' transactions originating from external accounts

### DIFF
--- a/canisters/nns_ui/src/transaction_store.rs
+++ b/canisters/nns_ui/src/transaction_store.rs
@@ -1499,8 +1499,7 @@ mod tests {
         };
         store.append_transaction(transfer, neuron_memo, block_height, TimeStamp { timestamp_nanos: 100 }).unwrap();
         assert!(matches!(store.transactions.back().unwrap().transaction_type.unwrap(), TransactionType::StakeNeuron));
-
-
+        
         let topup = Send {
             from: AccountIdentifier::new(PrincipalId::from_str(TEST_ACCOUNT_4).unwrap(), None),
             to: AccountIdentifier::from_hex("426f980e6fe0585996c0e9d799237bb5f738d6d5569dfc56e31a98f8a7d40a91").unwrap(),


### PR DESCRIPTION
Prior to this commit the code was only checking the transaction type after we had found a matching user account to link the transaction to.

This commit makes it so that if no user account is found, we then look in the known neuron accounts for a match.