### PR TITLE
Remove the principal text from the neurons page.

### DIFF
--- a/frontend/dart/lib/ui/neurons/tab/neurons_tab_widget.dart
+++ b/frontend/dart/lib/ui/neurons/tab/neurons_tab_widget.dart
@@ -25,9 +25,7 @@ class _NeuronsPageState extends State<NeuronsPage> {
               return TabTitleAndContent(
                 title: "Neurons",
                 subtitle:
-                    '''Earn rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by voting on Network Nervous System (NNS) proposals.
-                    
-Your principal id is "${context.icApi.getPrincipal()}"''',
+                    '''Earn rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by voting on Network Nervous System (NNS) proposals.''',
                 children: [
                   SmallFormDivider(),
                   ...(context.boxes.neurons.values


### PR DESCRIPTION
It serves no purpose and can be a potential source of confusion once
HW wallets are released.