### PR TITLE
EXC-566: Add "certification" to Ledger.getBalances calls.

### DIFF
--- a/frontend/dart/lib/ic_api/web/service_api.dart
+++ b/frontend/dart/lib/ic_api/web/service_api.dart
@@ -20,7 +20,7 @@ class ServiceApi {
   external Promise<dynamic> getAccount();
 
   @JS("getBalances")
-  external Promise<dynamic> getBalances(Object request);
+  external Promise<dynamic> getBalances(Object request, bool useUpdateCalls);
 
   @JS("createSubAccount")
   external Promise<dynamic> createSubAccount(String name);

--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -585,12 +585,8 @@ class PlatformICApi extends AbstractPlatformICApi {
   @override
   Future<void> refreshAccount(Account account) async {
     transactionSyncService!.syncAccount(account);
-    final res =
-        await balanceSyncService!.fetchBalances([account.accountIdentifier]);
-    account = hiveBoxes.accounts[account.accountIdentifier]!;
-    account.balance = res[account.accountIdentifier]!;
-    // ignore: deprecated_member_use
-    hiveBoxes.accounts.notifyChange();
+    await balanceSyncService!
+        .syncBalances(accountIds: [account.accountIdentifier]);
   }
 
   @override

--- a/frontend/ts/src/ServiceApi.ts
+++ b/frontend/ts/src/ServiceApi.ts
@@ -181,9 +181,10 @@ export default class ServiceApi {
   };
 
   public getBalances = (
-    request: GetBalancesRequest
+    request: GetBalancesRequest,
+    useUpdateCalls: boolean = false
   ): Promise<Record<AccountIdentifier, E8s>> => {
-    return executeWithLogging(() => this.ledgerService.getBalances(request));
+    return executeWithLogging(() => this.ledgerService.getBalances(request, useUpdateCalls));
   };
 
   public getTransactions = (

--- a/frontend/ts/src/ServiceApi.ts
+++ b/frontend/ts/src/ServiceApi.ts
@@ -182,9 +182,11 @@ export default class ServiceApi {
 
   public getBalances = (
     request: GetBalancesRequest,
-    useUpdateCalls: boolean = false
+    useUpdateCalls = false
   ): Promise<Record<AccountIdentifier, E8s>> => {
-    return executeWithLogging(() => this.ledgerService.getBalances(request, useUpdateCalls));
+    return executeWithLogging(() =>
+      this.ledgerService.getBalances(request, useUpdateCalls)
+    );
   };
 
   public getTransactions = (

--- a/frontend/ts/src/canisters/ledger/Service.ts
+++ b/frontend/ts/src/canisters/ledger/Service.ts
@@ -1,5 +1,5 @@
 import async from "async";
-import { Agent, UpdateCallRejectedError } from "@dfinity/agent";
+import { Agent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { AccountIdentifier, BlockHeight, E8s } from "../common/types";
 import ServiceInterface, {
@@ -25,7 +25,7 @@ export default class Service implements ServiceInterface {
 
   public getBalances = async (
     request: GetBalancesRequest,
-    useUpdateCalls: boolean = false
+    useUpdateCalls = false
   ): Promise<Record<AccountIdentifier, E8s>> => {
     const rawRequests = this.requestConverters.fromGetBalancesRequest(request);
 
@@ -35,7 +35,9 @@ export default class Service implements ServiceInterface {
     // Until the above is supported we must limit the max concurrency otherwise our requests may be throttled.
     const maxConcurrency = 10;
     await async.eachOfLimit(rawRequests, maxConcurrency, async (r, i) => {
-      const callMethod = useUpdateCalls ? submitUpdateRequest : submitQueryRequest;
+      const callMethod = useUpdateCalls
+        ? submitUpdateRequest
+        : submitQueryRequest;
       const responseBytes = await callMethod(
         this.agent,
         this.canisterId,

--- a/frontend/ts/src/canisters/ledger/Service.ts
+++ b/frontend/ts/src/canisters/ledger/Service.ts
@@ -1,5 +1,5 @@
 import async from "async";
-import { Agent } from "@dfinity/agent";
+import { Agent, UpdateCallRejectedError } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { AccountIdentifier, BlockHeight, E8s } from "../common/types";
 import ServiceInterface, {
@@ -24,7 +24,8 @@ export default class Service implements ServiceInterface {
   }
 
   public getBalances = async (
-    request: GetBalancesRequest
+    request: GetBalancesRequest,
+    useUpdateCalls: boolean = false
   ): Promise<Record<AccountIdentifier, E8s>> => {
     const rawRequests = this.requestConverters.fromGetBalancesRequest(request);
 
@@ -34,7 +35,8 @@ export default class Service implements ServiceInterface {
     // Until the above is supported we must limit the max concurrency otherwise our requests may be throttled.
     const maxConcurrency = 10;
     await async.eachOfLimit(rawRequests, maxConcurrency, async (r, i) => {
-      const responseBytes = await submitQueryRequest(
+      const callMethod = useUpdateCalls ? submitUpdateRequest : submitQueryRequest;
+      const responseBytes = await callMethod(
         this.agent,
         this.canisterId,
         "account_balance_pb",

--- a/frontend/ts/src/canisters/ledger/model.ts
+++ b/frontend/ts/src/canisters/ledger/model.ts
@@ -29,7 +29,8 @@ export interface NotifyCanisterRequest {
 
 export default interface ServiceInterface {
   getBalances(
-    request: GetBalancesRequest
+    request: GetBalancesRequest,
+    useUpdateCalls?: boolean
   ): Promise<Record<AccountIdentifier, E8s>>;
   sendICPTs(request: SendICPTsRequest): Promise<BlockHeight>;
   notify(request: NotifyCanisterRequest): Promise<Uint8Array>;


### PR DESCRIPTION
This PR adds additional security when fetching ICP balances from
Ledger.getBalances.

Instead of only having a query call, we now do two calls in parallel:

1. A query call, which is fast but uncertified. We show this result
   immediately.
2. An update call, which is certified. We update the page with this
   result as soon as it is received.

In 99% of the cases, the result of both calls will be the same and this
change will be completely unnoticeable to the user. There's a slight
chance of some race condition, but in that case, updating the UI with
the certified response remains a sensible approach.