### PR TITLE
feat: remove double quotes around principals

### DIFF
--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -27,9 +27,8 @@
         <li>{$i18n.canisters.step3}</li>
       </ul>
       <p>
-        {$i18n.canisters.principal_is} "{$authStore.identity
-          ?.getPrincipal()
-          .toText()}"
+        {$i18n.canisters.principal_is}
+        {$authStore.identity?.getPrincipal().toText()}
       </p>
     </section>
 

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -38,7 +38,8 @@
       <p>{$i18n.neurons.text}</p>
 
       <p>
-        {$i18n.neurons.principal_is} "{principalText}"
+        {$i18n.neurons.principal_is}
+        {principalText}
       </p>
 
       <NeuronCard />


### PR DESCRIPTION
# Motivation

UX inquiry to remove " around principals displayed as text since they don't adds much.

# Changes

- remove " around principals displayed as text

# Screenshots

<img width="1513" alt="Capture d’écran 2022-02-23 à 15 07 35" src="https://user-images.githubusercontent.com/16886711/155335637-5efa530f-3029-4f73-a48b-ac345afc3c53.png">
<img width="1513" alt="Capture d’écran 2022-02-23 à 15 07 38" src="https://user-images.githubusercontent.com/16886711/155335651-018cc250-aae5-4e5e-a31e-79bde5714bb1.png">
i