### PR TITLE
remove page transition animation

### DIFF
--- a/frontend/dart/lib/ui/home/home_tabs_widget.dart
+++ b/frontend/dart/lib/ui/home/home_tabs_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:nns_dapp/ui/_components/responsive.dart';
 import 'package:nns_dapp/ui/proposals/governance_tab_widget.dart';
 import '../../nns_dapp.dart';
@@ -52,6 +53,7 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
+    timeDilation = 0.05;
     final screenSize = context.mediaQuery.size;
     return Scaffold(
       backgroundColor: AppColors.lightBackground,


### PR DESCRIPTION
# Motivation
We wish to serve some tabs via svelte.  For that we need to break the current UI into distinct tabs rather than having them all flow together.

# Changes
* Make the transition very fast.

# Testing
Max:
* This PR is deployed here: https://wmio3-kqaaa-aaaaa-aaasq-cai.nnsdapp.dfinity.network
* I imagine that "scrolling fast" may still generate the intermediate tabs, so I temporarily added redirects to svelte and back to check that our desired goal works.  It does, so I believe that this is fine for our purposes.
  * That demo is deployed here: https://w6ozc-gaaaa-aaaaa-aaarq-cai.nnsdapp.dfinity.network/v2/
  * Try clicking on the various tabs, including e.g. first neurons (to the left of the svelte voting tab) then canisters (to the right, so it "swipes past" the voting tab very fast).  The page does not reload or pause to load the svelte page.