### PR TITLE
Testnet deployments have a mock ICP/cycles conversion rate.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,11 @@ ls -sh assets.tar.xz
 sha256sum assets.tar.xz
 
 echo Compiling rust package
-cargo build --target wasm32-unknown-unknown --release --package nns_ui
+if [[ $DEPLOY_ENV = "mainnet" ]]; then
+  cargo build --target wasm32-unknown-unknown --release --package nns_ui
+else
+  cargo build --target wasm32-unknown-unknown --release --package nns_ui --features mock_conversion_rate
+fi
 
 echo Optimising wasm
 wasm-opt target/wasm32-unknown-unknown/release/nns_ui.wasm --strip-debug -Oz -o target/wasm32-unknown-unknown/release/nns_ui-opt.wasm

--- a/canisters/nns_ui/Cargo.toml
+++ b/canisters/nns_ui/Cargo.toml
@@ -31,3 +31,6 @@ ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "779549eccfcf6
 ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f" }
 ledger-canister = { git = "https://github.com/dfinity/ic", rev = "779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f" }
 on_wire = { git = "https://github.com/dfinity/ic", rev = "779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f" }
+
+[features]
+mock_conversion_rate = []


### PR DESCRIPTION
Without this change, testnet deployments try to fetch the conversion
rate from the registry, which fails.