### PR TITLE
Revert "Revert "Svelte login cross link (#298)" (#304)"

### DIFF
--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -37,7 +37,10 @@ class PlatformICApi extends AbstractPlatformICApi {
 
   Future initialize() async {
     authApi = await promiseToFuture(createAuthApi(allowInterop(() {
-      html.window.location.reload();
+      if (!this.isLoggedIn()) {
+        // Go to the svelte app, which handles login.
+        html.window.location.assign("/v2/");
+      }
     })));
     fetchIdentityAndBuildServices();
   }
@@ -660,6 +663,8 @@ class PlatformICApi extends AbstractPlatformICApi {
   @override
   Future<void> logout() async {
     await promiseToFuture(authApi.logout());
+    // Go to the svelte login page.
+    html.window.location.assign("/v2/");
   }
 
   @override

--- a/frontend/dart/lib/ui/home/auth_widget.dart
+++ b/frontend/dart/lib/ui/home/auth_widget.dart
@@ -1,59 +1,16 @@
-import 'package:nns_dapp/ui/_components/custom_auto_size.dart';
-
 import '../../nns_dapp.dart';
 
 class AuthWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    // If we were about to render the flutter login page, call logout() which navigates to /v2 when finished.
+    // Note: Navigating directly to v2 here is unreliable as logout may not have completed yet.
+    context.icApi.logout();
     return Container(
       constraints: BoxConstraints.expand(),
       decoration: BoxDecoration(
         image: DecorationImage(
             image: AssetImage('assets/nns_background.jpeg'), fit: BoxFit.cover),
-      ),
-      child: Stack(
-        children: [
-          Container(
-            padding: EdgeInsets.all(MediaQuery.of(context).size.width * 0.1),
-            child: Center(
-              child: ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: 500),
-                child: Column(
-                  children: [
-                    AutoSizeText(
-                      'The Internet Computer',
-                      style: context.textTheme.headline1,
-                      textAlign: TextAlign.center,
-                    ),
-                    SizedBox(height: 20),
-                    AutoSizeText(
-                      'Network Nervous System',
-                      style: context.textTheme.headline2,
-                      textAlign: TextAlign.center,
-                    ),
-                    Expanded(child: Container()),
-                    ElevatedButton(
-                        child: Padding(
-                          padding: const EdgeInsets.all(20.0),
-                          child: Text(
-                            "LOGIN",
-                            style: context.textTheme.headline3,
-                          ),
-                        ),
-                        style: ButtonStyle(
-                            backgroundColor:
-                                MaterialStateProperty.all(AppColors.blue800)),
-                        onPressed: () {
-                          context.icApi.authenticate(() {
-                            context.nav.push(accountsTabPage);
-                          });
-                        }),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/frontend/dart/web/index.html
+++ b/frontend/dart/web/index.html
@@ -28,8 +28,30 @@
 
   <title>Network Nervous System</title>
   <link rel="manifest" href="manifest.json">
+  <style>
+    /* Very early styling before assets have loaded */
+    body {
+      background-color: #333;
+      color: #eee;
+    }
+  .initial-load {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-family: Arial;
+    font-size: 14px;
+  }
+  </style>
+  <script src="logout.js" type="application/javascript"></script>
 </head>
 <body>
+  <div class="initial-load"><span>Getting the NNS dapp ready for you…</span></div>
   <script src="/assets/assets/ic_agent.js" type="application/javascript"></script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>

--- a/frontend/dart/web/logout.js
+++ b/frontend/dart/web/logout.js
@@ -1,0 +1,23 @@
+// Listen for v2 login status events.
+// If the user logs out on one tab, they should be logged out on all tabs.
+// Svelte implements login and logout sync across tabs.  Here we have a minimal integration
+// with the svelte signalling channel so that flutter also logs out.
+(() => {
+    let loggingOut = false; // Debounce to protect against multiple simultaneous reload calls interfering with each other.
+    let checkLoginStatus = () => {
+      let currentStoredState = window.localStorage.getItem("AuthSync");
+      try {
+         const {action} = JSON.parse(currentStoredState);
+         if ((action !== "signIn") && (!loggingOut)) {
+             loggingOut = true;
+             window.location.assign('/v2/');
+         }
+      } catch(e) {
+         // Login status was not present and well formed.
+         console.info(e);
+         window.location.assign('/v2/');
+      }
+    }
+    checkLoginStatus();
+    window.addEventListener("storage", checkLoginStatus);
+})();

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -83,6 +83,15 @@ export default {
             ? "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/"
             : "https://identity.ic0.app/")
       ),
+      // When developing with live reload in svelte, redirecting to flutter is
+      // not desirable, so when there is no deployment target we don't do it.
+      "process.env.REDIRECT_TO_LEGACY": JSON.stringify(
+        process.env.REDIRECT_TO_LEGACY !== undefined
+          ? true
+          : process.env.DEPLOY_ENV === undefined
+          ? false
+          : true
+      ),
     }),
 
     // In dev mode, call `npm run start` once

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -8,6 +8,12 @@
 
 <main>
   <Auth bind:signedIn bind:principal />
+  {#if signedIn}
+    <!-- This must match the loading placeholder of the flutter app exactly, to make the transition seamless. -->
+    <div class="initial-load">
+      <span>Getting the NNS dapp ready for you…</span>
+    </div>
+  {/if}
 </main>
 
 <svelte:head>
@@ -45,13 +51,26 @@
   main {
     width: 100vw;
     height: 100vh;
-    background: linear-gradient(var(--background-grey) 80%, black);
-    font-family: var(--font-family);
+    background-color: #333;
+    color: #eee;
+    overflow: hidden;
   }
 
   @media (min-width: 640px) {
     main {
       max-width: none;
     }
+  }
+  .initial-load {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: Arial;
+    font-size: 14px;
   }
 </style>

--- a/frontend/svelte/src/Auth.svelte
+++ b/frontend/svelte/src/Auth.svelte
@@ -45,6 +45,9 @@
 
   // Gets a local copy of user data.
   const onSignIn = async () => {
+    if (process.env.REDIRECT_TO_LEGACY) {
+      window.location.replace(`/${window.location.hash}`);
+    }
     const identity = authClient.getIdentity();
     principal = identity.getPrincipal().toString();
     signedIn = true;
@@ -62,7 +65,13 @@
   };
 
   // Sets login status on first load.
-  onMount(checkAuth);
+  onMount(() => {
+    checkAuth();
+    // If logged out by flutter, we still need to broadcast the logout status.
+    if (!signedIn) {
+      authSync.onSignOut();
+    }
+  });
 </script>
 
 <div class="auth-expandable">
@@ -78,12 +87,6 @@
       <button on:click={signIn} class="auth-button">LOGIN</button>
     </div>
   {/if}
-
-  <div class="auth-section">
-    {#if signedIn}
-      <button on:click={signOut} class="auth-button">Logout</button>
-    {/if}
-  </div>
 </div>
 
 <style>

--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -154,6 +154,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
             "html" => Some("text/html"),
             "js" => Some("application/javascript"),
             "json" => Some("application/json"),
+            "map" => Some("application/json"),
             "svg" => Some("image/svg+xml"),
             _ => None,
         })


### PR DESCRIPTION
# Motivation
We wish to use the svelte login page, now that that svelte assets are included in the canister.

# Changes

This reverts commit bab9ee9ed4949eda7fdc940024e116b079c2226e.

# Tests

Does it work?  A docker-built canister has been deployed to: https://qhbym-qaaaa-aaaaa-aaafq-cai.peopleparty01.dfinity.network/  using `scripts/deploy-docker-build-to-testnet` (with --no-wallet, which should perhaps be added to the script permanently).

Note: `s/nnsdapp/peopleparty01/g` due to testnet availability.

Are the svelte assets included in mainnet builds?

Yes, as of the dockerfile fix, these assets are in mainnet docker builds:
```
./v2/build/
./v2/build/bundle.css
./v2/build/bundle.js
./v2/build/bundle.js.map
./v2/global.css
./v2/index.html
```

# TODO
*  Pre-deployment, verify again that the /v2/ files are in the assets.tar.xz generated by CI.
* Any other concerns?  Size perhaps?  We can compare wasm size with the predecessor.