### PR TITLE
Docker builds for testnets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 
 FROM ubuntu:20.10
 
+ARG DEPLOY_ENV=mainnet
 ARG rust_version=1.54.0
 ENV NODE_VERSION=14.15.4
 
@@ -47,7 +48,6 @@ RUN cargo install --version 0.3.1 ic-cdk-optimizer
 
 COPY . .
 
-ENV DEPLOY_ENV=mainnet
 RUN cd frontend/ts && ./build.sh
 
 RUN cd frontend/dart && flutter build web --web-renderer auto --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Development relies on the presence of a testnet that is setup with the II, gover
 To deploy to the testnet, run the following:
 
     docker build -t nns-dapp --build-arg DEPLOY_ENV=testnet .
+    mkdir -p target/wasm32-unknown-unknown/release
     docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
     ./deploy.sh testnet
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Development relies on the presence of a testnet that is setup with the II, gover
 
 To deploy to the testnet, run the following:
 
+    docker build -t nns-dapp --build-arg DEPLOY_ENV=testnet .
+    docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
     ./deploy.sh testnet
 
 You can now access the frontend using:


### PR DESCRIPTION
# Motivation
Creating a wasm image for deployment to a testnet is non-trivial as the developer laptop needs to be set up with various dependencies.  But we have a dockerfile that is perfect but for one word - why not surface that one word as a docker argument?

# Changes
- Replace `mainnet` with a docker variable with default value `mainnet`.
- Document how to create testnet builds with docker.