### PR TITLE
EXC-504: Persist some assets across upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,12 +183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
-name = "bumpalo"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
 name = "byte-unit"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,10 +869,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1454,15 +1446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
-name = "js-sys"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,7 +1677,7 @@ dependencies = [
  "dfn_json",
  "dfn_macro",
  "dfn_protobuf",
- "getrandom 0.2.2",
+ "hex",
  "ic-base-types",
  "ic-certified-map",
  "ic-crypto-sha256",
@@ -1705,6 +1688,7 @@ dependencies = [
  "lazy_static",
  "ledger-canister",
  "lzma-rs",
+ "maplit",
  "on_wire",
  "serde",
  "serde_bytes",
@@ -2891,60 +2875,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "which"

--- a/README.md
+++ b/README.md
@@ -25,34 +25,19 @@ The resulting `nns-dapp.wasm` is ready for deployment as
 
 Our CI also performs these steps; you can compare the SHA256 with the output there, or download the artifact there.
 
-### Software versions
+## Development
 
-What things you need to install the software and how to install them
-
-- [Flutter](https://flutter.dev/docs/get-started/install) version `2.0.6`
-- [Node/NPM](https://nodejs.org/en/) version `>= v14.17.0`
-- [DFX](https://sdk.dfinity.org/docs/index.html) version `>= 0.7.0`
-- `didc` in your `$PATH`: Can be downloaded [here](https://github.com/dfinity/candid/releases).
-
-### Development
-
-Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. We do not yet support fully local development.
+Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
 To deploy to the testnet, run the following:
 
-```shell
-./deploy.sh testnet
-```
+    ./deploy.sh testnet
 
 You can now access the frontend using:
 
-```shell
-open "https://$(dfx canister --no-wallet --network testnet id nns-dapp).nnsdapp.dfinity.network"
-```
+    open "https://$(dfx canister --no-wallet --network testnet id nns-dapp).nnsdapp.dfinity.network"
 
 To work on the UI locally, either use your IDE, or run the following:
 
-```
-cd frontend/dart
-flutter run --no-sound-null-safety --dart-define=DEPLOY_ENV=staging --web-port 5021
-```
+    cd frontend/dart
+    flutter run --no-sound-null-safety --dart-define=DEPLOY_ENV=staging --web-port 5021

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,8 @@ sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' buil
 # brew install xz
 
 cd build/web/ || exit
+# Remove the assets/NOTICES file, as it's large in size and not used.
+rm assets/NOTICES
 tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../../../../assets.tar.xz . || \
 gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../../../../assets.tar.xz .
 cd ../../../.. || exit

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 base64 = "0.13.0"
 candid = "0.6.21"
-getrandom = { version = "0.2.2", features = ["js"] }
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 serde = "1.0.119"
@@ -17,6 +16,7 @@ serde_cbor = "0.11"
 sha2 = "0.9.1"
 lzma-rs = "0.2.0"
 tar = "0.4.35"
+hex = "0.4.3"
 
 dfn_candid = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd61f98042ed4adde0a6d913387ff2" }
 dfn_core = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd61f98042ed4adde0a6d913387ff2" }
@@ -31,6 +31,9 @@ ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd6
 ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd61f98042ed4adde0a6d913387ff2" }
 ledger-canister = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd61f98042ed4adde0a6d913387ff2" }
 on_wire = { git = "https://github.com/dfinity/ic", rev = "074feaa2c6cd61f98042ed4adde0a6d913387ff2" }
+
+[dev-dependencies]
+maplit = "1.0.2"
 
 [features]
 mock_conversion_rate = []

--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -1,9 +1,10 @@
-use candid::CandidType;
+use crate::state::STATE;
+use crate::StableState;
+use candid::{CandidType, Decode, Encode};
 use ic_certified_map::{labeled, labeled_hash, AsHashTree, Hash, RbTree};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::Read;
 
@@ -25,50 +26,80 @@ pub struct HttpResponse {
 }
 
 const LABEL_ASSETS: &[u8] = b"http_assets";
-type AssetHashes = RbTree<Vec<u8>, Hash>;
+pub type AssetHashes = RbTree<Vec<u8>, Hash>;
 
-struct State {
-    asset_hashes: RefCell<AssetHashes>,
+/// An asset to be served via HTTP requests.
+#[derive(CandidType, Clone, Deserialize, PartialEq, Debug)]
+pub struct Asset {
+    headers: Vec<HeaderField>,
+    bytes: Vec<u8>,
+    // Whether the asset is persisted across upgrades.
+    stable: bool,
 }
 
-impl Default for State {
-    fn default() -> Self {
+impl Asset {
+    pub fn new(bytes: Vec<u8>) -> Self {
         Self {
-            asset_hashes: RefCell::new(AssetHashes::default()),
+            headers: vec![],
+            bytes,
+            stable: false,
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_stable(bytes: Vec<u8>) -> Self {
+        Self {
+            headers: vec![],
+            bytes,
+            stable: true,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_header<S: Into<String>>(mut self, key: S, val: S) -> Self {
+        self.headers.push((key.into(), val.into()));
+        self
     }
 }
 
-thread_local! {
-    static STATE: State = State::default();
+#[derive(Default, CandidType, Deserialize, PartialEq, Debug)]
+pub struct Assets(HashMap<String, Asset>);
 
-    #[allow(clippy::type_complexity)]
-    static ASSETS: RefCell<HashMap<String, (Vec<HeaderField>, Vec<u8>)>> = RefCell::new(HashMap::default());
+impl Assets {
+    fn insert<S: Into<String>>(&mut self, path: S, asset: Asset) {
+        self.0.insert(path.into(), asset);
+    }
+
+    fn get(&self, path: &str) -> Option<&Asset> {
+        self.0.get(path)
+    }
 }
 
 pub fn http_request(req: HttpRequest) -> HttpResponse {
     let parts: Vec<&str> = req.url.split('?').collect();
     let request_path = parts[0];
 
-    let certificate_header =
-        STATE.with(|s| make_asset_certificate_header(&s.asset_hashes.borrow(), request_path));
+    STATE.with(|s| {
+        let certificate_header =
+            make_asset_certificate_header(&s.asset_hashes.borrow(), request_path);
 
-    ASSETS.with(|a| match a.borrow().get(request_path) {
-        Some((headers, value)) => {
-            let mut headers = headers.clone();
-            headers.push(certificate_header);
+        match s.assets.borrow().get(request_path) {
+            Some(asset) => {
+                let mut headers = asset.headers.clone();
+                headers.push(certificate_header);
 
-            HttpResponse {
-                status_code: 200,
-                headers,
-                body: ByteBuf::from(value.clone()),
+                HttpResponse {
+                    status_code: 200,
+                    headers,
+                    body: ByteBuf::from(asset.bytes.clone()),
+                }
             }
+            None => HttpResponse {
+                status_code: 404,
+                headers: vec![certificate_header],
+                body: ByteBuf::from(format!("Asset {} not found.", request_path)),
+            },
         }
-        None => HttpResponse {
-            status_code: 404,
-            headers: vec![certificate_header],
-            body: ByteBuf::from(format!("Asset {} not found.", request_path)),
-        },
     })
 }
 
@@ -100,61 +131,103 @@ pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
     hasher.finalize().into()
 }
 
-// used both in init and post_upgrade
-pub fn init_assets() {
+/// Insert an asset into the state.
+pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
+    dfn_core::api::print(format!("Inserting asset {}", &path.clone().into()));
     STATE.with(|s| {
         let mut asset_hashes = s.asset_hashes.borrow_mut();
+        let mut assets = s.assets.borrow_mut();
+        let path = path.into();
 
-        ASSETS.with(|a| {
-            let mut assets = a.borrow_mut();
+        if path == "/index.html" {
+            asset_hashes.insert(b"/".to_vec(), hash_bytes(&asset.bytes));
+            assets.insert("/", asset.clone());
+        }
 
-            let compressed = include_bytes!("../../assets.tar.xz").to_vec();
-            let mut decompressed = Vec::new();
-            lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
-            let mut tar: tar::Archive<&[u8]> = tar::Archive::new(decompressed.as_ref());
-            for entry in tar.entries().unwrap() {
-                let mut entry = entry.unwrap();
+        asset_hashes.insert(path.as_bytes().to_vec(), hash_bytes(&asset.bytes));
+        assets.insert(path, asset);
 
-                let name_bytes = entry
-                    .path_bytes()
-                    .into_owned()
-                    .strip_prefix(b".")
-                    .unwrap()
-                    .to_vec();
-
-                if !entry.header().entry_type().is_file() {
-                    continue;
-                }
-                let name = String::from_utf8(name_bytes.clone()).unwrap_or_else(|e| {
-                    dfn_core::api::trap_with(&format!(
-                        "non-utf8 file name {}: {}",
-                        String::from_utf8_lossy(&name_bytes),
-                        e
-                    ));
-                    unreachable!()
-                });
-
-                let mut bytes = Vec::new();
-                entry.read_to_end(&mut bytes).unwrap();
-
-                dfn_core::api::print(format!("{}: {}", &name, bytes.len()));
-
-                if name == "/index.html" {
-                    let headers = vec![];
-                    asset_hashes.insert(b"/".to_vec(), hash_bytes(&bytes));
-                    assets.insert("/".to_string(), (headers, bytes.clone()));
-                }
-
-                let headers = vec![];
-                asset_hashes.insert(name_bytes.clone(), hash_bytes(&bytes));
-                assets.insert(name.to_string(), (headers, bytes));
-            }
-        });
         update_root_hash(&asset_hashes);
     });
+}
+
+// used both in init and post_upgrade
+pub fn init_assets() {
+    let compressed = include_bytes!("../../assets.tar.xz").to_vec();
+    let mut decompressed = Vec::new();
+    lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
+    let mut tar: tar::Archive<&[u8]> = tar::Archive::new(decompressed.as_ref());
+    for entry in tar.entries().unwrap() {
+        let mut entry = entry.unwrap();
+
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
+        let name_bytes = entry
+            .path_bytes()
+            .into_owned()
+            .strip_prefix(b".")
+            .unwrap()
+            .to_vec();
+
+        let name = String::from_utf8(name_bytes.clone()).unwrap_or_else(|e| {
+            dfn_core::api::trap_with(&format!(
+                "non-utf8 file name {}: {}",
+                String::from_utf8_lossy(&name_bytes),
+                e
+            ));
+            unreachable!()
+        });
+
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).unwrap();
+
+        dfn_core::api::print(format!("{}: {}", &name, bytes.len()));
+
+        insert_asset(name, Asset::new(bytes));
+    }
+}
+
+impl StableState for Assets {
+    fn encode(&self) -> Vec<u8> {
+        // Encode all stable assets.
+        let stable_assets: Assets = Assets(
+            self.0
+                .clone()
+                .into_iter()
+                .filter(|(_, asset)| asset.stable)
+                .collect(),
+        );
+
+        Encode!(&stable_assets).unwrap()
+    }
+
+    fn decode(bytes: Vec<u8>) -> Result<Self, String> {
+        Decode!(&bytes, Assets).map_err(|err| err.to_string())
+    }
 }
 
 fn update_root_hash(a: &AssetHashes) {
     let prefixed_root_hash = &labeled_hash(LABEL_ASSETS, &a.root_hash());
     dfn_core::api::set_certified_data(&prefixed_root_hash[..]);
+}
+
+#[test]
+fn encode_decode() {
+    // Test that encoding/decoding preserves stable assets.
+    use maplit::hashmap;
+    let assets = Assets(hashmap! {
+        "x".to_string() => Asset::new_stable(vec![1,2,3]),
+        "y".to_string() => Asset::new(vec![4,5,6])
+    });
+
+    let assets = Assets::decode(assets.encode()).unwrap();
+
+    assert_eq!(
+        assets,
+        Assets(hashmap! {
+            "x".to_string() => Asset::new_stable(vec![1,2,3])
+        })
+    );
 }


### PR DESCRIPTION
We need to load the canvaskit wasm from the canister itself as opposed
to an untrusted external domain. The wasm is quite large and doesn't fit
into our canister's payload.

To get around this, I plan to do the following:

1) Add the ability to persist assets across upgrades (this PR).
2) Add a new endpoint where we can upload the canvaskit.wasm, and mark
   it as a stable asset. This would be a one-time operation (upcoming PR)
3) Drop the endpoint, and completely move to serve the local copy of
   canvaskit.wasm (upcoming PR)