### PR TITLE
feat: do not reload list of proposals on back

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -34,6 +34,7 @@
       if (isKnownPath) {
         return;
       }
+      // if the path is unsupported (to mock the flutter dapp) the user will be redirected to the first page (/accounts/) page (unknown path will not be saved in session History)
       routeStore.replace({ path: AppPath.Accounts });
     }
   );

--- a/frontend/svelte/src/lib/stores/route.store.ts
+++ b/frontend/svelte/src/lib/stores/route.store.ts
@@ -18,7 +18,9 @@ export interface RouteStore {
  * The store contains following information:
  * - path: the application path - i.e. the page (see AppPath) that is displayed
  * - referrerPath: the page - i.e. the path - that linked to the current path. For example, if navigating from "Accounts" to "Voting" page, the referrerPath is `/#/accounts`. If the referrer is not the app, then is value is undefined.
- * - isKnownPath: tells if the path is a path that is supported by the app - e.g. useful to display a 404
+ * - isKnownPath: tells if the path is a path that is supported by the app
+ *  - currently is used to imitate the flutter dapp navigation (redirects the user to the first page "/accounts/")
+ *  - later could be used to display a 404
  *
  */
 const initRouteStore = () => {

--- a/frontend/svelte/src/lib/stores/route.store.ts
+++ b/frontend/svelte/src/lib/stores/route.store.ts
@@ -5,6 +5,7 @@ import { pushHistory, replaceHistory, routePath } from "../utils/route.utils";
 
 export interface RouteStore {
   path: AppPath | string;
+  previousPath?: AppPath | string;
   isKnownPath: boolean;
 }
 
@@ -27,6 +28,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
+        previousPath: state.path,
         isKnownPath: isAppPath(path),
       })),
 
@@ -34,6 +36,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
+        previousPath: state.path,
         isKnownPath: isAppPath(path),
       }));
 
@@ -44,6 +47,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
+        previousPath: state.path,
         isKnownPath: isAppPath(path),
       }));
 

--- a/frontend/svelte/src/lib/stores/route.store.ts
+++ b/frontend/svelte/src/lib/stores/route.store.ts
@@ -5,7 +5,7 @@ import { pushHistory, replaceHistory, routePath } from "../utils/route.utils";
 
 export interface RouteStore {
   path: AppPath | string;
-  previousPath?: AppPath | string;
+  referrerPath?: AppPath | string;
   isKnownPath: boolean;
 }
 
@@ -14,6 +14,12 @@ export interface RouteStore {
  * - update: update the state value
  * - navigate: update the state value and push the new route to the browser history i.e. update browser url with an entry in the navigation stack
  * - replace: update the state value and replace the route in the browser history i.e. update browser url without modifying the navigation stack
+ *
+ * The store contains following information:
+ * - path: the application path - i.e. the page (see AppPath) that is displayed
+ * - referrerPath: the page - i.e. the path - that linked to the current path. For example, if navigating from "Accounts" to "Voting" page, the referrerPath is `/#/accounts`. If the referrer is not the app, then is value is undefined.
+ * - isKnownPath: tells if the path is a path that is supported by the app - e.g. useful to display a 404
+ *
  */
 const initRouteStore = () => {
   const { subscribe, update } = writable<RouteStore>({
@@ -28,7 +34,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
-        previousPath: state.path,
+        referrerPath: state.path,
         isKnownPath: isAppPath(path),
       })),
 
@@ -36,7 +42,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
-        previousPath: state.path,
+        referrerPath: state.path,
         isKnownPath: isAppPath(path),
       }));
 
@@ -47,7 +53,7 @@ const initRouteStore = () => {
       update((state: RouteStore) => ({
         ...state,
         path,
-        previousPath: state.path,
+        referrerPath: state.path,
         isKnownPath: isAppPath(path),
       }));
 

--- a/frontend/svelte/src/lib/utils/app-path.utils.ts
+++ b/frontend/svelte/src/lib/utils/app-path.utils.ts
@@ -18,7 +18,7 @@ export const isRoutePath: ({
   routePath,
 }: {
   path: AppPath;
-  routePath: string;
+  routePath: string | undefined;
 }) => boolean = memoize(({ path, routePath }) =>
   new RegExp(`^${pathValidation(path)}$`).test(routePath)
 );

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -63,6 +63,8 @@
   onDestroy(unsubscribe);
 
   const goBack = () => {
+    unsubscribe();
+
     routeStore.navigate({
       path: AppPath.Proposals,
     });

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
   import HeadlessLayout from "../lib/components/common/HeadlessLayout.svelte";
   import Spinner from "../lib/components/ui/Spinner.svelte";
   import {

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -74,7 +74,7 @@
 {#if !process.env.REDIRECT_TO_LEGACY}
   <HeadlessLayout on:nnsBack={goBack} showFooter={false}>
     <svelte:fragment slot="header"
-    >{$i18n.proposal_detail.title}</svelte:fragment
+      >{$i18n.proposal_detail.title}</svelte:fragment
     >
 
     <section>

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -87,7 +87,7 @@
 
     const isReferrerProposalDetail: boolean = isRoutePath({
       path: AppPath.ProposalDetail,
-      routePath: $routeStore.previousPath,
+      routePath: $routeStore.referrerPath,
     });
 
     // If the previous page is the proposal detail page and if we have proposals in store, we don't reset and query the proposals after mount.

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -25,6 +25,8 @@
   import { authStore } from "../lib/stores/auth.store";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { errorToString } from "../lib/utils/error.utils";
+  import { routeStore } from "../lib/stores/route.store";
+  import { isRoutePath } from "../lib/utils/app-path.utils";
 
   let loading: boolean = false;
   let initialized: boolean = false;
@@ -81,6 +83,18 @@
     // TODO: To be removed once this page has been implemented
     if (process.env.REDIRECT_TO_LEGACY) {
       window.location.replace(AppPath.Proposals);
+    }
+
+    const isReferrerProposalDetail: boolean = isRoutePath({
+      path: AppPath.ProposalDetail,
+      routePath: $routeStore.previousPath,
+    });
+
+    // If the previous page is the proposal detail page and if we have proposals in store, we don't reset and query the proposals after mount.
+    // We do this to smoothness the back and forth navigation between this page and the detail page.
+    if (!emptyProposals($proposalsStore) && isReferrerProposalDetail) {
+      initDebounceFindProposals();
+      return;
     }
 
     proposalsFiltersStore.reset();

--- a/frontend/svelte/src/tests/lib/stores/route.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/route.store.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { get } from "svelte/store";
+import { AppPath } from "../../../lib/constants/routes.constants";
+import { routeStore } from "../../../lib/stores/route.store";
+
+describe("route-store", () => {
+  it("should set referrer path", () => {
+    routeStore.update({ path: AppPath.Accounts });
+
+    routeStore.navigate({ path: AppPath.Proposals });
+
+    let referrerPath = get(routeStore).referrerPath;
+    expect(referrerPath).toEqual(AppPath.Accounts);
+
+    routeStore.replace({ path: AppPath.Neurons });
+
+    referrerPath = get(routeStore).referrerPath;
+    expect(referrerPath).toEqual(AppPath.Proposals);
+  });
+});

--- a/frontend/svelte/src/tests/lib/utils/app-path.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/app-path.spec.ts
@@ -69,6 +69,12 @@ describe("routes", () => {
           routePath: "/#/wallet",
         })
       ).toBeFalsy();
+      expect(
+        isRoutePath({
+          path: AppPath.Wallet,
+          routePath: undefined,
+        })
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

To make the transition between "Proposal detail" and "Proposals list - Voting" pages smooth in case of "back" action, the proposals shall not be fetched again if already exist.

Scenario example: 

- Neurons > Voting > Fetch proposals > select Proposal > Detail > Back > No fetch - display existing proposals from store
- Proposal details > Fetch proposal > Back > Voting > Fetch proposals
- Neurons > Voting -> Fetch proposals  > Neurons > Voting > Fetch proposals


# Changes

- add `referrerPath` to route store
- do not reset proposals store on mount in `Proposals.svelte` if referrer is "Proposal detail" page and store not empty
- fix `navigate` and `replace` called at the same time on back in `ProposalDetail.svelte`

