### PR TITLE
Unblock builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -83,7 +83,7 @@ jobs:
          SHA="$(sha256sum < "${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm")"
          git fetch origin "+${NOTE}:${NOTE}"
          if git notes --ref="${{ matrix.BUILD_NAME }}/wasm-sha" add -m "$SHA"
-         then git push origin "${NOTE}:${NOTE}"
+         then git push origin "${NOTE}:${NOTE}" || true
          else echo SHA already set
          fi
       - name: "Verify that the WASM module is small enough to deploy"


### PR DESCRIPTION
# Motivation
Builds are failing because of the git notes.

A quick resolution is needed to stop breaking other PRs, a deeper solution can follow.

Diagnosis:
The code does a git fetch to get the notes, however it looks as if it should be doing something like a git reset --hard origin/notes/* of just the notes.  Doing that properly will require learning more about notes.

# Changes
- Ignore git note failures

# Tests