### PR TITLE
HW CLI: Remove benign error 'Cannot find canister id.'

### DIFF
--- a/ic-hardware-wallet-cli/ic-hardware-wallet-cli
+++ b/ic-hardware-wallet-cli/ic-hardware-wallet-cli
@@ -7,7 +7,7 @@ if [ ! -d "node_modules" ]; then
 fi
 
 # This isn't needed by the CLI, but is done to keep the TS compiler happy.
-DEPLOY_ENV=testnet ../../update_config.sh
+DEPLOY_ENV=mainnet ../../update_config.sh
 
 npm run ic-hardware-wallet-cli --silent -- $@
 popd > /dev/null


### PR DESCRIPTION
When using the CLI, an error `Cannot find canister id.` was present in the output of the CLI.

Right now, the TS code assumes the presence of a config file, even though it's not being used by the CLI. In the future, I'll refactor the code such that its independent of this file.