### PR TITLE
Add instructions for deploying the core NNS canisters to a testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,15 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
-To deploy to the testnet, run the following:
+When deploying the governance, ledger, and cycle minting canisters to the testnet you must first create a file called `test-accounts.json` whose contents is:
+
+    {"init_ledger_accounts":["5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087"]}
+
+Then run the following from the root directory of the IC repo:
+
+    ./testnet/tools/icos_deploy.sh --git-revision <commit_id> nnsdapp --ansible-args '-e @/home/<username>/test-accounts.json'
+
+To deploy the NNS Dapp canister to the testnet, run the following:
 
     ./deploy.sh testnet
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
-When deploying the governance, ledger, and cycle minting canisters to the testnet you must first create a file called `test-accounts.json` whose contents is:
+When deploying the governance, ledger, and cycle minting canisters to the testnet you must first create a file called `test-accounts.json` in the root of the repo whose contents is:
 
     {"init_ledger_accounts":["5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087"]}
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 Development relies on the presence of a testnet that is setup with the II, governance, ledger, and cycle minting canisters. Fully local development is unfortunately not yet supported and the tools for setting up a testnet are not yet available publicly. It is on the roadmap to make these tools available publicly for developers.
 
-When deploying the governance, ledger, and cycle minting canisters to the testnet you must first create a file called `test-accounts.json` in the root of the repo whose contents is:
+When deploying the governance, ledger, and cycle minting canisters to the testnet you must first create a file called `test-accounts.json` in the root of the IC repo whose contents is:
 
     {"init_ledger_accounts":["5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087"]}
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When deploying the governance, ledger, and cycle minting canisters to the testne
 
 Then run the following from the root directory of the IC repo:
 
-    ./testnet/tools/icos_deploy.sh --git-revision <commit_id> nnsdapp --ansible-args '-e @/home/<username>/test-accounts.json'
+    ./testnet/tools/icos_deploy.sh --git-revision <commit_id> nnsdapp --ansible-args "-e @$PWD/test-accounts.json"
 
 To deploy the NNS Dapp canister to the testnet, run the following:
 


### PR DESCRIPTION
This PR is currently only relevant for internal developers since the testnets are not currently accessible to the public.

This PR shows the steps involved to setup a testnet where a specific ledger account is pre-loaded with some ICP. The private key of this ledger account is hardcoded into the frontend code so that users wanting to use the NNS Dapp on the testnet can send ICP from this account to their own.