### PR TITLE
build: bump agent-js v0.10.3 and clean up dependencies

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/auth-client": "^0.10.3",
         "@dfinity/identity": "^0.10.3",
-        "@dfinity/nns": "^0.2.0"
+        "@dfinity/nns": "^0.2.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -672,13 +672,13 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.0.tgz",
-      "integrity": "sha512-wnEb6cLoTUDH5gn6fjwgYWrY4WfNLaulQ1v+/tK5LuYcAcnd7ErwxpAZJC4KvOSM+cZ3IivvbOsJ3fLkQS/Q4A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.1.tgz",
+      "integrity": "sha512-8zOGAkYGEkVcmuq8RP9py4VsZOQs1boZiYFajAKD7mCiij4wn+H6HpJVg1mVEnlZCl2VrBL+5ObqB81KNMlfrw==",
       "dependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/principal": "^0.10.2",
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/candid": "^0.10.3",
+        "@dfinity/principal": "^0.10.3",
         "crc": "^3.8.0",
         "crc-32": "^1.2.0",
         "google-protobuf": "^3.19.1",
@@ -8281,13 +8281,13 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.0.tgz",
-      "integrity": "sha512-wnEb6cLoTUDH5gn6fjwgYWrY4WfNLaulQ1v+/tK5LuYcAcnd7ErwxpAZJC4KvOSM+cZ3IivvbOsJ3fLkQS/Q4A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.1.tgz",
+      "integrity": "sha512-8zOGAkYGEkVcmuq8RP9py4VsZOQs1boZiYFajAKD7mCiij4wn+H6HpJVg1mVEnlZCl2VrBL+5ObqB81KNMlfrw==",
       "requires": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/principal": "^0.10.2",
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/candid": "^0.10.3",
+        "@dfinity/principal": "^0.10.3",
         "crc": "^3.8.0",
         "crc-32": "^1.2.0",
         "google-protobuf": "^3.19.1",

--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -8,13 +8,9 @@
       "name": "svelte-app",
       "version": "1.0.0",
       "dependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/auth-client": "^0.10.2",
-        "@dfinity/authentication": "^0.10.2",
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/identity": "^0.10.2",
-        "@dfinity/nns": "^0.2.0",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/auth-client": "^0.10.3",
+        "@dfinity/identity": "^0.10.3",
+        "@dfinity/nns": "^0.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -618,9 +614,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
-      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.3.tgz",
+      "integrity": "sha512-trbTm8/o7N0yoIsNIMeKfbfKsqphDQ0Ql5cL5VdIUb57ClFKQg7VrQJoFXn9CYuhgqC7u5EnkNhlfLc2SH1Y3A==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -629,40 +625,41 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/candid": "^0.10.3",
+        "@dfinity/principal": "^0.10.3"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.2.tgz",
-      "integrity": "sha512-u9RThzTvsrKb85PhnEUXgZ3KwdSJCeNwHBZ3zVCZ7XQEkDhwNZK87JD00Mh2Z5kCbN3+A+OdGZtYXloFlgENew==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.3.tgz",
+      "integrity": "sha512-1aNMWnqlwQ3/uvJFOPp1aK0S++nc68ZoG9dKPNdCQJ7AwSxyJbcyGDubFldd1stm2VloD4KOge81s/J7+h43gg==",
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/authentication": "^0.10.2",
-        "@dfinity/identity": "^0.10.2",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/authentication": "^0.10.3",
+        "@dfinity/identity": "^0.10.3",
+        "@dfinity/principal": "^0.10.3"
       }
     },
     "node_modules/@dfinity/authentication": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.2.tgz",
-      "integrity": "sha512-+fNuknjSl1SI4f0e+KQdCnJy3vuSTeGFriLXstjYDCO2ez432lMiyqoF9eC4Gvp6AX9RZifRt2BXuWnhzwZwEQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.3.tgz",
+      "integrity": "sha512-u4DScN3q5MuPusZ5NgORlPEnYsvjiSEXRdw0FzI2hegSU2KzocBs190WZPKFM0C52s6ZC5BP16xTX0eDm6NWgA==",
+      "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/identity": "^0.10.2",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/identity": "^0.10.3",
+        "@dfinity/principal": "^0.10.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
-      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.3.tgz",
+      "integrity": "sha512-+zhJGIlhPLsxh6ft2HPwKz6TQzkBIZHkOCgyrZ9ajvBWq1riyCEVlIgISlIiGfNcCWT4UjWZfe8s/2YIR2VqrQ=="
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.2.tgz",
-      "integrity": "sha512-ltAqR813Rm8pZjD5qCXAdBa4S/W9Afo7u6ue2m9UDHmOryiq4VR295hl1Mn4Svb2itgOE1omWl0oA3VDoQ1B1A==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.3.tgz",
+      "integrity": "sha512-5YnQPObtbcRb+wSmX92cukC5hwpk/GDEZAGp0/98oZJZYy5YdMb7mOIZ6mLdVm4UvtoBt76UyzwhTYjUn70Erg==",
       "dependencies": {
         "borc": "^2.1.1",
         "js-sha256": "^0.9.0",
@@ -670,8 +667,8 @@
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/principal": "^0.10.3"
       }
     },
     "node_modules/@dfinity/nns": {
@@ -689,9 +686,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
-      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.3.tgz",
+      "integrity": "sha512-32xwA+uSr3ieus55OG70b+wctiWxUJ5e/3JcmXgvC4o8TredAnfbQFuTqRi4AO+dh230hHqeRsKLoCvTdDRBXg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6779,12 +6776,12 @@
       }
     },
     "node_modules/secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "hasInstallScript": true,
       "dependencies": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       },
@@ -8243,9 +8240,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
-      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.3.tgz",
+      "integrity": "sha512-trbTm8/o7N0yoIsNIMeKfbfKsqphDQ0Ql5cL5VdIUb57ClFKQg7VrQJoFXn9CYuhgqC7u5EnkNhlfLc2SH1Y3A==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -8255,26 +8252,27 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.2.tgz",
-      "integrity": "sha512-u9RThzTvsrKb85PhnEUXgZ3KwdSJCeNwHBZ3zVCZ7XQEkDhwNZK87JD00Mh2Z5kCbN3+A+OdGZtYXloFlgENew==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.10.3.tgz",
+      "integrity": "sha512-1aNMWnqlwQ3/uvJFOPp1aK0S++nc68ZoG9dKPNdCQJ7AwSxyJbcyGDubFldd1stm2VloD4KOge81s/J7+h43gg==",
       "requires": {}
     },
     "@dfinity/authentication": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.2.tgz",
-      "integrity": "sha512-+fNuknjSl1SI4f0e+KQdCnJy3vuSTeGFriLXstjYDCO2ez432lMiyqoF9eC4Gvp6AX9RZifRt2BXuWnhzwZwEQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.10.3.tgz",
+      "integrity": "sha512-u4DScN3q5MuPusZ5NgORlPEnYsvjiSEXRdw0FzI2hegSU2KzocBs190WZPKFM0C52s6ZC5BP16xTX0eDm6NWgA==",
+      "peer": true,
       "requires": {}
     },
     "@dfinity/candid": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
-      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.3.tgz",
+      "integrity": "sha512-+zhJGIlhPLsxh6ft2HPwKz6TQzkBIZHkOCgyrZ9ajvBWq1riyCEVlIgISlIiGfNcCWT4UjWZfe8s/2YIR2VqrQ=="
     },
     "@dfinity/identity": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.2.tgz",
-      "integrity": "sha512-ltAqR813Rm8pZjD5qCXAdBa4S/W9Afo7u6ue2m9UDHmOryiq4VR295hl1Mn4Svb2itgOE1omWl0oA3VDoQ1B1A==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.10.3.tgz",
+      "integrity": "sha512-5YnQPObtbcRb+wSmX92cukC5hwpk/GDEZAGp0/98oZJZYy5YdMb7mOIZ6mLdVm4UvtoBt76UyzwhTYjUn70Erg==",
       "requires": {
         "borc": "^2.1.1",
         "js-sha256": "^0.9.0",
@@ -8297,9 +8295,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
-      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.3.tgz",
+      "integrity": "sha512-32xwA+uSr3ieus55OG70b+wctiWxUJ5e/3JcmXgvC4o8TredAnfbQFuTqRi4AO+dh230hHqeRsKLoCvTdDRBXg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -12879,11 +12877,11 @@
       }
     },
     "secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "requires": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -50,6 +50,6 @@
   "dependencies": {
     "@dfinity/auth-client": "^0.10.3",
     "@dfinity/identity": "^0.10.3",
-    "@dfinity/nns": "^0.2.0"
+    "@dfinity/nns": "^0.2.1"
   }
 }

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -48,12 +48,8 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.10.2",
-    "@dfinity/auth-client": "^0.10.2",
-    "@dfinity/authentication": "^0.10.2",
-    "@dfinity/candid": "^0.10.2",
-    "@dfinity/identity": "^0.10.2",
-    "@dfinity/nns": "^0.2.0",
-    "@dfinity/principal": "^0.10.2"
+    "@dfinity/auth-client": "^0.10.3",
+    "@dfinity/identity": "^0.10.3",
+    "@dfinity/nns": "^0.2.0"
   }
 }


### PR DESCRIPTION
# Motivation

Bump agent-js to [v0.10.3](https://github.com/dfinity/agent-js/releases/tag/v0.10.3) with latest security improvements

# Changes

- bump `auth-client` and `identity`
- bump `nns-js`
- remove implicit dependencies `candid`, `agent` and `principal` inherited from `nns-js`
- remove unused `authentication`

# Tests

Local tests with existing features - sign in, sign out, list proposals, get main account (gives expected 0.0 but no error). All good.
