### PR TITLE
Fix proposal topic enumeration

### DIFF
--- a/frontend/dart/lib/data/topic.dart
+++ b/frontend/dart/lib/data/topic.dart
@@ -1,6 +1,6 @@
 enum Topic {
   Unspecified,
-  // NeuronManagement - these proposals are not public so we hide this topic
+  NeuronManagement,
   ExchangeRate,
   NetworkEconomics,
   Governance,
@@ -17,6 +17,7 @@ extension Description on Topic {
 
   static const _topicNameMap = {
     Topic.Unspecified: "All Topics",
+    Topic.NeuronManagement: "Manage Neuron",
     Topic.ExchangeRate: "Exchange Rate",
     Topic.NetworkEconomics: "Network Economics",
     Topic.Governance: "Governance",
@@ -30,6 +31,7 @@ extension Description on Topic {
 
   static const _topicDescriptionMap = {
     Topic.Unspecified: "Follow neurons on all proposal topics",
+    Topic.NeuronManagement: "Proposals that manage specific neurons, for example making them perform actions.",
     Topic.ExchangeRate: "All proposals that provide “real time” information about the value of ICP, as measured by an IMF SDR, which allows the NNS to convert ICP to cycles (which power computation) at a rate which keeps their real world cost constant.",
     Topic.NetworkEconomics: "Proposals that administer network economics, for example, determining what rewards should be paid to node operators.",
     Topic.Governance: "All proposals that administer governance, for example to freeze malicious canisters that are harming the network.",

--- a/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
+++ b/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:dfinity_wallet/data/topic.dart';
 import 'package:dfinity_wallet/ui/_components/form_utils.dart';
 import 'package:dfinity_wallet/ui/_components/responsive.dart';
 import 'package:dfinity_wallet/ui/neurons/following/topic_card.dart';
@@ -32,7 +33,8 @@ class _ConfigureFollowersPageState extends State<ConfigureFollowersPage> {
         stream: context.boxes.neurons.changes,
         builder: (context, snapshot) {
           final refreshed = context.boxes.neurons[widget.neuron.id];
-          final followees = refreshed.followees;
+          // NeuronManagement proposals are not public so we hide these from the follow options
+          final followees = refreshed.followees.whereNot((e) => e.topic == Topic.NeuronManagement);
           rowKeys = followees.map((element) => GlobalKey()).toList();
           return Column(
             children: [


### PR DESCRIPTION
The proposal topics are assigned ids based on their position in the enum so when I removed 'NeuronManagement' this caused topics to mismatch.