### PR TITLE
feat: improve modal a11y

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -11,21 +11,27 @@
 </script>
 
 {#if visible}
-  <div class="modal" transition:fade>
+  <div
+    class="modal"
+    transition:fade
+    role="dialog"
+    aria-labelledby="modalTitle"
+    aria-describedby="modalContent"
+  >
     <div class="backdrop" on:click={close} />
     <div
       transition:scale={{ delay: 25, duration: 150, easing: quintOut }}
       class="wrapper"
     >
       <div class="toolbar">
-        <h2><slot name="title" /></h2>
+        <h2 id="modalTitle"><slot name="title" /></h2>
 
         <button on:click|stopPropagation={close} aria-label="Close"
           ><IconClose /></button
         >
       </div>
 
-      <div class="content">
+      <div class="content" id="modalContent">
         <slot />
       </div>
     </div>

--- a/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
@@ -22,6 +22,21 @@ describe("Modal", () => {
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
+  it("should be an accessible modal", () => {
+    const { container } = render(Modal, {
+      props,
+    });
+
+    const dialog: HTMLElement | null =
+      container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute("aria-labelledby")).toEqual("modalTitle");
+    expect(dialog.getAttribute("aria-describedby")).toEqual("modalContent");
+
+    expect(container.querySelector("#modalTitle")).not.toBeNull();
+    expect(container.querySelector("#modalContent")).not.toBeNull();
+  });
+
   it("should render a backdrop", () => {
     const { container } = render(Modal, {
       props,


### PR DESCRIPTION
# Motivation

The `<Modal />` component is a dialog, therefore is role should be set as such ([MDN doc](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role))

# Changes

- set `role=dialog` and aria information