### PR TITLE
Display the ManageNeuron topic if a neuron has followees on it

### DIFF
--- a/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
+++ b/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
@@ -32,9 +32,10 @@ class _ConfigureFollowersPageState extends State<ConfigureFollowersPage> {
         stream: context.boxes.neurons.changes,
         builder: (context, snapshot) {
           final refreshed = context.boxes.neurons[widget.neuron.id];
-          // NeuronManagement proposals are not public so we hide these from the follow options
+          // NeuronManagement proposals are not public so we hide this topic
+          // (unless the neuron already has followees on this topic)
           final followees = refreshed.followees
-              .whereNot((e) => e.topic == Topic.NeuronManagement);
+              .where((e) => e.topic != Topic.NeuronManagement || e.followees.isNotEmpty);
           rowKeys = followees.map((element) => GlobalKey()).toList();
           return Column(
             children: [

--- a/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
+++ b/frontend/dart/lib/ui/neurons/following/configure_followers_page.dart
@@ -35,7 +35,7 @@ class _ConfigureFollowersPageState extends State<ConfigureFollowersPage> {
           // NeuronManagement proposals are not public so we hide this topic
           // (unless the neuron already has followees on this topic)
           final followees = refreshed.followees
-              .where((e) => e.topic != Topic.NeuronManagement || e.followees.isNotEmpty);
+              .where((e) => (e.topic != Topic.NeuronManagement) || e.followees.isNotEmpty);
           rowKeys = followees.map((element) => GlobalKey()).toList();
           return Column(
             children: [


### PR DESCRIPTION
# Motivation

We currently hide the ManageNeuron topic from the followee options. But some neurons may be created with followees on the ManageNeuron topic. In these cases it is currently impossible for the neuron owner to remove the followee via the UI.

# Changes

- Show the ManageNeuron followee configuration options for neurons who already have followees on the ManageNeuron topic.

# Tests

I removed the topic filter, then followed a neuron on the ManageNeuron topic, then applied this change. I could then see the ManageNeuron topic on the followee options page. But when I removed the neuron from the ManageNeuron topic, the topic itself disappeared, as intended.
