### PR TITLE
Show the principal, not the public key

### DIFF
--- a/frontend/dart/lib/ui/wallet/account_detail_widget.dart
+++ b/frontend/dart/lib/ui/wallet/account_detail_widget.dart
@@ -142,7 +142,7 @@ class _AccountDetailPageState extends State<AccountDetailPage> {
                                               padding:
                                                   const EdgeInsets.all(16.0),
                                               child: Text(
-                                                "Show Address And Public Key On Device",
+                                                "Show Principal And Address On Device",
                                                 style: TextStyle(
                                                     fontSize:
                                                         Responsive.isMobile(

--- a/frontend/dart/lib/ui/wallet/hardware_wallet_connection_widget.dart
+++ b/frontend/dart/lib/ui/wallet/hardware_wallet_connection_widget.dart
@@ -102,12 +102,12 @@ class HardwareConnectionWidget extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        "Public Key",
+                        "Principal",
                         style: context.textTheme.bodyText1
                             ?.copyWith(fontSize: 14, color: AppColors.gray50),
                       ),
                       Text(
-                        getPublicKey(ledgerIdentity)!,
+                        ledgerIdentity.getPrincipal().toString(),
                         style: context.textTheme.subtitle2,
                       ),
                       SmallFormDivider(),

--- a/frontend/ts/ledger-cli.ts
+++ b/frontend/ts/ledger-cli.ts
@@ -376,8 +376,6 @@ async function main() {
         .option("-n --no-show-on-device")
         .description("Show the wallet's principal, address, and balance.")
         .action((args) => {
-          console.log(args);
-          console.log(program.opts().network);
           run(() => showInfo(args.showOnDevice));
         })
     )


### PR DESCRIPTION
For hardware wallets, we only show the principal. The public key itself is not useful to show in the UI.