### PR TITLE
feat: replace input fullWidth property with CSS variable

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -11,8 +11,6 @@
 
   export let placeholderLabelKey: string;
 
-  // TODO: Review LM and DDB
-  export let fullWidth: boolean = false;
   export let theme: "dark" | "light" = "light";
 
   const handleInput = ({ currentTarget }: InputEventHandler) =>
@@ -22,7 +20,7 @@
   $: step = inputType === "number" ? step || "any" : undefined;
 </script>
 
-<div class={`input-block ${theme}`} class:fullWidth>
+<div class={`input-block ${theme}`}>
   <input
     type={inputType}
     {required}
@@ -50,13 +48,11 @@
     display: flex;
     align-items: center;
 
+    width: var(--input-width);
+
     :global(button) {
       position: absolute;
       right: calc(2 * var(--padding));
-    }
-
-    &.fullWidth {
-      width: 100%;
     }
 
     &.dark {

--- a/frontend/svelte/src/lib/modals/CreateNeuronModal/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/modals/CreateNeuronModal/StakeNeuron.svelte
@@ -36,7 +36,6 @@
         placeholderLabelKey="neurons.amount"
         name="amount"
         bind:value={amount}
-        fullWidth
         theme="dark"
       />
       <small>{$i18n.neurons.may_take_while}</small>
@@ -84,6 +83,7 @@
     align-items: center;
 
     width: 100%;
+    --input-width: 100%;
 
     small {
       margin-top: calc(2 * var(--padding));


### PR DESCRIPTION
# Motivation

Prefer CSS variables over properties for styling purpose.

Exception: block of styles such as applying a all theme or color - i.g. options that affect multiples styles.

# Changes

- remove `fullWidth`
- add CSS variable

# Note

Follow-up of last week PR [Create Neuron UI](https://github.com/dfinity/nns-dapp/pull/423). Works for you @lmuntanerDfinity?
