### PR TITLE
Deduplicate build.sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,7 @@ frontend/dart/ios/Runner/GeneratedPluginRegistrant.m
 frontend/dart/lib/generated_plugin_registrant.dart
 frontend/dart/pubspec.lock
 frontend/dart/build/web
+frontend/svelte/node_modules/
+frontend/svelte/public/build/
+frontend/svelte/public/assets/
+**/*.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/*.wasm
 assets.tar.xz
 out
 

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ $DEPLOY_ENV = "nobuild" ]]; then
+  echo "Skipping build as requested"
+  exit 0
+fi
+
 if ! [[ $DEPLOY_ENV = "testnet" ]] && ! [[ $DEPLOY_ENV = "mainnet" ]] && ! [[ $DEPLOY_ENV = "local" ]]; then
   echo "Which deployment environment? Set DEPLOY_ENV to 'testnet' or 'mainnet' or 'local'"
   exit 1
@@ -58,6 +63,5 @@ else
 fi
 
 echo Optimising wasm
-wasm-opt target/wasm32-unknown-unknown/release/nns-dapp.wasm --strip-debug -Oz -o target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
-
+ic-cdk-optimizer target/wasm32-unknown-unknown/release/nns-dapp.wasm -o target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
 sha256sum target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(dirname "$(realpath "$0")")/.." || exit
 NETWORK=$1
 
 echo "Deploying to $NETWORK..."
 DEPLOY_ENV=$NETWORK dfx deploy --no-wallet --network "$NETWORK"
+echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"

--- a/scripts/deploy-docker-build-to-testnet
+++ b/scripts/deploy-docker-build-to-testnet
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$(realpath "$0")")/.." || exit
+
+WASM_PATH="$(jq -rc '.canisters["nns-dapp"].wasm' dfx.json)"
+
+docker build --build-arg DEPLOY_ENV=testnet -t nns-dapp .
+mkdir -p target/wasm32-unknown-unknown/release/
+# shellcheck disable=SC2094 # The source and destination files are not the same, the first is in docker.
+docker run --rm --entrypoint cat nns-dapp "$WASM_PATH" >"$WASM_PATH"
+docker run --rm --entrypoint cat nns-dapp /assets.tar.xz >assets.tar.xz
+DEPLOY_ENV=nobuild dfx deploy --network testnet
+
+set +x
+echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"


### PR DESCRIPTION
# Motivation
The dockerfile and build.sh duplicated code, fell out of sync and eventually caused a deploy to fail.  Therefore we wish to:

- call build.sh in the dockerfile rather than duplicating the code
- be able to deploy docker builds to the testnet, so that we can verify that docker builds work

# Changes
- Call build.sh in the dockerfile instead of replicating the steps.
- Take the target network as an env var.
- Cleanup and fix until testnet deployments work.


# Testing

## Differences observed

- A difference:  Before assets/NOTICES was included in the docker build.  In build .shit is removed with:
```
# Remove the assets/NOTICES file, as it's large in size and not used.
rm assets/NOTICES
```
That might explain why test deployments have more space than prod....

If the NOTICES file is left in, new docker builds are identical to the old.  But I will remove the NOTICES file as that seems to be the intent.  The hash was compared by checking out:

```
375bd498c56953cf4d98472956b1056e52bf306a = last commit before svelte.
```
building, then cherry picking this PR:
```
541e3f1803e288d09982aa4a95a509b2589db07f = build commit
```
and building again.  The build differed but commenting out the NOTICES line in build.sh gave the same hash.