### PR TITLE
Define manifest src

### DIFF
--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -52,6 +52,7 @@ const updateCSP = (content) => {
         content="default-src 'none';
         connect-src 'self' ${cspConnectSrc()};
         img-src 'self';
+        manifest-src 'self';
         script-src 'unsafe-eval' 'strict-dynamic' 'nonce-bundle-369ac6c9-8078-4625-82f7-f37a9ca8fb16';
         base-uri 'self';
         form-action 'none';


### PR DESCRIPTION
# Motivation
```
Refused to load manifest from 'https://qsgjb-riaaa-aaaaa-aaaga-cai.nnsdapp.dfinity.network/manifest.json' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'manifest-src' was not explicitly set, so 'default-src' is used as a fallback.
```

# Changes
Added a manifest-src to the CSP.

# Tests
The above error is seen in deployments such as:  https://qsgjb-riaaa-aaaaa-aaaga-cai.nnsdapp.dfinity.network/v2/#/neurons

But not a on a deployment of this branch: https://wflfh-4yaaa-aaaaa-aaata-cai.nnsdapp.dfinity.network/#/accounts