### PR TITLE
Add proxy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,4 +32,5 @@ frontend/dart/build/web
 frontend/svelte/node_modules/
 frontend/svelte/public/build/
 frontend/svelte/public/assets/
+proxy
 **/*.wasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,5 +98,11 @@ jobs:
           dfx canister --no-wallet create --all
           dfx stop
 
+      - name: Build proxy
+        working-directory: proxy
+        run: |
+          npm ci
+          npm run build
+
       - name: Build
         run: DEPLOY_ENV=local ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ frontend/dart/web/ic_agent.js
 frontend/ts/build/
 frontend/ts/agent/
 frontend/ts/src/config.json
+proxy/build/
+proxy/node_modules
 canister_ids.json
 
 .dfx/

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,12 +1,13 @@
 # Proxy
 
-Proxies that gives each local canister its own port and funnels the requests to
+A proxy that gives each local canister its own port and funnels the requests to
 the actual running replica.
 
 An example is worth a thousand words:
 
 ``` bash
-$ npm run start
+$ npm run start -- --replica-host 'http://localhost:8080' rwlgt-iiaaa-aaaaa-aaa:8086 rrkah-fqaaa-aaaaa-aaaaq-cai:8087 doesnt-exist-aaaa-aaaaa-cai:8088
+
 Forwarding 8086 to http://localhost:8080/?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
 [HPM] Proxy created: /  -> http://localhost:8080
 Forwarding 8087 to http://localhost:8080/?canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
@@ -22,15 +23,20 @@ Then, in another terminal:
 
 ``` bash
 $ curl http://localhost:8086
-$ curl http://localhost:8087
+<!DOCTYPE html>
+...
+$ curl http://localhost:8087/?foo=bar
+<!DOCTYPE html>
+...
 $ curl http://localhost:8088
+Could not find a canister id to forward to.
 ```
 
 The proxy will have logged the following requests:
 
 ``` bash
 rwlgt-iiaaa-aaaaa-aaaaa-cai (8086) 200 GET / -> /?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
-rrkah-fqaaa-aaaaa-aaaaq-cai (8087) 200 GET / -> /?canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
+rrkah-fqaaa-aaaaa-aaaaq-cai (8087) 200 GET /?foo=bar -> /?foo=bar&canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
 doesnt-exist-aaaa-aaaaa-cai (8088) 400 GET / -> /?canisterId=doesnt-exist-aaaa-aaaaa-cai
 ```
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,55 @@
+# Proxy
+
+Proxies that gives each local canister its own port and funnels the requests to
+the actual running replica.
+
+An example is worth a thousand words:
+
+``` bash
+$ npm run start
+Forwarding 8086 to http://localhost:8080/?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
+[HPM] Proxy created: /  -> http://localhost:8080
+Forwarding 8087 to http://localhost:8080/?canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
+[HPM] Proxy created: /  -> http://localhost:8080
+Forwarding 8088 to http://localhost:8080/?canisterId=doesnt-exist-aaaa-aaaaa-cai
+[HPM] Proxy created: /  -> http://localhost:8080
+Canister rwlgt-iiaaa-aaaaa-aaaaa-cai is listening on http://localhost:8086
+Canister rrkah-fqaaa-aaaaa-aaaaq-cai is listening on http://localhost:8087
+Canister doesnt-exist-aaaa-aaaaa-cai is listening on http://localhost:8088
+```
+
+Then, in another terminal:
+
+``` bash
+$ curl http://localhost:8086
+$ curl http://localhost:8087
+$ curl http://localhost:8088
+```
+
+The proxy will have logged the following requests:
+
+``` bash
+rwlgt-iiaaa-aaaaa-aaaaa-cai (8086) 200 GET / -> /?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
+rrkah-fqaaa-aaaaa-aaaaq-cai (8087) 200 GET / -> /?canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
+doesnt-exist-aaaa-aaaaa-cai (8088) 400 GET / -> /?canisterId=doesnt-exist-aaaa-aaaaa-cai
+```
+
+## Usage
+
+``` bash
+$ npm run start -- --help
+
+USAGE: proxy --replica-host http://... [<canister-id>:<port>]
+```
+
+## Build
+
+``` bash
+$ npm run build
+```
+
+or
+
+``` bash
+$ npm run start # builds _and_ starts
+```

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -5,7 +5,7 @@ the actual running replica.
 
 An example is worth a thousand words:
 
-``` bash
+```bash
 $ npm run start -- --replica-host 'http://localhost:8080' rwlgt-iiaaa-aaaaa-aaa:8086 rrkah-fqaaa-aaaaa-aaaaq-cai:8087 doesnt-exist-aaaa-aaaaa-cai:8088
 
 Forwarding 8086 to http://localhost:8080/?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
@@ -21,7 +21,7 @@ Canister doesnt-exist-aaaa-aaaaa-cai is listening on http://localhost:8088
 
 Then, in another terminal:
 
-``` bash
+```bash
 $ curl http://localhost:8086
 <!DOCTYPE html>
 ...
@@ -34,7 +34,7 @@ Could not find a canister id to forward to.
 
 The proxy will have logged the following requests:
 
-``` bash
+```bash
 rwlgt-iiaaa-aaaaa-aaaaa-cai (8086) 200 GET / -> /?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai
 rrkah-fqaaa-aaaaa-aaaaq-cai (8087) 200 GET /?foo=bar -> /?foo=bar&canisterId=rrkah-fqaaa-aaaaa-aaaaq-cai
 doesnt-exist-aaaa-aaaaa-cai (8088) 400 GET / -> /?canisterId=doesnt-exist-aaaa-aaaaa-cai
@@ -42,7 +42,7 @@ doesnt-exist-aaaa-aaaaa-cai (8088) 400 GET / -> /?canisterId=doesnt-exist-aaaa-a
 
 ## Usage
 
-``` bash
+```bash
 $ npm run start -- --help
 
 USAGE: proxy --replica-host http://... [<canister-id>:<port>]
@@ -50,12 +50,12 @@ USAGE: proxy --replica-host http://... [<canister-id>:<port>]
 
 ## Build
 
-``` bash
+```bash
 $ npm run build
 ```
 
 or
 
-``` bash
+```bash
 $ npm run start # builds _and_ starts
 ```

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -67,7 +67,7 @@ const parsePortMappings = (args: string[]): Record<CanisterId, Port> | string =>
 //      5XX)
 // * listens on the specified port and proxies to
 //      '<replicaHost>/?canisterId=<canisterId>'
-const mkApp = (replicaHost: string, port: number, canisterId: string) => {
+const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: number, canisterId: string}) => {
   const app = express();
 
   // could use morgan's .token() thingy but really not worth it here
@@ -144,5 +144,5 @@ if (Object.keys(parsed.canistersToPorts).length == 0) {
 for (let canisterId in parsed.canistersToPorts) {
   let port = parsed.canistersToPorts[canisterId];
   console.log(`Forwarding ${port} to ${parsed.replicaHost}/?canisterId=${canisterId}`);
-  mkApp(parsed.replicaHost, port, canisterId);
+  mkApp({ replicaHost: parsed.replicaHost, port, canisterId });
 }

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -120,7 +120,7 @@ const mkApp = (replicaHost: string, port: number, canisterId: string) => {
   });
 };
 
-const usage = 'USAGE: proxy --repilca-host http://... [<canister-id>:<port>]';
+const usage = 'USAGE: proxy --replica-host http://... [<canister-id>:<port>]';
 
 const args = process.argv.slice(2);
 

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -27,7 +27,6 @@ const parseArgs = (args: string[]): CLIArguments | string => {
     }
     let [_, replicaHost] = replicaArgs;
 
-
     // Parse the rest of the args as canister/port mappings
     const canistersToPorts = parsePortMappings(args);
 
@@ -62,7 +61,6 @@ const parsePortMappings = (args: string[]): Record<CanisterId, Port> | string =>
 
     return canistersToPorts;
 }
-
 
 // An app that:
 // * logs the requests (green for 2XX, blue for 3XX, yellow for 4XX and red for

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -96,15 +96,15 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
     createProxyMiddleware({
       target: replicaHost,
       pathRewrite: (pathAndParams, req) => {
-        let queryParamsString = "?";
+        let queryParamsString = `?`;
 
         let [path, params] = pathAndParams.split("?");
 
-        if (params === undefined) {
-          queryParamsString = `?canisterId=${canisterId}`;
-        } else {
-          queryParamsString = `?${params}&canisterId=${canisterId}`;
+        if (params) {
+          queryParamsString += `${params}&`;
         }
+
+        queryParamsString += `canisterId=${canisterId}`;
 
         return (path += queryParamsString);
       },

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -1,0 +1,70 @@
+import express from "express";
+import morgan from "morgan";
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+// Use value defined in dfx.json (.networks.local.bind)
+const REPLICA_HOST = "http://localhost:8080";
+
+// Use value defined in .dfx/local/canister_ids.json (.nns-dapp.local) as
+// canister ID
+const canistersToPorts: any = {
+  "rwlgt-iiaaa-aaaaa-aaaaa-cai": 8086,
+};
+
+const mkApp = (port: number, canisterId: string) => {
+  const app = express();
+
+  // could use morgan's .token() thingy but really not worth it here
+  app.use(
+    morgan((_, req, res) => {
+      let color = (rc: number) => {
+        if (rc >= 200 && rc < 300) {
+          return 32; // GREEN
+        } else if (rc >= 300 && rc < 400) {
+          return 34; // BLUE
+        } else if (rc >= 400 && rc < 500) {
+          return 33; // YELLOW
+        } else {
+          return 35; // RED
+        }
+      };
+
+      //console.log(req);
+      return `${canisterId} (${port}) \x1b[${color(res.statusCode)}m${
+        res.statusCode
+      }\x1b[0m ${req.method} ${req.originalUrl} -> ${req.url} `;
+    })
+  );
+
+  app.all(
+    "*",
+    createProxyMiddleware({
+      target: REPLICA_HOST,
+      pathRewrite: (pathAndParams, req) => {
+        let queryParamsString = "?";
+
+        let [path, params] = pathAndParams.split("?");
+
+        // TODO: check for existing canisterID param?
+        if (params === undefined) {
+          queryParamsString = `?canisterId=${canisterId}`;
+        } else {
+          queryParamsString = `?${params}&canisterId=${canisterId}`;
+        }
+
+        return (path += queryParamsString);
+      },
+    })
+  );
+
+  app.listen(port, "localhost", () => {
+    console.log(
+      `Canister ${canisterId} is listening on http://localhost:${port}`
+    );
+  });
+};
+
+for (let canisterId in canistersToPorts) {
+  let port = canistersToPorts[canisterId];
+  mkApp(port, canisterId);
+}

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -7,67 +7,75 @@ type CanisterId = string;
 type Port = number;
 
 interface CLIArguments {
-    replicaHost: string,
-    canistersToPorts: Record<CanisterId, Port>,
+  replicaHost: string;
+  canistersToPorts: Record<CanisterId, Port>;
 }
 
 // Parse all the arguments, returning an error string if parsing failed.
 const parseArgs = (args: string[]): CLIArguments | string => {
+  // Ensure '--replica-host http://...' was specified
+  const replicaArgIndex = args.indexOf("--replica-host");
+  if (replicaArgIndex == -1) {
+    return "Please specify --replica-host";
+  }
 
-    // Ensure '--replica-host http://...' was specified
-    const replicaArgIndex = args.indexOf("--replica-host");
-    if(replicaArgIndex == -1) {
-        return 'Please specify --replica-host';
-    }
+  // Remove the '--replica-host http://...' from the args and store the value
+  const replicaArgs = args.splice(replicaArgIndex, 2);
+  if (replicaArgs.length != 2) {
+    return "No value for --replica-host";
+  }
+  const [_, replicaHost] = replicaArgs;
 
-    // Remove the '--replica-host http://...' from the args and store the value
-    const replicaArgs = args.splice(replicaArgIndex, 2);
-    if(replicaArgs.length != 2) {
-        return 'No value for --replica-host';
-    }
-    const [_, replicaHost] = replicaArgs;
+  // Parse the rest of the args as canister/port mappings
+  const canistersToPorts = parsePortMappings(args);
 
-    // Parse the rest of the args as canister/port mappings
-    const canistersToPorts = parsePortMappings(args);
-
-    if(typeof canistersToPorts === "string") {
-        return canistersToPorts;
-    } else {
-        return { replicaHost, canistersToPorts };
-    }
-}
+  if (typeof canistersToPorts === "string") {
+    return canistersToPorts;
+  } else {
+    return { replicaHost, canistersToPorts };
+  }
+};
 
 // Parse the canister ID to port mappings (rwajt-...:8086 rdm6x-...:443 ...)
-const parsePortMappings = (args: string[]): Record<CanisterId, Port> | string => {
-    const canistersToPorts: Record<CanisterId,Port> = {};
-    for (const arg of args) {
+const parsePortMappings = (
+  args: string[]
+): Record<CanisterId, Port> | string => {
+  const canistersToPorts: Record<CanisterId, Port> = {};
+  for (const arg of args) {
+    const tokens = arg.split(":");
 
-        const tokens = arg.split(":");
-
-        if (tokens.length != 2) {
-            return `Could not parse '${arg}'`;
-        }
-
-        const [canisterId, portStr] = tokens;
-
-        const port = parseInt(portStr);
-
-        if(Number.isNaN(port)) {
-            return `Could not parse port '${portStr}' as number`;
-        }
-
-        canistersToPorts[canisterId] = port;
+    if (tokens.length != 2) {
+      return `Could not parse '${arg}'`;
     }
 
-    return canistersToPorts;
-}
+    const [canisterId, portStr] = tokens;
+
+    const port = parseInt(portStr);
+
+    if (Number.isNaN(port)) {
+      return `Could not parse port '${portStr}' as number`;
+    }
+
+    canistersToPorts[canisterId] = port;
+  }
+
+  return canistersToPorts;
+};
 
 // An app that:
 // * logs the requests (green for 2XX, blue for 3XX, yellow for 4XX and red for
 //      5XX)
 // * listens on the specified port and proxies to
 //      '<replicaHost>/?canisterId=<canisterId>'
-const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: number, canisterId: string}) => {
+const mkApp = ({
+  replicaHost,
+  port,
+  canisterId,
+}: {
+  replicaHost: string;
+  port: number;
+  canisterId: string;
+}) => {
   const app = express();
 
   // could use morgan's .token() thingy but really not worth it here
@@ -106,7 +114,7 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
 
         queryParamsString += `canisterId=${canisterId}`;
 
-        return (path + queryParamsString);
+        return path + queryParamsString;
       },
     })
   );
@@ -118,31 +126,33 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
   });
 };
 
-const usage = 'USAGE: proxy --replica-host http://... [<canister-id>:<port>]';
+const usage = "USAGE: proxy --replica-host http://... [<canister-id>:<port>]";
 
 const args = process.argv.slice(2);
 
-if(args.indexOf("--help") != -1) {
-    console.log(usage);
-    process.exit(0);
+if (args.indexOf("--help") != -1) {
+  console.log(usage);
+  process.exit(0);
 }
 
 const parsed = parseArgs(args);
 
-if(typeof parsed === "string") {
-    console.log(parsed);
-    console.log(usage);
-    process.exit(1);
+if (typeof parsed === "string") {
+  console.log(parsed);
+  console.log(usage);
+  process.exit(1);
 }
 
 if (Object.keys(parsed.canistersToPorts).length == 0) {
-    console.log("No canisters to proxy");
-    console.log(usage);
-    process.exit(1)
+  console.log("No canisters to proxy");
+  console.log(usage);
+  process.exit(1);
 }
 
 for (const canisterId in parsed.canistersToPorts) {
   const port = parsed.canistersToPorts[canisterId];
-  console.log(`Forwarding ${port} to ${parsed.replicaHost}/?canisterId=${canisterId}`);
+  console.log(
+    `Forwarding ${port} to ${parsed.replicaHost}/?canisterId=${canisterId}`
+  );
   mkApp({ replicaHost: parsed.replicaHost, port, canisterId });
 }

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -25,7 +25,7 @@ const parseArgs = (args: string[]): CLIArguments | string => {
     if(replicaArgs.length != 2) {
         return 'No value for --replica-host';
     }
-    let [_, replicaHost] = replicaArgs;
+    const [_, replicaHost] = replicaArgs;
 
     // Parse the rest of the args as canister/port mappings
     const canistersToPorts = parsePortMappings(args);
@@ -39,18 +39,18 @@ const parseArgs = (args: string[]): CLIArguments | string => {
 
 // Parse the canister ID to port mappings (rwajt-...:8086 rdm6x-...:443 ...)
 const parsePortMappings = (args: string[]): Record<CanisterId, Port> | string => {
-    let canistersToPorts: Record<CanisterId,Port> = {};
-    for (let arg of args) {
+    const canistersToPorts: Record<CanisterId,Port> = {};
+    for (const arg of args) {
 
-        let tokens = arg.split(":");
+        const tokens = arg.split(":");
 
         if (tokens.length != 2) {
             return `Could not parse '${arg}'`;
         }
 
-        let [canisterId, portStr] = tokens;
+        const [canisterId, portStr] = tokens;
 
-        let port = parseInt(portStr);
+        const port = parseInt(portStr);
 
         if(Number.isNaN(port)) {
             return `Could not parse port '${portStr}' as number`;
@@ -73,7 +73,7 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
   // could use morgan's .token() thingy but really not worth it here
   app.use(
     morgan((_, req, res) => {
-      let color = (rc: number) => {
+      const color = (rc: number) => {
         if (rc >= 200 && rc < 300) {
           return 32; // GREEN
         } else if (rc >= 300 && rc < 400) {
@@ -98,7 +98,7 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
       pathRewrite: (pathAndParams, req) => {
         let queryParamsString = `?`;
 
-        let [path, params] = pathAndParams.split("?");
+        const [path, params] = pathAndParams.split("?");
 
         if (params) {
           queryParamsString += `${params}&`;
@@ -106,7 +106,7 @@ const mkApp = ({replicaHost, port, canisterId} : { replicaHost: string, port: nu
 
         queryParamsString += `canisterId=${canisterId}`;
 
-        return (path += queryParamsString);
+        return (path + queryParamsString);
       },
     })
   );
@@ -141,8 +141,8 @@ if (Object.keys(parsed.canistersToPorts).length == 0) {
     process.exit(1)
 }
 
-for (let canisterId in parsed.canistersToPorts) {
-  let port = parsed.canistersToPorts[canisterId];
+for (const canisterId in parsed.canistersToPorts) {
+  const port = parsed.canistersToPorts[canisterId];
   console.log(`Forwarding ${port} to ${parsed.replicaHost}/?canisterId=${canisterId}`);
   mkApp({ replicaHost: parsed.replicaHost, port, canisterId });
 }

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,0 +1,620 @@
+{
+  "name": "proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.27",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz",
+      "integrity": "sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/http-proxy": {
+      "version": "1.17.8",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
+      "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/http-proxy-middleware": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-1.0.0.tgz",
+      "integrity": "sha512-/s8lFX6rT43hSPqjjD8KNuu0SkPKY7uIdR6u9DCxVqCRhAvfKxGbVOixJsAT2mdpSnCyrGFAGoB39KFh6tmRxw==",
+      "requires": {
+        "http-proxy-middleware": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
+    "@types/morgan": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
+      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "requires": {
+        "bytes": "3.1.1",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
+        "type-is": "~1.6.18"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "bytes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "express": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.6",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
+      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+      "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+      "requires": {
+        "@types/http-proxy": "^1.17.5",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+    },
+    "mime-types": {
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "requires": {
+        "mime-db": "1.51.0"
+      }
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "requires": {
+        "bytes": "3.1.1",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -288,9 +288,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "forwarded": {
       "version": "0.2.0",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "proxy",
+  "version": "1.0.0",
+  "description": "A proxy for local canisters",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc --outDir build",
+    "start": "npm run build && node ./build/index.js",
+    "format": "prettier --write --plugin-search-dir=. ."
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/http-proxy-middleware": "^1.0.0",
+    "@types/morgan": "^1.9.3",
+    "express": "^4.17.2",
+    "http-proxy-middleware": "^2.0.1",
+    "morgan": "^1.10.0",
+    "typescript": "^4.5.4",
+    "prettier": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13"
+  }
+}

--- a/proxy/tsconfig.json
+++ b/proxy/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
This adds a proxy that gives each local canister its own port and funnels the requests to the actual running replica. This is necessary, otherwise redirects between the svelte app and the flutter code fail when served from `dfx` and a local replica, since the local replica expects the `canisterId` query param to be set.

I'll sync with @krpeacock to figure out if this should be `dfx`'s default behavior, in the meantime this works just fine.

---

Used by https://github.com/dfinity/nns-dapp/pull/367