### PR TITLE
feat: infinite scroll component

### DIFF
--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -1,7 +1,32 @@
 import "@testing-library/jest-dom";
-
 // jsdom does not implement TextEncoder
 // Polyfill the encoders with node
-import { TextEncoder, TextDecoder } from "util";
+import { TextDecoder, TextEncoder } from "util";
+
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// @ts-ignore
+global.IntersectionObserver = class IntersectionObserver {
+  constructor(
+    private callback: (entries: IntersectionObserverEntry[]) => void,
+    private options?: IntersectionObserverInit
+  ) {}
+
+  observe(element: HTMLElement) {
+    this.callback([
+      {
+        isIntersecting: true,
+        target: element,
+      } as unknown as IntersectionObserverEntry,
+    ]);
+  }
+
+  disconnect() {
+    return null;
+  }
+
+  unobserve() {
+    return null;
+  }
+};

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { afterUpdate, createEventDispatcher, onDestroy } from "svelte";
+
+  /**
+   * The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance from the bottom or top of the page.
+   *
+   * Usage: To be wrapped around loops `<InfiniteScroll>{#each ...}</InfiniteScroll>`
+   *
+   * The component observe the last HTML element of the list using the IntersectionObserver.
+   * It set the reference after each re-render of the list. Pay attention to not trigger unnecessary updates.
+   */
+
+  export let options: IntersectionObserverInit = {
+    rootMargin: "300px",
+    threshold: 0,
+  };
+
+  let container!: HTMLDivElement;
+
+  const dispatch = createEventDispatcher();
+
+  const onIntersection = (entries: IntersectionObserverEntry[]) => {
+    const intersecting: IntersectionObserverEntry | undefined = entries.find(
+      ({ isIntersecting }: IntersectionObserverEntry) => isIntersecting
+    );
+
+    if (intersecting === undefined) {
+      return;
+    }
+
+    dispatch("nnsIntersect");
+  };
+
+  let observer: IntersectionObserver = new IntersectionObserver(
+    onIntersection,
+    options
+  );
+
+  afterUpdate(() => {
+    // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
+    observer.disconnect();
+
+    if (!container.lastElementChild) {
+      return;
+    }
+
+    observer.observe(container.lastElementChild);
+  });
+
+  onDestroy(() => observer.disconnect());
+</script>
+
+<div bind:this={container}>
+  <slot />
+</div>

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -15,7 +15,7 @@
     threshold: 0,
   };
 
-  let container!: HTMLDivElement;
+  let container: HTMLDivElement;
 
   const dispatch = createEventDispatcher();
 

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -7,7 +7,7 @@
    * Usage: To be wrapped around loops `<InfiniteScroll>{#each ...}</InfiniteScroll>`
    *
    * The component observe the last HTML element of the list using the IntersectionObserver.
-   * It set the reference after each re-render of the list. Pay attention to not trigger unnecessary updates.
+   * It sets the reference after each re-render of the list. Pay attention to not trigger unnecessary updates.
    */
 
   export let options: IntersectionObserverInit = {

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
+import InfiniteScrollTest from "./InfiniteScrollTest.svelte";
+
+describe("InfiniteScroll", () => {
+  it("should render a container", () => {
+    const { container } = render(InfiniteScroll);
+
+    expect(container.querySelector("div")).not.toBeNull();
+  });
+
+  it("should trigger an intersect event", () => {
+    const spyIntersect = jest.fn();
+
+    render(InfiniteScrollTest, {
+      props: { elements: new Array(3), spy: spyIntersect },
+    });
+
+    expect(spyIntersect).toHaveBeenCalled();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
+
+    export let elements!: number[];
+    export let spy!: () => void;
+
+    const intersect = () => spy();
+</script>
+
+<InfiniteScroll on:nnsIntersect={intersect}>
+    {#each elements as element, i}
+        <div>Test {i}</div>
+    {/each}
+</InfiniteScroll>

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
 
-    export let elements!: number[];
-    export let spy!: () => void;
+    export let elements: number[];
+    export let spy: () => void;
 
     const intersect = () => spy();
 </script>

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-    import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
+  import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
 
-    export let elements: number[];
-    export let spy: () => void;
+  export let elements: number[];
+  export let spy: () => void;
 
-    const intersect = () => spy();
+  const intersect = () => spy();
 </script>
 
 <InfiniteScroll on:nnsIntersect={intersect}>
-    {#each elements as element, i}
-        <div>Test {i}</div>
-    {/each}
+  {#each elements as element, i}
+    <div>Test {i}</div>
+  {/each}
 </InfiniteScroll>

--- a/frontend/svelte/tsconfig.json
+++ b/frontend/svelte/tsconfig.json
@@ -12,6 +12,7 @@
     "public/*",
     "**/*.spec.ts",
     "jest.setup.ts",
-    "**/*.mock.ts"
+    "**/*.mock.ts",
+    "**/*Test.svelte"
   ]
 }


### PR DESCRIPTION
# Motivation

Proposals and other list are not fetched integrally when displayed but through subsets that are displayed when the user scrolls a specified distance from the bottom or top of the page.

This PR introduces an "infinite scroll" component which implements such behavior for any lists ("for each").

# Changes

- new `<InfiniteScroll />` component

# Notes

The component relies on the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).

Such API is [not supported](https://caniuse.com/?search=intersection%20Observer) on Safari version older than v12.1 on desktop and v12.2 on mobile. There browsers are out of the scope of the browser we are currently supporting ("latest 2"). That's why the PR does not include any polyfill or some sort of custom code for old browsers.

# Tests

Unit test a basic since there is no implementation of the Intersection Observer in jest. It will need e2e tests for a proper behavioral tests.