### PR TITLE
build: redo ignore test and mock in tsconfig

### DIFF
--- a/frontend/svelte/tsconfig.json
+++ b/frontend/svelte/tsconfig.json
@@ -11,7 +11,9 @@
     "node_modules/*",
     "__sapper__/*",
     "public/*",
+    "**/*.spec.ts",
     "jest.setup.ts",
+    "**/*.mock.ts",
     "**/*Test.svelte"
   ]
 }


### PR DESCRIPTION
# Motivation

Ignore `.spec.ts` and `*.mock.ts` for the TypeScript includes resolution.

# Changes

- redo `"**/*.mock.ts"` and  `"**/*.spec.ts"` in `tsconfig.json`
