### PR TITLE
L2-322: Stake neurons from subaccounts

### DIFF
--- a/frontend/svelte/src/lib/api/accounts.api.ts
+++ b/frontend/svelte/src/lib/api/accounts.api.ts
@@ -14,6 +14,34 @@ import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
 import { createAgent } from "../utils/agent.utils";
 
+// export const transferIcpstest = async () => {
+//   const auth = get(authStore);
+//   if (auth.identity) {
+//     const agent = await createAgent({
+//       identity: auth.identity,
+//       host: identityServiceURL,
+//     });
+//     const ledger: LedgerCanister = LedgerCanister.create({
+//       agent,
+//       canisterId: LEDGER_CANISTER_ID,
+//     });
+//     const accounts = get(accountsStore);
+//     if (accounts.subAccounts && accounts.subAccounts.length > 0) {
+//       const firstSubaccount = accounts.subAccounts[0];
+//       console.log("subaccount", firstSubaccount);
+//       try {
+//         await ledger.transfer({
+//           to: AccountIdentifier.fromHex(firstSubaccount.identifier),
+//           amount: ICP.fromString("5") as ICP,
+//         });
+//         console.log("after da transfer");
+//       } catch (error) {
+//         console.error(error);
+//       }
+//     }
+//   }
+// };
+
 export const loadAccounts = async ({
   identity,
 }: {
@@ -46,8 +74,9 @@ export const loadAccounts = async ({
       certified: true,
     });
     return {
-      identifier: mainAccount.account_identifier,
+      identifier: account.account_identifier,
       balance,
+      subAccount: "sub_account" in account ? account.sub_account : undefined,
       // Account does not have "name" property. Typescript needed a check like this.
       name: "name" in account ? account.name : undefined,
     };

--- a/frontend/svelte/src/lib/api/accounts.api.ts
+++ b/frontend/svelte/src/lib/api/accounts.api.ts
@@ -14,34 +14,6 @@ import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
 import { createAgent } from "../utils/agent.utils";
 
-// export const transferIcpstest = async () => {
-//   const auth = get(authStore);
-//   if (auth.identity) {
-//     const agent = await createAgent({
-//       identity: auth.identity,
-//       host: identityServiceURL,
-//     });
-//     const ledger: LedgerCanister = LedgerCanister.create({
-//       agent,
-//       canisterId: LEDGER_CANISTER_ID,
-//     });
-//     const accounts = get(accountsStore);
-//     if (accounts.subAccounts && accounts.subAccounts.length > 0) {
-//       const firstSubaccount = accounts.subAccounts[0];
-//       console.log("subaccount", firstSubaccount);
-//       try {
-//         await ledger.transfer({
-//           to: AccountIdentifier.fromHex(firstSubaccount.identifier),
-//           amount: ICP.fromString("5") as ICP,
-//         });
-//         console.log("after da transfer");
-//       } catch (error) {
-//         console.error(error);
-//       }
-//     }
-//   }
-// };
-
 export const loadAccounts = async ({
   identity,
 }: {
@@ -76,8 +48,8 @@ export const loadAccounts = async ({
     return {
       identifier: account.account_identifier,
       balance,
+      // AccountDetails does not have "name" or "sub_account" property. Typescript needed a check like this.
       subAccount: "sub_account" in account ? account.sub_account : undefined,
-      // Account does not have "name" property. Typescript needed a check like this.
       name: "name" in account ? account.name : undefined,
     };
   };

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -6,11 +6,13 @@ import {
   LedgerCanister,
   StakeNeuronError,
 } from "@dfinity/nns";
+import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import {
   GOVERNANCE_CANISTER_ID,
   LEDGER_CANISTER_ID,
 } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
+import { toSubAccountId } from "./utils.api";
 
 export const queryNeuron = async ({
   neuronId,
@@ -89,16 +91,16 @@ export const queryNeurons = async ({
 };
 
 /**
- * Uses governance and ledger canisters to create a neuron and adds it to the store
- *
- * TODO: L2-322 Create neurons from subaccount
+ * Uses governance and ledger canisters to create a neuron
  */
 export const stakeNeuron = async ({
   stake,
   identity,
+  fromSubAccount,
 }: {
   stake: ICP;
   identity: Identity;
+  fromSubAccount?: SubAccountArray;
 }): Promise<NeuronId> => {
   const { canister, agent } = await governanceCanister({ identity });
 
@@ -107,9 +109,12 @@ export const stakeNeuron = async ({
     canisterId: LEDGER_CANISTER_ID,
   });
 
+  const fromSubAccountId =
+    fromSubAccount !== undefined ? toSubAccountId(fromSubAccount) : undefined;
   const response = await canister.stakeNeuron({
     stake,
     principal: identity.getPrincipal(),
+    fromSubAccountId,
     ledgerCanister,
   });
 

--- a/frontend/svelte/src/lib/api/utils.api.ts
+++ b/frontend/svelte/src/lib/api/utils.api.ts
@@ -1,18 +1,5 @@
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 
-// Source: as in ts/src/canisters/converters.ts
-export const arrayOfNumberToUint8Array = (
-  numbers: Array<number>
-): Uint8Array => {
-  return new Uint8Array(numbers);
-};
-
-export const arrayOfNumberToArrayBuffer = (
-  numbers: Array<number>
-): ArrayBuffer => {
-  return arrayOfNumberToUint8Array(numbers).buffer;
-};
-
 export const arrayBufferToNumber = (buffer: ArrayBuffer): number => {
   const view = new DataView(buffer);
   return view.getUint32(view.byteLength - 4);
@@ -20,11 +7,12 @@ export const arrayBufferToNumber = (buffer: ArrayBuffer): number => {
 
 /**
  * Converts a subAccount from NNS Dapp canister to the type that nns-js needs.
+ * as in ts/src/canisters/converters.ts
  *
  * @param subAccount Array<number> from SubAccountArray type in nns-dapp canister
  * @returns subAccountId that `ledgerCanister` from nns-js requires.
  */
 export const toSubAccountId = (subAccount: SubAccountArray): number => {
-  const bytes = arrayOfNumberToArrayBuffer(subAccount);
+  const bytes = new Uint8Array(subAccount).buffer;
   return arrayBufferToNumber(bytes);
 };

--- a/frontend/svelte/src/lib/api/utils.api.ts
+++ b/frontend/svelte/src/lib/api/utils.api.ts
@@ -1,0 +1,30 @@
+import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
+
+// Source: as in ts/src/canisters/converters.ts
+export const arrayOfNumberToUint8Array = (
+  numbers: Array<number>
+): Uint8Array => {
+  return new Uint8Array(numbers);
+};
+
+export const arrayOfNumberToArrayBuffer = (
+  numbers: Array<number>
+): ArrayBuffer => {
+  return arrayOfNumberToUint8Array(numbers).buffer;
+};
+
+export const arrayBufferToNumber = (buffer: ArrayBuffer): number => {
+  const view = new DataView(buffer);
+  return view.getUint32(view.byteLength - 4);
+};
+
+/**
+ * Converts a subAccount from NNS Dapp canister to the type that nns-js needs.
+ *
+ * @param subAccount Array<number> from SubAccountArray type in nns-dapp canister
+ * @returns subAccountId that `ledgerCanister` from nns-js requires.
+ */
+export const toSubAccountId = (subAccount: SubAccountArray): number => {
+  const bytes = arrayOfNumberToArrayBuffer(subAccount);
+  return arrayBufferToNumber(bytes);
+};

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -26,7 +26,6 @@
   }
   let stateStep = new StepsState<typeof Steps>(Steps);
 
-  // TODO: Get all the accounts and be able to select one https://dfinity.atlassian.net/browse/L2-322
   let selectedAccount: Account | undefined;
   const unsubscribeAccounts: Unsubscriber = accountsStore.subscribe(
     (accountStore) => {
@@ -41,8 +40,10 @@
     currentStep
   );
 
-  const chooseAccount = () => {
-    // TODO: Stake Neurons From subaccounts https://dfinity.atlassian.net/browse/L2-322
+  const chooseAccount = ({
+    detail,
+  }: CustomEvent<{ selectedAccount: Account }>) => {
+    selectedAccount = detail.selectedAccount;
     stateStep = stateStep.next();
   };
   const goBack = () => {
@@ -93,10 +94,7 @@
     <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
     {#if currentStep === Steps.SelectAccount && selectedAccount}
       <Transition {diff}>
-        <SelectAccount
-          main={selectedAccount}
-          on:nnsSelectAccount={chooseAccount}
-        />
+        <SelectAccount on:nnsSelectAccount={chooseAccount} />
       </Transition>
     {/if}
     <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->

--- a/frontend/svelte/src/lib/modals/neurons/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SelectAccount.svelte
@@ -2,21 +2,35 @@
   import { createEventDispatcher } from "svelte";
   import AccountCard from "../../components/accounts/AccountCard.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
+  import { accountsStore } from "../../stores/accounts.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
 
-  export let main: Account;
   const dispatch = createEventDispatcher();
-  const chooseAccount = () => {
-    dispatch("nnsSelectAccount", main);
+  const chooseAccount = (selectedAccount: Account) => {
+    dispatch("nnsSelectAccount", { selectedAccount });
   };
+  let { main: mainAccount } = $accountsStore;
 </script>
 
 <h4>{$i18n.neurons.my_accounts}</h4>
-{#if main}
-  <AccountCard role="button" on:click={chooseAccount} account={main}
-    >{$i18n.accounts.main}</AccountCard
+{#if mainAccount}
+  <!-- Needed mainAccount && because TS didn't learn that `mainAccount` is present in the click listener -->
+  <AccountCard
+    role="button"
+    on:click={() => mainAccount && chooseAccount(mainAccount)}
+    account={mainAccount}>{$i18n.accounts.main}</AccountCard
   >
+  {#if $accountsStore.subAccounts}
+    {#each $accountsStore.subAccounts as subAccount}
+      <AccountCard
+        role="button"
+        on:click={() => chooseAccount(subAccount)}
+        account={subAccount}>{subAccount.name}</AccountCard
+      >
+    {/each}
+  {/if}
 {:else}
+  <!-- TODO: https://dfinity.atlassian.net/browse/L2-411 Add Text Skeleton while loading -->
   <Spinner />
 {/if}

--- a/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
@@ -26,6 +26,8 @@
       const neuronId = await stakeAndLoadNeuron({
         amount,
         identity: $authStore.identity,
+        fromSubAccount:
+          "subAccount" in account ? account.subAccount : undefined,
       });
 
       // We don't wait for `syncAccounts` to finish to give a better UX to the user.

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -9,6 +9,7 @@ import {
   setFollowees,
   stakeNeuron,
 } from "../api/governance.api";
+import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import { i18n } from "../stores/i18n";
 import { neuronsStore } from "../stores/neurons.store";
@@ -18,16 +19,17 @@ import { getLastPathDetailId } from "../utils/app-path.utils";
 import { errorToString } from "../utils/error.utils";
 
 /**
- * Uses governance and ledger canisters to create a neuron and adds it to the store
+ * Uses governance api to create a neuron and adds it to the store
  *
- * TODO: L2-322 Create neurons from subaccount
  */
 export const stakeAndLoadNeuron = async ({
   amount,
   identity,
+  fromSubAccount,
 }: {
   amount: number;
   identity: Identity | null | undefined;
+  fromSubAccount?: SubAccountArray;
 }): Promise<NeuronId> => {
   const stake = ICP.fromString(String(amount));
 
@@ -44,7 +46,11 @@ export const stakeAndLoadNeuron = async ({
     throw new Error("No identity");
   }
 
-  const neuronId: NeuronId = await stakeNeuron({ stake, identity });
+  const neuronId: NeuronId = await stakeNeuron({
+    stake,
+    identity,
+    fromSubAccount,
+  });
 
   await loadNeuron({
     neuronId,

--- a/frontend/svelte/src/lib/types/account.ts
+++ b/frontend/svelte/src/lib/types/account.ts
@@ -1,8 +1,10 @@
 import type { ICP } from "@dfinity/nns";
+import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 
 export interface Account {
   identifier: string;
   balance: ICP;
-  // Subaccounts have name
+  // Subaccounts have name and subAccount
   name?: string;
+  subAccount?: SubAccountArray;
 }

--- a/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
@@ -16,7 +16,10 @@ import {
 import { accountsStore } from "../../../lib/stores/accounts.store";
 import { authStore } from "../../../lib/stores/auth.store";
 import { neuronsStore } from "../../../lib/stores/neurons.store";
-import { mockAccountsStoreSubscribe } from "../../mocks/accounts.store.mock";
+import {
+  mockAccountsStoreSubscribe,
+  mockSubAccount,
+} from "../../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import {
   buildMockNeuronsStoreSubscribe,
@@ -43,7 +46,7 @@ describe("CreateNeuronModal", () => {
   beforeEach(() => {
     jest
       .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -76,6 +79,22 @@ describe("CreateNeuronModal", () => {
     accountCard && (await fireEvent.click(accountCard));
 
     expect(queryByText(en.neurons.stake_neuron)).not.toBeNull();
+  });
+
+  it("should be able to select a subaccount and move to the next view", async () => {
+    const { container, queryByText } = render(CreateNeuronModal);
+
+    const accountCards = container.querySelectorAll('article[role="button"]');
+    expect(accountCards.length).toBe(2);
+
+    const subAccountCard = queryByText(mockSubAccount.name as string, {
+      exact: false,
+    });
+
+    subAccountCard && (await fireEvent.click(subAccountCard));
+
+    expect(queryByText(en.neurons.stake_neuron)).toBeInTheDocument();
+    expect(queryByText(mockSubAccount.identifier)).toBeInTheDocument();
   });
 
   it("should have disabled Create neuron button", async () => {


### PR DESCRIPTION
# Motivation

User can stake a neuron from subaccounts.

# Changes

* Add subaccounts to SelectAccount screen in CreatenNeuronModal.
* Add `fromSubAccount` parameter to all the stake neuron flow.
* New helper to transform from SubAccountArray to number that is needed for nns-js.

# Tests

* New test to check that user can select a subaccount in CreatenNeuronModal.
