### PR TITLE
feat: display unexpected auth sync and sign-in errors

### DIFF
--- a/frontend/svelte/src/lib/components/Guard.svelte
+++ b/frontend/svelte/src/lib/components/Guard.svelte
@@ -3,6 +3,16 @@
   import { routeStore } from "../stores/route.store";
   import { routePath } from "../utils/route.utils";
   import Spinner from "./Spinner.svelte";
+  import { toastsStore } from "../stores/toasts.store";
+
+  const syncAuthStore = async () => {
+    try {
+      await authStore.sync();
+    } catch (err) {
+      toastsStore.show({ labelKey: "error.auth_sync", level: "error" });
+      console.error(err);
+    }
+  };
 </script>
 
 <!-- storage: on every change in local storage we sync the auth state -->
@@ -12,10 +22,8 @@
   on:popstate={() => routeStore.update({ path: routePath() })}
 />
 
-{#await authStore.sync()}
+{#await syncAuthStore()}
   <Spinner />
 {:then value}
   <slot />
-{:catch error}
-  <!-- TODO(L2-176): display the errors -->
 {/await}

--- a/frontend/svelte/src/lib/components/Toast.svelte
+++ b/frontend/svelte/src/lib/components/Toast.svelte
@@ -52,6 +52,8 @@
     padding: var(--padding) calc(var(--padding) * 2);
     box-sizing: border-box;
 
+    z-index: calc(var(--z-index) + 999);
+
     @media (min-width: 880px) {
       max-width: var(--section-max-width);
     }

--- a/frontend/svelte/src/lib/components/Toast.svelte
+++ b/frontend/svelte/src/lib/components/Toast.svelte
@@ -12,8 +12,11 @@
 
   const close = () => toastsStore.hide();
 
-  $: ({ labelKey, level, detail } =
-    msg || ({ labelKey: "", level: "info" } as ToastMsg));
+  $: ({ labelKey, level, detail } = msg || {
+    labelKey: "",
+    level: "info",
+    detail: undefined,
+  });
 </script>
 
 <div

--- a/frontend/svelte/src/lib/components/Toast.svelte
+++ b/frontend/svelte/src/lib/components/Toast.svelte
@@ -12,7 +12,7 @@
 
   const close = () => toastsStore.hide();
 
-  $: ({ labelKey, level } = msg || { labelKey: "", level: "info" });
+  $: ({ labelKey, level, detail } = msg || { labelKey: "", level: "info" } as ToastMsg);
 </script>
 
 <div
@@ -23,7 +23,7 @@
   out:fade={{ delay: 100 }}
 >
   <p>
-    {translate({ labelKey })}
+    {translate({ labelKey })}{detail ? ` ${detail}` : ''}
   </p>
 
   <button on:click={close} aria-label={$i18n.core.close}><IconClose /></button>
@@ -80,5 +80,7 @@
     justify-content: center;
     align-items: center;
     flex-direction: column;
+
+    padding: 0;
   }
 </style>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -3,7 +3,8 @@
     "close": "Close"
   },
   "error": {
-    "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser."
+    "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
+    "sign_in": "The sign-in process was aborted or did not succeed. Reason:"
   },
   "navigation": {
     "icp": "ICP",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -4,7 +4,7 @@
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
-    "sign_in": "The sign-in process was aborted or did not succeed. Reason:"
+    "sign_in": "The sign-in process was aborted or did not succeed."
   },
   "navigation": {
     "icp": "ICP",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -2,6 +2,9 @@
   "core": {
     "close": "Close"
   },
+  "error": {
+    "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser."
+  },
   "navigation": {
     "icp": "ICP",
     "neurons": "Neurons",

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -45,7 +45,7 @@
     position: fixed;
     inset: 0;
 
-    z-index: calc(var(--z-index) + 999);
+    z-index: calc(var(--z-index) + 998);
   }
 
   .backdrop {

--- a/frontend/svelte/src/lib/stores/toasts.store.ts
+++ b/frontend/svelte/src/lib/stores/toasts.store.ts
@@ -3,6 +3,7 @@ import { writable } from "svelte/store";
 export interface ToastMsg {
   labelKey: string;
   level: "info" | "error";
+  detail?: string;
 }
 
 /**

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -6,6 +6,10 @@ interface I18nCore {
   close: string;
 }
 
+interface I18nError {
+  auth_sync: string;
+}
+
 interface I18nNavigation {
   icp: string;
   neurons: string;
@@ -77,6 +81,7 @@ interface I18nProposals {
 interface I18n {
   lang: Languages;
   core: I18nCore;
+  error: I18nError;
   navigation: I18nNavigation;
   header: I18nHeader;
   auth: I18nAuth;

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -6,6 +6,7 @@
   import { isSignedIn } from "../lib/utils/auth.utils";
   import { i18n } from "../lib/stores/i18n";
   import Toasts from "../lib/components/Toasts.svelte";
+  import { toastsStore } from "../lib/stores/toasts.store";
 
   let signedIn: boolean = false;
 
@@ -13,8 +14,8 @@
   const signIn = async () => {
     try {
       await authStore.signIn();
-    } catch (err) {
-      // TODO(L2-176): display the errors
+    } catch (err: string) {
+      toastsStore.show({ labelKey: "error.sign_in", level: "error", detail: err });
       console.error(err);
     }
   };

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -5,6 +5,7 @@
   import { routeStore } from "../lib/stores/route.store";
   import { isSignedIn } from "../lib/utils/auth.utils";
   import { i18n } from "../lib/stores/i18n";
+  import Toasts from "../lib/components/Toasts.svelte";
 
   let signedIn: boolean = false;
 
@@ -66,6 +67,8 @@
     class="bottom-banner"
     loading="lazy"
   />
+
+  <Toasts />
 {/if}
 
 <style lang="scss">

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -14,8 +14,12 @@
   const signIn = async () => {
     try {
       await authStore.signIn();
-    } catch (err: string) {
-      toastsStore.show({ labelKey: "error.sign_in", level: "error", detail: err });
+    } catch (err: any) {
+      toastsStore.show({
+        labelKey: "error.sign_in",
+        level: "error",
+        detail: typeof err === "string" ? (err as string) : undefined,
+      });
       console.error(err);
     }
   };

--- a/frontend/svelte/src/tests/lib/components/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/Toast.spec.ts
@@ -8,7 +8,7 @@ import type { ToastMsg } from "../../../lib/stores/toasts.store";
 
 describe("Toast", () => {
   const props: { msg: ToastMsg } = {
-    msg: { labelKey: "core.close", level: "info" },
+    msg: { labelKey: "core.close", level: "info", detail: "more details" },
   };
 
   it("should render a text", async () => {
@@ -19,7 +19,7 @@ describe("Toast", () => {
     const p: HTMLParagraphElement | null = container.querySelector("p");
 
     expect(p).not.toBeNull();
-    expect(p.textContent).toEqual("Close");
+    expect(p.textContent).toContain("Close");
   });
 
   it("should render a close button", async () => {
@@ -31,5 +31,16 @@ describe("Toast", () => {
 
     expect(button).not.toBeNull();
     expect(button.getAttribute("aria-label")).toEqual("Close");
+  });
+
+  it("should render details", async () => {
+    const { container } = render(Toast, {
+      props,
+    });
+
+    const p: HTMLParagraphElement | null = container.querySelector("p");
+
+    expect(p).not.toBeNull();
+    expect(p.textContent).toContain("more details");
   });
 });


### PR DESCRIPTION
# Motivation

Display unexpected auth sync and sign-in errors to users.

# Changes

- add `<Toasts />` to login page (it does not use the main layout)
- stack a toast message for unexpected auth sync errors
- stack a toast message for sign-in errors
- add `detail` to toast store to display an optional string error in addition to an internationalized label
- display 5 lines in toast instead of 4 on mobile devices to display more details about the error