### PR TITLE
Env var to control switching between front ends

### DIFF
--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -90,9 +90,9 @@ export default {
       // - false after flutter has been replaced, but before all scaffolding has been removed
       // - the flag may then be removed.
       "process.env.REDIRECT_TO_LEGACY": JSON.stringify(
-        -1 !== ["true", "1"].indexOf(process.env.REDIRECT_TO_LEGACY)
+        ["true", "1"].includes(process.env.REDIRECT_TO_LEGACY)
           ? true
-          : -1 !== ["false", "0"].indexOf(process.env.REDIRECT_TO_LEGACY)
+          : ["false", "0"].includes(process.env.REDIRECT_TO_LEGACY)
           ? false
           : false // default
       ),

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -83,6 +83,19 @@ export default {
             ? "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/"
             : "https://identity.ic0.app/")
       ),
+      // When developing with live reload in svelte, redirecting to flutter is
+      // not desirable.  The default should match production:
+      // - false while svelte is inactive
+      // - true while flutter is being replaced by svelte
+      // - false after flutter has been replaced, but before all scaffolding has been removed
+      // - the flag may then be removed.
+      "process.env.REDIRECT_TO_LEGACY": JSON.stringify(
+        -1 !== ["true", "1"].indexOf(process.env.REDIRECT_TO_LEGACY)
+          ? true
+          : -1 !== ["false", "0"].indexOf(process.env.REDIRECT_TO_LEGACY)
+          ? false
+          : false // default
+      ),
     }),
 
     // In dev mode, call `npm run start` once


### PR DESCRIPTION
# Motivation
When developing in svelte with live reloading of the single page app, it is not usually desirable to switch to the legacy app, however such switching will be needed in production during the transition phase.

# Changes
- Added a compile time environment variable `REDIRECT_TO_LEGACY` that controls whether the switch is made.
  - If set to "true" or "1" the flag is considered to be enabled.
  - If set to "false" or "0" the flag is considered to be disabled.
  - Otherwise the default should match production.  The production default will change over time.

# Testing
I changed the main app code to:
```
  {#if process.env.REDIRECT_TO_LEGACY}
    <Auth bind:signedIn bind:principal />
  {/if}
```
and ran:
```
REDIRECT_TO_LEGACY=asdfhlkjsdf npm run dev
```
with various values and none.