### PR TITLE
feat: clear storage and reload browser on idle auth

### DIFF
--- a/frontend/svelte/src/lib/components/common/Logout.svelte
+++ b/frontend/svelte/src/lib/components/common/Logout.svelte
@@ -1,18 +1,9 @@
 <script lang="ts">
-  import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
-
-  const logout = async () => {
-    await authStore.signOut();
-
-    window.localStorage.clear();
-
-    // We reload the page to make sure all the states are cleared
-    window.location.reload();
-  };
+  import { logout } from "../../services/auth.services";
 </script>
 
-<button on:click={logout} class="text">{$i18n.header.logout}</button>
+<button on:click={() => logout({})} class="text">{$i18n.header.logout}</button>
 
 <style lang="scss">
   button {

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -1,0 +1,82 @@
+import { authStore } from "../stores/auth.store";
+import { toastsStore } from "../stores/toasts.store";
+import type { ToastLevel, ToastMsg } from "../types/toast";
+import { replaceHistory } from "../utils/route.utils";
+
+const msgParam: string = "msg";
+const levelParam: string = "level";
+
+export const logout = async ({
+  msg = undefined,
+}: {
+  msg?: Pick<ToastMsg, "labelKey" | "level">;
+}) => {
+  await authStore.signOut();
+
+  appendOptionalMsgToUrl(msg);
+
+  window.localStorage.clear();
+
+  // We reload the page to make sure all the states are cleared
+  window.location.reload();
+};
+
+/**
+ * If a message was provided to the logout process - e.g. a message informing the logout happened because the session timedout - append the information to the url as query params
+ */
+const appendOptionalMsgToUrl = (msg?: Pick<ToastMsg, "labelKey" | "level">) => {
+  if (!msg) {
+    return;
+  }
+
+  const { labelKey, level } = msg;
+
+  const urlParams: URLSearchParams = new URLSearchParams(
+    window.location.search
+  );
+
+  urlParams.append(msgParam, encodeURI(labelKey));
+  urlParams.append(levelParam, level);
+
+  updateAuthUrl(urlParams);
+};
+
+/**
+ * If the url contains a msg that has been provided on logout, display it as a toast message. Cleanup url afterwards - we don't want the user to see the message again if reloads the browser
+ */
+export const displayAndCleanLogoutMsg = () => {
+  const urlParams: URLSearchParams = new URLSearchParams(
+    window.location.search
+  );
+
+  const msg: string | null = urlParams.get(msgParam);
+
+  if (msg === null) {
+    return;
+  }
+
+  // For simplicity reason we assume the level pass as query params is one of the type ToastLevel
+  const level: ToastLevel =
+    (urlParams.get(levelParam) as ToastLevel | null) ?? "info";
+
+  toastsStore.show({ labelKey: msg, level });
+
+  cleanUpMsgUrl();
+};
+
+const cleanUpMsgUrl = () => {
+  const urlParams: URLSearchParams = new URLSearchParams(
+    window.location.search
+  );
+
+  urlParams.delete(msgParam);
+  urlParams.delete(levelParam);
+
+  updateAuthUrl(urlParams);
+};
+
+const updateAuthUrl = (urlParams: URLSearchParams) =>
+  replaceHistory({
+    path: "/",
+    query: urlParams.toString(),
+  });

--- a/frontend/svelte/src/lib/services/worker.services.ts
+++ b/frontend/svelte/src/lib/services/worker.services.ts
@@ -1,8 +1,7 @@
 import type { AuthStore } from "../stores/auth.store";
-import { authStore } from "../stores/auth.store";
-import { toastsStore } from "../stores/toasts.store";
 import type { PostMessageEventData } from "../types/post-messages";
 import { localStorageAuth } from "../utils/auth.utils";
+import { logout } from "./auth.services";
 
 const initWorker = () => {
   const worker = new Worker("./build/worker.js", { type: "module" });
@@ -12,11 +11,11 @@ const initWorker = () => {
 
     switch (msg) {
       case "nnsSignOut":
-        await authStore.signOut();
-
-        toastsStore.show({
-          labelKey: "warning.auth_sign_out",
-          level: "warn",
+        await logout({
+          msg: {
+            labelKey: "warning.auth_sign_out",
+            level: "warn",
+          },
         });
 
         return;

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { Unsubscriber } from "svelte/types/runtime/store";
   import { authStore } from "../lib/stores/auth.store";
   import type { AuthStore } from "../lib/stores/auth.store";
@@ -8,6 +8,7 @@
   import { i18n } from "../lib/stores/i18n";
   import { toastsStore } from "../lib/stores/toasts.store";
   import Banner from "../lib/components/common/Banner.svelte";
+  import { displayAndCleanLogoutMsg } from "../lib/services/auth.services";
 
   let signedIn: boolean = false;
 
@@ -43,6 +44,8 @@
       routeStore.replace({ path: redirectPath });
     }
   );
+
+  onMount(() => displayAndCleanLogoutMsg());
 
   onDestroy(unsubscribe);
 </script>

--- a/frontend/svelte/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/auth.services.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AuthClient } from "@dfinity/auth-client";
+import { mock } from "jest-mock-extended";
+import {
+  displayAndCleanLogoutMsg,
+  logout,
+} from "../../../lib/services/auth.services";
+import { toastsStore } from "../../../lib/stores/toasts.store";
+import * as routeUtils from "../../../lib/utils/route.utils";
+
+describe("auth-services", () => {
+  const mockAuthClient = mock<AuthClient>();
+
+  const { reload, href, search } = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { reload: jest.fn(), href, search },
+    });
+
+    jest
+      .spyOn(AuthClient, "create")
+      .mockImplementation(async (): Promise<AuthClient> => mockAuthClient);
+  });
+
+  afterAll(() => (window.location.reload = reload));
+
+  it("should call auth-client logout on logout", async () => {
+    const spy = jest.spyOn(mockAuthClient, "logout");
+
+    await logout({});
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should clear storage", async () => {
+    const spy = jest.spyOn(Storage.prototype, "clear");
+
+    await logout({});
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should reload browser", async () => {
+    const spy = jest.spyOn(window.location, "reload");
+
+    await logout({});
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should add msg to url", async () => {
+    const spy = jest.spyOn(routeUtils, "replaceHistory");
+
+    await logout({ msg: { labelKey: "test.key", level: "warn" } });
+
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockClear();
+  });
+
+  it("should not add msg to url", async () => {
+    const spy = jest.spyOn(routeUtils, "replaceHistory");
+
+    await logout({});
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockClear();
+  });
+
+  it("should not display msg from url", async () => {
+    const spy = jest.spyOn(toastsStore, "show");
+
+    await displayAndCleanLogoutMsg();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should display msg from url", async () => {
+    const spy = jest.spyOn(toastsStore, "show");
+
+    const location = window.location;
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...location, search: "msg=test.key&level=warn" },
+    });
+
+    await displayAndCleanLogoutMsg();
+
+    expect(spy).toHaveBeenCalled();
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...location },
+    });
+
+    spy.mockClear();
+  });
+
+  it("should clean msg from url", async () => {
+    const spy = jest.spyOn(routeUtils, "replaceHistory");
+
+    const location = window.location;
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...location, search: "msg=test.key&level=warn" },
+    });
+
+    await displayAndCleanLogoutMsg();
+
+    expect(spy).toHaveBeenCalled();
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...location },
+    });
+
+    spy.mockClear();
+  });
+});


### PR DESCRIPTION
# Motivation

As for a standard logout we should clear storage and reload browser to clean the stores on automatic logout if the session becomes invalid.

In addition this PR adds tests that check that clear storage and reload of the browser are effectively called on any logout.

# Changes

- refactor/move `logout` function to a new service `auth.service`
- pass msg (`ToastMsg`)  that needs to be displayed after automatic logout through query params
- display msg on auth screen
- clean up msg from query params once displayed
