### PR TITLE
Make staging builds in CI

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -34,10 +34,16 @@ jobs:
     strategy:
       matrix:
        include:
-         - DEPLOY_ENV: "testnet"
+         - BUILD_NAME: "testnet"
+           DEPLOY_ENV: "testnet"
            OWN_CANISTER_ID: "qhbym-qaaaa-aaaaa-aaafq-cai"
            REDIRECT_TO_LEGACY: "false"
-         - DEPLOY_ENV: "mainnet"
+         - BUILD_NAME: "staging"
+           DEPLOY_ENV: "testnet"
+           OWN_CANISTER_ID: "qhbym-qaaaa-aaaaa-aaafq-cai"
+           REDIRECT_TO_LEGACY: "staging"
+         - BUILD_NAME: "mainnet"
+           DEPLOY_ENV: "mainnet"
            OWN_CANISTER_ID: ""
            REDIRECT_TO_LEGACY: "true"
     steps:
@@ -56,17 +62,17 @@ jobs:
             REDIRECT_TO_LEGACY=${{ matrix.REDIRECT_TO_LEGACY }}
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
-          outputs: ./${{ matrix.DEPLOY_ENV }}-out
-      - name: 'Upload ${{ matrix.DEPLOY_ENV }} wasm module'
+          outputs: ./${{ matrix.BUILD_NAME }}-out
+      - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
         uses: actions/upload-artifact@v2
         with:
-          name: NNS ${{ matrix.DEPLOY_ENV }} backend wasm module
-          path: ${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm
-      - name: 'Upload ${{ matrix.DEPLOY_ENV }} frontend assets'
+          name: NNS ${{ matrix.BUILD_NAME }} backend wasm module
+          path: ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
+      - name: 'Upload ${{ matrix.BUILD_NAME }} frontend assets'
         uses: actions/upload-artifact@v2
         with:
-          name: NNS ${{ matrix.DEPLOY_ENV }} frontend assets
-          path: ${{ matrix.DEPLOY_ENV }}-out/assets.tar.xz
+          name: NNS ${{ matrix.BUILD_NAME }} frontend assets
+          path: ${{ matrix.BUILD_NAME }}-out/assets.tar.xz
       - name: "Link the build sha to this commit"
         run: |
          : Set up git
@@ -74,15 +80,15 @@ jobs:
          git config user.email "<>"
          : Make a note of the WASM shasum.
          NOTE="refs/notes/${{ matrix.DEPLOY_ENV }}/wasm-sha"
-         SHA="$(sha256sum < "${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm")"
+         SHA="$(sha256sum < "${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm")"
          git fetch origin "+${NOTE}:${NOTE}"
-         if git notes --ref="${{ matrix.DEPLOY_ENV }}/wasm-sha" add -m "$SHA"
+         if git notes --ref="${{ matrix.BUILD_NAME }}/wasm-sha" add -m "$SHA"
          then git push origin "${NOTE}:${NOTE}"
          else echo SHA already set
          fi
       - name: "Verify that the WASM module is small enough to deploy"
         run: |
-         wasm_size="$(wc -c < "${{ matrix.DEPLOY_ENV }}-out/nns-dapp.wasm")"
+         wasm_size="$(wc -c < "${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm")"
          max_size=3670016
          echo "WASM size:          $wasm_size"
          echo "Max supported size: $max_size"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,7 +45,7 @@ jobs:
          - BUILD_NAME: "mainnet"
            DEPLOY_ENV: "mainnet"
            OWN_CANISTER_ID: ""
-           REDIRECT_TO_LEGACY: "true"
+           REDIRECT_TO_LEGACY: "prod"
     steps:
       - uses: actions/checkout@v2
       - name: Set up docker buildx

--- a/scripts/deploy-ci-to-testnet
+++ b/scripts/deploy-ci-to-testnet
@@ -18,7 +18,7 @@ else
 
   # Gets the most recent 'Backend wasm module' download:
   # shellcheck disable=SC2010 # we really do want this, not globbing.
-  DOWNLOAD_FILENAME="$(ls -t "$DOWNLOADS_DIR" | grep -E '.*(T|t)estnet backend wasm module( [(][0-9]+[)])?.zip$' | head -n1)"
+  DOWNLOAD_FILENAME="$(ls -t "$DOWNLOADS_DIR" | grep -E '.*backend wasm module( [(][0-9]+[)])?.zip$' | head -n1)"
   DOWNLOAD_PATH="$DOWNLOADS_DIR/$DOWNLOAD_FILENAME"
   echo "Sourcing WASM from: $DOWNLOAD_PATH"
 fi


### PR DESCRIPTION
# Motivation
We now have three levels of `REDIRECT_TO_LEGACY`:
- never == false == pure svelte
- prod == as in production, which currently means that all tabs are served by flutter
- staging == as in production, but wit hone more tab served as svelte.

As M1 macs cannot make docker builds, it would be useful if CI could produce at least "never" and "staging" for development.

We keep the existing names for existing builds to avoid disruption.

# Changes
- Add a third build for staging
- Rename "true" to "prod" as "true" will be misleading as soon as we have 1 tab in svelte in prod.
 
# Tests
The docker builds in CI have succeeded.
- The mainnet build should be unaltered by this change.  Checking:
  - The CI mainnet build hash is: 
  - 1e3a424407eac5a8dc1eeb27109cd48b0005264624302eec86a6d735b111dc9d
  - The merge root is: 354af16031b7da1b7d2852909346a3f325ea459a 
  - Building the merge root locally yields: 1e3a424407eac5a8dc1eeb27109cd48b0005264624302eec86a6d735b111dc9d
  - Result: PASS
- The staging deployment SHOULD work with `./scripts/deploy-ci-to-testnet`
  - The canister gets deployed and redirects for the voting tab.
  - Result:  PASS

# Future work not addressed in this PR
There is a bunch of errors related to OWN_CANISTER_ID.  I have checked, they are unrelated to this PR and caused by the way OWN_CANISTER_ID is set.  This needs to be addressed, however that is orthogonal to this PR.