### PR TITLE
Refactor submit button

### DIFF
--- a/frontend/svelte/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/svelte/src/lib/components/ic/GetICPs.svelte
@@ -39,7 +39,7 @@
 
     <Input placeholderLabelKey="core.icp" name="icp" bind:value={inputValue} />
 
-    <button type="submit" class="submit" disabled={invalidForm}>Get</button>
+    <button type="submit" class="primary" disabled={invalidForm}>Get</button>
   </form>
 </Modal>
 

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -39,33 +39,13 @@ button {
       color: var(--gray-600);
     }
 
-    background: var(--blue-600);
-    color: var(--blue-600-contrast);
+    background: var(--blue-500);
+    color: var(--blue-500-contrast);
 
     font-size: var(--font-size-small);
     @media (min-width: 768px) {
       font-size: var(--font-size-h3);
     }
-
-    @include effect.ripple-effect(--blue-500-tint);
-
-    &:focus {
-      background: var(--blue-600);
-      @include effect.ripple-effect(--blue-600-tint);
-    }
-  }
-
-  &[type="submit"] {
-    border-radius: var(--border-radius);
-    margin: var(--padding) 0;
-
-    &[disabled] {
-      background: var(--gray-50);
-      color: var(--gray-400);
-    }
-
-    background: var(--blue-500);
-    color: var(--blue-500-contrast);
 
     @include effect.ripple-effect(--blue-500-tint);
 

--- a/frontend/svelte/src/lib/themes/theme.scss
+++ b/frontend/svelte/src/lib/themes/theme.scss
@@ -50,7 +50,7 @@ main {
 }
 
 section {
-  padding: calc(2 * var(--padding)) calc(4 * var(--padding));
+  padding: calc(2 * var(--padding)) calc(3 * var(--padding));
 
   max-width: var(--section-max-width);
   margin: 0 auto;


### PR DESCRIPTION
# Motivation

Currently two button styles overlap each other (type=submit & .primary)
The idea was to refactor / rename the existing style [type="submit"] to .primary.
[L2-237](https://dfinity.atlassian.net/browse/L2-237)

# Changes

- Blue button colours were reversed to submit.
- Was refactored only `Get ICPs` button
<img width="432" alt="image" src="https://user-images.githubusercontent.com/98811342/152758003-21ffcc65-a47a-4860-88f6-ba8f1bfb4c36.png">
## original:
<img width="681" alt="image" src="https://user-images.githubusercontent.com/98811342/152759069-c7ad5b7d-60d3-490a-aff5-abc5725ee592.png">

- section padding was updated to avoid separate PR

