### PR TITLE
fix: missing csp

### DIFF
--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -43,7 +43,7 @@ const updateBaseHref = (content) =>
  */
 const updateCSP = (content) => {
   // In local development mode, no CSP rule
-  if (envConfig.ENVIRONMENT === 'local') {
+  if (envConfig.ENVIRONMENT === "local") {
     return content.replace("<!-- CONTENT_SECURITY_POLICY -->", "");
   }
 

--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -42,8 +42,8 @@ const updateBaseHref = (content) =>
  *    source: https://github.com/sveltejs/svelte/issues/6662
  */
 const updateCSP = (content) => {
-  // In development mode, no CSP rule
-  if (!envConfig.PRODUCTION) {
+  // In local development mode, no CSP rule
+  if (envConfig.ENVIRONMENT === 'local') {
     return content.replace("<!-- CONTENT_SECURITY_POLICY -->", "");
   }
 


### PR DESCRIPTION
# Motivation

The CSP for the svelte app is not injected because there is no more `env.PRODUCTION` config.

# Changes

- fix `env.PRODUCTION` with `env.ENVIRONMENT`
