### PR TITLE
feat: display skeleton text while loading voting history

### DIFF
--- a/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
@@ -6,6 +6,7 @@
   import ProposalSummary from "../proposal-detail/ProposalDetailCard/ProposalSummary.svelte";
   import { Vote } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
+  import SkeletonText from "../ui/SkeletonText.svelte";
 
   export let ballot: Required<BallotInfo>;
 
@@ -21,14 +22,22 @@
   );
 </script>
 
-<!-- TODO(L2-282): use spinner or skeleton while loading if ux is not well suited -->
-
 {#if proposal?.proposal !== undefined}
   <p>{proposal.id}</p>
 
   <p class="vote">{$i18n.core[Vote[ballot.vote].toLowerCase()]}</p>
 
   <div class="summary"><ProposalSummary proposal={proposal.proposal} /></div>
+{:else}
+  <p><SkeletonText /></p>
+
+  <p><SkeletonText /></p>
+
+  <div class="summary">
+    <SkeletonText />
+    <SkeletonText />
+    <SkeletonText />
+  </div>
 {/if}
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
@@ -6,7 +6,7 @@
   import ProposalSummary from "../proposal-detail/ProposalDetailCard/ProposalSummary.svelte";
   import { Vote } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
-  import SkeletonText from "../ui/SkeletonText.svelte";
+  import SkeletonParagraph from "../ui/SkeletonParagraph.svelte";
 
   export let ballot: Required<BallotInfo>;
 
@@ -29,14 +29,14 @@
 
   <div class="summary"><ProposalSummary proposal={proposal.proposal} /></div>
 {:else}
-  <p><SkeletonText /></p>
+  <SkeletonParagraph />
 
-  <p><SkeletonText /></p>
+  <SkeletonParagraph />
 
   <div class="summary">
-    <SkeletonText />
-    <SkeletonText />
-    <SkeletonText />
+    <SkeletonParagraph />
+    <SkeletonParagraph />
+    <SkeletonParagraph />
   </div>
 {/if}
 

--- a/frontend/svelte/src/lib/components/ui/Markdown.svelte
+++ b/frontend/svelte/src/lib/components/ui/Markdown.svelte
@@ -31,5 +31,5 @@
   {@html parse(removeHTMLTags(text))}
 {:else}
   <!-- fallback text content -->
-  <p>{text}</p>
+  <p data-tid="markdown-text">{text}</p>
 {/if}

--- a/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
@@ -3,7 +3,7 @@
   export let animated: boolean = true;
 </script>
 
-<p class:animated data-tid="skeleton-text" aria-busy={true}>
+<p class:animated data-tid="skeleton-text" aria-busy="true">
   <span>&nbsp;</span>
 </p>
 

--- a/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
@@ -3,7 +3,7 @@
   export let animated: boolean = true;
 </script>
 
-<p class:animated data-tid="skeleton-text" aria-busy="true">
+<p class:animated data-tid="skeleton-paragraph" aria-busy="true">
   <span>&nbsp;</span>
 </p>
 

--- a/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
@@ -3,12 +3,12 @@
   export let animated: boolean = true;
 </script>
 
-<div class:animated data-tid="skeleton-text" aria-busy={true}>
+<p class:animated data-tid="skeleton-text" aria-busy={true}>
   <span>&nbsp;</span>
-</div>
+</p>
 
 <style lang="scss">
-  div {
+  p {
     display: block;
 
     width: 100%;

--- a/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
@@ -3,7 +3,7 @@
   export let animated: boolean = true;
 </script>
 
-<div class:animated data-tid="skeleton-text">
+<div class:animated data-tid="skeleton-text" aria-busy={true}>
   <span>&nbsp;</span>
 </div>
 

--- a/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
@@ -1,0 +1,60 @@
+<!-- adapted source: https://github.com/ionic-team/ionic-framework/tree/main/core/src/components/skeleton-text -->
+<script lang="ts">
+  export let animated: boolean = true;
+</script>
+
+<div class:animated data-tid="skeleton-text">
+  <span>&nbsp;</span>
+</div>
+
+<style lang="scss">
+  div {
+    display: block;
+
+    width: 100%;
+    height: inherit;
+
+    margin: calc(var(--padding) / 2) 0;
+
+    --skeleton-text-background: rgba(var(--light-background-rgb), 0.065);
+    --skeleton-text-background-animated: rgba(var(--light-background-rgb), 0.135);
+    background: var(--skeleton-text-background);
+
+    line-height: 0.8;
+
+    user-select: none;
+    pointer-events: none;
+  }
+
+  span {
+    display: inline-block;
+  }
+
+  .animated {
+    position: relative;
+
+    background: linear-gradient(
+      to right,
+      var(--skeleton-text-background) 8%,
+      var(--skeleton-text-background-animated) 18%,
+      var(--skeleton-text-background) 33%
+    );
+    background-size: 800px 104px;
+    animation-duration: 1s;
+    animation-fill-mode: forwards;
+    animation-iteration-count: infinite;
+    animation-name: skeleton-text-shimmer;
+    animation-timing-function: linear;
+  }
+
+  /* -global- */
+  @keyframes -global-skeleton-text-shimmer {
+    0% {
+      background-position: -400px 0;
+    }
+
+    100% {
+      background-position: 400px 0;
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonText.svelte
@@ -17,7 +17,10 @@
     margin: calc(var(--padding) / 2) 0;
 
     --skeleton-text-background: rgba(var(--light-background-rgb), 0.065);
-    --skeleton-text-background-animated: rgba(var(--light-background-rgb), 0.135);
+    --skeleton-text-background-animated: rgba(
+      var(--light-background-rgb),
+      0.135
+    );
     background: var(--skeleton-text-background);
 
     line-height: 0.8;

--- a/frontend/svelte/src/tests/lib/modals/VoteHistoryCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/VoteHistoryCard.spec.ts
@@ -66,7 +66,9 @@ describe("VoteHistoryCard", () => {
     });
 
     await waitFor(() =>
-      expect(container.querySelectorAll("div.markdown").length).toEqual(2)
+      expect(
+        container.querySelectorAll('[data-tid="markdown-text"]').length
+      ).toEqual(2)
     );
 
     expect(
@@ -76,5 +78,15 @@ describe("VoteHistoryCard", () => {
     expect(
       getByText((mockProposals[1].proposal as Proposal).summary)
     ).toBeInTheDocument();
+  });
+
+  it("should render skeleton texts", async () => {
+    const { container } = render(VotingHistoryCard, {
+      props,
+    });
+
+    expect(
+      container.querySelectorAll('[data-tid="skeleton-text"]').length
+    ).toEqual(props.neuron.recentBallots.length * 5);
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/VoteHistoryCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/VoteHistoryCard.spec.ts
@@ -86,7 +86,7 @@ describe("VoteHistoryCard", () => {
     });
 
     expect(
-      container.querySelectorAll('[data-tid="skeleton-text"]').length
+      container.querySelectorAll('[data-tid="skeleton-paragraph"]').length
     ).toEqual(props.neuron.recentBallots.length * 5);
   });
 });


### PR DESCRIPTION
# Motivation

Loading voting history can take time and displaying another or multiple additional spinners would look weird. That's why we can present skeleton text while we are loading all the proposals of the selected voting history.

# Changes

- add ui element `SkeletonText`
- display skeleton texts until voting history proposal is loaded

# Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/16886711/159218455-83381401-5ad3-494f-b215-80bd9d43f47c.gif)

