### PR TITLE
Rename TransactionStore to AccountsStore

### DIFF
--- a/canisters/nns_ui/src/accounts_store.rs
+++ b/canisters/nns_ui/src/accounts_store.rs
@@ -21,7 +21,7 @@ const MEMO_TOP_UP_CANISTER: Memo = Memo(0x50555054); // == 'TPUP'
 type TransactionIndex = u64;
 
 #[derive(Default)]
-pub struct TransactionStore {
+pub struct AccountsStore {
     account_identifier_lookup: HashMap<AccountIdentifier, AccountLocation>,
     transactions: VecDeque<Transaction>,
     accounts: Vec<Option<Account>>,
@@ -188,7 +188,7 @@ pub enum GetStakeNeuronStatusResponse {
     NotFound
 }
 
-impl TransactionStore {
+impl AccountsStore {
     pub fn get_account(&self, caller: PrincipalId) -> Option<AccountDetails> {
         let account_identifier = AccountIdentifier::from(caller);
         if let Some(account) = self.try_get_account_by_default_identifier(&account_identifier) {
@@ -967,7 +967,7 @@ impl TransactionStore {
     }
 }
 
-impl StableState for TransactionStore {
+impl StableState for AccountsStore {
     fn encode(&self) -> Vec<u8> {
         Candid((
             Vec::from_iter(self.transactions.iter()),
@@ -1008,7 +1008,7 @@ impl StableState for TransactionStore {
             }
         }
 
-        Ok(TransactionStore {
+        Ok(AccountsStore {
             account_identifier_lookup,
             transactions: VecDeque::from_iter(transactions),
             accounts,
@@ -1171,7 +1171,7 @@ mod tests {
     #[test]
     fn get_non_existant_account_produces_empty_results() {
         let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
-        let store = TransactionStore::default();
+        let store = AccountsStore::default();
 
         let results = store.get_transactions(principal, GetTransactionsRequest {
             account_identifier: AccountIdentifier::from(principal),
@@ -1671,12 +1671,12 @@ mod tests {
         assert!(stats.seconds_since_last_ledger_sync < 10);
     }
 
-    fn setup_test_store() -> TransactionStore {
+    fn setup_test_store() -> AccountsStore {
         let principal1 = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
         let principal2 = PrincipalId::from_str(TEST_ACCOUNT_2).unwrap();
         let account_identifier1 = AccountIdentifier::from(principal1);
         let account_identifier2 = AccountIdentifier::from(principal2);
-        let mut store = TransactionStore::default();
+        let mut store = AccountsStore::default();
         store.add_account(principal1);
         store.add_account(principal2);
         let timestamp = TimeStamp {

--- a/canisters/nns_ui/src/ledger_sync.rs
+++ b/canisters/nns_ui/src/ledger_sync.rs
@@ -30,7 +30,7 @@ async fn sync_transactions_within_lock() -> Result<u32, String> {
         // We only reach here on service initialization and we don't care about previous blocks, so
         // we mark that we are synced with the latest tip_of_chain and return so that subsequent
         // syncs will continue from there
-        let store = &mut STATE.write().unwrap().transactions_store;
+        let store = &mut STATE.write().unwrap().accounts_store;
         store.init_block_height_synced_up_to(tip_of_chain);
         store.mark_ledger_sync_complete();
         return Ok(0);
@@ -39,12 +39,12 @@ async fn sync_transactions_within_lock() -> Result<u32, String> {
     let next_block_height_required = block_height_synced_up_to.unwrap() + 1;
     if tip_of_chain < next_block_height_required {
         // There are no new blocks since our last sync, so mark sync complete and return
-        let store = &mut STATE.write().unwrap().transactions_store;
+        let store = &mut STATE.write().unwrap().accounts_store;
         store.mark_ledger_sync_complete();
         Ok(0)
     } else {
         let blocks = get_blocks(next_block_height_required, tip_of_chain).await?;
-        let store = &mut STATE.write().unwrap().transactions_store;
+        let store = &mut STATE.write().unwrap().accounts_store;
         let blocks_count = blocks.len() as u32;
         for (block_height, block) in blocks.into_iter() {
             let transaction = block.transaction().into_owned();
@@ -60,7 +60,7 @@ async fn sync_transactions_within_lock() -> Result<u32, String> {
 }
 
 fn get_block_height_synced_up_to() -> Option<BlockHeight> {
-    let store = &STATE.read().unwrap().transactions_store;
+    let store = &STATE.read().unwrap().accounts_store;
     store.get_block_height_synced_up_to()
 }
 

--- a/canisters/nns_ui/src/main.rs
+++ b/canisters/nns_ui/src/main.rs
@@ -8,7 +8,7 @@ use crate::canister_store::{
 };
 use crate::periodic_tasks_runner::run_periodic_tasks;
 use crate::state::{StableState, STATE, State};
-use crate::transaction_store::{
+use crate::accounts_store::{
     AccountDetails,
     CreateSubAccountResponse,
     GetStakeNeuronStatusRequest,
@@ -27,13 +27,13 @@ use dfn_candid::{candid, candid_one};
 use dfn_core::{stable, over, over_async};
 use ledger_canister::AccountIdentifier;
 
+mod accounts_store;
 mod assets;
 mod canisters;
 mod canister_store;
 mod ledger_sync;
 mod periodic_tasks_runner;
 mod state;
-mod transaction_store;
 
 const CYCLES_PER_XDR: u64 = 1_000_000_000_000;
 
@@ -69,7 +69,7 @@ pub fn get_account() {
 
 fn get_account_impl() -> GetAccountResponse {
     let principal = dfn_core::api::caller();
-    let store = &STATE.read().unwrap().transactions_store;
+    let store = &STATE.read().unwrap().accounts_store;
     if let Some(account) = store.get_account(principal) {
         GetAccountResponse::Ok(account)
     } else {
@@ -84,7 +84,7 @@ pub fn add_account() {
 
 fn add_account_impl() -> AccountIdentifier {
     let principal = dfn_core::api::caller();
-    let store = &mut STATE.write().unwrap().transactions_store;
+    let store = &mut STATE.write().unwrap().accounts_store;
     store.add_account(principal);
     AccountIdentifier::from(principal)
 }
@@ -96,7 +96,7 @@ pub fn get_transactions() {
 
 fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResponse {
     let principal = dfn_core::api::caller();
-    let store = &STATE.read().unwrap().transactions_store;
+    let store = &STATE.read().unwrap().accounts_store;
     store.get_transactions(principal, request)
 }
 
@@ -107,7 +107,7 @@ pub fn create_sub_account() {
 
 fn create_sub_account_impl(sub_account_name: String) -> CreateSubAccountResponse {
     let principal = dfn_core::api::caller();
-    let store = &mut STATE.write().unwrap().transactions_store;
+    let store = &mut STATE.write().unwrap().accounts_store;
     store.create_sub_account(principal, sub_account_name)
 }
 
@@ -118,7 +118,7 @@ pub fn rename_sub_account() {
 
 fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccountResponse {
     let principal = dfn_core::api::caller();
-    let store = &mut STATE.write().unwrap().transactions_store;
+    let store = &mut STATE.write().unwrap().accounts_store;
     store.rename_sub_account(principal, request)
 }
 
@@ -129,7 +129,7 @@ pub fn register_hardware_wallet() {
 
 fn register_hardware_wallet_impl(request: RegisterHardwareWalletRequest) -> RegisterHardwareWalletResponse {
     let principal = dfn_core::api::caller();
-    let store = &mut STATE.write().unwrap().transactions_store;
+    let store = &mut STATE.write().unwrap().accounts_store;
     store.register_hardware_wallet(principal, request)
 }
 
@@ -140,7 +140,7 @@ pub fn remove_hardware_wallet() {
 
 fn remove_hardware_wallet_impl(request: RemoveHardwareWalletRequest) -> RemoveHardwareWalletResponse {
     let principal = dfn_core::api::caller();
-    let store = &mut STATE.write().unwrap().transactions_store;
+    let store = &mut STATE.write().unwrap().accounts_store;
     store.remove_hardware_wallet(principal, request)
 }
 
@@ -151,7 +151,7 @@ pub fn get_stake_neuron_status() {
 
 fn get_stake_neuron_status_impl(request: GetStakeNeuronStatusRequest) -> GetStakeNeuronStatusResponse {
     let principal = dfn_core::api::caller();
-    let store = &STATE.read().unwrap().transactions_store;
+    let store = &STATE.read().unwrap().accounts_store;
     store.get_stake_neuron_status(principal, request)
 }
 
@@ -208,7 +208,7 @@ pub fn get_stats() {
 }
 
 fn get_stats_impl() -> Stats {
-    let store = &STATE.read().unwrap().transactions_store;
+    let store = &STATE.read().unwrap().accounts_store;
     store.get_stats()
 }
 

--- a/canisters/nns_ui/src/state.rs
+++ b/canisters/nns_ui/src/state.rs
@@ -1,5 +1,5 @@
 use crate::canister_store::CanisterStore;
-use crate::transaction_store::TransactionStore;
+use crate::accounts_store::AccountsStore;
 use dfn_candid::Candid;
 use lazy_static::lazy_static;
 use on_wire::{IntoWire, FromWire};
@@ -7,7 +7,7 @@ use std::sync::RwLock;
 
 #[derive(Default)]
 pub struct State {
-    pub transactions_store: TransactionStore,
+    pub accounts_store: AccountsStore,
     pub canisters_store: CanisterStore
 }
 
@@ -22,14 +22,14 @@ lazy_static! {
 
 impl StableState for State {
     fn encode(&self) -> Vec<u8> {
-        Candid((self.transactions_store.encode(), self.canisters_store.encode())).into_bytes().unwrap()
+        Candid((self.accounts_store.encode(), self.canisters_store.encode())).into_bytes().unwrap()
     }
 
     fn decode(bytes: Vec<u8>) -> Result<Self, String> {
-        let (transactions_store_bytes, canisters_store_bytes): (Vec<u8>, Vec<u8>) = Candid::from_bytes(bytes).map(|c| c.0)?;
+        let (accounts_store_bytes, canisters_store_bytes): (Vec<u8>, Vec<u8>) = Candid::from_bytes(bytes).map(|c| c.0)?;
 
         Ok(State {
-            transactions_store: TransactionStore::decode(transactions_store_bytes)?,
+            accounts_store: AccountsStore::decode(accounts_store_bytes)?,
             canisters_store: CanisterStore::decode(canisters_store_bytes)?
         })
     }


### PR DESCRIPTION
Originally transactions were the key component but now we are storing much more info for each user and so the accounts are now the key component.