### PR TITLE
feat: add title to <Toast> message

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -11,12 +11,14 @@
   export let msg: ToastMsg;
 
   const close = () => toastsStore.hide();
+  let text: string;
 
   $: ({ labelKey, level, detail } = msg || {
     labelKey: "",
     level: "info",
     detail: undefined,
   });
+  $: text = `${translate({ labelKey })}${detail || ""}`;
 </script>
 
 <div
@@ -26,8 +28,8 @@
   in:fly={{ y: 100, duration: 200 }}
   out:fade={{ delay: 100 }}
 >
-  <p>
-    {translate({ labelKey })}{detail ? ` ${detail}` : ""}
+  <p title={text}>
+    {text}
   </p>
 
   <button on:click={close} aria-label={$i18n.core.close}><IconClose /></button>

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -11,7 +11,7 @@
   export let msg: ToastMsg;
 
   const close = () => toastsStore.hide();
-  let text: string;
+  let text: string | undefined;
 
   $: ({ labelKey, level, detail } = msg || {
     labelKey: "",

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -18,7 +18,7 @@
     level: "info",
     detail: undefined,
   });
-  $: text = `${translate({ labelKey })}${detail || ""}`;
+  $: text = `${translate({ labelKey })}${detail ? ` ${detail}` : ""}`;
 </script>
 
 <div

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -43,4 +43,14 @@ describe("Toast", () => {
     expect(p).not.toBeNull();
     expect(p.textContent).toContain("more details");
   });
+
+  it("should render title", async () => {
+    const { container } = render(Toast, {
+      props,
+    });
+
+    const elementWithTitle: HTMLParagraphElement | null =
+      container.querySelector('[title="Close more details"]');
+    expect(elementWithTitle).not.toBeNull();
+  });
 });


### PR DESCRIPTION
# Motivation

Some long error messages are not fully visible (see screenshot)
<img width="896" alt="image" src="https://user-images.githubusercontent.com/98811342/156530573-24e387d7-3712-4f9a-a2f7-f4c45179c4c3.png">

# Changes

- Added title attribute to the message (quick solution)

# Tests

- Added title test
