### PR TITLE
Add new 'node_provider_id' field to UpdateNodeOperatorConfigPayload

### DIFF
--- a/frontend/ts/src/canisters/governance/nnsFunctions/payloads.did
+++ b/frontend/ts/src/canisters/governance/nnsFunctions/payloads.did
@@ -99,6 +99,7 @@ type UpdateIcpXdrConversionRatePayload = record {
 };
 type UpdateNodeOperatorConfigPayload = record {
   node_operator_id : opt principal;
+  node_provider_id : opt principal;
   node_allowance : opt nat64;
   rewardable_nodes : vec record { text; nat32 };
   dc_id : opt text;

--- a/frontend/ts/src/canisters/governance/nnsFunctions/payloads.js
+++ b/frontend/ts/src/canisters/governance/nnsFunctions/payloads.js
@@ -110,6 +110,7 @@ export const UpdateIcpXdrConversionRatePayload = IDL.Record({
 });
 export const UpdateNodeOperatorConfigPayload = IDL.Record({
   node_operator_id: IDL.Opt(IDL.Principal),
+  node_provider_id: IDL.Opt(IDL.Principal),
   node_allowance: IDL.Opt(IDL.Nat64),
   rewardable_nodes: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
   dc_id: IDL.Opt(IDL.Text),

--- a/rs/nns_functions_candid_gen/src/payloads.rs
+++ b/rs/nns_functions_candid_gen/src/payloads.rs
@@ -212,7 +212,7 @@ pub struct SetAuthorizedSubnetworkListArgs {
     pub subnets: Vec<SubnetId>,
 }
 
-// https://gitlab.com/dfinity-lab/core/ic/-/blob/1e167e754b674f612e989cdee02acb79cfe40be8/rs/registry/canister/src/mutations/do_update_node_operator_config.rs#L79
+// https://gitlab.com/dfinity-lab/public/ic/-/blob/7061a8357f5a2d196d19654bc540f7aab56418b6/rs/registry/canister/src/mutations/do_update_node_operator_config.rs#L89
 #[derive(CandidType, Deserialize, Clone, PartialEq, Eq)]
 pub struct UpdateNodeOperatorConfigPayload {
     /// The principal id of the node operator. This principal is the entity that
@@ -228,6 +228,9 @@ pub struct UpdateNodeOperatorConfigPayload {
     /// A map from node type to the number of nodes for which the associated
     /// Node Provider should be rewarded.
     pub rewardable_nodes: BTreeMap<String, u32>,
+
+    /// The principal id of this node's provider.
+    pub node_provider_id: Option<PrincipalId>,
 }
 
 // https://gitlab.com/dfinity-lab/core/ic/-/blob/1e167e754b674f612e989cdee02acb79cfe40be8/rs/protobuf/def/registry/node_rewards/v2/node_rewards.proto#L24


### PR DESCRIPTION
# Motivation

A new field has been added to the payload for UpdateNodeOperatorConfig proposals so we need to update the NNS Dapp's definition of these proposals so that it can render the new field. 

# Changes

- Update the Rust payload definition
- Re-generate the candid from the Rust
- Re-generate the js from the candid

# Tests

None yet. We should submit a proposal of this new type to the testnet and check that it renders correctly.
