### PR TITLE
Style flutter navbar

### DIFF
--- a/frontend/dart/lib/ui/home/home_tabs_widget.dart
+++ b/frontend/dart/lib/ui/home/home_tabs_widget.dart
@@ -154,31 +154,35 @@ class _HomePageState extends State<HomePage>
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                         vertical: 10.0, horizontal: 20.0),
-                    child: Container(
-                      decoration: BoxDecoration(
-                          color: Color(0xff282A2D),
-                          borderRadius: BorderRadius.circular(16)),
-                      child: TabBar(
-                        physics: const NeverScrollableScrollPhysics(),
-                        controller: _tabController,
-                        indicator: BoxDecoration(
-                            color: Color(0xff0081FF),
-                            borderRadius: BorderRadius.circular(8)),
-                        indicatorSize: TabBarIndicatorSize.tab,
-                        labelPadding:
-                            EdgeInsets.symmetric(vertical: 8, horizontal: 10),
-                        unselectedLabelColor: AppColors.gray400,
-                        labelColor: AppColors.white,
-                        labelStyle: TextStyle(
-                            fontFamily: Fonts.circularMedium,
-                            fontSize: 20,
-                            letterSpacing: 0),
-                        tabs: [
-                          TabDesign(title: "ICP"),
-                          TabDesign(title: "NEURONS"),
-                          TabDesign(title: "VOTING"),
-                          TabDesign(title: "CANISTERS"),
-                        ],
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+			      decoration: BoxDecoration(
+				  color: Color(0xff282A2D)),
+			      child: TabBar(
+				physics: const NeverScrollableScrollPhysics(),
+				controller: _tabController,
+				indicator: BoxDecoration(
+					color: Color(0xff0081FF),
+					borderRadius: BorderRadius.all(
+						    Radius.zero,
+					    )),
+				indicatorSize: TabBarIndicatorSize.tab,
+				labelPadding:
+				    EdgeInsets.symmetric(vertical: 8, horizontal: 10),
+				unselectedLabelColor: AppColors.gray400,
+				labelColor: AppColors.white,
+				labelStyle: TextStyle(
+				    fontFamily: Fonts.circularMedium,
+				    fontSize: 20,
+				    letterSpacing: 0),
+				tabs: [
+				  TabDesign(title: "ICP"),
+				  TabDesign(title: "NEURONS"),
+				  TabDesign(title: "VOTING"),
+				  TabDesign(title: "CANISTERS"),
+				],
+			      ),
                       ),
                     ),
                   ),

--- a/frontend/dart/lib/ui/home/home_tabs_widget.dart
+++ b/frontend/dart/lib/ui/home/home_tabs_widget.dart
@@ -157,32 +157,31 @@ class _HomePageState extends State<HomePage>
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: Container(
-			      decoration: BoxDecoration(
-				  color: Color(0xff282A2D)),
-			      child: TabBar(
-				physics: const NeverScrollableScrollPhysics(),
-				controller: _tabController,
-				indicator: BoxDecoration(
-					color: Color(0xff0081FF),
-					borderRadius: BorderRadius.all(
-						    Radius.zero,
-					    )),
-				indicatorSize: TabBarIndicatorSize.tab,
-				labelPadding:
-				    EdgeInsets.symmetric(vertical: 8, horizontal: 10),
-				unselectedLabelColor: AppColors.gray400,
-				labelColor: AppColors.white,
-				labelStyle: TextStyle(
-				    fontFamily: Fonts.circularMedium,
-				    fontSize: 20,
-				    letterSpacing: 0),
-				tabs: [
-				  TabDesign(title: "ICP"),
-				  TabDesign(title: "NEURONS"),
-				  TabDesign(title: "VOTING"),
-				  TabDesign(title: "CANISTERS"),
-				],
-			      ),
+                        decoration: BoxDecoration(color: Color(0xff282A2D)),
+                        child: TabBar(
+                          physics: const NeverScrollableScrollPhysics(),
+                          controller: _tabController,
+                          indicator: BoxDecoration(
+                              color: Color(0xff0081FF),
+                              borderRadius: BorderRadius.all(
+                                Radius.zero,
+                              )),
+                          indicatorSize: TabBarIndicatorSize.tab,
+                          labelPadding:
+                              EdgeInsets.symmetric(vertical: 8, horizontal: 10),
+                          unselectedLabelColor: AppColors.gray400,
+                          labelColor: AppColors.white,
+                          labelStyle: TextStyle(
+                              fontFamily: Fonts.circularMedium,
+                              fontSize: 20,
+                              letterSpacing: 0),
+                          tabs: [
+                            TabDesign(title: "ICP"),
+                            TabDesign(title: "NEURONS"),
+                            TabDesign(title: "VOTING"),
+                            TabDesign(title: "CANISTERS"),
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/frontend/dart/lib/ui/home/home_tabs_widget.dart
+++ b/frontend/dart/lib/ui/home/home_tabs_widget.dart
@@ -161,11 +161,7 @@ class _HomePageState extends State<HomePage>
                         child: TabBar(
                           physics: const NeverScrollableScrollPhysics(),
                           controller: _tabController,
-                          indicator: BoxDecoration(
-                              color: Color(0xff0081FF),
-                              borderRadius: BorderRadius.all(
-                                Radius.zero,
-                              )),
+                          indicator: BoxDecoration(color: Color(0xff0081FF)),
                           indicatorSize: TabBarIndicatorSize.tab,
                           labelPadding:
                               EdgeInsets.symmetric(vertical: 8, horizontal: 10),


### PR DESCRIPTION
# Motivation
The flutter navbar style needs to match svelte.  This style had already been changed, but with a refactoring that has been reverted so it needs to be reimplemented.

# Changes
* Make the nav bar buttons square except at the outside corners of the first and last button.
  * Note: This is done with a clip box rather than tracking the index of the current selection and applying conditional styles.
  * Also: I have removed the radius of the grey background and let the clipping box round the corners of that as well.  This is because the background radius had a different radius from the one used in svelte.  In svelte the background radius is the same as the button radius.  Using the clipping box achieves that effect.

# Tests
The code has been deployed here:   https://wmio3-kqaaa-aaaaa-aaasq-cai.nnsdapp.dfinity.network/#/accounts
You can compare with svelte, deployed here: https://tfuft-aqaaa-aaaaa-aaaoq-cai.nnsdapp.dfinity.network/v2/#/canisters