### PR TITLE
style: fix modal overflow

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -182,7 +182,8 @@
 
     min-height: calc(var(--modal-min-height) - var(--modal-toolbar-height));
     max-height: calc(100vh - 156px);
-    overflow-y: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     color: var(--gray-800);
   }


### PR DESCRIPTION
# Motivation

When the wizard is used in the modal, the transition are glitchy because an horizontal scroll is briefly displayed on transitions.

When the content of the modal fits, a vertical scrollbar is displayed. That should not be the case. Such a scroll should be displayed only if the content can be scrolled.

# Changes

- style `overflow-x` and `overflow-y` of the modal's content
