### PR TITLE
EXC-805: Add console command for `addHotKey`.

### DIFF
--- a/frontend/ts/src/ServiceApi.ts
+++ b/frontend/ts/src/ServiceApi.ts
@@ -126,6 +126,7 @@ export default class ServiceApi {
     this.cyclesMintingService = cyclesMintingServiceBuilder(agent);
     this.icManagementService = icManagementBuilder(agent);
     this.identity = identity;
+    setupExports(this.governanceService);
   }
 
   /* ACCOUNTS */
@@ -642,4 +643,24 @@ async function ledgerService(identity: Identity): Promise<LedgerService> {
   }
 
   return ledgerBuilder(agent);
+}
+
+// Exports methods that can be triggered from the console.
+// Eventually we'll add support to all the commands, but that's better and easier
+// to do once we migrate to using @dfinity/nns.
+//
+// e.g. await nns.governance.addHotKey("<neuron-id>", "<principal>")
+function setupExports(governance: GovernanceService) {
+  // @ts-ignore
+  window["nns"] = {
+    governance: {
+      // Modifying the method signature to be a bit more ergonomic for the console.
+      addHotKey: function(neuronId: NeuronId, principal: PrincipalString) {
+        return governance.addHotKey({
+          neuronId: neuronId,
+          principal: principal
+        })
+      },
+    }
+  }
 }

--- a/frontend/ts/src/ServiceApi.ts
+++ b/frontend/ts/src/ServiceApi.ts
@@ -655,12 +655,12 @@ function setupExports(governance: GovernanceService) {
   window["nns"] = {
     governance: {
       // Modifying the method signature to be a bit more ergonomic for the console.
-      addHotKey: function(neuronId: NeuronId, principal: PrincipalString) {
+      addHotKey: function (neuronId: NeuronId, principal: PrincipalString) {
         return governance.addHotKey({
           neuronId: neuronId,
-          principal: principal
-        })
+          principal: principal,
+        });
       },
-    }
-  }
+    },
+  };
 }


### PR DESCRIPTION
This PR adds a console command that allows users to add hotkeys to
their neurons. Example:

```
await nns.governance.addHotKey("<neuron-id>", "<principal>");
```

The motivation for this is to resolve https://forum.dfinity.org/t/8-year-locked-neuron-missing-from-neurons-tab