### PR TITLE
EXC-333: Enhancements to `LedgerIdentity`.

### DIFF
--- a/js-agent/src/AuthApi.ts
+++ b/js-agent/src/AuthApi.ts
@@ -73,21 +73,18 @@ export default class AuthApi {
 
     public connectToHardwareWallet = async () : Promise<LedgerIdentity | null> => {
         if (this.ledgerIdentity) {
-            console.log("Closing existing connection to hardware wallet.");
-            this.ledgerIdentity.close();
-            console.log("Done.");
-            this.ledgerIdentity = null;
+            return this.ledgerIdentity;
         }
 
         try {
             console.log("Creating new connection to hardware wallet");
             this.ledgerIdentity = await LedgerIdentity.create();
+            return this.ledgerIdentity;
         } catch (err) {
             console.log(`An exception has occurred: ${err}`)
             alert(err);
+            return null;
         }
-
-        return this.ledgerIdentity
     }
 
     public getPrincipal = () : string => {


### PR DESCRIPTION
1. Made the `Transport` completely internal to the `LedgerIdentity`. The
  caller previously had to manage a `Transport` connection to the wallet,
  and was responsible for closing it in case a new one needed to be created.
2. `LedgerIdentity` now verifies that the public key of the wallet is
  the public key of the identity. That way, a `LedgerIdentity` can only
  be used with the wallet that it was instantiated with.
3. Added more error-handling.