### PR TITLE
Get the ICP to cycles conversion rate from the CMC

### DIFF
--- a/frontend/ts/src/ServiceApi.ts
+++ b/frontend/ts/src/ServiceApi.ts
@@ -49,6 +49,8 @@ import NnsDappService, {
   RenameSubAccountRequest,
   RenameSubAccountResponse,
 } from "./canisters/nnsDapp/model";
+import cyclesMintingServiceBuilder from "./canisters/cyclesMinting/builder";
+import CyclesMintingService from "./canisters/cyclesMinting/model";
 import icManagementBuilder from "./canisters/icManagement/builder";
 import ICManagementService, {
   CanisterDetailsResponse,
@@ -99,6 +101,7 @@ export default class ServiceApi {
   private readonly ledgerService: LedgerService;
   private readonly nnsDappService: NnsDappService;
   private readonly governanceService: GovernanceService;
+  private readonly cyclesMintingService: CyclesMintingService;
   private readonly icManagementService: ICManagementService;
   private readonly identity: SignIdentity;
 
@@ -121,6 +124,7 @@ export default class ServiceApi {
     this.ledgerService = ledgerBuilder(agent);
     this.nnsDappService = nnsDappBuilder(agent);
     this.governanceService = governanceBuilder(agent, identity);
+    this.cyclesMintingService = cyclesMintingServiceBuilder(agent);
     this.icManagementService = icManagementBuilder(agent);
     this.identity = identity;
   }
@@ -469,7 +473,7 @@ export default class ServiceApi {
 
   public getIcpToCyclesConversionRate = (): Promise<bigint> => {
     return executeWithLogging(() =>
-      this.nnsDappService.getIcpToCyclesConversionRate()
+      this.cyclesMintingService.getIcpToCyclesConversionRate()
     );
   };
 

--- a/frontend/ts/src/canisters/cyclesMinting/Service.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/Service.ts
@@ -1,0 +1,19 @@
+import ServiceInterface from "./model";
+import { _SERVICE } from "./rawService";
+
+const CYCLES_PER_XDR = BigInt(1_000_000_000_000); // 1 trillion
+
+export default class Service implements ServiceInterface {
+  private readonly service: _SERVICE;
+
+  public constructor(service: _SERVICE) {
+    this.service = service;
+  }
+
+  public getIcpToCyclesConversionRate = async (): Promise<bigint> => {
+    const response = await this.service.get_icp_xdr_conversion_rate();
+
+    // TODO validate the certificate in the response
+    return response.data.xdr_permyriad_per_icp * CYCLES_PER_XDR / BigInt(10_000);
+  };
+}

--- a/frontend/ts/src/canisters/cyclesMinting/Service.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/Service.ts
@@ -14,6 +14,8 @@ export default class Service implements ServiceInterface {
     const response = await this.service.get_icp_xdr_conversion_rate();
 
     // TODO validate the certificate in the response
-    return response.data.xdr_permyriad_per_icp * CYCLES_PER_XDR / BigInt(10_000);
+    return (
+      (response.data.xdr_permyriad_per_icp * CYCLES_PER_XDR) / BigInt(10_000)
+    );
   };
 }

--- a/frontend/ts/src/canisters/cyclesMinting/builder.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/builder.ts
@@ -1,0 +1,14 @@
+import { Actor, Agent } from "@dfinity/agent";
+import { idlFactory } from "./canister.did.js";
+import CANISTER_ID from "./canisterId";
+import { _SERVICE } from "./rawService";
+import Service from "./Service";
+import ServiceInterface from "./model";
+
+export default function (agent: Agent): ServiceInterface {
+  const service = Actor.createActor(idlFactory, {
+    agent,
+    canisterId: CANISTER_ID,
+  }) as _SERVICE;
+  return new Service(service);
+}

--- a/frontend/ts/src/canisters/cyclesMinting/canister.did
+++ b/frontend/ts/src/canisters/cyclesMinting/canister.did
@@ -1,0 +1,16 @@
+type IcpXdrConversionRate =
+    record {
+        timestamp_seconds: nat64;
+        xdr_permyriad_per_icp: nat64;
+    };
+
+type IcpXdrConversionRateCertifiedResponse =
+    record {
+        data: IcpXdrConversionRate;
+        hash_tree: blob;
+        certificate: blob;
+    };
+
+service : {
+    get_icp_xdr_conversion_rate: () -> (IcpXdrConversionRateCertifiedResponse) query;
+}

--- a/frontend/ts/src/canisters/cyclesMinting/canister.did.js
+++ b/frontend/ts/src/canisters/cyclesMinting/canister.did.js
@@ -1,0 +1,19 @@
+export const idlFactory = ({ IDL }) => {
+  const IcpXdrConversionRate = IDL.Record({
+    'xdr_permyriad_per_icp' : IDL.Nat64,
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const IcpXdrConversionRateCertifiedResponse = IDL.Record({
+    'certificate' : IDL.Vec(IDL.Nat8),
+    'data' : IcpXdrConversionRate,
+    'hash_tree' : IDL.Vec(IDL.Nat8),
+  });
+  return IDL.Service({
+    'get_icp_xdr_conversion_rate' : IDL.Func(
+        [],
+        [IcpXdrConversionRateCertifiedResponse],
+        ['query'],
+    ),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/frontend/ts/src/canisters/cyclesMinting/canisterId.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/canisterId.ts
@@ -1,0 +1,5 @@
+import { Principal } from "@dfinity/principal";
+
+const CANISTER_ID = Principal.fromText("rkp4c-7iaaa-aaaaa-aaaca-cai");
+
+export default CANISTER_ID;

--- a/frontend/ts/src/canisters/cyclesMinting/model.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/model.ts
@@ -1,0 +1,3 @@
+export default interface ServiceInterface {
+  getIcpToCyclesConversionRate: () => Promise<bigint>;
+}

--- a/frontend/ts/src/canisters/cyclesMinting/rawService.ts
+++ b/frontend/ts/src/canisters/cyclesMinting/rawService.ts
@@ -1,0 +1,14 @@
+export interface IcpXdrConversionRate {
+  'xdr_permyriad_per_icp' : bigint,
+  'timestamp_seconds' : bigint,
+}
+export interface IcpXdrConversionRateCertifiedResponse {
+  'certificate' : Array<number>,
+  'data' : IcpXdrConversionRate,
+  'hash_tree' : Array<number>,
+}
+export interface _SERVICE {
+  'get_icp_xdr_conversion_rate' : () => Promise<
+      IcpXdrConversionRateCertifiedResponse
+      >,
+}

--- a/frontend/ts/src/canisters/nnsDapp/Service.ts
+++ b/frontend/ts/src/canisters/nnsDapp/Service.ts
@@ -117,8 +117,4 @@ export default class Service implements ServiceInterface {
     );
     return this.responseConverters.toMultiPartTransactionStatus(rawResponse);
   };
-
-  public getIcpToCyclesConversionRate = (): Promise<bigint> => {
-    return this.service.get_icp_to_cycles_conversion_rate();
-  };
 }

--- a/frontend/ts/src/canisters/nnsDapp/canister.did.js
+++ b/frontend/ts/src/canisters/nnsDapp/canister.did.js
@@ -172,7 +172,6 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_account' : IDL.Func([], [GetAccountResponse], ['query']),
     'get_canisters' : IDL.Func([], [IDL.Vec(CanisterDetails)], ['query']),
-    'get_icp_to_cycles_conversion_rate' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_multi_part_transaction_errors' : IDL.Func(
         [],
         [IDL.Vec(MultiPartTransactionError)],

--- a/frontend/ts/src/canisters/nnsDapp/model.ts
+++ b/frontend/ts/src/canisters/nnsDapp/model.ts
@@ -146,7 +146,6 @@ export default interface ServiceInterface {
   ) => Promise<DetachCanisterResponse>;
   getAccount: (certified: boolean) => Promise<GetAccountResponse>;
   getCanisters: () => Promise<Array<CanisterDetails>>;
-  getIcpToCyclesConversionRate: () => Promise<bigint>;
   getMultiPartTransactionStatus: (
     principal: Principal,
     blockHeight: BlockHeight

--- a/frontend/ts/src/canisters/nnsDapp/rawService.ts
+++ b/frontend/ts/src/canisters/nnsDapp/rawService.ts
@@ -148,7 +148,6 @@ export interface _SERVICE {
     >,
   'get_account' : () => Promise<GetAccountResponse>,
   'get_canisters' : () => Promise<Array<CanisterDetails>>,
-  'get_icp_to_cycles_conversion_rate' : () => Promise<bigint>,
   'get_multi_part_transaction_errors' : () => Promise<
       Array<MultiPartTransactionError>
     >,

--- a/rs/nns-dapp.did
+++ b/rs/nns-dapp.did
@@ -232,7 +232,6 @@ service : {
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
     get_multi_part_transaction_status: (principal, BlockHeight) -> (MultiPartTransactionStatus) query;
     get_multi_part_transaction_errors: () -> (vec MultiPartTransactionError) query;
-    get_icp_to_cycles_conversion_rate: () -> (nat64) query;
     get_stats: () -> (Stats) query;
 
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -10,7 +10,7 @@ use crate::periodic_tasks_runner::run_periodic_tasks;
 use crate::state::{StableState, State, STATE};
 use candid::CandidType;
 use dfn_candid::{candid, candid_one};
-use dfn_core::{api::trap_with, over, over_async, stable};
+use dfn_core::{api::trap_with, over, stable};
 use ic_base_types::PrincipalId;
 use ledger_canister::{AccountIdentifier, BlockHeight};
 
@@ -247,31 +247,6 @@ pub fn get_multi_part_transaction_errors() {
 
 fn get_multi_part_transaction_errors_impl() -> Vec<MultiPartTransactionError> {
     STATE.with(|s| s.accounts_store.borrow().get_multi_part_transaction_errors())
-}
-
-/// Returns the current conversion rate between ICP and cycles.
-#[export_name = "canister_query get_icp_to_cycles_conversion_rate"]
-pub fn get_icp_to_cycles_conversion_rate() {
-    over_async(candid, |()| get_icp_to_cycles_conversion_rate_impl());
-}
-
-async fn get_icp_to_cycles_conversion_rate_impl() -> u64 {
-    #[cfg(feature = "mock_conversion_rate")]
-    {
-        100_000_000_000_000 // Assume a conversion rate of 100T cycles per 1 ICP.
-    }
-
-    #[cfg(not(feature = "mock_conversion_rate"))]
-    {
-        const CYCLES_PER_XDR: u64 = 1_000_000_000_000;
-
-        let xdr_permyriad_per_icp = match ic_nns_common::registry::get_icp_xdr_conversion_rate_record().await {
-            None => panic!("ICP/XDR conversion rate is not available."),
-            Some((rate_record, _)) => rate_record.xdr_permyriad_per_icp,
-        };
-
-        xdr_permyriad_per_icp * (CYCLES_PER_XDR / 10_000)
-    }
 }
 
 /// Returns stats about the canister.


### PR DESCRIPTION
This PR makes the NNS Dapp frontend get the ICP to cycles conversion rate from the cycles minting canister rather than from the registry.