### PR TITLE
Fix overlays when staking in NNS dapp.

### DIFF
--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -156,10 +156,8 @@ class PlatformICApi extends AbstractPlatformICApi {
         }
       }();
 
-      await Future.wait([
-        accountsSyncService!.syncBalances(),
-        neuronSyncService!.sync()
-      ]);
+      await Future.wait(
+          [accountsSyncService!.syncBalances(), neuronSyncService!.sync()]);
 
       return Result.ok(NeuronId.fromString(neuronId));
     } catch (err) {
@@ -211,10 +209,8 @@ class PlatformICApi extends AbstractPlatformICApi {
               neuronId: neuron.id, amount: null, toAccountId: toAccountId)));
 
       neuronSyncService!.removeNeuron(neuron.id);
-      await Future.wait([
-        accountsSyncService!.syncBalances(),
-        neuronSyncService!.sync()
-      ]);
+      await Future.wait(
+          [accountsSyncService!.syncBalances(), neuronSyncService!.sync()]);
 
       return Result.ok(unit);
     } catch (err) {
@@ -302,7 +298,7 @@ class PlatformICApi extends AbstractPlatformICApi {
       final res = await promiseToFuture(
           hwApi.addHotKey(neuronId.toString(), principal));
       validateGovernanceResponse(res);
-      await this.refreshNeurons();
+      await neuronSyncService!.sync();
       return Result.ok(unit);
     } catch (err) {
       return Result.err(Exception(err));


### PR DESCRIPTION
We were removing the overlay before fetching the newly staked neuron,
which can result in a couple of seconds where there's no overlay (indicating
that the request is being processed) and no feedback at all to the user.