### PR TITLE
build: i18n script mjs to js

### DIFF
--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "copy:index": "node ./scripts/copy.index.mjs",
-    "i18n": "node --experimental-json-modules ./scripts/i18n.types.mjs",
+    "i18n": "node scripts/i18n.types.js",
     "import-assets": "rm -fr public/assets/assets && mkdir -p public/assets && cp -R ../dart/assets public/assets",
     "build": "rm -fr public/assets/assets && npm run i18n && rollup -c && npm run copy:index && ./scripts/sort-css",
     "dev": "npm run import-assets && npm run i18n && BASE_HREF=/ npm run copy:index && rollup -c -w",

--- a/frontend/svelte/scripts/i18n.types.js
+++ b/frontend/svelte/scripts/i18n.types.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { writeFileSync } from "fs";
-import prettier from "prettier";
-import en from "../src/lib/i18n/en.json";
+const { writeFileSync } = require("fs");
+const prettier = require("prettier");
+const en = require("../src/lib/i18n/en.json");
 
 /**
  * Generate the TypeScript interfaces from the english translation file.


### PR DESCRIPTION
# Motivation

As of Node v16.14.0, json import requires an addition assertion (as in the [tc39 proposal](https://github.com/tc39/proposal-import-assertions).

Unfortunately, until v16.13.x, such assertion is not supported nor ignored.

Since we are using misc Node version and because we cannot add the assertion while remaining backwards compatible, the current easiest way to solve the issue it to transform the module script to a standard js script aka use good old `require`. 

# Changes

- transform `.mjs` i18n script to `.js`
- use `require`

# Tests

Add some modification in auto-generated i18n files, run a build, changes were correctly overwritten by build.
