### PR TITLE
Use Ubuntu 20.04 for everything

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,6 +59,13 @@ jobs:
           # the pushing fail
           pull_strategy: "NO-PULL"
 
+  clippy:
+    needs: formatting
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Noop
+        run: echo clippy is run by the formatting step
+
 
   cargo-tests:
     needs: formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DEPLOY_ENV: mainnet
 
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         rust: [ '1.54.0' ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -104,7 +104,7 @@ jobs:
 
   flutter-tests:
     needs: formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DEPLOY_ENV: mainnet
 
@@ -144,7 +144,7 @@ jobs:
 
   svelte-tests:
     needs: formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -168,7 +168,7 @@ jobs:
   shell-checks:
     needs: formatting
     name: ShellCheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t nns-dapp .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # docker build -t nns-dapp .
 # docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > nns-dapp.wasm
 
-FROM ubuntu:20.10 as builder
+FROM ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.54.0


### PR DESCRIPTION
# Motivation
The Dockerfile specifies Ubuntu 20.10, which is beyond end of life and failing to build on github.  It is necessary to update this.  It seems sensible to switch to along term release.

The current state is:
- Our github actions use ubuntu-latest which is Ubuntu 20.04 (see https://github.com/actions/virtual-environments).
- Our dockerfile uses 20.10 which reached end of life in July 2021 (see https://lists.ubuntu.com/archives/ubuntu-announce/2021-July/000270.html).
- The current long term release, 20.04, has standard support until 2025 and reaches end of life in 2030  (see https://wiki.ubuntu.com/Releases).

# Changes
Use Ubuntu 20.04 explicitly everywhere.

# Testing
- The github actions should be unaffected as there is no ubuntu version change there, the version is stated explicitly.  No special tests are required.
- For the dockerfile, I have created the latest wasm file on main and on this branch.  The results are:
  - Main: 
    - commit: d6e2e7f64f197045c46dbc83988e7f92439940b5
    - wasm hash: 3791bceff0f3af1c32f7a382eeacda607e987a3f83fc22849c5466c9a590cde6  nns-dapp.wasm
  - This branch:
    - commit: c2ac4e01d13568ef4fbc99713c1232dbf072b030
    - wasm hash: 3791bceff0f3af1c32f7a382eeacda607e987a3f83fc22849c5466c9a590cde6