### PR TITLE
fix: backdrop dismiss click propagation

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -27,7 +27,7 @@
     aria-labelledby="modalTitle"
     aria-describedby="modalContent"
   >
-    <div class="backdrop" on:click={close} />
+    <div class="backdrop" on:click|stopPropagation={close} />
     <div
       transition:scale={{ delay: 25, duration: 150, easing: quintOut }}
       class={`wrapper ${size}`}


### PR DESCRIPTION
# Motivation

Modal's backdrop dismiss should not be propagated. For example, in the list of proposals, dismissing the modal leads to navigating to detail page 🤪.

# Changes

- add `stopPropagation` to backdrop dismiss

# Use case

<img width="1174" alt="Capture d’écran 2022-03-07 à 13 00 43" src="https://user-images.githubusercontent.com/16886711/157030689-556b3def-6f8a-4a30-9033-d9442e923e3f.png">

