### PR TITLE
Fix memo sync to work with archive nodes

### DIFF
--- a/canisters/nns_ui/src/canisters/ledger.rs
+++ b/canisters/nns_ui/src/canisters/ledger.rs
@@ -75,8 +75,14 @@ pub async fn get_block(
     canister_id: CanisterId,
     block_height: BlockHeight,
 ) -> Result<EncodedBlock, String> {
+    let method_name = if canister_id == LEDGER_CANISTER_ID {
+        "block_pb"
+    } else {
+        "get_block_pb"
+    };
+
     let response: BlockRes =
-        dfn_core::call(canister_id, "block_pb", protobuf, BlockArg(block_height))
+        dfn_core::call(canister_id, method_name, protobuf, BlockArg(block_height))
             .await
             .map_err(|e| e.1)?;
 


### PR DESCRIPTION
In my local testing of the memo sync I had only ever called into the ledger but not the archive nodes.

I had assumed the API of the archive nodes was the same as the main ledger (as is the case for the `get_blocks_pb` method), but that turned out to not be the case.

Because of this all of the memo values for transactions made before May 19th are still 0.

I have created a canister on mainnet and run tests from there and it can now successfully retrieve the memo values from the archive nodes.