### PR TITLE
Fix query proposal certified

### DIFF
--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -129,7 +129,7 @@ const queryProposal = async ({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
 
-  return governance.getProposal({ proposalId });
+  return governance.getProposal({ proposalId, certified: true });
 };
 
 export const getProposalId = (path: string): ProposalId | undefined => {

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -106,7 +106,7 @@ describe("proposals-services", () => {
         setProposal: (proposal: ProposalInfo) => {
           expect(proposal?.id).toBe(mockProposals[1].id);
           expect(spyListProposals).not.toBeCalled();
-          expect(spyProposalInfo).not.toBeCalled();
+          expect(spyGetProposal).not.toBeCalled();
 
           done();
         },

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -150,7 +150,7 @@ describe("proposals-services", () => {
             proposalId: BigInt(404),
             certified: true,
           });
-          
+
           done();
         },
       });

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -20,7 +20,7 @@ describe("proposals-services", () => {
     new MockGovernanceCanister(mockProposals);
 
   let spyListProposals;
-  let spyProposalInfo;
+  let spyGetProposal;
   let spyRegisterVote;
 
   beforeEach(() => {
@@ -29,7 +29,7 @@ describe("proposals-services", () => {
       .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
 
     spyListProposals = jest.spyOn(mockGovernanceCanister, "listProposals");
-    spyProposalInfo = jest.spyOn(mockGovernanceCanister, "getProposal");
+    spyGetProposal = jest.spyOn(mockGovernanceCanister, "getProposal");
     spyRegisterVote = jest.spyOn(mockGovernanceCanister, "registerVote");
   });
 
@@ -118,7 +118,7 @@ describe("proposals-services", () => {
     });
     expect(proposal?.id).toBe(BigInt(100));
     expect(spyListProposals).not.toBeCalled();
-    expect(spyProposalInfo).not.toBeCalled();
+    expect(spyGetProposal).not.toBeCalled();
   });
 
   it("should call the canister to get proposalInfo", async () => {
@@ -127,7 +127,11 @@ describe("proposals-services", () => {
       identity: mockIdentity,
     });
     expect(proposal?.id).toBe(BigInt(404));
-    expect(spyProposalInfo).toBeCalledTimes(1);
+    expect(spyGetProposal).toBeCalledTimes(1);
+    expect(spyGetProposal).toBeCalledWith({
+      proposalId: BigInt(404),
+      certified: true,
+    });
   });
 
   it("should not call listProposals if not in the store", async () => {

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -145,7 +145,6 @@ describe("proposals-services", () => {
         identity: mockIdentity,
         setProposal: (proposal: ProposalInfo) => {
           expect(proposal?.id).toBe(BigInt(404));
-          expect(spyProposalInfo).toBeCalledTimes(1);
           expect(spyGetProposal).toBeCalledTimes(1);
           expect(spyGetProposal).toBeCalledWith({
             proposalId: BigInt(404),


### PR DESCRIPTION
# Motivation

Currently `queryProposal` uses query to fetch the data. But all request should use update instead.

# Changes

- getProposal function -> certified: true

# Tests

- updated getProposal.spec
