### PR TITLE
Update build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,6 @@ dist
 screenshots
 target
 out
-assets.tar.xz
 web-assets
 frontend/ts/node_modules
 frontend/ts/build

--- a/.dockerignore
+++ b/.dockerignore
@@ -33,5 +33,4 @@ frontend/svelte/node_modules/
 frontend/svelte/public/build/
 frontend/svelte/public/assets/
 proxy
-scripts
 **/*.wasm

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ screenshots
 target
 out
 assets.tar.xz
+web-assets
 frontend/ts/node_modules
 frontend/ts/build
 frontend/dart/.dart_tool

--- a/.dockerignore
+++ b/.dockerignore
@@ -33,4 +33,5 @@ frontend/svelte/node_modules/
 frontend/svelte/public/build/
 frontend/svelte/public/assets/
 proxy
+scripts
 **/*.wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use this with
 #
 # docker build . -t nns-dapp
-# container_id=$(docker create nns-dapp)
+# container_id=$(docker create nns-dapp no-op)
 # docker cp $container_id:nns-dapp.wasm nns-dapp.wasm
 # docker rm --volumes $container_id
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Use this with
 #
-# docker build -t nns-dapp .
-# docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > nns-dapp.wasm
+# docker build . -t nns-dapp
+# container_id=$(docker create nns-dapp)
+# docker cp $container_id:nns-dapp.wasm nns-dapp.wasm
+# docker rm --volumes $container_id
 
 # This is the "builder", i.e. the base image used later to build the final
 # code.
@@ -76,10 +78,8 @@ RUN echo "OWN_CANISTER_ID: '$OWN_CANISTER_ID'"
 COPY . .
 RUN ./build.sh
 
-# Copy the wasm to the traditional location.
-RUN cp "$(jq -rc '.canisters["nns-dapp"].wasm' dfx.json)" nns-dapp.wasm
 RUN ls -sh nns-dapp.wasm; sha256sum nns-dapp.wasm
 
-FROM scratch
+FROM scratch AS scratch
 COPY --from=build /nns-dapp.wasm /
 COPY --from=build /assets.tar.xz /

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ can validate that we really deploy what we claim to deploy.
 We try to achieve some level of reproducibility using a Dockerized build
 environment. The following steps _should_ build the official Wasm image
 
-    docker build -t nns-dapp .
-    docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > nns-dapp.wasm
+    ./scripts/docker-build
     sha256sum nns-dapp.wasm
 
 The resulting `nns-dapp.wasm` is ready for deployment as

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,29 @@ set -x
 #################
 # assets.tar.xz #
 #################
+
+# we need GNU tar (see below) so we check early
+if tar --help | grep GNU >/dev/null
+then
+    echo "found GNU tar as tar"
+    tar="tar"
+elif command -v gtar >/dev/null
+then
+    echo "found GNU tar as gtar"
+    tar="gtar"
+else
+    echo "did not find GNU tar, please install"
+    echo "  brew install gnu-tar"
+    exit 1
+fi
+
+if ! command -v xz >/dev/null
+then
+    echo "did not find xz, please install"
+    echo "  brew install xz"
+    exit 1
+fi
+
 tarball_dir=$(mktemp -d)
 echo "using $tarball_dir for tarball directory"
 cp -R "$TOPLEVEL/frontend/dart/build/web/". "$tarball_dir"/
@@ -70,8 +93,7 @@ cd "$tarball_dir"
 
 # Remove the assets/NOTICES file, as it's large in size and not used.
 rm assets/NOTICES
-tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" . ||
-  gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
+"$tar" cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
 
 cd "$TOPLEVEL"
 rm -rf "$tarball_dir"

--- a/build.sh
+++ b/build.sh
@@ -59,25 +59,22 @@ set -x
 #################
 
 # we need GNU tar (see below) so we check early
-if tar --help | grep GNU >/dev/null
-then
-    echo "found GNU tar as tar"
-    tar="tar"
-elif command -v gtar >/dev/null
-then
-    echo "found GNU tar as gtar"
-    tar="gtar"
+if tar --help | grep GNU >/dev/null; then
+  echo "found GNU tar as tar"
+  tar="tar"
+elif command -v gtar >/dev/null; then
+  echo "found GNU tar as gtar"
+  tar="gtar"
 else
-    echo "did not find GNU tar, please install"
-    echo "  brew install gnu-tar"
-    exit 1
+  echo "did not find GNU tar, please install"
+  echo "  brew install gnu-tar"
+  exit 1
 fi
 
-if ! command -v xz >/dev/null
-then
-    echo "did not find xz, please install"
-    echo "  brew install xz"
-    exit 1
+if ! command -v xz >/dev/null; then
+  echo "did not find xz, please install"
+  echo "  brew install xz"
+  exit 1
 fi
 
 tarball_dir=$(mktemp -d)

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-TOPLEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOPLEVEL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ $DEPLOY_ENV = "nobuild" ]]; then
   echo "Skipping build as requested"
@@ -44,18 +44,15 @@ set -x
 # build requires "ic_agent.js" which is generated from frontend/ts.
 (cd "$TOPLEVEL/frontend/ts" && ./build.sh)
 
-
 #################
 # frontend/dart # (output: frontend/dart/build/web/)
 #################
 (cd "$TOPLEVEL/frontend/dart" && ./build.sh)
 
-
 ###################
 # frontend/svelte # (output: frontend/svelte/public/)
 ###################
 (cd "$TOPLEVEL/frontend/svelte" && npm ci && npm run build)
-
 
 #################
 # assets.tar.xz #
@@ -82,17 +79,16 @@ rm -rf "$tarball_dir"
 ls -sh "$TOPLEVEL/assets.tar.xz"
 sha256sum "$TOPLEVEL/assets.tar.xz"
 
-
 ###############
 # cargo build # (output: target/release/.../nns-dapp.wasm)
 ###############
 echo Compiling rust package
-cargo_args=( --target wasm32-unknown-unknown --release --package nns-dapp)
+cargo_args=(--target wasm32-unknown-unknown --release --package nns-dapp)
 if [[ $DEPLOY_ENV != "mainnet" ]]; then
-    cargo_args+=( --features mock_conversion_rate )
+  cargo_args+=(--features mock_conversion_rate)
 fi
 
-(cd "$TOPLEVEL" &&  cargo build "${cargo_args[@]}")
+(cd "$TOPLEVEL" && cargo build "${cargo_args[@]}")
 
 ####################
 # ic-cdk-optimizer # (output: nns-dapp.wasm)

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
+#
+# First the typescript shim is built and bundled into ic_agent.js, which is
+# then added to the frontend/dart codebase. This dart codebase is then built
+# into build/web. The frontend/svelte is built into public/. Both the dart
+# output (build/web/) and svelte output (public/) are bundled into a tarball,
+# assets.tar.xz. This tarball is baked into the wasm binary output at build
+# time by cargo, and finally the wasm binary is read by ic-cdk-optimizer and
+# optimizer. This scripts outputs a single file, nns-dapp.wasm.
+#
+#              ic_agent.js               build/web/
+#  frontend/ts◄────────────frontend/dart ◄──────────┐
+#                                          public/  ├──assets.tar.xz
+#                          frontend/svelte◄─────────┘       ▲
+#                                                           │
+#                                                           │
+#                                                      cargo build
+#                                                           ▲
+#                                                           │ ic-cdk-optimizer
+#                                                           │
+#                                                      nns-dapp.wasm
 
-set -e
+set -euo pipefail
+
+TOPLEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ $DEPLOY_ENV = "nobuild" ]]; then
   echo "Skipping build as requested"
@@ -14,48 +36,69 @@ fi
 
 set -x
 
+###############
+# frontend/ts # (output: ic_agent.js written to frontend/dart/assets)
+###############
+
 # build typescript code. Must happen before the dart build because the dart
 # build requires "ic_agent.js" which is generated from frontend/ts.
-(cd frontend/ts && ./build.sh)
+(cd "$TOPLEVEL/frontend/ts" && ./build.sh)
 
-# Build the Flutter codebase
-./frontend/dart/build.sh
 
-rm -f assets.tar.xz
-rm -fr web-assets
-cp -R frontend/dart/build/web/ web-assets
+#################
+# frontend/dart # (output: frontend/dart/build/web/)
+#################
+(cd "$TOPLEVEL/frontend/dart" && ./build.sh)
 
-# Build the svelte app
-pushd frontend/svelte || exit
-npm ci
-npm run build
-popd || exit
 
-rm -fr web-assets/v2
-cp -R frontend/svelte/public web-assets/v2
+###################
+# frontend/svelte # (output: frontend/svelte/public/)
+###################
+(cd "$TOPLEVEL/frontend/svelte" && npm ci && npm run build)
+
+
+#################
+# assets.tar.xz #
+#################
+tarball_dir=$(mktemp -d)
+echo "using $tarball_dir for tarball directory"
+cp -R "$TOPLEVEL/frontend/dart/build/web/". "$tarball_dir"/
+cp -R "$TOPLEVEL/frontend/svelte/public" "$tarball_dir/v2"
 
 # Bundle into a tight tarball
 # On macOS you need to install gtar + xz
 # brew install gnu-tar
 # brew install xz
-pushd web-assets || exit
+cd "$tarball_dir"
+
 # Remove the assets/NOTICES file, as it's large in size and not used.
 rm assets/NOTICES
-tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../assets.tar.xz . ||
-  gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f ../assets.tar.xz .
-popd || exit
+tar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" . ||
+  gtar cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
 
-ls -sh assets.tar.xz
-sha256sum assets.tar.xz
+cd "$TOPLEVEL"
+rm -rf "$tarball_dir"
 
+ls -sh "$TOPLEVEL/assets.tar.xz"
+sha256sum "$TOPLEVEL/assets.tar.xz"
+
+
+###############
+# cargo build # (output: target/release/.../nns-dapp.wasm)
+###############
 echo Compiling rust package
-if [[ $DEPLOY_ENV = "mainnet" ]]; then
-  cargo build --target wasm32-unknown-unknown --release --package nns-dapp
-else
-  cargo build --target wasm32-unknown-unknown --release --package nns-dapp --features mock_conversion_rate
+cargo_args=( --target wasm32-unknown-unknown --release --package nns-dapp)
+if [[ $DEPLOY_ENV != "mainnet" ]]; then
+    cargo_args+=( --features mock_conversion_rate )
 fi
 
+(cd "$TOPLEVEL" &&  cargo build "${cargo_args[@]}")
+
+####################
+# ic-cdk-optimizer # (output: nns-dapp.wasm)
+####################
 echo Optimising wasm
-ic-cdk-optimizer target/wasm32-unknown-unknown/release/nns-dapp.wasm -o target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
-ls -sh target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
-sha256sum target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm
+cd "$TOPLEVEL"
+ic-cdk-optimizer ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
+ls -sh ./nns-dapp.wasm
+sha256sum ./nns-dapp.wasm

--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,7 @@ fi
 # We use a local directory, and we don't delete it after the build, so that
 # assets can be inspected.
 tarball_dir="$TOPLEVEL/web-assets"
+rm -rf "$tarball_dir"
 mkdir -p "$tarball_dir"
 echo "using $tarball_dir for tarball directory"
 cp -R "$TOPLEVEL/frontend/dart/build/web/". "$tarball_dir"/

--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,10 @@ if ! command -v xz >/dev/null; then
   exit 1
 fi
 
-tarball_dir=$(mktemp -d)
+# We use a local directory, and we don't delete it after the build, so that
+# assets can be inspected.
+tarball_dir="$TOPLEVEL/web-assets"
+mkdir -p "$tarball_dir"
 echo "using $tarball_dir for tarball directory"
 cp -R "$TOPLEVEL/frontend/dart/build/web/". "$tarball_dir"/
 cp -R "$TOPLEVEL/frontend/svelte/public" "$tarball_dir/v2"
@@ -93,7 +96,6 @@ rm assets/NOTICES
 "$tar" cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
 
 cd "$TOPLEVEL"
-rm -rf "$tarball_dir"
 
 ls -sh "$TOPLEVEL/assets.tar.xz"
 sha256sum "$TOPLEVEL/assets.tar.xz"

--- a/dfx.json
+++ b/dfx.json
@@ -4,9 +4,8 @@
     "nns-dapp": {
       "type": "custom",
       "candid": "rs/nns-dapp.did",
-      "wasm": "target/wasm32-unknown-unknown/release/nns-dapp-opt.wasm",
-      "build": "./build.sh",
-      "source": ["assets.tar.xz"]
+      "wasm": "nns-dapp.wasm",
+      "build": "./build.sh"
     }
   },
   "networks": {

--- a/frontend/dart/build.sh
+++ b/frontend/dart/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Build the flutter app
+# Build the flutter app. This populates ./build/web/, a directory that has the
+# same hierarchy as how the files should be served.
 
 set -euo pipefail
 

--- a/frontend/ts/build.sh
+++ b/frontend/ts/build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 TS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$TS_DIR/../../"
+TOPLEVEL="$TS_DIR/../../"
 
 # Check that the DEPLOY_ENV is set
 DEPLOY_ENV="${DEPLOY_ENV:-}"
@@ -12,7 +12,7 @@ if ! [[ $DEPLOY_ENV = "testnet" ]] && ! [[ $DEPLOY_ENV = "mainnet" ]] && ! [[ $D
   exit 1
 fi
 
-cd "$ROOT"
+cd "$TOPLEVEL"
 # Create config file with proper configurations.
 ./update_config.sh
 

--- a/frontend/ts/build.sh
+++ b/frontend/ts/build.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
-set -e
+# Build the typescript shim. This outputs a single file, ic_agent.js.
+set -euo pipefail
 
+TS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$TS_DIR/../../"
+
+# Check that the DEPLOY_ENV is set
+DEPLOY_ENV="${DEPLOY_ENV:-}"
 if ! [[ $DEPLOY_ENV = "testnet" ]] && ! [[ $DEPLOY_ENV = "mainnet" ]] && ! [[ $DEPLOY_ENV = "local" ]]; then
   echo "Which deployment environment? Set DEPLOY_ENV to 'testnet' or 'mainnet' or 'local'"
   exit 1
 fi
 
-npm ci
-
-pushd "$(dirname "$0")"
-cd ../..
+cd "$ROOT"
 # Create config file with proper configurations.
 ./update_config.sh
-popd
 
+cd "$TS_DIR"
+
+npm ci
 npx tsc
 echo "Bundling..."
+# Unfortunately dart relies on ic_agent.js at build time so we have to actually
+# modify the codebase
 npx browserify ./build/index.js --standalone IcAgent >../dart/assets/ic_agent.js
 echo "Done."

--- a/frontend/ts/build.sh
+++ b/frontend/ts/build.sh
@@ -2,7 +2,7 @@
 # Build the typescript shim. This outputs a single file, ic_agent.js.
 set -euo pipefail
 
-TS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$TS_DIR/../../"
 
 # Check that the DEPLOY_ENV is set

--- a/scripts/deploy-docker-build-to-testnet
+++ b/scripts/deploy-docker-build-to-testnet
@@ -2,13 +2,8 @@
 set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
-WASM_PATH="$(jq -rc '.canisters["nns-dapp"].wasm' dfx.json)"
+./scripts/docker-build
 
-docker build --build-arg DEPLOY_ENV=testnet -t nns-dapp .
-mkdir -p target/wasm32-unknown-unknown/release/
-# shellcheck disable=SC2094 # The source and destination files are not the same, the first is in docker.
-docker run --rm --entrypoint cat nns-dapp "$WASM_PATH" >"$WASM_PATH"
-docker run --rm --entrypoint cat nns-dapp /assets.tar.xz >assets.tar.xz
 DEPLOY_ENV=nobuild dfx deploy --no-wallet --network testnet
 
 set +x

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -41,9 +41,6 @@ docker build \
     -t "$image_name" .
 set +x
 
-echo creating
-set -x
-
 # use no-op as a command, doesn't matter since the container is never run
 container_id=$(docker create "$image_name" no-op)
 

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,0 +1,78 @@
+#/usr/bin/env bash
+# vim: ft=bash
+# Build nns-dapp.wasm inside docker. This outputs a single file, nns-dapp.wasm,
+# in the top-level directory.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$SCRIPTS_DIR/.."
+
+DEPLOY_ENV=${DEPLOY_ENV:-mainnet}
+
+case "$DEPLOY_ENV" in
+    mainnet)
+        OWN_CANISTER_ID=""
+        ;;
+    "local")
+        OWN_CANISTER_ID=${OWN_CANISTER_ID:-rwlgt-iiaaa-aaaaa-aaaaa-cai}
+        ;;
+    *)
+        echo "don't know how to set OWN_CANISTER_ID for DEPLOY_ENV $DEPLOY_ENV"
+        echo "please set the environment variable OWN_CANISTER_ID"
+        exit 1
+        ;;
+esac
+
+echo "DEPLOY_ENV: $DEPLOY_ENV"
+echo "OWN_CANISTER_ID: $OWN_CANISTER_ID"
+echo "PWD: $PWD"
+
+image_name="nns-dapp-$DEPLOY_ENV"
+
+echo "The following image name will be used: $image_name"
+
+set -x
+docker build \
+    --target scratch \
+    --build-arg DEPLOY_ENV="$DEPLOY_ENV" \
+    --build-arg OWN_CANISTER_ID="$OWN_CANISTER_ID" \
+    -t "$image_name" .
+set +x
+
+echo creating
+set -x
+
+# use no-op as a command, doesn't matter since the container is never run
+container_id=$(docker create "$image_name" no-op)
+
+echo "created container with id $container_id"
+
+success=true
+
+copy() {
+    local container_id="$1"
+    local container_path="$2"
+    local local_path="$3"
+
+    if docker cp $container_id:/"$container_path" "$local_path"
+    then
+        echo "$container_path -> $local_path (from container $container_id)"
+        return 0
+    else
+        echo "could not copy $container_path from container $container_id"
+        return 1
+    fi
+}
+
+copy "$container_id" "nns-dapp.wasm" "nns-dapp.wasm" || success=false
+
+if [[ $success = true ]]
+then
+    echo "Removing container $container_id"
+    docker rm --volumes "$container_id"
+else
+    echo "container is left for inspection, once done run:"
+    echo "  docker rm -v $container_id"
+fi


### PR DESCRIPTION
This scratches an old itch I had and fixes some documentation for running the docker build. In particular:

* Adds `scripts/docker-build` which outputs `nns-dapp.wasm` in the top-level (that's the final, optimized wasm).
* Removes `source` from dfx.json. `source` (i.e. `assets.tar.xz`) isn't used in `custom` builds AFAICT. 
* Specifies `nns-dapp.wasm` as the wasm input for `dfx`, there's no reason to actually modify cargo's generated files in `target` with `ic-cdk-optimizer`; instead we only read those files, and place the (optimized) output in the top-level.
* Performs some checks on the tar version used. Not only does this not obfuscate tar errors anymore (which was done with `||`) but also clarifies the intent. It also gives the user directions on how to install GNU tar.
* Clarifies `build.sh` a ton by:
  * adding a diagram of what happens during the build
  * making most steps resemble each other (svelte, dart and ts builds)
  * use absolute paths with `cd` as opposed to `pushd`ing (greatly reduces the cognitive load since the person reading the scripts doesn't have to keep track of `$PWD`) (also applied to other build scripts)
  * actually use `set -euo pipefail` for sanity (also applied to other build scripts)
  * remove `web-assets`, which really was a temp directory in disguise (as are assets.tar.xz and ic_agent.js, but right now we can't get rid of those because they are referenced in resp the rust and dart builds)