### PR TITLE
Add mime types to HTTP responses

### DIFF
--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -129,6 +129,9 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     Some(asset) => {
                         let mut headers = asset.headers.clone();
                         headers.push(certificate_header);
+                        if let Some(content_type) = content_type_of(request_path) {
+                           headers.push(("Content-Type".to_string(), content_type.to_string()));
+                        }
 
                         HttpResponse {
                             status_code: 200,
@@ -145,6 +148,18 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
             })
         }
     }
+}
+
+fn content_type_of(request_path: &str) -> Option<&'static str> {
+    request_path.split(".").last().map(|suffix|
+        match suffix {
+         "css" => Some("text/css"),
+         "html" => Some("text/html"),
+         "js" => Some("application/javascript"),
+         "json" => Some("application/json"),
+         _    => None,
+        }
+    ).flatten()
 }
 
 fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> (String, String) {

--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -151,7 +151,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 }
 
 fn content_type_of(request_path: &str) -> Option<&'static str> {
-    request_path.split(".").last().map(|suffix|
+    request_path.split('.').last().map(|suffix|
         match suffix {
          "css" => Some("text/css"),
          "html" => Some("text/html"),


### PR DESCRIPTION
# Motivation
Loading javascript modules via script tag fails if the returned mime type is incorrect.  I have observed this with new code and this requirement is documented in the [Mozilla modules guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

# Changes
- Provide mime types for static assets, including but not limited to javascript.

# Tests
- I have verified manually that these mime types are set and that the module loading error goes away.
- There are no full automated tests; I assume that we need a test framework that we currently don't have here (see the comment with details of my attempt writing a test below).  I have one test for the new function but it is trivial; I didn't create an enum for mime types so complete coverage is not robust.
- I have run cargo-clippy and it is clean.
- `cargo tarpaulin -o Html` failed to compile, but it also failed on main.
- `cargo fmt` created many changes outside my code; I did not commit them as I guess the project uses different defaults.