### PR TITLE
Update wording as requested by Jan

### DIFF
--- a/frontend/dart/web/index.html
+++ b/frontend/dart/web/index.html
@@ -51,7 +51,7 @@
   </style>
  </head>
  <body>
-  <div class="initial-load"><span>Getting the NNS dapp ready for you…</span></div>
+  <div class="initial-load"><span>Getting the NNS frontend dapp ready for you…</span></div>
   <script src="/assets/assets/ic_agent.js" type="application/javascript"></script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>


### PR DESCRIPTION
# Motivation
Jan Camenisch: Also „getting NNS dapp ready for you“ -> „getting NNS frontend dapp ready for you“ (text that shows while loading after login)