### PR TITLE
feat: trim query string in route path and tests

### DIFF
--- a/frontend/svelte/jest.config.cjs
+++ b/frontend/svelte/jest.config.cjs
@@ -11,4 +11,5 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/jest-setup.ts"],
   collectCoverageFrom: ["src/**/*.{ts,tsx,svelte,js,jsx}"],
   testPathIgnorePatterns: ["nns-js"],
+  testURL: 'https://nns.ic0.app/'
 };

--- a/frontend/svelte/src/lib/utils/route.utils.ts
+++ b/frontend/svelte/src/lib/utils/route.utils.ts
@@ -1,10 +1,10 @@
 /**
- * The pathname and the hash without base href
+ * The pathname and the hash without base href and without the query string
  */
 export const routePath = (): string => {
   const base: string = baseHref();
   const { pathname, hash } = window.location;
-  return `${pathname.replace(base, "/")}${hash.toLowerCase()}`;
+  return `${pathname.replace(base, "/")}${hash.replace(/\?.*/,'').toLowerCase()}`;
 };
 
 // e.g. #/accounts => accounts

--- a/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
@@ -3,14 +3,32 @@
  */
 
 import {
+  baseHref,
   pushHistory,
   replaceHistory,
   routeContext,
   routePath,
-} from "../../../lib/utils/route.utils";
+} from '../../../lib/utils/route.utils';
 import * as routeUtils from "../../../lib/utils/route.utils";
 
 describe("route-utils", () => {
+
+  describe('base href', () => {
+    it("should return base href according document uri", () => {
+      expect(baseHref()).toEqual("/");
+    });
+
+    it("should return base href according head tag", () => {
+      const base = document.createElement('base');
+      base.href = '/test/';
+      document.head.appendChild(base);
+
+      expect(baseHref()).toEqual("/test/");
+
+      base.parentElement.removeChild(base);
+    });
+  })
+
   const resetTestURL = (baseUrl) =>
     window.history.replaceState({}, "Test Title", baseUrl);
 

--- a/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  replaceHistory,
+  routeContext,
+  routePath,
+} from "../../../lib/utils/route.utils";
+
+describe("route-utils", () => {
+  const baseHref = "https://nns.ic0.app/";
+
+  const resetTestURL = () =>
+    window.history.replaceState({}, "Test Title", baseHref);
+
+  afterEach(() => resetTestURL());
+
+  // TODO: base href /v2/
+
+  it("should return the pathname and the hash without base href", () => {
+    expect(routePath()).toEqual("/");
+
+    window.history.replaceState({}, undefined, "/?redirect=accounts");
+    expect(routePath()).toEqual("/");
+
+    window.history.replaceState({}, undefined, "/#/accounts");
+    expect(routePath()).toEqual("/#/accounts");
+
+    window.history.replaceState({}, undefined, "/accounts");
+    expect(routePath()).toEqual("/accounts");
+
+    // TODO: ?
+    window.history.replaceState({}, undefined, "/#/accounts?param=test");
+    expect(routePath()).toEqual("/#/accounts?param=test");
+
+    window.history.replaceState({}, undefined, "/accounts?param=test");
+    expect(routePath()).toEqual("/accounts");
+  });
+
+  it("should find context for the route", () => {
+    expect(routeContext()).toEqual("");
+
+    window.history.replaceState({}, undefined, "/?redirect=accounts");
+    expect(routeContext()).toEqual("");
+
+    window.history.replaceState({}, undefined, "/#/accounts");
+    expect(routeContext()).toEqual("accounts");
+
+    window.history.replaceState({}, undefined, "/accounts");
+    expect(routeContext()).toEqual("accounts");
+
+    // TODO: ?
+    window.history.replaceState({}, undefined, "/#/accounts?param=test");
+    expect(routeContext()).toEqual("accounts?param=test");
+
+    window.history.replaceState({}, undefined, "/accounts?param=test");
+    expect(routeContext()).toEqual("accounts");
+  });
+
+  it("should replace location", () => {
+    replaceHistory({ path: "/" });
+    expect(window.location.href).toEqual(baseHref);
+
+    replaceHistory({ path: "/", query: "redirect=accounts"});
+    expect(window.location.href).toEqual(`${baseHref}?redirect=accounts`);
+
+    replaceHistory({ path: "/#/accounts"});
+    expect(window.location.href).toEqual(`${baseHref}#/accounts`);
+
+    replaceHistory({ path: "/accounts"});
+    expect(window.location.href).toEqual(`${baseHref}accounts`);
+
+    replaceHistory({ path: "/#/accounts?param=test"});
+    expect(window.location.href).toEqual(`${baseHref}#/accounts?param=test`);
+
+    replaceHistory({ path: "/accounts?param=test"});
+    expect(window.location.href).toEqual(`${baseHref}accounts?param=test`);
+  });
+});

--- a/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
@@ -7,19 +7,14 @@ import {
   replaceHistory,
   routeContext,
   routePath,
-} from '../../../lib/utils/route.utils';
+} from "../../../lib/utils/route.utils";
+import * as routeUtils from "../../../lib/utils/route.utils";
 
 describe("route-utils", () => {
-  const baseHref = "https://nns.ic0.app/";
+  const resetTestURL = (baseUrl) =>
+    window.history.replaceState({}, "Test Title", baseUrl);
 
-  const resetTestURL = () =>
-    window.history.replaceState({}, "Test Title", baseHref);
-
-  afterEach(() => resetTestURL());
-
-  // TODO: base href /v2/
-
-  it("should return the pathname and the hash without base href", () => {
+  const testRoutePath = () => {
     expect(routePath()).toEqual("/");
 
     window.history.replaceState({}, undefined, "/?redirect=accounts");
@@ -37,9 +32,9 @@ describe("route-utils", () => {
 
     window.history.replaceState({}, undefined, "/accounts?param=test");
     expect(routePath()).toEqual("/accounts");
-  });
+  };
 
-  it("should find context for the route", () => {
+  const testRouteContext = () => {
     expect(routeContext()).toEqual("");
 
     window.history.replaceState({}, undefined, "/?redirect=accounts");
@@ -57,57 +52,113 @@ describe("route-utils", () => {
 
     window.history.replaceState({}, undefined, "/accounts?param=test");
     expect(routeContext()).toEqual("accounts");
-  });
+  };
 
-  it("should replace location", () => {
+  const testReplaceHistory = ({
+    baseUrl,
+    historyIndex,
+  }: {
+    baseUrl: string;
+    historyIndex: number;
+  }) => {
     replaceHistory({ path: "/" });
-    expect(window.location.href).toEqual(baseHref);
-    expect(window.history.length).toEqual(1);
+    expect(window.location.href).toEqual(baseUrl);
+    expect(window.history.length).toEqual(historyIndex + 1);
 
-    replaceHistory({ path: "/", query: "redirect=accounts"});
-    expect(window.location.href).toEqual(`${baseHref}?redirect=accounts`);
-    expect(window.history.length).toEqual(1);
+    replaceHistory({ path: "/", query: "redirect=accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}?redirect=accounts`);
+    expect(window.history.length).toEqual(historyIndex + 1);
 
-    replaceHistory({ path: "/#/accounts"});
-    expect(window.location.href).toEqual(`${baseHref}#/accounts`);
-    expect(window.history.length).toEqual(1);
+    replaceHistory({ path: "/#/accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}#/accounts`);
+    expect(window.history.length).toEqual(historyIndex + 1);
 
-    replaceHistory({ path: "/accounts"});
-    expect(window.location.href).toEqual(`${baseHref}accounts`);
-    expect(window.history.length).toEqual(1);
+    replaceHistory({ path: "/accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}accounts`);
+    expect(window.history.length).toEqual(historyIndex + 1);
 
-    replaceHistory({ path: "/#/accounts?param=test"});
-    expect(window.location.href).toEqual(`${baseHref}#/accounts?param=test`);
-    expect(window.history.length).toEqual(1);
+    replaceHistory({ path: "/#/accounts?param=test" });
+    expect(window.location.href).toEqual(`${baseUrl}#/accounts?param=test`);
+    expect(window.history.length).toEqual(historyIndex + 1);
 
-    replaceHistory({ path: "/accounts?param=test"});
-    expect(window.location.href).toEqual(`${baseHref}accounts?param=test`);
-    expect(window.history.length).toEqual(1);
+    replaceHistory({ path: "/accounts?param=test" });
+    expect(window.location.href).toEqual(`${baseUrl}accounts?param=test`);
+    expect(window.history.length).toEqual(historyIndex + 1);
+  };
+
+  const testPushHistory = ({
+    baseUrl,
+    historyIndex,
+  }: {
+    baseUrl: string;
+    historyIndex: number;
+  }) => {
+    pushHistory({ path: "/" });
+    expect(window.location.href).toEqual(baseUrl);
+    expect(window.history.length).toEqual(historyIndex + 2);
+
+    pushHistory({ path: "/", query: "redirect=accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}?redirect=accounts`);
+    expect(window.history.length).toEqual(historyIndex + 3);
+
+    pushHistory({ path: "/#/accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}#/accounts`);
+    expect(window.history.length).toEqual(historyIndex + 4);
+
+    pushHistory({ path: "/accounts" });
+    expect(window.location.href).toEqual(`${baseUrl}accounts`);
+    expect(window.history.length).toEqual(historyIndex + 5);
+
+    pushHistory({ path: "/#/accounts?param=test" });
+    expect(window.location.href).toEqual(`${baseUrl}#/accounts?param=test`);
+    expect(window.history.length).toEqual(historyIndex + 6);
+
+    pushHistory({ path: "/accounts?param=test" });
+    expect(window.location.href).toEqual(`${baseUrl}accounts?param=test`);
+    expect(window.history.length).toEqual(historyIndex + 7);
+  };
+
+  describe("base href is /", () => {
+    const baseUrl = "https://nns.ic0.app/";
+
+    beforeAll(() =>
+      jest.spyOn(routeUtils, "baseHref").mockImplementation(() => "/")
+    );
+
+    afterEach(() => resetTestURL(baseUrl));
+
+    it("should return the pathname and the hash without base href", () =>
+      testRoutePath());
+
+    it("should find context for the route", () => testRouteContext());
+
+    it("should replace location", () =>
+      testReplaceHistory({ baseUrl, historyIndex: window.history.length - 1 }));
+
+    it("should push location", () =>
+      testPushHistory({ baseUrl, historyIndex: window.history.length - 1 }));
   });
 
-  it("should push location", () => {
-    pushHistory({ path: "/" });
-    expect(window.location.href).toEqual(baseHref);
-    expect(window.history.length).toEqual(2);
+  describe("base href is /v2/", () => {
+    const baseUrl = "https://nns.ic0.app/v2/";
 
-    pushHistory({ path: "/", query: "redirect=accounts"});
-    expect(window.location.href).toEqual(`${baseHref}?redirect=accounts`);
-    expect(window.history.length).toEqual(3);
+    beforeAll(() =>
+      jest.spyOn(routeUtils, "baseHref").mockImplementation(() => "/v2/")
+    );
 
-    pushHistory({ path: "/#/accounts"});
-    expect(window.location.href).toEqual(`${baseHref}#/accounts`);
-    expect(window.history.length).toEqual(4);
+    afterEach(() => resetTestURL(baseUrl));
 
-    pushHistory({ path: "/accounts"});
-    expect(window.location.href).toEqual(`${baseHref}accounts`);
-    expect(window.history.length).toEqual(5);
+    it("should return the pathname and the hash without base href", () =>
+      testRoutePath());
 
-    pushHistory({ path: "/#/accounts?param=test"});
-    expect(window.location.href).toEqual(`${baseHref}#/accounts?param=test`);
-    expect(window.history.length).toEqual(6);
+    it("should find context for the route", () => testRouteContext());
 
-    pushHistory({ path: "/accounts?param=test"});
-    expect(window.location.href).toEqual(`${baseHref}accounts?param=test`);
-    expect(window.history.length).toEqual(7);
+    // We already ran the test for baseHref / that's why there are already pushHistory
+
+    it("should replace location", () =>
+      testReplaceHistory({ baseUrl, historyIndex: window.history.length - 1 }));
+
+    it("should push location", () =>
+      testPushHistory({ baseUrl, historyIndex: window.history.length - 1 }));
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
@@ -3,10 +3,11 @@
  */
 
 import {
+  pushHistory,
   replaceHistory,
   routeContext,
   routePath,
-} from "../../../lib/utils/route.utils";
+} from '../../../lib/utils/route.utils';
 
 describe("route-utils", () => {
   const baseHref = "https://nns.ic0.app/";
@@ -61,20 +62,52 @@ describe("route-utils", () => {
   it("should replace location", () => {
     replaceHistory({ path: "/" });
     expect(window.location.href).toEqual(baseHref);
+    expect(window.history.length).toEqual(1);
 
     replaceHistory({ path: "/", query: "redirect=accounts"});
     expect(window.location.href).toEqual(`${baseHref}?redirect=accounts`);
+    expect(window.history.length).toEqual(1);
 
     replaceHistory({ path: "/#/accounts"});
     expect(window.location.href).toEqual(`${baseHref}#/accounts`);
+    expect(window.history.length).toEqual(1);
 
     replaceHistory({ path: "/accounts"});
     expect(window.location.href).toEqual(`${baseHref}accounts`);
+    expect(window.history.length).toEqual(1);
 
     replaceHistory({ path: "/#/accounts?param=test"});
     expect(window.location.href).toEqual(`${baseHref}#/accounts?param=test`);
+    expect(window.history.length).toEqual(1);
 
     replaceHistory({ path: "/accounts?param=test"});
     expect(window.location.href).toEqual(`${baseHref}accounts?param=test`);
+    expect(window.history.length).toEqual(1);
+  });
+
+  it("should push location", () => {
+    pushHistory({ path: "/" });
+    expect(window.location.href).toEqual(baseHref);
+    expect(window.history.length).toEqual(2);
+
+    pushHistory({ path: "/", query: "redirect=accounts"});
+    expect(window.location.href).toEqual(`${baseHref}?redirect=accounts`);
+    expect(window.history.length).toEqual(3);
+
+    pushHistory({ path: "/#/accounts"});
+    expect(window.location.href).toEqual(`${baseHref}#/accounts`);
+    expect(window.history.length).toEqual(4);
+
+    pushHistory({ path: "/accounts"});
+    expect(window.location.href).toEqual(`${baseHref}accounts`);
+    expect(window.history.length).toEqual(5);
+
+    pushHistory({ path: "/#/accounts?param=test"});
+    expect(window.location.href).toEqual(`${baseHref}#/accounts?param=test`);
+    expect(window.history.length).toEqual(6);
+
+    pushHistory({ path: "/accounts?param=test"});
+    expect(window.location.href).toEqual(`${baseHref}accounts?param=test`);
+    expect(window.history.length).toEqual(7);
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/route.utils.spec.ts
@@ -44,9 +44,8 @@ describe("route-utils", () => {
     window.history.replaceState({}, undefined, "/accounts");
     expect(routePath()).toEqual("/accounts");
 
-    // TODO: ?
     window.history.replaceState({}, undefined, "/#/accounts?param=test");
-    expect(routePath()).toEqual("/#/accounts?param=test");
+    expect(routePath()).toEqual("/#/accounts");
 
     window.history.replaceState({}, undefined, "/accounts?param=test");
     expect(routePath()).toEqual("/accounts");
@@ -64,9 +63,8 @@ describe("route-utils", () => {
     window.history.replaceState({}, undefined, "/accounts");
     expect(routeContext()).toEqual("accounts");
 
-    // TODO: ?
     window.history.replaceState({}, undefined, "/#/accounts?param=test");
-    expect(routeContext()).toEqual("accounts?param=test");
+    expect(routeContext()).toEqual("accounts");
 
     window.history.replaceState({}, undefined, "/accounts?param=test");
     expect(routeContext()).toEqual("accounts");


### PR DESCRIPTION
# Motivation

At the time we developed the routing, the test framework was not set. This PR adds the tests to fulfill the gap.

In addition, it provides a small improvement to the route path function to harmonize its behavior if used with or without hash routing.

# Changes

- trim query string from location hash in function `routePath`
- add tests