### PR TITLE
L2-317: AccountCard link role

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
@@ -6,7 +6,7 @@
 
   export let account: Account;
   export let showCopy: boolean = false;
-  export let role: "button" | undefined = undefined;
+  export let role: "button" | "link" | undefined = undefined;
 
   $: ({ identifier, balance } = account);
 </script>

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -62,12 +62,14 @@
 
       {#if accounts?.main}
         <AccountCard
+          role="link"
           on:click={() => cardClick(accounts?.main?.identifier)}
           showCopy
           account={accounts?.main}>{$i18n.accounts.main}</AccountCard
         >
         {#each accounts.subAccounts as subAccount}
           <AccountCard
+            role="link"
             on:click={() => cardClick(subAccount.identifier)}
             showCopy
             account={subAccount}>{subAccount.name}</AccountCard

--- a/frontend/svelte/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -32,4 +32,14 @@ describe("AccountCard", () => {
       `${formatICP(mockMainAccount.balance.toE8s())}`
     );
   });
+
+  it("should add the role passed", () => {
+    const { container } = render(AccountCard, {
+      props: { ...props, role: "link" },
+    });
+
+    const article = container.querySelector("article");
+
+    expect(article.getAttribute("role")).toEqual("link");
+  });
 });


### PR DESCRIPTION
# Motivation

AccountCard can be role `"link"`

# Changes

Add type `"link"` to role prop in AccountCard.

# Tests

Add test to check role prop
