### PR TITLE
style: account hover background

### DIFF
--- a/frontend/svelte/src/lib/modals/accounts/SelectTypeAccount.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/SelectTypeAccount.svelte
@@ -41,7 +41,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: var(--blue-700);
+      background: var(--background-hover);
     }
 
     h4 {


### PR DESCRIPTION
# Motivation

Current hover background on accounts (in modal) is blue. We can use the same color as for card to make it follows the same style.

# Changes

- replace blue with `--background-hover`

# Screenshot

Is:

<img width="1513" alt="Capture d’écran 2022-03-08 à 15 14 38" src="https://user-images.githubusercontent.com/16886711/157256243-3e85eff9-125a-4094-bfe0-80932d0aa095.png">

With PR:

<img width="1513" alt="Capture d’écran 2022-03-08 à 15 14 12" src="https://user-images.githubusercontent.com/16886711/157256276-f3a24695-321b-49c2-83c2-72041ffd7297.png">

