### PR TITLE
L2-214: Dark Modal

### DIFF
--- a/frontend/svelte/src/lib/components/Checkbox.svelte
+++ b/frontend/svelte/src/lib/components/Checkbox.svelte
@@ -4,7 +4,7 @@
   export let inputId: string;
   export let checked: boolean;
 
-  export let color: "dark" | "light" = "light";
+  export let theme: "dark" | "light" = "light";
   export let text: "block" | "inline" = "inline";
 
   export let selector: string | undefined = undefined;
@@ -19,7 +19,7 @@
 
 <div
   on:click|preventDefault={onClick}
-  class={`checkbox ${color} ${selector || ""}`}
+  class={`checkbox ${theme} ${selector || ""}`}
 >
   <label for={inputId} class={text}><slot /></label>
   <input

--- a/frontend/svelte/src/lib/components/VotingFilters.svelte
+++ b/frontend/svelte/src/lib/components/VotingFilters.svelte
@@ -46,7 +46,7 @@
 <Checkbox
   inputId="hide-unavailable-proposals"
   checked={false}
-  color="dark"
+  theme="dark"
   text="block"
   selector="hide-unavailable-proposals"
   >{$i18n.voting.hide_unavailable_proposals}</Checkbox

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -65,5 +65,8 @@
     "accepted": "Adopted",
     "executed": "Executed",
     "failed": "Failed"
+  },
+  "modals": {
+    "back": "Back"
   }
 }

--- a/frontend/svelte/src/lib/icons/IconBack.svelte
+++ b/frontend/svelte/src/lib/icons/IconBack.svelte
@@ -1,0 +1,11 @@
+<!-- source: https://material.io/icons/ -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24px"
+  height="24px"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  ><path d="M0 0h24v24H0z" fill="none" /><path
+    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+  /></svg
+>

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -10,6 +10,7 @@
   export let theme: "dark" | "light" = "light";
   // There is no way to know to know whether a parent is listening to the "nnsBack" event
   // https://github.com/sveltejs/svelte/issues/4249#issuecomment-573312191
+  // Please do not use `showBackButton` without listening on `nnsBack`
   export let showBackButton: boolean = false;
 
   let dark: boolean;

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -3,16 +3,27 @@
   import { quintOut } from "svelte/easing";
   import IconClose from "../icons/IconClose.svelte";
   import { createEventDispatcher } from "svelte";
+  import IconBack from "../icons/IconBack.svelte";
+  import { i18n } from "../stores/i18n";
 
   export let visible: boolean = false;
+  export let theme: "dark" | "light" = "light";
+  // There is no way to know to know whether a parent is listening to the "nnsBack" event
+  // https://github.com/sveltejs/svelte/issues/4249#issuecomment-573312191
+  export let showBackButton: boolean = false;
+
+  let dark: boolean;
+  $: dark = theme === "dark";
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
+  const back = () => dispatch("nnsBack");
 </script>
 
 {#if visible}
   <div
     class="modal"
+    class:dark
     transition:fade
     role="dialog"
     aria-labelledby="modalTitle"
@@ -24,9 +35,15 @@
       class="wrapper"
     >
       <div class="toolbar">
-        <h2 id="modalTitle"><slot name="title" /></h2>
-
-        <button on:click|stopPropagation={close} aria-label="Close"
+        {#if showBackButton}
+          <button
+            class="back"
+            on:click|stopPropagation={back}
+            aria-label={$i18n.modals.back}><IconBack /></button
+          >
+        {/if}
+        <h3 id="modalTitle"><slot name="title" /></h3>
+        <button on:click|stopPropagation={close} aria-label={$i18n.core.close}
           ><IconClose /></button
         >
       </div>
@@ -46,6 +63,28 @@
     inset: 0;
 
     z-index: calc(var(--z-index) + 998);
+
+    &.dark {
+      color: var(--background-contrast);
+
+      .wrapper {
+        background: none;
+      }
+
+      .toolbar {
+        background: var(--gray-50-background);
+        box-shadow: 0 2px 8px var(--background);
+
+        h3,
+        button {
+          color: var(--background-contrast);
+        }
+      }
+
+      .content {
+        background: var(--gray-50-background);
+      }
+    }
   }
 
   .backdrop {
@@ -85,20 +124,23 @@
     background: var(--gray-100);
     color: var(--gray-800);
 
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: var(--icon-width) 1fr var(--icon-width);
 
-    h2 {
+    h3 {
       color: inherit;
       font-weight: 400;
       margin-bottom: 0;
       line-height: 1.5;
+      text-align: center;
+      grid-column-start: 2;
     }
 
     button {
       display: flex;
       justify-content: center;
       align-items: center;
+      padding: 0;
 
       &:active,
       &:focus,

--- a/frontend/svelte/src/lib/themes/variables.scss
+++ b/frontend/svelte/src/lib/themes/variables.scss
@@ -1,6 +1,7 @@
 :root {
   --header-height: 76px;
   --nav-height: 64px;
+  --icon-width: 24px;
 
   --padding: 10px;
   --border-radius: 10px;

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -80,6 +80,10 @@ interface I18nProposals {
   failed: string;
 }
 
+interface I18nModals {
+  back: string;
+}
+
 interface I18n {
   lang: Languages;
   core: I18nCore;
@@ -93,4 +97,5 @@ interface I18n {
   topics: I18nTopics;
   rewards: I18nRewards;
   proposals: I18nProposals;
+  modals: I18nModals;
 }

--- a/frontend/svelte/src/tests/lib/components/Checkbox.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/Checkbox.spec.ts
@@ -98,7 +98,7 @@ describe("Checkbox", () => {
 
   it("should render a dark container", () => {
     const { container } = render(Checkbox, {
-      props: { ...props, color: "dark" },
+      props: { ...props, theme: "dark" },
     });
 
     const div: HTMLDivElement | null = container.querySelector("div.checkbox");

--- a/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
@@ -24,7 +24,7 @@ describe("Modal", () => {
 
   it("should display a dark modal", () => {
     const { container } = render(Modal, {
-      props: { visible: true, dark: true },
+      props: { visible: true, theme: "dark" },
     });
 
     expect(container.querySelector("div.modal.dark")).not.toBeNull();

--- a/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
@@ -22,6 +22,14 @@ describe("Modal", () => {
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
+  it("should display a dark modal", () => {
+    const { container } = render(Modal, {
+      props: { visible: true, dark: true },
+    });
+
+    expect(container.querySelector("div.modal.dark")).not.toBeNull();
+  });
+
   it("should be an accessible modal", () => {
     const { container } = render(Modal, {
       props,
@@ -68,7 +76,7 @@ describe("Modal", () => {
       container.querySelector("div.toolbar");
 
     expect(toolbar).not.toBeNull();
-    expect(toolbar.querySelector("h2")).not.toBeNull();
+    expect(toolbar.querySelector("h3")).not.toBeNull();
     expect(toolbar.querySelector("button")).not.toBeNull();
   });
 
@@ -106,7 +114,24 @@ describe("Modal", () => {
       done();
     });
 
-    const button: HTMLButtonElement | null = container.querySelector("button");
+    const button: HTMLButtonElement | null = container.querySelector(
+      'button[aria-label="Close"]'
+    );
+    fireEvent.click(button);
+  });
+
+  it("should trigger back event on click on back button", (done) => {
+    const { container, component } = render(Modal, {
+      props: { visible: true, showBackButton: true },
+    });
+
+    component.$on("nnsBack", (e) => {
+      done();
+    });
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      'button[aria-label="Back"]'
+    );
     fireEvent.click(button);
   });
 });


### PR DESCRIPTION
# Motivation

Add the dark version of the modal.

# Changes

- Add `dark` prop to `Modal` component.
- Changed `Modal` title to h3. Previous Modal had different sizes for dark and light modals. Some dark modals had long titles. I changed to a midway solution. Old dark modal title was too small.