### PR TITLE
Add the svelte app to the canister

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - svelte-rc1
   pull_request:
 
 jobs:

--- a/build.sh
+++ b/build.sh
@@ -9,32 +9,47 @@ fi
 
 set -x
 
+# Prepare a clean new home for the assets
+rm -fr web-assets assets.tar.xz
+
 # build typescript code
 (cd frontend/ts && ./build.sh)
 
 # build the flutter app
-cd frontend/dart || exit
-if [[ $DEPLOY_ENV = "mainnet" ]]; then
-  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
-else
-  # For all networks that are not main net, build with the staging config
-  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
-fi
-sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' build/web/index.html
+pushd frontend/dart || exit
+  if [[ $DEPLOY_ENV = "mainnet" ]]; then
+    flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
+  else
+    # For all networks that are not main net, build with the staging config
+    flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
+  fi
+  sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' build/web/index.html
+popd || exit
+cp -R frontend/dart/build/web/ web-assets
+
+# Build the svelte app
+SVELTE_APP_DIR=frontend/svelte
+pushd "$SVELTE_APP_DIR" || exit
+  npm run "build:${DEPLOY_ENV}"
+popd || exit
+
+rm -fr web-assets/v2 # There should not be anything here but just in case...
+cp -R "$SVELTE_APP_DIR"/dist web-assets/v2
 
 # Bundle into a tight tarball
 # On macOS you need to install gtar + xz
 # brew install gnu-tar
 # brew install xz
 
-cd build/web/ || exit
-# Remove the assets/NOTICES file, as it's large in size and not used.
-rm assets/NOTICES
-tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../../../../assets.tar.xz . || \
-gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../../../../assets.tar.xz .
-cd ../../../.. || exit
-ls -sh assets.tar.xz
-sha256sum assets.tar.xz
+pushd web-assets || exit
+  # Remove the assets/NOTICES file, as it's large in size and not used.
+  rm assets/NOTICES
+  tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../assets.tar.xz . || \
+  gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../assets.tar.xz .
+  cd ../../../.. || exit
+  ls -sh assets.tar.xz
+  sha256sum assets.tar.xz
+popd || exit
 
 echo Compiling rust package
 if [[ $DEPLOY_ENV = "mainnet" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -30,11 +30,12 @@ cp -R frontend/dart/build/web/ web-assets
 # Build the svelte app
 SVELTE_APP_DIR=frontend/svelte
 pushd "$SVELTE_APP_DIR" || exit
-  npm run "build:${DEPLOY_ENV}"
+  npm ci
+  npm run "build"
 popd || exit
 
 rm -fr web-assets/v2 # There should not be anything here but just in case...
-cp -R "$SVELTE_APP_DIR"/dist web-assets/v2
+cp -R "$SVELTE_APP_DIR"/public web-assets/v2
 
 # Bundle into a tight tarball
 # On macOS you need to install gtar + xz

--- a/frontend/svelte/public/index.html
+++ b/frontend/svelte/public/index.html
@@ -8,10 +8,10 @@
 
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAADb0lEQVRYw+2Vz2sTQRTH8yfkH2gck2yyiVBiBdFGoSJIvWj9hU20uj2IooeIv9ps1UzbFLFQU1QQq7gFwWoSuy16EA9WPHhS4kmwhw6Jooi2a1Jpta37fJMfYtbUrGfz4DFZwszn+33zZsZiqUUtalELQxCVWcUEa/LE04PeZEbho5h8d/Bf1tBaiDW7XwhlWx1KLuhQsgFnTAs4WqpO9CTfhryJjOZJZKBCMjNCZoPOSG6foH0JOiHLM+DQ+Tjb7tJzx0T2Nbyq8hreOLotwuqHXsMyIoBXhSjM+odrSSQISmVL4GKiGMi1u2D2mAhfT6+CuUg9zF1siJVNFhNvI+vlCWhuvgk73X2wx92nHRB6BzfSZxJuwXDFaqiM/IK3EoQLrAQsOM9/U61NkHJHRQXhbI7Ww3z/avh2ZQ18V9ZGCnBcaHNgBHa4ojrC9d1idLiF0DKH4ggjCJ2oJKLgXGC5oFPnWYA7Y8YKzVMfmev3qd+uIvzWWlgYWQegriOWrZuuDXPXuzD3uvvY3/ZXTKRpuYh0KiM1sN9LrrU6pGWbM+azovPUwt31sDTm1xfUxkELwhkX0OqKQrs7ur1akxlFbLvxBN4d9AFvulzAUbVJF+KN0qLqh8UxP/wY3zDFBUDAHYVDQq9+hFBi5pgZRZwaGEL3QsjM3Hks+9L4hryAxbFG3RJE54cxTwg9eodJAZpNjpw48/iP02FmLpbdx+FLYwURliOuXnbS2aNTZ7d+wUElM/AZW1iftoWhre952Z3hxdNkQoDEnRfSn7KccdIYwmHAQeG6PcIUwwkwwqfrOvNwnlOe7pQXG9FsJUBtsi6N+1kRDiP3zykWKlLC4UP2CNyxn4cHK8+mJgxboZHj1um6sFoCz6yQ+cg+kA7iw6vbKMJ4T5T2njvOlx974PLoJeDHO//nTXt36K79vP5w5Tl4ivmCnIXJOnn0o60THYdjCNNK8KKAlIbw0uLLiABPPKN2JG7TV2qbMq1u0dJqCyRHceuSj3C70rSsPA/sXfQpgl+SLniDDt8XYDov+UxxzAuo61R4RSq/JenB5a7w8l4xwEvxgsjS5AqZvbfJBXjJMf6esclTn0m46osmxhle3xlWCSzibcpf2qpH5RPpaNKIHEI45cm///VZ5yDxXpry5K+sKXAtalGL/zJ+Aobf1VhGoFk3AAAAAElFTkSuQmCC" />
 
-    <link rel="stylesheet" href="/global.css" />
-    <link rel="stylesheet" href="/build/bundle.css" />
+    <link rel="stylesheet" href="./global.css" />
+    <link rel="stylesheet" href="./build/bundle.css" />
 
-    <script defer src="/build/bundle.js"></script>
+    <script defer src="./build/bundle.js"></script>
   </head>
 
   <body></body>


### PR DESCRIPTION
# Motivation
The new svelte app will be served from the same canister as the flutter app.  This implements that goal.

# Changes
- Adapt `build.sh` to include the svelte app under /v2
- Make the paths in index.html relative.
  - Alternative considered:  Set base to /v2.  However I need to be able to interact with the flutter app and setting the base may interfere with that.
- Update CI to run when merging to svelte-rc1

# Testing
- I have deployed this PR to https://t6rzw-2iaaa-aaaaa-aaama-cai.nnsdapp.dfinity.network/
- The flutter page launches by default, as usual
- The svelte is available here: https://t6rzw-2iaaa-aaaaa-aaama-cai.nnsdapp.dfinity.network/v2/index.html