### PR TITLE
L2 387 no neurons initially on proposal detail

### DIFF
--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -211,7 +211,7 @@ const requestRegisterVotes = async ({
   identity: Identity;
 }): Promise<void> => {
   // TODO: switch to Promise.allSettled -- https://dfinity.atlassian.net/browse/L2-369
-  const errors: Array<GovernanceError | undefined> = await Promise.all(
+  const responses: Array<GovernanceError | undefined> = await Promise.all(
     neuronIds.map((neuronId: NeuronId) =>
       registerVote({
         neuronId,
@@ -221,9 +221,9 @@ const requestRegisterVotes = async ({
       })
     )
   );
-
-  // show only unique error messages
-  const errorDetails: string = uniqueObjects(errors.filter(Boolean))
+  const errors = responses.filter(Boolean);
+  // collect unique error messages
+  const errorDetails: string = uniqueObjects(errors)
     .map((error) =>
       typeof error?.errorMessage === "string" && error.errorMessage.length > 0
         ? stringifyJson(error?.errorMessage, { indentation: 2 })

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -20,6 +20,7 @@
 
   let proposalInfo: ProposalInfo | undefined;
   let neurons: NeuronInfo[] | undefined;
+  let neuronsReady = false;
   $: neurons = $neuronsStore;
 
   // TODO: To be removed once this page has been implemented
@@ -34,9 +35,12 @@
 
     // TODO: catch and error handling -- https://dfinity.atlassian.net/browse/L2-370
     await listNeurons({ identity: $authStore.identity });
+    neuronsReady = true;
   });
 
   const unsubscribe = routeStore.subscribe(async ({ path }) => {
+    proposalInfo = undefined;
+
     const proposalIdMaybe = getProposalId(path);
     if (proposalIdMaybe === undefined) {
       unsubscribe();
@@ -79,7 +83,7 @@
     >
 
     <section>
-      {#if proposalInfo && neurons}
+      {#if proposalInfo && neuronsReady}
         <ProposalDetailCard {proposalInfo} />
         <VotesCard {proposalInfo} {neurons} />
         <VotingCard {proposalInfo} {neurons} />

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -83,7 +83,7 @@
     >
 
     <section>
-      {#if proposalInfo && neuronsReady}
+      {#if proposalInfo && neurons && neuronsReady}
         <ProposalDetailCard {proposalInfo} />
         <VotesCard {proposalInfo} {neurons} />
         <VotingCard {proposalInfo} {neurons} />

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -216,6 +216,17 @@ describe("proposals-services", () => {
         expect(spyBusyStart).toBeCalledWith("vote");
         expect(spyBusyStop).toBeCalledWith("vote");
       });
+
+      it("should not display errors on successful vote registration", async () => {
+        const spyToastShow = jest.spyOn(toastsStore, "show");
+        await registerVotes({
+          neuronIds,
+          proposalId,
+          vote: Vote.YES,
+          identity,
+        });
+        expect(spyToastShow).not.toBeCalled();
+      });
     });
 
     describe("refresh", () => {


### PR DESCRIPTION
# Motivation

🪲🪲🪲
1. the proposal detail info was shown before the neurons were loaded. That could make wrong impression that for example there was no voting done
2. after successful voting an error was always shown
3. in case the proposal id is changed directly in URL there was no visible feedback that the new proposal is loading

# Changes

- for now the unknown store state is fixed on the component level (could be changed after update/query research).

# Tests

- added test to not show error messages on successful response
