### PR TITLE
feat: reset and find proposals on route mount

### DIFF
--- a/frontend/svelte/src/lib/stores/proposals.store.ts
+++ b/frontend/svelte/src/lib/stores/proposals.store.ts
@@ -55,7 +55,7 @@ const initProposalsStore = () => {
  *
  */
 const initProposalsFiltersStore = () => {
-  const { subscribe, update } = writable<ProposalsFiltersStore>(
+  const { subscribe, update, set } = writable<ProposalsFiltersStore>(
     DEFAULT_PROPOSALS_FILTERS
   );
 
@@ -88,6 +88,10 @@ const initProposalsFiltersStore = () => {
         ...filters,
         excludeVotedProposals: !filters.excludeVotedProposals,
       }));
+    },
+
+    reset() {
+      set(DEFAULT_PROPOSALS_FILTERS);
     },
   };
 };

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -30,7 +30,7 @@
 
     try {
       await listNextProposals({
-        beforeProposal: lastProposalId(proposals),
+        beforeProposal: lastProposalId($proposalsStore),
         identity: $authStore.identity,
       });
     } catch (err: any) {
@@ -51,7 +51,7 @@
     try {
       // If proposals are already displayed we reset the store first otherwise it might give the user the feeling than the new filters were already applied while the proposals are still being searched.
       await listProposals({
-        clearBeforeQuery: !emptyProposals(proposals),
+        clearBeforeQuery: !emptyProposals($proposalsStore),
         identity: $authStore.identity,
       });
     } catch (err: any) {
@@ -79,12 +79,6 @@
       window.location.replace(AppPath.Proposals);
     }
 
-    // Load proposals on mount only if none were fetched before
-    if (!emptyProposals(proposals)) {
-      initDebounceFindProposals();
-      return;
-    }
-
     await findProposals();
 
     initDebounceFindProposals();
@@ -95,9 +89,6 @@
   );
 
   onDestroy(unsubscribe);
-
-  let proposals: ProposalInfo[];
-  $: proposals = $proposalsStore;
 </script>
 
 {#if !process.env.REDIRECT_TO_LEGACY}

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -79,6 +79,8 @@
       window.location.replace(AppPath.Proposals);
     }
 
+    proposalsFiltersStore.reset();
+
     await findProposals();
 
     initDebounceFindProposals();

--- a/frontend/svelte/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/proposals.store.spec.ts
@@ -53,6 +53,16 @@ describe("proposals-store", () => {
       expect(filters).toEqual(DEFAULT_PROPOSALS_FILTERS);
     });
 
+    it("should reset filters", () => {
+      const filter = [Topic.NetworkEconomics, Topic.SubnetManagement];
+      proposalsFiltersStore.filterTopics(filter);
+
+      proposalsFiltersStore.reset();
+
+      const filters = get(proposalsFiltersStore);
+      expect(filters).toEqual(DEFAULT_PROPOSALS_FILTERS);
+    });
+
     it("should update topic filters", () => {
       const filter = [Topic.NetworkEconomics, Topic.SubnetManagement];
       proposalsFiltersStore.filterTopics(filter);

--- a/frontend/svelte/src/tests/routes/Proposals.spec.ts
+++ b/frontend/svelte/src/tests/routes/Proposals.spec.ts
@@ -25,10 +25,6 @@ describe("Proposals", () => {
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
 
-    proposalsStoreMock = jest
-      .spyOn(proposalsStore, "subscribe")
-      .mockImplementation(mockProposalsStoreSubscribe);
-
     jest
       .spyOn(GovernanceCanister, "create")
       .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
@@ -58,12 +54,17 @@ describe("Proposals", () => {
     ).toBeInTheDocument();
   });
 
-  it("should not render a spinner", async () => {
-    const { container, component } = render(Proposals);
-    expect(container.querySelector("div.spinner")).toBeNull();
+  it("should render a spinner while searching proposals", () => {
+    const { container } = render(Proposals);
+
+    expect(container.querySelector("div.spinner")).not.toBeNull();
   });
 
   it("should render proposals", () => {
+    proposalsStoreMock = jest
+      .spyOn(proposalsStore, "subscribe")
+      .mockImplementation(mockProposalsStoreSubscribe);
+
     const { getByText } = render(Proposals);
 
     expect(getByText(mockProposals[0].proposal.title)).toBeInTheDocument();


### PR DESCRIPTION
# Motivation

In a first version we want to mimic the Flutter app behavior by triggering a new search of the proposals each time the page "Voting" is opened.

# Changes

- trigger find and reset proposals store on mount
- reset proposals filter on mount

# Note

We keep the proposal store as it allows a smooth transition between list and detail page.
