### PR TITLE
chore: remove unused formatProposalSummary

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
@@ -2,14 +2,12 @@
   import type { Proposal } from "@dfinity/nns";
   import CardBlock from "../../ui/CardBlock.svelte";
   import { i18n } from "../../../../lib/stores/i18n";
-  import { formatProposalSummary } from "../../../../lib/utils/proposals.utils";
   import Markdown from "../../ui/Markdown.svelte";
-  import { removeHTMLTags } from "../../../utils/security.utils";
 
   export let proposal: Proposal | undefined;
 
   let summary: string | undefined;
-  $: summary = formatProposalSummary(removeHTMLTags(proposal?.summary));
+  $: summary = proposal?.summary;
 </script>
 
 <CardBlock>

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -37,16 +37,6 @@ export const proposalActionFields = (
     ]);
 };
 
-// TODO: replace w/ markdown renderer -- eg https://nns.ic0.app/#/proposal/43574
-export const formatProposalSummary = (summary: string): string => {
-  if (!summary) return "";
-  // extend urls
-  return summary.replace(
-    /(https?:\/\/[\S]+)/g,
-    '<a target="_blank" href="$1">$1</a>'
-  );
-};
-
 /**
  * Hide a proposal if checkbox "excludeVotedProposals" is selected and the proposal is OPEN and has at least one UNSPECIFIED ballots' vote.
  */


### PR DESCRIPTION
# Motivation

Because of switching to the markdown component `formatProposalSummary` function is not necessary anymore.

# Changes

- remove `formatProposalSummary`
- remove it's usage

# Tests

**no changes**