### PR TITLE
Equal box sizing given to neuron identifier and icp value 

### DIFF
--- a/frontend/dart/lib/ui/neurons/tab/neuron_row.dart
+++ b/frontend/dart/lib/ui/neurons/tab/neuron_row.dart
@@ -58,10 +58,10 @@ class NeuronRow extends StatelessWidget {
               ),
             ),
             Flexible(
-              flex: 1,
+              flex: 2,
               child: LabelledBalanceDisplayWidget(
                   amount: neuron.stake,
-                  amountSize: Responsive.isMobile(context) ? 16 : 24,
+                  amountSize: Responsive.isMobile(context) ? 16 : 20,
                   icpLabelSize: 25,
                   text: Text(
                     "Stake",


### PR DESCRIPTION
The icp value is now in a single line  for icps with 8 decimal digits 