### PR TITLE
Amd64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       DFX_VERSION: 0.8.3
       RUSTC_VERSION: 1.58.1
       FLUTTER_VERSION: 2.2.3
-      IC_CDK_OPTIMIZER_VERSION: 0.3.1
     steps:
       - uses: actions/checkout@v2
 
@@ -54,24 +53,8 @@ jobs:
           rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
-      # Cache the ic-cdk-optimizer
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.local/bin/ic-cdk-optimizer
-            target
-          key: ${{ runner.os }}-ic-cdk-optimizer-${{ env.IC_CDK_OPTIMIZER_VERSION }}
-
-      - name: Install ic-cdk-optimizer
-        run: |
-          install_dir="$HOME/.local/bin/"
-          mkdir -p "$install_dir"
-          if [ ! -x "$install_dir/ic-cdk-optimizer" ]
-          then
-            cargo install --version "$IC_CDK_OPTIMIZER_VERSION" ic-cdk-optimizer
-            cp $HOME/.cargo/bin/ic-cdk-optimizer "$install_dir"
-            echo "$install_dir" >> $GITHUB_PATH
-          fi
+      - name: Install wassm-opt
+        run: apt-get update && apt-get install -yy binaryen
 
       - name: Install DFX
         run: |
@@ -87,7 +70,7 @@ jobs:
           npm --version
           rustc --version
           cargo --version
-          ic-cdk-optimizer --version
+          wasm-opt --version
 
       - name: Start replica
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
           rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
-      - name: Install wassm-opt
-        run: apt-get update && apt-get install -yy binaryen
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -yy binaryen
 
       - name: Install DFX
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ ENV NODE_VERSION=16.13.2
 
 ENV TZ=UTC
 
+ENV RUST_BACKTRACE=full
+
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
         build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
-        git jq
+        git jq binaryen
 
 # Install node
 RUN curl --fail -sSf https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
@@ -46,9 +48,6 @@ ENV PATH=/cargo/bin:$PATH
 RUN curl https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_2.2.3-stable.tar.xz -o flutter.tar.xz
 RUN tar xJf flutter.tar.xz
 ENV PATH=/flutter/bin:$PATH
-
-# Install IC CDK optimizer
-RUN cargo install --version 0.3.1 ic-cdk-optimizer
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependecies, we pretend that our project is a simple, empty

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@
 # into build/web. The frontend/svelte is built into public/. Both the dart
 # output (build/web/) and svelte output (public/) are bundled into a tarball,
 # assets.tar.xz. This tarball is baked into the wasm binary output at build
-# time by cargo, and finally the wasm binary is read by ic-cdk-optimizer and
-# optimizer. This scripts outputs a single file, nns-dapp.wasm.
+# time by cargo, and finally the wasm binary is read by an optimizer. These
+# scripts outputs a single file, nns-dapp.wasm.
 #
 #              ic_agent.js               build/web/
 #  frontend/ts◄────────────frontend/dart ◄──────────┐
@@ -16,7 +16,7 @@
 #                                                           │
 #                                                      cargo build
 #                                                           ▲
-#                                                           │ ic-cdk-optimizer
+#                                                           │ wasm optimizer
 #                                                           │
 #                                                      nns-dapp.wasm
 
@@ -112,11 +112,11 @@ fi
 
 (cd "$TOPLEVEL" && cargo build "${cargo_args[@]}")
 
-####################
-# ic-cdk-optimizer # (output: nns-dapp.wasm)
-####################
+##################
+# wasm optimizer # (output: nns-dapp.wasm)
+##################
 echo Optimising wasm
 cd "$TOPLEVEL"
-ic-cdk-optimizer ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
+wasm-opt -O2 ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
 ls -sh ./nns-dapp.wasm
 sha256sum ./nns-dapp.wasm

--- a/build.sh
+++ b/build.sh
@@ -117,6 +117,6 @@ fi
 ##################
 echo Optimising wasm
 cd "$TOPLEVEL"
-wasm-opt -O2 ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
+wasm-opt -O2 --strip-debug --shrink-level 2 ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
 ls -sh ./nns-dapp.wasm
 sha256sum ./nns-dapp.wasm

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -47,6 +47,7 @@ assets=(assets.tar.xz nns-dapp.wasm build-inputs.txt)
 
 set -x
 DOCKER_BUILDKIT=1 docker build \
+  --platform=linux/amd64 \
   --target scratch \
   --build-arg DEPLOY_ENV="$DEPLOY_ENV" \
   --build-arg OWN_CANISTER_ID="$OWN_CANISTER_ID" \


### PR DESCRIPTION
# Motivation
Docker builds fail on mac.

# Changes
- Specify the architecture in the docker run command.
- Use wasm-opt directly rather than through the ic-cdk-optimizer wrapper.

# Tests
### Intel mac:
```
7229f6613882e71c8885bdb28a1b6e4070f969265eb74fdefa713df8cd9d487f  assets.tar.xz
9bce3ac05bb9bb4f654a86fb531b99a362ebe2fe2c615355170280dc055ee1e9  nns-dapp.wasm
a0222e1dc6c44bb4832248646dfc469db9455f787ba4782f80d537c7215e3ae1  build-inputs.txt
FIN
SUCCESS (7:56): ./scripts/docker-build
max@Maximillian-Murphys-MacBook-Pro:~/dfn/nns-dapp (7:56)$ git rev-parse HEAD
c5424903f857912dbb0f7838e60e882a250a2266
SUCCESS (0): git rev-parse HEAD
```
### Linux AMD64
```
7229f6613882e71c8885bdb28a1b6e4070f969265eb74fdefa713df8cd9d487f  assets.tar.xz
9bce3ac05bb9bb4f654a86fb531b99a362ebe2fe2c615355170280dc055ee1e9  nns-dapp.wasm
151bfe8905e274a27edff6b295b1e3090645355d77887d30966c9407e8f420a5  build-inputs.txt
FIN
max@sinkpad:~/dfn/nns-dapp/branches/amd64 (9:33)$ git rev-parse HEAD
c5424903f857912dbb0f7838e60e882a250a2266
max@sinkpad:~/dfn/nns-dapp/branches/amd64 (17:12)$ 
```