### PR TITLE
EXC-525: Load correctly on iPads with iOS 15

### DIFF
--- a/frontend/dart/web/index.html
+++ b/frontend/dart/web/index.html
@@ -30,6 +30,30 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <script type="text/javascript">
+    function iOS() {
+      return [
+        'iPad Simulator',
+        'iPhone Simulator',
+        'iPod Simulator',
+        'iPad',
+        'iPhone',
+        'iPod'
+      ].includes(navigator.platform)
+      // iPad on iOS 13 detection
+      || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
+    }
+
+    function isMobile() {
+      return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    }
+
+    if(isMobile() || iOS()) {
+      window.flutterWebRenderer = "html";
+    } else {
+      window.flutterWebRenderer = "canvaskit";
+    }
+  </script>
   <script src="/assets/assets/ic_agent.js" type="application/javascript"></script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>


### PR DESCRIPTION
This change makes us use the HTML renderer on iOS tablets in addition to mobile devices.