### PR TITLE
feat: testnet banner

### DIFF
--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -51,11 +51,11 @@
     left: 0;
     right: 0;
 
-    margin: 0;
-
     &.headless {
       position: relative;
     }
+
+    z-index: var(--z-index);
 
     height: var(--header-offset);
 
@@ -77,9 +77,13 @@
     font-weight: 400;
     @include text.clamp(2);
 
+    margin: 0;
+
     grid-column-start: 2;
 
     text-align: center;
+
+    line-height: inherit;
   }
 
   button {

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -3,11 +3,14 @@
   import IconClose from "../../icons/IconClose.svelte";
 
   export let headless: boolean = false;
+
   let visible: boolean = JSON.parse(
     localStorage.getItem("nnsdapp-testnet-banner-display") || "true"
   );
 
-  const deployEnv: string = process.env.DEPLOY_ENV;
+  const testnet: boolean = process.env.DEPLOY_ENV === 'testnet';
+  const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH);
+  const banner: boolean = testnet && !localEnv;
 
   let rootStyle: string | undefined;
 
@@ -29,12 +32,12 @@
 </script>
 
 <svelte:head>
-  {#if deployEnv === "testnet" && rootStyle}
+  {#if banner && rootStyle}
     {@html rootStyle}
   {/if}
 </svelte:head>
 
-{#if deployEnv === "testnet" && visible}
+{#if banner && visible}
   <div class:headless>
     <h4>For <strong>test</strong> purpose only.</h4>
     <button on:click={close} aria-label={$i18n.core.close}><IconClose /></button

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  export let headless: boolean = false;
+
+  const deployEnv: string = process.env.DEPLOY_ENV;
+
+  const rootStyle: string = `
+    <style>
+      :root {
+        --header-offset: 50px;
+      }
+    </style>
+  `;
+</script>
+
+<svelte:head>
+  {#if deployEnv === "testnet"}
+    {@html rootStyle}
+  {/if}
+</svelte:head>
+
+{#if deployEnv === "testnet"}
+  <div class:headless>
+    <h4>For <strong>test</strong> purpose only.</h4>
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "../../themes/mixins/text";
+
+  div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+
+    &.headless {
+      position: relative;
+    }
+
+    height: var(--header-offset);
+
+    display: grid;
+    grid-template-columns: 25% 50% 25%;
+
+    justify-content: center;
+    align-items: center;
+
+    background: var(--pink);
+    color: var(--pink-contrast);
+
+    :global(:root) {
+      --header-offset: 60px;
+    }
+  }
+
+  h4 {
+    font-weight: 400;
+    @include text.clamp(2);
+
+    grid-column-start: 2;
+
+    text-align: center;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -1,26 +1,44 @@
 <script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import IconClose from "../../icons/IconClose.svelte";
+
   export let headless: boolean = false;
+  let visible: boolean = JSON.parse(
+    localStorage.getItem("nnsdapp-testnet-banner-display") || "true"
+  );
 
   const deployEnv: string = process.env.DEPLOY_ENV;
 
-  const rootStyle: string = `
+  let rootStyle: string | undefined;
+
+  $: rootStyle = visible
+    ? `
     <style>
       :root {
         --header-offset: 50px;
       }
     </style>
-  `;
+  `
+    : undefined;
+
+  const close = () => {
+    visible = false;
+
+    localStorage.setItem("nnsdapp-testnet-banner-display", "false");
+  };
 </script>
 
 <svelte:head>
-  {#if deployEnv === "testnet"}
+  {#if deployEnv === "testnet" && rootStyle}
     {@html rootStyle}
   {/if}
 </svelte:head>
 
-{#if deployEnv === "testnet"}
+{#if deployEnv === "testnet" && visible}
   <div class:headless>
     <h4>For <strong>test</strong> purpose only.</h4>
+    <button on:click={close} aria-label={$i18n.core.close}><IconClose /></button
+    >
   </div>
 {/if}
 
@@ -32,6 +50,8 @@
     top: 0;
     left: 0;
     right: 0;
+
+    margin: 0;
 
     &.headless {
       position: relative;
@@ -60,5 +80,11 @@
     grid-column-start: 2;
 
     text-align: center;
+  }
+
+  button {
+    display: flex;
+    justify-self: flex-end;
+    margin: 0 var(--padding);
   }
 </style>

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -4,8 +4,10 @@
 
   export let headless: boolean = false;
 
+  const localstorageKey: string = "nnsdapp-testnet-banner-display";
+
   let visible: boolean = JSON.parse(
-    localStorage.getItem("nnsdapp-testnet-banner-display") || "true"
+    localStorage.getItem(localstorageKey) || "true"
   );
 
   const testnet: boolean = process.env.DEPLOY_ENV === "testnet";
@@ -27,7 +29,7 @@
   const close = () => {
     visible = false;
 
-    localStorage.setItem("nnsdapp-testnet-banner-display", "false");
+    localStorage.setItem(localstorageKey, "false");
   };
 </script>
 

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -8,7 +8,7 @@
     localStorage.getItem("nnsdapp-testnet-banner-display") || "true"
   );
 
-  const testnet: boolean = process.env.DEPLOY_ENV === 'testnet';
+  const testnet: boolean = process.env.DEPLOY_ENV === "testnet";
   const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH);
   const banner: boolean = testnet && !localEnv;
 

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -14,7 +14,7 @@
   const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH || "false");
   const banner: boolean = testnet && !localEnv;
 
-  const rootStyle: string | undefined = `
+  const rootStyle: string = `
     <style>
       :root {
         --header-offset: 50px;

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -9,7 +9,7 @@
   );
 
   const testnet: boolean = process.env.DEPLOY_ENV === "testnet";
-  const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH);
+  const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH || "false");
   const banner: boolean = testnet && !localEnv;
 
   let rootStyle: string | undefined;

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -14,17 +14,13 @@
   const localEnv: boolean = JSON.parse(process.env.ROLLUP_WATCH || "false");
   const banner: boolean = testnet && !localEnv;
 
-  let rootStyle: string | undefined;
-
-  $: rootStyle = visible
-    ? `
+  const rootStyle: string | undefined = `
     <style>
       :root {
         --header-offset: 50px;
       }
     </style>
-  `
-    : undefined;
+  `;
 
   const close = () => {
     visible = false;
@@ -34,7 +30,7 @@
 </script>
 
 <svelte:head>
-  {#if banner && rootStyle}
+  {#if banner && visible}
     {@html rootStyle}
   {/if}
 </svelte:head>

--- a/frontend/svelte/src/lib/components/common/Header.svelte
+++ b/frontend/svelte/src/lib/components/common/Header.svelte
@@ -24,10 +24,11 @@
 
 <style lang="scss">
   @use "../../themes/mixins/img";
+  @use "../../themes/mixins/text";
 
   header {
     position: absolute;
-    top: 0;
+    top: var(--header-offset, 0);
     left: 0;
     right: 0;
 
@@ -53,10 +54,7 @@
 
     grid-column-start: 2;
 
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    @include text.clamp(2);
 
     text-align: center;
 

--- a/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
+++ b/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
@@ -5,9 +5,12 @@
   import Toasts from "../ui/Toasts.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
   import Footer from "./Footer.svelte";
+  import Banner from "./Banner.svelte";
 
   const dispatch = createEventDispatcher();
 </script>
+
+<Banner headless={true} />
 
 <header>
   <Tooltip id="back" text={$i18n.modals.back}>

--- a/frontend/svelte/src/lib/components/common/Layout.svelte
+++ b/frontend/svelte/src/lib/components/common/Layout.svelte
@@ -25,7 +25,10 @@
 <style lang="scss">
   main {
     position: absolute;
-    top: calc(var(--header-offset, 0px) + var(--header-height) + var(--nav-height) + (2 * var(--padding)));
+    top: calc(
+      var(--header-offset, 0px) + var(--header-height) + var(--nav-height) +
+        (2 * var(--padding))
+    );
     left: 0;
     right: 0;
     bottom: 0;

--- a/frontend/svelte/src/lib/components/common/Layout.svelte
+++ b/frontend/svelte/src/lib/components/common/Layout.svelte
@@ -25,7 +25,7 @@
 <style lang="scss">
   main {
     position: absolute;
-    top: calc(var(--header-offset, 0) + var(--header-height) + var(--nav-height) + (2 * var(--padding)));
+    top: calc(var(--header-offset, 0px) + var(--header-height) + var(--nav-height) + (2 * var(--padding)));
     left: 0;
     right: 0;
     bottom: 0;

--- a/frontend/svelte/src/lib/components/common/Layout.svelte
+++ b/frontend/svelte/src/lib/components/common/Layout.svelte
@@ -3,7 +3,10 @@
   import Header from "./Header.svelte";
   import Nav from "./Nav.svelte";
   import Toasts from "../ui/Toasts.svelte";
+  import Banner from "./Banner.svelte";
 </script>
+
+<Banner />
 
 <Header />
 
@@ -22,7 +25,7 @@
 <style lang="scss">
   main {
     position: absolute;
-    top: calc(var(--header-height) + var(--nav-height) + (2 * var(--padding)));
+    top: calc(var(--header-offset, 0) + var(--header-height) + var(--nav-height) + (2 * var(--padding)));
     left: 0;
     right: 0;
     bottom: 0;

--- a/frontend/svelte/src/lib/components/common/Nav.svelte
+++ b/frontend/svelte/src/lib/components/common/Nav.svelte
@@ -29,7 +29,7 @@
 
   nav {
     position: absolute;
-    top: calc(var(--header-offset, 0) + var(--header-height));
+    top: calc(var(--header-offset, 0px) + var(--header-height));
     left: 0;
     right: 0;
 

--- a/frontend/svelte/src/lib/components/common/Nav.svelte
+++ b/frontend/svelte/src/lib/components/common/Nav.svelte
@@ -29,7 +29,7 @@
 
   nav {
     position: absolute;
-    top: var(--header-height);
+    top: calc(var(--header-offset, 0) + var(--header-height));
     left: 0;
     right: 0;
 

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -8,6 +8,7 @@
   import Toasts from "../lib/components/ui/Toasts.svelte";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { errorToString } from "../lib/utils/error.utils";
+  import Banner from "../lib/components/common/Banner.svelte";
 
   let signedIn: boolean = false;
 
@@ -58,6 +59,8 @@
     aria-hidden="true"
     class="background"
   />
+
+  <Banner />
 
   <main>
     <h1>{$i18n.auth.nns}</h1>


### PR DESCRIPTION
# Motivation

Some users find their way to the application deployed on testnet (source [forum](https://forum.dfinity.org/t/internet-identity-doubt-in-creating-a-new-ii-anchor/11179/8?u=peterparker)). To make them aware they are accessing a version that has only test purpose, we can display a banner about it.

# Changes

- test purpose banner displayed if environment is "testnet" and not "local development"
- css variable `--header-offset` for layout

# Screenshots

<img width="1026" alt="Capture d’écran 2022-03-01 à 08 01 15" src="https://user-images.githubusercontent.com/16886711/156121263-5cdaa5bc-1d01-41de-98a2-13adacefb145.png">
<img width="1026" alt="Capture d’écran 2022-03-01 à 08 01 38" src="https://user-images.githubusercontent.com/16886711/156121281-bb0fb61f-172b-44db-a6be-d8483030f2d7.png">
<img width="1026" alt="Capture d’écran 2022-03-01 à 08 01 43" src="https://user-images.githubusercontent.com/16886711/156121283-09679ba8-e2a3-40e6-93f9-d0359a83fd1d.png">

