### PR TITLE
fix: missing modal status title

### DIFF
--- a/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
@@ -61,7 +61,7 @@
         category: "status",
         filters: ProposalStatus,
         selectedFilters: status,
-      })}>{$i18n.voting.proposals}</FiltersCard
+      })}>{$i18n.voting.status}</FiltersCard
   >
 </div>
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -61,7 +61,7 @@
     "text": "The Internet Computer network runs under the control of the Network Nervous System, which adopts proposals and automatically executes corresponding actions. Anyone can submit a proposal, which are decided as the result of voting activity by neurons.",
     "topics": "Topics",
     "rewards": "Reward Status",
-    "proposals": "Proposal Status",
+    "status": "Proposal Status",
     "hide_unavailable_proposals": "Hide \"Open\" proposals where all your neurons have voted or are ineligible to vote"
   },
   "canisters": {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -71,7 +71,7 @@ interface I18nVoting {
   text: string;
   topics: string;
   rewards: string;
-  proposals: string;
+  status: string;
   hide_unavailable_proposals: string;
 }
 


### PR DESCRIPTION
# Motivation

The title of the filters' modal "proposal status" is not rendered

# Changes

- rename i18n according correct category definition ("status" instead of "proposals")

# Screenshot

Before:

<img width="1163" alt="Capture d’écran 2022-02-23 à 11 55 40" src="https://user-images.githubusercontent.com/16886711/155306489-d80c0b8f-9597-4d8f-9fcd-66b7971c0131.png">

After:

<img width="1163" alt="Capture d’écran 2022-02-23 à 11 59 17" src="https://user-images.githubusercontent.com/16886711/155306511-76936321-565d-42c6-8785-85de9228899c.png">
