### PR TITLE
Cleanup media queries

### DIFF
--- a/frontend/svelte/src/lib/components/common/Nav.svelte
+++ b/frontend/svelte/src/lib/components/common/Nav.svelte
@@ -25,6 +25,8 @@
 </nav>
 
 <style lang="scss">
+  @use "../../themes/mixins/media.scss";
+
   nav {
     position: absolute;
     top: var(--header-height);
@@ -57,6 +59,7 @@
 
     color: var(--gray-400);
 
+    font-size: var(--font-size-ultra-small);
     font-weight: 700;
 
     text-decoration: none;
@@ -77,8 +80,8 @@
       background: var(--background-tint);
     }
 
-    @media (max-width: 576px) {
-      font-size: var(--font-size-ultra-small);
+    @include media.min-width(small) {
+      font-size: var(--font-size-h4);
     }
   }
 

--- a/frontend/svelte/src/lib/components/ic/ICP.svelte
+++ b/frontend/svelte/src/lib/components/ic/ICP.svelte
@@ -13,10 +13,13 @@
 {/if}
 
 <style lang="scss">
+  @use "../../themes/mixins/media.scss";
+
   div {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
+    display: inline-grid;
+    grid-template-columns: repeat(2, auto);
+    grid-gap: 5px;
+    align-items: baseline;
 
     span:first-of-type {
       font-weight: 700;
@@ -24,12 +27,12 @@
       color: var(--gray-50);
     }
 
-    @media (max-width: 768px) {
-      align-items: baseline;
-      display: inline-grid;
-      grid-template-columns: repeat(2, auto);
-      grid-gap: 5px;
+    @include media.min-width(medium) {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
       justify-content: flex-end;
+      grid-gap: 0;
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/ui/Card.svelte
+++ b/frontend/svelte/src/lib/components/ui/Card.svelte
@@ -18,6 +18,7 @@
 
 <style lang="scss">
   @use "../../themes/mixins/interaction";
+  @use "../../themes/mixins/media.scss";
 
   article {
     text-decoration: none;
@@ -42,15 +43,15 @@
   }
 
   div {
-    display: inline-flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    display: block;
     width: 100%;
 
     margin: 0 0 var(--padding);
 
-    @media (max-width: 768px) {
-      display: block;
+    @include media.min-width(medium) {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: flex-start;
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -35,6 +35,7 @@
 
 <style lang="scss">
   @use "../../themes/mixins/text";
+  @use "../../themes/mixins/media.scss";
 
   .toast {
     display: flex;
@@ -58,7 +59,7 @@
 
     z-index: calc(var(--z-index) + 999);
 
-    @media (min-width: 880px) {
+    @include media.min-width(large) {
       max-width: var(--section-max-width);
     }
 
@@ -74,7 +75,7 @@
     margin: 0;
     font-size: 1rem;
 
-    @media (min-width: 768px) {
+    @include media.min-width(medium) {
       @include text.clamp(2);
     }
   }

--- a/frontend/svelte/src/lib/components/ui/Toolbar.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toolbar.svelte
@@ -3,6 +3,8 @@
 </div>
 
 <style lang="scss">
+  @use "../../themes/mixins/media.scss";
+
   .toolbar {
     position: absolute;
     inset: 0;
@@ -16,12 +18,12 @@
     justify-content: center;
     align-items: end;
 
-    @media (min-width: 300px) {
+    @include media.min-width(xsmall) {
       min-width: 280px;
       width: 70%;
     }
 
-    @media (min-width: 768px) {
+    @include media.min-width(medium) {
       margin-bottom: calc(3 * var(--padding));
     }
 
@@ -33,7 +35,7 @@
       margin: 0 calc(0.5 * var(--padding));
       max-width: 60%;
 
-      @media (min-width: 768px) {
+      @include media.min-width(medium) {
         margin: 0 calc(2 * var(--padding));
         max-width: 406px;
       }

--- a/frontend/svelte/src/lib/components/voting/VotingFilters.svelte
+++ b/frontend/svelte/src/lib/components/voting/VotingFilters.svelte
@@ -61,7 +61,6 @@
   @use "../../themes/mixins/media.scss";
 
   .status {
-    border: 1px solid red;
     display: block;
     width: 100%;
 

--- a/frontend/svelte/src/lib/components/voting/VotingFilters.svelte
+++ b/frontend/svelte/src/lib/components/voting/VotingFilters.svelte
@@ -58,15 +58,18 @@
 />
 
 <style lang="scss">
-  .status {
-    display: grid;
-    width: calc(100% - var(--padding));
-    grid-template-columns: repeat(2, 50%);
-    grid-column-gap: var(--padding);
+  @use "../../themes/mixins/media.scss";
 
-    @media (max-width: 768px) {
-      display: block;
-      width: 100%;
+  .status {
+    border: 1px solid red;
+    display: block;
+    width: 100%;
+
+    @include media.min-width(medium) {
+      display: grid;
+      width: calc(100% - var(--padding));
+      grid-template-columns: repeat(2, 50%);
+      grid-column-gap: var(--padding);
     }
   }
 

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -1,4 +1,5 @@
 @use "mixins/effect";
+@use "mixins/media";
 
 button {
   &.text {
@@ -43,7 +44,7 @@ button {
     color: var(--blue-500-contrast);
 
     font-size: var(--font-size-small);
-    @media (min-width: 768px) {
+    @include media.min-width(medium) {
       font-size: var(--font-size-h3);
     }
 

--- a/frontend/svelte/src/lib/themes/mixins/_media.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_media.scss
@@ -1,0 +1,51 @@
+$layout-breakpoint-xs: 320px;
+$layout-breakpoint-s: 576px;
+$layout-breakpoint-m: 768px;
+$layout-breakpoint-l: 880px;
+
+@mixin min-width($breakpoint) {
+  @if ($breakpoint == xsmall) {
+    @media (min-width: $layout-breakpoint-xs) {
+      @content;
+    }
+  }
+  @if ($breakpoint == small) {
+    @media (min-width: $layout-breakpoint-s) {
+      @content;
+    }
+  }
+  @if ($breakpoint == medium) {
+    @media (min-width: $layout-breakpoint-m) {
+      @content;
+    }
+  }
+  @if ($breakpoint == large) {
+    @media (min-width: $layout-breakpoint-l) {
+      @content;
+    }
+  }
+}
+
+@mixin media-min-xs {
+  @media (min-width: $layout-breakpoint-xs) {
+    @content;
+  }
+}
+
+@mixin media-min-s {
+  @media (min-width: $layout-breakpoint-s) {
+    @content;
+  }
+}
+
+@mixin media-min-m {
+  @media (min-width: $layout-breakpoint-m) {
+    @content;
+  }
+}
+
+@mixin media-min-l {
+  @media (min-width: $layout-breakpoint-l) {
+    @content;
+  }
+}

--- a/frontend/svelte/src/lib/themes/mixins/_media.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_media.scss
@@ -1,51 +1,27 @@
-$layout-breakpoint-xs: 320px;
-$layout-breakpoint-s: 576px;
-$layout-breakpoint-m: 768px;
-$layout-breakpoint-l: 880px;
+$breakpoint-xsmall: 320px;
+$breakpoint-small: 576px;
+$breakpoint-medium: 768px;
+$breakpoint-large: 880px;
 
 @mixin min-width($breakpoint) {
   @if ($breakpoint == xsmall) {
-    @media (min-width: $layout-breakpoint-xs) {
+    @media (min-width: $breakpoint-xsmall) {
       @content;
     }
   }
   @if ($breakpoint == small) {
-    @media (min-width: $layout-breakpoint-s) {
+    @media (min-width: $breakpoint-small) {
       @content;
     }
   }
   @if ($breakpoint == medium) {
-    @media (min-width: $layout-breakpoint-m) {
+    @media (min-width: $breakpoint-medium) {
       @content;
     }
   }
   @if ($breakpoint == large) {
-    @media (min-width: $layout-breakpoint-l) {
+    @media (min-width: $breakpoint-large) {
       @content;
     }
-  }
-}
-
-@mixin media-min-xs {
-  @media (min-width: $layout-breakpoint-xs) {
-    @content;
-  }
-}
-
-@mixin media-min-s {
-  @media (min-width: $layout-breakpoint-s) {
-    @content;
-  }
-}
-
-@mixin media-min-m {
-  @media (min-width: $layout-breakpoint-m) {
-    @content;
-  }
-}
-
-@mixin media-min-l {
-  @media (min-width: $layout-breakpoint-l) {
-    @content;
   }
 }

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -65,18 +65,20 @@
 {/if}
 
 <style lang="scss">
+  @use "../lib/themes/mixins/media.scss";
+
   .title {
-    display: inline-flex;
-    justify-content: space-between;
-    align-items: center;
+    display: block;
     width: 100%;
 
     margin-bottom: calc(2 * var(--padding));
 
     --icp-font-size: var(--font-size-h1);
 
-    @media (max-width: 768px) {
-      display: block;
+    @include media.min-width(medium) {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: center;
     }
   }
 </style>

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -78,6 +78,7 @@
 
 <style lang="scss">
   @use "../lib/themes/mixins/img";
+  @use "../lib/themes/mixins/media";
 
   main {
     height: 100%;
@@ -174,7 +175,7 @@
     }
   }
 
-  @media screen and (min-width: 768px) and (min-height: 640px) {
+  @media screen and (min-width: media.$breakpoint-medium) and (min-height: 640px) {
     main {
       position: absolute;
       top: 50%;


### PR DESCRIPTION
# Motivation

To provide a unique approach for styling “small to wide”. And make adjustment of current media queries if needed.
https://dfinity.atlassian.net/browse/L2-228

# Changes

- new mixin `media`
- all `max-width` refactored to be `min-width`
- replace all `@media...` occurrences with the `media` mixin

# Notes

- Unfortunately I didn't find the appropriate way to make max-width forbidden by ESLint
- Breakpoints:
`$breakpoint-xsmall: 320px;`
`$breakpoint-small: 576px;`
`$breakpoint-medium: 768px;`
`$breakpoint-large: 880px;`
