### PR TITLE
NU-149 Hide neurons with balance <= transaction fee

### DIFF
--- a/frontend/dart/lib/ic_api/platform_ic_api.dart
+++ b/frontend/dart/lib/ic_api/platform_ic_api.dart
@@ -72,7 +72,7 @@ abstract class AbstractPlatformICApi {
 
   Future<Proposal> fetchProposal({required BigInt proposalId});
 
-  Future<Neuron> fetchNeuron({required BigInt neuronId});
+  Future<Neuron?> fetchNeuron({required BigInt neuronId});
 
   Future<NeuronInfo> fetchNeuronInfo({required BigInt neuronId});
 

--- a/frontend/dart/lib/ic_api/web/neuron_sync_service.dart
+++ b/frontend/dart/lib/ic_api/web/neuron_sync_service.dart
@@ -65,6 +65,11 @@ class NeuronSyncService {
     hiveBoxes.neurons.notifyChange();
   }
 
+  void removeNeuron(String neuronId) {
+    hiveBoxes.neurons.remove(neuronId);
+    hiveBoxes.neurons.notifyChange();
+  }
+
   void parseFullNeuron(dynamic fullNeuron, Neuron neuron) {
     final dissolveState = fullNeuron['dissolveState'];
     if (dissolveState != null) {

--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -223,10 +223,15 @@ class PlatformICApi extends AbstractPlatformICApi {
   }
 
   @override
-  Future<Neuron> fetchNeuron({required BigInt neuronId}) async {
+  Future<Neuron?> fetchNeuron({required BigInt neuronId}) async {
     final res = await promiseToFuture(serviceApi!.getNeuron(neuronId.toJS));
-    final neuronInfo = jsonDecode(stringify(res));
-    return neuronSyncService!.storeNeuron(neuronInfo);
+    if (res == null) {
+      neuronSyncService!.removeNeuron(neuronId.toString());
+      return null;
+    } else {
+      final neuronInfo = jsonDecode(stringify(res));
+      return neuronSyncService!.storeNeuron(neuronInfo);
+    }
   }
 
   @override

--- a/frontend/ts/src/canisters/constants.ts
+++ b/frontend/ts/src/canisters/constants.ts
@@ -1,6 +1,9 @@
 export const SUB_ACCOUNT_BYTE_LENGTH = 32;
 export const CREATE_CANISTER_MEMO = BigInt(0x41455243); // CREA,
 export const TOP_UP_CANISTER_MEMO = BigInt(0x50555054); // TPUP
+
+export const TRANSACTION_FEE = BigInt(10_000);
+
 import config from "../config.json";
 
 // @ts-ignore

--- a/frontend/ts/src/canisters/governance/ResponseConverters.ts
+++ b/frontend/ts/src/canisters/governance/ResponseConverters.ts
@@ -53,6 +53,7 @@ import {
   Tally as RawTally,
 } from "./rawService";
 import { UnsupportedValueError } from "../../utils";
+import { TRANSACTION_FEE } from "../constants";
 
 export default class ResponseConverters {
   public toProposalInfo = (proposalInfo: RawProposalInfo): ProposalInfo => {
@@ -86,15 +87,23 @@ export default class ResponseConverters {
   ): Array<NeuronInfo> => {
     const principalString = principal.toString();
 
-    return response.neuron_infos.map(([id, neuronInfo]) =>
-      this.toNeuronInfo(
-        id,
-        principalString,
-        neuronInfo,
-        response.full_neurons.find(
-          (neuron) => neuron.id.length && neuron.id[0].id === id
+    return (
+      response.neuron_infos
+        .map(([id, neuronInfo]) =>
+          this.toNeuronInfo(
+            id,
+            principalString,
+            neuronInfo,
+            response.full_neurons.find(
+              (neuron) => neuron.id.length && neuron.id[0].id === id
+            )
+          )
         )
-      )
+        // hide neurons where the stake is less than or equal to 1 transaction fee
+        .filter(
+          (n) =>
+            !n.fullNeuron || n.fullNeuron.cachedNeuronStake > TRANSACTION_FEE
+        )
     );
   };
 

--- a/frontend/ts/src/canisters/ledger/RequestConverters.ts
+++ b/frontend/ts/src/canisters/ledger/RequestConverters.ts
@@ -6,7 +6,7 @@ import {
   SendICPTsRequest,
 } from "./model";
 import * as convert from "../converter";
-import { SUB_ACCOUNT_BYTE_LENGTH } from "../constants";
+import { TRANSACTION_FEE, SUB_ACCOUNT_BYTE_LENGTH } from "../constants";
 import { PrincipalId } from "./proto/base_types_pb";
 import {
   AccountBalanceRequest,
@@ -19,8 +19,6 @@ import {
   SendRequest,
   Subaccount,
 } from "./proto/types_pb";
-
-export const TRANSACTION_FEE = BigInt(10_000);
 
 export default class RequestConverters {
   public fromGetBalancesRequest = (


### PR DESCRIPTION
Eventually the governance canister will garbage collect neurons where the balance is less than or equal to 1 transaction fee but for now we will simply hide them on the front end.