### PR TITLE
Let the svelte linter fail

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Compile typescript
+        run: npm run build
+
       - name: Run linter
         run: npm run check
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,11 +169,33 @@ jobs:
       - name: Compile typescript
         run: npm run build
 
-      - name: Run linter
-        run: npm run check
+      # Temporarily disabled:
+      #- name: Run linter
+      #  run: npm run check
 
       - name: Test
         run: npm run test
+
+  # Temporarily added:
+  svelte-lint:
+    needs: formatting
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./frontend/svelte
+    env:
+      DEPLOY_ENV: mainnet
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run check
 
   shell-checks:
     needs: formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -210,3 +210,10 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       env:
         SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
+
+  checks-pass:
+    needs: ["formatting", "clippy", "cargo-tests (1.58.1, ubuntu-20.04)", "flutter-tests", "svelte-tests", "ShellCheck"]
+    runs-on: ubuntu-20.04
+    steps:
+       - name: Checks workflow passes
+         run: echo OK

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -212,7 +212,7 @@ jobs:
         SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
 
   checks-pass:
-    needs: ["formatting", "clippy", "cargo-tests (1.58.1, ubuntu-20.04)", "flutter-tests", "svelte-tests", "ShellCheck"]
+    needs: ["formatting", "clippy", "cargo-tests", "flutter-tests", "svelte-tests", "ShellCheck"]
     runs-on: ubuntu-20.04
     steps:
        - name: Checks workflow passes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -212,7 +212,7 @@ jobs:
         SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
 
   checks-pass:
-    needs: ["formatting", "clippy", "cargo-tests", "flutter-tests", "svelte-tests", "ShellCheck"]
+    needs: ["formatting", "clippy", "cargo-tests", "flutter-tests", "svelte-tests", "shell-checks"]
     runs-on: ubuntu-20.04
     steps:
        - name: Checks workflow passes


### PR DESCRIPTION
# Motivation
The svelte linter rules have been or will soon be updated.  This causes, as expected, a lot of errors.  According to our plan, we are going to allow these errors to appear for a while, to give people time to fix them.  However for that github must not block PR merges on account of lint failures.

# Changes
* Put the svelte lint job in a separate task.
* Make a new dummy task that controls whether we may merge, rather than listing requirements in the admin panel.

![Screenshot from 2022-03-03 15-37-36](https://user-images.githubusercontent.com/5982633/156586606-017b121b-2dea-46f4-a658-05f77afdb7f8.png)

# TODO
* Update the merge rules, but this can be done a few fays after this has been merged to minimise disruption.

# Tests
Let's see whether this PR is mergeable with a failed lint result....