### PR TITLE
EXC-583: Fix flow of adding hardware wallet accounts.

### DIFF
--- a/frontend/dart/lib/ic_api/platform_ic_api.dart
+++ b/frontend/dart/lib/ic_api/platform_ic_api.dart
@@ -20,7 +20,7 @@ abstract class AbstractPlatformICApi {
 
   Future<void> buildServices(dynamic identity);
 
-  Future<void> refreshAccounts();
+  Future<void> refreshAccounts({bool waitForFullSync = false});
 
   Future<void> acquireICPTs(
       {required String accountIdentifier, required BigInt doms});

--- a/frontend/dart/lib/ic_api/web/account_sync_service.dart
+++ b/frontend/dart/lib/ic_api/web/account_sync_service.dart
@@ -35,17 +35,24 @@ class AccountsSyncService {
   }
 
   /// Syncs accounts along with their balances and transactions.
-  Future<void> syncAll({List<Account>? accounts}) async {
+  Future<void> syncAll(
+      {List<Account>? accounts, bool waitForFullSync = false}) async {
     // Do a quick sync with queries.
     print("[${DateTime.now()}] Syncing accounts with a query call...");
     await this._syncAll(accounts: accounts, useUpdateCalls: false);
 
-    // Do a slow sync with update calls in the background.
-    // Note that we don't `await` here as to not block the caller.
+    // Do a slow sync with update calls.
     print("[${DateTime.now()}] Syncing accounts with an update call...");
-    this
-        ._syncAll(accounts: accounts, useUpdateCalls: true)
-        .then((_) => {print("[${DateTime.now()}] Syncing accounts complete.")});
+    if (waitForFullSync) {
+      // Wait for the sync to happen.
+      await this._syncAll(accounts: accounts, useUpdateCalls: true);
+      print("[${DateTime.now()}] Syncing accounts complete.");
+    } else {
+      // The sync happens in the background.
+      // Note that we don't `await` here as to not block the caller.
+      this._syncAll(accounts: accounts, useUpdateCalls: true).then(
+          (_) => {print("[${DateTime.now()}] Syncing accounts complete.")});
+    }
   }
 
   Future<void> syncBalances({List<String>? accountIds}) async {

--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -459,8 +459,8 @@ class PlatformICApi extends AbstractPlatformICApi {
   }
 
   @override
-  Future<void> refreshAccounts() async {
-    await accountsSyncService!.syncAll();
+  Future<void> refreshAccounts({bool waitForFullSync = false}) async {
+    await accountsSyncService!.syncAll(waitForFullSync: waitForFullSync);
   }
 
   @override

--- a/frontend/dart/lib/ui/wallet/attach_hardware_wallet.dart
+++ b/frontend/dart/lib/ui/wallet/attach_hardware_wallet.dart
@@ -61,8 +61,7 @@ class _AttachHardwareWalletWidgetState
                   context.callUpdate(() async {
                     await context.icApi.registerHardwareWallet(
                         name: widget.name, ledgerIdentity: ledgerIdentity);
-                    await 0.2.seconds.delay;
-                    await context.icApi.refreshAccounts();
+                    await context.icApi.refreshAccounts(waitForFullSync: true);
                     final accountIdentifier =
                         getAccountIdentifier(ledgerIdentity);
                     final account = context.boxes.accounts.hardwareWallets


### PR DESCRIPTION
With the latest changes related to PUQ certification, the flow of adding
hardware wallets worked, but the dialog didn't properly close and the
user wasn't redirected to the account's page.

This PR fixes the flow - the dialog now disappears and the user is
redirected to the hardware wallet account's page as before.