### PR TITLE
Use PrincipalId rather than Vec<u8> in payload definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,8 +1753,6 @@ dependencies = [
  "candid_derive",
  "ic-base-types",
  "ic-registry-subnet-type",
- "prost",
- "prost-build",
  "serde",
 ]
 

--- a/frontend/ts/src/canisters/governance/nnsFunctions/payloads.did
+++ b/frontend/ts/src/canisters/governance/nnsFunctions/payloads.did
@@ -69,7 +69,7 @@ type RecoverSubnetPayload = record {
   time_ns : nat64;
 };
 type RemoveNodeOperatorsPayload = record {
-  node_operators_to_remove : vec vec nat8;
+  node_operators_to_remove : vec principal;
 };
 type RemoveNodesFromSubnetPayload = record { node_ids : vec principal };
 type RerouteCanisterRangePayload = record {

--- a/frontend/ts/src/canisters/governance/nnsFunctions/payloads.js
+++ b/frontend/ts/src/canisters/governance/nnsFunctions/payloads.js
@@ -79,7 +79,7 @@ export const RecoverSubnetPayload = IDL.Record({
   time_ns: IDL.Nat64,
 });
 export const RemoveNodeOperatorsPayload = IDL.Record({
-  node_operators_to_remove: IDL.Vec(IDL.Vec(IDL.Nat8)),
+  node_operators_to_remove: IDL.Vec(IDL.Principal),
 });
 export const RemoveNodesFromSubnetPayload = IDL.Record({
   node_ids: IDL.Vec(IDL.Principal),

--- a/rs/nns_functions_candid_gen/Cargo.toml
+++ b/rs/nns_functions_candid_gen/Cargo.toml
@@ -10,8 +10,4 @@ candid = "0.7.4"
 candid_derive = "0.4.5"
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "89446f5a04f053040b4863eab5458446d925ed0e" }
 ic-registry-subnet-type = { git = "https://github.com/dfinity/ic", rev = "89446f5a04f053040b4863eab5458446d925ed0e" }
-prost = "0.7.0"
 serde = "1.0.119"
-
-[build-dependencies]
-prost-build = "0.7.0"

--- a/rs/nns_functions_candid_gen/src/payloads.rs
+++ b/rs/nns_functions_candid_gen/src/payloads.rs
@@ -1,7 +1,6 @@
 use candid::CandidType;
 use ic_base_types::{CanisterId, NodeId, PrincipalId, SubnetId};
 use ic_registry_subnet_type::SubnetType;
-use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -152,34 +151,28 @@ pub struct RecoverSubnetPayload {
 }
 
 // https://github.com/dfinity-lab/dfinity/blob/bd842628a462dfa30604a2e2352fe50e9066d637/rs/registry/canister/src/mutations/do_set_firewall_config.rs#L38
-#[derive(CandidType, Deserialize, Clone, PartialEq, Eq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq, Eq)]
 pub struct SetFirewallConfigPayload {
     /// The firewall configuration content
-    #[prost(string, tag = "1")]
-    pub firewall_config: ::prost::alloc::string::String,
+    pub firewall_config: String,
     /// List of allowed IPv4 prefixes
-    #[prost(string, repeated, tag = "2")]
-    pub ipv4_prefixes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub ipv4_prefixes: Vec<String>,
     /// List of allowed IPv6 prefixes
-    #[prost(string, repeated, tag = "3")]
-    pub ipv6_prefixes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub ipv6_prefixes: Vec<String>,
 }
 
 // https://github.com/dfinity-lab/dfinity/blob/bd842628a462dfa30604a2e2352fe50e9066d637/rs/registry/canister/src/mutations/do_add_node_operator.rs#L38
-#[derive(CandidType, Deserialize, Clone, PartialEq, Eq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq, Eq)]
 pub struct AddNodeOperatorPayload {
     /// The principal id of the node operator. This principal is the entity that
     /// is able to add and remove nodes.
     ///
     /// This must be unique across NodeOperatorRecords.
-    #[prost(message, optional, tag = "1")]
     pub node_operator_principal_id: Option<PrincipalId>,
 
-    #[prost(message, optional, tag = "2")]
     pub node_provider_principal_id: Option<PrincipalId>,
 
     /// The remaining number of nodes that could be added by this Node Operator.
-    #[prost(uint64, tag = "3")]
     pub node_allowance: u64,
 }
 
@@ -227,77 +220,62 @@ pub struct SetAuthorizedSubnetworkListArgs {
 }
 
 // https://gitlab.com/dfinity-lab/core/ic/-/blob/1e167e754b674f612e989cdee02acb79cfe40be8/rs/registry/canister/src/mutations/do_update_node_operator_config.rs#L79
-#[derive(CandidType, Deserialize, Clone, PartialEq, Eq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq, Eq)]
 pub struct UpdateNodeOperatorConfigPayload {
     /// The principal id of the node operator. This principal is the entity that
     /// is able to add and remove nodes.
-    #[prost(message, optional, tag = "1")]
     pub node_operator_id: Option<PrincipalId>,
 
     /// The remaining number of nodes that could be added by this Node Operator.
-    #[prost(message, optional, tag = "2")]
     pub node_allowance: Option<u64>,
 
     /// The ID of the data center where this Node Operator hosts nodes.
-    #[prost(message, optional, tag = "3")]
     pub dc_id: Option<String>,
 
     /// A map from node type to the number of nodes for which the associated
     /// Node Provider should be rewarded.
-    #[prost(btree_map = "string, uint32", tag = "4")]
     pub rewardable_nodes: BTreeMap<String, u32>,
 }
 
 // https://gitlab.com/dfinity-lab/core/ic/-/blob/1e167e754b674f612e989cdee02acb79cfe40be8/rs/protobuf/def/registry/node_rewards/v2/node_rewards.proto#L24
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct UpdateNodeRewardsTableProposalPayload {
     /// Maps regions to the node reward rates in that region
-    #[prost(btree_map = "string, message", tag = "1")]
-    pub new_entries: ::prost::alloc::collections::BTreeMap<::prost::alloc::string::String, NodeRewardRates>,
+    pub new_entries: BTreeMap<String, NodeRewardRates>,
 }
 
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct NodeRewardRate {
     /// The number of 10,000ths of IMF SDR (currency code XDR) to be rewarded per
     /// node per month.
-    #[prost(uint64, tag = "1")]
     pub xdr_permyriad_per_node_per_month: u64,
 }
 
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct NodeRewardRates {
     /// Maps node types to the reward rate for that node type
-    #[prost(btree_map = "string, message", tag = "1")]
-    pub rates: ::prost::alloc::collections::BTreeMap<::prost::alloc::string::String, NodeRewardRate>,
+    pub rates: BTreeMap<String, NodeRewardRate>,
 }
 
 // https://gitlab.com/dfinity-lab/core/ic/-/blob/1e167e754b674f612e989cdee02acb79cfe40be8/rs/protobuf/def/registry/dc/v1/dc.proto#L27
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct AddOrRemoveDataCentersProposalPayload {
-    #[prost(message, repeated, tag = "1")]
-    pub data_centers_to_add: ::prost::alloc::vec::Vec<DataCenterRecord>,
+    pub data_centers_to_add: Vec<DataCenterRecord>,
     /// The IDs of data centers to remove
-    #[prost(string, repeated, tag = "2")]
-    pub data_centers_to_remove: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub data_centers_to_remove: Vec<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct DataCenterRecord {
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub region: ::prost::alloc::string::String,
-    #[prost(string, tag = "3")]
-    pub owner: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "4")]
-    pub gps: ::core::option::Option<Gps>,
+    pub id: String,
+    pub region: String,
+    pub owner: String,
+    pub gps: Option<Gps>,
 }
 
-#[derive(CandidType, Deserialize, Clone, PartialEq, Message)]
+#[derive(CandidType, Deserialize, Clone, PartialEq)]
 pub struct Gps {
-    #[prost(float, tag = "1")]
     pub latitude: f32,
-    #[prost(float, tag = "2")]
     pub longitude: f32,
 }
 
@@ -310,10 +288,9 @@ pub struct UpdateUnassignedNodesConfigPayload {
 
 // https://gitlab.com/dfinity-lab/public/ic/-/blob/9527797958c2e02c8d975190e10c72efbb164646/rs/protobuf/def/registry/node_operator/v1/node_operator.proto#L32
 //// The payload of a request to remove Node Operator records from the Registry
-#[derive(candid::CandidType, serde::Serialize, candid::Deserialize, Clone, PartialEq, ::prost::Message)]
+#[derive(CandidType, Serialize, Deserialize, Clone, PartialEq)]
 pub struct RemoveNodeOperatorsPayload {
-    #[prost(bytes = "vec", repeated, tag = "1")]
-    pub node_operators_to_remove: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    pub node_operators_to_remove: Vec<PrincipalId>,
 }
 
 // https://gitlab.com/dfinity-lab/public/ic/-/blob/9527797958c2e02c8d975190e10c72efbb164646/rs/registry/canister/src/mutations/reroute_canister_range.rs#L46


### PR DESCRIPTION
# Motivation

We should display Principals in human readable form (base32 encoded), but for the new RemoveNodeOperators proposal type, the field in the payload is defined using byte arrays rather than Principals. This is because the Rust type was auto generated from the proto type definition.

A Principal _is_ just a byte array but candid detects Principals and deserializes them into the Principal class. This allows us to display them in human readable form. So in order to make the RemoveNodeOperators proposal payloads display nicely we simply need to change the NNS Dapp's copy of the payload definition to use Principals rather than byte arrays.

# Changes

The RemoveNodeOperatorsPayload `node_operators_to_remove` field was changed from a Vec of byte array to a Vec of PrincipalId.
This PR also removes all of the unused proto attributes from the payload definitions.

# Tests

Forthcoming... I'm trying to create a dummy proposal of type RemoveNodeOperators but am currently running into deployment issues.
