### PR TITLE
style: square check-boxes and align close modal

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -128,7 +128,9 @@
 
     display: grid;
     --toolbar-icon-width: calc((var(--padding) / 2) + var(--icon-width));
-    grid-template-columns: var(--toolbar-icon-width) 1fr var(--toolbar-icon-width);
+    grid-template-columns: var(--toolbar-icon-width) 1fr var(
+        --toolbar-icon-width
+      );
 
     z-index: var(--z-index);
 

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -127,7 +127,8 @@
     color: var(--gray-800);
 
     display: grid;
-    grid-template-columns: var(--icon-width) 1fr var(--icon-width);
+    --toolbar-icon-width: calc((var(--padding) / 2) + var(--icon-width));
+    grid-template-columns: var(--toolbar-icon-width) 1fr var(--toolbar-icon-width);
 
     z-index: var(--z-index);
 

--- a/frontend/svelte/src/lib/themes/mixins/_select.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_select.scss
@@ -47,7 +47,7 @@
 
   border: var(--select-input-border) solid currentColor;
 
-  border-radius: 50%;
+  border-radius: 2px;
 
   transition: background 0.2s, border 0.2s;
 


### PR DESCRIPTION
# Motivation

Product - UX mgmt rather like square check-boxes (material design instead of ios round design).

# Changes

- make check-boxes square
- align modal close button

# Screenshots

<img width="1153" alt="Capture d’écran 2022-02-21 à 12 51 00" src="https://user-images.githubusercontent.com/16886711/154950417-707b5689-66c9-4260-9120-8d0ebdf065db.png">
<img width="1153" alt="Capture d’écran 2022-02-21 à 12 51 05" src="https://user-images.githubusercontent.com/16886711/154950431-b1fbec76-590f-4bc1-a321-cbe197f8503f.png">
<img width="706" alt="Capture d’écran 2022-02-21 à 12 50 52" src="https://user-images.githubusercontent.com/16886711/154950450-24e7d3f4-a93c-47cb-9a42-7fc2965bdb54.png">

