### PR TITLE
L2-403: Follow and unfollow known neurons

### DIFF
--- a/frontend/svelte/src/lib/api/constants.api.ts
+++ b/frontend/svelte/src/lib/api/constants.api.ts
@@ -1,0 +1,11 @@
+export const dfinityNeuron = {
+  id: BigInt(27),
+  name: "DFINITY Foundation",
+  description: undefined,
+};
+
+export const icNeuron = {
+  id: BigInt(28),
+  name: "Internet Computer Association",
+  description: undefined,
+};

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -118,7 +118,25 @@ export const queryKnownNeurons = async ({
 }): Promise<KnownNeuron[]> => {
   const { canister } = await governanceCanister({ identity });
 
-  return canister.listKnownNeurons(certified);
+  const knownNeurons = await canister.listKnownNeurons(certified);
+
+  if (!knownNeurons.find(({ id }) => id === BigInt(27))) {
+    knownNeurons.push({
+      id: BigInt(27),
+      name: "DFINITY Foundation",
+      description: undefined,
+    });
+  }
+
+  if (!knownNeurons.find(({ id }) => id === BigInt(28))) {
+    knownNeurons.push({
+      id: BigInt(28),
+      name: "Internet Computer Association",
+      description: undefined,
+    });
+  }
+
+  return knownNeurons;
 };
 
 // TODO: Apply pattern to other canister instantiation L2-371

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -7,6 +7,7 @@ import {
   LEDGER_CANISTER_ID,
 } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
+import { dfinityNeuron, icNeuron } from "./constants.api";
 import { toSubAccountId } from "./utils.api";
 
 export const queryNeuron = async ({
@@ -120,20 +121,12 @@ export const queryKnownNeurons = async ({
 
   const knownNeurons = await canister.listKnownNeurons(certified);
 
-  if (!knownNeurons.find(({ id }) => id === BigInt(27))) {
-    knownNeurons.push({
-      id: BigInt(27),
-      name: "DFINITY Foundation",
-      description: undefined,
-    });
+  if (!knownNeurons.find(({ id }) => id === dfinityNeuron.id)) {
+    knownNeurons.push(dfinityNeuron);
   }
 
-  if (!knownNeurons.find(({ id }) => id === BigInt(28))) {
-    knownNeurons.push({
-      id: BigInt(28),
-      name: "Internet Computer Association",
-      description: undefined,
-    });
+  if (!knownNeurons.find(({ id }) => id === icNeuron.id)) {
+    knownNeurons.push(icNeuron);
   }
 
   return knownNeurons;

--- a/frontend/svelte/src/lib/api/utils.api.ts
+++ b/frontend/svelte/src/lib/api/utils.api.ts
@@ -1,6 +1,6 @@
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 
-export const arrayBufferToNumber = (buffer: ArrayBuffer): number => {
+const arrayBufferToNumber = (buffer: ArrayBuffer): number => {
   const view = new DataView(buffer);
   return view.getUint32(view.byteLength - 4);
 };

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -203,6 +203,7 @@ export const idlFactory = ({ IDL }) => {
     ),
   });
 };
-export const init = ({ IDL }) => {
+// Remove param `{ IDL }` because TS was complaining of unused variable
+export const init = () => {
   return [];
 };

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -203,6 +203,7 @@ export const idlFactory = ({ IDL }) => {
     ),
   });
 };
-export const init = ({ IDL }) => {
+// Remove param `{ IDL }` because TS was complaining of unused variable
+export const init = () => {
   return [];
 };

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -157,10 +157,6 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-
-      span {
-        @include interaction.tappable;
-      }
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
   import type { KnownNeuron, NeuronId, Topic } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
   import { addFollowee, removeFollowee } from "../../services/neurons.services";
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
-  import { toastsStore } from "../../stores/toasts.store";
   import Spinner from "../ui/Spinner.svelte";
 
   export let knownNeuron: KnownNeuron;
   export let topic: Topic;
   export let neuronId: NeuronId;
   export let isFollowed: boolean = false;
+  export let disabled: boolean = false;
 
   let loading: boolean = false;
+  const dispatcher = createEventDispatcher();
 
   const addKnownNeuronFollowee = async () => {
     loading = true;
+    dispatcher("nnsLoading", { loading: true });
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({
       identity: $authStore.identity,
@@ -23,17 +26,14 @@
       followee: knownNeuron.id,
     });
     loading = false;
-    toastsStore.show({
-      labelKey: "new_followee.success_add_followee",
-      level: "info",
-    });
+    dispatcher("nnsLoading", { loading: false });
   };
 </script>
 
 <div data-tid={`known-neuron-item-${knownNeuron.id}`}>
   <p>{knownNeuron.name}</p>
   <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-404 -->
-  <button class="secondary small" on:click={addKnownNeuronFollowee}>
+  <button class="secondary small" {disabled} on:click={addKnownNeuronFollowee}>
     {#if loading}
       <Spinner />
     {:else if isFollowed}

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import type { KnownNeuron, NeuronId, Topic } from "@dfinity/nns";
+  import { addFollowee, removeFollowee } from "../../services/neurons.services";
+  import { authStore } from "../../stores/auth.store";
+  import { i18n } from "../../stores/i18n";
+  import { toastsStore } from "../../stores/toasts.store";
+  import Spinner from "../ui/Spinner.svelte";
+
+  export let knownNeuron: KnownNeuron;
+  export let topic: Topic;
+  export let neuronId: NeuronId;
+  export let isFollowed: boolean = false;
+
+  let loading: boolean = false;
+
+  const addKnownNeuronFollowee = async () => {
+    loading = true;
+    const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
+    await toggleFollowee({
+      identity: $authStore.identity,
+      neuronId: neuronId,
+      topic,
+      followee: knownNeuron.id,
+    });
+    loading = false;
+    toastsStore.show({
+      labelKey: "new_followee.success_add_followee",
+      level: "info",
+    });
+  };
+</script>
+
+<div data-tid={`known-neuron-item-${knownNeuron.id}`}>
+  <p>{knownNeuron.name}</p>
+  <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-404 -->
+  <button class="secondary small" on:click={addKnownNeuronFollowee}>
+    {#if loading}
+      <Spinner />
+    {:else if isFollowed}
+      {$i18n.new_followee.unfollow}
+    {:else}
+      {$i18n.new_followee.follow}
+    {/if}
+  </button>
+</div>
+
+<style lang="scss">
+  div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -15,13 +15,13 @@
   let loading: boolean = false;
   const dispatcher = createEventDispatcher();
 
-  const addKnownNeuronFollowee = async () => {
+  const toggleKnownNeuronFollowee = async () => {
     loading = true;
     dispatcher("nnsLoading", { loading: true });
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({
       identity: $authStore.identity,
-      neuronId: neuronId,
+      neuronId,
       topic,
       followee: knownNeuron.id,
     });
@@ -33,7 +33,11 @@
 <div data-tid={`known-neuron-item-${knownNeuron.id}`}>
   <p>{knownNeuron.name}</p>
   <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-404 -->
-  <button class="secondary small" {disabled} on:click={addKnownNeuronFollowee}>
+  <button
+    class="secondary small"
+    {disabled}
+    on:click={toggleKnownNeuronFollowee}
+  >
     {#if loading}
       <Spinner />
     {:else if isFollowed}

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -2,7 +2,6 @@
   import type { KnownNeuron, NeuronId, Topic } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { addFollowee, removeFollowee } from "../../services/neurons.services";
-  import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import Spinner from "../ui/Spinner.svelte";
 
@@ -20,7 +19,6 @@
     dispatcher("nnsLoading", { loading: true });
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({
-      identity: $authStore.identity,
       neuronId,
       topic,
       followee: knownNeuron.id,

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -109,6 +109,7 @@
     "follow_neuron": "Follow Neuron",
     "options_title": "Options for Following",
     "follow": "Follow",
+    "unfollow": "Unfollow",
     "success_add_followee": "Followee added successfully",
     "success_remove_followee": "Followee removed successfully"
   },

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -33,7 +33,9 @@
     }
   );
 
+  let newNeuronId: NeuronId | undefined;
   let newNeuron: NeuronInfo | undefined;
+  $: newNeuron = $neuronsStore.find(({ neuronId }) => newNeuronId === neuronId);
   let delayInSeconds: number = 0;
   let showBackButton: boolean;
   $: showBackButton = [Steps.StakeNeuron, Steps.ConfirmDisseolveDelay].includes(
@@ -55,9 +57,7 @@
   const goToDissolveDelay = ({
     detail,
   }: CustomEvent<{ neuronId: NeuronId }>) => {
-    newNeuron = $neuronsStore.find(
-      ({ neuronId }) => neuronId === detail.neuronId
-    );
+    newNeuronId = detail.neuronId;
     stateStep = stateStep.next();
   };
   const goEditFollowers = () => {

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -21,7 +21,7 @@
     const topicInfo = neuron.fullNeuron?.followees.find(
       (followee) => followee.topic === topic
     );
-    topicFollowees = topicInfo === undefined ? [] : topicInfo.followees;
+    topicFollowees = topicInfo?.followees ?? [];
   }
 
   onMount(() => listKnownNeurons());
@@ -32,7 +32,7 @@
   }: {
     followees: NeuronId[];
     knownNeuronId: NeuronId;
-  }) => followees.find((id) => id === knownNeuronId) !== undefined;
+  }): boolean => followees.find((id) => id === knownNeuronId) !== undefined;
 
   const addFolloweeByAddress = async () => {
     loading = true;

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -8,13 +8,13 @@
   import { addFollowee } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
   import { sortedknownNeuronsStore } from "../../stores/knownNeurons.store";
-  import { toastsStore } from "../../stores/toasts.store";
   import Modal from "../Modal.svelte";
 
   export let neuron: NeuronInfo;
   export let topic: Topic;
 
   let followeeAddress: number | undefined;
+  let loadingAddress: boolean = false;
   let loading: boolean = false;
   let topicFollowees: NeuronId[];
   $: {
@@ -34,8 +34,15 @@
     knownNeuronId: NeuronId;
   }): boolean => followees.find((id) => id === knownNeuronId) !== undefined;
 
+  // We can't edit two followees at the same time.
+  // Canister edits followees by sending the new array of followees.
+  const updateLoading = ({ detail }: CustomEvent<{ loading: boolean }>) => {
+    loading = detail.loading;
+  };
+
   const addFolloweeByAddress = async () => {
     loading = true;
+    loadingAddress = true;
     let followee: bigint;
     if (followeeAddress === undefined) {
       return;
@@ -54,11 +61,8 @@
       followee,
     });
     loading = false;
+    loadingAddress = false;
     followeeAddress = undefined;
-    toastsStore.show({
-      labelKey: "new_followee.success_add_followee",
-      level: "info",
-    });
   };
 </script>
 
@@ -80,7 +84,7 @@
           type="submit"
           disabled={followeeAddress === undefined || loading}
         >
-          {#if loading}
+          {#if loadingAddress}
             <Spinner />
           {:else}
             {$i18n.new_followee.follow_neuron}
@@ -97,6 +101,8 @@
           {#each $sortedknownNeuronsStore as knownNeuron}
             <li data-tid="known-neuron-item">
               <KnownNeuronFollowItem
+                on:nnsLoading={updateLoading}
+                disabled={loading}
                 {knownNeuron}
                 neuronId={neuron.neuronId}
                 {topic}

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { NeuronId, NeuronInfo, Topic } from "@dfinity/nns";
   import { onMount } from "svelte";
+  import KnownNeuronFollowItem from "../../components/neurons/KnownNeuronFollowItem.svelte";
   import Input from "../../components/ui/Input.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
   import { listKnownNeurons } from "../../services/knownNeurons.services";
@@ -15,8 +16,23 @@
 
   let followeeAddress: number | undefined;
   let loading: boolean = false;
+  let topicFollowees: NeuronId[];
+  $: {
+    const topicInfo = neuron.fullNeuron?.followees.find(
+      (followee) => followee.topic === topic
+    );
+    topicFollowees = topicInfo === undefined ? [] : topicInfo.followees;
+  }
 
   onMount(() => listKnownNeurons());
+
+  const followsKnownNeuron = ({
+    followees,
+    knownNeuronId,
+  }: {
+    followees: NeuronId[];
+    knownNeuronId: NeuronId;
+  }) => followees.find((id) => id === knownNeuronId) !== undefined;
 
   const addFolloweeByAddress = async () => {
     loading = true;
@@ -44,22 +60,6 @@
       level: "info",
     });
   };
-
-  // TODO: Check with known neurons https://dfinity.atlassian.net/browse/L2-403
-  const addKnownNeuronFollowee = async (followeeId: NeuronId) => {
-    loading = true;
-    await addFollowee({
-      neuronId: neuron.neuronId,
-      topic,
-      followee: followeeId,
-    });
-    loading = false;
-    followeeAddress = undefined;
-    toastsStore.show({
-      labelKey: "new_followee.success_add_followee",
-      level: "info",
-    });
-  };
 </script>
 
 <Modal theme="dark" size="medium" on:nnsClose>
@@ -74,7 +74,7 @@
           bind:value={followeeAddress}
           theme="dark"
         />
-        <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-403 -->
+        <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-404 -->
         <button
           class="primary small"
           type="submit"
@@ -94,14 +94,17 @@
         <Spinner />
       {:else}
         <ul>
-          {#each $sortedknownNeuronsStore as knowNeuron}
+          {#each $sortedknownNeuronsStore as knownNeuron}
             <li data-tid="known-neuron-item">
-              <p>{knowNeuron.name}</p>
-              <button
-                class="secondary small"
-                on:click={() => addKnownNeuronFollowee(knowNeuron.id)}
-                >{$i18n.new_followee.follow}</button
-              >
+              <KnownNeuronFollowItem
+                {knownNeuron}
+                neuronId={neuron.neuronId}
+                {topic}
+                isFollowed={followsKnownNeuron({
+                  followees: topicFollowees,
+                  knownNeuronId: knownNeuron.id,
+                })}
+              />
             </li>
           {/each}
         </ul>
@@ -131,11 +134,5 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding);
-
-    li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
   }
 </style>

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -100,12 +100,12 @@ const setFolloweesHelper = async ({
   neuronId,
   topic,
   followees,
-  errorKey,
+  labelKey,
 }: {
   neuronId: NeuronId;
   topic: Topic;
   followees: NeuronId[];
-  errorKey: "add_followee" | "remove_followee";
+  labelKey: "add_followee" | "remove_followee";
 }) => {
   const identity: Identity = await getIdentity();
 
@@ -127,9 +127,14 @@ const setFolloweesHelper = async ({
       throw new Error("Neuron not found");
     }
     neuronsStore.pushNeurons([neuron]);
+
+    toastsStore.show({
+      labelKey: `new_followee.success_${labelKey}`,
+      level: "info",
+    });
   } catch (err) {
     toastsStore.error({
-      labelKey: `error.${errorKey}`,
+      labelKey: `error.${labelKey}`,
       err,
     });
   }
@@ -160,7 +165,7 @@ export const addFollowee = async ({
     neuronId,
     topic,
     followees: newFollowees,
-    errorKey: "add_followee",
+    labelKey: "add_followee",
   });
 };
 
@@ -197,7 +202,7 @@ export const removeFollowee = async ({
     neuronId,
     topic,
     followees: newFollowees,
-    errorKey: "remove_followee",
+    labelKey: "remove_followee",
   });
 };
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -116,11 +116,17 @@ const setFolloweesHelper = async ({
       topic,
       followees,
     });
-
-    await loadNeuron({
+    const neuron: NeuronInfo | undefined = await getNeuron({
       neuronId,
-      setNeuron: (neuron: NeuronInfo) => neuronsStore.pushNeurons([neuron]),
+      identity,
+      certified: true,
+      nocache: true,
     });
+
+    if (!neuron) {
+      throw new Error("Neuron not found");
+    }
+    neuronsStore.pushNeurons([neuron]);
   } catch (error) {
     toastsStore.show({
       labelKey: `error.${errorKey}`,
@@ -150,6 +156,7 @@ export const addFollowee = async ({
     topicFollowees === undefined
       ? [followee]
       : [...topicFollowees.followees, followee];
+
   await setFolloweesHelper({
     neuronId,
     topic,
@@ -202,11 +209,16 @@ const getNeuron = async ({
   neuronId,
   identity,
   certified,
+  nocache = false,
 }: {
   neuronId: NeuronId;
   identity: Identity;
   certified: boolean;
+  nocache?: boolean;
 }): Promise<NeuronInfo | undefined> => {
+  if (nocache) {
+    return queryNeuron({ neuronId, identity, certified });
+  }
   const neuron = get(neuronsStore).find(
     (neuron) => neuron.neuronId === neuronId
   );

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -116,7 +116,7 @@ const setFolloweesHelper = async ({
       neuronId,
       identity,
       certified: true,
-      noCache: true,
+      forceFetch: true,
     });
 
     if (!neuron) {
@@ -207,14 +207,14 @@ const getNeuron = async ({
   neuronId,
   identity,
   certified,
-  noCache = false,
+  forceFetch = false,
 }: {
   neuronId: NeuronId;
   identity: Identity;
   certified: boolean;
-  noCache?: boolean;
+  forceFetch?: boolean;
 }): Promise<NeuronInfo | undefined> => {
-  if (noCache) {
+  if (forceFetch) {
     return queryNeuron({ neuronId, identity, certified });
   }
   const neuron = get(neuronsStore).find(

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -120,18 +120,17 @@ const setFolloweesHelper = async ({
       neuronId,
       identity,
       certified: true,
-      nocache: true,
+      noCache: true,
     });
 
     if (!neuron) {
       throw new Error("Neuron not found");
     }
     neuronsStore.pushNeurons([neuron]);
-  } catch (error) {
-    toastsStore.show({
+  } catch (err) {
+    toastsStore.error({
       labelKey: `error.${errorKey}`,
-      level: "error",
-      detail: `id: "${neuronId}"`,
+      err,
     });
   }
 };
@@ -209,14 +208,14 @@ const getNeuron = async ({
   neuronId,
   identity,
   certified,
-  nocache = false,
+  noCache = false,
 }: {
   neuronId: NeuronId;
   identity: Identity;
   certified: boolean;
-  nocache?: boolean;
+  noCache?: boolean;
 }): Promise<NeuronInfo | undefined> => {
-  if (nocache) {
+  if (noCache) {
     return queryNeuron({ neuronId, identity, certified });
   }
   const neuron = get(neuronsStore).find(

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -14,7 +14,6 @@ import { E8S_PER_ICP } from "../constants/icp.constants";
 import { neuronsStore } from "../stores/neurons.store";
 import { toastsStore } from "../stores/toasts.store";
 import { getLastPathDetailId } from "../utils/app-path.utils";
-import { errorToString } from "../utils/error.utils";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -61,8 +60,6 @@ export const listNeurons = async (): Promise<void> => {
     request: (options) => queryNeurons(options),
     onLoad: ({ response: neurons }) => neuronsStore.setNeurons(neurons),
     onError: ({ error, certified }) => {
-      console.error(error);
-
       if (certified !== true) {
         return;
       }
@@ -70,10 +67,9 @@ export const listNeurons = async (): Promise<void> => {
       // Explicitly handle only UPDATE errors
       neuronsStore.setNeurons([]);
 
-      toastsStore.show({
+      toastsStore.error({
         labelKey: "error.get_neurons",
-        level: "error",
-        detail: errorToString(error),
+        err: error,
       });
     },
   });
@@ -188,10 +184,8 @@ export const removeFollowee = async ({
     );
   if (topicFollowees === undefined) {
     // Followee in that topic already does not exist.
-    toastsStore.show({
+    toastsStore.error({
       labelKey: "error.followee_does_not_exist",
-      level: "warn",
-      detail: `id: "${neuronId}"`,
     });
     return;
   }

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -149,6 +149,7 @@ export const addFollowee = async ({
   const neuron = neurons.find(
     ({ neuronId: currentNeuronId }) => currentNeuronId === neuronId
   );
+
   const topicFollowees = neuron?.fullNeuron?.followees.find(
     ({ topic: currentTopic }) => currentTopic === topic
   );

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -242,13 +242,10 @@ export const loadNeuron = ({
   setNeuron: (neuron: NeuronInfo) => void;
   handleError?: () => void;
 }): Promise<void> => {
-  const catchError = (error: unknown) => {
-    console.error(error);
-
-    toastsStore.show({
+  const catchError = (err: unknown) => {
+    toastsStore.error({
       labelKey: "error.neuron_not_found",
-      level: "error",
-      detail: `id: "${neuronId}"`,
+      err,
     });
 
     handleError?.();

--- a/frontend/svelte/src/lib/stores/neurons.store.ts
+++ b/frontend/svelte/src/lib/stores/neurons.store.ts
@@ -19,8 +19,16 @@ const initNeuronsStore = () => {
       set([...neurons]);
     },
 
-    pushNeurons(neurons: NeuronInfo[]) {
-      update((neuronInfos: NeuronInfo[]) => [...neuronInfos, ...neurons]);
+    pushNeurons(newNeurons: NeuronInfo[]) {
+      update((oldNeurons: NeuronInfo[]) => {
+        const filteredNeurons = oldNeurons.filter(
+          ({ neuronId: oldNeuronId }) =>
+            newNeurons.find(
+              ({ neuronId: newNeuronId }) => oldNeuronId === newNeuronId
+            ) === undefined
+        );
+        return [...filteredNeurons, ...newNeurons];
+      });
     },
   };
 };

--- a/frontend/svelte/src/lib/stores/neurons.store.ts
+++ b/frontend/svelte/src/lib/stores/neurons.store.ts
@@ -3,13 +3,6 @@ import { writable } from "svelte/store";
 
 export type NeuronsStore = NeuronInfo[];
 
-const notInNewList =
-  (newNeurons: NeuronInfo[]) =>
-  ({ neuronId: oldNeuronId }) =>
-    newNeurons.find(
-      ({ neuronId: newNeuronId }) => oldNeuronId === newNeuronId
-    ) === undefined;
-
 /**
  * A store that contains the neurons
  *
@@ -28,8 +21,11 @@ const initNeuronsStore = () => {
 
     pushNeurons(newNeurons: NeuronInfo[]) {
       update((oldNeurons: NeuronInfo[]) => {
-        const filteredNeurons = oldNeurons.filter(notInNewList(newNeurons));
-        return [...filteredNeurons, ...newNeurons];
+        const newIds = new Set(newNeurons.map(({ neuronId }) => neuronId));
+        return [
+          ...oldNeurons.filter(({ neuronId }) => !newIds.has(neuronId)),
+          ...newNeurons,
+        ];
       });
     },
   };

--- a/frontend/svelte/src/lib/stores/neurons.store.ts
+++ b/frontend/svelte/src/lib/stores/neurons.store.ts
@@ -3,6 +3,13 @@ import { writable } from "svelte/store";
 
 export type NeuronsStore = NeuronInfo[];
 
+const notInNewList =
+  (newNeurons: NeuronInfo[]) =>
+  ({ neuronId: oldNeuronId }) =>
+    newNeurons.find(
+      ({ neuronId: newNeuronId }) => oldNeuronId === newNeuronId
+    ) === undefined;
+
 /**
  * A store that contains the neurons
  *
@@ -21,12 +28,7 @@ const initNeuronsStore = () => {
 
     pushNeurons(newNeurons: NeuronInfo[]) {
       update((oldNeurons: NeuronInfo[]) => {
-        const filteredNeurons = oldNeurons.filter(
-          ({ neuronId: oldNeuronId }) =>
-            newNeurons.find(
-              ({ neuronId: newNeuronId }) => oldNeuronId === newNeuronId
-            ) === undefined
-        );
+        const filteredNeurons = oldNeurons.filter(notInNewList(newNeurons));
         return [...filteredNeurons, ...newNeurons];
       });
     },

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -120,6 +120,7 @@ interface I18nNew_followee {
   follow_neuron: string;
   options_title: string;
   follow: string;
+  unfollow: string;
   success_add_followee: string;
   success_remove_followee: string;
 }

--- a/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
@@ -17,6 +17,9 @@ describe("neurons-api", () => {
     mockGovernanceCanister.listNeurons.mockImplementation(
       jest.fn().mockResolvedValue([])
     );
+    mockGovernanceCanister.listKnownNeurons.mockImplementation(
+      jest.fn().mockResolvedValue([])
+    );
     mockGovernanceCanister.stakeNeuron.mockImplementation(jest.fn());
     mockGovernanceCanister.getNeuron.mockImplementation(
       jest.fn().mockResolvedValue(mockNeuron)

--- a/frontend/svelte/src/tests/lib/api/utils.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/utils.api.spec.ts
@@ -1,0 +1,10 @@
+import { toSubAccountId } from "../../../lib/api/utils.api";
+
+describe("toSubAccountId", () => {
+  it("should successfully transform subaccount to ids", () => {
+    expect(toSubAccountId([0, 0, 0, 0, 1])).toBe(1);
+    expect(toSubAccountId([0, 0, 3, 0, 1])).toBe(196609);
+    expect(toSubAccountId([4, 0, 0, 0, 1])).toBe(1);
+    expect(toSubAccountId([0, 4, 0, 0, 1])).toBe(67108865);
+  });
+});

--- a/frontend/svelte/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/neurons.store.spec.ts
@@ -4,7 +4,7 @@ import { neuronsStore } from "../../../lib/stores/neurons.store";
 import { mockNeuron } from "../../mocks/neurons.mock";
 
 describe("neurons-store", () => {
-  it("should set proposals", () => {
+  it("should set neurons", () => {
     const neurons: NeuronInfo[] = [
       { ...mockNeuron, neuronId: BigInt(1) },
       { ...mockNeuron, neuronId: BigInt(2) },
@@ -15,7 +15,7 @@ describe("neurons-store", () => {
     expect(neuronsInStore).toEqual(neurons);
   });
 
-  it("should push proposals", () => {
+  it("should push neurons", () => {
     const neurons: NeuronInfo[] = [
       { ...mockNeuron, neuronId: BigInt(1) },
       { ...mockNeuron, neuronId: BigInt(2) },
@@ -30,5 +30,23 @@ describe("neurons-store", () => {
 
     const neuronsInStore = get(neuronsStore);
     expect(neuronsInStore).toEqual([...neurons, ...moreNeurons]);
+  });
+
+  it("should substitute duplicated neurons", () => {
+    const duplicatedNeuron = { ...mockNeuron, neuronId: BigInt(2) };
+    const neurons: NeuronInfo[] = [
+      { ...mockNeuron, neuronId: BigInt(1) },
+      duplicatedNeuron,
+    ];
+    neuronsStore.setNeurons(neurons);
+
+    const moreNeurons: NeuronInfo[] = [
+      { ...mockNeuron, neuronId: BigInt(3) },
+      duplicatedNeuron,
+    ];
+    neuronsStore.pushNeurons(moreNeurons);
+
+    const neuronsInStore = get(neuronsStore);
+    expect(neuronsInStore.length).toEqual(3);
   });
 });


### PR DESCRIPTION
# Motivation

User can follow and unfollow known neurons.

# Changes

* Hardcode two known neurons in the governance api.
* New Component `KnownNeuronFollowItem`.
* Upgrade NewFolloweeModal to use new component.
* Add features to service `getNeuron` to not get cached data.
* neuronsStore.pushNeurons should not add duplicated neurons to store.

# Tests

* New tests in NewFolloweeModal to test for the unfollow functionality.
* New test for api util `toSubAccountId`.
* New test for pushNeurons.
