### PR TITLE
Fix: Do not allow Eslint warnings

### DIFF
--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run import-assets && npm run i18n && BASE_HREF=/ ROLLUP_WATCH=true npm run build:index && rollup -c -w",
     "start": "sirv public",
     "check": "svelte-check --tsconfig ./tsconfig.json && npm run lint",
-    "lint": "eslint './src/**/*.{js,ts,svelte}'",
+    "lint": "eslint --max-warnings 0 './src/**/*.{js,ts,svelte}'",
     "format": "prettier --write --plugin-search-dir=. .",
     "test": "jest",
     "test:watch": "npm run test -- --watchAll",

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronFollowingCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronFollowingCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-354 -->
-  Following Card
+  Following Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronHotkeysCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronHotkeysCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-358 -->
-  Hokeys Card
+  Hokeys Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-353 -->
-  Maturity Card
+  Maturity Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-352 -->
-  Meta Info Card
+  Meta Info Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronProposalsCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronProposalsCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-355 -->
-  Proposals Card
+  Proposals Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronVotingHistoryCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronVotingHistoryCard.svelte
@@ -7,5 +7,5 @@
 
 <Card>
   <!-- TODO: https://dfinity.atlassian.net/browse/L2-359 -->
-  Voting History Card
+  Voting History Card {neuron.neuronId}
 </Card>

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -8,7 +8,6 @@ import { mock } from "jest-mock-extended";
 import App from "../App.svelte";
 import { NNSDappCanister } from "../lib/canisters/nns-dapp/nns-dapp.canister";
 import { worker } from "../lib/services/worker.services";
-import type { AuthStore } from "../lib/stores/auth.store";
 import { authStore } from "../lib/stores/auth.store";
 import { mockAccountDetails } from "./mocks/accounts.store.mock";
 import {
@@ -19,7 +18,7 @@ import {
 
 jest.mock("../lib/services/worker.services", () => ({
   worker: {
-    syncAuthIdle: jest.fn((auth: AuthStore) => Promise.resolve()),
+    syncAuthIdle: jest.fn(() => Promise.resolve()),
   },
 }));
 

--- a/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/governance.canister.mock.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
   ICP,
   LedgerCanister,


### PR DESCRIPTION
# Motivation

Max Lint Warnings of 0.

# Changes

* Change in `npm run lint` to set max warnings to 0.
* Fix current lint warnings.

# Tests

No new tests
