### PR TITLE
Refresh balances after staking or topping up a neuron

### DIFF
--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -121,7 +121,10 @@ class PlatformICApi extends AbstractPlatformICApi {
       {required ICP stake, int? fromSubAccount}) async {
     await promiseToFuture(serviceApi!.createNeuron(CreateNeuronRequest(
         stake: stake.asE8s().toJS, fromSubAccountId: fromSubAccount)));
-    await neuronSyncService!.fetchNeurons();
+    await Future.wait([
+      balanceSyncService!.syncBalances(),
+      neuronSyncService!.fetchNeurons()
+    ]);
   }
 
   @override
@@ -133,7 +136,10 @@ class PlatformICApi extends AbstractPlatformICApi {
         neuronAccountIdentifier: neuronAccountIdentifier,
         amount: amount.asE8s().toJS,
         fromSubAccountId: fromSubAccount)));
-    await neuronSyncService!.fetchNeurons();
+    await Future.wait([
+      balanceSyncService!.syncBalances(),
+      neuronSyncService!.fetchNeurons()
+    ]);
   }
 
   @override


### PR DESCRIPTION
After staking or topping up a neuron the user's balances must be refreshed to take into account the ICP which was just sent to the neuron.