### PR TITLE
Fix text entry fields on iOS

### DIFF
--- a/frontend/dart/lib/main.dart
+++ b/frontend/dart/lib/main.dart
@@ -57,56 +57,65 @@ class NnsDapp extends StatelessWidget {
         child: ICApiManager(
           child: Builder(builder: (context) {
             return MaterialApp.router(
+              builder: (context, child) {
+                return Theme(
+                  data: getTheme(Responsive.isMobile(context)),
+                  child: child!
+                );
+              },
               debugShowCheckedModeBanner: false,
               routerDelegate: router,
               routeInformationParser: WalletRouteParser(hiveBoxes, context),
               title: 'Network Nervous System',
-              theme: ThemeData(
-                primarySwatch: MaterialColor(AppColors.blue500.value, {
-                  1000: AppColors.blue1000,
-                  900: AppColors.blue900,
-                  800: AppColors.blue800,
-                  700: AppColors.blue700,
-                  600: AppColors.blue600,
-                  500: AppColors.blue500,
-                  400: AppColors.blue400,
-                  300: AppColors.blue300,
-                  200: AppColors.blue200,
-                  100: AppColors.blue100,
-                  50: AppColors.blue50,
-                }),
-                textTheme: nnsDappTextTheme(Responsive.isMobile(context)),
-                elevatedButtonTheme: ElevatedButtonThemeData(
-                    style: ButtonStyle(
-                  shape: MaterialStateProperty.all(RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10))),
-                  backgroundColor: MaterialStateProperty.resolveWith((states) {
-                    if (states.contains(MaterialState.disabled)) {
-                      return AppColors.gray400;
-                    } else {
-                      return AppColors.blue600;
-                    }
-                  }),
-                )),
-                textButtonTheme: TextButtonThemeData(
-                    style: ButtonStyle(
-                        textStyle: MaterialStateProperty.all(
-                            TextStyle(color: Colors.white)),
-                        overlayColor: MaterialStateProperty.all(
-                            AppColors.gray400.withOpacity(0.04)))),
-                cardTheme: CardTheme(
-                    color: AppColors.background,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(20)),
-                    shadowColor: Colors.white.withOpacity(0.3),
-                    elevation: 7,
-                    margin: EdgeInsets.only(
-                        left: 20, right: 20, top: 20, bottom: 0)),
-              ),
             );
           }),
         ),
       ),
+    );
+  }
+
+  ThemeData getTheme(bool isMobile) {
+    return ThemeData(
+      primarySwatch: MaterialColor(AppColors.blue500.value, {
+        1000: AppColors.blue1000,
+        900: AppColors.blue900,
+        800: AppColors.blue800,
+        700: AppColors.blue700,
+        600: AppColors.blue600,
+        500: AppColors.blue500,
+        400: AppColors.blue400,
+        300: AppColors.blue300,
+        200: AppColors.blue200,
+        100: AppColors.blue100,
+        50: AppColors.blue50,
+      }),
+      textTheme: nnsDappTextTheme(isMobile),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          shape: MaterialStateProperty.all(RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10))),
+          backgroundColor: MaterialStateProperty.resolveWith((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return AppColors.gray400;
+            } else {
+              return AppColors.blue600;
+            }
+          }),
+        )),
+      textButtonTheme: TextButtonThemeData(
+        style: ButtonStyle(
+          textStyle: MaterialStateProperty.all(
+            TextStyle(color: Colors.white)),
+          overlayColor: MaterialStateProperty.all(
+            AppColors.gray400.withOpacity(0.04)))),
+      cardTheme: CardTheme(
+        color: AppColors.background,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20)),
+        shadowColor: Colors.white.withOpacity(0.3),
+        elevation: 7,
+        margin: EdgeInsets.only(
+          left: 20, right: 20, top: 20, bottom: 0)),
     );
   }
 }

--- a/frontend/dart/lib/ui/transaction/wizard_overlay.dart
+++ b/frontend/dart/lib/ui/transaction/wizard_overlay.dart
@@ -18,7 +18,6 @@ class WizardOverlayState extends State<WizardOverlay> {
   final GlobalKey navigatorKey = GlobalKey();
 
   List<MaterialPage> pages = [];
-  bool _didChangeDependencies = false;
 
   @override
   void initState() {

--- a/frontend/dart/lib/ui/transaction/wizard_overlay.dart
+++ b/frontend/dart/lib/ui/transaction/wizard_overlay.dart
@@ -21,19 +21,9 @@ class WizardOverlayState extends State<WizardOverlay> {
   bool _didChangeDependencies = false;
 
   @override
-  void didChangeDependencies() {
-    // Only run 'didChangeDependencies' once
-    if (_didChangeDependencies) {
-      return;
-    }
-    _didChangeDependencies = true;
-    super.didChangeDependencies();
-    pages.add(createPage(title: widget.rootTitle, widget: widget.rootWidget));
-  }
-
-  @override
   void initState() {
     super.initState();
+    pages.add(createPage(title: widget.rootTitle, widget: widget.rootWidget));
   }
 
   void pushPage(String? title, Widget widget) {
@@ -104,7 +94,11 @@ class WizardOverlayState extends State<WizardOverlay> {
                         title: Text(
                           title,
                           overflow: TextOverflow.visible,
-                          style: context.textTheme.headline3,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontFamily: Fonts.circularBold,
+                            color: AppColors.gray50,
+                          ),
                         ),
                       ),
                     )

--- a/frontend/dart/lib/ui/transaction/wizard_overlay.dart
+++ b/frontend/dart/lib/ui/transaction/wizard_overlay.dart
@@ -18,9 +18,15 @@ class WizardOverlayState extends State<WizardOverlay> {
   final GlobalKey navigatorKey = GlobalKey();
 
   List<MaterialPage> pages = [];
+  bool _didChangeDependencies = false;
 
   @override
   void didChangeDependencies() {
+    // Only run 'didChangeDependencies' once
+    if (_didChangeDependencies) {
+      return;
+    }
+    _didChangeDependencies = true;
     super.didChangeDependencies();
     pages.add(createPage(title: widget.rootTitle, widget: widget.rootWidget));
   }


### PR DESCRIPTION
In `main.dart` the theme is dependent on the context so we switched it to use the 'builder' pattern which takes the context as an input.

In `wizard_overlay.dart` we have hardcoded the font size rather than pulling it from the context since when using context, `didChangeDependencies` was being called multiple times causing issues on iOS.

This is a bit hacky... it would be better to retrieve the font styles from the context... if any flutter expert out there knows how to make this work your help would be greatly appreciated!