### PR TITLE
feat: list proposals - "filter" modal footer button

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -2,7 +2,8 @@
   "core": {
     "close": "Close",
     "icp": "ICP",
-    "create": "Create"
+    "create": "Create",
+    "filter": "Filter"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -49,6 +49,8 @@
       <div class="content" id="modalContent">
         <slot />
       </div>
+
+      <slot name="footer" />
     </div>
   </div>
 {/if}
@@ -159,7 +161,12 @@
   }
 
   .content {
+    display: flex;
+    flex-direction: column;
+
+    max-height: calc(100vh - 156px);
     overflow-y: scroll;
+
     color: var(--gray-800);
   }
 </style>

--- a/frontend/svelte/src/lib/modals/ProposalsFilterModal.svelte
+++ b/frontend/svelte/src/lib/modals/ProposalsFilterModal.svelte
@@ -61,10 +61,13 @@
     }
   };
 
-  const onChange = (filter: Topic | ProposalRewardStatus | ProposalStatus) => {
+  const onChange = (filter: Topic | ProposalRewardStatus | ProposalStatus) =>
     applyFilterChange(filter);
 
+  const filter = () => {
     updateProposalStoreFilters();
+
+    close();
   };
 </script>
 
@@ -81,4 +84,14 @@
       >
     {/each}
   {/if}
+
+  <svelte:fragment slot="footer">
+    <button class="primary" type="button" on:click={filter}> Filter </button>
+  </svelte:fragment>
 </Modal>
+
+<style lang="scss">
+  button {
+    margin: var(--padding);
+  }
+</style>

--- a/frontend/svelte/src/lib/modals/ProposalsFilterModal.svelte
+++ b/frontend/svelte/src/lib/modals/ProposalsFilterModal.svelte
@@ -86,7 +86,9 @@
   {/if}
 
   <svelte:fragment slot="footer">
-    <button class="primary" type="button" on:click={filter}> Filter </button>
+    <button class="primary" type="button" on:click={filter}>
+      {$i18n.core.filter}
+    </button>
   </svelte:fragment>
 </Modal>
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -6,6 +6,7 @@ interface I18nCore {
   close: string;
   icp: string;
   create: string;
+  filter: string;
 }
 
 interface I18nError {

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -22,7 +22,6 @@
     listNextProposals,
     listProposals,
   } from "../lib/services/proposals.services";
-  import type { ProposalInfo } from "@dfinity/nns";
   import { authStore } from "../lib/stores/auth.store";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { errorToString } from "../lib/utils/error.utils";
@@ -75,7 +74,7 @@
 
   // We do not want to fetch the proposals twice when the component is mounting because the filter subscriber will emit a first value
   const initDebounceFindProposals = () => {
-    debounceFindProposals = debounce(async () => await findProposals(), 750);
+    debounceFindProposals = debounce(async () => await findProposals(), 250);
   };
 
   onMount(async () => {

--- a/frontend/svelte/src/tests/lib/modals/ProposalsFilterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposalsFilterModal.spec.ts
@@ -3,8 +3,12 @@
  */
 
 import { Topic } from "@dfinity/nns";
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import { DEFAULT_PROPOSALS_FILTERS } from "../../../lib/constants/proposals.constants";
 import ProposalsFilterModal from "../../../lib/modals/ProposalsFilterModal.svelte";
+import { proposalsFiltersStore } from "../../../lib/stores/proposals.store";
 import type { ProposalsFilterModalProps } from "../../../lib/types/proposals";
 import { enumKeys } from "../../../lib/utils/enum.utils";
 
@@ -15,7 +19,7 @@ describe("ProposalsFilterModal", () => {
     props: {
       category: "topics",
       filters: Topic,
-      selectedFilters: enumKeys(Topic).map((key: string) => Topic[key]),
+      selectedFilters: DEFAULT_PROPOSALS_FILTERS.topics,
     },
   };
 
@@ -54,7 +58,37 @@ describe("ProposalsFilterModal", () => {
       done();
     });
 
-    const button: HTMLButtonElement | null = container.querySelector("button");
+    const button: HTMLButtonElement | null = container.querySelector(
+      "button:first-of-type"
+    );
     fireEvent.click(button);
+  });
+
+  it("should filter filters", async () => {
+    const { container, component } = render(ProposalsFilterModal, {
+      props,
+    });
+
+    const firstInput = container.querySelector(
+      "div.content div.checkbox:first-of-type input"
+    ) as HTMLInputElement;
+    fireEvent.click(firstInput);
+    await waitFor(() => expect(firstInput.checked).toBeTruthy());
+
+    const secondInput = container.querySelector(
+      "div.content div.checkbox:nth-child(2) input"
+    ) as HTMLInputElement;
+    fireEvent.click(secondInput);
+    await waitFor(() => expect(secondInput.checked).toBeTruthy());
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      "div.wrapper > button"
+    );
+    fireEvent.click(button);
+
+    await tick();
+
+    const selectedTopics = get(proposalsFiltersStore).topics;
+    expect(selectedTopics).toEqual([...DEFAULT_PROPOSALS_FILTERS.topics, 0, 1]);
   });
 });


### PR DESCRIPTION
# Motivation

To improve the UX, we are not going to fetch new proposals every time a checkbox is clicked but rather make it as a user choice. To do so, we add a "filter" button in the filter modals for the list of proposals.

# Changes

- add button "Filter"
- apply filtering only if button is clicked
- add `footer` slot to modal
- improve `content` slot scrolling in modal

# Screenshots

<img width="1335" alt="Capture d’écran 2022-02-28 à 14 00 31" src="https://user-images.githubusercontent.com/16886711/155987805-57c18c4b-efe0-4a22-ab1d-b661953cdd0c.png">

<img width="1040" alt="Capture d’écran 2022-02-28 à 14 00 40" src="https://user-images.githubusercontent.com/16886711/155987822-bfac92a8-1986-43a8-996d-20eb2d1be855.png">

