### PR TITLE
changed http_request method to return prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
+First, install gnu-tar, flutter and binaryen by typing the following command: 
+    
+    brew install gnu-tar flutter binaryen
+
 To deploy to the testnet, run the following:
 
     ./deploy.sh testnet

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -1578,18 +1578,18 @@ pub enum TransferResult {
 
 #[derive(CandidType)]
 pub struct Stats {
-    accounts_count: u64,
-    sub_accounts_count: u64,
+    pub accounts_count: u64,
+    pub sub_accounts_count: u64,
     hardware_wallet_accounts_count: u64,
-    transactions_count: u64,
+    pub transactions_count: u64,
     block_height_synced_up_to: Option<u64>,
     earliest_transaction_timestamp_nanos: u64,
     earliest_transaction_block_height: BlockHeight,
     latest_transaction_timestamp_nanos: u64,
     latest_transaction_block_height: BlockHeight,
     seconds_since_last_ledger_sync: u64,
-    neurons_created_count: u64,
-    neurons_topped_up_count: u64,
+    pub neurons_created_count: u64,
+    pub neurons_topped_up_count: u64,
     transactions_to_process_queue_length: u32,
 }
 

--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -3,10 +3,13 @@ use crate::StableState;
 use candid::{CandidType, Decode, Encode};
 use ic_certified_map::{labeled, labeled_hash, AsHashTree, Hash, RbTree};
 use serde::{Deserialize, Serialize};
-use serde_bytes::ByteBuf;
+use serde_bytes::{ByteBuf};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::Read;
+
+use crate::metrics_encoder::MetricsEncoder;
+use dfn_core::api::ic0::time;
 
 type HeaderField = (String, String);
 
@@ -23,6 +26,7 @@ pub struct HttpResponse {
     status_code: u16,
     headers: Vec<HeaderField>,
     body: ByteBuf,
+    // body: Cow<'static, Bytes>,
 }
 
 const LABEL_ASSETS: &[u8] = b"http_assets";
@@ -85,33 +89,131 @@ impl Assets {
     }
 }
 
-pub fn http_request(req: HttpRequest) -> HttpResponse {
-    let parts: Vec<&str> = req.url.split('?').collect();
-    let request_path = parts[0];
 
+fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     STATE.with(|s| {
-        let certificate_header =
-            make_asset_certificate_header(&s.asset_hashes.borrow(), request_path);
-
-        match s.assets.borrow().get(request_path) {
-            Some(asset) => {
-                let mut headers = asset.headers.clone();
-                headers.push(certificate_header);
-
-                HttpResponse {
-                    status_code: 200,
-                    headers,
-                    body: ByteBuf::from(asset.bytes.clone()),
-                }
-            }
-            None => HttpResponse {
-                status_code: 404,
-                headers: vec![certificate_header],
-                body: ByteBuf::from(format!("Asset {} not found.", request_path)),
-            },
-        }
+        let stats = s.accounts_store.borrow().get_stats(); 
+        w.encode_gauge(
+            "neurons_created_count",
+            stats.neurons_created_count as f64,
+            "Number of neurons created.",
+        )?;
+        w.encode_gauge(
+            "neurons_topped_up_count",
+            stats.neurons_topped_up_count as f64,
+            "Number of neurons topped up by the canister.",
+        )?;
+        w.encode_gauge(
+            "transactions_count",
+            stats.transactions_count as f64,
+            "Number of transactions processed by the canister.",
+        )?;
+        w.encode_gauge(
+            "accounts_count",
+            stats.accounts_count as f64,
+            "Number of accounts created.",
+        )?;
+        w.encode_gauge(
+            "sub_accounts_count",
+            stats.sub_accounts_count as f64,
+            "Number of sub accounts created.",
+        )?;
+        Ok(())
     })
 }
+
+
+
+
+pub fn http_request(req: HttpRequest) -> HttpResponse {
+    let parts: Vec<&str>   = req.url.split('?').collect();
+    match parts[0] {
+        "/metrics" => {
+            let now;
+            unsafe {
+                now = time();
+            };
+            let mut writer = MetricsEncoder::new(vec![], now / 1_000_000);
+            match encode_metrics(&mut writer) {
+                Ok(()) => {
+                    let body = writer.into_inner();
+                    HttpResponse {
+                        status_code: 200,
+                        headers: vec![
+                            (
+                                "Content-Type".to_string(),
+                                "text/plain; version=0.0.4".to_string(),
+                            ),
+                            ("Content-Length".to_string(), body.len().to_string()),
+                        ],
+                        body: ByteBuf::from(body),    
+                        // body: Cow::Owned(ByteBuf::from(body)),
+                    }
+                }
+                Err(err) => HttpResponse {
+                    status_code: 500,
+                    headers: vec![],
+                    body: ByteBuf::from(format!("Failed to encode metrics: {}", err)),
+                    // body: Cow::Owned(ByteBuf::from(format!("Failed to encode metrics: {}", err))),
+                },
+            }
+        }
+        request_path => {
+                STATE.with(|s| {
+                let certificate_header =
+                    make_asset_certificate_header(&s.asset_hashes.borrow(), request_path);
+
+                match s.assets.borrow().get(request_path) {
+                    Some(asset) => {
+                        let mut headers = asset.headers.clone();
+                        headers.push(certificate_header);
+
+                        HttpResponse {
+                            status_code: 200,
+                            headers,
+                            body: ByteBuf::from(asset.bytes.clone()),
+                            // body: Cow::Owned(ByteBuf::from(asset.bytes.clone())),
+                        }
+                    }
+                    None => HttpResponse {
+                        status_code: 404,
+                        headers: vec![certificate_header],
+                        body: ByteBuf::from(format!("Asset {} not found.", request_path)),
+                        // body: Cow::Owned(ByteBuf::from(format!("Asset {} not found.", request_path))),
+                    },
+                }
+            })
+        }
+    }
+}
+
+// pub fn http_request(req: HttpRequest) -> HttpResponse {
+//     let parts: Vec<&str> = req.url.split('?').collect();
+//     let request_path = parts[0];
+
+//     STATE.with(|s| {
+//         let certificate_header =
+//             make_asset_certificate_header(&s.asset_hashes.borrow(), request_path);
+
+//         match s.assets.borrow().get(request_path) {
+//             Some(asset) => {
+//                 let mut headers = asset.headers.clone();
+//                 headers.push(certificate_header);
+
+//                 HttpResponse {
+//                     status_code: 200,
+//                     headers,
+//                     body: ByteBuf::from(asset.bytes.clone()),
+//                 }
+//             }
+//             None => HttpResponse {
+//                 status_code: 404,
+//                 headers: vec![certificate_header],
+//                 body: ByteBuf::from(format!("Asset {} not found.", request_path)),
+//             },
+//         }
+//     })
+// }
 
 fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> (String, String) {
     let certificate = dfn_core::api::data_certificate().unwrap_or_else(|| {

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -24,6 +24,7 @@ mod ledger_sync;
 mod multi_part_transactions_processor;
 mod periodic_tasks_runner;
 mod state;
+mod metrics_encoder;
 
 #[export_name = "canister_init"]
 fn main() {

--- a/rs/src/metrics_encoder.rs
+++ b/rs/src/metrics_encoder.rs
@@ -1,0 +1,104 @@
+//! Encodes metrics for Prometheus.
+use std::io;
+
+/// `MetricsEncoder` provides methods to encode metrics in a text format
+/// that can be understood by Prometheus.
+///
+/// Metrics are encoded with the block time included, to allow Prometheus
+/// to discard out-of-order samples collected from replicas that are behind.
+///
+/// See [Exposition Formats][1] for an informal specification of the text format.
+///
+/// [1]: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
+pub struct MetricsEncoder<W: io::Write> {
+    writer: W,
+    now_millis: u64,
+}
+
+impl<W: io::Write> MetricsEncoder<W> {
+    /// Constructs a new encoder dumping metrics with the given timestamp into
+    /// the specified writer.
+    pub fn new(writer: W, now_millis: u64) -> Self {
+        Self { writer, now_millis }
+    }
+
+    /// Returns the internal buffer that was used to record the
+    /// metrics.
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+
+    fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
+        writeln!(self.writer, "# HELP {} {}", name, help)?;
+        writeln!(self.writer, "# TYPE {} {}", name, typ)
+    }
+
+    /// Encodes the metadata and the value of a histogram.
+    ///
+    /// SUM is the sum of all observed values, before they were put
+    /// into buckets.
+    ///
+    /// BUCKETS is a list (key, value) pairs, where KEY is the bucket
+    /// and VALUE is the number of items *in* this bucket (i.e., it's
+    /// not a cumulative value).
+    /*pub fn encode_histogram(
+        &mut self,
+        name: &str,
+        buckets: impl Iterator<Item = (f64, f64)>,
+        sum: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, "histogram")?;
+        let mut total: f64 = 0.0;
+        let mut saw_infinity = false;
+        for (bucket, v) in buckets {
+            total += v;
+            if bucket == std::f64::INFINITY {
+                saw_infinity = true;
+                writeln!(
+                    self.writer,
+                    "{}_bucket{{le=\"+Inf\"}} {} {}",
+                    name, total, self.now_millis
+                )?;
+            } else {
+                writeln!(
+                    self.writer,
+                    "{}_bucket{{le=\"{}\"}} {} {}",
+                    name, bucket, total, self.now_millis
+                )?;
+            }
+        }
+        if !saw_infinity {
+            writeln!(
+                self.writer,
+                "{}_bucket{{le=\"+Inf\"}} {} {}",
+                name, total, self.now_millis
+            )?;
+        }
+        writeln!(self.writer, "{}_sum {} {}", name, sum, self.now_millis)?;
+        writeln!(self.writer, "{}_count {} {}", name, total, self.now_millis)
+    }
+    */
+
+    pub fn encode_single_value(
+        &mut self,
+        typ: &str,
+        name: &str,
+        value: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, typ)?;
+        writeln!(self.writer, "{} {} {}", name, value, self.now_millis)
+    }
+
+    /// Encodes the metadata and the value of a counter.
+    /*pub fn encode_counter(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("counter", name, value, help)
+    }
+    */
+
+    /// Encodes the metadata and the value of a gauge.
+    pub fn encode_gauge(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("gauge", name, value, help)
+    }
+}


### PR DESCRIPTION
Changed http_request method in assets.rs to return prometheus metrics.
Added metrics_encoder.rs file.
The metrics can be accessed at <canister id>.raw.nnsdapp.network/metrics