### PR TITLE
build: remove implicit defer

### DIFF
--- a/frontend/svelte/src/index.html
+++ b/frontend/svelte/src/index.html
@@ -13,7 +13,7 @@
 
     <link rel="stylesheet" href="./build/bundle.css" />
 
-    <script type="module" defer src="./build/bundle.js"></script>
+    <script type="module" src="./build/bundle.js"></script>
 
     <!-- BASE_HREF -->
   </head>


### PR DESCRIPTION
# Motivation

Remove implicit `defer` attribute in `script` tag.

# Changes

> There is no need to use the defer attribute (see [<script> attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes)) when loading a module script; modules are deferred automatically.

[MDN Source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
