### PR TITLE
build: prevent screenshots commit on main build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           path: e2e-tests/wdio.log
 
       - name: Commit screenshots
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: EndBug/add-and-commit@v7.4.0
         with:
           add: e2e-tests/screenshots


### PR DESCRIPTION
# Motivation

Do not commit of screenshots if `main` build.

Prevent issue such as https://github.com/dfinity/nns-dapp/actions/runs/1852192135

# Changes

- add test `${{ github.ref != 'refs/heads/main' }}` in build actions
