### PR TITLE
fix: display stake and align state and stake

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -48,18 +48,21 @@
     {#if isHotKeyControl}
       <span class="neuron-control">{$i18n.neurons.hotkey_control}</span>
     {/if}
-
-    <p style={`color: var(${stateInfo.colorVar});`} class="status info">
-      {$i18n.neurons[`status_${stateInfo.textKey}`]}
-      <svelte:component this={stateInfo.Icon} />
-    </p>
   </div>
 
   <div slot="end" class="currency">
     {#if neuronICP}
       <ICPComponent icp={neuronICP} />
-      <p class="info">{$i18n.neurons.stake}</p>
     {/if}
+  </div>
+
+  <div class="info">
+    <p style={`color: var(${stateInfo.colorVar});`} class="status">
+      {$i18n.neurons[`status_${stateInfo.textKey}`]}
+      <svelte:component this={stateInfo.Icon} />
+    </p>
+
+    <p>{$i18n.neurons.stake}</p>
   </div>
 
   {#if dissolvingTime !== undefined}
@@ -76,6 +79,8 @@
 </Card>
 
 <style lang="scss">
+  @use "../../themes/mixins/display";
+
   :global(div.modal article > div) {
     margin-bottom: 0;
   }
@@ -107,7 +112,14 @@
   }
 
   .info {
+    @include display.space-between;
+    align-items: center;
+
     margin: calc(2 * var(--padding)) 0 0;
+
+    p {
+      margin: 0;
+    }
   }
 
   .duration {

--- a/frontend/svelte/src/lib/components/ui/Card.svelte
+++ b/frontend/svelte/src/lib/components/ui/Card.svelte
@@ -19,6 +19,7 @@
 <style lang="scss">
   @use "../../themes/mixins/interaction";
   @use "../../themes/mixins/media.scss";
+  @use "../../themes/mixins/display";
 
   article {
     text-decoration: none;
@@ -43,11 +44,8 @@
   }
 
   div {
-    display: inline-flex;
-    justify-content: space-between;
+    @include display.space-between;
     align-items: flex-start;
-
-    width: 100%;
 
     margin: 0 0 var(--padding);
   }

--- a/frontend/svelte/src/lib/themes/mixins/_display.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_display.scss
@@ -1,0 +1,6 @@
+@mixin space-between {
+  display: inline-flex;
+  justify-content: space-between;
+
+  width: 100%;
+}


### PR DESCRIPTION
# Motivation

If I am not wrong, "Stake" text can be displayed even if no ICP.

This PR also fix the alignment in case not hotkey are displayed and no community fund are displayed.

# Changes

- display "Stake" text also without ICP
- align state and stake for all cases

# Screenshots

Is:

<img width="1513" alt="Capture d’écran 2022-03-09 à 10 28 03" src="https://user-images.githubusercontent.com/16886711/157413090-228fed46-fc4f-4d38-a435-7ba802f471d7.png">

Will be:

<img width="1513" alt="Capture d’écran 2022-03-09 à 10 24 59" src="https://user-images.githubusercontent.com/16886711/157413121-1eb28101-37f3-441b-95da-d5633b144d8e.png">

