### PR TITLE
Allow specifying OWN_CANISTER_ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,10 @@ RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfini
 FROM builder AS build
 SHELL ["bash", "-c"]
 ARG DEPLOY_ENV=mainnet
-RUN echo $DEPLOY_ENV
+RUN echo "DEPLOY_ENV: '$DEPLOY_ENV'"
+
+ARG OWN_CANISTER_ID
+RUN echo "OWN_CANISTER_ID: '$OWN_CANISTER_ID'"
 
 # Build
 COPY . .

--- a/update_config.sh
+++ b/update_config.sh
@@ -10,7 +10,7 @@ fi
 
 if [[ $DEPLOY_ENV = "testnet" ]]; then
   # testnet config
-  OWN_CANISTER_ID="$(dfx canister --no-wallet --network testnet id nns-dapp)"
+  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --no-wallet --network testnet id nns-dapp)}"
   cat >frontend/ts/src/config.json <<EOF
 {
     "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/",
@@ -22,6 +22,10 @@ EOF
 
 elif [[ $DEPLOY_ENV = "mainnet" ]]; then
   # mainnet config
+  if [ -n "${OWN_CANISTER_ID:-}" ]; then
+    echo "OWN_CANISTER_ID is set which is incompatible with mainnet: '$OWN_CANISTER_ID'"
+  fi
+
   cat >frontend/ts/src/config.json <<EOF
 {
     "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
@@ -32,7 +36,7 @@ EOF
 
 else
   # local config
-  OWN_CANISTER_ID="$(dfx canister --no-wallet --network local id nns-dapp)"
+  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --no-wallet --network local id nns-dapp)}"
   cat >frontend/ts/src/config.json <<EOF
 {
     "IDENTITY_SERVICE_URL": "",


### PR DESCRIPTION
The `update_config.sh` script needs to know which canister ID we build
for, and so far has called out to `dfx` to know which canisters have
been deployed locally (for local deploys). This is a problem in the
docker build since we don't deploy canisters. Instead, we allow
specifying the canister ID. Stop gap measure while we find a better
solution.