### PR TITLE
refactor: rename voting to proposals

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -4,7 +4,7 @@
   import Guard from "./lib/components/Guard.svelte";
   import Accounts from "./routes/Accounts.svelte";
   import Neurons from "./routes/Neurons.svelte";
-  import Voting from "./routes/Voting.svelte";
+  import Proposals from "./routes/Proposals.svelte";
   import Canisters from "./routes/Canisters.svelte";
   import Auth from "./routes/Auth.svelte";
 </script>
@@ -23,7 +23,7 @@
   <Route path="/" component={Auth} />
   <PrivateRoute path="/#/accounts" component={Accounts} />
   <PrivateRoute path="/#/neurons" component={Neurons} />
-  <PrivateRoute path="/#/voting" component={Voting} />
+  <PrivateRoute path="/#/proposals" component={Proposals} />
   <PrivateRoute path="/#/canisters" component={Canisters} />
 </Guard>
 

--- a/frontend/svelte/src/lib/components/Nav.svelte
+++ b/frontend/svelte/src/lib/components/Nav.svelte
@@ -8,7 +8,7 @@
   const routes: { context: string; label: string }[] = [
     { context: "accounts", label: "ICP" },
     { context: "neurons", label: "NEURONS" },
-    { context: "voting", label: "VOTING" },
+    { context: "proposals", label: "VOTING" },
     { context: "canisters", label: "CANISTERS" },
   ];
 </script>

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -5,7 +5,7 @@
   // TODO: To be removed once this page has been implemented
   onMount(() => {
     if (process.env.REDIRECT_TO_LEGACY) {
-      window.location.replace("/#/voting");
+      window.location.replace("/#/proposals");
     }
   });
 </script>


### PR DESCRIPTION
# Motivation

In current Flutter app, the "Voting" page actually points to route `#/proposals`. For backwards compatibility between this app and the current rewrite, we want to maintain the same route name.

# Changes

- rename route `#/voting` to `#/proposals`