### PR TITLE
Log response from list_neurons. 

### DIFF
--- a/frontend/ts/src/canisters/governance/Service.ts
+++ b/frontend/ts/src/canisters/governance/Service.ts
@@ -83,10 +83,14 @@ export default class Service implements ServiceInterface {
     };
     const serviceToUse = certified ? this.certifiedService : this.service;
     const rawResponse = await serviceToUse.list_neurons(rawRequest);
-    return this.responseConverters.toArrayOfNeuronInfo(
+    const response =  this.responseConverters.toArrayOfNeuronInfo(
       rawResponse,
       this.myPrincipal
     );
+
+    console.log("Response from list_neurons");
+    console.log(response);
+    return response;
   };
 
   public getNeuronsForHW = async (): Promise<Array<NeuronInfoForHw>> => {

--- a/frontend/ts/src/canisters/governance/Service.ts
+++ b/frontend/ts/src/canisters/governance/Service.ts
@@ -83,7 +83,7 @@ export default class Service implements ServiceInterface {
     };
     const serviceToUse = certified ? this.certifiedService : this.service;
     const rawResponse = await serviceToUse.list_neurons(rawRequest);
-    const response =  this.responseConverters.toArrayOfNeuronInfo(
+    const response = this.responseConverters.toArrayOfNeuronInfo(
       rawResponse,
       this.myPrincipal
     );

--- a/frontend/ts/src/canisters/governance/Service.ts
+++ b/frontend/ts/src/canisters/governance/Service.ts
@@ -88,8 +88,8 @@ export default class Service implements ServiceInterface {
       this.myPrincipal
     );
 
-    console.log("Response from list_neurons");
-    console.log(response);
+    console.debug("Response from list_neurons:");
+    console.debug(response);
     return response;
   };
 


### PR DESCRIPTION
This is to identify whether the issue we're seeing in
https://forum.dfinity.org/t/8-year-locked-neuron-missing-from-neurons-tab/9619/32
is due to a FE issue or a governance canister issue.