### PR TITLE
Release 2022-02-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Proposal placeholder
+
+
 ## Proposal 45369
 * Upgrade agent-js to 0.10.3 (to resolve some issues with proposal rendering)
 * Add "Powered by IC" badge to the login page

--- a/PROPOSAL_TEMPLATE.md
+++ b/PROPOSAL_TEMPLATE.md
@@ -20,6 +20,5 @@ To build the wasm module yourself and verify its hash, run the following command
 
 git pull  # to ensure you have the latest changes.
 git checkout `$COMMIT`
-docker build -t nns-dapp .
-docker run --rm --entrypoint cat nns-dapp /nns-dapp.wasm > nns-dapp.wasm
+./scripts/docker-build
 sha256sum nns-dapp.wasm

--- a/PROPOSAL_TEMPLATE.md
+++ b/PROPOSAL_TEMPLATE.md
@@ -21,4 +21,4 @@ To build the wasm module yourself and verify its hash, run the following command
 git pull  # to ensure you have the latest changes.
 git checkout `$COMMIT`
 ./scripts/docker-build
-sha256sum nns-dapp.wasm
+shasum -a 256 nns-dapp.wasm


### PR DESCRIPTION
# Motivation
A new release of the nns-dapp is being made.

## Details
PR: https://github.com/dfinity/nns-dapp/pull/472
Docker build in CI: https://github.com/dfinity/nns-dapp/actions/runs/1886296965
CI shasum: f4fb75d5ee24a9e57ee56aedeaab38514b64e9f2842151c28f4b8df9b6a6943c
Max's local shasum: f4fb75d5ee24a9e57ee56aedeaab38514b64e9f2842151c28f4b8df9b6a6943c
Changes:
* Update dependencies and Rust version.
* Enable merge maturity for hardware wallets.  (Needs a hardware wallet software update which does not appear to be out yet?.)
* End to end test for login.
* Update icon when installed as an Android app.
* More svelte front end changes.

# Changes
Update `CHANGELOG.md`.

# Tests
## Deployments

We have two deployments:
* https://wqmuk-5qaaa-aaaaa-aaaqq-cai.nnsdapp.dfinity.network <-- always the release candidate
  * ![Screenshot from 2022-02-23 12-49-11](https://user-images.githubusercontent.com/5982633/155313919-f705a873-adf6-4b66-a08f-f6f081917edf.png)
* https://tlwi3-3aaaa-aaaaa-aaapq-cai.nnsdapp.dfinity.network/v2/ <-- used for testing upgrading the last release to the current one.
  * ![Screenshot from 2022-02-23 12-48-12](https://user-images.githubusercontent.com/5982633/155313803-5388c743-8aff-4569-aedc-f6a4decb49b6.png)

## Upgrade tests:
* Deployed the last release candidate (tag proposal-45369) to https://nns.winning.gold 
* Populated with:
```
Auth with 10003
Get 20 ICP
Add linked account
Send 2 ICP from main account to linked account
Attach hardware wallet
Send 2 ICP from main account to hw wallet
Stake 1 ICP from linked account into a neuron with 8 year dissolve delay
Stake 1 ICP from hw wallet account into a neuron with no dissolve delay
Add hotkey from hw wallet neuron to NNS Dapp principal
Increate neuron stake of the 8 year neuron by 10 ICP
Make dummy proposals from the 8 year neuron

Auth with 10004
Get 20 ICP
Add linked account
Send 2 ICP from main account to linked account
Attach hardware wallet
Send 2 ICP from main account to hw wallet
Stake 1.9999 ICP from linked account into a neuron with 8 year dissolve delay
```
* Upgraded to the current release candidate (git tag release-candidate)
* Verified by:
  * Checking balances, neurons, hotkeys in the dapp.

## Frontend tests
* App installs on Android, with a logo - OK
* Basic login, check balance, create neuron tests - the relevant code has not been changed so a scan of basic functionality SHOULD suffice
  * Linux + Chrome OK
  * Mac + Safari OK
  * Android + Chrome OK