### PR TITLE
build: eslint

### DIFF
--- a/frontend/svelte/.eslintrc.cjs
+++ b/frontend/svelte/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+  ],
+  plugins: ["svelte3", "@typescript-eslint"],
+  ignorePatterns: ["*.cjs"],
+  overrides: [{ files: ["*.svelte"], processor: "svelte3/svelte3" }],
+  settings: {
+    "svelte3/typescript": () => require("typescript"),
+  },
+  parserOptions: {
+    sourceType: "module",
+    ecmaVersion: 2020,
+  },
+  env: {
+    browser: true,
+    es2017: true,
+    node: true,
+  },
+};

--- a/frontend/svelte/.eslintrc.cjs
+++ b/frontend/svelte/.eslintrc.cjs
@@ -15,10 +15,17 @@ module.exports = {
   parserOptions: {
     sourceType: "module",
     ecmaVersion: 2020,
+    project: ["./tsconfig.json"]
   },
   env: {
     browser: true,
     es2017: true,
     node: true,
+  },
+  rules: {
+    "@typescript-eslint/strict-boolean-expressions": [
+      2,
+      { allowString: false, allowNumber: false },
+    ],
   },
 };

--- a/frontend/svelte/.eslintrc.cjs
+++ b/frontend/svelte/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
   parserOptions: {
     sourceType: "module",
     ecmaVersion: 2020,
-    project: ["./tsconfig.json"]
+    project: ["./tsconfig.json"],
   },
   env: {
     browser: true,

--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -25,6 +25,10 @@
         "@rollup/plugin-replace": "^3.0.0",
         "@rollup/plugin-typescript": "^8.0.0",
         "@tsconfig/svelte": "^2.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.8.1",
+        "@typescript-eslint/parser": "^5.8.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-svelte3": "^3.2.1",
         "prettier": "^2.5.0",
         "prettier-plugin-svelte": "^2.5.0",
         "rollup": "^2.3.4",
@@ -35,7 +39,6 @@
         "svelte": "^3.0.0",
         "svelte-check": "^2.0.0",
         "svelte-preprocess": "^4.0.0",
-        "tslib": "^2.0.0",
         "typescript": "^4.0.0"
       }
     },
@@ -1856,13 +1859,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
-      "integrity": "sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.1.tgz",
+      "integrity": "sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.5.0",
-        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/experimental-utils": "5.8.1",
+        "@typescript-eslint/scope-manager": "5.8.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1888,15 +1891,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz",
-      "integrity": "sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.1.tgz",
+      "integrity": "sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.5.0",
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/typescript-estree": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.8.1",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/typescript-estree": "5.8.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1908,19 +1911,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.5.0.tgz",
-      "integrity": "sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.1.tgz",
+      "integrity": "sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.5.0",
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/typescript-estree": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.8.1",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/typescript-estree": "5.8.1",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1940,13 +1942,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
-      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.1.tgz",
+      "integrity": "sha512-DGxJkNyYruFH3NIZc3PwrzwOQAg7vvgsHsHCILOLvUpupgkwDZdNq/cXU3BjF4LNrCsVg0qxEyWasys5AiJ85Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0"
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/visitor-keys": "5.8.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1957,9 +1959,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.1.tgz",
+      "integrity": "sha512-L/FlWCCgnjKOLefdok90/pqInkomLnAcF9UAzNr+DSqMC3IffzumHTQTrINXhP1gVp9zlHiYYjvozVZDPleLcA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1970,13 +1972,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz",
-      "integrity": "sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.1.tgz",
+      "integrity": "sha512-26lQ8l8tTbG7ri7xEcCFT9ijU5Fk+sx/KRRyyzCv7MQ+rZZlqiDPtMKWLC8P7o+dtCnby4c+OlxuX1tp8WfafQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/visitor-keys": "5.8.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1997,12 +1999,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
-      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.1.tgz",
+      "integrity": "sha512-SWgiWIwocK6NralrJarPZlWdr0hZnj5GXHIgfdm8hNkyKvpeQuFyLP6YjSIe9kf3YBIfU6OHSZLYkQ+smZwtNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/types": "5.8.1",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3298,6 +3300,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-standard": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
@@ -3526,6 +3540,19 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-svelte3": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.2.1.tgz",
+      "integrity": "sha512-YoBR9mLoKCjGghJ/gvpnFZKaMEu/VRcuxpSRS8KuozuEo7CdBH7bmBHa6FmMm0i4kJnOyx+PVsaptz96K6H/4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0",
+        "svelte": "^3.2.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -8701,7 +8728,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10515,13 +10543,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
-      "integrity": "sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.1.tgz",
+      "integrity": "sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.5.0",
-        "@typescript-eslint/scope-manager": "5.5.0",
+        "@typescript-eslint/experimental-utils": "5.8.1",
+        "@typescript-eslint/scope-manager": "5.8.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -10531,56 +10559,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz",
-      "integrity": "sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.1.tgz",
+      "integrity": "sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.5.0",
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/typescript-estree": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.8.1",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/typescript-estree": "5.8.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.5.0.tgz",
-      "integrity": "sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.1.tgz",
+      "integrity": "sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.5.0",
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/typescript-estree": "5.5.0",
+        "@typescript-eslint/scope-manager": "5.8.1",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/typescript-estree": "5.8.1",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
-      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.1.tgz",
+      "integrity": "sha512-DGxJkNyYruFH3NIZc3PwrzwOQAg7vvgsHsHCILOLvUpupgkwDZdNq/cXU3BjF4LNrCsVg0qxEyWasys5AiJ85Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0"
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/visitor-keys": "5.8.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.1.tgz",
+      "integrity": "sha512-L/FlWCCgnjKOLefdok90/pqInkomLnAcF9UAzNr+DSqMC3IffzumHTQTrINXhP1gVp9zlHiYYjvozVZDPleLcA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz",
-      "integrity": "sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.1.tgz",
+      "integrity": "sha512-26lQ8l8tTbG7ri7xEcCFT9ijU5Fk+sx/KRRyyzCv7MQ+rZZlqiDPtMKWLC8P7o+dtCnby4c+OlxuX1tp8WfafQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0",
+        "@typescript-eslint/types": "5.8.1",
+        "@typescript-eslint/visitor-keys": "5.8.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -10589,12 +10616,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
-      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.1.tgz",
+      "integrity": "sha512-SWgiWIwocK6NralrJarPZlWdr0hZnj5GXHIgfdm8hNkyKvpeQuFyLP6YjSIe9kf3YBIfU6OHSZLYkQ+smZwtNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.5.0",
+        "@typescript-eslint/types": "5.8.1",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -11665,6 +11692,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-standard": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
@@ -11830,6 +11864,13 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-svelte3": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.2.1.tgz",
+      "integrity": "sha512-YoBR9mLoKCjGghJ/gvpnFZKaMEu/VRcuxpSRS8KuozuEo7CdBH7bmBHa6FmMm0i4kJnOyx+PVsaptz96K6H/4Q==",
       "dev": true,
       "requires": {}
     },
@@ -15527,7 +15568,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -39,6 +39,7 @@
         "svelte": "^3.0.0",
         "svelte-check": "^2.0.0",
         "svelte-preprocess": "^4.0.0",
+        "tslib": "^2.0.0",
         "typescript": "^4.0.0"
       }
     },
@@ -8725,11 +8726,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true,
-      "peer": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -15565,11 +15565,10 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true,
-      "peer": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -8,6 +8,7 @@
     "dev": "npm run import-assets && rollup -c -w",
     "start": "sirv public --no-clear",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "lint": "prettier --check --plugin-search-dir=. . && eslint src",
     "format": "prettier --write --plugin-search-dir=. ."
   },
   "devDependencies": {
@@ -18,6 +19,10 @@
     "@rollup/plugin-replace": "^3.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@tsconfig/svelte": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.8.1",
+    "@typescript-eslint/parser": "^5.8.1",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-svelte3": "^3.2.1",
     "prettier": "^2.5.0",
     "prettier-plugin-svelte": "^2.5.0",
     "rollup": "^2.3.4",
@@ -28,7 +33,6 @@
     "svelte": "^3.0.0",
     "svelte-check": "^2.0.0",
     "svelte-preprocess": "^4.0.0",
-    "tslib": "^2.0.0",
     "typescript": "^4.0.0"
   },
   "dependencies": {

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -33,6 +33,7 @@
     "svelte": "^3.0.0",
     "svelte-check": "^2.0.0",
     "svelte-preprocess": "^4.0.0",
+    "tslib": "^2.0.0",
     "typescript": "^4.0.0"
   },
   "dependencies": {

--- a/frontend/svelte/tsconfig.json
+++ b/frontend/svelte/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
-
+  "compilerOptions": {
+    "strict": true
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
 }


### PR DESCRIPTION
# Motivation

Detects JS errors ahead of compilation time.

# Changes

- adds default eslint configuration

# Notes

- to ignore folders in eslint, an `.eslintignore` can be created but needs to finds place at the root. since we have a mono-repo, to avoid conflicts, I just configured the linter to lint the svelte `src` folder

- this PR does not adds yet the linter to the ci or build chain