### PR TITLE
Clear cached neurons after calling getNeurons

### DIFF
--- a/frontend/dart/lib/ic_api/web/neuron_sync_service.dart
+++ b/frontend/dart/lib/ic_api/web/neuron_sync_service.dart
@@ -32,6 +32,8 @@ class NeuronSyncService {
     final string = stringify(res);
     // print("fetched neurons $string");
     dynamic response = (jsonDecode(string) as List<dynamic>).toList();
+    // We've just retrieved all the neurons, so clear whatever we currently have
+    hiveBoxes.neurons.clear();
     response.forEach((e) => storeNeuron(e));
   }
 


### PR DESCRIPTION
The call to getNeurons returns all of the user's neurons, so by clearing the cached neurons we remove any that should no longer be displayed.