### PR TITLE
Fix: npm run check fails

### DIFF
--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -111,7 +111,7 @@ export const loadProposal = async ({
   handleError,
 }: {
   proposalId: ProposalId;
-  identity: Identity | undefined;
+  identity: Identity | undefined | null;
   setProposal: (proposal: ProposalInfo) => void;
   handleError?: () => void;
 }): Promise<void> => {


### PR DESCRIPTION
# Motivation

Fix `npm run check` failing.

# Changes

* `identity` can also be `null`.

# Tests

No extra tests.
