### PR TITLE
fix: card-block max height

### DIFF
--- a/frontend/svelte/src/lib/components/ui/CardBlock.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardBlock.svelte
@@ -24,7 +24,7 @@
     </Collapsible>
   {:else}
     <h3><slot name="title" /></h3>
-    <div class="content">
+    <div class="content limit-height">
       <slot />
     </div>
   {/if}
@@ -71,5 +71,10 @@
 
   .content {
     margin: calc(2 * var(--padding)) 0 var(--padding);
+
+    &.limit-height {
+      max-height: 300px;
+      overflow-y: auto;
+    }
   }
 </style>


### PR DESCRIPTION
# Motivation

Fix CardBlock max height (see screenshots)

## Before
<img width="640" alt="Screenshot 2022-03-22 at 09 08 01" src="https://user-images.githubusercontent.com/98811342/159435674-6cbd3941-4df5-449a-8ea3-b3eaec1f1f1f.png">
## After
<img width="1375" alt="Screenshot 2022-03-22 at 09 06 57" src="https://user-images.githubusercontent.com/98811342/159435685-344daa9c-031e-4eeb-b661-74a973751ddb.png">

