### PR TITLE
Create build script for dart code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,19 +14,12 @@ fi
 
 set -x
 
-# build typescript code
+# build typescript code. Must happen before the dart build because the dart
+# build requires "ic_agent.js" which is generated from frontend/ts.
 (cd frontend/ts && ./build.sh)
 
-# build the flutter app
-pushd frontend/dart || exit
-if [[ $DEPLOY_ENV = "mainnet" ]]; then
-  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
-else
-  # For all networks that are not main net, build with the staging config
-  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
-fi
-sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' build/web/index.html
-popd || exit
+# Build the Flutter codebase
+./frontend/dart/build.sh
 
 rm -f assets.tar.xz
 rm -fr web-assets

--- a/frontend/dart/build.sh
+++ b/frontend/dart/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Build the flutter app
+
+set -euo pipefail
+
+MYPATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1
+  pwd -P
+)"
+
+echo "Assuming dart codebase path is $MYPATH"
+cd "$MYPATH"
+
+if [[ $DEPLOY_ENV = "mainnet" ]]; then
+  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=FLUTTER_WEB_CANVASKIT_URL=/assets/canvaskit/
+else
+  # For all networks that are not mainnet, build with the staging config
+  flutter build web --web-renderer html --release --no-sound-null-safety --pwa-strategy=none --dart-define=DEPLOY_ENV=staging
+fi
+
+# Remove the random hash from flutter output
+sed -i -e 's/flutter_service_worker.js?v=[0-9]*/flutter_service_worker.js/' build/web/index.html


### PR DESCRIPTION
This makes the top-level `build.sh` more readable and is more in line
with e.g. `frontend/ts`'s `build.sh`.