### PR TITLE
feat: add identity, host and fetch root key to create agent 

### DIFF
--- a/frontend/svelte/jest-spy.ts
+++ b/frontend/svelte/jest-spy.ts
@@ -1,4 +1,4 @@
 import * as agent from "./src/lib/utils/agent.utils";
 
-const mockCreateAgent = () => undefined;
+const mockCreateAgent = () => Promise.resolve(undefined);
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);

--- a/frontend/svelte/jest-spy.ts
+++ b/frontend/svelte/jest-spy.ts
@@ -1,0 +1,4 @@
+import * as agent from "./src/lib/utils/agent.utils";
+
+const mockCreateAgent = () => undefined;
+jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);

--- a/frontend/svelte/jest.config.cjs
+++ b/frontend/svelte/jest.config.cjs
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.js$": "ts-jest",
   },
   moduleFileExtensions: ["js", "ts", "svelte"],
-  setupFilesAfterEnv: ["<rootDir>/jest-setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest-setup.ts", "<rootDir>/jest-spy.ts"],
   collectCoverageFrom: ["src/**/*.{ts,tsx,svelte,js,jsx}"],
   testPathIgnorePatterns: ["nns-js"],
   testURL: "https://nns.ic0.app/",

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -107,6 +107,8 @@ export default {
       "process.env.REDIRECT_TO_LEGACY": JSON.stringify(
         envConfig.REDIRECT_TO_LEGACY
       ),
+      "process.env.FETCH_ROOT_KEY": JSON.stringify(envConfig.FETCH_ROOT_KEY),
+      "process.env.HOST": JSON.stringify(envConfig.HOST),
     }),
 
     // In dev mode, call `npm run start` once

--- a/frontend/svelte/src/lib/components/common/PrivateRoute.svelte
+++ b/frontend/svelte/src/lib/components/common/PrivateRoute.svelte
@@ -30,8 +30,8 @@
   };
 
   const unsubscribe: Unsubscriber = authStore.subscribe(
-    ({ principal }: AuthStore) => {
-      signedIn = isSignedIn(principal);
+    ({ identity }: AuthStore) => {
+      signedIn = isSignedIn(identity);
 
       redirectLogin();
     }

--- a/frontend/svelte/src/lib/constants/identity.constants.ts
+++ b/frontend/svelte/src/lib/constants/identity.constants.ts
@@ -1,0 +1,2 @@
+export const identityServiceURL: string =
+  process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/constants/identity.constants.ts
+++ b/frontend/svelte/src/lib/constants/identity.constants.ts
@@ -1,2 +1,1 @@
-export const identityServiceURL: string =
-  process.env.IDENTITY_SERVICE_URL;
+export const identityServiceURL: string = process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/constants/utils.constants.ts
+++ b/frontend/svelte/src/lib/constants/utils.constants.ts
@@ -1,1 +1,1 @@
-export const serviceURL: string = process.env.IDENTITY_SERVICE_URL;
+export const internetIdentityServiceURL: string = process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/constants/utils.constants.ts
+++ b/frontend/svelte/src/lib/constants/utils.constants.ts
@@ -1,2 +1,0 @@
-export const internetIdentityServiceURL: string =
-  process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/constants/utils.constants.ts
+++ b/frontend/svelte/src/lib/constants/utils.constants.ts
@@ -1,1 +1,2 @@
-export const internetIdentityServiceURL: string = process.env.IDENTITY_SERVICE_URL;
+export const internetIdentityServiceURL: string =
+  process.env.IDENTITY_SERVICE_URL;

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -1,5 +1,5 @@
+import type { Identity } from "@dfinity/agent";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { createAgent } from "../utils/agent.utils";
@@ -10,30 +10,30 @@ import { createAgent } from "../utils/agent.utils";
  * b. If a `principal` is provided, e.g. after sign-in, then the information are loaded using the ledger and the nns dapp canister itself
  */
 export const syncAccounts = async ({
-  principal,
+  identity,
 }: {
-  principal: Principal;
+  identity: Identity | undefined | null;
 }): Promise<void> => {
-  if (!principal) {
+  if (!identity) {
     accountsStore.set(undefined);
     return;
   }
 
-  const accounts: AccountsStore = await loadAccounts({ principal });
+  const accounts: AccountsStore = await loadAccounts({ identity });
   accountsStore.set(accounts);
 };
 
 const loadAccounts = async ({
-  principal,
+  identity,
 }: {
-  principal: Principal;
+  identity: Identity;
 }): Promise<AccountsStore> => {
   const ledger: LedgerCanister = LedgerCanister.create({
     agent: createAgent(),
   });
 
   const accountIdentifier: AccountIdentifier = AccountIdentifier.fromPrincipal({
-    principal,
+    principal: identity.getPrincipal(),
   });
 
   const balance: ICP = await ledger.accountBalance({

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -1,6 +1,6 @@
 import type { Identity } from "@dfinity/agent";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
-import { internetIdentityServiceURL } from "../constants/utils.constants";
+import { identityServiceURL } from "../constants/identity.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { createAgent } from "../utils/agent.utils";
@@ -30,7 +30,7 @@ const loadAccounts = async ({
   identity: Identity;
 }): Promise<AccountsStore> => {
   const ledger: LedgerCanister = LedgerCanister.create({
-    agent: await createAgent({ identity, host: internetIdentityServiceURL }),
+    agent: await createAgent({ identity, host: identityServiceURL }),
   });
 
   const accountIdentifier: AccountIdentifier = AccountIdentifier.fromPrincipal({

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -1,5 +1,6 @@
 import type { Identity } from "@dfinity/agent";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
+import { internetIdentityServiceURL } from "../constants/utils.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { createAgent } from "../utils/agent.utils";
@@ -29,7 +30,7 @@ const loadAccounts = async ({
   identity: Identity;
 }): Promise<AccountsStore> => {
   const ledger: LedgerCanister = LedgerCanister.create({
-    agent: createAgent(),
+    agent: await createAgent({ identity, host: internetIdentityServiceURL }),
   });
 
   const accountIdentifier: AccountIdentifier = AccountIdentifier.fromPrincipal({

--- a/frontend/svelte/src/lib/services/dev.services.ts
+++ b/frontend/svelte/src/lib/services/dev.services.ts
@@ -19,6 +19,6 @@ export const getICPs = async (icps: number) => {
     throw new Error(JSON.stringify(result));
   }
 
-  const { principal }: AuthStore = get(authStore);
-  await syncAccounts({ principal });
+  const { identity }: AuthStore = get(authStore);
+  await syncAccounts({ identity });
 };

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -1,7 +1,7 @@
 import { AuthClient } from "@dfinity/auth-client";
 import type { Principal } from "@dfinity/principal";
 import { writable } from "svelte/store";
-import { serviceURL } from "../constants/utils.constants";
+import { internetIdentityServiceURL } from "../constants/utils.constants";
 
 export interface AuthStore {
   principal: Principal | undefined | null;
@@ -49,7 +49,7 @@ const initAuthStore = () => {
         const authClient: AuthClient = await AuthClient.create();
 
         await authClient.login({
-          identityProvider: serviceURL,
+          identityProvider: internetIdentityServiceURL,
           maxTimeToLive: BigInt(30 * 60 * 1_000_000_000), // 30 minutes
           onSuccess: () => {
             update((state: AuthStore) => ({

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -1,7 +1,7 @@
 import type { Identity } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
 import { writable } from "svelte/store";
-import { internetIdentityServiceURL } from "../constants/utils.constants";
+import { identityServiceURL } from "../constants/identity.constants";
 
 export interface AuthStore {
   identity: Identity | undefined | null;
@@ -47,7 +47,7 @@ const initAuthStore = () => {
         const authClient: AuthClient = await AuthClient.create();
 
         await authClient.login({
-          identityProvider: internetIdentityServiceURL,
+          identityProvider: identityServiceURL,
           maxTimeToLive: BigInt(30 * 60 * 1_000_000_000), // 30 minutes
           onSuccess: () => {
             update((state: AuthStore) => ({

--- a/frontend/svelte/src/lib/stores/auth.store.ts
+++ b/frontend/svelte/src/lib/stores/auth.store.ts
@@ -1,17 +1,17 @@
+import type { Identity } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
-import type { Principal } from "@dfinity/principal";
 import { writable } from "svelte/store";
 import { internetIdentityServiceURL } from "../constants/utils.constants";
 
 export interface AuthStore {
-  principal: Principal | undefined | null;
+  identity: Identity | undefined | null;
 }
 
 /**
- * A store to handle authentication and the principal of the user.
+ * A store to handle authentication and the identity of the user.
  *
  * - sync: query auth-client to get the status of the authentication
- * a. if authenticated only, set principal in the global state
+ * a. if authenticated only, set identity in the global state
  * b. if not authenticated, set null in store
  *
  * the sync function is performed when the app boots and on any change in the local storage (see <Guard/>)
@@ -27,7 +27,7 @@ export interface AuthStore {
  */
 const initAuthStore = () => {
   const { subscribe, set, update } = writable<AuthStore>({
-    principal: undefined,
+    identity: undefined,
   });
 
   return {
@@ -38,9 +38,7 @@ const initAuthStore = () => {
       const isAuthenticated: boolean = await authClient.isAuthenticated();
 
       set({
-        principal: isAuthenticated
-          ? authClient.getIdentity().getPrincipal()
-          : null,
+        identity: isAuthenticated ? authClient.getIdentity() : null,
       });
     },
 
@@ -54,7 +52,7 @@ const initAuthStore = () => {
           onSuccess: () => {
             update((state: AuthStore) => ({
               ...state,
-              principal: authClient.getIdentity().getPrincipal(),
+              identity: authClient.getIdentity(),
             }));
 
             resolve();
@@ -70,7 +68,7 @@ const initAuthStore = () => {
 
       update((state: AuthStore) => ({
         ...state,
-        principal: null,
+        identity: null,
       }));
     },
   };

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,5 +1,5 @@
 import { HttpAgent } from "@dfinity/agent";
-import { serviceURL } from "../constants/utils.constants";
+import { internetIdentityServiceURL } from "../constants/utils.constants";
 
 // To avoid being executed in tests that only import it
-export const createAgent = () => new HttpAgent({ host: serviceURL });
+export const createAgent = () => new HttpAgent({ host: internetIdentityServiceURL });

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,6 +1,18 @@
-import { HttpAgent } from "@dfinity/agent";
-import { internetIdentityServiceURL } from "../constants/utils.constants";
+import { HttpAgent, Identity } from "@dfinity/agent";
 
-// To avoid being executed in tests that only import it
-export const createAgent = () =>
-  new HttpAgent({ host: internetIdentityServiceURL });
+export const createAgent = async ({
+  identity,
+  host,
+}: {
+  identity: Identity;
+  host?: string;
+}): Promise<HttpAgent> => {
+  const agent: HttpAgent = new HttpAgent({ identity, ...(host && { host }) });
+
+  if (process.env.FETCH_ROOT_KEY) {
+    // Fetch root key for certificate validation during development or on testnet
+    await agent.fetchRootKey();
+  }
+
+  return agent;
+};

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -2,4 +2,5 @@ import { HttpAgent } from "@dfinity/agent";
 import { internetIdentityServiceURL } from "../constants/utils.constants";
 
 // To avoid being executed in tests that only import it
-export const createAgent = () => new HttpAgent({ host: internetIdentityServiceURL });
+export const createAgent = () =>
+  new HttpAgent({ host: internetIdentityServiceURL });

--- a/frontend/svelte/src/lib/utils/auth.utils.ts
+++ b/frontend/svelte/src/lib/utils/auth.utils.ts
@@ -1,11 +1,11 @@
-import type { Principal } from "@dfinity/principal";
+import type { Identity } from "@dfinity/agent";
 
 /**
- * The user is signed in when the principal is not undefined and not null.
+ * The user is signed in when the identity is not undefined and not null.
  *
- * Note: we do not check if the principal is anonymous or not.
+ * Note: we do not check if the principal of the identity is anonymous or not.
  * The authStore takes care of applying the correct value according the auth state.
- * It adds only a principal in memory if it is an authenticated one.
+ * It adds only an identity in memory if it is an authenticated one.
  */
-export const isSignedIn = (principal: Principal | undefined | null): boolean =>
-  principal !== undefined && principal !== null;
+export const isSignedIn = (identity: Identity | undefined | null): boolean =>
+  identity !== undefined && identity !== null;

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -26,8 +26,8 @@
   };
 
   const unsubscribe: Unsubscriber = authStore.subscribe(
-    async ({ principal }: AuthStore) => {
-      signedIn = isSignedIn(principal);
+    async ({ identity }: AuthStore) => {
+      signedIn = isSignedIn(identity);
 
       if (!signedIn) {
         return;

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -27,7 +27,9 @@
         <li>{$i18n.canisters.step3}</li>
       </ul>
       <p>
-        {$i18n.canisters.principal_is} "{$authStore.principal?.toText()}"
+        {$i18n.canisters.principal_is} "{$authStore.identity
+          ?.getPrincipal()
+          .toText()}"
       </p>
     </section>
 

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -18,7 +18,8 @@
   let principalText: string = "";
 
   const unsubscribe: Unsubscriber = authStore.subscribe(
-    ({ principal }: AuthStore) => (principalText = principal?.toText() ?? "")
+    ({ identity }: AuthStore) =>
+      (principalText = identity?.getPrincipal().toText() ?? "")
   );
 
   onDestroy(unsubscribe);

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -19,6 +19,7 @@
     listProposals,
   } from "../lib/services/proposals.services";
   import type { ProposalInfo } from "@dfinity/nns";
+  import { authStore } from "../lib/stores/auth.store";
 
   let loading: boolean = false;
 
@@ -27,7 +28,10 @@
 
     // TODO(L2-206): catch and display errors
 
-    await listNextProposals({ beforeProposal: lastProposalId(proposals) });
+    await listNextProposals({
+      beforeProposal: lastProposalId(proposals),
+      identity: $authStore.identity,
+    });
 
     loading = false;
   };
@@ -38,7 +42,10 @@
     // TODO(L2-206): catch and display errors
 
     // If proposals are already displayed we reset the store first otherwise it might give the user the feeling than the new filters were already applied while the proposals are still being searched.
-    await listProposals({ clearBeforeQuery: !emptyProposals(proposals) });
+    await listProposals({
+      clearBeforeQuery: !emptyProposals(proposals),
+      identity: $authStore.identity,
+    });
 
     loading = false;
   };

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -3,13 +3,12 @@
  */
 
 import { LedgerCanister } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 import App from "../App.svelte";
 import { authStore } from "../lib/stores/auth.store";
 import {
   authStoreMock,
-  mockPrincipal,
+  mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "./mocks/auth.store.mock";
 import { MockLedgerCanister } from "./mocks/ledger.canister.mock";
@@ -36,7 +35,7 @@ describe("App", () => {
     expect(spyLedger).toHaveBeenCalledTimes(0);
 
     authStoreMock.next({
-      principal: mockPrincipal as Principal,
+      identity: mockIdentity,
     });
 
     expect(spyLedger).toHaveBeenCalledTimes(1);

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -7,7 +7,6 @@ import type { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 import App from "../App.svelte";
 import { authStore } from "../lib/stores/auth.store";
-import * as agent from "../lib/utils/agent.utils";
 import {
   authStoreMock,
   mockPrincipal,
@@ -29,10 +28,6 @@ describe("App", () => {
       .mockImplementation((): LedgerCanister => mockLedgerCanister);
 
     spyLedger = jest.spyOn(mockLedgerCanister, "accountBalance");
-
-    // TODO(L2-206): mock http agent globally
-    const mockCreateAgent = () => undefined;
-    jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
   });
 
   it("should synchronize the accounts after sign in", async () => {

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -4,6 +4,7 @@
 
 import { LedgerCanister } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
 import App from "../App.svelte";
 import { authStore } from "../lib/stores/auth.store";
 import {
@@ -37,6 +38,8 @@ describe("App", () => {
     authStoreMock.next({
       identity: mockIdentity,
     });
+
+    await tick();
 
     expect(spyLedger).toHaveBeenCalledTimes(1);
   });

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -1,7 +1,7 @@
 import { LedgerCanister } from "@dfinity/nns";
 import { syncAccounts } from "../../../lib/services/accounts.services";
 import * as agent from "../../../lib/utils/agent.utils";
-import { mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 import { MockLedgerCanister } from "../../mocks/ledger.canister.mock";
 
 describe("accounts-services", () => {
@@ -19,7 +19,7 @@ describe("accounts-services", () => {
 
     const spy = jest.spyOn(mockLedgerCanister, "accountBalance");
 
-    await syncAccounts({ principal: mockPrincipal });
+    await syncAccounts({ identity: mockIdentity });
 
     expect(spy).toHaveReturnedTimes(1);
   });

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -4,6 +4,7 @@ import {
   listProposals,
 } from "../../../lib/services/proposals.services";
 import { proposalsStore } from "../../../lib/stores/proposals.store";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 import { MockGovernanceCanister } from "../../mocks/proposals.store.mock";
 
 describe("proposals-services", () => {
@@ -30,7 +31,7 @@ describe("proposals-services", () => {
   afterEach(() => spyListProposals.mockClear());
 
   it("should call the canister to list proposals", async () => {
-    await listProposals({});
+    await listProposals({ identity: mockIdentity });
 
     expect(spyListProposals).toHaveReturnedTimes(1);
   });
@@ -38,6 +39,7 @@ describe("proposals-services", () => {
   it("should call the canister to list the next proposals", async () => {
     await listNextProposals({
       beforeProposal: mockProposals[mockProposals.length - 1].id,
+      identity: mockIdentity,
     });
 
     expect(spyListProposals).toHaveReturnedTimes(1);
@@ -45,14 +47,14 @@ describe("proposals-services", () => {
 
   it("should clear the list proposals before query", async () => {
     const spy = jest.spyOn(proposalsStore, "setProposals");
-    await listProposals({ clearBeforeQuery: true });
+    await listProposals({ clearBeforeQuery: true, identity: mockIdentity });
     expect(spy).toHaveBeenCalledTimes(2);
     spy.mockClear();
   });
 
   it("should not clear the list proposals before query", async () => {
     const spy = jest.spyOn(proposalsStore, "setProposals");
-    await listProposals({ clearBeforeQuery: false });
+    await listProposals({ clearBeforeQuery: false, identity: mockIdentity });
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockClear();
   });
@@ -61,6 +63,7 @@ describe("proposals-services", () => {
     const spy = jest.spyOn(proposalsStore, "pushProposals");
     await listNextProposals({
       beforeProposal: mockProposals[mockProposals.length - 1].id,
+      identity: mockIdentity,
     });
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockClear();
@@ -84,6 +87,7 @@ describe("proposals-services", () => {
     const spy = jest.spyOn(proposalsStore, "pushProposals");
     await listNextProposals({
       beforeProposal: mockProposals[mockProposals.length - 1].id,
+      identity: mockIdentity,
     });
     expect(spy).toHaveBeenCalledTimes(0);
     spy.mockClear();

--- a/frontend/svelte/src/tests/lib/stores/auth.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/auth.store.spec.ts
@@ -1,7 +1,7 @@
 import type { Identity } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
 import { authStore } from "../../../lib/stores/auth.store";
-import { mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 
 class MockAuthClient extends AuthClient {
   constructor() {
@@ -17,7 +17,7 @@ class MockAuthClient extends AuthClient {
   }
 
   getIdentity(): Identity {
-    return { getPrincipal: () => mockPrincipal } as unknown as Identity;
+    return mockIdentity;
   }
 
   async login({ onSuccess }: { onSuccess?: () => void }) {

--- a/frontend/svelte/src/tests/lib/utils/auth.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/auth.utils.spec.ts
@@ -1,6 +1,5 @@
-import type { Principal } from "@dfinity/principal";
 import { isSignedIn } from "../../../lib/utils/auth.utils";
-import { mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 
 describe("auth-utils", () => {
   it("should not be signed in", () => {
@@ -9,6 +8,6 @@ describe("auth-utils", () => {
   });
 
   it("should be signed in", () => {
-    expect(isSignedIn(mockPrincipal as Principal)).toBeTruthy();
+    expect(isSignedIn(mockIdentity)).toBeTruthy();
   });
 });

--- a/frontend/svelte/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/auth.store.mock.ts
@@ -1,3 +1,4 @@
+import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
 import type { AuthStore } from "../../lib/stores/auth.store";
@@ -6,13 +7,17 @@ export const mockPrincipal = Principal.fromText(
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
 );
 
+export const mockIdentity = {
+  getPrincipal: () => mockPrincipal,
+} as unknown as Identity;
+
 /**
  * A static mock of the auth store. The component that uses it will be rendered for test with a value that is already defined on mount.
  */
 export const mockAuthStoreSubscribe = (
   run: Subscriber<AuthStore>
 ): (() => void) => {
-  run({ principal: mockPrincipal });
+  run({ identity: mockIdentity });
 
   return () => {};
 };
@@ -23,7 +28,7 @@ export const mockAuthStoreSubscribe = (
  */
 
 export class AuthStoreMock {
-  private _store: AuthStore = { principal: undefined };
+  private _store: AuthStore = { identity: undefined };
 
   private _callback: (store: AuthStore) => void;
 

--- a/frontend/svelte/src/tests/routes/Canisters.spec.ts
+++ b/frontend/svelte/src/tests/routes/Canisters.spec.ts
@@ -9,7 +9,6 @@ import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "../mocks/auth.store.mock";
-const en = require("../../lib/i18n/en.json");
 
 describe("Canisters", () => {
   let authStoreMock;


### PR DESCRIPTION
# Motivation

Canisters calls shall be identified with user' identity.
Host and fetch root key are useful to develop locally and use testnet.

# Changes

- refactor `authStore` to contain user' `Identity` instead of `Principal` ("one level of information higher)
- rename constant `serviceURL` to `identityServiceURL`
- add `Identity`, optional `host` and `fetchRootKey` to agent utils
- `createAgent` is now promise based
- use `Identity` and `identityServiceURL` in `accounts.services` to fetch account balance
- use `Identity` and `host` in `proposals.services` to fetch the list of proposals (was only done in prod, now support testnet)
- globally mock `createAgent` for all tests
- extend rollup config to build app with `HOST` and `FETCH_ROOT_KEY` information
