### PR TITLE
L2-301: Fetch accounts subaccounts on init

### DIFF
--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -12,3 +12,4 @@ global.IntersectionObserver = IntersectionObserverPassive;
 // Environment Variables Setup
 process.env.IDENTITY_SERVICE_URL = "http://localhost:8000/";
 process.env.OWN_CANISTER_ID = "qhbym-qaaaa-aaaaa-aaafq-cai";
+process.env.LEDGER_CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai";

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -110,6 +110,9 @@ export default {
       "process.env.FETCH_ROOT_KEY": JSON.stringify(envConfig.FETCH_ROOT_KEY),
       "process.env.HOST": JSON.stringify(envConfig.HOST),
       "process.env.OWN_CANISTER_ID": JSON.stringify(envConfig.OWN_CANISTER_ID),
+      "process.env.LEDGER_CANISTER_ID": JSON.stringify(
+        envConfig.LEDGER_CANISTER_ID
+      ),
     }),
 
     // In dev mode, call `npm run start` once

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -23,7 +23,9 @@
         return;
       }
 
-      await syncAccounts(auth);
+      if (auth.identity) {
+        await syncAccounts(auth);
+      }
     }
   );
 

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -19,13 +19,12 @@
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
       // TODO: We do not need to load and sync the account data if we redirect to the Flutter app. Currently these data are not displayed with this application.
-      if (process.env.REDIRECT_TO_LEGACY) {
+      if (process.env.REDIRECT_TO_LEGACY || !auth.identity) {
         return;
       }
 
-      if (auth.identity) {
-        await syncAccounts(auth);
-      }
+      // TODO: L2-316 Manage errors
+      await syncAccounts(auth);
     }
   );
 

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -8,6 +8,7 @@ import {
 } from "./nns-dapp.errors";
 import { idlFactory, NNSDappService } from "./nns-dapp.idl";
 import type {
+  AccountDetails,
   CreateSubAccountResponse,
   SubAccountDetails,
 } from "./nns-dapp.types";
@@ -45,16 +46,32 @@ export class NNSDappCanister {
   }
 
   /**
-   * Used to be able to create subAccounts
-   *
-   * TODO: Understand why we need this?
-   * TODO: Remove if not needed?
+   * Add account to NNSDapp Canister if it doesn't exist.
    *
    * @returns Promise<void>
    */
   public addAccount = async (): Promise<AccountIdentifier> => {
     const identifierText = await this.certifiedService.add_account();
     return AccountIdentifier.fromHex(identifierText);
+  };
+
+  /**
+   * Get Account Details
+   *
+   * @returns Promise<void>
+   */
+  public getAccount = async (): Promise<AccountDetails> => {
+    const { AccountNotFound, Ok } = await this.certifiedService.get_account();
+    if (AccountNotFound === null) {
+      throw new AccountNotFoundError("Error creating subAccount");
+    }
+
+    if (Ok) {
+      return Ok;
+    }
+
+    // We should never reach here. Some of the previous properties should be present.
+    throw new Error("Error getting account details");
   };
 
   /**

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -32,9 +32,10 @@ export interface DetachCanisterRequest {
   canister_id: Principal;
 }
 export type DetachCanisterResponse = { Ok: null } | { CanisterNotFound: null };
-export type GetAccountResponse =
-  | { Ok: AccountDetails }
-  | { AccountNotFound: null };
+export type GetAccountResponse = {
+  Ok?: AccountDetails;
+  AccountNotFound?: null;
+};
 export interface GetTransactionsRequest {
   page_size: number;
   offset: number;

--- a/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <Card on:click {role}>
-  <p slot="start"><slot /></p>
+  <h4 slot="start"><slot /></h4>
   <ICP slot="end" icp={balance} />
   <Identifier {identifier} {showCopy} />
 </Card>

--- a/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
@@ -6,7 +6,7 @@
 
   export let account: Account;
   export let showCopy: boolean = false;
-  export let role: "button" | "link" | undefined = undefined;
+  export let role: "button" | undefined = undefined;
 
   $: ({ identifier, balance } = account);
 </script>

--- a/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
@@ -6,7 +6,7 @@
 
   export let account: Account;
   export let showCopy: boolean = false;
-  export let role: "button" | undefined = undefined;
+  export let role: "button" | "link" | undefined = undefined;
 
   $: ({ identifier, balance } = account);
 </script>

--- a/frontend/svelte/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/svelte/src/lib/constants/canister-ids.constants.ts
@@ -1,3 +1,6 @@
 import { Principal } from "@dfinity/principal";
 
 export const OWN_CANISTER_ID = Principal.fromText(process.env.OWN_CANISTER_ID);
+export const LEDGER_CANISTER_ID = Principal.fromText(
+  process.env.LEDGER_CANISTER_ID
+);

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -8,7 +8,10 @@
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
     "sign_in": "The sign-in process was aborted or did not succeed.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
-    "missing_identity": "The operation cannot be executed without any identity."
+    "missing_identity": "The operation cannot be executed without any identity.",
+    "create_subaccount": "Sorry, there was an expected error when creating your subaccount, please try again",
+    "create_subaccount_too_long": "The name of the subaccount is too long. Please, choose a shorter name.",
+    "create_subaccount_limit_exceeded": "Sorry, you reached the limit of subaccounts in this account."
   },
   "navigation": {
     "icp": "ICP",

--- a/frontend/svelte/src/lib/modals/AddAccountModal/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/modals/AddAccountModal/AddNewAccount.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import Input from "../../components/ui/Input.svelte";
   import { i18n } from "../../stores/i18n";
-  import { accountsStore } from "../../stores/accounts.store";
   import { createEventDispatcher } from "svelte";
   import { createSubAccount } from "../../services/accounts.services";
   import Spinner from "../../components/ui/Spinner.svelte";
+  import {
+    NameTooLongError,
+    SubAccountLimitExceededError,
+  } from "../../canisters/nns-dapp/nns-dapp.errors";
+  import { toastsStore } from "../../stores/toasts.store";
+  import { errorToString } from "../../utils/error.utils";
 
   let newAccountName: string = "";
 
@@ -15,10 +20,20 @@
       creating = true;
       await createSubAccount(newAccountName);
       dispatcher("nnsClose");
-    } catch (error) {
-      // TODO: Manage errors
-      console.error("Error creating subAccount");
-      console.error(error);
+    } catch (err) {
+      let labelKey = "create_subaccount";
+      if (err instanceof NameTooLongError) {
+        labelKey = "create_subaccount_too_long";
+      }
+      if (err instanceof SubAccountLimitExceededError) {
+        labelKey = "create_subaccount_limit_exceeded";
+      }
+      toastsStore.show({
+        labelKey,
+        level: "error",
+        detail: errorToString(err),
+      });
+      console.error(err);
     } finally {
       creating = false;
     }

--- a/frontend/svelte/src/lib/modals/AddAccountModal/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/modals/AddAccountModal/AddNewAccount.svelte
@@ -21,13 +21,12 @@
       await createSubAccount(newAccountName);
       dispatcher("nnsClose");
     } catch (err) {
-      let labelKey = "create_subaccount";
-      if (err instanceof NameTooLongError) {
-        labelKey = "create_subaccount_too_long";
-      }
-      if (err instanceof SubAccountLimitExceededError) {
-        labelKey = "create_subaccount_limit_exceeded";
-      }
+      const labelKey =
+        err instanceof NameTooLongError
+          ? "create_subaccount_too_long"
+          : err instanceof SubAccountLimitExceededError
+          ? "create_subaccount_limit_exceeded"
+          : "create_subaccount";
       toastsStore.show({
         labelKey,
         level: "error",

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -43,6 +43,8 @@ const loadAccounts = async ({
     canisterId: OWN_CANISTER_ID,
   });
   // Ensure account exists in NNSDapp Canister
+  // https://github.com/dfinity/nns-dapp/blob/main/rs/src/accounts_store.rs#L271
+  // https://github.com/dfinity/nns-dapp/blob/main/rs/src/accounts_store.rs#L232
   await nnsDapp.addAccount();
 
   const mainAccount: AccountDetails = await nnsDapp.getAccount();

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -25,13 +25,8 @@ import { createAgent } from "../utils/agent.utils";
 export const syncAccounts = async ({
   identity,
 }: {
-  identity: Identity | undefined | null;
+  identity: Identity;
 }): Promise<void> => {
-  if (!identity) {
-    accountsStore.set(undefined);
-    return;
-  }
-
   const accounts: AccountsStore = await loadAccounts({ identity });
   accountsStore.set(accounts);
 };

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -58,7 +58,7 @@ const loadAccounts = async ({
   ): Promise<Account> => {
     const balance: ICP = await ledger.accountBalance({
       accountIdentifier: AccountIdentifier.fromHex(account.account_identifier),
-      certified: false,
+      certified: true,
     });
     return {
       identifier: mainAccount.account_identifier,

--- a/frontend/svelte/src/lib/stores/accounts.store.ts
+++ b/frontend/svelte/src/lib/stores/accounts.store.ts
@@ -9,7 +9,6 @@ export interface AccountsStore {
 /**
  * A store that contains the account information.
  */
-
 export const initAccountsStore = () => {
   const { subscribe, set, update } = writable<AccountsStore>({
     main: undefined,
@@ -19,13 +18,6 @@ export const initAccountsStore = () => {
   return {
     subscribe,
     set,
-    // TODO: Remove in L2-301
-    addSubAccount(newAccount) {
-      update((state) => ({
-        ...state,
-        subAccounts: [newAccount, ...(state?.subAccounts || [])],
-      }));
-    },
   };
 };
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -13,6 +13,9 @@ interface I18nError {
   sign_in: string;
   list_proposals: string;
   missing_identity: string;
+  create_subaccount: string;
+  create_subaccount_too_long: string;
+  create_subaccount_limit_exceeded: string;
 }
 
 interface I18nNavigation {

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -9,5 +9,5 @@ export const formatICP = (value: bigint): string =>
     .format(Number(value) / E8S_PER_ICP)
     .replace(",", ".");
 
-export const addICPs = (icp1: ICP, icp2: ICP): ICP =>
-  ICP.fromE8s(icp1.toE8s() + icp2.toE8s());
+export const addICPs = (...icps: ICP[]): ICP =>
+  ICP.fromE8s(icps.reduce<bigint>((acc, icp) => acc + icp.toE8s(), BigInt(0)));

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -9,5 +9,5 @@ export const formatICP = (value: bigint): string =>
     .format(Number(value) / E8S_PER_ICP)
     .replace(",", ".");
 
-export const addICPs = (...icps: ICP[]): ICP =>
+export const sumICPs = (...icps: ICP[]): ICP =>
   ICP.fromE8s(icps.reduce<bigint>((acc, icp) => acc + icp.toE8s(), BigInt(0)));

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -1,3 +1,4 @@
+import { ICP } from "@dfinity/nns";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 
 export const formatICP = (value: bigint): string =>
@@ -7,3 +8,6 @@ export const formatICP = (value: bigint): string =>
   })
     .format(Number(value) / E8S_PER_ICP)
     .replace(",", ".");
+
+export const addICPs = (icp1: ICP, icp2: ICP): ICP =>
+  ICP.fromE8s(icp1.toE8s() + icp2.toE8s());

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -12,6 +12,7 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import AddAcountModal from "../lib/modals/AddAccountModal/AddAccountModal.svelte";
   import { ICP } from "@dfinity/nns";
+  import { addICPs } from "../lib/utils/icp.utils";
 
   // TODO: To be removed once this page has been implemented
   onMount(() => {
@@ -39,13 +40,14 @@
   const closeModal = () => (showAddAccountModal = false);
 
   let totalBalance: ICP;
+  const zeroICPs = () => ICP.fromE8s(BigInt(0));
   $: {
-    totalBalance = ICP.fromE8s(
-      accounts?.main.balance.toE8s() +
-        accounts?.subAccounts.reduce(
-          (acc, subAccount) => acc + subAccount.balance.toE8s(),
-          BigInt(0)
-        )
+    totalBalance = addICPs(
+      accounts?.main.balance || zeroICPs(),
+      accounts?.subAccounts.reduce(
+        (acc, subAccount) => addICPs(acc, subAccount.balance),
+        zeroICPs()
+      ) || zeroICPs()
     );
   }
 </script>

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -12,7 +12,7 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import AddAcountModal from "../lib/modals/AddAccountModal/AddAccountModal.svelte";
   import { ICP } from "@dfinity/nns";
-  import { addICPs } from "../lib/utils/icp.utils";
+  import { sumICPs } from "../lib/utils/icp.utils";
 
   // TODO: To be removed once this page has been implemented
   onMount(() => {
@@ -42,7 +42,7 @@
   let totalBalance: ICP;
   const zeroICPs = ICP.fromE8s(BigInt(0));
   $: {
-    totalBalance = addICPs(
+    totalBalance = sumICPs(
       accounts?.main?.balance || zeroICPs,
       ...(accounts?.subAccounts || []).map(({ balance }) => balance)
     );

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -44,10 +44,7 @@
   $: {
     totalBalance = addICPs(
       accounts?.main.balance || zeroICPs(),
-      accounts?.subAccounts.reduce(
-        (acc, subAccount) => addICPs(acc, subAccount.balance),
-        zeroICPs()
-      ) || zeroICPs()
+      ...(accounts?.subAccounts || []).map(({ balance }) => balance)
     );
   }
 </script>

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -62,14 +62,12 @@
 
       {#if accounts?.main}
         <AccountCard
-          role="link"
           on:click={() => cardClick(accounts?.main?.identifier)}
           showCopy
           account={accounts?.main}>{$i18n.accounts.main}</AccountCard
         >
         {#each accounts.subAccounts as subAccount}
           <AccountCard
-            role="link"
             on:click={() => cardClick(subAccount.identifier)}
             showCopy
             account={subAccount}>{subAccount.name}</AccountCard

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -40,10 +40,10 @@
   const closeModal = () => (showAddAccountModal = false);
 
   let totalBalance: ICP;
-  const zeroICPs = () => ICP.fromE8s(BigInt(0));
+  const zeroICPs = ICP.fromE8s(BigInt(0));
   $: {
     totalBalance = addICPs(
-      accounts?.main.balance || zeroICPs(),
+      accounts?.main?.balance || zeroICPs,
       ...(accounts?.subAccounts || []).map(({ balance }) => balance)
     );
   }
@@ -60,7 +60,7 @@
         {/if}
       </div>
 
-      {#if accounts}
+      {#if accounts?.main}
         <AccountCard
           role="link"
           on:click={() => cardClick(accounts?.main?.identifier)}

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -2,21 +2,23 @@
  * @jest-environment jsdom
  */
 
-import { LedgerCanister } from "@dfinity/nns";
+import { ICP, LedgerCanister } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 import { tick } from "svelte";
 import App from "../App.svelte";
+import { NNSDappCanister } from "../lib/canisters/nns-dapp/nns-dapp.canister";
 import { authStore } from "../lib/stores/auth.store";
+import { mockAccountDetails } from "./mocks/accounts.store.mock";
 import {
   authStoreMock,
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "./mocks/auth.store.mock";
-import { MockLedgerCanister } from "./mocks/ledger.canister.mock";
 
 describe("App", () => {
-  let spyLedger;
-  const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();
+  const mockLedgerCanister = mock<LedgerCanister>();
+  const mockNNSDappCanister = mock<NNSDappCanister>();
 
   beforeEach(() => {
     jest
@@ -27,20 +29,36 @@ describe("App", () => {
       .spyOn(LedgerCanister, "create")
       .mockImplementation((): LedgerCanister => mockLedgerCanister);
 
-    spyLedger = jest.spyOn(mockLedgerCanister, "accountBalance");
+    jest
+      .spyOn(NNSDappCanister, "create")
+      .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   it("should synchronize the accounts after sign in", async () => {
-    render(App);
+    mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
+    mockLedgerCanister.accountBalance.mockResolvedValue(
+      ICP.fromString("1") as ICP
+    );
 
-    expect(spyLedger).toHaveBeenCalledTimes(0);
+    render(App);
 
     authStoreMock.next({
       identity: mockIdentity,
     });
 
     await tick();
+    expect(mockNNSDappCanister.addAccount).toHaveBeenCalledTimes(1);
 
-    expect(spyLedger).toHaveBeenCalledTimes(1);
+    await tick();
+    expect(mockNNSDappCanister.getAccount).toHaveBeenCalledTimes(1);
+
+    await tick();
+    await tick();
+    await tick();
+    expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -1,39 +1,108 @@
+import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
+import {
+  AccountNotFoundError,
+  NameTooLongError,
+  SubAccountLimitExceededError,
+} from "../../../lib/canisters/nns-dapp/nns-dapp.errors";
 import type { NNSDappService } from "../../../lib/canisters/nns-dapp/nns-dapp.idl";
 import type {
   CreateSubAccountResponse,
-  SubAccountDetails,
+  GetAccountResponse,
 } from "../../../lib/canisters/nns-dapp/nns-dapp.types";
 import { createAgent } from "../../../lib/utils/agent.utils";
+import {
+  mockAccountDetails,
+  mockSubAccountDetails,
+} from "../../mocks/accounts.store.mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 
-describe("NNSDapp.createSubAccount", () => {
-  it("returns subaccount details when success", async () => {
+describe("NNSDapp.addAccount", () => {
+  it("returns account identifier when success", async () => {
     const defaultAgent = await createAgent({ identity: mockIdentity });
-    const subAccountName = "longName";
-    const subAccountDetails: SubAccountDetails = {
-      name: subAccountName,
-      sub_account: [0, 0],
-      account_identifier: "account-identifier",
-    };
-    const response: CreateSubAccountResponse = {
-      Ok: subAccountDetails,
-    };
+    const response: string =
+      "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f";
     const service = mock<NNSDappService>();
-    service.create_sub_account.mockResolvedValue(response);
+    service.add_account.mockResolvedValue(response);
 
     const canisterId = Principal.fromText("aaaaa-aa");
-    const governance = NNSDappCanister.create({
+    const nnsDapp = NNSDappCanister.create({
       agent: defaultAgent,
       certifiedServiceOverride: service,
       canisterId,
     });
 
-    const res = await governance.createSubAccount({ subAccountName });
+    const res = await nnsDapp.addAccount();
 
-    expect(res).toEqual(subAccountDetails);
+    expect(res).toEqual(AccountIdentifier.fromHex(response));
+  });
+});
+
+describe("NNSDapp.getAccount", () => {
+  it("returns account details when success", async () => {
+    const defaultAgent = await createAgent({ identity: mockIdentity });
+    const response: GetAccountResponse = {
+      Ok: mockAccountDetails,
+    };
+    const service = mock<NNSDappService>();
+    service.get_account.mockResolvedValue(response);
+
+    const canisterId = Principal.fromText("aaaaa-aa");
+    const nnsDapp = NNSDappCanister.create({
+      agent: defaultAgent,
+      certifiedServiceOverride: service,
+      canisterId,
+    });
+
+    const res = await nnsDapp.getAccount();
+
+    expect(res).toEqual(mockAccountDetails);
+  });
+
+  it("throws error if account not found", async () => {
+    const defaultAgent = await createAgent({ identity: mockIdentity });
+    const response: GetAccountResponse = {
+      AccountNotFound: null,
+    };
+    const service = mock<NNSDappService>();
+    service.get_account.mockResolvedValue(response);
+
+    const canisterId = Principal.fromText("aaaaa-aa");
+    const nnsDapp = NNSDappCanister.create({
+      certifiedServiceOverride: service,
+      canisterId,
+      agent: defaultAgent,
+    });
+
+    const call = async () => nnsDapp.getAccount();
+
+    expect(call).rejects.toThrow(AccountNotFoundError);
+  });
+});
+
+describe("NNSDapp.createSubAccount", () => {
+  it("returns subaccount details when success", async () => {
+    const defaultAgent = await createAgent({ identity: mockIdentity });
+    const response: CreateSubAccountResponse = {
+      Ok: mockSubAccountDetails,
+    };
+    const service = mock<NNSDappService>();
+    service.create_sub_account.mockResolvedValue(response);
+
+    const canisterId = Principal.fromText("aaaaa-aa");
+    const nnsDapp = NNSDappCanister.create({
+      agent: defaultAgent,
+      certifiedServiceOverride: service,
+      canisterId,
+    });
+
+    const res = await nnsDapp.createSubAccount({
+      subAccountName: mockSubAccountDetails.name,
+    });
+
+    expect(res).toEqual(mockSubAccountDetails);
   });
 
   it("throws error if name too long", async () => {
@@ -45,16 +114,16 @@ describe("NNSDapp.createSubAccount", () => {
     service.create_sub_account.mockResolvedValue(response);
 
     const canisterId = Principal.fromText("aaaaa-aa");
-    const governance = NNSDappCanister.create({
+    const nnsDapp = NNSDappCanister.create({
       certifiedServiceOverride: service,
       canisterId,
       agent: defaultAgent,
     });
 
     const call = async () =>
-      governance.createSubAccount({ subAccountName: "testSubaccount" });
+      nnsDapp.createSubAccount({ subAccountName: "testSubaccount" });
 
-    expect(call).rejects.toThrow(Error);
+    expect(call).rejects.toThrow(NameTooLongError);
   });
 
   it("throws error if subaccount limit reached", async () => {
@@ -66,16 +135,16 @@ describe("NNSDapp.createSubAccount", () => {
     service.create_sub_account.mockResolvedValue(response);
 
     const canisterId = Principal.fromText("aaaaa-aa");
-    const governance = NNSDappCanister.create({
+    const nnsDapp = NNSDappCanister.create({
       agent: defaultAgent,
       certifiedServiceOverride: service,
       canisterId,
     });
 
     const call = async () =>
-      governance.createSubAccount({ subAccountName: "testSubaccount" });
+      nnsDapp.createSubAccount({ subAccountName: "testSubaccount" });
 
-    expect(call).rejects.toThrow(Error);
+    expect(call).rejects.toThrow(SubAccountLimitExceededError);
   });
 
   it("throws error if account not found", async () => {
@@ -87,15 +156,15 @@ describe("NNSDapp.createSubAccount", () => {
     service.create_sub_account.mockResolvedValue(response);
 
     const canisterId = Principal.fromText("aaaaa-aa");
-    const governance = NNSDappCanister.create({
+    const nnsDapp = NNSDappCanister.create({
       agent: defaultAgent,
       certifiedServiceOverride: service,
       canisterId,
     });
 
     const call = async () =>
-      governance.createSubAccount({ subAccountName: "testSubaccount" });
+      nnsDapp.createSubAccount({ subAccountName: "testSubaccount" });
 
-    expect(call).rejects.toThrow(Error);
+    expect(call).rejects.toThrow(AccountNotFoundError);
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
@@ -5,6 +5,7 @@
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import AddAccountModal from "../../../lib/modals/AddAccountModal/AddAccountModal.svelte";
+import * as accountsServices from "../../../lib/services/accounts.services";
 
 const en = require("../../../lib/i18n/en.json");
 
@@ -33,7 +34,7 @@ describe("AddAccountModal", () => {
     expect(queryByText(en.accounts.new_linked_account_title)).not.toBeNull();
   });
 
-  it("should have disabled Create neuron button", async () => {
+  it("should have disabled Add Account button", async () => {
     const { container, queryByText } = render(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
@@ -46,7 +47,7 @@ describe("AddAccountModal", () => {
     expect(createButton.getAttribute("disabled")).not.toBeNull();
   });
 
-  it("should have enabled Create neuron button when entering amount", async () => {
+  it("should have enabled Add Account button when entering name", async () => {
     const { container, queryByText } = render(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
@@ -62,5 +63,31 @@ describe("AddAccountModal", () => {
     const createButton = container.querySelector('button[type="submit"]');
     expect(createButton).not.toBeNull();
     expect(createButton.getAttribute("disabled")).toBeNull();
+  });
+
+  // TODO: Cannot mock `createSubAccount` function from account.services.ts
+  // Is it because it's importing it in another component?
+  xit("should have enabled Add Account button when entering name", async () => {
+    const createSubAccountMock = jest.fn().mockResolvedValue(undefined);
+    jest
+      .spyOn(accountsServices, "createSubAccount")
+      .mockImplementation(createSubAccountMock);
+    const { container, queryByText } = render(AddAccountModal);
+
+    const accountCard = queryByText(en.accounts.new_linked_title);
+    expect(accountCard).not.toBeNull();
+
+    await fireEvent.click(accountCard.parentElement);
+
+    const input = container.querySelector('input[name="newAccount"]');
+    // Svelte generates code for listening to the `input` event
+    // https://github.com/testing-library/svelte-testing-library/issues/29#issuecomment-498055823
+    await fireEvent.input(input, { target: { value: "test name" } });
+
+    const createButton = container.querySelector('button[type="submit"]');
+
+    await fireEvent.click(createButton);
+
+    expect(createSubAccountMock).toBeCalled();
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
@@ -72,10 +72,7 @@ describe("AddAccountModal", () => {
     expect(createButton.getAttribute("disabled")).toBeNull();
   });
 
-  it("should have enabled Add Account button when entering name", async () => {
-    // jest
-    //   .spyOn(accountsServices, "createSubAccount")
-    //   .mockImplementation(createSubAccountMock);
+  it("should create a subaccount", async () => {
     const { container, queryByText } = render(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);

--- a/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-// prettier-ignore
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import AddAccountModal from "../../../lib/modals/AddAccountModal/AddAccountModal.svelte";

--- a/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
@@ -1,13 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-
+// prettier-ignore
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import AddAccountModal from "../../../lib/modals/AddAccountModal/AddAccountModal.svelte";
-import * as accountsServices from "../../../lib/services/accounts.services";
+import { createSubAccount } from "../../../lib/services/accounts.services";
 
 const en = require("../../../lib/i18n/en.json");
+
+// This is the way to mock when we import in a destructured manner
+// and we want to mock the imported function
+jest.mock("../../../lib/services/accounts.services", () => {
+  return {
+    createSubAccount: jest.fn().mockResolvedValue(undefined),
+  };
+});
 
 describe("AddAccountModal", () => {
   it("should display modal", () => {
@@ -65,13 +73,10 @@ describe("AddAccountModal", () => {
     expect(createButton.getAttribute("disabled")).toBeNull();
   });
 
-  // TODO: Cannot mock `createSubAccount` function from account.services.ts
-  // Is it because it's importing it in another component?
-  xit("should have enabled Add Account button when entering name", async () => {
-    const createSubAccountMock = jest.fn().mockResolvedValue(undefined);
-    jest
-      .spyOn(accountsServices, "createSubAccount")
-      .mockImplementation(createSubAccountMock);
+  it("should have enabled Add Account button when entering name", async () => {
+    // jest
+    //   .spyOn(accountsServices, "createSubAccount")
+    //   .mockImplementation(createSubAccountMock);
     const { container, queryByText } = render(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
@@ -88,6 +93,6 @@ describe("AddAccountModal", () => {
 
     await fireEvent.click(createButton);
 
-    expect(createSubAccountMock).toBeCalled();
+    expect(createSubAccount).toBeCalled();
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
@@ -13,7 +13,7 @@ describe("CreateNeuronModal", () => {
   beforeEach(() => {
     jest
       .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe);
+      .mockImplementation(mockAccountsStoreSubscribe());
   });
 
   it("should display modal", () => {

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -1,30 +1,66 @@
-import { LedgerCanister } from "@dfinity/nns";
-import { syncAccounts } from "../../../lib/services/accounts.services";
+import { ICP, LedgerCanister } from "@dfinity/nns";
+import { mock } from "jest-mock-extended";
+import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
+import type { AccountDetails } from "../../../lib/canisters/nns-dapp/nns-dapp.types";
+import * as services from "../../../lib/services/accounts.services";
+import {
+  mockAccountDetails,
+  mockSubAccountDetails,
+} from "../../mocks/accounts.store.mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
-import { MockLedgerCanister } from "../../mocks/ledger.canister.mock";
 
 describe("accounts-services", () => {
-  const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();
-
-  it("should call ledger to get the account balance", async () => {
+  it("should call ledger and nnsdapp to get account and balance", async () => {
+    // Ledger mock
+    const ledgerMock = mock<LedgerCanister>();
+    ledgerMock.accountBalance.mockResolvedValue(ICP.fromString("1") as ICP);
     jest
       .spyOn(LedgerCanister, "create")
-      .mockImplementation((): LedgerCanister => mockLedgerCanister);
+      .mockImplementation((): LedgerCanister => ledgerMock);
 
-    const spy = jest.spyOn(mockLedgerCanister, "accountBalance");
+    // NNSDapp mock
+    const nnsDappMock = mock<NNSDappCanister>();
+    nnsDappMock.getAccount.mockResolvedValue(mockAccountDetails);
+    jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
 
-    await syncAccounts({ identity: mockIdentity });
+    await services.syncAccounts({ identity: mockIdentity });
 
-    expect(spy).toHaveReturnedTimes(1);
+    expect(ledgerMock.accountBalance).toBeCalled();
+    expect(nnsDappMock.getAccount).toBeCalled();
+    expect(nnsDappMock.addAccount).toBeCalledTimes(1);
   });
 
-  // TODO: Reset when fixed L2-301
-  // it("should call nnsDappCanister to create subaccount", async () => {
-  //   const nnsDappMock = mock<NNSDappCanister>();
-  //   jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+  it("should get balances of subaccounts", async () => {
+    // Ledger mock
+    const ledgerMock = mock<LedgerCanister>();
+    ledgerMock.accountBalance.mockResolvedValue(ICP.fromString("1") as ICP);
+    jest
+      .spyOn(LedgerCanister, "create")
+      .mockImplementation((): LedgerCanister => ledgerMock);
 
-  //   await createSubAccount("test subaccount");
+    // NNSDapp mock
+    const nnsDappMock = mock<NNSDappCanister>();
+    const accountDetails: AccountDetails = {
+      ...mockAccountDetails,
+      sub_accounts: [mockSubAccountDetails],
+    };
+    nnsDappMock.getAccount.mockResolvedValue(accountDetails);
+    jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
 
-  //   expect(nnsDappMock.createSubAccount).toHaveBeenCalled();
-  // });
+    await services.syncAccounts({ identity: mockIdentity });
+
+    // Called once for main, another for the subaccount = 2
+    expect(ledgerMock.accountBalance).toBeCalledTimes(2);
+  });
+
+  it("should call nnsDappCanister to create subaccount", async () => {
+    const nnsDappMock = mock<NNSDappCanister>();
+    jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+    const mockSyncAccounts = jest.fn();
+    jest.spyOn(services, "syncAccounts").mockImplementation(mockSyncAccounts);
+
+    await services.createSubAccount("test subaccount");
+
+    expect(nnsDappMock.createSubAccount).toBeCalled();
+  });
 });

--- a/frontend/svelte/src/tests/lib/services/dev.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/dev.services.spec.ts
@@ -6,7 +6,7 @@ describe("dev-services", () => {
   beforeEach(() => {
     jest
       .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe);
+      .mockImplementation(mockAccountsStoreSubscribe());
   });
 
   it("should throw an error if the environment is not testnet", async () => {

--- a/frontend/svelte/src/tests/lib/stores/accounts.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/accounts.store.spec.ts
@@ -3,8 +3,6 @@ import {
   AccountsStore,
   initAccountsStore,
 } from "../../../lib/stores/accounts.store";
-import type { Account } from "../../../lib/types/account";
-import { mockMainAccount } from "../../mocks/accounts.store.mock";
 
 describe("accountsStore", () => {
   it("initializes to undefined", () => {
@@ -14,27 +12,5 @@ describe("accountsStore", () => {
 
     expect(initState.main).toBeUndefined();
     expect(initState.subAccounts).toBeUndefined();
-  });
-
-  it("adds subaccounts", () => {
-    const store = initAccountsStore();
-
-    const initState: AccountsStore = get(store);
-
-    expect(initState.main).toBeUndefined();
-    expect(initState.subAccounts).toBeUndefined();
-
-    const subAccount: Account = {
-      ...mockMainAccount,
-      name: "Test SubAccount",
-    };
-
-    store.addSubAccount(subAccount);
-
-    const state: AccountsStore = get(store);
-
-    expect(state.subAccounts).not.toBeUndefined();
-    expect(state.subAccounts.length).toBe(1);
-    expect(state.subAccounts[0]).toEqual(subAccount);
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,4 +1,5 @@
-import { formatICP } from "../../../lib/utils/icp.utils";
+import { ICP } from "@dfinity/nns";
+import { addICPs, formatICP } from "../../../lib/utils/icp.utils";
 
 describe("icp-utils", () => {
   it("should format icp", () => {
@@ -15,5 +16,20 @@ describe("icp-utils", () => {
     expect(formatICP(BigInt(200000000000000))).toEqual(
       `2${"\u202F"}000${"\u202F"}000.00000000`
     );
+  });
+
+  it("should add ICPs", () => {
+    const icp0 = ICP.fromString("0") as ICP;
+    const icp1 = ICP.fromString("1") as ICP;
+    const icp15 = ICP.fromString("1.5") as ICP;
+    const icp2 = ICP.fromString("2") as ICP;
+    const icp3 = ICP.fromString("3") as ICP;
+    const icp35 = ICP.fromString("3.5") as ICP;
+    const icp6 = ICP.fromString("6") as ICP;
+
+    expect(addICPs(icp0, icp1)).toEqual(icp1);
+    expect(addICPs(icp1, icp2)).toEqual(icp3);
+    expect(addICPs(icp1, icp2, icp3)).toEqual(icp6);
+    expect(addICPs(icp15, icp2)).toEqual(icp35);
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,5 +1,5 @@
 import { ICP } from "@dfinity/nns";
-import { addICPs, formatICP } from "../../../lib/utils/icp.utils";
+import { formatICP, sumICPs } from "../../../lib/utils/icp.utils";
 
 describe("icp-utils", () => {
   it("should format icp", () => {
@@ -27,9 +27,9 @@ describe("icp-utils", () => {
     const icp35 = ICP.fromString("3.5") as ICP;
     const icp6 = ICP.fromString("6") as ICP;
 
-    expect(addICPs(icp0, icp1)).toEqual(icp1);
-    expect(addICPs(icp1, icp2)).toEqual(icp3);
-    expect(addICPs(icp1, icp2, icp3)).toEqual(icp6);
-    expect(addICPs(icp15, icp2)).toEqual(icp35);
+    expect(sumICPs(icp0, icp1)).toEqual(icp1);
+    expect(sumICPs(icp1, icp2)).toEqual(icp3);
+    expect(sumICPs(icp1, icp2, icp3)).toEqual(icp6);
+    expect(sumICPs(icp15, icp2)).toEqual(icp35);
   });
 });

--- a/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
@@ -1,5 +1,10 @@
 import { ICP } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
+import type {
+  AccountDetails,
+  SubAccountDetails,
+} from "../../lib/canisters/nns-dapp/nns-dapp.types";
 import type { AccountsStore } from "../../lib/stores/accounts.store";
 import type { Account } from "../../lib/types/account";
 
@@ -9,10 +14,30 @@ export const mockMainAccount: Account = {
   balance: ICP.fromString("1234567.8901") as ICP,
 };
 
-export const mockAccountsStoreSubscribe = (
-  run: Subscriber<AccountsStore>
-): (() => void) => {
-  run({ main: mockMainAccount, subAccounts: [] });
-
-  return () => {};
+export const mockSubAccount: Account = {
+  identifier:
+    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+  balance: ICP.fromString("1234567.8901") as ICP,
+  name: "test subaccount",
 };
+
+export const mockAccountDetails: AccountDetails = {
+  principal: Principal.fromText("aaaaa-aa"),
+  sub_accounts: [],
+  hardware_wallet_accounts: [],
+  account_identifier: "account-identifier",
+};
+
+export const mockSubAccountDetails: SubAccountDetails = {
+  name: "test",
+  sub_account: [0, 0],
+  account_identifier: "account-identifier",
+};
+
+export const mockAccountsStoreSubscribe =
+  (subAccounts = []) =>
+  (run: Subscriber<AccountsStore>): (() => void) => {
+    run({ main: mockMainAccount, subAccounts });
+
+    return () => {};
+  };

--- a/frontend/svelte/src/tests/routes/Accounts.spec.ts
+++ b/frontend/svelte/src/tests/routes/Accounts.spec.ts
@@ -10,6 +10,7 @@ import Accounts from "../../routes/Accounts.svelte";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
+  mockSubAccount,
 } from "../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
 
@@ -20,13 +21,12 @@ describe("Accounts", () => {
     authStoreMock = jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
-
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe);
   });
 
   it("should render title", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
     const { container } = render(Accounts);
 
     const title = container.querySelector("h1");
@@ -36,6 +36,9 @@ describe("Accounts", () => {
   });
 
   it("should render title and account icp", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
     const { container } = render(Accounts);
 
     const titleRow = container.querySelector("section > div");
@@ -46,6 +49,9 @@ describe("Accounts", () => {
   });
 
   it("should render a main card", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
     const { container } = render(Accounts);
 
     const article = container.querySelector("article");
@@ -53,6 +59,9 @@ describe("Accounts", () => {
   });
 
   it("should render account icp in card too", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
     const { container } = render(Accounts);
 
     const cardTitleRow = container.querySelector("article > div > div");
@@ -63,10 +72,44 @@ describe("Accounts", () => {
   });
 
   it("should render account identifier", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
     const { getByText } = render(Accounts);
     getByText(mockMainAccount.identifier);
   });
 
-  it("should subscribe to store", () =>
-    expect(accountsStoreMock).toHaveBeenCalled());
+  it("should render subaccount cards", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+    const { container } = render(Accounts);
+
+    const articles = container.querySelectorAll("article");
+
+    expect(articles).not.toBeNull();
+    expect(articles.length).toBe(2);
+  });
+
+  it("should render total accounts icp", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+    const { container } = render(Accounts);
+
+    const titleRow = container.querySelector("section > div");
+
+    const totalBalance =
+      mockMainAccount.balance.toE8s() + mockSubAccount.balance.toE8s();
+    expect(titleRow.textContent).toEqual(
+      `Accounts ${formatICP(totalBalance)} ICP`
+    );
+  });
+
+  it("should subscribe to store", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    expect(accountsStoreMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Motivation

Fetch account and subaccount details and render them in Accounts page.

# Changes

* `syncAccounts` calls to addAccount from NNSDapp canister. To ensure the user has an account in NNS.
* `syncAccounts` calls `getAccount` to get account details. Then gets the balances of all accounts.
* Route `Accounts` renders main and subaccounts.
* After creating a subaccount, `syncAccounts` is called to syncrhonize all accounts at once.
* `accountsStore` simplified to only set or subscribe.
* new icp util `addICPs` to add ICPs.

# Tests

* updated `App` test.
* updated `AddAccoountModal` test.
* updated `Accounts` route test.
* Test for `createSubAccount`, `getAccount` and `addAccount` in NNSDappCanister.
* Test for `addICPs`.
* updated `accounts.services.ts` test.

