### PR TITLE
feat: remove pages title

### DIFF
--- a/frontend/svelte/src/lib/themes/fonts.scss
+++ b/frontend/svelte/src/lib/themes/fonts.scss
@@ -91,8 +91,3 @@ button {
   font-size: var(--font-size-h4);
   line-height: var(--line-height-title);
 }
-
-p,
-li {
-  font-size: var(--font-size-h3);
-}

--- a/frontend/svelte/src/lib/themes/theme.scss
+++ b/frontend/svelte/src/lib/themes/theme.scss
@@ -65,7 +65,7 @@ h5 {
 }
 
 p {
-  margin: 0;
+  margin: var(--padding) 0;
 }
 
 ul {

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -19,7 +19,6 @@
 {#if !process.env.REDIRECT_TO_LEGACY}
   <Layout>
     <section>
-      <h1>{$i18n.canisters.title}</h1>
       <p>{$i18n.canisters.text}</p>
       <ul>
         <li>{$i18n.canisters.step1}</li>
@@ -42,11 +41,3 @@
     </svelte:fragment>
   </Layout>
 {/if}
-
-<style lang="scss">
-  p,
-  ul,
-  li {
-    margin-bottom: calc(2 * var(--padding));
-  }
-</style>

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -33,8 +33,6 @@
 {#if !process.env.REDIRECT_TO_LEGACY}
   <Layout>
     <section>
-      <h1>{$i18n.neurons.title}</h1>
-
       <p>{$i18n.neurons.text}</p>
 
       <p>
@@ -57,7 +55,7 @@
 {/if}
 
 <style lang="scss">
-  p {
-    margin-bottom: calc(2 * var(--padding));
+  p:last-of-type {
+    margin-bottom: calc(3 * var(--padding));
   }
 </style>

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -103,8 +103,6 @@
 {#if !process.env.REDIRECT_TO_LEGACY}
   <Layout>
     <section>
-      <h1>{$i18n.voting.title}</h1>
-
       <p>{$i18n.voting.text}</p>
 
       <ProposalsFilters />

--- a/frontend/svelte/src/tests/routes/Canisters.spec.ts
+++ b/frontend/svelte/src/tests/routes/Canisters.spec.ts
@@ -20,12 +20,7 @@ describe("Canisters", () => {
   });
 
   it("should render content", () => {
-    const { container, getByText } = render(Canisters);
-
-    const title = container.querySelector("h1");
-    expect(title).not.toBeNull();
-    expect(title).toBeVisible();
-    expect(title).toHaveTextContent("Canisters");
+    const { getByText } = render(Canisters);
 
     expect(
       getByText(

--- a/frontend/svelte/src/tests/routes/Neurons.spec.ts
+++ b/frontend/svelte/src/tests/routes/Neurons.spec.ts
@@ -22,12 +22,7 @@ describe("Neurons", () => {
   });
 
   it("should render content", () => {
-    const { container, getByText } = render(Neurons);
-
-    const title = container.querySelector("h1");
-    expect(title).not.toBeNull();
-    expect(title).toBeVisible();
-    expect(title).toHaveTextContent("Neurons");
+    const { getByText } = render(Neurons);
 
     expect(
       getByText("Earn rewards by staking your ICP in neurons.", {

--- a/frontend/svelte/src/tests/routes/Proposals.spec.ts
+++ b/frontend/svelte/src/tests/routes/Proposals.spec.ts
@@ -34,14 +34,6 @@ describe("Proposals", () => {
       .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
   });
 
-  it("should render a title", () => {
-    const { container } = render(Proposals);
-
-    const title: HTMLHeadingElement | null = container.querySelector("h1");
-    expect(title).not.toBeNull();
-    expect(title.textContent).toEqual("Voting");
-  });
-
   it("should render a description", () => {
     const { getByText } = render(Proposals);
 


### PR DESCRIPTION
# Motivation

Titles displayed on pages (except "Accounts") are redundant information. The "blue indicator" in the navbar already highlights which page is selected.

The paragraphs that introduce the pages is rendered with a large font-size.

As we aim to spare spaces for what's matter, UX had the idea to get rid of the redundant titles and make the paragraphs font-size less big.

# Changes

- remove redundant pages' title
- style paragraph with an inherited font-size
- adds a bit of spacing next to the paragraphs if needed
- remove large space around paragraphs to inherits default compact spacing

# Screenshots

<img width="1513" alt="Capture d’écran 2022-02-23 à 15 04 42" src="https://user-images.githubusercontent.com/16886711/155334996-cef7a9cb-31bb-4d95-89f8-213bdc89bf6e.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 04 46" src="https://user-images.githubusercontent.com/16886711/155335015-366142f0-c4c9-4853-8e05-864394419783.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 04 49" src="https://user-images.githubusercontent.com/16886711/155335019-8ad4aeb3-9ea3-4a6b-b3c0-9f38ee84fe25.png">
<img width="914" alt="Capture d’écran 2022-02-23 à 15 04 54" src="https://user-images.githubusercontent.com/16886711/155335035-bb10dde8-1215-4e30-932b-c9d9363c913d.png">
<img width="914" alt="Capture d’écran 2022-02-23 à 15 04 55" src="https://user-images.githubusercontent.com/16886711/155335037-60ca64b7-cb14-4053-86f5-954f3319ed27.png">
<img width="914" alt="Capture d’écran 2022-02-23 à 15 04 57" src="https://user-images.githubusercontent.com/16886711/155335041-b243d676-1c9a-4f49-aab8-6abe61258ffb.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 05 06" src="https://user-images.githubusercontent.com/16886711/155335062-96b3171b-a7ce-4d85-9d9c-f997d15e73ba.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 05 10" src="https://user-images.githubusercontent.com/16886711/155335066-756ce4ae-12a4-48bc-ad60-2ce7ff10da40.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 05 12" src="https://user-images.githubusercontent.com/16886711/155335068-e3a6526f-1ae9-466b-b28d-34131735fc57.png">

# Note

In above screenshots the spacing looks a-ok on the "Voting" page but #478 will improve this.