### PR TITLE
L2-330: Display new neuron details

### DIFF
--- a/frontend/svelte/src/lib/constants/constants.ts
+++ b/frontend/svelte/src/lib/constants/constants.ts
@@ -8,3 +8,5 @@ export const SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60;
 export const SECONDS_IN_DAY = SECONDS_IN_HOUR * 24;
 // Taking into account 1/4 of leap year
 export const SECONDS_IN_YEAR = ((4 * 365 + 1) * SECONDS_IN_DAY) / 4;
+export const SECONDS_IN_HALF_YEAR = SECONDS_IN_YEAR / 2;
+export const SECONDS_IN_EIGHT_YEARS = SECONDS_IN_YEAR * 8;

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -76,7 +76,7 @@
     "community_fund": "[community fund]",
     "hotkey_control": "[hotkey control]",
     "stake": "Stake",
-    "icp_stake": "ICP Stake",
+    "icp_stake": "$amount ICP Stake",
     "staked": "Staked",
     "aria_label_neuron_card": "Go to neuron details",
     "neuron_id": "Neuron ID",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -76,6 +76,7 @@
     "community_fund": "[community fund]",
     "hotkey_control": "[hotkey control]",
     "stake": "Stake",
+    "icp_stake": "ICP Stake",
     "staked": "Staked",
     "aria_label_neuron_card": "Go to neuron details",
     "neuron_id": "Neuron ID",

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -12,6 +12,8 @@
   import { StepsState } from "../../services/stepsState.services";
   import SetDissolveDelay from "./SetDissolveDelay.svelte";
   import type { NeuronId } from "@dfinity/nns";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { neuronsStore } from "../../stores/neurons.store";
 
   enum Steps {
     SelectAccount,
@@ -28,7 +30,7 @@
     }
   );
 
-  let newNeuronId: NeuronId | undefined;
+  let newNeuron: NeuronInfo | undefined;
 
   const chooseAccount = () => {
     stateStep = stateStep.next();
@@ -39,7 +41,9 @@
   const goToDissolveDelay = ({
     detail,
   }: CustomEvent<{ neuronId: NeuronId }>) => {
-    newNeuronId = detail.neuronId;
+    newNeuron = $neuronsStore.find(
+      (neuron) => neuron.neuronId === detail.neuronId
+    );
     stateStep = stateStep.next();
   };
 
@@ -92,10 +96,10 @@
       </Transition>
     {/if}
     <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-    {#if currentStep === Steps.SetDissolveDelay && newNeuronId}
+    {#if currentStep === Steps.SetDissolveDelay && newNeuron}
       <Transition {diff}>
         <!-- TODO: Edit Followees https://dfinity.atlassian.net/browse/L2-337 -->
-        <SetDissolveDelay neuronId={newNeuronId} on:nnsNext={close} />
+        <SetDissolveDelay neuron={newNeuron} on:nnsNext={close} />
       </Transition>
     {/if}
   </main>

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -42,7 +42,7 @@
     detail,
   }: CustomEvent<{ neuronId: NeuronId }>) => {
     newNeuron = $neuronsStore.find(
-      (neuron) => neuron.neuronId === detail.neuronId
+      ({ neuronId }) => neuronId === detail.neuronId
     );
     stateStep = stateStep.next();
   };

--- a/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
@@ -62,7 +62,9 @@
   </div>
   <div>
     <h5>{$i18n.neurons.neuron_balance}</h5>
-    <p>{`${formatICP(neuronICP)} ${$i18n.neurons.icp_stake}`}</p>
+    <p data-tid="neuron-stake">
+      {`${formatICP(neuronICP)} ${$i18n.neurons.icp_stake}`}
+    </p>
   </div>
   <div>
     {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}

--- a/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
@@ -13,6 +13,7 @@
   import { secondsToDuration } from "../../utils/date.utils";
   import { formatICP } from "../../utils/icp.utils";
   import { votingPower } from "../../utils/neuron.utils";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
 
   export let neuron: NeuronInfo;
 
@@ -63,7 +64,9 @@
   <div>
     <h5>{$i18n.neurons.neuron_balance}</h5>
     <p data-tid="neuron-stake">
-      {`${formatICP(neuronICP)} ${$i18n.neurons.icp_stake}`}
+      {replacePlaceholders($i18n.neurons.icp_stake, {
+        $amount: formatICP(neuronICP),
+      })}
     </p>
   </div>
   <div>

--- a/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
@@ -90,7 +90,12 @@
       />
       <div class="details">
         <div>
-          <h5>{votingPower(neuronICP, delayInSeconds).toFixed(2)}</h5>
+          <h5>
+            {votingPower({
+              stake: neuronICP,
+              dissolveDelayInSeconds: delayInSeconds,
+            }).toFixed(2)}
+          </h5>
           <p>{$i18n.neurons.voting_power}</p>
         </div>
         <div>

--- a/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SetDissolveDelay.svelte
@@ -4,29 +4,33 @@
   import { createEventDispatcher } from "svelte";
   import Card from "../../components/ui/Card.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
-  import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "../../constants/constants";
+  import {
+    SECONDS_IN_EIGHT_YEARS,
+    SECONDS_IN_HALF_YEAR,
+  } from "../../constants/constants";
   import { updateDelay } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
   import { secondsToDuration } from "../../utils/date.utils";
   import { formatICP } from "../../utils/icp.utils";
+  import { votingPower } from "../../utils/neuron.utils";
 
   export let neuron: NeuronInfo;
 
-  let EIGHT_YEARS = SECONDS_IN_YEAR * 8;
-  let SIX_MONTHS = (SECONDS_IN_DAY * 365) / 2;
   let delayInSeconds: number = 0;
   let loading: boolean = false;
 
   let backgroundStyle: string;
   $: {
-    const firstHalf: number = Math.round((delayInSeconds / EIGHT_YEARS) * 100);
+    const firstHalf: number = Math.round(
+      (delayInSeconds / SECONDS_IN_EIGHT_YEARS) * 100
+    );
     backgroundStyle = `linear-gradient(90deg, var(--background-contrast) ${firstHalf}%, var(--gray-200) ${
       1 - firstHalf
     }%)`;
   }
 
   let disableUpdate: boolean;
-  $: disableUpdate = delayInSeconds < SIX_MONTHS;
+  $: disableUpdate = delayInSeconds < SECONDS_IN_HALF_YEAR;
   const dispatcher = createEventDispatcher();
   const goToNext = (): void => {
     dispatcher("nnsNext");
@@ -77,15 +81,14 @@
     <div class="select-delay-container">
       <input
         min={0}
-        max={EIGHT_YEARS}
+        max={SECONDS_IN_EIGHT_YEARS}
         type="range"
         bind:value={delayInSeconds}
         style={`background-image: ${backgroundStyle};`}
       />
       <div class="details">
         <div>
-          <!-- TODO: Voting Power Calculation https://dfinity.atlassian.net/browse/L2-330 -->
-          <h5>1.26</h5>
+          <h5>{votingPower(neuronICP, delayInSeconds).toFixed(2)}</h5>
           <p>{$i18n.neurons.voting_power}</p>
         </div>
         <div>

--- a/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
@@ -8,7 +8,7 @@
     TRANSACTION_FEE_E8S,
   } from "../../constants/icp.constants";
   import { syncAccounts } from "../../services/accounts.services";
-  import { stakeNeuron } from "../../services/neurons.services";
+  import { listNeuron, stakeNeuron } from "../../services/neurons.services";
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
@@ -23,9 +23,14 @@
   const createNeuron = async () => {
     creating = true;
     try {
+      const stake = ICP.fromString(String(amount));
+      if (!(stake instanceof ICP)) {
+        throw new Error(`Amount ${amount} is not valid`);
+      }
       const neuronId = await stakeNeuron({
-        stake: ICP.fromE8s(BigInt(amount * E8S_PER_ICP)),
+        stake,
       });
+      await listNeuron(neuronId);
       // We don't wait for `syncAccounts` to finish to give a better UX to the user.
       // `syncAccounts` might be slow since it loads all accounts and balances.
       // in the neurons page there are no balances nor accounts

--- a/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
@@ -8,7 +8,7 @@
     TRANSACTION_FEE_E8S,
   } from "../../constants/icp.constants";
   import { syncAccounts } from "../../services/accounts.services";
-  import { listNeuron, stakeNeuron } from "../../services/neurons.services";
+  import { loadNeuron, stakeNeuron } from "../../services/neurons.services";
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
@@ -30,7 +30,7 @@
       const neuronId = await stakeNeuron({
         stake,
       });
-      await listNeuron(neuronId);
+      await loadNeuron(neuronId);
       // We don't wait for `syncAccounts` to finish to give a better UX to the user.
       // `syncAccounts` might be slow since it loads all accounts and balances.
       // in the neurons page there are no balances nor accounts

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -21,6 +21,18 @@ import { AuthStore, authStore } from "../stores/auth.store";
 import { neuronsStore } from "../stores/neurons.store";
 import { createAgent } from "../utils/agent.utils";
 
+export const getNeuron = async (
+  neuronId: NeuronId
+): Promise<NeuronInfo | undefined> => {
+  const { canister, identity } = await governanceCanister();
+
+  return canister.getNeuron({
+    certified: true,
+    principal: identity.getPrincipal(),
+    neuronId,
+  });
+};
+
 /**
  * Uses governance and ledger canisters to create a neuron and adds it to the store
  *
@@ -42,7 +54,6 @@ export const stakeNeuron = async ({
     canisterId: LEDGER_CANISTER_ID,
   });
 
-  // TODO: L2-332 Get neuron information and add to store
   const response = await canister.stakeNeuron({
     stake,
     principal: identity.getPrincipal(),
@@ -53,8 +64,7 @@ export const stakeNeuron = async ({
     throw response;
   }
 
-  // TODO: Remove after L2-332
-  await listNeurons();
+  await listNeuron(response);
 
   return response;
 };
@@ -70,16 +80,13 @@ export const listNeurons = async (): Promise<void> => {
   neuronsStore.setNeurons(neurons);
 };
 
-export const getNeuron = async (
-  neuronId: NeuronId
-): Promise<NeuronInfo | undefined> => {
-  const { canister, identity } = await governanceCanister();
+export const listNeuron = async (neuronId: NeuronId): Promise<void> => {
+  const neuron = await getNeuron(neuronId);
 
-  return canister.getNeuron({
-    certified: true,
-    principal: identity.getPrincipal(),
-    neuronId,
-  });
+  // TODO: Manage errors and edge cases: https://dfinity.atlassian.net/browse/L2-329
+  if (neuron) {
+    neuronsStore.pushNeurons([neuron]);
+  }
 };
 
 export const updateDelay = async ({
@@ -100,8 +107,7 @@ export const updateDelay = async ({
     throw response.Err;
   }
 
-  // TODO: Remove after L2-332
-  await listNeurons();
+  await listNeuron(neuronId);
 };
 
 // TODO: Apply pattern to other canister instantiation L2-371

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -64,7 +64,7 @@ export const stakeNeuron = async ({
     throw response;
   }
 
-  await listNeuron(response);
+  await loadNeuron(response);
 
   return response;
 };
@@ -80,7 +80,7 @@ export const listNeurons = async (): Promise<void> => {
   neuronsStore.setNeurons(neurons);
 };
 
-export const listNeuron = async (neuronId: NeuronId): Promise<void> => {
+export const loadNeuron = async (neuronId: NeuronId): Promise<void> => {
   const neuron = await getNeuron(neuronId);
 
   // TODO: Manage errors and edge cases: https://dfinity.atlassian.net/browse/L2-329
@@ -107,7 +107,7 @@ export const updateDelay = async ({
     throw response.Err;
   }
 
-  await listNeuron(neuronId);
+  await loadNeuron(neuronId);
 };
 
 // TODO: Apply pattern to other canister instantiation L2-371

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -85,6 +85,7 @@ interface I18nNeurons {
   community_fund: string;
   hotkey_control: string;
   stake: string;
+  icp_stake: string;
   staked: string;
   aria_label_neuron_card: string;
   neuron_id: string;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -1,5 +1,10 @@
 import { NeuronState } from "@dfinity/nns";
 import type { SvelteComponent } from "svelte";
+import {
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_HALF_YEAR,
+} from "../constants/constants";
+import { E8S_PER_ICP } from "../constants/icp.constants";
 import IconHistoryToggleOff from "../icons/IconHistoryToggleOff.svelte";
 import IconLockClock from "../icons/IconLockClock.svelte";
 import IconLockOpen from "../icons/IconLockOpen.svelte";
@@ -37,3 +42,12 @@ const stateTextMapper: StateMapper = {
 
 export const getStateInfo = (neuronState: NeuronState): StateInfo =>
   stateTextMapper[neuronState];
+
+export const votingPower = (
+  stake: bigint,
+  dissolveDelayInSeconds: number
+): number =>
+  dissolveDelayInSeconds > SECONDS_IN_HALF_YEAR
+    ? (Number(stake) / E8S_PER_ICP) *
+      (1 + dissolveDelayInSeconds / SECONDS_IN_EIGHT_YEARS)
+    : 0;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -43,10 +43,13 @@ const stateTextMapper: StateMapper = {
 export const getStateInfo = (neuronState: NeuronState): StateInfo =>
   stateTextMapper[neuronState];
 
-export const votingPower = (
-  stake: bigint,
-  dissolveDelayInSeconds: number
-): number =>
+export const votingPower = ({
+  stake,
+  dissolveDelayInSeconds,
+}: {
+  stake: bigint;
+  dissolveDelayInSeconds: number;
+}): number =>
   dissolveDelayInSeconds > SECONDS_IN_HALF_YEAR
     ? (Number(stake) / E8S_PER_ICP) *
       (1 + dissolveDelayInSeconds / SECONDS_IN_EIGHT_YEARS)

--- a/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
@@ -28,7 +28,7 @@ jest.mock("../../../lib/services/neurons.services", () => {
     // need to return the same neuron id as mockNeuron.neuronId
     stakeNeuron: jest.fn().mockResolvedValue(BigInt(1)),
     updateDelay: jest.fn().mockResolvedValue(undefined),
-    listNeuron: jest.fn().mockResolvedValue(undefined),
+    loadNeuron: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
@@ -2,24 +2,33 @@
  * @jest-environment jsdom
  */
 
-import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
+import { GovernanceCanister, LedgerCanister, NeuronInfo } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
+import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
+import * as en from "../../../lib/i18n/en.json";
 import CreateNeuronModal from "../../../lib/modals/neurons/CreateNeuronModal.svelte";
 import {
   stakeNeuron,
   updateDelay,
 } from "../../../lib/services/neurons.services";
 import { accountsStore } from "../../../lib/stores/accounts.store";
+import { authStore } from "../../../lib/stores/auth.store";
+import { neuronsStore } from "../../../lib/stores/neurons.store";
 import { mockAccountsStoreSubscribe } from "../../mocks/accounts.store.mock";
-
-/* eslint-disable-next-line */
-const en = require("../../../lib/i18n/en.json");
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import {
+  buildMockNeuronsStoreSubscibe,
+  fullNeuronMock,
+  neuronMock,
+} from "../../mocks/neurons.mock";
 
 jest.mock("../../../lib/services/neurons.services", () => {
   return {
-    stakeNeuron: jest.fn().mockResolvedValue(BigInt(10)),
+    // need to return the same neuron id as mockNeuron.neuronId
+    stakeNeuron: jest.fn().mockResolvedValue(BigInt(1)),
     updateDelay: jest.fn().mockResolvedValue(undefined),
+    listNeuron: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -34,6 +43,9 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(accountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe());
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation(() => mock<LedgerCanister>());
@@ -119,7 +131,10 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should move to update dissolve delay after creating a neuron", async () => {
-    const { container, queryByText } = render(CreateNeuronModal);
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscibe([neuronMock]));
+    const { container } = render(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -135,12 +150,17 @@ describe("CreateNeuronModal", () => {
 
     createButton && (await fireEvent.click(createButton));
 
-    waitFor(() =>
-      expect(queryByText(en.neurons.set_dissolve_delay)).not.toBeNull()
+    await waitFor(() =>
+      expect(
+        container.querySelector("[data-tid='update-button']")
+      ).not.toBeNull()
     );
   });
 
   it("should have the update delay button disabled", async () => {
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscibe([neuronMock]));
     const { container } = render(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
@@ -157,14 +177,21 @@ describe("CreateNeuronModal", () => {
 
     createButton && (await fireEvent.click(createButton));
 
+    await waitFor(() =>
+      expect(
+        container.querySelector("[data-tid='update-button']")
+      ).not.toBeNull()
+    );
     const updateDelayButton = container.querySelector(
       '[data-tid="update-button"]'
     );
-    waitFor(() => expect(updateDelayButton).not.toBeNull());
     expect(updateDelayButton?.getAttribute("disabled")).not.toBeNull();
   });
 
   it("should have disabled button for dissolve less than six months", async () => {
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscibe([neuronMock]));
     const { container } = render(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
@@ -181,8 +208,10 @@ describe("CreateNeuronModal", () => {
 
     createButton && (await fireEvent.click(createButton));
 
+    await waitFor(() =>
+      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+    );
     const inputRange = container.querySelector('input[type="range"]');
-    waitFor(() => expect(inputRange).not.toBeNull());
 
     const FIVE_MONTHS = 60 * 60 * 24 * 30 * 5;
     inputRange &&
@@ -191,11 +220,14 @@ describe("CreateNeuronModal", () => {
     const updateDelayButton = container.querySelector(
       '[data-tid="update-button"]'
     );
-
     expect(updateDelayButton?.getAttribute("disabled")).not.toBeNull();
   });
 
   it("should be able to change dissolve delay value", async () => {
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscibe([neuronMock]));
+
     const { container } = render(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
@@ -212,8 +244,10 @@ describe("CreateNeuronModal", () => {
 
     createButton && (await fireEvent.click(createButton));
 
+    await waitFor(() =>
+      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+    );
     const inputRange = container.querySelector('input[type="range"]');
-    waitFor(() => expect(inputRange).not.toBeNull());
 
     const ONE_YEAR = 60 * 60 * 24 * 365;
     inputRange &&
@@ -222,11 +256,47 @@ describe("CreateNeuronModal", () => {
     const updateDelayButton = container.querySelector(
       '[data-tid="update-button"]'
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(updateDelayButton?.getAttribute("disabled")).toBeNull()
     );
 
     updateDelayButton && (await fireEvent.click(updateDelayButton));
-    waitFor(() => expect(updateDelay).toBeCalled());
+    await waitFor(() => expect(updateDelay).toBeCalled());
+  });
+
+  it("should be able to create a neuron and see the stake of the new neuron in the dissolve modal", async () => {
+    const neuronStake = 2.2;
+    const newNeuron: NeuronInfo = {
+      ...neuronMock,
+      fullNeuron: {
+        ...fullNeuronMock,
+        cachedNeuronStake: BigInt(Math.round(neuronStake * E8S_PER_ICP)),
+      },
+    };
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscibe([newNeuron]));
+
+    const { container, getByText } = render(CreateNeuronModal);
+
+    const accountCard = container.querySelector('article[role="button"]');
+    expect(accountCard).not.toBeNull();
+
+    accountCard && (await fireEvent.click(accountCard));
+
+    const input = container.querySelector('input[name="amount"]');
+    // Svelte generates code for listening to the `input` event
+    // https://github.com/testing-library/svelte-testing-library/issues/29#issuecomment-498055823
+    input && (await fireEvent.input(input, { target: { value: neuronStake } }));
+
+    const createButton = container.querySelector('button[type="submit"]');
+
+    createButton && (await fireEvent.click(createButton));
+
+    await waitFor(() =>
+      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+    );
+
+    expect(getByText(neuronStake, { exact: false })).not.toBeNull();
   });
 });

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -4,8 +4,8 @@ import { get } from "svelte/store";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import {
   getNeuron,
-  listNeuron,
   listNeurons,
+  loadNeuron,
   stakeNeuron,
   updateDelay,
 } from "../../../lib/services/neurons.services";
@@ -82,10 +82,10 @@ describe("neurons-services", () => {
     expect(neuron?.neuronId).toEqual(neuronMock.neuronId);
   });
 
-  it("listNeuron fetches one neuron and adds it to the store", async () => {
+  it("loadNeuron fetches one neuron and adds it to the store", async () => {
     expect(mockGovernanceCanister.getNeuron).not.toBeCalled();
 
-    await listNeuron(neuronMock.neuronId);
+    await loadNeuron(neuronMock.neuronId);
 
     expect(mockGovernanceCanister.getNeuron).toBeCalled();
     const neuronsInStore = get(neuronsStore);

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1,13 +1,16 @@
 import { GovernanceCanister, ICP, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
+import { get } from "svelte/store";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import {
   getNeuron,
+  listNeuron,
   listNeurons,
   stakeNeuron,
   updateDelay,
 } from "../../../lib/services/neurons.services";
 import { authStore } from "../../../lib/stores/auth.store";
+import { neuronsStore } from "../../../lib/stores/neurons.store";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { neuronMock } from "../../mocks/neurons.mock";
 
@@ -77,6 +80,16 @@ describe("neurons-services", () => {
     expect(mockGovernanceCanister.getNeuron).toBeCalled();
     expect(neuron).not.toBeUndefined();
     expect(neuron?.neuronId).toEqual(neuronMock.neuronId);
+  });
+
+  it("listNeuron fetches one neuron and adds it to the store", async () => {
+    expect(mockGovernanceCanister.getNeuron).not.toBeCalled();
+
+    await listNeuron(neuronMock.neuronId);
+
+    expect(mockGovernanceCanister.getNeuron).toBeCalled();
+    const neuronsInStore = get(neuronsStore);
+    expect(neuronsInStore.length).toBe(1);
   });
 
   it("updateDelay updates neuron", async () => {

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -9,23 +9,31 @@ import { votingPower } from "../../../lib/utils/neuron.utils";
 describe("neuron-utils", () => {
   describe("votingPower", () => {
     it("should return zero for delays less than six months", () => {
-      expect(votingPower(BigInt(2), 100)).toBe(0);
+      expect(
+        votingPower({ stake: BigInt(2), dissolveDelayInSeconds: 100 })
+      ).toBe(0);
     });
 
     it("should return more than stake when delay more than six months", () => {
       const stake = "2.2";
       const icp = ICP.fromString(stake) as ICP;
       expect(
-        votingPower(icp.toE8s(), SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR)
+        votingPower({
+          stake: icp.toE8s(),
+          dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
+        })
       ).toBeGreaterThan(Number(stake));
     });
 
     it("should return the doulbe when delay is eight years", () => {
       const stake = "2.2";
       const icp = ICP.fromString(stake) as ICP;
-      expect(votingPower(icp.toE8s(), SECONDS_IN_EIGHT_YEARS)).toBe(
-        Number(stake) * 2
-      );
+      expect(
+        votingPower({
+          stake: icp.toE8s(),
+          dissolveDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+        })
+      ).toBe(Number(stake) * 2);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1,0 +1,31 @@
+import { ICP } from "@dfinity/nns";
+import {
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_HOUR,
+} from "../../../lib/constants/constants";
+import { votingPower } from "../../../lib/utils/neuron.utils";
+
+describe("neuron-utils", () => {
+  describe("votingPower", () => {
+    it("should return zero for delays less than six months", () => {
+      expect(votingPower(BigInt(2), 100)).toBe(0);
+    });
+
+    it("should return more than stake when delay more than six months", () => {
+      const stake = "2.2";
+      const icp = ICP.fromString(stake) as ICP;
+      expect(
+        votingPower(icp.toE8s(), SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR)
+      ).toBeGreaterThan(Number(stake));
+    });
+
+    it("should return the doulbe when delay is eight years", () => {
+      const stake = "2.2";
+      const icp = ICP.fromString(stake) as ICP;
+      expect(votingPower(icp.toE8s(), SECONDS_IN_EIGHT_YEARS)).toBe(
+        Number(stake) * 2
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Show new neuron details when updating the delay after creating it.

# Changes

* SetDissolveDelayModal expects a neuron and uses the data to render the details.
* votingPower util.

# Tests

* Upgraded CreateNeuronModal tests to check that information used to create a neuron is there.
* votingPower util tests
