### PR TITLE
Feat: Add Fetch Root Key in development

### DIFF
--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -85,7 +85,7 @@ export default {
       preventAssignment: true,
       "process.env.ROLLUP_WATCH": !!process.env.ROLLUP_WATCH,
       "process.env.FETCH_ROOT_KEY": JSON.stringify(
-        process.env.DEPLOY_ENV ? true : false
+        process.env.DEPLOY_ENV === "testnet" ? true : false
       ),
       "process.env.IDENTITY_SERVICE_URL": JSON.stringify(
         process.env.IDENTITY_SERVICE_URL ||

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -84,6 +84,9 @@ export default {
     replace({
       preventAssignment: true,
       "process.env.ROLLUP_WATCH": !!process.env.ROLLUP_WATCH,
+      "process.env.FETCH_ROOT_KEY": JSON.stringify(
+        process.env.DEPLOY_ENV ? true : false
+      ),
       "process.env.IDENTITY_SERVICE_URL": JSON.stringify(
         process.env.IDENTITY_SERVICE_URL ||
           (process.env.DEPLOY_ENV === "testnet"
@@ -102,7 +105,9 @@ export default {
           ? true
           : ["false", "0"].includes(process.env.REDIRECT_TO_LEGACY)
           ? false
-          : true // default
+          : process.env.DEPLOY_ENV === "testnet"
+          ? false
+          : true
       ),
     }),
 

--- a/frontend/svelte/src/lib/utils/accounts.utils.ts
+++ b/frontend/svelte/src/lib/utils/accounts.utils.ts
@@ -9,7 +9,7 @@ export const loadAccounts = async ({
   principal: Principal;
 }): Promise<AccountsStore> => {
   const ledger: LedgerCanister = LedgerCanister.create({
-    agent: createAgent(),
+    agent: await createAgent(),
   });
 
   const accountIdentifier: AccountIdentifier = AccountIdentifier.fromPrincipal({

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -2,4 +2,12 @@ import { HttpAgent } from "@dfinity/agent";
 import { serviceURL } from "../constants/utils.constants";
 
 // To avoid being executed in tests that only import it
-export const createAgent = () => new HttpAgent({ host: serviceURL });
+export const createAgent = async () => {
+  const agent = new HttpAgent({ host: serviceURL });
+
+  if (process.env.FETCH_ROOT_KEY === "true") {
+    await agent.fetchRootKey();
+  }
+
+  return agent;
+};

--- a/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,3 +1,4 @@
+import type { HttpAgent } from "@dfinity/agent";
 import type { ICP } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { loadAccounts } from "../../../lib/utils/accounts.utils";
@@ -26,7 +27,8 @@ class MockLedgerCanister extends LedgerCanister {
 describe("accounts-utils", () => {
   beforeAll(() => {
     // Needed to prevent importing Http from @dfinity/agent
-    const mockCreateAgent = () => undefined;
+    const mockCreateAgent = () =>
+      new Promise<HttpAgent>((resolve) => resolve(undefined));
     jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
   });
   const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();

--- a/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,4 +1,3 @@
-import type { HttpAgent } from "@dfinity/agent";
 import type { ICP } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { loadAccounts } from "../../../lib/utils/accounts.utils";
@@ -27,8 +26,7 @@ class MockLedgerCanister extends LedgerCanister {
 describe("accounts-utils", () => {
   beforeAll(() => {
     // Needed to prevent importing Http from @dfinity/agent
-    const mockCreateAgent = () =>
-      new Promise<HttpAgent>((resolve) => resolve(undefined));
+    const mockCreateAgent = () => Promise.resolve(undefined);
     jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
   });
   const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();


### PR DESCRIPTION
# Motivation

Calls in testnet need to fetch the root key.

# Changes

When creating the agent, if the environment is development, then it fetches the root key.

# Tests

No new functionality.
