### PR TITLE
fix: i18n type definition keys

### DIFF
--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -127,9 +127,8 @@ interface I18n {
   canisters: I18nCanisters;
   topics: I18nTopics;
   rewards: I18nRewards;
-  proposals: I18nProposals;
+  status: I18nStatus;
   wallet: I18nWallet;
   proposal_details: I18nProposal_details;
-  status: I18nStatus;
   modals: I18nModals;
 }


### PR DESCRIPTION
# Motivation

Some i18n keys were not generated and added to the description file

# Changes

- generate keys from `en.json` and update `i18n.d.ts` with the related keys
