### PR TITLE
timeDilation speed is now only increased when a tab is tapped .

### DIFF
--- a/frontend/dart/lib/ui/home/home_tabs_widget.dart
+++ b/frontend/dart/lib/ui/home/home_tabs_widget.dart
@@ -41,6 +41,9 @@ class _HomePageState extends State<HomePage>
           pageName = canistersTabPage;
         }
         context.nav.push(pageName);
+        setState(() {
+          timeDilation = 0.6;
+        });
       }
     });
   }
@@ -53,7 +56,6 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
-    timeDilation = 0.05;
     final screenSize = context.mediaQuery.size;
     return Scaffold(
       backgroundColor: AppColors.lightBackground,
@@ -159,6 +161,9 @@ class _HomePageState extends State<HomePage>
                       child: Container(
                         decoration: BoxDecoration(color: Color(0xff282A2D)),
                         child: TabBar(
+                          onTap: (value) {
+                            timeDilation = 0.05;
+                          },
                           physics: const NeverScrollableScrollPhysics(),
                           controller: _tabController,
                           indicator: BoxDecoration(color: Color(0xff0081FF)),


### PR DESCRIPTION
time dilation is a global variable. The time is increased during page transition , so that the sliding animation is not noticeable . 
Once the page has transitioned , the time dilation time is reduced , so that page overlay effects , spinners are sped up throughout the app