### PR TITLE
feat: update agent-js from `0.10.1` to `0.10.2`

### DIFF
--- a/frontend/svelte/nns-js/package-lock.json
+++ b/frontend/svelte/nns-js/package-lock.json
@@ -7,9 +7,10 @@
     "": {
       "name": "@dfinity/nns",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/principal": "^0.10.1",
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/principal": "^0.10.2",
         "crc-32": "^1.2.0",
         "js-sha256": "^0.9.0"
       },
@@ -619,9 +620,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.1.tgz",
-      "integrity": "sha512-VUHO5mveK0XX8b9xbfg5SThEGLhMAwkfejuwS5fzF9gqQVWqnIx5ISrbre8UvNNyuzM5v4/vZI+kpE2zL54rwg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
+      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -630,20 +631,20 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.10.1",
-        "@dfinity/principal": "^0.10.1"
+        "@dfinity/candid": "^0.10.2",
+        "@dfinity/principal": "^0.10.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.1.tgz",
-      "integrity": "sha512-Z7C125quoAYafj+yK20KQKI/MkXgB9tgPkvtIk1Ec8eGXIU7OXOHSIknvJR6zXdE9eUc/veiD4+VDWK7I82sDw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
+      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w==",
       "peer": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.1.tgz",
-      "integrity": "sha512-1/r726xwVlSsCc+Fl2szM+P9xNfsu5TItC56n/KRuhGEE9sN8NLnorxcNvpzoII0f99XBNCNMRJPUkWSZPLpbw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
+      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -6700,9 +6701,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.1.tgz",
-      "integrity": "sha512-VUHO5mveK0XX8b9xbfg5SThEGLhMAwkfejuwS5fzF9gqQVWqnIx5ISrbre8UvNNyuzM5v4/vZI+kpE2zL54rwg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
+      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -6712,15 +6713,15 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.1.tgz",
-      "integrity": "sha512-Z7C125quoAYafj+yK20KQKI/MkXgB9tgPkvtIk1Ec8eGXIU7OXOHSIknvJR6zXdE9eUc/veiD4+VDWK7I82sDw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
+      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w==",
       "peer": true
     },
     "@dfinity/principal": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.1.tgz",
-      "integrity": "sha512-1/r726xwVlSsCc+Fl2szM+P9xNfsu5TItC56n/KRuhGEE9sN8NLnorxcNvpzoII0f99XBNCNMRJPUkWSZPLpbw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
+      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/frontend/svelte/nns-js/package.json
+++ b/frontend/svelte/nns-js/package.json
@@ -30,8 +30,8 @@
     "whatwg-fetch": "^3.6.2"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.10.1",
-    "@dfinity/principal": "^0.10.1",
+    "@dfinity/agent": "^0.10.2",
+    "@dfinity/principal": "^0.10.2",
     "crc-32": "^1.2.0",
     "js-sha256": "^0.9.0"
   }

--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -8,13 +8,13 @@
       "name": "svelte-app",
       "version": "1.0.0",
       "dependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/auth-client": "^0.10.1",
-        "@dfinity/authentication": "^0.10.1",
-        "@dfinity/candid": "^0.10.1",
-        "@dfinity/identity": "^0.10.1",
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/auth-client": "^0.10.2",
+        "@dfinity/authentication": "^0.10.2",
+        "@dfinity/candid": "^0.10.2",
+        "@dfinity/identity": "^0.10.2",
         "@dfinity/nns": "file:./nns-js",
-        "@dfinity/principal": "^0.10.1",
+        "@dfinity/principal": "^0.10.2",
         "sirv-cli": "^1.0.0"
       },
       "devDependencies": {
@@ -44,8 +44,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/principal": "^0.10.1",
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/principal": "^0.10.2",
         "crc-32": "^1.2.0",
         "js-sha256": "^0.9.0"
       },
@@ -611,9 +611,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.1.tgz",
-      "integrity": "sha512-VUHO5mveK0XX8b9xbfg5SThEGLhMAwkfejuwS5fzF9gqQVWqnIx5ISrbre8UvNNyuzM5v4/vZI+kpE2zL54rwg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
+      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -622,40 +622,40 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.10.1",
-        "@dfinity/principal": "^0.10.1"
+        "@dfinity/candid": "^0.10.2",
+        "@dfinity/principal": "^0.10.2"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.1.tgz",
-      "integrity": "sha512-nKEUOyislqX4IklLh1kPGZyh5NHKusJCA6W+ySgh5VmGvE1qXHajRof0SY6z/i/lncjg7vi4fxtod/4knWtp/A==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.2.tgz",
+      "integrity": "sha512-u9RThzTvsrKb85PhnEUXgZ3KwdSJCeNwHBZ3zVCZ7XQEkDhwNZK87JD00Mh2Z5kCbN3+A+OdGZtYXloFlgENew==",
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/authentication": "^0.10.1",
-        "@dfinity/identity": "^0.10.1",
-        "@dfinity/principal": "^0.10.1"
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/authentication": "^0.10.2",
+        "@dfinity/identity": "^0.10.2",
+        "@dfinity/principal": "^0.10.2"
       }
     },
     "node_modules/@dfinity/authentication": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.1.tgz",
-      "integrity": "sha512-k8D80Ba27Kw3sgVtnz9j3jZ/7rpg5r8n1/NWdmy8aHMJnVhTXghIskptM0YRpA7bS9cJW5tSFLnvalKNGWcnuA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.2.tgz",
+      "integrity": "sha512-+fNuknjSl1SI4f0e+KQdCnJy3vuSTeGFriLXstjYDCO2ez432lMiyqoF9eC4Gvp6AX9RZifRt2BXuWnhzwZwEQ==",
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/identity": "^0.10.1",
-        "@dfinity/principal": "^0.10.1"
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/identity": "^0.10.2",
+        "@dfinity/principal": "^0.10.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.1.tgz",
-      "integrity": "sha512-Z7C125quoAYafj+yK20KQKI/MkXgB9tgPkvtIk1Ec8eGXIU7OXOHSIknvJR6zXdE9eUc/veiD4+VDWK7I82sDw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
+      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.1.tgz",
-      "integrity": "sha512-d5rkr5Sg1Eiwnmd2mkz1xvrzAdITbMBcIaU0LlKCG+eKMxcgDLm4eB8FBvS5Pqr0S5sHb/YXpLZrhpL5xC38bg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.2.tgz",
+      "integrity": "sha512-ltAqR813Rm8pZjD5qCXAdBa4S/W9Afo7u6ue2m9UDHmOryiq4VR295hl1Mn4Svb2itgOE1omWl0oA3VDoQ1B1A==",
       "dependencies": {
         "borc": "^2.1.1",
         "js-sha256": "^0.9.0",
@@ -663,8 +663,8 @@
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/principal": "^0.10.1"
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/principal": "^0.10.2"
       }
     },
     "node_modules/@dfinity/nns": {
@@ -672,9 +672,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.1.tgz",
-      "integrity": "sha512-1/r726xwVlSsCc+Fl2szM+P9xNfsu5TItC56n/KRuhGEE9sN8NLnorxcNvpzoII0f99XBNCNMRJPUkWSZPLpbw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
+      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -9510,9 +9510,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.1.tgz",
-      "integrity": "sha512-VUHO5mveK0XX8b9xbfg5SThEGLhMAwkfejuwS5fzF9gqQVWqnIx5ISrbre8UvNNyuzM5v4/vZI+kpE2zL54rwg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
+      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -9522,26 +9522,26 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.1.tgz",
-      "integrity": "sha512-nKEUOyislqX4IklLh1kPGZyh5NHKusJCA6W+ySgh5VmGvE1qXHajRof0SY6z/i/lncjg7vi4fxtod/4knWtp/A==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.2.tgz",
+      "integrity": "sha512-u9RThzTvsrKb85PhnEUXgZ3KwdSJCeNwHBZ3zVCZ7XQEkDhwNZK87JD00Mh2Z5kCbN3+A+OdGZtYXloFlgENew==",
       "requires": {}
     },
     "@dfinity/authentication": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.1.tgz",
-      "integrity": "sha512-k8D80Ba27Kw3sgVtnz9j3jZ/7rpg5r8n1/NWdmy8aHMJnVhTXghIskptM0YRpA7bS9cJW5tSFLnvalKNGWcnuA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.2.tgz",
+      "integrity": "sha512-+fNuknjSl1SI4f0e+KQdCnJy3vuSTeGFriLXstjYDCO2ez432lMiyqoF9eC4Gvp6AX9RZifRt2BXuWnhzwZwEQ==",
       "requires": {}
     },
     "@dfinity/candid": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.1.tgz",
-      "integrity": "sha512-Z7C125quoAYafj+yK20KQKI/MkXgB9tgPkvtIk1Ec8eGXIU7OXOHSIknvJR6zXdE9eUc/veiD4+VDWK7I82sDw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
+      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
     },
     "@dfinity/identity": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.1.tgz",
-      "integrity": "sha512-d5rkr5Sg1Eiwnmd2mkz1xvrzAdITbMBcIaU0LlKCG+eKMxcgDLm4eB8FBvS5Pqr0S5sHb/YXpLZrhpL5xC38bg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.2.tgz",
+      "integrity": "sha512-ltAqR813Rm8pZjD5qCXAdBa4S/W9Afo7u6ue2m9UDHmOryiq4VR295hl1Mn4Svb2itgOE1omWl0oA3VDoQ1B1A==",
       "requires": {
         "borc": "^2.1.1",
         "js-sha256": "^0.9.0",
@@ -9552,8 +9552,8 @@
     "@dfinity/nns": {
       "version": "file:nns-js",
       "requires": {
-        "@dfinity/agent": "^0.10.1",
-        "@dfinity/principal": "^0.10.1",
+        "@dfinity/agent": "^0.10.2",
+        "@dfinity/principal": "^0.10.2",
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^27.0.3",
         "@types/text-encoding": "^0.0.36",
@@ -9575,9 +9575,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.1.tgz",
-      "integrity": "sha512-1/r726xwVlSsCc+Fl2szM+P9xNfsu5TItC56n/KRuhGEE9sN8NLnorxcNvpzoII0f99XBNCNMRJPUkWSZPLpbw=="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
+      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -32,13 +32,13 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.10.1",
-    "@dfinity/auth-client": "^0.10.1",
-    "@dfinity/authentication": "^0.10.1",
-    "@dfinity/candid": "^0.10.1",
-    "@dfinity/identity": "^0.10.1",
+    "@dfinity/agent": "^0.10.2",
+    "@dfinity/auth-client": "^0.10.2",
+    "@dfinity/authentication": "^0.10.2",
+    "@dfinity/candid": "^0.10.2",
+    "@dfinity/identity": "^0.10.2",
     "@dfinity/nns": "file:./nns-js",
-    "@dfinity/principal": "^0.10.1",
+    "@dfinity/principal": "^0.10.2",
     "sirv-cli": "^1.0.0"
   }
 }


### PR DESCRIPTION
`agent-js` (as of `0.10.2`) avoids `ic0.app` subdomains, and thus 307 redirects.