### PR TITLE
Changed http_request to return prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
+First, install gnu-tar, flutter and binaryen by typing the following command: 
+    
+    brew install gnu-tar flutter binaryen
+
 To deploy to the testnet, run the following:
 
     ./deploy.sh testnet

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.7.2",
+  "dfx": "0.8.1",
   "canisters": {
     "nns-dapp": {
       "type": "custom",

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -1613,18 +1613,18 @@ pub enum TransferResult {
 
 #[derive(CandidType)]
 pub struct Stats {
-    accounts_count: u64,
-    sub_accounts_count: u64,
+    pub accounts_count: u64,
+    pub sub_accounts_count: u64,
     hardware_wallet_accounts_count: u64,
-    transactions_count: u64,
+    pub transactions_count: u64,
     block_height_synced_up_to: Option<u64>,
     earliest_transaction_timestamp_nanos: u64,
     earliest_transaction_block_height: BlockHeight,
     latest_transaction_timestamp_nanos: u64,
     latest_transaction_block_height: BlockHeight,
     seconds_since_last_ledger_sync: u64,
-    neurons_created_count: u64,
-    neurons_topped_up_count: u64,
+    pub neurons_created_count: u64,
+    pub neurons_topped_up_count: u64,
     transactions_to_process_queue_length: u32,
 }
 

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -24,6 +24,7 @@ mod ledger_sync;
 mod multi_part_transactions_processor;
 mod periodic_tasks_runner;
 mod state;
+mod metrics_encoder;
 
 #[export_name = "canister_init"]
 fn main() {
@@ -55,11 +56,6 @@ pub fn http_request() {
     over(candid_one, assets::http_request);
 }
 
-/// Returns the user's account details if they have an account, else AccountNotFound.
-///
-/// The account details contain each of the AccountIdentifiers linked to the user's account. These
-/// include all accounts controlled by the user's principal directly and also any hardware wallet
-/// accounts they have registered.
 #[export_name = "canister_query get_account"]
 pub fn get_account() {
     over(candid, |()| get_account_impl());
@@ -73,12 +69,8 @@ fn get_account_impl() -> GetAccountResponse {
     })
 }
 
-/// Creates a new account controlled by the caller's principal.
-///
-/// Returns true if the account was created, else false (which happens if the principal already has
-/// an account).
 #[export_name = "canister_update add_account"]
-fn add_account() {
+pub fn add_account() {
     over(candid, |()| add_account_impl());
 }
 
@@ -88,10 +80,6 @@ fn add_account_impl() -> AccountIdentifier {
     AccountIdentifier::from(principal)
 }
 
-/// Returns a page of transactions for a given AccountIdentifier.
-///
-/// The AccountIdentifier must be linked to the caller's account, else an empty Vec will be
-/// returned.
 #[export_name = "canister_query get_transactions"]
 pub fn get_transactions() {
     over(candid_one, get_transactions_impl);
@@ -106,11 +94,6 @@ fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResp
     })
 }
 
-/// Creates a new ledger sub account and links it to the user's account.
-///
-/// This newly created account can be used to send and receive ICP and is controlled only by the
-/// user's principal (the fact that it is controlled by the same principal as the user's other
-/// ledger accounts is not derivable externally).
 #[export_name = "canister_update create_sub_account"]
 pub fn create_sub_account() {
     over(candid_one, create_sub_account_impl);
@@ -125,9 +108,6 @@ fn create_sub_account_impl(sub_account_name: String) -> CreateSubAccountResponse
     })
 }
 
-/// Changes the alias given to the chosen sub account.
-///
-/// These aliases are not visible externally or to anyone else.
 #[export_name = "canister_update rename_sub_account"]
 pub fn rename_sub_account() {
     over(candid_one, rename_sub_account_impl);
@@ -142,11 +122,6 @@ fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccount
     })
 }
 
-/// Links a hardware wallet to the user's account.
-///
-/// A single hardware wallet can be linked to multiple user accounts, but in order to make calls to
-/// the IC from the account, the user must use the hardware wallet to sign each request.
-/// Some readonly calls do not require signing, eg. viewing the account's ICP balance.
 #[export_name = "canister_update register_hardware_wallet"]
 pub fn register_hardware_wallet() {
     over(candid_one, register_hardware_wallet_impl);
@@ -163,7 +138,6 @@ fn register_hardware_wallet_impl(
     })
 }
 
-/// Returns the list of canisters which the user has attached to their account.
 #[export_name = "canister_query get_canisters"]
 pub fn get_canisters() {
     over(candid, |()| get_canisters_impl());
@@ -174,7 +148,6 @@ fn get_canisters_impl() -> Vec<NamedCanister> {
     STATE.with(|s| s.accounts_store.borrow_mut().get_canisters(principal))
 }
 
-/// Attaches a canister to the user's account.
 #[export_name = "canister_update attach_canister"]
 pub fn attach_canister() {
     over(candid_one, attach_canister_impl);
@@ -189,7 +162,6 @@ fn attach_canister_impl(request: AttachCanisterRequest) -> AttachCanisterRespons
     })
 }
 
-/// Detaches a canister from the user's account.
 #[export_name = "canister_update detach_canister"]
 pub fn detach_canister() {
     over(candid_one, detach_canister_impl);
@@ -204,11 +176,6 @@ fn detach_canister_impl(request: DetachCanisterRequest) -> DetachCanisterRespons
     })
 }
 
-/// Gets the current status of a 'multi-part' action.
-///
-/// Some actions are 'multi-part' and are handled by background processes, eg. staking a neuron or
-/// topping up a canister, this method can be polled by the front end to check on the statuses of
-/// these actions.
 #[export_name = "canister_query get_multi_part_transaction_status"]
 pub fn get_multi_part_transaction_status() {
     over(
@@ -261,7 +228,6 @@ fn get_multi_part_transaction_status_impl(
     })
 }
 
-/// Returns the list of errors, if any, that have occurred while processing 'multi-part' actions.
 #[export_name = "canister_query get_multi_part_transaction_errors"]
 pub fn get_multi_part_transaction_errors() {
     over(candid, |()| get_multi_part_transaction_errors_impl());
@@ -275,7 +241,6 @@ fn get_multi_part_transaction_errors_impl() -> Vec<MultiPartTransactionError> {
     })
 }
 
-/// Returns the current conversion rate between ICP and cycles.
 #[export_name = "canister_query get_icp_to_cycles_conversion_rate"]
 pub fn get_icp_to_cycles_conversion_rate() {
     over_async(candid, |()| get_icp_to_cycles_conversion_rate_impl());
@@ -301,10 +266,6 @@ async fn get_icp_to_cycles_conversion_rate_impl() -> u64 {
     }
 }
 
-/// Returns stats about the canister.
-///
-/// These stats include things such as the number of accounts registered, the memory usage, the
-/// number of neurons created, etc.
 #[export_name = "canister_query get_stats"]
 pub fn get_stats() {
     over(candid, |()| get_stats_impl());
@@ -314,12 +275,6 @@ fn get_stats_impl() -> Stats {
     STATE.with(|s| s.accounts_store.borrow().get_stats())
 }
 
-/// Executes on every block height and is used to run background processes.
-///
-/// These background processes include:
-/// - Sync transactions from the ledger
-/// - Process any queued 'multi-part' actions (eg. staking a neuron or topping up a canister)
-/// - Prune old transactions if memory usage is too high
 #[export_name = "canister_heartbeat"]
 pub fn canister_heartbeat() {
     let future = run_periodic_tasks();

--- a/rs/src/metrics_encoder.rs
+++ b/rs/src/metrics_encoder.rs
@@ -1,0 +1,105 @@
+//! Encodes metrics for Prometheus.
+use std::io;
+
+/// `MetricsEncoder` provides methods to encode metrics in a text format
+/// that can be understood by Prometheus.
+///
+/// Metrics are encoded with the block time included, to allow Prometheus
+/// to discard out-of-order samples collected from replicas that are behind.
+///
+/// See [Exposition Formats][1] for an informal specification of the text format.
+///
+/// [1]: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
+pub struct MetricsEncoder<W: io::Write> {
+    writer: W,
+    now_millis: u64,
+}
+
+impl<W: io::Write> MetricsEncoder<W> {
+    /// Constructs a new encoder dumping metrics with the given timestamp into
+    /// the specified writer.
+    pub fn new(writer: W, now_millis: u64) -> Self {
+        Self { writer, now_millis }
+    }
+
+    /// Returns the internal buffer that was used to record the
+    /// metrics.
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+
+    fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
+        writeln!(self.writer, "# HELP {} {}", name, help)?;
+        writeln!(self.writer, "# TYPE {} {}", name, typ)
+    }
+
+    /// Encodes the metadata and the value of a histogram.
+    ///
+    /// SUM is the sum of all observed values, before they were put
+    /// into buckets.
+    ///
+    /// BUCKETS is a list (key, value) pairs, where KEY is the bucket
+    /// and VALUE is the number of items *in* this bucket (i.e., it's
+    /// not a cumulative value).
+    pub fn encode_histogram(
+        &mut self,
+        name: &str,
+        buckets: impl Iterator<Item = (f64, f64)>,
+        sum: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, "histogram")?;
+        let mut total: f64 = 0.0;
+        let mut saw_infinity = false;
+        for (bucket, v) in buckets {
+            total += v;
+            if bucket == std::f64::INFINITY {
+                saw_infinity = true;
+                writeln!(
+                    self.writer,
+                    "{}_bucket{{le=\"+Inf\"}} {} {}",
+                    name, total, self.now_millis
+                )?;
+            } else {
+                writeln!(
+                    self.writer,
+                    "{}_bucket{{le=\"{}\"}} {} {}",
+                    name, bucket, total, self.now_millis
+                )?;
+            }
+        }
+        if !saw_infinity {
+            writeln!(
+                self.writer,
+                "{}_bucket{{le=\"+Inf\"}} {} {}",
+                name, total, self.now_millis
+            )?;
+        }
+        writeln!(self.writer, "{}_sum {} {}", name, sum, self.now_millis)?;
+        writeln!(self.writer, "{}_count {} {}", name, total, self.now_millis)
+    }
+
+    pub fn encode_single_value(
+        &mut self,
+        typ: &str,
+        name: &str,
+        value: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, typ)?;
+        writeln!(self.writer, "{} {} {}", name, value, self.now_millis)
+    }
+
+    /// Encodes the metadata and the value of a counter.
+    pub fn encode_counter(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("counter", name, value, help)
+    }
+
+    /// Encodes the metadata and the value of a gauge.
+    pub fn encode_gauge(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("gauge", name, value, help)
+    }
+}
+
+#[cfg(test)]
+mod test;


### PR DESCRIPTION
Changed http_request method in assets.rs to return prometheus metrics.
Added metrics_encoder.rs file. 
The metrics can be accessed at <canister id>.raw.nnsdapp.network/metrics

