### PR TITLE
L2 417 apply query and update strategy to get neuron

### DIFF
--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -17,14 +17,16 @@ import { toSubAccountId } from "./utils.api";
 export const queryNeuron = async ({
   neuronId,
   identity,
+  certified,
 }: {
   neuronId: NeuronId;
   identity: Identity;
+  certified: boolean;
 }): Promise<NeuronInfo | undefined> => {
   const { canister } = await governanceCanister({ identity });
 
   return canister.getNeuron({
-    certified: true,
+    certified,
     principal: identity.getPrincipal(),
     neuronId,
   });

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -24,7 +24,6 @@
     "create_subaccount_limit_exceeded": "Sorry, you reached the limit of subaccounts in this account.",
     "get_neurons": "There was an unexpected issue while searching for the neurons.",
     "get_known_neurons": "There was an unexpected issue while searching for the known neurons.",
-    "get_neuron": "There was an unexpected issue while loading the neuron.",
     "register_vote": "Sorry, there was an error while registering the vote. Please try again.",
     "register_vote_unknown": "Sorry, there was an unexpectedf error while registering the vote. Please try again later.",
     "add_followee": "Sorry, there was an unexpectedf error while adding the followee. Please try again later.",

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -20,6 +20,7 @@
       return;
     }
 
+    // The fetched neuron belongs to a proposer so it should not be added to the neuronsStore
     loadNeuron({
       neuronId: proposer,
       identity: $authStore.identity,

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -10,6 +10,7 @@
   import { onMount } from "svelte";
   import VotingHistoryCard from "../../components/neurons/VotingHistoryCard.svelte";
   import { authStore } from "../../stores/auth.store";
+  import { loadNeuron } from "../../services/neurons.services";
 
   export let proposer: NeuronId;
   let neuron: NeuronInfo | undefined;
@@ -20,16 +21,12 @@
       return;
     }
 
-    try {
-      neuron = await queryNeuron({
-        neuronId: proposer,
-        identity: $authStore.identity,
-      });
-    } catch (err) {
-      neuron = undefined;
-
-      toastsStore.error({ labelKey: "error.get_neuron", err });
-    }
+    loadNeuron({
+      neuronId: proposer,
+      identity: $authStore.identity,
+      setNeuron: (neuronInfo) => (neuron = neuronInfo),
+      handleError: (neuron = undefined),
+    });
   });
 </script>
 

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -3,7 +3,6 @@
   import type { NeuronId } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { queryNeuron } from "../../api/governance.api";
   import Spinner from "../../components/ui/Spinner.svelte";
   import NeuronCard from "../../components/neurons/NeuronCard.svelte";
   import { toastsStore } from "../../stores/toasts.store";

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -28,7 +28,6 @@ interface I18nError {
   create_subaccount_limit_exceeded: string;
   get_neurons: string;
   get_known_neurons: string;
-  get_neuron: string;
   register_vote: string;
   register_vote_unknown: string;
   add_followee: string;

--- a/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
@@ -65,6 +65,7 @@ describe("neurons-api", () => {
     const neuron = await queryNeuron({
       neuronId: mockNeuron.neuronId,
       identity: mockIdentity,
+      certified: true,
     });
 
     expect(mockGovernanceCanister.getNeuron).toBeCalled();

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1,6 +1,7 @@
 import type { NeuronInfo } from "@dfinity/nns";
 import { LedgerCanister, Topic } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
+import { tick } from "svelte/internal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/governance.api";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
@@ -225,29 +226,27 @@ describe("neurons-services", () => {
   });
 
   describe("load neuron", () => {
-    it("should get neuron from neurons store if presented and not call queryNeuron", (done) => {
+    it("should get neuron from neurons store if presented and not call queryNeuron", async () => {
       neuronsStore.pushNeurons([mockNeuron]);
-      loadNeuron({
+      await loadNeuron({
         neuronId: mockNeuron.neuronId,
         identity: mockIdentity,
         setNeuron: (neuron: NeuronInfo) => {
-          expect(neuron?.neuronId).toBe(mockNeuron.neuronId);
-          expect(spyGetNeuron).not.toBeCalled();
           neuronsStore.setNeurons([]);
-          done();
+          expect(neuron?.neuronId).toBe(mockNeuron.neuronId);
         },
       });
+      await tick();
+      expect(spyGetNeuron).not.toBeCalled();
     });
 
-    it("should call the api to get neuron if not in store", (done) => {
-      loadNeuron({
+    it("should call the api to get neuron if not in store", async () => {
+      await loadNeuron({
         neuronId: mockNeuron.neuronId,
         identity: mockIdentity,
-        setNeuron: () => {
-          expect(spyGetNeuron).toBeCalled();
-          done();
-        },
+        setNeuron: jest.fn,
       });
+      expect(spyGetNeuron).toBeCalled();
     });
   });
 });


### PR DESCRIPTION
# Motivation

Switch to queryAndUpdate approach for loading a neuron

[L2-417](https://dfinity.atlassian.net/browse/L2-417)

# Changes

- `i18n.error.get_neuron` was removed because the error handling is done in neuron service

# Tests

- no extra tests are necessary
