### PR TITLE
Fix: Eslint errors 2

### DIFF
--- a/frontend/svelte/.eslintrc.js
+++ b/frontend/svelte/.eslintrc.js
@@ -50,5 +50,11 @@ module.exports = {
         allowNumber: false,
       },
     ],
+    "@typescript-eslint/ban-ts-comment": [
+      2,
+      {
+        "ts-ignore": "allow-with-description",
+      },
+    ],
   },
 };

--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -5,10 +5,8 @@ import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 
 global.TextEncoder = TextEncoder;
-// @ts-ignore: test setup
-global.TextDecoder = TextDecoder;
-// @ts-ignore: test setup
-global.IntersectionObserver = IntersectionObserverPassive;
+global.TextDecoder = TextDecoder as any;
+global.IntersectionObserver = IntersectionObserverPassive as any;
 
 // Environment Variables Setup
 process.env.REDIRECT_TO_LEGACY = "never";

--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -5,9 +5,9 @@ import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 
 global.TextEncoder = TextEncoder;
-// @ts-ignore
+// @ts-ignore: test setup
 global.TextDecoder = TextDecoder;
-// @ts-ignore
+// @ts-ignore: test setup
 global.IntersectionObserver = IntersectionObserverPassive;
 
 // Environment Variables Setup

--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -5,8 +5,10 @@ import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 
 global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder as any;
-global.IntersectionObserver = IntersectionObserverPassive as any;
+(global as { TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder;
+(
+  global as { IntersectionObserver: typeof IntersectionObserver }
+).IntersectionObserver = IntersectionObserverPassive;
 
 // Environment Variables Setup
 process.env.REDIRECT_TO_LEGACY = "never";

--- a/frontend/svelte/src/lib/stores/accounts.store.ts
+++ b/frontend/svelte/src/lib/stores/accounts.store.ts
@@ -10,7 +10,7 @@ export interface AccountsStore {
  * A store that contains the account information.
  */
 export const initAccountsStore = () => {
-  const { subscribe, set, update } = writable<AccountsStore>({
+  const { subscribe, set } = writable<AccountsStore>({
     main: undefined,
     subAccounts: undefined,
   });

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -13,7 +13,7 @@ export const createAgent = async ({
   });
 
   // process.env.FETCH_ROOT_KEY is changed to `true`, but we hande nullish/empty cases explicitly
-  // @ts-ignore
+  // @ts-ignore: rollup substitutes process.env.FETCH_ROOT_KEY for `true`, not a string. TS cannot recognize it as boolean.
   if (process.env.FETCH_ROOT_KEY === true) {
     // Fetch root key for certificate validation during development or on testnet
     await agent.fetchRootKey();

--- a/frontend/svelte/src/tests/lib/components/common/Guard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/common/Guard.spec.ts
@@ -11,7 +11,7 @@ describe("Guard", () => {
     // Promise that never resolves to test if a spinner is rendered while loading
     jest
       .spyOn(authStore, "sync")
-      .mockImplementation(() => new Promise((resolve) => {}));
+      .mockImplementation(() => new Promise(() => undefined));
 
     const { container } = render(Guard);
 

--- a/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
@@ -5,10 +5,9 @@
 import { Neuron, NeuronState } from "@dfinity/nns";
 import { fireEvent, render } from "@testing-library/svelte";
 import NeuronCard from "../../../../lib/components/neurons/NeuronCard.svelte";
+import * as en from "../../../../lib/i18n/en.json";
 import { formatICP } from "../../../../lib/utils/icp.utils";
 import { fullNeuronMock, neuronMock } from "../../../mocks/neurons.mock";
-
-const en = require("../../../../lib/i18n/en.json");
 
 describe("NeuronCard", () => {
   it("renders a Card", () => {

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.spec.ts
@@ -18,7 +18,7 @@ describe("ProposalDetailCard", () => {
   });
 
   it("should render title", () => {
-    const { getByText, container } = renderResult;
+    const { getByText } = renderResult;
     expect(getByText("title")).toBeInTheDocument();
   });
 

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.spec.ts
@@ -5,9 +5,8 @@
 import { Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import ProposalMeta from "../../../../../lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte";
+import * as en from "../../../../../lib/i18n/en.json";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
-
-const en = require("../../../../../lib/i18n/en.json");
 
 describe("ProposalMeta", () => {
   it("should render proposal url", () => {

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.spec.ts
@@ -5,9 +5,8 @@
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import ProposalSummary from "../../../../../lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte";
+import * as en from "../../../../../lib/i18n/en.json";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
-
-const en = require("../../../../../lib/i18n/en.json");
 
 describe("ProposalSummary", () => {
   it("should render title", () => {
@@ -20,7 +19,7 @@ describe("ProposalSummary", () => {
   });
 
   it("should render content", async () => {
-    const { getByText, container } = render(ProposalSummary, {
+    const { getByText } = render(ProposalSummary, {
       props: {
         proposal: mockProposalInfo.proposal,
       },

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotesCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotesCard.spec.ts
@@ -5,6 +5,7 @@ import { Vote } from "@dfinity/nns";
 import { render, RenderResult } from "@testing-library/svelte";
 import VotesCard from "../../../../lib/components/proposal-detail/VotesCard.svelte";
 import { E8S_PER_ICP } from "../../../../lib/constants/icp.constants";
+import * as en from "../../../../lib/i18n/en.json";
 import { neuronsStore } from "../../../../lib/stores/neurons.store";
 import { formatNumber } from "../../../../lib/utils/format.utils";
 import {
@@ -12,9 +13,6 @@ import {
   neuronMock,
 } from "../../../mocks/neurons.mock";
 import { mockProposalInfo } from "../../../mocks/proposal.mock";
-
-/* eslint-disable-next-line */
-const en = require("../../../../lib/i18n/en.json");
 
 describe("VotesCard", () => {
   describe("Adopt-Reject section", () => {

--- a/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -11,13 +11,12 @@ import {
 } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import ProposalCard from "../../../../lib/components/proposals/ProposalCard.svelte";
+import * as en from "../../../../lib/i18n/en.json";
 import { authStore } from "../../../../lib/stores/auth.store";
 import { proposalsFiltersStore } from "../../../../lib/stores/proposals.store";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
 import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
 import { mockProposals } from "../../../mocks/proposals.store.mock";
-
-const en = require("../../../../lib/i18n/en.json");
 
 describe("ProposalCard", () => {
   const mockGovernanceCanister: MockGovernanceCanister =

--- a/frontend/svelte/src/tests/lib/components/proposals/ProposalsFilters.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/ProposalsFilters.spec.ts
@@ -6,9 +6,8 @@ import { ProposalRewardStatus, ProposalStatus, Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import ProposalsFilters from "../../../../lib/components/proposals/ProposalsFilters.svelte";
 import { DEFAULT_PROPOSALS_FILTERS } from "../../../../lib/constants/proposals.constants";
+import * as en from "../../../../lib/i18n/en.json";
 import { enumSize } from "../../../../lib/utils/enum.utils";
-
-const en = require("../../../../lib/i18n/en.json");
 
 describe("ProposalsFilters", () => {
   const shouldRenderFilter = ({

--- a/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/Proposer.spec.ts
@@ -5,13 +5,12 @@
 import { GovernanceCanister } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import Proposer from "../../../../lib/components/proposals/Proposer.svelte";
+import * as en from "../../../../lib/i18n/en.json";
 import { authStore } from "../../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
 import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
 import { mockProposalInfo } from "../../../mocks/proposal.mock";
 import { mockProposals } from "../../../mocks/proposals.store.mock";
-
-const en = require("../../../../lib/i18n/en.json");
 
 describe("Proposer", () => {
   const props = {

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -15,10 +15,10 @@ import {
 import InfiniteScrollTest from "./InfiniteScrollTest.svelte";
 
 describe("InfiniteScroll", () => {
-  // @ts-ignore
+  // @ts-ignore: test file
   beforeAll(() => (global.IntersectionObserver = IntersectionObserverActive));
 
-  // @ts-ignore
+  // @ts-ignore: test file
   afterAll(() => (global.IntersectionObserver = IntersectionObserverPassive));
 
   it("should render a container", () => {

--- a/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/AddAccountModal.spec.ts
@@ -3,10 +3,9 @@
  */
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import * as en from "../../../lib/i18n/en.json";
 import AddAccountModal from "../../../lib/modals/accounts/AddAccountModal.svelte";
 import { createSubAccount } from "../../../lib/services/accounts.services";
-
-const en = require("../../../lib/i18n/en.json");
 
 // This is the way to mock when we import in a destructured manner
 // and we want to mock the imported function

--- a/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/Modal.spec.ts
@@ -117,7 +117,7 @@ describe("Modal", () => {
       props: { ...props, showBackButton: true },
     });
 
-    component.$on("nnsClose", (e) => {
+    component.$on("nnsClose", () => {
       done();
     });
 
@@ -132,7 +132,7 @@ describe("Modal", () => {
       props: { visible: true, showBackButton: true },
     });
 
-    component.$on("nnsBack", (e) => {
+    component.$on("nnsBack", () => {
       done();
     });
 

--- a/frontend/svelte/src/tests/lib/modals/ProposalsFilterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposalsFilterModal.spec.ts
@@ -6,12 +6,11 @@ import { Topic } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import { DEFAULT_PROPOSALS_FILTERS } from "../../../lib/constants/proposals.constants";
+import * as en from "../../../lib/i18n/en.json";
 import ProposalsFilterModal from "../../../lib/modals/proposals/ProposalsFilterModal.svelte";
 import { proposalsFiltersStore } from "../../../lib/stores/proposals.store";
 import type { ProposalsFilterModalProps } from "../../../lib/types/proposals";
 import { enumKeys } from "../../../lib/utils/enum.utils";
-
-const en = require("../../../lib/i18n/en.json");
 
 describe("ProposalsFilterModal", () => {
   const props: { props: ProposalsFilterModalProps } = {

--- a/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/ProposerModal.spec.ts
@@ -4,14 +4,13 @@
 
 import { GovernanceCanister } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import * as en from "../../../lib/i18n/en.json";
 import ProposerModal from "../../../lib/modals/proposals/ProposerModal.svelte";
 import { authStore } from "../../../lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { MockGovernanceCanister } from "../../mocks/governance.canister.mock";
 import { mockProposalInfo } from "../../mocks/proposal.mock";
 import { mockProposals } from "../../mocks/proposals.store.mock";
-
-const en = require("../../../lib/i18n/en.json");
 
 describe("ProposerModal", () => {
   const props = {

--- a/frontend/svelte/src/tests/lib/modals/VoteConfirmationModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/VoteConfirmationModal.spec.ts
@@ -4,9 +4,8 @@
 
 import { Vote } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import * as en from "../../../lib/i18n/en.json";
 import VoteConfirmationModal from "../../../lib/modals/proposals/VoteConfirmationModal.svelte";
-
-const en = require("../../../lib/i18n/en.json");
 
 describe("VoteConfirmationModal", () => {
   it("should display Adopt state", () => {

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -117,7 +117,7 @@ describe("proposals-services", () => {
       loadProposal({
         proposalId: mockProposals[0].id as bigint,
         identity: mockIdentity,
-        setProposal: (_proposalInfo: ProposalInfo) => {
+        setProposal: () => {
           expect(spyListProposals).not.toBeCalled();
           done();
         },

--- a/frontend/svelte/src/tests/lib/stores/auth.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/auth.store.spec.ts
@@ -20,7 +20,7 @@ describe("auth-store", () => {
   });
 
   it("should call auth-client login on sign-in", async () => {
-    // @ts-ignore
+    // @ts-ignore: test file
     mockAuthClient.login = async ({ onSuccess }: { onSuccess: () => void }) => {
       expect(true).toBeTruthy();
       onSuccess();

--- a/frontend/svelte/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/date.utils.spec.ts
@@ -1,6 +1,5 @@
+import * as en from "../../../lib/i18n/en.json";
 import { secondsToDuration } from "../../../lib/utils/date.utils";
-
-const en = require("../../../lib/i18n/en.json");
 
 describe("secondsToDuration", () => {
   it("should give year details", () => {

--- a/frontend/svelte/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/auth.store.mock.ts
@@ -54,5 +54,5 @@ export const mutableMockAuthStoreSubscribe = (
 ): (() => void) => {
   authStoreMock.subscribe((store: AuthStore) => run(store));
 
-  return () => {};
+  return () => undefined;
 };

--- a/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   GovernanceCanister,
   ICP,
@@ -39,7 +40,7 @@ export class MockGovernanceCanister extends GovernanceCanister {
   public getProposal = async ({
     proposalId,
   }: {
-    proposalId: any;
+    proposalId: bigint;
   }): Promise<ProposalInfo | undefined> => {
     return this.proposals.find(({ id }) => id === proposalId);
   };

--- a/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
@@ -15,7 +15,7 @@ import type { Principal } from "@dfinity/principal";
 import { neuronMock } from "./neurons.mock";
 
 // eslint-disable-next-line
-// @ts-ignore
+// @ts-ignore: test file
 export class MockGovernanceCanister extends GovernanceCanister {
   constructor(private proposals: ProposalInfo[]) {
     super();

--- a/frontend/svelte/src/tests/mocks/infinitescroll.mock.ts
+++ b/frontend/svelte/src/tests/mocks/infinitescroll.mock.ts
@@ -1,24 +1,21 @@
-export class IntersectionObserverPassive {
+export const IntersectionObserverPassive = jest.fn();
+IntersectionObserverPassive.mockReturnValue({
+  observe: () => null,
+  unobserve: () => null,
+  disconnect: () => null,
+});
+
+export class IntersectionObserverActive implements IntersectionObserver {
+  public readonly root: Element | Document | null;
+  public readonly rootMargin: string;
+  public readonly thresholds: ReadonlyArray<number>;
+  public takeRecords: () => IntersectionObserverEntry[];
+
   constructor(
-    private callback: (entries: IntersectionObserverEntry[], observer) => void,
-    private options?: IntersectionObserverInit
-  ) {}
-
-  /* eslint-disable-next-line */
-  observe = (element: HTMLElement) => undefined;
-
-  disconnect() {
-    return null;
-  }
-
-  unobserve() {
-    return null;
-  }
-}
-
-export class IntersectionObserverActive {
-  constructor(
-    private callback: (entries: IntersectionObserverEntry[], observer) => void,
+    private callback: (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => void,
     private options?: IntersectionObserverInit
   ) {}
 
@@ -33,12 +30,6 @@ export class IntersectionObserverActive {
       this
     );
   }
-
-  disconnect() {
-    return null;
-  }
-
-  unobserve() {
-    return null;
-  }
+  disconnect = () => null;
+  unobserve = () => null;
 }

--- a/frontend/svelte/src/tests/mocks/infinitescroll.mock.ts
+++ b/frontend/svelte/src/tests/mocks/infinitescroll.mock.ts
@@ -4,7 +4,8 @@ export class IntersectionObserverPassive {
     private options?: IntersectionObserverInit
   ) {}
 
-  observe(element: HTMLElement) {}
+  /* eslint-disable-next-line */
+  observe = (element: HTMLElement) => undefined;
 
   disconnect() {
     return null;

--- a/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/proposals.store.mock.ts
@@ -32,7 +32,7 @@ export const mockProposalsStoreSubscribe = (
 ): (() => void) => {
   run(mockProposals);
 
-  return () => {};
+  return () => undefined;
 };
 
 export const mockEmptyProposalsStoreSubscribe = (
@@ -40,5 +40,5 @@ export const mockEmptyProposalsStoreSubscribe = (
 ): (() => void) => {
   run([]);
 
-  return () => {};
+  return () => undefined;
 };

--- a/frontend/svelte/src/tests/routes/Proposals.spec.ts
+++ b/frontend/svelte/src/tests/routes/Proposals.spec.ts
@@ -4,6 +4,7 @@
 
 import { GovernanceCanister, Proposal, ProposalInfo } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import * as en from "../../lib/i18n/en.json";
 import { authStore } from "../../lib/stores/auth.store";
 import { proposalsStore } from "../../lib/stores/proposals.store";
 import Proposals from "../../routes/Proposals.svelte";
@@ -14,9 +15,6 @@ import {
   mockProposals,
   mockProposalsStoreSubscribe,
 } from "../mocks/proposals.store.mock";
-
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const en = require("../../lib/i18n/en.json") as I18n;
 
 describe("Proposals", () => {
   const nothingFound = (


### PR DESCRIPTION
# Motivation

Fix eslint errors, part 2

# Changes

* Fix no-require.
* Fix no-empty-function.
* Allow `ts-ignore` with description.
* Fix no-unused-var

# Tests

No extra tests.