### PR TITLE
build: prettier ignore all public folder

### DIFF
--- a/frontend/svelte/.prettierignore
+++ b/frontend/svelte/.prettierignore
@@ -1,1 +1,1 @@
-public/build
+public/


### PR DESCRIPTION
# Motivation

When run in the svelte app, prettier currently format the "public" folder except sub-folder "build".
The sub-folder "assets" can also contains js files such as `public/assets/assets/ic_agent.js` which takes 7017ms to be formatted.
Neither does this file nor any files of the "public" folder need actually to be formatted.

# Changes

- prettier ignores all "public" folder
