### PR TITLE
feat: badge component

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Badge.svelte
+++ b/frontend/svelte/src/lib/components/ui/Badge.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+    export let color: 'warning' | 'success' | undefined = undefined;
+</script>
+
+<div class={color}>
+    <slot />
+</div>
+
+<style lang="scss">
+  div {
+    display: inline-block;
+
+    width: fit-content;
+
+    margin: var(--padding) 0;
+    padding: var(--padding);
+    border-radius: var(--border-radius);
+
+    border: 2px solid var(--badge-color, currentColor);
+    color: var(--badge-color);
+
+    font-size: var(--font-size-h3);
+
+    &.warning {
+      --badge-color: var(--yellow-400);
+    }
+
+    &.success {
+      --badge-color: var(--green-500);
+    }
+
+    @media (min-width: 768px) {
+      margin: 0;
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/Badge.svelte
+++ b/frontend/svelte/src/lib/components/ui/Badge.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-    export let color: 'warning' | 'success' | undefined = undefined;
+  export let color: "warning" | "success" | undefined = undefined;
 </script>
 
 <div class={color}>
-    <slot />
+  <slot />
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import Badge from '../../../../lib/components/ui/Badge.svelte';
+import BadgeTest from './BadgeTest.svelte';
+
+describe("Badge", () => {
+  it("should render a badge container", () => {
+    const { container } = render(Badge);
+
+    expect(container.querySelector("div")).not.toBeNull();
+  });
+
+  it("should render a badge container", () => {
+    const { getByText } = render(BadgeTest);
+
+    expect(getByText('Test_badge')).toBeInTheDocument();
+  });
+
+  it("should render a success badge", () => {
+    const { container } = render(Badge, {props: {color: 'success'}});
+
+    expect(container.querySelector('div.success')).not.toBeNull();
+  });
+
+  it("should render a warning badge", () => {
+    const { container } = render(Badge, {props: {color: 'warning'}});
+
+    expect(container.querySelector('div.warning')).not.toBeNull();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
@@ -13,7 +13,7 @@ describe("Badge", () => {
     expect(container.querySelector("div")).not.toBeNull();
   });
 
-  it("should render a badge container", () => {
+  it("should render the slot of the badge", () => {
     const { getByText } = render(BadgeTest);
 
     expect(getByText("Test_badge")).toBeInTheDocument();

--- a/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Badge.spec.ts
@@ -3,8 +3,8 @@
  */
 
 import { render } from "@testing-library/svelte";
-import Badge from '../../../../lib/components/ui/Badge.svelte';
-import BadgeTest from './BadgeTest.svelte';
+import Badge from "../../../../lib/components/ui/Badge.svelte";
+import BadgeTest from "./BadgeTest.svelte";
 
 describe("Badge", () => {
   it("should render a badge container", () => {
@@ -16,18 +16,18 @@ describe("Badge", () => {
   it("should render a badge container", () => {
     const { getByText } = render(BadgeTest);
 
-    expect(getByText('Test_badge')).toBeInTheDocument();
+    expect(getByText("Test_badge")).toBeInTheDocument();
   });
 
   it("should render a success badge", () => {
-    const { container } = render(Badge, {props: {color: 'success'}});
+    const { container } = render(Badge, { props: { color: "success" } });
 
-    expect(container.querySelector('div.success')).not.toBeNull();
+    expect(container.querySelector("div.success")).not.toBeNull();
   });
 
   it("should render a warning badge", () => {
-    const { container } = render(Badge, {props: {color: 'warning'}});
+    const { container } = render(Badge, { props: { color: "warning" } });
 
-    expect(container.querySelector('div.warning')).not.toBeNull();
+    expect(container.querySelector("div.warning")).not.toBeNull();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/ui/BadgeTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/BadgeTest.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Badge from "../../../../lib/components/ui/Badge.svelte";
+</script>
+
+<Badge>Test_badge</Badge>


### PR DESCRIPTION
# Motivation

A new inline block element `<Badge />` to display notification or status.

# Changes

- new `<Badge />` element

# Screenshot

<img width="1512" alt="Capture d’écran 2022-02-08 à 09 13 31" src="https://user-images.githubusercontent.com/16886711/152947236-f3622c54-708f-411e-94ea-b40b925224bb.png">

