### PR TITLE
Serialize VecDeque directly as it is now supported by candid

### DIFF
--- a/canisters/nns_ui/src/accounts_store.rs
+++ b/canisters/nns_ui/src/accounts_store.rs
@@ -1162,7 +1162,7 @@ impl AccountsStore {
 impl StableState for AccountsStore {
     fn encode(&self) -> Vec<u8> {
         Candid((
-            self.transactions.iter().collect::<Vec<_>>(),
+            &self.transactions,
             &self.accounts,
             &self.neuron_accounts,
             &self.block_height_synced_up_to,


### PR DESCRIPTION
Previously VecDeque wasn't supported by candid so we had to convert the VecDeque into a Vec before serializing, but that is no longer the case.