### PR TITLE
build: fix default host empty

### DIFF
--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -29,7 +29,7 @@ const IDENTITY_SERVICE_URL =
     : "https://identity.ic0.app/");
 
 const HOST =
-  process.env.HOST || (development ? `https://${domainTestnet}/` : "");
+  process.env.HOST || (development ? `https://${domainTestnet}/` : undefined);
 
 // Canister Ids for testnet and mainnet
 const GOVERNANCE_CANISTER_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai";


### PR DESCRIPTION
# Motivation

The config currently set the default value for `HOST` to empty `""`. This property is ignored in our agent-js utils if `undefined`.

# Changes

- set `HOST` as `undefined` for default value in config
