### PR TITLE
feat: provide own canister url in csp

### DIFF
--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -42,6 +42,7 @@ const OWN_CANISTER_ID =
 
 const GOVERNANCE_CANISTER_URL = `https://${GOVERNANCE_CANISTER_ID}${domain}/`;
 const LEDGER_CANISTER_URL = `https://${LEDGER_CANISTER_ID}${domain}/`;
+const OWN_CANISTER_URL = `https://${OWN_CANISTER_ID}${domain}/`;
 
 // When developing with live reload in svelte, redirecting to flutter is
 // not desirable.  The default should match production:
@@ -66,6 +67,7 @@ export const envConfig = {
   MAINNET,
   HOST,
   OWN_CANISTER_ID,
+  OWN_CANISTER_URL,
   IDENTITY_SERVICE_URL,
   GOVERNANCE_CANISTER_ID,
   LEDGER_CANISTER_ID,

--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -66,7 +66,7 @@ const updateCSP = (content) => {
 const cspConnectSrc = () => {
   const {
     IDENTITY_SERVICE_URL,
-    OWN_CANISTER_ID,
+    OWN_CANISTER_URL,
     HOST,
     GOVERNANCE_CANISTER_URL,
     LEDGER_CANISTER_URL,
@@ -75,7 +75,7 @@ const cspConnectSrc = () => {
 
   const src = [
     IDENTITY_SERVICE_URL,
-    OWN_CANISTER_ID,
+    OWN_CANISTER_URL,
     HOST,
     GOVERNANCE_CANISTER_URL,
     LEDGER_CANISTER_URL,


### PR DESCRIPTION
# Motivation

Provide the own canister url and not only id in the csp.

# Changes

- parse full url instead of id in the csp rule (same behavior as other canisters we allow)
