### PR TITLE
Cache docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
-.dockerignore
+# by default, ignore all hidden files and make some exceptions
+.*
+!.rustfmt.toml
+!.gitignore
+
+
 Dockerfile
-.git
-.github
 backend-tests
 node_modules
 demos
@@ -9,7 +12,6 @@ docs
 dist
 screenshots
 target
-.dfx
 out
 assets.tar.xz
 frontend/ts/node_modules

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -24,12 +24,15 @@ jobs:
       # This is fine as long as this layer is rarely rebuilt. Moreover we make
       # sure to have exact cache hits (i.e. no restore-keys matching) to ensure
       # the cache is not uploaded (unless there is a cache miss).
-      # NOTE: about files involved
+      #
+      # The `hashFiles` should include every single file involved in the
+      # "builder" build, otherwise the action will fetch the cache but start
+      # from scratch nonetheless, never uploading the build output.
       - name: Cache docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -48,9 +51,16 @@ jobs:
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252
-      # TODO: check if still necessary
       - name: Move cache
-        run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        run: |
+          echo old cache
+          ls /tmp/.buildx-cache
+
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+          echo new cache
+          ls /tmp/.buildx-cache
 
       - name: Build nns-dapp Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -62,25 +62,26 @@ jobs:
           echo new cache
           ls /tmp/.buildx-cache
 
-      - name: Build nns-dapp Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push:  false # otherwise docker tries to push to dockerhub
-          tags: nns-dapp
-          file: Dockerfile
+      #- name: Build nns-dapp Docker image
+        #uses: docker/build-push-action@v2
+        #with:
+          #context: .
+          #push:  false # otherwise docker tries to push to dockerhub
+          #tags: nns-dapp
+          #load: true # effectively makes the image usable in 'docker run'
+          #file: Dockerfile
 
-      - run: mkdir out/
-      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      - run: sha256sum out/nns-dapp.wasm
-      - name: 'Upload wasm module'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Backend wasm module
-          path: out/nns-dapp.wasm
-      - name: 'Upload frontend assets'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Frontend assets
-          path: out/assets.tar.xz
+      #- run: mkdir out/
+      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      #- run: sha256sum out/nns-dapp.wasm
+      #- name: 'Upload wasm module'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Backend wasm module
+          #path: out/nns-dapp.wasm
+      #- name: 'Upload frontend assets'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Frontend assets
+          #path: out/assets.tar.xz

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -44,63 +44,63 @@ jobs:
           CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
           BLAH: ${{ steps.docker-cache.outputs.cache-hit && 'Oh yes' || 'Oh no...' }}
 
-      #- name: test not prop
-        #run: |
-          #echo "yes it's happening '$FOO' '$CACHE_HIT'"
-        #if: ${{ steps.docker-cache.outputs.cache-hit != 'true' }}
-        #env:
-          #FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
-          #CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
+      - name: test not prop
+        run: |
+          echo "yes it's happening '$FOO' '$CACHE_HIT'"
+        if: ${{ steps.docker-cache.outputs.cache-hit != 'true' }}
+        env:
+          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
 
-      #- name: Build base Docker image
-        #uses: docker/build-push-action@v2
-        #with:
-          #context: .
-          #push:  false # otherwise docker tries to push to dockerhub
-          #tags: nns-dapp-builder
-          #file: Dockerfile
-          #cache-from: type=local,src=/tmp/.buildx-cache
-          ## NOTE: we set "mode=max" to make sure _all_ layers are exported, not
-          ## only those in the final image. Exporting only the finaly layers
-          ## would be pointless since we only/mostly care about the layers that are
-          ## used in the build.
-          ## https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
-          ## TODO: should we "cache-to" iff !cache-hit?
-          ## TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
-          ## TODO: directly feed image from first build
-          #cache-to: ${{ steps.docker-cache.outputs.cache-hit == 'true' && '' || steps.docker-cache.outputs.cache-hit }}
-          #target: builder
+      - name: Build base Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push:  false # otherwise docker tries to push to dockerhub
+          tags: nns-dapp-builder
+          file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          # NOTE: we set "mode=max" to make sure _all_ layers are exported, not
+          # only those in the final image. Exporting only the finaly layers
+          # would be pointless since we only/mostly care about the layers that are
+          # used in the build.
+          # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
+          # TODO: should we "cache-to" iff !cache-hit?
+          # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
+          # TODO: directly feed image from first build
+          cache-to: ${{ steps.docker-cache.outputs.cache-hit && 'Oh yes' || 'Oh no...' }}
+          target: builder
 
-      ## https://github.com/docker/build-push-action/issues/252
-      #- name: Move cache
-        #run: |
-          #if [ -d /tmp/.buildx-cache-new ]
-          #then
-            #rm -rf /tmp/.buildx-cache
-            #mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          #fi
+      # https://github.com/docker/build-push-action/issues/252
+      - name: Move cache
+        run: |
+          if [ -d /tmp/.buildx-cache-new ]
+          then
+            rm -rf /tmp/.buildx-cache
+            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          fi
 
-      #- name: Build nns-dapp Docker image
-        #uses: docker/build-push-action@v2
-        #with:
-          #context: .
-          #push: false # otherwise docker tries to push to dockerhub
-          #tags: nns-dapp
-          #load: true # effectively makes the image usable in 'docker run'
-          #file: Dockerfile
-          #cache-from: type=local,src=/tmp/.buildx-cache
+      - name: Build nns-dapp Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false # otherwise docker tries to push to dockerhub
+          tags: nns-dapp
+          load: true # effectively makes the image usable in 'docker run'
+          file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
 
-      #- run: mkdir out/
-      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      #- run: sha256sum out/nns-dapp.wasm
-      #- name: 'Upload wasm module'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Backend wasm module
-          #path: out/nns-dapp.wasm
-      #- name: 'Upload frontend assets'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Frontend assets
-          #path: out/assets.tar.xz
+      - run: mkdir out/
+      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      - run: sha256sum out/nns-dapp.wasm
+      - name: 'Upload wasm module'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Backend wasm module
+          path: out/nns-dapp.wasm
+      - name: 'Upload frontend assets'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Frontend assets
+          path: out/assets.tar.xz

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -47,29 +47,25 @@ jobs:
           # would be pointless since we only/mostly care about the layers that are
           # used in the build.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
+          # TODO: should we "cache-to" iff !cache-hit?
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252
       - name: Move cache
         run: |
-          echo old cache
-          ls /tmp/.buildx-cache
-
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-          echo new cache
-          ls /tmp/.buildx-cache
 
       - name: Build nns-dapp Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          push:  false # otherwise docker tries to push to dockerhub
+          push: false # otherwise docker tries to push to dockerhub
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -62,26 +62,26 @@ jobs:
           echo new cache
           ls /tmp/.buildx-cache
 
-      #- name: Build nns-dapp Docker image
-        #uses: docker/build-push-action@v2
-        #with:
-          #context: .
-          #push:  false # otherwise docker tries to push to dockerhub
-          #tags: nns-dapp
-          #load: true # effectively makes the image usable in 'docker run'
-          #file: Dockerfile
+      - name: Build nns-dapp Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push:  false # otherwise docker tries to push to dockerhub
+          tags: nns-dapp
+          load: true # effectively makes the image usable in 'docker run'
+          file: Dockerfile
 
-      #- run: mkdir out/
-      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      #- run: sha256sum out/nns-dapp.wasm
-      #- name: 'Upload wasm module'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Backend wasm module
-          #path: out/nns-dapp.wasm
-      #- name: 'Upload frontend assets'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Frontend assets
-          #path: out/assets.tar.xz
+      - run: mkdir out/
+      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      - run: sha256sum out/nns-dapp.wasm
+      - name: 'Upload wasm module'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Backend wasm module
+          path: out/nns-dapp.wasm
+      - name: 'Upload frontend assets'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Frontend assets
+          path: out/assets.tar.xz

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,3 +1,4 @@
+# TODO: note about cache size (~2800MB)
 name: Docker build
 
 on:
@@ -11,18 +12,67 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: docker build -t nns-dapp .
-      - run: mkdir out/
-      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      - run: sha256sum out/nns-dapp.wasm
-      - name: 'Upload wasm module'
-        uses: actions/upload-artifact@v2
+
+      # buildx is needed by the docker caching step, see next steps
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Cache the docker layers
+      # NOTE: the rust dependency build is about 2.7GB, which is about a third
+      # of our cache capacity
+      # (https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows).
+      # This is fine as long as this layer is rarely rebuilt. Moreover we make
+      # sure to have exact cache hits (i.e. no restore-keys matching) to ensure
+      # the cache is not uploaded (unless there is a cache miss).
+      # NOTE: about files involved
+      - name: Cache docker layers
+        uses: actions/cache@v2
         with:
-          name: Backend wasm module
-          path: out/nns-dapp.wasm
-      - name: 'Upload frontend assets'
-        uses: actions/upload-artifact@v2
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles( 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/*', 'dfx.json' ) }}
+
+      - name: Build base Docker image
+        uses: docker/build-push-action@v2
         with:
-          name: Frontend assets
-          path: out/assets.tar.xz
+          context: .
+          push:  false # otherwise docker tries to push to dockerhub
+          tags: nns-dapp-builder
+          file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          # NOTE: we set "mode=max" to make sure _all_ layers are exported, not
+          # only those in the final image. Exporting only the finaly layers
+          # would be pointless since we only/mostly care about the layers that are
+          # used in the build.
+          # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          target: builder
+
+      # https://github.com/docker/build-push-action/issues/252
+      # TODO: check if still necessary
+      - name: Move cache
+        run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Build nns-dapp Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push:  false # otherwise docker tries to push to dockerhub
+          tags: nns-dapp
+          file: Dockerfile
+
+
+      #- run: docker build -t nns-dapp .
+      #- run: mkdir out/
+      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      #- run: sha256sum out/nns-dapp.wasm
+      #- name: 'Upload wasm module'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Backend wasm module
+          #path: out/nns-dapp.wasm
+      #- name: 'Upload frontend assets'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Frontend assets
+          #path: out/assets.tar.xz

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # buildx is needed by the docker caching step, see next steps
+      # We use buildx and its GitHub Actions caching support `type=gha`. For
+      # more information, see
+      # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,4 +1,3 @@
-# TODO: note about cache size (~2800MB)
 name: Docker build
 
 on:
@@ -23,20 +22,21 @@ jobs:
       # (https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows).
       # This is fine as long as this layer is rarely rebuilt. Moreover we make
       # sure to have exact cache hits (i.e. no restore-keys matching) to ensure
-      # the cache is not uploaded (unless there is a cache miss).
+      # the cache is never re-uploaded (unless there is a cache miss).
       #
       # The `hashFiles` should include every single file involved in the
       # "builder" build, otherwise the action will fetch the cache but start
       # from scratch nonetheless, never uploading the build output.
-      # NOTE: If this isn't enough, we could try experiemental GitHub Actions
-      # support:
+      #
+      # NOTE: If this caching isn't enough, we could try experimental GitHub
+      # Actions support:
       # https://github.com/moby/buildkit#github-actions-cache-experimental
       - name: Cache docker layers
         uses: actions/cache@v2
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-no-max
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -57,7 +57,7 @@ jobs:
           # actually use the exported data.
           # NOTE: the empty string must be at the end, otherwise `''` is
           # considered falsy and is never used
-          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=max' || '' }}
+          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new' || '' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -46,11 +46,6 @@ jobs:
           tags: nns-dapp-builder
           file: Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
-          # NOTE: we set "mode=max" to make sure _all_ layers are exported, not
-          # only those in the final image. Exporting only the finaly layers
-          # would be pointless since we only/mostly care about the layers that are
-          # used in the build.
-          # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
           # TODO: directly feed image from first build
           # NOTE: Here we ensure we only export the cache if there was no cache
           # hit.  Otherwise, we export many GBs (a few minutes) to never

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -78,6 +78,7 @@ jobs:
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
+          cache-from: type=gha,scope=cached-stage
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push:  false # otherwise docker tries to push to dockerhub
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
           cache-to: type=gha,scope=cached-stage,mode=max
@@ -31,7 +30,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false # otherwise docker tries to push to dockerhub
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -37,17 +37,18 @@ jobs:
 
       - name: test prop
         run: |
-          echo "yes it's happening '$FOO'"
-        if: ${{ steps.docker-cache.cache-hit == 'true' }}
+          echo "yes it's happening '$FOO' '$CACHE_HIT'"
+        if: steps.docker-cache.cache-hit == 'true'
         env:
           FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
 
       - name: test not prop
         run: |
-          echo "yes it's happening '$FOO'"
-        if: ${{ steps.docker-cache.cache-hit != 'true' }}
+          echo "yes it's happening '$FOO' '$CACHE_HIT'"
+        if: steps.docker-cache.cache-hit != 'true'
         env:
           FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          CACHE_HIT: ${{ steps.docker-cache.cache-hit }}
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -60,19 +60,17 @@ jobs:
           tags: nns-dapp
           file: Dockerfile
 
-
-      #- run: docker build -t nns-dapp .
-      #- run: mkdir out/
-      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      #- run: sha256sum out/nns-dapp.wasm
-      #- name: 'Upload wasm module'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Backend wasm module
-          #path: out/nns-dapp.wasm
-      #- name: 'Upload frontend assets'
-        #uses: actions/upload-artifact@v2
-        #with:
-          #name: Frontend assets
-          #path: out/assets.tar.xz
+      - run: mkdir out/
+      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      - run: sha256sum out/nns-dapp.wasm
+      - name: 'Upload wasm module'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Backend wasm module
+          path: out/nns-dapp.wasm
+      - name: 'Upload frontend assets'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Frontend assets
+          path: out/assets.tar.xz

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/*', 'dfx.json' ) }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles( 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,7 +52,7 @@ jobs:
           # actually use the exported data.
           # NOTE: the empty string must be at the end, otherwise `''` is
           # considered falsy and is never used
-          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=gha,scope=cached-stage,mode=max' || '' }}
+          cache-to: type=gha,scope=cached-stage,mode=max
           outputs: type=cacheonly
           target: builder
 
@@ -78,7 +78,6 @@ jobs:
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
-          cache-from: type=gha,scope=builder-stage
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -36,7 +36,7 @@ jobs:
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-no-max
+          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-mode-min
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -52,7 +52,7 @@ jobs:
           # actually use the exported data.
           # NOTE: the empty string must be at the end, otherwise `''` is
           # considered falsy and is never used
-          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new' || '' }}
+          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=min' || '' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -66,7 +66,7 @@ jobs:
           # TODO: should we "cache-to" iff !cache-hit?
           # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
           # TODO: directly feed image from first build
-          cache-to: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          cache-to: ${{ steps.docker-cache.outputs.cache-hit == 'true' && '' || steps.docker-cache.outputs.cache-hit }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -31,12 +31,12 @@ jobs:
       # NOTE: If this caching isn't enough, we could try experimental GitHub
       # Actions support:
       # https://github.com/moby/buildkit#github-actions-cache-experimental
-      - name: Cache docker layers
-        uses: actions/cache@v2
-        id: docker-cache
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-mode-min
+      #- name: Cache docker layers
+        #uses: actions/cache@v2
+        #id: docker-cache
+        #with:
+          #path: /tmp/.buildx-cache
+          #key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-mode-min
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -45,27 +45,28 @@ jobs:
           push:  false # otherwise docker tries to push to dockerhub
           tags: nns-dapp-builder
           file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=gha,scope=builder-stage
           # TODO: directly feed image from first build
           # NOTE: Here we ensure we only export the cache if there was no cache
           # hit.  Otherwise, we export many GBs (a few minutes) to never
           # actually use the exported data.
           # NOTE: the empty string must be at the end, otherwise `''` is
           # considered falsy and is never used
-          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=min' || '' }}
+          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=gha,scope=cached-stage,mode=max' || '' }}
+          outputs: type=cacheonly
           target: builder
 
-      # https://github.com/docker/build-push-action/issues/252
-      # NOTE: /tmp/.buildx-cache is NOT reuploaded if there was a perfect
-      # cache-hit (that's how GHA works and it means we don't re-upload 3GB
-      # that we already have)
-      - name: Move cache
-        run: |
-          if [ -d /tmp/.buildx-cache-new ]
-          then
-            rm -rf /tmp/.buildx-cache
-            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          fi
+      ## https://github.com/docker/build-push-action/issues/252
+      ## NOTE: /tmp/.buildx-cache is NOT reuploaded if there was a perfect
+      ## cache-hit (that's how GHA works and it means we don't re-upload 3GB
+      ## that we already have)
+      #- name: Move cache
+        #run: |
+          #if [ -d /tmp/.buildx-cache-new ]
+          #then
+            #rm -rf /tmp/.buildx-cache
+            #mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          #fi
 
       # Actual image build. We may be able to shave another few minutes
       # off: https://github.com/docker/build-push-action/issues/539
@@ -77,7 +78,7 @@ jobs:
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=gha,scope=builder-stage
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -38,17 +38,17 @@ jobs:
       - name: test prop
         run: |
           echo "yes it's happening '$FOO' '$CACHE_HIT'"
-        if: steps.docker-cache.cache-hit == 'true'
+        if: steps.docker-cache.outputs.cache-hit
         env:
-          FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
 
       - name: test not prop
         run: |
           echo "yes it's happening '$FOO' '$CACHE_HIT'"
-        if: steps.docker-cache.cache-hit != 'true'
+        if: steps.docker-cache.outputs.cache-hit
         env:
-          FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
-          CACHE_HIT: ${{ steps.docker-cache.cache-hit }}
+          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -66,7 +66,7 @@ jobs:
           # TODO: should we "cache-to" iff !cache-hit?
           # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
           # TODO: directly feed image from first build
-          cache-to: ${{ steps.docker-cache.cache-hit == 'true' && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          cache-to: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -30,6 +30,7 @@ jobs:
       # from scratch nonetheless, never uploading the build output.
       - name: Cache docker layers
         uses: actions/cache@v2
+        id: docker-cache
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
@@ -48,14 +49,19 @@ jobs:
           # used in the build.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
           # TODO: should we "cache-to" iff !cache-hit?
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
+          # TODO: directly feed image from first build
+          cache-to: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252
       - name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          if [ -d /tmp/.buildx-cache-new ]
+          then
+            rm -rf /tmp/.buildx-cache
+            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          fi
 
       - name: Build nns-dapp Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -72,6 +72,8 @@ jobs:
             mv /tmp/.buildx-cache-new /tmp/.buildx-cache
           fi
 
+      # Actual image build. We may be able to shave another few minutes
+      # off: https://github.com/docker/build-push-action/issues/539
       - name: Build nns-dapp Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -35,6 +35,18 @@ jobs:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
 
+      - name: test prop
+        run: "echo yes it's happening '$FOO'"
+        if: ${{ steps.docker-cache.cache-hit }}
+        env:
+          FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+
+      - name: test not prop
+        run: "echo yes it's happening '$FOO'"
+        if: ${{ ! steps.docker-cache.cache-hit }}
+        env:
+          FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+
       - name: Build base Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -28,29 +28,15 @@ jobs:
       # The `hashFiles` should include every single file involved in the
       # "builder" build, otherwise the action will fetch the cache but start
       # from scratch nonetheless, never uploading the build output.
+      # NOTE: If this isn't enough, we could try experiemental GitHub Actions
+      # support:
+      # https://github.com/moby/buildkit#github-actions-cache-experimental
       - name: Cache docker layers
         uses: actions/cache@v2
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
-
-      - name: test prop
-        run: |
-          echo "yes it's happening '$FOO' '$CACHE_HIT' '$BLAH'"
-        if: steps.docker-cache.outputs.cache-hit
-        env:
-          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
-          CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
-          BLAH: ${{ steps.docker-cache.outputs.cache-hit && 'Oh yes' || 'Oh no...' }}
-
-      - name: test not prop
-        run: |
-          echo "yes it's happening '$FOO' '$CACHE_HIT'"
-        if: ${{ steps.docker-cache.outputs.cache-hit != 'true' }}
-        env:
-          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
-          CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
 
       - name: Build base Docker image
         uses: docker/build-push-action@v2
@@ -65,13 +51,19 @@ jobs:
           # would be pointless since we only/mostly care about the layers that are
           # used in the build.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
-          # TODO: should we "cache-to" iff !cache-hit?
-          # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
           # TODO: directly feed image from first build
-          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=max' || '' }} # note about order
+          # NOTE: Here we ensure we only export the cache if there was no cache
+          # hit.  Otherwise, we export many GBs (a few minutes) to never
+          # actually use the exported data.
+          # NOTE: the empty string must be at the end, otherwise `''` is
+          # considered falsy and is never used
+          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=max' || '' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252
+      # NOTE: /tmp/.buildx-cache is NOT reuploaded if there wasa a perfect
+      # cache-hit (that's how GHA works and it means we don't re-upload 3GB
+      # that we already have)
       - name: Move cache
         run: |
           if [ -d /tmp/.buildx-cache-new ]

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -68,7 +68,7 @@ jobs:
           # TODO: should we "cache-to" iff !cache-hit?
           # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
           # TODO: directly feed image from first build
-          cache-to: ${{ steps.docker-cache.outputs.cache-hit && 'Oh yes' || 'Oh no...' }}
+          cache-to: ${{ (! steps.docker-cache.outputs.cache-hit) && 'type=local,dest=/tmp/.buildx-cache-new,mode=max' || '' }} # note about order
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -56,7 +56,7 @@ jobs:
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252
-      # NOTE: /tmp/.buildx-cache is NOT reuploaded if there wasa a perfect
+      # NOTE: /tmp/.buildx-cache is NOT reuploaded if there was a perfect
       # cache-hit (that's how GHA works and it means we don't re-upload 3GB
       # that we already have)
       - name: Move cache
@@ -77,7 +77,6 @@ jobs:
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,7 +45,7 @@ jobs:
           push:  false # otherwise docker tries to push to dockerhub
           tags: nns-dapp-builder
           file: Dockerfile
-          cache-from: type=gha,scope=builder-stage
+          cache-from: type=gha,scope=cached-stage
           # TODO: directly feed image from first build
           # NOTE: Here we ensure we only export the cache if there was no cache
           # hit.  Otherwise, we export many GBs (a few minutes) to never

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -16,72 +16,26 @@ jobs:
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v1
 
-      # Cache the docker layers
-      # NOTE: the rust dependency build is about 2.7GB, which is about a third
-      # of our cache capacity
-      # (https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows).
-      # This is fine as long as this layer is rarely rebuilt. Moreover we make
-      # sure to have exact cache hits (i.e. no restore-keys matching) to ensure
-      # the cache is never re-uploaded (unless there is a cache miss).
-      #
-      # The `hashFiles` should include every single file involved in the
-      # "builder" build, otherwise the action will fetch the cache but start
-      # from scratch nonetheless, never uploading the build output.
-      #
-      # NOTE: If this caching isn't enough, we could try experimental GitHub
-      # Actions support:
-      # https://github.com/moby/buildkit#github-actions-cache-experimental
-      #- name: Cache docker layers
-        #uses: actions/cache@v2
-        #id: docker-cache
-        #with:
-          #path: /tmp/.buildx-cache
-          #key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}-mode-min
-
       - name: Build base Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push:  false # otherwise docker tries to push to dockerhub
-          tags: nns-dapp-builder
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
-          # TODO: directly feed image from first build
-          # NOTE: Here we ensure we only export the cache if there was no cache
-          # hit.  Otherwise, we export many GBs (a few minutes) to never
-          # actually use the exported data.
-          # NOTE: the empty string must be at the end, otherwise `''` is
-          # considered falsy and is never used
           cache-to: type=gha,scope=cached-stage,mode=max
           outputs: type=cacheonly
           target: builder
 
-      ## https://github.com/docker/build-push-action/issues/252
-      ## NOTE: /tmp/.buildx-cache is NOT reuploaded if there was a perfect
-      ## cache-hit (that's how GHA works and it means we don't re-upload 3GB
-      ## that we already have)
-      #- name: Move cache
-        #run: |
-          #if [ -d /tmp/.buildx-cache-new ]
-          #then
-            #rm -rf /tmp/.buildx-cache
-            #mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          #fi
-
-      # Actual image build. We may be able to shave another few minutes
-      # off: https://github.com/docker/build-push-action/issues/539
       - name: Build nns-dapp Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: false # otherwise docker tries to push to dockerhub
-          tags: nns-dapp
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
+          # Exports the artefacts from the final stage
           outputs: ./out
-
-      - run: ls
-      - run: ls out
 
       - run: sha256sum out/nns-dapp.wasm
       - name: 'Upload wasm module'

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -76,13 +76,13 @@ jobs:
           context: .
           push: false # otherwise docker tries to push to dockerhub
           tags: nns-dapp
-          load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
+          outputs: ./out
 
-      - run: mkdir out/
-      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      - run: ls
+      - run: ls out
+
       - run: sha256sum out/nns-dapp.wasm
       - name: 'Upload wasm module'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,6 +77,7 @@ jobs:
           tags: nns-dapp
           load: true # effectively makes the image usable in 'docker run'
           file: Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
 
       - run: mkdir out/
       - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -36,14 +36,16 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ hashFiles( '.dockerignore', 'Dockerfile', 'Cargo.lock', 'Cargo.toml', 'rs/Cargo.toml', 'rs/nns_functions_candid_gen/**', 'dfx.json' ) }}
 
       - name: test prop
-        run: "echo yes it's happening '$FOO'"
-        if: ${{ steps.docker-cache.cache-hit }}
+        run: |
+          echo "yes it's happening '$FOO'"
+        if: ${{ steps.docker-cache.cache-hit == 'true' }}
         env:
           FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
 
       - name: test not prop
-        run: "echo yes it's happening '$FOO'"
-        if: ${{ ! steps.docker-cache.cache-hit }}
+        run: |
+          echo "yes it's happening '$FOO'"
+        if: ${{ steps.docker-cache.cache-hit != 'true' }}
         env:
           FOO: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
 
@@ -63,7 +65,7 @@ jobs:
           # TODO: should we "cache-to" iff !cache-hit?
           # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
           # TODO: directly feed image from first build
-          cache-to: ${{ steps.docker-cache.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          cache-to: ${{ steps.docker-cache.cache-hit == 'true' && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
           target: builder
 
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -37,68 +37,70 @@ jobs:
 
       - name: test prop
         run: |
-          echo "yes it's happening '$FOO' '$CACHE_HIT'"
-        if: steps.docker-cache.outputs.cache-hit
-        env:
-          FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
-
-      - name: test not prop
-        run: |
-          echo "yes it's happening '$FOO' '$CACHE_HIT'"
+          echo "yes it's happening '$FOO' '$CACHE_HIT' '$BLAH'"
         if: steps.docker-cache.outputs.cache-hit
         env:
           FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
           CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
+          BLAH: ${{ steps.docker-cache.outputs.cache-hit && 'Oh yes' || 'Oh no...' }}
 
-      - name: Build base Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push:  false # otherwise docker tries to push to dockerhub
-          tags: nns-dapp-builder
-          file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          # NOTE: we set "mode=max" to make sure _all_ layers are exported, not
-          # only those in the final image. Exporting only the finaly layers
-          # would be pointless since we only/mostly care about the layers that are
-          # used in the build.
-          # https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
-          # TODO: should we "cache-to" iff !cache-hit?
-          # TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
-          # TODO: directly feed image from first build
-          cache-to: ${{ steps.docker-cache.outputs.cache-hit == 'true' && '' || steps.docker-cache.outputs.cache-hit }}
-          target: builder
+      #- name: test not prop
+        #run: |
+          #echo "yes it's happening '$FOO' '$CACHE_HIT'"
+        #if: ${{ steps.docker-cache.outputs.cache-hit != 'true' }}
+        #env:
+          #FOO: ${{ steps.docker-cache.outputs.cache-hit && '' || 'type=local,dest=/tmp/.buildx-cache-new,mode=max' }}
+          #CACHE_HIT: ${{ steps.docker-cache.outputs.cache-hit }}
 
-      # https://github.com/docker/build-push-action/issues/252
-      - name: Move cache
-        run: |
-          if [ -d /tmp/.buildx-cache-new ]
-          then
-            rm -rf /tmp/.buildx-cache
-            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          fi
+      #- name: Build base Docker image
+        #uses: docker/build-push-action@v2
+        #with:
+          #context: .
+          #push:  false # otherwise docker tries to push to dockerhub
+          #tags: nns-dapp-builder
+          #file: Dockerfile
+          #cache-from: type=local,src=/tmp/.buildx-cache
+          ## NOTE: we set "mode=max" to make sure _all_ layers are exported, not
+          ## only those in the final image. Exporting only the finaly layers
+          ## would be pointless since we only/mostly care about the layers that are
+          ## used in the build.
+          ## https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
+          ## TODO: should we "cache-to" iff !cache-hit?
+          ## TODO: try experiemental GitHub Actions support: https://github.com/moby/buildkit#github-actions-cache-experimental
+          ## TODO: directly feed image from first build
+          #cache-to: ${{ steps.docker-cache.outputs.cache-hit == 'true' && '' || steps.docker-cache.outputs.cache-hit }}
+          #target: builder
 
-      - name: Build nns-dapp Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: false # otherwise docker tries to push to dockerhub
-          tags: nns-dapp
-          load: true # effectively makes the image usable in 'docker run'
-          file: Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
+      ## https://github.com/docker/build-push-action/issues/252
+      #- name: Move cache
+        #run: |
+          #if [ -d /tmp/.buildx-cache-new ]
+          #then
+            #rm -rf /tmp/.buildx-cache
+            #mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          #fi
 
-      - run: mkdir out/
-      - run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
-      - run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
-      - run: sha256sum out/nns-dapp.wasm
-      - name: 'Upload wasm module'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Backend wasm module
-          path: out/nns-dapp.wasm
-      - name: 'Upload frontend assets'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Frontend assets
-          path: out/assets.tar.xz
+      #- name: Build nns-dapp Docker image
+        #uses: docker/build-push-action@v2
+        #with:
+          #context: .
+          #push: false # otherwise docker tries to push to dockerhub
+          #tags: nns-dapp
+          #load: true # effectively makes the image usable in 'docker run'
+          #file: Dockerfile
+          #cache-from: type=local,src=/tmp/.buildx-cache
+
+      #- run: mkdir out/
+      #- run: docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > out/nns-dapp.wasm
+      #- run: docker run --rm --entrypoint cat nns-dapp /assets.tar.xz > out/assets.tar.xz
+      #- run: sha256sum out/nns-dapp.wasm
+      #- name: 'Upload wasm module'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Backend wasm module
+          #path: out/nns-dapp.wasm
+      #- name: 'Upload frontend assets'
+        #uses: actions/upload-artifact@v2
+        #with:
+          #name: Frontend assets
+          #path: out/assets.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,5 @@ RUN cp "$(jq -rc '.canisters["nns-dapp"].wasm' dfx.json)" nns-dapp.wasm
 RUN ls -sh nns-dapp.wasm; sha256sum nns-dapp.wasm
 
 FROM scratch
-COPY --from=build nns-dapp.wasm out/nns-dapp.wasm
-COPY --from=build assets.tar.xz out/assets.tar.xz
+COPY --from=build /nns-dapp.wasm /
+COPY --from=build /assets.tar.xz /

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY dfx.json dfx.json
 RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
 # Start the second container
-FROM builder
+FROM builder AS build
 SHELL ["bash", "-c"]
 ARG DEPLOY_ENV=mainnet
 RUN echo $DEPLOY_ENV
@@ -79,3 +79,7 @@ RUN ./build.sh
 # Copy the wasm to the traditional location.
 RUN cp "$(jq -rc '.canisters["nns-dapp"].wasm' dfx.json)" nns-dapp.wasm
 RUN ls -sh nns-dapp.wasm; sha256sum nns-dapp.wasm
+
+FROM scratch
+COPY --from=build nns-dapp.wasm out/nns-dapp.wasm
+COPY --from=build assets.tar.xz out/assets.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,8 @@
 # docker build -t nns-dapp .
 # docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > nns-dapp.wasm
 
-
 # This is the "builder", i.e. the base image used later to build the final
 # code.
-# NOTE: When modifying the COPY statements, make sure you modify the list of
-# hashed files (hashFiles) in the docker-build GitHub Action.
 FROM ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 

--- a/frontend/svelte/README.md
+++ b/frontend/svelte/README.md
@@ -6,7 +6,6 @@ _Looking for a shareable component template instead? You can [use SvelteKit for 
 
 # svelte app
 
-FOO
 This is a project template for [Svelte](https://svelte.dev) apps. It lives at https://github.com/sveltejs/template.
 
 To create a new project based on this template using [degit](https://github.com/Rich-Harris/degit):

--- a/frontend/svelte/README.md
+++ b/frontend/svelte/README.md
@@ -6,6 +6,7 @@ _Looking for a shareable component template instead? You can [use SvelteKit for 
 
 # svelte app
 
+FOO
 This is a project template for [Svelte](https://svelte.dev) apps. It lives at https://github.com/sveltejs/template.
 
 To create a new project based on this template using [degit](https://github.com/Rich-Harris/degit):


### PR DESCRIPTION
This adds caching to our docker build through [`buildx` Github Actions support](https://github.com/moby/buildkit#github-actions-cache-experimental). This saves 75% of the build time (22mn -> 5mn). The `.dockerignore` is also updated to fix some issues when local files ending up polluting the build.

Big, big thanks @crazy-max for your help!