### PR TITLE
feat: marked rendered types

### DIFF
--- a/frontend/svelte/jest.config.cjs
+++ b/frontend/svelte/jest.config.cjs
@@ -2,9 +2,7 @@ module.exports = {
   preset: "ts-jest",
   globals: {
     "ts-jest": {
-      tsconfig: {
-        allowJs: true,
-      },
+      tsconfig: "tsconfig.spec.json",
     },
   },
   transform: {

--- a/frontend/svelte/src/lib/components/ui/Markdown.svelte
+++ b/frontend/svelte/src/lib/components/ui/Markdown.svelte
@@ -3,19 +3,10 @@
   import ScriptLoader from "../common/ScriptLoader.svelte";
   import Spinner from "./Spinner.svelte";
   import { removeHTMLTags } from "../../utils/security.utils";
-  import { targetBlankLinkRenderer } from "../../utils/utils";
-
+  import { renderer } from "../../utils/markdown.utils";
   type Marked = typeof marked;
-  type Renderer = marked.Renderer;
 
   export let text: string | undefined;
-
-  const renderer = (marked: Marked): Renderer => {
-    const renderer = new marked.Renderer();
-    // custom link renderer
-    renderer.link = targetBlankLinkRenderer;
-    return renderer;
-  };
 
   // do not load the lib if available
   /* eslint-disable-next-line no-undef */

--- a/frontend/svelte/src/lib/utils/markdown.utils.ts
+++ b/frontend/svelte/src/lib/utils/markdown.utils.ts
@@ -1,0 +1,11 @@
+import {targetBlankLinkRenderer} from './utils';
+import type { marked as markedTypes, Renderer } from "marked";
+
+type Marked = typeof markedTypes;
+
+export const renderer = (marked: Marked): Renderer => {
+    const renderer = new marked.Renderer();
+    // custom link renderer
+    renderer.link = targetBlankLinkRenderer;
+    return renderer;
+};

--- a/frontend/svelte/src/lib/utils/markdown.utils.ts
+++ b/frontend/svelte/src/lib/utils/markdown.utils.ts
@@ -1,11 +1,11 @@
-import {targetBlankLinkRenderer} from './utils';
 import type { marked as markedTypes, Renderer } from "marked";
+import { targetBlankLinkRenderer } from "./utils";
 
 type Marked = typeof markedTypes;
 
 export const renderer = (marked: Marked): Renderer => {
-    const renderer = new marked.Renderer();
-    // custom link renderer
-    renderer.link = targetBlankLinkRenderer;
-    return renderer;
+  const renderer = new marked.Renderer();
+  // custom link renderer
+  renderer.link = targetBlankLinkRenderer;
+  return renderer;
 };

--- a/frontend/svelte/src/tests/lib/components/ui/Markdown.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Markdown.spec.ts
@@ -5,13 +5,19 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import Markdown from "../../../../lib/components/ui/Markdown.svelte";
+import { targetBlankLinkRenderer } from "../../../../lib/utils/utils";
 
 const HTML_TEXT = "<p>demo<p>";
+
+class Renderer {
+  link: () => void;
+}
 
 describe("Markdown", () => {
   beforeEach(() => {
     globalThis.marked = {
       parse: jest.fn(() => HTML_TEXT),
+      Renderer,
     };
   });
 
@@ -38,6 +44,7 @@ describe("Markdown", () => {
     // lib load mock
     globalThis.marked = {
       parse: jest.fn(() => HTML_TEXT),
+      Renderer,
     };
 
     expect(container.querySelector("svg")).toBeInTheDocument();
@@ -59,6 +66,8 @@ describe("Markdown", () => {
       props: { text: "<script>alert('hack')</script>" },
     });
     await tick();
-    expect(globalThis.marked.parse).toBeCalledWith("alert('hack')");
+    expect(globalThis.marked.parse).toBeCalledWith("alert('hack')", {
+      renderer: { link: targetBlankLinkRenderer },
+    });
   });
 });

--- a/frontend/svelte/tsconfig.spec.json
+++ b/frontend/svelte/tsconfig.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
# Introduction

This PR is a branch of a branch so that @mstrasinskis can have a look and use what he think is useful or not for his PR.

# Motivation

I extracted the function to a utils because it was easier to debug.

I think the tests did not work out mostly because the mock had to be extended with the new `Rendered()` class.

I also extracted the `tsconfig` for the jest spec tests to a separate file. Not sure it is needed but it does not arm in any case.

