### PR TITLE
EXC-334 (HW Wallets): Display error message in unsupported browsers.

### DIFF
--- a/js-agent/src/ledger/identity.ts
+++ b/js-agent/src/ledger/identity.ts
@@ -51,6 +51,11 @@ import {
      * Connect to a ledger hardware wallet.
      */
     private static async _connect(): Promise<[DfinityApp, TransportClass]> {
+        if (!await TransportClass.isSupported()) {
+          // Data on browser compatibility is taken from https://caniuse.com/webhid
+          throw "Your browser doesn't support WebHID, which is necessary to communicate with your wallet.\n\nSupported browsers:\n* Chrome (Desktop) v89+\n* Edge v89+\n* Opera v76+";
+        }
+
         const transport = await TransportClass.create();
         const app = new DfinityApp(transport);
     


### PR DESCRIPTION
If you're using an unsupported browser and try connecting to a hardware wallet, you'll now see this:

![image](https://user-images.githubusercontent.com/208628/123813042-dd383400-d8f4-11eb-8551-f69ccc84ae4f.png)
