### PR TITLE
build: eslint fix parsing error parserOptions.project has been set for @typescript-eslint/parser

### DIFF
--- a/frontend/svelte/.eslintrc.js
+++ b/frontend/svelte/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: "module",
     tsconfigRootDir: __dirname,
-    project: ["./tsconfig.json"],
+    project: ["./tsconfig.eslint.json"],
     extraFileExtensions: [".svelte"],
     types: ["jest"],
   },

--- a/frontend/svelte/tsconfig.eslint.json
+++ b/frontend/svelte/tsconfig.eslint.json
@@ -1,8 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "node_modules/*",
-    "__sapper__/*",
-    "public/*"
-  ]
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
 }

--- a/frontend/svelte/tsconfig.eslint.json
+++ b/frontend/svelte/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules/*",
+    "__sapper__/*",
+    "public/*"
+  ]
+}


### PR DESCRIPTION
# Motivation

Fix 36 errors:

>   0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
> The file does not match your project config: src/tests/lib/utils/route.utils.spec.ts.
> The file must be included in at least one of the projects provided

# Changes

- provide a `tsconfig.eslint.json` for eslint that includes test files
