### PR TITLE
Changelog for proposal 47824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Placeholder
+
 ## Proposal 47476
 * Update dependencies and Rust version.
 * Enable merge maturity for hardware wallets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Placeholder
+## Proposal 47824
+* Update changelog for the last release
+* Remove upgrade code needed for the last release only
+* Show new `node_provider_id` field in `UpdateNodeOperatorConfigPayload` proposals.
+* Svelte UI development
+* Fix tests
+* Update js library dependencies
 
 ## Proposal 47476
 * Update dependencies and Rust version.

--- a/PROPOSAL_TEMPLATE.md
+++ b/PROPOSAL_TEMPLATE.md
@@ -10,7 +10,7 @@ Wasm sha256 hash: `$WASM_HASH` (`$LINK_TO_GITHUB_ACTION`)
 ## Commit log:
 
 ```
-bash -xc "git log --format='%C(auto) %h %s' $(git tags/rev-parse prod)..$(git rev-parse tags/release-candidate)"
+bash -xc "git log --format='%C(auto) %h %s' $(git rev-parse tags/prod)..$(git rev-parse tags/release-candidate)"
  ADD THE OUTPUT OF THE ABOVE COMMAND HERE
 ```
 


### PR DESCRIPTION
# Motivation
A new release has been made: https://dashboard.internetcomputer.org/proposal/47824

# Changes
* Update CHANGELOG.

# Details:
commit-id: e40bd206e28343b8c8b90d621802aa448277c250
deployment:
* https://nns.winning.gold
* https://txssk-maaaa-aaaaa-aaanq-cai.nnsdapp.dfinity.network/v2/
* ![Screenshot from 2022-03-03 16-34-36](https://user-images.githubusercontent.com/5982633/156597474-0a0c36b9-1cc4-4d11-82b3-6d1518e3d8d3.png)

Sha:
```
git-notes: 5eb3b0da3a9eb89bbf921cbe67361b7a0c5cfe2bf3e60dd84a6b42b92f1f0fed  -
       ci: 5eb3b0da3a9eb89bbf921cbe67361b7a0c5cfe2bf3e60dd84a6b42b92f1f0fed
max: 5eb3b0da3a9eb89bbf921cbe67361b7a0c5cfe2bf3e60dd84a6b42b92f1f0fed
```

# Proposal
https://dashboard.internetcomputer.org/proposal/47824

# Tests

## iOS

- Authenticated with II Anchor 10000
- Used 'Get ICPs' to get 10 ICP
- Created a subaccount
- Sent 4 ICP from main to the subaccount
- Staked 1 ICP into a neuron and set its dissolve delay to just over 2 years
- Increased the neuron's dissolve delay to 8 years
- Started dissolving the neuron
- Added 1 ICP to the neuron's stake from main account
- Stopped dissolving the neuron
- Added the Dfinity Foundation neuron as a followee
- Added a hotkey to the neuron (the hotkey appears twice, after refreshing the page it only appears once)
- Removed the hotkey from the neuron
- Voted on a proposal
- Checked that the transactions in each account appear correctly
- Checked that a few proposal payloads are rendered correctly

## Android
### Android+Chrome

## OsX

## Linux

<!-- Please provide any information or screenshots about the tests that have been done -->
