### PR TITLE
EXC-704: Switch to HTML renderer.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,10 +15,10 @@ set -x
 # build the flutter app
 cd frontend/dart || exit
 if [[ $DEPLOY_ENV = "mainnet" ]]; then
-  flutter build web --web-renderer auto --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
+  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
 else
   # For all networks that are not main net, build with the staging config
-  flutter build web --web-renderer auto --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
+  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
 fi
 sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' build/web/index.html
 


### PR DESCRIPTION
Based on experimentation, switching to the HTML renderer avoids
the flickering issues users are reporting on Monterey, and fixes the
rendering issues iOS 15 users are reporting.

There are likely some minor UI issues that will be introduced with
this change (especially on Firefox), but that's something we can
live with until we replace Flutter with Svelte.