### PR TITLE
build: import favicon for dev

### DIFF
--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build:index": "node scripts/build.index.mjs",
     "i18n": "node scripts/i18n.types.js",
-    "import-assets": "rm -fr public/assets/assets && mkdir -p public/assets && cp -R ../dart/assets public/assets && cp ../dart/web/manifest.json public/",
+    "import-assets-for-dev": "cp -R ../dart/assets public/assets && cp ../dart/web/manifest.json public/ && cp ../dart/web/favicon.ico public/",
+    "import-assets": "rm -fr public/assets/assets && mkdir -p public/assets && npm run import-assets-for-dev",
     "build": "rm -fr public/assets/assets && npm run i18n && rollup -c && npm run build:index",
     "dev": "npm run import-assets && npm run i18n && BASE_HREF=/ ROLLUP_WATCH=true npm run build:index && rollup -c -w",
     "start": "sirv public",


### PR DESCRIPTION
# Motivation

Even though we do not need it for dev, not having the favicon at the root display an error in the Chrome debugger. This PR also copy the favicon when we start the dev server.

# Changes

- copy favicon to public dir on `npm run dev`
