### PR TITLE
Cleanup: Deduplicate internet identity env var

### DIFF
--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -77,8 +77,8 @@ export default {
     replace({
       preventAssignment: true,
       "process.env.ROLLUP_WATCH": !!process.env.ROLLUP_WATCH,
-      "process.env.INTERNET_IDENTITY_URL": JSON.stringify(
-        process.env.INTERNET_IDENTITY_URL ||
+      "process.env.IDENTITY_SERVICE_URL": JSON.stringify(
+        process.env.IDENTITY_SERVICE_URL ||
           (process.env.DEPLOY_ENV === "testnet"
             ? "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/"
             : "https://identity.ic0.app/")

--- a/frontend/svelte/src/Auth.svelte
+++ b/frontend/svelte/src/Auth.svelte
@@ -9,7 +9,7 @@
 
   // Signs in, out, round and all about.
   let authClient;
-  let identityProvider = process.env.INTERNET_IDENTITY_URL;
+  let identityProvider = process.env.IDENTITY_SERVICE_URL;
 
   // Check for any change in authentication status and act upon it.
   const checkAuth = async () => {


### PR DESCRIPTION
# Motivation
There are two environment variables for the internet identity URL.  There should be only one.

- `IDENTITY_SERVICE_URL` already existed in `update_config.sh` and `frontend/ts`
- `IDENTITY_SERVICE_URL` was newly added in svelte

# Changes
- `s/INTERNET_IDENTITY_URL/IDENTITY_SERVICE_URL/g`