### PR TITLE
Fix docker build

### DIFF
--- a/scripts/deploy-docker-build-to-testnet
+++ b/scripts/deploy-docker-build-to-testnet
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
-./scripts/docker-build
+DEPLOY_ENV=testnet ./scripts/docker-build
 
 DEPLOY_ENV=nobuild dfx deploy --no-wallet --network testnet
 

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -11,6 +11,23 @@ cd "$SCRIPTS_DIR/.."
 
 DEPLOY_ENV=${DEPLOY_ENV:-mainnet}
 
+# Here the OWN_CANISTER_ID is set.  The value is taken from the following, in order of priority:
+# - The env var OWN_CANISTER_ID
+# - canister_ids.json
+# - try to deduce the value.
+if test -n "${OWN_CANISTER_ID:-}"
+then echo "Using env var OWN_CANISTER_ID: $OWN_CANISTER_ID"
+fi
+
+if test -z "${OWN_CANISTER_ID:-}" && test -e canister_ids.json
+then OWN_CANISTER_ID="$(jq -r '.["nns-dapp"]["'"$DEPLOY_ENV"'"]' canister_ids.json)"
+     if test -n "${OWN_CANISTER_ID:-}"
+     then echo "Using caniser ID from canister_ids.json: $OWN_CANISTER_ID"
+     fi
+fi
+
+if test -z "${OWN_CANISTER_ID:-}"
+then
 case "$DEPLOY_ENV" in
     mainnet)
         OWN_CANISTER_ID=""
@@ -24,6 +41,7 @@ case "$DEPLOY_ENV" in
         exit 1
         ;;
 esac
+fi
 
 echo "DEPLOY_ENV: $DEPLOY_ENV"
 echo "OWN_CANISTER_ID: $OWN_CANISTER_ID"


### PR DESCRIPTION
# Motivation
The prod release process broke due to changes introduced for ci testing.  This PR is an attempt to find a clean solution that works for both.

Design goals:
- Simplify code.
- Have a documented algorithm for setting OWN_CANISTER_ID.
- Centralize logic, so that developers don't need to search through the codebase to try to figure out how variables are set.
  - Note: We can and probably should also set the default own_canister_id in this code block.  That requires more changes and more testing though, and right now deployments break so it would be better to add that later.

# Changes
The logic for determining OWN_CANISTER_ID implements this design:
```
# Here the OWN_CANISTER_ID is set.  The value is taken from the following, in order of priority:
# - The env var OWN_CANISTER_ID
# - canister_ids.json
# - try to deduce the value.
```