### PR TITLE
refactor: toast error

### DIFF
--- a/frontend/svelte/src/lib/components/common/Guard.svelte
+++ b/frontend/svelte/src/lib/components/common/Guard.svelte
@@ -9,8 +9,7 @@
     try {
       await authStore.sync();
     } catch (err) {
-      toastsStore.show({ labelKey: "error.auth_sync", level: "error" });
-      console.error(err);
+      toastsStore.error({ labelKey: "error.auth_sync", err });
     }
   };
 </script>

--- a/frontend/svelte/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/svelte/src/lib/components/ic/GetICPs.svelte
@@ -7,7 +7,6 @@
   import { getICPs } from "../../services/dev.services";
   import Spinner from "../ui/Spinner.svelte";
   import { toastsStore } from "../../stores/toasts.store";
-  import { errorToString } from "../../utils/error.utils";
 
   let visible: boolean = false;
   let transferring: boolean = false;
@@ -16,9 +15,8 @@
 
   const onSubmit = async ({ target }) => {
     if (invalidForm) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "Invalid ICPs input.",
-        level: "error",
       });
       return;
     }
@@ -33,11 +31,9 @@
 
       reset();
     } catch (err: unknown) {
-      console.error(err);
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "ICPs could not be transferred.",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
     }
 

--- a/frontend/svelte/src/lib/modals/accounts/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/AddNewAccount.svelte
@@ -9,7 +9,6 @@
     SubAccountLimitExceededError,
   } from "../../canisters/nns-dapp/nns-dapp.errors";
   import { toastsStore } from "../../stores/toasts.store";
-  import { errorToString } from "../../utils/error.utils";
   import { authStore } from "../../stores/auth.store";
 
   let newAccountName: string = "";
@@ -31,12 +30,10 @@
           : err instanceof SubAccountLimitExceededError
           ? "create_subaccount_limit_exceeded"
           : "create_subaccount";
-      toastsStore.show({
+      toastsStore.error({
         labelKey,
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
-      console.error(err);
     } finally {
       creating = false;
     }

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -16,7 +16,7 @@
 
   onMount(async () => {
     if (!$authStore.identity) {
-      toastsStore.show({ labelKey: "error.missing_identity", level: "error" });
+      toastsStore.error({ labelKey: "error.missing_identity" });
       return;
     }
 
@@ -28,8 +28,7 @@
     } catch (err) {
       neuron = undefined;
 
-      toastsStore.show({ labelKey: "error.get_neuron", level: "error" });
-      console.error(err);
+      toastsStore.error({ labelKey: "error.get_neuron", err });
     }
   });
 </script>

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -233,6 +233,7 @@ const requestRegisterVotes = async ({
     .join("\n");
 
   if (errors.length > 0) {
+    // TODO: replace w/ console.error mock
     if (!isNode()) {
       // avoid in unit-test
       console.error("vote:", errorDetails);

--- a/frontend/svelte/src/lib/stores/toasts.store.ts
+++ b/frontend/svelte/src/lib/stores/toasts.store.ts
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 import type { ToastMsg } from "../types/toast";
+import { errorToString } from "../utils/error.utils";
 
 /**
  * Toast messages.
@@ -15,6 +16,15 @@ const initToastsStore = () => {
 
     show(msg: ToastMsg) {
       update((messages: ToastMsg[]) => [...messages, msg]);
+    },
+
+    error({ labelKey, err }: { labelKey: string; err?: unknown }) {
+      update((messages: ToastMsg[]) => [
+        ...messages,
+        { labelKey, level: "error", detail: errorToString(err) },
+      ]);
+
+      console.error(err);
     },
 
     hide() {

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -7,7 +7,6 @@
   import { isSignedIn } from "../lib/utils/auth.utils";
   import { i18n } from "../lib/stores/i18n";
   import { toastsStore } from "../lib/stores/toasts.store";
-  import { errorToString } from "../lib/utils/error.utils";
   import Banner from "../lib/components/common/Banner.svelte";
 
   let signedIn: boolean = false;

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -17,12 +17,10 @@
     try {
       await authStore.signIn();
     } catch (err: unknown) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "error.sign_in",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
-      console.error(err);
     }
   };
 

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -5,7 +5,6 @@
   import Toolbar from "../lib/components/ui/Toolbar.svelte";
   import { authStore } from "../lib/stores/auth.store";
   import { toastsStore } from "../lib/stores/toasts.store";
-  import { errorToString } from "../lib/utils/error.utils";
   import { listCanisters } from "../lib/services/canisters.services";
   import { canistersStore } from "../lib/stores/canisters.store";
   import Spinner from "../lib/components/ui/Spinner.svelte";
@@ -21,12 +20,10 @@
         identity: $authStore.identity,
       });
     } catch (err: unknown) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "error.list_canisters",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
-      console.error(err);
     }
 
     loading = false;

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -12,7 +12,6 @@
   import { listNeurons } from "../lib/services/neurons.services";
   import Spinner from "../lib/components/ui/Spinner.svelte";
   import { toastsStore } from "../lib/stores/toasts.store";
-  import { errorToString } from "../lib/utils/error.utils";
   import { neuronsStore } from "../lib/stores/neurons.store";
   import { routeStore } from "../lib/stores/route.store";
   import { AppPath } from "../lib/constants/routes.constants";
@@ -28,10 +27,9 @@
       isLoading = true;
       await listNeurons({ identity: $authStore.identity });
     } catch (err) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "errors.get_neurons",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
     } finally {
       isLoading = false;

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -24,7 +24,6 @@
   } from "../lib/services/proposals.services";
   import { authStore } from "../lib/stores/auth.store";
   import { toastsStore } from "../lib/stores/toasts.store";
-  import { errorToString } from "../lib/utils/error.utils";
   import { routeStore } from "../lib/stores/route.store";
   import { isRoutePath } from "../lib/utils/app-path.utils";
 
@@ -40,12 +39,10 @@
         identity: $authStore.identity,
       });
     } catch (err: unknown) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "error.list_proposals",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
-      console.error(err);
     }
 
     loading = false;
@@ -61,12 +58,10 @@
         identity: $authStore.identity,
       });
     } catch (err: unknown) {
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "error.list_proposals",
-        level: "error",
-        detail: errorToString(err),
+        err,
       });
-      console.error(err);
     }
 
     loading = false;


### PR DESCRIPTION
# Motivation

Reduce or remove duplicate code. Simplify error logging.

# Changes

- defer `consoler.error` and error parsing to `toastStore`
