### PR TITLE
Minify ic_agent.js

### DIFF
--- a/frontend/ts/build.sh
+++ b/frontend/ts/build.sh
@@ -16,5 +16,5 @@ popd
 
 npx tsc
 echo "Bundling..."
-npx browserify ./build/index.js --standalone IcAgent > ../dart/assets/ic_agent.js
+npx browserify ./build/index.js --standalone IcAgent | npx uglify-js --compress --mangle > ../dart/assets/ic_agent.js
 echo "Done."

--- a/frontend/ts/package-lock.json
+++ b/frontend/ts/package-lock.json
@@ -4502,6 +4502,11 @@
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg=="
+    },
     "uglifyify": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/uglifyify/-/uglifyify-5.0.2.tgz",

--- a/frontend/ts/package.json
+++ b/frontend/ts/package.json
@@ -24,7 +24,8 @@
     "source-map-explorer": "^2.5.2",
     "tinyify": "^3.0.0",
     "ts-protoc-gen": "^0.14.0",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "uglify-js": "^3.13.10"
   },
   "devDependencies": {
     "@types/randombytes": "^2.0.0",


### PR DESCRIPTION
The typescript we generate can be minified and mangle to reduce size.
This optimization reduces the size of ic_agent.js from 1.8MiB to ~950KiB.