### PR TITLE
L2-251: Development agent for nns

### DIFF
--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -84,8 +84,8 @@ export default {
     replace({
       preventAssignment: true,
       "process.env.ROLLUP_WATCH": !!process.env.ROLLUP_WATCH,
-      "process.env.IDENTITY_SERVICE_URL": JSON.stringify(
-        process.env.IDENTITY_SERVICE_URL ||
+      "process.env.SERVICE_URL": JSON.stringify(
+        process.env.SERVICE_URL ||
           (process.env.DEPLOY_ENV === "testnet"
             ? "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/"
             : "https://identity.ic0.app/")

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -84,8 +84,8 @@ export default {
     replace({
       preventAssignment: true,
       "process.env.ROLLUP_WATCH": !!process.env.ROLLUP_WATCH,
-      "process.env.SERVICE_URL": JSON.stringify(
-        process.env.SERVICE_URL ||
+      "process.env.IDENTITY_SERVICE_URL": JSON.stringify(
+        process.env.IDENTITY_SERVICE_URL ||
           (process.env.DEPLOY_ENV === "testnet"
             ? "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/"
             : "https://identity.ic0.app/")

--- a/frontend/svelte/src/lib/constants/utils.constants.ts
+++ b/frontend/svelte/src/lib/constants/utils.constants.ts
@@ -1,0 +1,1 @@
+export const serviceURL: string = process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -1,12 +1,11 @@
 import { AuthClient } from "@dfinity/auth-client";
 import type { Principal } from "@dfinity/principal";
 import { writable } from "svelte/store";
+import { serviceURL } from "../constants/utils.constants";
 
 export interface AuthStore {
   principal: Principal | undefined | null;
 }
-
-const identityProvider: string = process.env.IDENTITY_SERVICE_URL;
 
 /**
  * A store to handle authentication and the principal of the user.
@@ -50,7 +49,7 @@ const initAuthStore = () => {
         const authClient: AuthClient = await AuthClient.create();
 
         await authClient.login({
-          identityProvider,
+          identityProvider: serviceURL,
           maxTimeToLive: BigInt(30 * 60 * 1_000_000_000), // 30 minutes
           onSuccess: () => {
             update((state: AuthStore) => ({

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -6,7 +6,7 @@ export interface AuthStore {
   principal: Principal | undefined | null;
 }
 
-const identityProvider: string = process.env.IDENTITY_SERVICE_URL;
+const identityProvider: string = process.env.SERVICE_URL;
 
 /**
  * A store to handle authentication and the principal of the user.

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -6,7 +6,7 @@ export interface AuthStore {
   principal: Principal | undefined | null;
 }
 
-const identityProvider: string = process.env.SERVICE_URL;
+const identityProvider: string = process.env.IDENTITY_SERVICE_URL;
 
 /**
  * A store to handle authentication and the principal of the user.

--- a/frontend/svelte/src/lib/utils/accounts.utils.ts
+++ b/frontend/svelte/src/lib/utils/accounts.utils.ts
@@ -1,13 +1,14 @@
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { AccountsStore } from "../stores/accounts.store";
+import { agent } from "./agent.utils";
 
 export const loadAccounts = async ({
   principal,
 }: {
   principal: Principal;
 }): Promise<AccountsStore> => {
-  const ledger: LedgerCanister = LedgerCanister.create();
+  const ledger: LedgerCanister = LedgerCanister.create({ agent });
 
   const accountIdentifier: AccountIdentifier =
     AccountIdentifier.fromPrincipal(principal);

--- a/frontend/svelte/src/lib/utils/accounts.utils.ts
+++ b/frontend/svelte/src/lib/utils/accounts.utils.ts
@@ -1,14 +1,16 @@
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { AccountsStore } from "../stores/accounts.store";
-import { agent } from "./agent.utils";
+import { createAgent } from "./agent.utils";
 
 export const loadAccounts = async ({
   principal,
 }: {
   principal: Principal;
 }): Promise<AccountsStore> => {
-  const ledger: LedgerCanister = LedgerCanister.create({ agent });
+  const ledger: LedgerCanister = LedgerCanister.create({
+    agent: createAgent(),
+  });
 
   const accountIdentifier: AccountIdentifier =
     AccountIdentifier.fromPrincipal(principal);

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -2,4 +2,5 @@ import { HttpAgent } from "@dfinity/agent";
 
 const host = process.env.SERVICE_URL;
 
-export const agent = new HttpAgent({ host });
+// To avoid being executed in tests that only import it
+export const createAgent = () => new HttpAgent({ host });

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,6 +1,5 @@
 import { HttpAgent } from "@dfinity/agent";
-
-const host = process.env.IDENTITY_SERVICE_URL;
+import { serviceURL } from "../constants/utils.constants";
 
 // To avoid being executed in tests that only import it
-export const createAgent = () => new HttpAgent({ host });
+export const createAgent = () => new HttpAgent({ host: serviceURL });

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,0 +1,5 @@
+import { HttpAgent } from "@dfinity/agent";
+
+const host = process.env.SERVICE_URL;
+
+export const agent = new HttpAgent({ host });

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,6 +1,6 @@
 import { HttpAgent } from "@dfinity/agent";
 
-const host = process.env.SERVICE_URL;
+const host = process.env.IDENTITY_SERVICE_URL;
 
 // To avoid being executed in tests that only import it
 export const createAgent = () => new HttpAgent({ host });

--- a/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,6 +1,7 @@
 import type { ICP } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { loadAccounts } from "../../../lib/utils/accounts.utils";
+import * as agent from "../../../lib/utils/agent.utils";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 
 // @ts-ignore
@@ -20,6 +21,11 @@ class MockLedgerCanister extends LedgerCanister {
 }
 
 describe("accounts-utils", () => {
+  beforeAll(() => {
+    // Needed to prevent importing Http from @dfinity/agent
+    const mockCreateAgent = () => undefined;
+    jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
+  });
   const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();
 
   it("should call ledger to get the account balance", async () => {


### PR DESCRIPTION
# Motivation

NNS-JS should make requests to testnet during development.

# Changes

* Create an agent that expects a host as optional parameter and use it with nns-js.
* Rename `IDENTITY_SERVICE_URL` to `SERVICE_URL`. It is more than just for identity.

# Tests

No new functionality added; therefore, no new tests added. Yet, a current test had to be edited to mock importing a module.
