### PR TITLE
Use the same npm version in gh and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.54.0
-ENV NODE_VERSION=14.15.4
+ENV NODE_VERSION=16.13.2
 
 ENV TZ=UTC
 


### PR DESCRIPTION
# Motivation
A small discrepancy in build systems:  The node version:
- The dockerfile specifies NODE_VERSION=14.15.4
  - But if I npm install with 14.15.4 the lockfile changes quite a lot.
- The github actions use the default for Ubuntu 20.04 github image, which is 16.13.2

# Changes
- Bump the Docker npm version to 16.13.2

# Testing
This SHOULD produce the same wasm build hash as main.
- At the time of writing, the builds to compare are:
  - https://github.com/dfinity/nns-dapp/actions/runs/1740097395
  - https://github.com/dfinity/nns-dapp/actions/runs/1740855380 (building...)