### PR TITLE
Sharpen up the sha code and add utilities

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -73,9 +73,9 @@ jobs:
          git config user.name "GitHub Actions Bot"
          git config user.email "<>"
          : Make a note of the WASM shasum.
-         NOTES_REF="refs/notes/${{ matrix.DEPLOY_ENV }}/wasm-sha"
-         SHA="$(sha256sum < "${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm")"
-         echo "$NOTES_REF: $SHA"
+         NOTES_REF="refs/notes/${{ matrix.DEPLOY_ENV }}/sha"
+         SHA="$(sha256sum "${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm")"
+         printf "%s\n" "$NOTES_REF:" "$SHA"
          git fetch origin "+${NOTES_REF}:${NOTES_REF}"
          if git notes --ref="$NOTES_REF" add -m "$SHA"
          then git push origin "${NOTES_REF}:${NOTES_REF}"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -73,11 +73,12 @@ jobs:
          git config user.name "GitHub Actions Bot"
          git config user.email "<>"
          : Make a note of the WASM shasum.
-         NOTE="refs/notes/${{ matrix.DEPLOY_ENV }}/wasm-sha"
+         NOTES_REF="refs/notes/${{ matrix.DEPLOY_ENV }}/wasm-sha"
          SHA="$(sha256sum < "${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm")"
-         git fetch origin "+${NOTE}:${NOTE}"
-         if git notes --ref="${{ matrix.DEPLOY_ENV }}/wasm-sha" add -m "$SHA"
-         then git push origin "${NOTE}:${NOTE}"
+         echo "$NOTES_REF: $SHA"
+         git fetch origin "+${NOTES_REF}:${NOTES_REF}"
+         if git notes --ref="$NOTES_REF" add -m "$SHA"
+         then git push origin "${NOTES_REF}:${NOTES_REF}"
          else echo SHA already set
          fi
       - name: "Verify that the WASM module is small enough to deploy"

--- a/scripts/wasm-shasum-log
+++ b/scripts/wasm-shasum-log
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+git fetch origin refs/notes/*:refs/notes/* > /dev/null
+# DEPLOY_ENV - typical values are 'testnet' and 'mainnet'
+NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/wasm-sha
+git log --pretty=format:"%H %N" --show-notes="$NOTES_REF" "${@}"

--- a/scripts/wasm-shasum-log
+++ b/scripts/wasm-shasum-log
@@ -2,5 +2,5 @@
 set -eu
 git fetch origin refs/notes/*:refs/notes/* > /dev/null
 # DEPLOY_ENV - typical values are 'testnet' and 'mainnet'
-NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/wasm-sha
+NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/sha
 git log --pretty=format:"%H %N" --show-notes="$NOTES_REF" "${@}"

--- a/scripts/wasm-shasum-lookup
+++ b/scripts/wasm-shasum-lookup
@@ -3,5 +3,5 @@
 set -eu
 git fetch origin refs/notes/*:refs/notes/* > /dev/null || true
 # DEPLOY_ENV - typical values are 'testnet' and 'mainnet'
-NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/wasm-sha
+NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/sha
 git grep "${@}" -- "$NOTES_REF"

--- a/scripts/wasm-shasum-lookup
+++ b/scripts/wasm-shasum-lookup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Does a reverse lookup from wasm sha sum to commits.
+set -eu
+git fetch origin refs/notes/*:refs/notes/* > /dev/null || true
+# DEPLOY_ENV - typical values are 'testnet' and 'mainnet'
+NOTES_REF=refs/notes/${DEPLOY_ENV:-testnet}/wasm-sha
+git grep "${@}" -- "$NOTES_REF"


### PR DESCRIPTION
# Motivation
We now have a lookup mechanism from wasm sha to commit(s) however it is still a bit rough.

# Changes
* Add utilities for looking up and listing shas.
* Disambiguate the reference used when marking the commit with the sha.
* Make the name of the git note less specific, so that other artifact shas can be included as well.  At the moment there is only one that seems worth tracking but it seems unnecessary to bake that assumption in.

# Tests
