### PR TITLE
bump: nns-js nightly 2022/02/28

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/auth-client": "^0.10.3",
         "@dfinity/identity": "^0.10.3",
-        "@dfinity/nns": "^0.2.1"
+        "@dfinity/nns": "^0.2.2-nightly-2022-02-28"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.1.tgz",
-      "integrity": "sha512-8zOGAkYGEkVcmuq8RP9py4VsZOQs1boZiYFajAKD7mCiij4wn+H6HpJVg1mVEnlZCl2VrBL+5ObqB81KNMlfrw==",
+      "version": "0.2.2-nightly-2022-02-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.2-nightly-2022-02-28.tgz",
+      "integrity": "sha512-Qcppcqm8eRDnp9F/fgF3tc7TRdYeb1wdbgS2pvQdHp/WBtInNoIWGe7A9fiPO8+mSUboY2ldgSfoeJk8DmoRJg==",
       "dependencies": {
         "@dfinity/agent": "^0.10.3",
         "@dfinity/candid": "^0.10.3",
@@ -9194,9 +9194,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.1.tgz",
-      "integrity": "sha512-8zOGAkYGEkVcmuq8RP9py4VsZOQs1boZiYFajAKD7mCiij4wn+H6HpJVg1mVEnlZCl2VrBL+5ObqB81KNMlfrw==",
+      "version": "0.2.2-nightly-2022-02-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.2.2-nightly-2022-02-28.tgz",
+      "integrity": "sha512-Qcppcqm8eRDnp9F/fgF3tc7TRdYeb1wdbgS2pvQdHp/WBtInNoIWGe7A9fiPO8+mSUboY2ldgSfoeJk8DmoRJg==",
       "requires": {
         "@dfinity/agent": "^0.10.3",
         "@dfinity/candid": "^0.10.3",

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -57,6 +57,6 @@
   "dependencies": {
     "@dfinity/auth-client": "^0.10.3",
     "@dfinity/identity": "^0.10.3",
-    "@dfinity/nns": "^0.2.1"
+    "@dfinity/nns": "^0.2.2-nightly-2022-02-28"
   }
 }

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -6,16 +6,14 @@
   import { i18n } from "../../stores/i18n";
   import { proposalsFiltersStore } from "../../stores/proposals.store";
   import { hideProposal } from "../../utils/proposals.utils";
-
-  // TODO: nns-js in v0.2.2 does not expose types yet - solved in https://github.com/dfinity/nns-js/pull/43
-  // import type { NeuronId, ProposalId } from "@dfinity/nns";
+  import type { NeuronId, ProposalId } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 
   let proposal: Proposal | undefined;
   let status: ProposalStatus | undefined;
-  let proposer: bigint | undefined;
-  let id: bigint | undefined;
+  let proposer: NeuronId | undefined;
+  let id: ProposalId | undefined;
   let title: string | undefined;
 
   let color: "warning" | "success" | undefined;


### PR DESCRIPTION
# Motivation

Bump nns-js nightly 2022/02/28 to introduce the new exposed typings and `getProposalInfo`

# Changes

- bump nns-js nightly 2022/02/28
- use types in proposal card