### PR TITLE
refactor: clean up canister types

### DIFF
--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -1,5 +1,6 @@
 import { Actor } from "@dfinity/agent";
 import { AccountIdentifier } from "@dfinity/nns";
+import type { NNSDappCanisterOptions } from "./nns-dapp.canister.types";
 import { idlFactory as certifiedIdlFactory } from "./nns-dapp.certified.idl";
 import {
   AccountNotFoundError,
@@ -13,7 +14,6 @@ import type {
   CreateSubAccountResponse,
   SubAccountDetails,
 } from "./nns-dapp.types";
-import type { NNSDappCanisterOptions } from "./types";
 
 export class NNSDappCanister {
   private constructor(

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.types.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.types.ts
@@ -2,8 +2,6 @@ import type { Agent } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type { NNSDappService } from "./nns-dapp.idl";
 
-export type { AccountIdentifier, SubAccountDetails } from "./nns-dapp.types";
-
 export interface NNSDappCanisterOptions {
   // The agent to use when communicating with the governance canister.
   agent: Agent;

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -1,11 +1,14 @@
+import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 export interface AccountDetails {
   principal: Principal;
-  account_identifier: AccountIdentifier;
+  account_identifier: AccountIdentifierString;
   hardware_wallet_accounts: Array<HardwareWalletAccountDetails>;
   sub_accounts: Array<SubAccountDetails>;
 }
-export type AccountIdentifier = string;
+// ledger and account canisters in nns-js define a AccountIdentifier as an object that contains the bytes array as a variable
+// nns-dapp canister returns a string
+export type AccountIdentifierString = string;
 export interface AttachCanisterRequest {
   name: string;
   canister_id: Principal;
@@ -16,7 +19,6 @@ export type AttachCanisterResponse =
   | { NameAlreadyTaken: null }
   | { NameTooLong: null }
   | { CanisterLimitExceeded: null };
-export type BlockHeight = bigint;
 export interface CanisterDetails {
   name: string;
   canister_id: Principal;
@@ -39,7 +41,7 @@ export type GetAccountResponse = {
 export interface GetTransactionsRequest {
   page_size: number;
   offset: number;
-  account_identifier: AccountIdentifier;
+  account_identifier: AccountIdentifierString;
 }
 export interface GetTransactionsResponse {
   total: number;
@@ -48,7 +50,7 @@ export interface GetTransactionsResponse {
 export interface HardwareWalletAccountDetails {
   principal: Principal;
   name: string;
-  account_identifier: AccountIdentifier;
+  account_identifier: AccountIdentifierString;
 }
 export type HeaderField = [string, string];
 export interface HttpRequest {
@@ -63,9 +65,8 @@ export interface HttpResponse {
   status_code: number;
 }
 export interface ICPTs {
-  e8s: bigint;
+  e8s: E8s;
 }
-export type Memo = bigint;
 export interface MultiPartTransactionError {
   error_message: string;
   block_height: BlockHeight;
@@ -80,10 +81,9 @@ export type MultiPartTransactionStatus =
   | { NeuronCreated: NeuronId }
   | { PendingSync: null }
   | { ErrorWithRefundPending: string };
-export type NeuronId = bigint;
 export interface Receive {
   fee: ICPTs;
-  from: AccountIdentifier;
+  from: AccountIdentifierString;
   amount: ICPTs;
 }
 export interface RegisterHardwareWalletRequest {
@@ -98,7 +98,7 @@ export type RegisterHardwareWalletResponse =
   | { NameTooLong: null };
 export interface RenameSubAccountRequest {
   new_name: string;
-  account_identifier: AccountIdentifier;
+  account_identifier: AccountIdentifierString;
 }
 export type RenameSubAccountResponse =
   | { Ok: null }
@@ -106,7 +106,7 @@ export type RenameSubAccountResponse =
   | { SubAccountNotFound: null }
   | { NameTooLong: null };
 export interface Send {
-  to: AccountIdentifier;
+  to: AccountIdentifierString;
   fee: ICPTs;
   amount: ICPTs;
 }
@@ -125,11 +125,13 @@ export interface Stats {
   latest_transaction_timestamp_nanos: bigint;
   earliest_transaction_timestamp_nanos: bigint;
 }
-export type SubAccount = Array<number>;
+// ledger and account canisters in nns-js define a SubAccount as an object that contains the bytes array as a variable
+// nns-dapp canister returns a string
+export type SubAccountArray = Array<number>;
 export interface SubAccountDetails {
   name: string;
-  sub_account: SubAccount;
-  account_identifier: AccountIdentifier;
+  sub_account: SubAccountArray;
+  account_identifier: AccountIdentifierString;
 }
 export interface Timestamp {
   timestamp_nanos: bigint;
@@ -156,7 +158,7 @@ export type Transfer =
   | { Send: Send }
   | { Receive: Receive };
 export default interface _SERVICE {
-  add_account: () => Promise<AccountIdentifier>;
+  add_account: () => Promise<AccountIdentifierString>;
   add_stable_asset: (arg_0: Array<number>) => Promise<undefined>;
   attach_canister: (
     arg_0: AttachCanisterRequest

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -3,6 +3,7 @@ import { Ed25519KeyIdentity } from "@dfinity/identity";
 import {
   AccountIdentifier,
   BlockHeight,
+  E8s,
   ICP,
   LedgerCanister,
   TransferError,
@@ -17,7 +18,7 @@ export const acquireICPTs = async ({
   e8s,
 }: {
   accountIdentifier: string;
-  e8s: bigint;
+  e8s: E8s;
 }): Promise<BlockHeight | TransferError> => {
   assertTestnet();
 


### PR DESCRIPTION
# Motivation

The nns-dapp canister uses some types of the ledge and account canisters and overwrite some types. This PR clean up the typescript code that did not implement the distinction.

# Changes

- reuse `BlockHeight, E8s, NeuronId` from nns-js
- make `AccountIdentifier` and `Subaccount` dinstinctive from the types defined in nns-js
- rename canister options type filename
