### PR TITLE
feat: load and display neuron for proposer

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -53,30 +53,33 @@
       {$i18n.neurons[`status_${stateInfo.textKey}`]}
       <svelte:component this={stateInfo.Icon} />
     </p>
-
-    {#if dissolvingTime !== undefined}
-      <p class="duration">
-        {secondsToDuration(dissolvingTime)} - {$i18n.neurons.staked}
-      </p>
-    {/if}
-
-    {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
-      <p class="duration">
-        {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons
-          .staked}
-      </p>
-    {/if}
   </div>
 
   <div slot="end" class="currency">
     {#if neuronICP}
       <ICPComponent icp={neuronICP} />
-      <h5>{$i18n.neurons.stake}</h5>
+      <p class="info">{$i18n.neurons.stake}</p>
     {/if}
   </div>
+
+  {#if dissolvingTime !== undefined}
+    <p class="duration">
+      {secondsToDuration(dissolvingTime)} - {$i18n.neurons.staked}
+    </p>
+  {/if}
+
+  {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
+    <p class="duration">
+      {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons.staked}
+    </p>
+  {/if}
 </Card>
 
 <style lang="scss">
+  :global(div.modal article > div) {
+    margin-bottom: 0;
+  }
+
   h3 {
     line-height: var(--line-height-standard);
     margin-bottom: 0;

--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -17,65 +17,68 @@
   let isCommunityFund: boolean;
   $: isCommunityFund = !!neuron.joinedCommunityFundTimestampSeconds;
   let isHotKeyControl: boolean;
-  $: isHotKeyControl = !neuron.fullNeuron.isCurrentUserController;
+  $: isHotKeyControl = !neuron.fullNeuron?.isCurrentUserController;
   let neuronICP: ICP;
-  $: neuronICP = ICP.fromE8s(neuron.fullNeuron.cachedNeuronStake);
+  $: neuronICP = ICP.fromE8s(neuron.fullNeuron?.cachedNeuronStake || BigInt(0));
 </script>
 
 <Card {role} on:click {ariaLabel}>
   <div slot="start" class="lock">
-    <h4 class:has-neuron-control={isCommunityFund || isHotKeyControl}>
+    <h3 class:has-neuron-control={isCommunityFund || isHotKeyControl}>
       {neuron.neuronId}
-    </h4>
+    </h3>
+
     {#if isCommunityFund}
-      <p class="neuron-control">{$i18n.neurons.community_fund}</p>
+      <span class="neuron-control">{$i18n.neurons.community_fund}</span>
     {/if}
     {#if isHotKeyControl}
-      <p class="neuron-control">{$i18n.neurons.hotkey_control}</p>
+      <span class="neuron-control">{$i18n.neurons.hotkey_control}</span>
     {/if}
-    <h5 style={`color: var(${stateInfo.colorVar});`}>
+
+    <p style={`color: var(${stateInfo.colorVar});`} class="status info">
       {$i18n.neurons[`status_${stateInfo.textKey}`]}
       <svelte:component this={stateInfo.Icon} />
-    </h5>
+    </p>
+
+    {#if neuron.state === NeuronState.DISSOLVING && "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState}
+      <p class="duration">
+        {secondsToDuration(
+          neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
+        )} - {$i18n.neurons.staked}
+      </p>
+    {/if}
+
+    {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
+      <p class="duration">
+        {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons.staked}
+      </p>
+    {/if}
   </div>
 
   <div slot="end" class="currency">
     <ICPComponent icp={neuronICP} />
-    <h5>{$i18n.neurons.stake}</h5>
+    <p class="info">{$i18n.neurons.stake}</p>
   </div>
-
-  {#if neuron.state === NeuronState.DISSOLVING && "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState}
-    <p class="duration">
-      {secondsToDuration(
-        neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
-      )}
-    </p>
-  {/if}
-
-  {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
-    <p class="duration">{secondsToDuration(neuron.dissolveDelaySeconds)}</p>
-  {/if}
 </Card>
 
 <style lang="scss">
-  h4 {
+  h3 {
     line-height: var(--line-height-standard);
-  }
-
-  h4.has-neuron-control {
     margin-bottom: 0;
-  }
-
-  .neuron-control {
-    margin-top: 0;
   }
 
   .lock {
-    margin-bottom: 0;
-    h5 {
-      display: flex;
-      align-items: center;
-      gap: 0.3rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .status {
+    display: inline-flex;
+
+    :global {
+      svg {
+        margin-left: calc(var(--padding) / 2);
+      }
     }
   }
 
@@ -85,7 +88,11 @@
     align-items: flex-end;
   }
 
+  .info {
+    margin: calc(2 * var(--padding)) 0 0;
+  }
+
   .duration {
-    font-size: var(--font-size-h5);
+    margin: 0;
   }
 </style>

--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -40,17 +40,18 @@
       <svelte:component this={stateInfo.Icon} />
     </p>
 
-  {#if neuron.state === NeuronState.DISSOLVING && neuron.fullNeuron?.dissolveState && "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState}
-    <p class="duration">
-      {secondsToDuration(
-        neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
-      )} - {$i18n.neurons.staked}
-    </p>
-  {/if}
+    {#if neuron.state === NeuronState.DISSOLVING && neuron.fullNeuron?.dissolveState && "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState}
+      <p class="duration">
+        {secondsToDuration(
+          neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
+        )} - {$i18n.neurons.staked}
+      </p>
+    {/if}
 
     {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
       <p class="duration">
-        {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons.staked}
+        {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons
+          .staked}
       </p>
     {/if}
   </div>

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -12,7 +12,7 @@
   } from "../../constants/proposals.constants";
   import { proposalsFiltersStore } from "../../stores/proposals.store";
   import { hideProposal } from "../../utils/proposals.utils";
-  import type { NeuronId, ProposalId } from "@dfinity/nns";
+  import type { ProposalId } from "@dfinity/nns";
   import Proposer from "./Proposer.svelte";
 
   export let proposalInfo: ProposalInfo;

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -14,6 +14,7 @@
   import { hideProposal } from "../../utils/proposals.utils";
   import type { NeuronId, ProposalId } from "@dfinity/nns";
   import ProposerModal from "../../modals/proposals/ProposerModal.svelte";
+  import Proposer from "./Proposer.svelte";
 
   export let proposalInfo: ProposalInfo;
 
@@ -52,7 +53,7 @@
         >{status ? $i18n.status[ProposalStatus[status]] : ""}</Badge
       >
 
-      <p class="info"><ProposerModal {proposalInfo} /></p>
+      <p class="info"><Proposer {proposalInfo} /></p>
       <p class="info"><small>Id: {id || ""}</small></p>
     </Card>
   {/if}

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -13,7 +13,6 @@
   import { proposalsFiltersStore } from "../../stores/proposals.store";
   import { hideProposal } from "../../utils/proposals.utils";
   import type { NeuronId, ProposalId } from "@dfinity/nns";
-  import ProposerModal from "../../modals/proposals/ProposerModal.svelte";
   import Proposer from "./Proposer.svelte";
 
   export let proposalInfo: ProposalInfo;

--- a/frontend/svelte/src/lib/components/proposals/Proposer.svelte
+++ b/frontend/svelte/src/lib/components/proposals/Proposer.svelte
@@ -6,17 +6,21 @@
 
   export let proposalInfo: ProposalInfo;
 
-  let visible: boolean = false;
+  let modalOpen = false;
 
   let proposer: NeuronId | undefined;
   $: ({ proposer } = proposalInfo);
 </script>
 
-<button class="text" on:click|stopPropagation={() => (visible = true)}
-  ><small>{$i18n.neuron_detail.proposer}: {proposer || ""}</small></button
->
+{#if proposer !== undefined}
+  <button class="text" on:click|stopPropagation={() => (modalOpen = true)}
+    ><small>{$i18n.neuron_detail.proposer}: {proposer}</small></button
+  >
 
-<ProposerModal bind:visible {proposalInfo} />
+  {#if modalOpen}
+    <ProposerModal {proposer} on:nnsClose={() => (modalOpen = false)} />
+  {/if}
+{/if}
 
 <style lang="scss">
   button {

--- a/frontend/svelte/src/lib/components/proposals/Proposer.svelte
+++ b/frontend/svelte/src/lib/components/proposals/Proposer.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { NeuronId } from "@dfinity/nns";
+  import ProposerModal from "../../modals/proposals/ProposerModal.svelte";
+  import { i18n } from "../../stores/i18n";
+
+  export let proposalInfo: ProposalInfo;
+
+  let visible: boolean = false;
+
+  let proposer: NeuronId | undefined;
+  $: ({ proposer } = proposalInfo);
+</script>
+
+<button class="text" on:click|stopPropagation={() => (visible = true)}
+  ><small>{$i18n.neuron_detail.proposer}: {proposer || ""}</small></button
+>
+
+<ProposerModal bind:visible {proposalInfo} />
+
+<style lang="scss">
+  button {
+    padding: 0;
+    line-height: var(--line-height-standard);
+    margin: 0;
+  }
+</style>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -16,7 +16,8 @@
     "create_subaccount": "Sorry, there was an expected error when creating your subaccount, please try again",
     "create_subaccount_too_long": "The name of the subaccount is too long. Please, choose a shorter name.",
     "create_subaccount_limit_exceeded": "Sorry, you reached the limit of subaccounts in this account.",
-    "get_neurons": "There was an unexpected issue while searching for the neurons."
+    "get_neurons": "There was an unexpected issue while searching for the neurons.",
+    "get_neuron": "There was an unexpected issue while loading the neuron."
   },
   "navigation": {
     "icp": "ICP",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -71,6 +71,7 @@
     "community_fund": "[community fund]",
     "hotkey_control": "[hotkey control]",
     "stake": "Stake",
+    "staked": "Staked",
     "aria_label_neuron_card": "Go to neuron details",
     "neuron_id": "Neuron ID",
     "neuron_balance": "Balance",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -143,7 +143,8 @@
     "my_votes": "My Votes"
   },
   "neuron_detail": {
-    "title": "Neuron"
+    "title": "Neuron",
+    "proposer": "Proposer"
   },
   "time": {
     "year": "year",

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -110,7 +110,10 @@
     height: fit-content;
     max-width: calc(100vw - (4 * var(--padding)));
     max-height: calc(100vw - (2 * var(--padding)));
-    min-height: 100px;
+
+    --modal-min-height: 100px;
+    --modal-toolbar-height: 35px;
+    min-height: var(--modal-min-height);
 
     background: white;
 
@@ -137,6 +140,8 @@
 
     z-index: var(--z-index);
 
+    height: var(--modal-toolbar-height);
+
     h3 {
       color: inherit;
       font-weight: 400;
@@ -162,9 +167,12 @@
   }
 
   .content {
+    position: relative;
+
     display: flex;
     flex-direction: column;
 
+    min-height: calc(var(--modal-min-height) - var(--modal-toolbar-height));
     max-height: calc(100vh - 156px);
     overflow-y: scroll;
 

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -26,6 +26,7 @@
     role="dialog"
     aria-labelledby="modalTitle"
     aria-describedby="modalContent"
+    on:click|stopPropagation
   >
     <div class="backdrop" on:click|stopPropagation={close} />
     <div
@@ -63,6 +64,8 @@
     inset: 0;
 
     z-index: calc(var(--z-index) + 998);
+
+    @include interaction.initial;
 
     &.dark {
       color: var(--background-contrast);

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -10,10 +10,10 @@
   import NeuronCard from "../../components/neurons/NeuronCard.svelte";
 
   export let proposalInfo: ProposalInfo;
+  export let visible: boolean = false;
 
   let proposer: NeuronId | undefined;
   let neuron: NeuronInfo | undefined;
-  let visible: boolean = false;
 
   const initNeuron = async () => {
     if (!visible || !proposer) {
@@ -28,10 +28,6 @@
   $: ({ proposer } = proposalInfo);
   $: visible, proposer, (async () => initNeuron())();
 </script>
-
-<button class="text" on:click|stopPropagation={() => (visible = true)}
-  ><small>{$i18n.neuron_detail.proposer}: {proposer || ""}</small></button
->
 
 <Modal {visible} on:nnsClose={() => (visible = false)} theme="dark">
   <span slot="title">{$i18n.neuron_detail.title}</span>
@@ -51,11 +47,6 @@
 </Modal>
 
 <style lang="scss">
-  button {
-    padding: 0;
-    margin: 0;
-  }
-
   .content {
     padding: calc(2 * var(--padding));
   }

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <button class="text" on:click|stopPropagation={() => (visible = true)}
-  ><small>Proposer: {proposer || ""}</small></button
+  ><small>{$i18n.neuron_detail.proposer}: {proposer || ""}</small></button
 >
 
 <Modal {visible} on:nnsClose={() => (visible = false)} theme="dark">

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -32,9 +32,6 @@
 <Modal {visible} on:nnsClose={() => (visible = false)} theme="dark">
   <span slot="title">{$i18n.neuron_detail.title}</span>
 
-  <!-- TODO: Both neuron details card and fetching neuron itself are implemented in L2-313 -->
-  <!-- Above task needs to be solved first before being able to implement following TODOs -->
-
   {#if neuron !== undefined}
     <div class="content">
       <NeuronCard {neuron} />

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -7,6 +7,7 @@
   import { NeuronInfo } from "@dfinity/nns";
   import { getNeuron } from "../../services/neurons.services";
   import Spinner from "../../components/ui/Spinner.svelte";
+  import NeuronCard from "../../components/neurons/NeuronCard.svelte";
 
   export let proposalInfo: ProposalInfo;
 
@@ -39,9 +40,11 @@
   <!-- Above task needs to be solved first before being able to implement following TODOs -->
 
   {#if neuron !== undefined}
-    <Card><h4>TODO: Neuron details {neuron.neuronId}</h4></Card>
+    <div class="content">
+      <NeuronCard {neuron} />
 
-    <Card><h4>TODO: Voting history</h4></Card>
+      <Card><h4>TODO: Voting history</h4></Card>
+    </div>
   {:else}
     <Spinner />
   {/if}
@@ -51,5 +54,9 @@
   button {
     padding: 0;
     margin: 0;
+  }
+
+  .content {
+    padding: calc(2 * var(--padding));
   }
 </style>

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -9,35 +9,24 @@
   import Spinner from "../../components/ui/Spinner.svelte";
   import NeuronCard from "../../components/neurons/NeuronCard.svelte";
   import { toastsStore } from "../../stores/toasts.store";
+  import { onMount } from "svelte";
 
-  export let proposalInfo: ProposalInfo;
-  export let visible: boolean = false;
-
-  let proposer: NeuronId | undefined;
+  export let proposer: NeuronId;
   let neuron: NeuronInfo | undefined;
 
-  const initNeuron = async () => {
-    if (!visible || !proposer) {
-      neuron = undefined;
-      return;
-    }
-
+  onMount(async () => {
     try {
       neuron = await getNeuron(proposer);
     } catch (err) {
-      visible = false;
       neuron = undefined;
 
       toastsStore.show({ labelKey: "error.get_neuron", level: "error" });
       console.error(err);
     }
-  };
-
-  $: ({ proposer } = proposalInfo);
-  $: visible, proposer, (async () => initNeuron())();
+  });
 </script>
 
-<Modal {visible} on:nnsClose={() => (visible = false)} theme="dark">
+<Modal on:nnsClose theme="dark">
   <span slot="title">{$i18n.neuron_detail.title}</span>
 
   {#if neuron !== undefined}

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -4,13 +4,28 @@
   import type { NeuronId } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
   import Card from "../../components/ui/Card.svelte";
+  import { NeuronInfo } from "@dfinity/nns";
+  import { getNeuron } from "../../services/neurons.services";
+  import Spinner from "../../components/ui/Spinner.svelte";
 
   export let proposalInfo: ProposalInfo;
 
   let proposer: NeuronId | undefined;
+  let neuron: NeuronInfo | undefined;
   let visible: boolean = false;
 
+  const initNeuron = async () => {
+    if (!visible || !proposer) {
+      neuron = undefined;
+      return;
+    }
+
+    // TODO: catch error
+    neuron = await getNeuron(proposer);
+  };
+
   $: ({ proposer } = proposalInfo);
+  $: visible, proposer, (async () => initNeuron())();
 </script>
 
 <button class="text" on:click|stopPropagation={() => (visible = true)}
@@ -23,9 +38,13 @@
   <!-- TODO: Both neuron details card and fetching neuron itself are implemented in L2-313 -->
   <!-- Above task needs to be solved first before being able to implement following TODOs -->
 
-  <Card><h4>TODO: Neuron details</h4></Card>
+  {#if neuron !== undefined}
+    <Card><h4>TODO: Neuron details {neuron.neuronId}</h4></Card>
 
-  <Card><h4>TODO: Voting history</h4></Card>
+    <Card><h4>TODO: Voting history</h4></Card>
+  {:else}
+    <Spinner />
+  {/if}
 </Modal>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -8,6 +8,7 @@
   import { getNeuron } from "../../services/neurons.services";
   import Spinner from "../../components/ui/Spinner.svelte";
   import NeuronCard from "../../components/neurons/NeuronCard.svelte";
+  import { toastsStore } from "../../stores/toasts.store";
 
   export let proposalInfo: ProposalInfo;
   export let visible: boolean = false;
@@ -21,8 +22,15 @@
       return;
     }
 
-    // TODO: catch error
-    neuron = await getNeuron(proposer);
+    try {
+      neuron = await getNeuron(proposer);
+    } catch (err) {
+      visible = false;
+      neuron = undefined;
+
+      toastsStore.show({ labelKey: "error.get_neuron", level: "error" });
+      console.error(err);
+    }
   };
 
   $: ({ proposer } = proposalInfo);

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -104,6 +104,7 @@ export const updateDelay = async ({
   await listNeurons();
 };
 
+// TODO: Apply pattern to other canister instantiation L2-371
 const governanceCanister = async (): Promise<{
   canister: GovernanceCanister;
   identity: Identity;

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -2,8 +2,15 @@
 // - calls that require multiple canisters.
 // - calls that require additional systems such as hardware wallets.
 
-import { GovernanceCanister, ICP, LedgerCanister } from "@dfinity/nns";
+import type { HttpAgent, Identity } from "@dfinity/agent";
+import {
+  GovernanceCanister,
+  ICP,
+  LedgerCanister,
+  NeuronInfo,
+} from "@dfinity/nns";
 import { get } from "svelte/store";
+import type { NeuronId } from "../canisters/nns-dapp/nns-dapp.types";
 import {
   GOVERNANCE_CANISTER_ID,
   LEDGER_CANISTER_ID,
@@ -22,23 +29,16 @@ export const stakeNeuron = async ({ stake }: { stake: ICP }): Promise<void> => {
   if (stake.toE8s() < E8S_PER_ICP) {
     throw new Error("Need a minimum of 1 ICP to stake a neuron");
   }
-  const { identity }: AuthStore = get(authStore);
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error("No identity found staking a neuron");
-  }
-  const agent = await createAgent({ identity, host: process.env.HOST });
-  const governanceCanister: GovernanceCanister = GovernanceCanister.create({
-    agent,
-    canisterId: GOVERNANCE_CANISTER_ID,
-  });
+
+  const { canister, identity, agent } = await governanceCanister();
+
   const ledgerCanister: LedgerCanister = LedgerCanister.create({
     agent,
     canisterId: LEDGER_CANISTER_ID,
   });
 
   // TODO: L2-332 Get neuron information and add to store
-  await governanceCanister.stakeNeuron({
+  await canister.stakeNeuron({
     stake,
     principal: identity.getPrincipal(),
     ledgerCanister,
@@ -50,19 +50,50 @@ export const stakeNeuron = async ({ stake }: { stake: ICP }): Promise<void> => {
 
 // Gets neurons and adds them to the store
 export const listNeurons = async (): Promise<void> => {
-  const { identity }: AuthStore = get(authStore);
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error("No identity found listing neurons");
-  }
-  const agent = await createAgent({ identity, host: process.env.HOST });
-  const governanceCanister: GovernanceCanister = GovernanceCanister.create({
-    agent,
-    canisterId: GOVERNANCE_CANISTER_ID,
-  });
-  const neurons = await governanceCanister.getNeurons({
+  const { canister, identity } = await governanceCanister();
+
+  const neurons = await canister.getNeurons({
     certified: true,
     principal: identity.getPrincipal(),
   });
   neuronsStore.setNeurons(neurons);
+};
+
+export const getNeuron = async (
+  neuronId: NeuronId
+): Promise<NeuronInfo | undefined> => {
+  const { canister, identity } = await governanceCanister();
+
+  return canister.getNeuron({
+    certified: true,
+    principal: identity.getPrincipal(),
+    neuronId,
+  });
+};
+
+const governanceCanister = async (): Promise<{
+  canister: GovernanceCanister;
+  identity: Identity;
+  agent: HttpAgent;
+}> => {
+  const { identity }: AuthStore = get(authStore);
+
+  if (!identity) {
+    // TODO: https://dfinity.atlassian.net/browse/L2-346
+    throw new Error("No identity found listing neurons");
+  }
+
+  const agent: HttpAgent = await createAgent({
+    identity,
+    host: process.env.HOST,
+  });
+
+  return {
+    canister: GovernanceCanister.create({
+      agent,
+      canisterId: GOVERNANCE_CANISTER_ID,
+    }),
+    identity,
+    agent,
+  };
 };

--- a/frontend/svelte/src/lib/themes/mixins/_interaction.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_interaction.scss
@@ -2,3 +2,8 @@
   touch-action: manipulation;
   cursor: pointer;
 }
+
+@mixin initial {
+  touch-action: initial;
+  cursor: initial;
+}

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -21,6 +21,7 @@ interface I18nError {
   create_subaccount_too_long: string;
   create_subaccount_limit_exceeded: string;
   get_neurons: string;
+  get_neuron: string;
 }
 
 interface I18nNavigation {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -161,6 +161,7 @@ interface I18nProposal_detail {
 
 interface I18nNeuron_detail {
   title: string;
+  proposer: string;
 }
 
 interface I18nTime {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -80,6 +80,7 @@ interface I18nNeurons {
   community_fund: string;
   hotkey_control: string;
   stake: string;
+  staked: string;
   aria_label_neuron_card: string;
   neuron_id: string;
   neuron_balance: string;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -7,7 +7,7 @@ import IconLockOpen from "../icons/IconLockOpen.svelte";
 export type StateInfo = {
   textKey: string;
   Icon?: typeof SvelteComponent;
-  colorVar: "--background-contrast" | "--yellow-500" | "--gray-200";
+  colorVar: "--gray-50" | "--yellow-500" | "--gray-200";
 };
 
 type StateMapper = {
@@ -17,11 +17,11 @@ const stateTextMapper: StateMapper = {
   [NeuronState.LOCKED]: {
     textKey: "locked",
     Icon: IconLockClock,
-    colorVar: "--background-contrast",
+    colorVar: "--gray-50",
   },
   [NeuronState.UNSPECIFIED]: {
     textKey: "unspecified",
-    colorVar: "--background-contrast",
+    colorVar: "--gray-50",
   },
   [NeuronState.DISSOLVED]: {
     textKey: "dissolved",

--- a/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -2,15 +2,39 @@
  * @jest-environment jsdom
  */
 
-import { Ballot, Proposal, ProposalInfo, Vote } from "@dfinity/nns";
+import {
+  Ballot,
+  GovernanceCanister,
+  Proposal,
+  ProposalInfo,
+  Vote,
+} from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import ProposalCard from "../../../../lib/components/proposals/ProposalCard.svelte";
+import { authStore } from "../../../../lib/stores/auth.store";
 import { proposalsFiltersStore } from "../../../../lib/stores/proposals.store";
-import { mockProposals } from "../../../mocks/proposals.store.mock";
+import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
+import {
+  MockGovernanceCanister,
+  mockProposals,
+} from "../../../mocks/proposals.store.mock";
 
 const en = require("../../../../lib/i18n/en.json");
 
 describe("ProposalCard", () => {
+  const mockGovernanceCanister: MockGovernanceCanister =
+    new MockGovernanceCanister(mockProposals);
+
+  beforeEach(() => {
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
   it("should render a proposal title", () => {
     const { getByText } = render(ProposalCard, {
       props: {

--- a/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -14,10 +14,8 @@ import ProposalCard from "../../../../lib/components/proposals/ProposalCard.svel
 import { authStore } from "../../../../lib/stores/auth.store";
 import { proposalsFiltersStore } from "../../../../lib/stores/proposals.store";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
-import {
-  MockGovernanceCanister,
-  mockProposals,
-} from "../../../mocks/proposals.store.mock";
+import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
+import { mockProposals } from "../../../mocks/proposals.store.mock";
 
 const en = require("../../../../lib/i18n/en.json");
 

--- a/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { GovernanceCanister } from "@dfinity/nns";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import Proposer from "../../../../lib/components/proposals/Proposer.svelte";
 import { authStore } from "../../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
@@ -47,5 +47,19 @@ describe("Proposer", () => {
     });
 
     expect(container.querySelector("button.text")).not.toBeNull();
+  });
+
+  it("should open proposer modal", async () => {
+    const { container } = render(Proposer, {
+      props,
+    });
+
+    const button = container.querySelector("button.text");
+    expect(button).not.toBeNull();
+    button && (await fireEvent.click(button));
+
+    await waitFor(() =>
+      expect(container.querySelector("div.modal")).not.toBeNull()
+    );
   });
 });

--- a/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
@@ -4,16 +4,16 @@
 
 import { GovernanceCanister } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
-import { authStore } from "../../../lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
-import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
-import { mockProposalInfo } from "../../mocks/proposal.mock";
-import { mockProposals } from "../../mocks/proposals.store.mock";
+import Proposer from "../../../../lib/components/proposals/Proposer.svelte";
+import { authStore } from "../../../../lib/stores/auth.store";
+import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
+import { mockProposalInfo } from "../../../mocks/proposal.mock";
+import { mockProposals } from "../../../mocks/proposals.store.mock";
 
-const en = require("../../../lib/i18n/en.json");
+const en = require("../../../../lib/i18n/en.json");
 
-describe("ProposerModal", () => {
+describe("Proposer", () => {
   const props = {
     proposalInfo: mockProposalInfo,
   };
@@ -32,7 +32,7 @@ describe("ProposerModal", () => {
   });
 
   it("should render proposer", () => {
-    const { container } = render(ProposerModal, {
+    const { container } = render(Proposer, {
       props,
     });
 
@@ -42,7 +42,7 @@ describe("ProposerModal", () => {
   });
 
   it("should render button to open modal", () => {
-    const { container } = render(ProposerModal, {
+    const { container } = render(Proposer, {
       props,
     });
 

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -4,7 +4,6 @@
 
 import { GovernanceCanister } from "@dfinity/nns";
 import {render, waitFor} from "@testing-library/svelte";
-import { tick } from "svelte";
 import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
 import { authStore } from "../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { GovernanceCanister } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import { authStore } from "../../../lib/stores/auth.store";
+import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
+import { mockProposalInfo } from "../../mocks/proposal.mock";
+import { mockProposals } from "../../mocks/proposals.store.mock";
+
+const en = require("../../../lib/i18n/en.json");
+
+describe("ProposerModal", () => {
+  const props = {
+    proposalInfo: mockProposalInfo,
+    visible: true,
+  };
+
+  const mockGovernanceCanister: MockGovernanceCanister =
+    new MockGovernanceCanister(mockProposals);
+
+  beforeEach(() => {
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
+  it("should display modal", () => {
+    const { container } = render(ProposerModal, {
+      props,
+    });
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -15,7 +15,7 @@ const en = require("../../../lib/i18n/en.json");
 
 describe("ProposerModal", () => {
   const props = {
-    proposer: mockProposalInfo.proposer
+    proposer: mockProposalInfo.proposer,
   };
 
   const mockGovernanceCanister: MockGovernanceCanister =

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { GovernanceCanister } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
+import { authStore } from "../../../lib/stores/auth.store";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
+import { mockProposalInfo } from "../../mocks/proposal.mock";
+import { mockProposals } from "../../mocks/proposals.store.mock";
+
+const en = require("../../../lib/i18n/en.json");
+
+describe("ProposerModal", () => {
+  const props = {
+    proposalInfo: mockProposalInfo,
+  };
+
+  const mockGovernanceCanister: MockGovernanceCanister =
+    new MockGovernanceCanister(mockProposals);
+
+  beforeEach(() => {
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
+  it("should render proposer", () => {
+    const { container } = render(ProposerModal, {
+      props,
+    });
+
+    expect(container.querySelector("button small")?.textContent).toEqual(
+      `${en.neuron_detail.proposer}: ${mockProposalInfo.proposer}`
+    );
+  });
+
+  it("should render button to open modal", () => {
+    const { container } = render(ProposerModal, {
+      props,
+    });
+
+    expect(container.querySelector("button.text")).not.toBeNull();
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -15,8 +15,7 @@ const en = require("../../../lib/i18n/en.json");
 
 describe("ProposerModal", () => {
   const props = {
-    proposalInfo: mockProposalInfo,
-    visible: true,
+    proposer: mockProposalInfo.proposer
   };
 
   const mockGovernanceCanister: MockGovernanceCanister =

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { GovernanceCanister } from "@dfinity/nns";
-import {render, waitFor} from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
 import { authStore } from "../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
@@ -54,7 +54,7 @@ describe("ProposerModal", () => {
     });
 
     await waitFor(() =>
-        expect(container.querySelector("article")).not.toBeNull()
+      expect(container.querySelector("article")).not.toBeNull()
     );
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -3,9 +3,10 @@
  */
 
 import { GovernanceCanister } from "@dfinity/nns";
-import { render } from "@testing-library/svelte";
-import { authStore } from "../../../lib/stores/auth.store";
+import {render, waitFor} from "@testing-library/svelte";
+import { tick } from "svelte";
 import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
+import { authStore } from "../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
 import { mockProposalInfo } from "../../mocks/proposal.mock";
@@ -38,5 +39,23 @@ describe("ProposerModal", () => {
     });
 
     expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should render a title", () => {
+    const { getByText } = render(ProposerModal, {
+      props,
+    });
+
+    expect(getByText(en.neuron_detail.title)).toBeInTheDocument();
+  });
+
+  it("should render a neuron card", async () => {
+    const { container } = render(ProposerModal, {
+      props,
+    });
+
+    await waitFor(() =>
+        expect(container.querySelector("article")).not.toBeNull()
+    );
   });
 });

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1,21 +1,14 @@
 import { GovernanceCanister, ICP, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
-import { readable } from "svelte/store";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import {
+  getNeuron,
   listNeurons,
   stakeNeuron,
 } from "../../../lib/services/neurons.services";
-
-jest.mock("../../../lib/stores/auth.store", () => {
-  return {
-    authStore: readable({
-      identity: {
-        getPrincipal: jest.fn(),
-      },
-    }),
-  };
-});
+import { authStore } from "../../../lib/stores/auth.store";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import { neuronMock } from "../../mocks/neurons.mock";
 
 describe("neurons-services", () => {
   const mockGovernanceCanister = mock<GovernanceCanister>();
@@ -24,14 +17,22 @@ describe("neurons-services", () => {
       jest.fn().mockResolvedValue([])
     );
     mockGovernanceCanister.stakeNeuron.mockImplementation(jest.fn());
+    mockGovernanceCanister.getNeuron.mockImplementation(
+      jest.fn().mockResolvedValue(neuronMock)
+    );
     jest
       .spyOn(GovernanceCanister, "create")
       .mockImplementation(() => mockGovernanceCanister);
+
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
+
   it("stakeNeuron creates a new neuron", async () => {
     jest
       .spyOn(LedgerCanister, "create")
@@ -56,7 +57,7 @@ describe("neurons-services", () => {
         stake: ICP.fromString("0.1") as ICP,
       });
 
-    expect(call).rejects.toThrow(Error);
+    await expect(call).rejects.toThrow(Error);
   });
 
   it("listNeurons fetches neurons", async () => {
@@ -65,5 +66,15 @@ describe("neurons-services", () => {
     await listNeurons();
 
     expect(mockGovernanceCanister.listNeurons).toBeCalled();
+  });
+
+  it("get neuron returns expected neuron", async () => {
+    expect(mockGovernanceCanister.getNeuron).not.toBeCalled();
+
+    const neuron = await getNeuron(neuronMock.neuronId);
+
+    expect(mockGovernanceCanister.getNeuron).toBeCalled();
+    expect(neuron).not.toBeUndefined();
+    expect(neuron?.neuronId).toEqual(neuronMock.neuronId);
   });
 });

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../lib/services/proposals.services";
 import { proposalsStore } from "../../../lib/stores/proposals.store";
 import { mockIdentity } from "../../mocks/auth.store.mock";
-import { MockGovernanceCanister } from "../../mocks/proposals.store.mock";
+import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
 
 describe("proposals-services", () => {
   const mockProposals: ProposalInfo[] = [

--- a/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
@@ -1,0 +1,100 @@
+import {
+  EmptyResponse,
+  GovernanceCanister,
+  ICP,
+  LedgerCanister,
+  ListProposalsRequest,
+  ListProposalsResponse,
+  NeuronId,
+  NeuronInfo,
+  ProposalId,
+  ProposalInfo,
+  StakeNeuronError,
+  Vote,
+} from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { neuronMock } from "./neurons.mock";
+
+// eslint-disable-next-line
+// @ts-ignore
+export class MockGovernanceCanister extends GovernanceCanister {
+  constructor(private proposals: ProposalInfo[]) {
+    super();
+  }
+
+  create() {
+    return this;
+  }
+
+  public listProposals = async ({
+    request,
+    certified = true,
+  }: {
+    request: ListProposalsRequest;
+    certified?: boolean;
+  }): Promise<ListProposalsResponse> => {
+    return {
+      proposals: this.proposals,
+    };
+  };
+
+  public getProposal = async ({
+    proposalId,
+  }: {
+    proposalId: any;
+  }): Promise<ProposalInfo | undefined> => {
+    return { id: BigInt(404) } as unknown as ProposalInfo;
+  };
+
+  public listNeurons = async ({
+    certified,
+    principal,
+    neuronIds,
+  }: {
+    certified: boolean;
+    principal: Principal;
+    neuronIds?: bigint[] | undefined;
+  }): Promise<NeuronInfo[]> => {
+    return [
+      {
+        ...neuronMock,
+      },
+    ];
+  };
+
+  public getNeuron = async ({
+    certified,
+    principal,
+    neuronId,
+  }: {
+    certified: boolean;
+    principal: Principal;
+    neuronId: NeuronId;
+  }): Promise<NeuronInfo | undefined> => {
+    return neuronMock;
+  };
+
+  public registerVote = async ({
+    neuronId,
+    vote,
+    proposalId,
+  }: {
+    neuronId: NeuronId;
+    vote: Vote;
+    proposalId: ProposalId;
+  }): Promise<EmptyResponse> => {
+    return { Ok: null };
+  };
+
+  public stakeNeuron = async ({
+    stake,
+    principal,
+    ledgerCanister,
+  }: {
+    stake: ICP;
+    principal: Principal;
+    ledgerCanister: LedgerCanister;
+  }): Promise<NeuronId | StakeNeuronError> => {
+    return neuronMock.neuronId;
+  };
+}

--- a/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
@@ -1,21 +1,6 @@
 import type { ProposalInfo } from "@dfinity/nns";
-import {
-  EmptyResponse,
-  GovernanceCanister,
-  ICP,
-  LedgerCanister,
-  ListProposalsRequest,
-  ListProposalsResponse,
-  NeuronId,
-  NeuronInfo,
-  ProposalId,
-  ProposalStatus,
-  StakeNeuronError,
-  Vote,
-} from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
+import { ProposalStatus } from "@dfinity/nns";
 import type { Subscriber } from "svelte/store";
-import { neuronMock } from "./neurons.mock";
 
 export const mockProposals: ProposalInfo[] = [
   {
@@ -53,86 +38,3 @@ export const mockEmptyProposalsStoreSubscribe = (
 
   return () => {};
 };
-
-// @ts-ignore
-export class MockGovernanceCanister extends GovernanceCanister {
-  constructor(private proposals: ProposalInfo[]) {
-    super();
-  }
-
-  create() {
-    return this;
-  }
-
-  public listProposals = async ({
-    request,
-    certified = true,
-  }: {
-    request: ListProposalsRequest;
-    certified?: boolean;
-  }): Promise<ListProposalsResponse> => {
-    return {
-      proposals: this.proposals,
-    };
-  };
-
-  public getProposal = async ({
-    proposalId,
-  }: {
-    proposalId: any;
-  }): Promise<ProposalInfo | undefined> => {
-    return { id: BigInt(404) } as unknown as ProposalInfo;
-  };
-
-  public listNeurons = async ({
-    certified,
-    principal,
-    neuronIds,
-  }: {
-    certified: boolean;
-    principal: Principal;
-    neuronIds?: bigint[] | undefined;
-  }): Promise<NeuronInfo[]> => {
-    return [
-      {
-        ...neuronMock,
-      },
-    ];
-  };
-
-  public getNeuron = async ({
-    certified,
-    principal,
-    neuronId,
-  }: {
-    certified: boolean;
-    principal: Principal;
-    neuronId: NeuronId;
-  }): Promise<NeuronInfo | undefined> => {
-    return neuronMock;
-  };
-
-  public registerVote = async ({
-    neuronId,
-    vote,
-    proposalId,
-  }: {
-    neuronId: NeuronId;
-    vote: Vote;
-    proposalId: ProposalId;
-  }): Promise<EmptyResponse> => {
-    return { Ok: null };
-  };
-
-  public stakeNeuron = async ({
-    stake,
-    principal,
-    ledgerCanister,
-  }: {
-    stake: ICP;
-    principal: Principal;
-    ledgerCanister: LedgerCanister;
-  }): Promise<NeuronId | StakeNeuronError> => {
-    return neuronMock.neuronId;
-  };
-}

--- a/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
@@ -1,11 +1,21 @@
 import type { ProposalInfo } from "@dfinity/nns";
 import {
+  EmptyResponse,
   GovernanceCanister,
+  ICP,
+  LedgerCanister,
   ListProposalsRequest,
   ListProposalsResponse,
+  NeuronId,
+  NeuronInfo,
+  ProposalId,
   ProposalStatus,
+  StakeNeuronError,
+  Vote,
 } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
+import { neuronMock } from "./neurons.mock";
 
 export const mockProposals: ProposalInfo[] = [
   {
@@ -72,5 +82,57 @@ export class MockGovernanceCanister extends GovernanceCanister {
     proposalId: any;
   }): Promise<ProposalInfo | undefined> => {
     return { id: BigInt(404) } as unknown as ProposalInfo;
+  };
+
+  public listNeurons = async ({
+    certified,
+    principal,
+    neuronIds,
+  }: {
+    certified: boolean;
+    principal: Principal;
+    neuronIds?: bigint[] | undefined;
+  }): Promise<NeuronInfo[]> => {
+    return [
+      {
+        ...neuronMock,
+      },
+    ];
+  };
+
+  public getNeuron = async ({
+    certified,
+    principal,
+    neuronId,
+  }: {
+    certified: boolean;
+    principal: Principal;
+    neuronId: NeuronId;
+  }): Promise<NeuronInfo | undefined> => {
+    return neuronMock;
+  };
+
+  public registerVote = async ({
+    neuronId,
+    vote,
+    proposalId,
+  }: {
+    neuronId: NeuronId;
+    vote: Vote;
+    proposalId: ProposalId;
+  }): Promise<EmptyResponse> => {
+    return { Ok: null };
+  };
+
+  public stakeNeuron = async ({
+    stake,
+    principal,
+    ledgerCanister,
+  }: {
+    stake: ICP;
+    principal: Principal;
+    ledgerCanister: LedgerCanister;
+  }): Promise<NeuronId | StakeNeuronError> => {
+    return neuronMock.neuronId;
   };
 }

--- a/frontend/svelte/src/tests/routes/Proposals.spec.ts
+++ b/frontend/svelte/src/tests/routes/Proposals.spec.ts
@@ -8,9 +8,9 @@ import { authStore } from "../../lib/stores/auth.store";
 import { proposalsStore } from "../../lib/stores/proposals.store";
 import Proposals from "../../routes/Proposals.svelte";
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../mocks/governance.canister.mock";
 import {
   mockEmptyProposalsStoreSubscribe,
-  MockGovernanceCanister,
   mockProposals,
   mockProposalsStoreSubscribe,
 } from "../mocks/proposals.store.mock";


### PR DESCRIPTION
# Motivation

- Load and display the neuron of a proposer of a proposal in a modal.
- Fix modal click propagation
- Style neuron card

# Changes

## Features

- add `getNeuron` to `neurons.services.ts`
- add `NeuronCard` to `ProposerModal`
- load neuron in `ProposerModal` and display a spinner until loaded

### Fix

- `Modal` click propagation

## Style

- `NeuronCard` (font, spacing, etc.) and move elements for display purpose
- default cursor and touch action for `Modal` (it is not clickable but Svelte propagate style to children)

## Refactor

- refactor double code to a single function that init agent and governance canister in `neurons.services.ts`
- extract `Proposer` (action button) from `ProposerModal` to standalone component
- extract governance canister mock to a dedicated file

# Screenshots

<img width="1067" alt="Capture d’écran 2022-03-08 à 10 28 51" src="https://user-images.githubusercontent.com/16886711/157209320-55b56e70-92c1-4052-8cde-f5dfe6e2f1de.png">
<img width="1067" alt="Capture d’écran 2022-03-08 à 10 29 09" src="https://user-images.githubusercontent.com/16886711/157209327-c1eec6dd-ed4d-4bfc-91cf-0d4e9a099d12.png">
<img width="1067" alt="Capture d’écran 2022-03-08 à 10 29 23" src="https://user-images.githubusercontent.com/16886711/157209333-2c7ba81b-e3ed-488a-811d-b499fab7ed22.png">

