### PR TITLE
Redirect to login page if principal is null

### DIFF
--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -647,7 +647,14 @@ class PlatformICApi extends AbstractPlatformICApi {
 
   @override
   String getPrincipal() {
-    return authApi.getPrincipal() ?? "null";
+    final principal = authApi.getPrincipal();
+    if (principal != null) {
+      return principal;
+    } else {
+      // We're not logged in. Redirect to the login page.
+      this.logout();
+      return "null";
+    }
   }
 
   @override


### PR DESCRIPTION
This PR fixes #273. The fundamental problem lies in the fact that `getPrincipal`
returned a "null" string when the user's session has expired, as opposed to return an
`Option<String>`.

Updating the API to return `Option<String>` (i.e. the proper fix) will involve quite a bit
of changes. The solution I have here is a stop gap measure until we migrate to Svelte.

In the current solution, when fetching the principal, if the principal isn't found, we simply
redirect to the login page.