### PR TITLE
feat: refactor get identity for services and logout if no identity is provided

### DIFF
--- a/frontend/svelte/jest-spy.ts
+++ b/frontend/svelte/jest-spy.ts
@@ -1,6 +1,12 @@
 import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
+import * as authServices from "./src/lib/services/auth.services";
 import * as agent from "./src/lib/utils/agent.utils";
+import { mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
+
+jest
+  .spyOn(authServices, "getIdentity")
+  .mockImplementation(() => Promise.resolve(mockGetIdentity()));

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -34,7 +34,7 @@
         return;
       }
 
-      await syncAccounts(auth);
+      await syncAccounts();
     }
   );
 

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -4,7 +4,6 @@
   import IconExpandMore from "../../icons/IconExpandMore.svelte";
   import NewFolloweeModal from "../../modals/neurons/NewFolloweeModal.svelte";
   import { removeFollowee } from "../../services/neurons.services";
-  import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import { toastsStore } from "../../stores/toasts.store";
 
@@ -31,7 +30,6 @@
   // TODO: Check that it works - https://dfinity.atlassian.net/browse/L2-365
   const removeCurrentFollowee = async (followee: NeuronId) => {
     await removeFollowee({
-      identity: $authStore.identity,
       neuronId: neuron.neuronId,
       topic,
       followee,

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -3,7 +3,6 @@
   import { notVotedNeurons, ProposalStatus } from "@dfinity/nns";
   import { onDestroy } from "svelte";
   import { registerVotes } from "../../../services/proposals.services";
-  import { authStore } from "../../../stores/auth.store";
   import { i18n } from "../../../stores/i18n";
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
   import Card from "../../ui/Card.svelte";
@@ -30,7 +29,6 @@
       neuronIds: $votingNeuronSelectStore.selectedIds,
       vote: detail.voteType,
       proposalId: proposalInfo.id as bigint,
-      identity: $authStore.identity,
     });
 
   onDestroy(() => votingNeuronSelectStore.reset());

--- a/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { BallotInfo, ProposalId, ProposalInfo } from "@dfinity/nns";
   import { onMount } from "svelte";
-  import { authStore } from "../../stores/auth.store";
   import { loadProposal } from "../../services/proposals.services";
   import ProposalSummary from "../proposal-detail/ProposalDetailCard/ProposalSummary.svelte";
   import { Vote } from "@dfinity/nns";
@@ -16,7 +15,6 @@
     async () =>
       await loadProposal({
         proposalId: ballot.proposalId as ProposalId,
-        identity: $authStore.identity,
         setProposal: (proposalInfo: ProposalInfo) => (proposal = proposalInfo),
       })
   );

--- a/frontend/svelte/src/lib/modals/accounts/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/AddNewAccount.svelte
@@ -9,7 +9,6 @@
     SubAccountLimitExceededError,
   } from "../../canisters/nns-dapp/nns-dapp.errors";
   import { toastsStore } from "../../stores/toasts.store";
-  import { authStore } from "../../stores/auth.store";
 
   let newAccountName: string = "";
 
@@ -20,7 +19,6 @@
       creating = true;
       await addSubAccount({
         name: newAccountName,
-        identity: $authStore.identity,
       });
       dispatcher("nnsClose");
     } catch (err) {

--- a/frontend/svelte/src/lib/modals/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/ConfirmDissolveDelay.svelte
@@ -8,7 +8,6 @@
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formatICP } from "../../utils/icp.utils";
   import { votingPower } from "../../utils/neuron.utils";
-  import { authStore } from "../../stores/auth.store";
 
   export let delayInSeconds: number;
   export let neuron: NeuronInfo;
@@ -24,7 +23,6 @@
       await updateDelay({
         neuronId: neuron.neuronId,
         dissolveDelayInSeconds: delayInSeconds,
-        identity: $authStore.identity,
       });
       dispatcher("nnsNext");
     } catch (error) {

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -16,7 +16,7 @@
   let followeeAddress: number | undefined;
   let loading: boolean = false;
 
-  onMount(async () => await listKnownNeurons());
+  onMount(() => listKnownNeurons());
 
   const addFolloweeByAddress = async () => {
     loading = true;

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -5,7 +5,6 @@
   import Spinner from "../../components/ui/Spinner.svelte";
   import { listKnownNeurons } from "../../services/knownNeurons.services";
   import { addFollowee } from "../../services/neurons.services";
-  import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import { sortedknownNeuronsStore } from "../../stores/knownNeurons.store";
   import { toastsStore } from "../../stores/toasts.store";
@@ -17,11 +16,7 @@
   let followeeAddress: number | undefined;
   let loading: boolean = false;
 
-  onMount(() => {
-    listKnownNeurons({
-      identity: $authStore.identity,
-    });
-  });
+  onMount(async () => await listKnownNeurons());
 
   const addFolloweeByAddress = async () => {
     loading = true;
@@ -38,7 +33,6 @@
       return;
     }
     await addFollowee({
-      identity: $authStore.identity,
       neuronId: neuron.neuronId,
       topic,
       followee,
@@ -55,7 +49,6 @@
   const addKnownNeuronFollowee = async (followeeId: NeuronId) => {
     loading = true;
     await addFollowee({
-      identity: $authStore.identity,
       neuronId: neuron.neuronId,
       topic,
       followee: followeeId,

--- a/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/StakeNeuron.svelte
@@ -9,7 +9,6 @@
   } from "../../constants/icp.constants";
   import { syncAccounts } from "../../services/accounts.services";
   import { stakeAndLoadNeuron } from "../../services/neurons.services";
-  import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { formatICP } from "../../utils/icp.utils";
@@ -25,7 +24,6 @@
     try {
       const neuronId = await stakeAndLoadNeuron({
         amount,
-        identity: $authStore.identity,
         fromSubAccount:
           "subAccount" in account ? account.subAccount : undefined,
       });
@@ -34,7 +32,7 @@
       // `syncAccounts` might be slow since it loads all accounts and balances.
       // in the neurons page there are no balances nor accounts
       // TODO: L2-329 Manage edge cases
-      syncAccounts({ identity: $authStore.identity });
+      syncAccounts();
 
       dispatcher("nnsNeuronCreated", { neuronId });
     } catch (err) {

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -21,9 +21,8 @@
     }
 
     // The fetched neuron belongs to a proposer so it should not be added to the neuronsStore
-    loadNeuron({
+    await loadNeuron({
       neuronId: proposer,
-      identity: $authStore.identity,
       setNeuron: (neuronInfo) => (neuron = neuronInfo),
       handleError: (neuron = undefined),
     });

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -12,7 +12,7 @@ import { queryAndUpdate } from "./utils.services";
  */
 export const syncAccounts = (): Promise<void> => {
   return queryAndUpdate<AccountsStore, unknown>({
-    request: (params) => loadAccounts(params),
+    request: (options) => loadAccounts(options),
     onLoad: ({ response: accounts }) => accountsStore.set(accounts),
     onError: ({ error, certified }) => {
       console.error(error);

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -3,24 +3,16 @@ import { createSubAccount, loadAccounts } from "../api/accounts.api";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { toastsStore } from "../stores/toasts.store";
-import { queryAndUpdate } from "../utils/api.utils";
 import { errorToString } from "../utils/error.utils";
+import { getIdentity } from "./auth.services";
+import { queryAndUpdate } from "./utils.services";
 
 /**
  * - sync: load the account data using the ledger and the nns dapp canister itself
  */
-export const syncAccounts = async ({
-  identity,
-}: {
-  identity: Identity | undefined | null;
-}): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error("No identity");
-  }
-
+export const syncAccounts = async (): Promise<void> => {
   return queryAndUpdate<AccountsStore, unknown>({
-    request: ({ certified }) => loadAccounts({ identity, certified }),
+    request: (params) => loadAccounts(params),
     onLoad: ({ response: accounts }) => accountsStore.set(accounts),
     onError: ({ error, certified }) => {
       console.error(error);
@@ -43,17 +35,12 @@ export const syncAccounts = async ({
 
 export const addSubAccount = async ({
   name,
-  identity,
 }: {
   name: string;
-  identity: Identity | null | undefined;
 }): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error("No identity found to create subaccount");
-  }
+  const identity: Identity = await getIdentity();
 
   await createSubAccount({ name, identity });
 
-  await syncAccounts({ identity });
+  await syncAccounts();
 };

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -10,7 +10,7 @@ import { queryAndUpdate } from "./utils.services";
 /**
  * - sync: load the account data using the ledger and the nns dapp canister itself
  */
-export const syncAccounts = async (): Promise<void> => {
+export const syncAccounts = (): Promise<void> => {
   return queryAndUpdate<AccountsStore, unknown>({
     request: (params) => loadAccounts(params),
     onLoad: ({ response: accounts }) => accountsStore.set(accounts),

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -31,16 +31,19 @@ export const logout = async ({
  * If none is provided logout the user automatically. Services that are using this getter need an identity no matter what.
  */
 export const getIdentity = async (): Promise<Identity> => {
-  const identity: Identity | undefined | null = get(authStore).identity;
+  /* eslint-disable-next-line no-async-promise-executor */
+  return new Promise<Identity>(async (resolve) => {
+    const identity: Identity | undefined | null = get(authStore).identity;
 
-  if (!identity) {
-    await logout({msg: {labelKey: 'error.missing_identity', level: 'error'}});
+    if (!identity) {
+      await logout({msg: {labelKey: 'error.missing_identity', level: 'error'}});
 
-    // This point will never be reached because logout() does reload the browser
-    throw new Error(get(i18n).error.missing_identity);
-  }
+      // We do not resolve on purpose. logout() does reload the browser
+      return;
+    }
 
-  return identity;
+    resolve(identity);
+  })
 };
 
 /**

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -34,7 +34,6 @@ export const getIdentity = async (): Promise<Identity> => {
   const identity: Identity | undefined | null = get(authStore).identity;
 
   if (!identity) {
-    // get(i18n).error.missing_identity
     await logout({msg: {labelKey: 'error.missing_identity', level: 'error'}});
 
     // This point will never be reached because logout() does reload the browser

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -1,7 +1,10 @@
+import type { Identity } from "@dfinity/agent";
+import { get } from "svelte/store";
 import { authStore } from "../stores/auth.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { ToastLevel, ToastMsg } from "../types/toast";
 import { replaceHistory } from "../utils/route.utils";
+import {i18n} from '../stores/i18n';
 
 const msgParam: string = "msg";
 const levelParam: string = "level";
@@ -21,6 +24,24 @@ export const logout = async ({
 
   // We reload the page to make sure all the states are cleared
   window.location.reload();
+};
+
+/**
+ * Provide the identity that has been authorized.
+ * If none is provided logout the user automatically. Services that are using this getter need an identity no matter what.
+ */
+export const getIdentity = async (): Promise<Identity> => {
+  const identity: Identity | undefined | null = get(authStore).identity;
+
+  if (!identity) {
+    // get(i18n).error.missing_identity
+    await logout({msg: {labelKey: 'error.missing_identity', level: 'error'}});
+
+    // This point will never be reached because logout() does reload the browser
+    throw new Error(get(i18n).error.missing_identity);
+  }
+
+  return identity;
 };
 
 /**

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -4,7 +4,6 @@ import { authStore } from "../stores/auth.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { ToastLevel, ToastMsg } from "../types/toast";
 import { replaceHistory } from "../utils/route.utils";
-import {i18n} from '../stores/i18n';
 
 const msgParam: string = "msg";
 const levelParam: string = "level";
@@ -36,14 +35,16 @@ export const getIdentity = async (): Promise<Identity> => {
     const identity: Identity | undefined | null = get(authStore).identity;
 
     if (!identity) {
-      await logout({msg: {labelKey: 'error.missing_identity', level: 'error'}});
+      await logout({
+        msg: { labelKey: "error.missing_identity", level: "error" },
+      });
 
       // We do not resolve on purpose. logout() does reload the browser
       return;
     }
 
     resolve(identity);
-  })
+  });
 };
 
 /**

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -15,7 +15,7 @@ export const listCanisters = async ({
   }
 
   return queryAndUpdate<CanisterDetails[], unknown>({
-    request: (params) => queryCanisters(params),
+    request: (options) => queryCanisters(options),
     onLoad: ({ response: canisters }) => canistersStore.setCanisters(canisters),
     onError: ({ error, certified }) => {
       console.error(error);

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -1,31 +1,21 @@
-import type { Identity } from "@dfinity/agent";
-import { get } from "svelte/store";
 import { queryCanisters } from "../api/canisters.api";
 import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 import { canistersStore } from "../stores/canisters.store";
-import { i18n } from "../stores/i18n";
 import { toastsStore } from "../stores/toasts.store";
-import { queryAndUpdate } from "../utils/api.utils";
 import { errorToString } from "../utils/error.utils";
+import { queryAndUpdate } from "./utils.services";
 
 export const listCanisters = async ({
   clearBeforeQuery,
-  identity,
 }: {
   clearBeforeQuery?: boolean;
-  identity: Identity | null | undefined;
 }) => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error(get(i18n).error.missing_identity);
-  }
-
   if (clearBeforeQuery === true) {
     canistersStore.setCanisters([]);
   }
 
   return queryAndUpdate<CanisterDetails[], unknown>({
-    request: ({ certified }) => queryCanisters({ identity, certified }),
+    request: (params) => queryCanisters(params),
     onLoad: ({ response: canisters }) => canistersStore.setCanisters(canisters),
     onError: ({ error, certified }) => {
       console.error(error);

--- a/frontend/svelte/src/lib/services/dev.services.ts
+++ b/frontend/svelte/src/lib/services/dev.services.ts
@@ -3,15 +3,12 @@ import { acquireICPTs } from "../api/dev.api";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
-import type { AuthStore } from "../stores/auth.store";
-import { authStore } from "../stores/auth.store";
 import { syncAccounts } from "./accounts.services";
 
 export const getICPs = async (icps: number) => {
   const { main }: AccountsStore = get(accountsStore);
 
   if (!main) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
     throw new Error("No account found to get ICPs");
   }
 
@@ -20,12 +17,5 @@ export const getICPs = async (icps: number) => {
     accountIdentifier: main.identifier,
   });
 
-  const { identity }: AuthStore = get(authStore);
-
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error("No identity found to sync accounts after getting ICPs");
-  }
-
-  await syncAccounts({ identity });
+  await syncAccounts();
 };

--- a/frontend/svelte/src/lib/services/knownNeurons.services.ts
+++ b/frontend/svelte/src/lib/services/knownNeurons.services.ts
@@ -1,29 +1,13 @@
-import type { Identity } from "@dfinity/agent";
 import type { KnownNeuron } from "@dfinity/nns";
-import { get } from "svelte/store";
 import * as api from "../api/governance.api";
-import { i18n } from "../stores/i18n";
 import { knownNeuronsStore } from "../stores/knownNeurons.store";
 import { toastsStore } from "../stores/toasts.store";
-import { queryAndUpdate } from "../utils/api.utils";
 import { errorToString } from "../utils/error.utils";
+import { queryAndUpdate } from "./utils.services";
 
-export const listKnownNeurons = async ({
-  identity,
-}: {
-  identity: Identity | undefined | null;
-}) => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-346
-    throw new Error(get(i18n).error.missing_identity);
-  }
-
-  queryAndUpdate<KnownNeuron[], unknown>({
-    request: ({ certified }) =>
-      api.queryKnownNeurons({
-        identity,
-        certified,
-      }),
+export const listKnownNeurons = (): Promise<void> => {
+  return queryAndUpdate<KnownNeuron[], unknown>({
+    request: (params) => api.queryKnownNeurons(params),
     onLoad: ({ response: neurons }) => knownNeuronsStore.setNeurons(neurons),
     onError: ({ error, certified }) => {
       console.error(error);

--- a/frontend/svelte/src/lib/services/knownNeurons.services.ts
+++ b/frontend/svelte/src/lib/services/knownNeurons.services.ts
@@ -7,7 +7,7 @@ import { queryAndUpdate } from "./utils.services";
 
 export const listKnownNeurons = (): Promise<void> => {
   return queryAndUpdate<KnownNeuron[], unknown>({
-    request: (params) => api.queryKnownNeurons(params),
+    request: (options) => api.queryKnownNeurons(options),
     onLoad: ({ response: neurons }) => knownNeuronsStore.setNeurons(neurons),
     onError: ({ error, certified }) => {
       console.error(error);

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -11,12 +11,12 @@ import {
 } from "../api/governance.api";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { E8S_PER_ICP } from "../constants/icp.constants";
-import { i18n } from "../stores/i18n";
 import { neuronsStore } from "../stores/neurons.store";
 import { toastsStore } from "../stores/toasts.store";
-import { queryAndUpdate } from "../utils/api.utils";
 import { getLastPathDetailId } from "../utils/app-path.utils";
 import { errorToString } from "../utils/error.utils";
+import { getIdentity } from "./auth.services";
+import { queryAndUpdate } from "./utils.services";
 
 /**
  * Uses governance api to create a neuron and adds it to the store
@@ -24,11 +24,9 @@ import { errorToString } from "../utils/error.utils";
  */
 export const stakeAndLoadNeuron = async ({
   amount,
-  identity,
   fromSubAccount,
 }: {
   amount: number;
-  identity: Identity | null | undefined;
   fromSubAccount?: SubAccountArray;
 }): Promise<NeuronId> => {
   const stake = ICP.fromString(String(amount));
@@ -41,10 +39,7 @@ export const stakeAndLoadNeuron = async ({
     throw new Error("Need a minimum of 1 ICP to stake a neuron");
   }
 
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-348
-    throw new Error("No identity");
-  }
+  const identity: Identity = await getIdentity();
 
   const neuronId: NeuronId = await stakeNeuron({
     stake,
@@ -54,7 +49,6 @@ export const stakeAndLoadNeuron = async ({
 
   await loadNeuron({
     neuronId,
-    identity,
     setNeuron: (neuron: NeuronInfo) => neuronsStore.pushNeurons([neuron]),
   });
 
@@ -62,18 +56,9 @@ export const stakeAndLoadNeuron = async ({
 };
 
 // Gets neurons and adds them to the store
-export const listNeurons = async ({
-  identity,
-}: {
-  identity: Identity | null | undefined;
-}): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-348
-    throw new Error("No identity found listing neurons");
-  }
-
+export const listNeurons = async (): Promise<void> => {
   return queryAndUpdate<NeuronInfo[], unknown>({
-    request: ({ certified }) => queryNeurons({ identity, certified }),
+    request: (params) => queryNeurons(params),
     onLoad: ({ response: neurons }) => neuronsStore.setNeurons(neurons),
     onError: ({ error, certified }) => {
       console.error(error);
@@ -97,39 +82,33 @@ export const listNeurons = async ({
 export const updateDelay = async ({
   neuronId,
   dissolveDelayInSeconds,
-  identity,
 }: {
   neuronId: NeuronId;
   dissolveDelayInSeconds: number;
-  identity: Identity | null | undefined;
 }): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-348
-    throw new Error("No identity");
-  }
+  const identity: Identity = await getIdentity();
 
   await increaseDissolveDelay({ neuronId, dissolveDelayInSeconds, identity });
 
   await loadNeuron({
     neuronId,
-    identity,
     setNeuron: (neuron: NeuronInfo) => neuronsStore.pushNeurons([neuron]),
   });
 };
 
 const setFolloweesHelper = async ({
-  identity,
   neuronId,
   topic,
   followees,
   errorKey,
 }: {
-  identity: Identity;
   neuronId: NeuronId;
   topic: Topic;
   followees: NeuronId[];
   errorKey: "add_followee" | "remove_followee";
 }) => {
+  const identity: Identity = await getIdentity();
+
   try {
     await setFollowees({
       identity,
@@ -137,9 +116,9 @@ const setFolloweesHelper = async ({
       topic,
       followees,
     });
+
     await loadNeuron({
       neuronId,
-      identity,
       setNeuron: (neuron: NeuronInfo) => neuronsStore.pushNeurons([neuron]),
     });
   } catch (error) {
@@ -152,20 +131,14 @@ const setFolloweesHelper = async ({
 };
 
 export const addFollowee = async ({
-  identity,
   neuronId,
   topic,
   followee,
 }: {
-  identity: Identity | null | undefined;
   neuronId: NeuronId;
   topic: Topic;
   followee: NeuronId;
 }): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-348
-    throw new Error("No identity");
-  }
   const neurons = get(neuronsStore);
   const neuron = neurons.find(
     ({ neuronId: currentNeuronId }) => currentNeuronId === neuronId
@@ -178,7 +151,6 @@ export const addFollowee = async ({
       ? [followee]
       : [...topicFollowees.followees, followee];
   await setFolloweesHelper({
-    identity,
     neuronId,
     topic,
     followees: newFollowees,
@@ -187,20 +159,14 @@ export const addFollowee = async ({
 };
 
 export const removeFollowee = async ({
-  identity,
   neuronId,
   topic,
   followee,
 }: {
-  identity: Identity | null | undefined;
   neuronId: NeuronId;
   topic: Topic;
   followee: NeuronId;
 }): Promise<void> => {
-  if (!identity) {
-    // TODO: https://dfinity.atlassian.net/browse/L2-348
-    throw new Error("No identity");
-  }
   const neurons = get(neuronsStore);
   const neuron = neurons.find(
     ({ neuronId: currentNeuronId }) => currentNeuronId === neuronId
@@ -222,7 +188,6 @@ export const removeFollowee = async ({
     (id) => id !== followee
   );
   await setFolloweesHelper({
-    identity,
     neuronId,
     topic,
     followees: newFollowees,
@@ -239,14 +204,9 @@ const getNeuron = async ({
   certified,
 }: {
   neuronId: NeuronId;
-  identity: Identity | null | undefined;
+  identity: Identity;
   certified: boolean;
 }): Promise<NeuronInfo | undefined> => {
-  // TODO: https://dfinity.atlassian.net/browse/L2-348
-  if (!identity) {
-    throw new Error(get(i18n).error.missing_identity);
-  }
-
   const neuron = get(neuronsStore).find(
     (neuron) => neuron.neuronId === neuronId
   );
@@ -259,12 +219,10 @@ const getNeuron = async ({
  */
 export const loadNeuron = ({
   neuronId,
-  identity,
   setNeuron,
   handleError,
 }: {
   neuronId: NeuronId;
-  identity: Identity | undefined | null;
   setNeuron: (neuron: NeuronInfo) => void;
   handleError?: () => void;
 }): Promise<void> => {
@@ -281,11 +239,10 @@ export const loadNeuron = ({
   };
 
   return queryAndUpdate<NeuronInfo | undefined, unknown>({
-    request: ({ certified }) =>
+    request: (params) =>
       getNeuron({
         neuronId,
-        identity,
-        certified,
+        ...params,
       }),
     onLoad: ({ response: neuron }) => {
       if (neuron === undefined) {

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -58,7 +58,7 @@ export const stakeAndLoadNeuron = async ({
 // Gets neurons and adds them to the store
 export const listNeurons = async (): Promise<void> => {
   return queryAndUpdate<NeuronInfo[], unknown>({
-    request: (params) => queryNeurons(params),
+    request: (options) => queryNeurons(options),
     onLoad: ({ response: neurons }) => neuronsStore.setNeurons(neurons),
     onError: ({ error, certified }) => {
       console.error(error);
@@ -239,10 +239,10 @@ export const loadNeuron = ({
   };
 
   return queryAndUpdate<NeuronInfo | undefined, unknown>({
-    request: (params) =>
+    request: (options) =>
       getNeuron({
         neuronId,
-        ...params,
+        ...options,
       }),
     onLoad: ({ response: neuron }) => {
       if (neuron === undefined) {

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -17,7 +17,6 @@
     try {
       await listCanisters({
         clearBeforeQuery: true,
-        identity: $authStore.identity,
       });
     } catch (err: unknown) {
       toastsStore.error({

--- a/frontend/svelte/src/routes/NeuronDetail.svelte
+++ b/frontend/svelte/src/routes/NeuronDetail.svelte
@@ -15,7 +15,6 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import { i18n } from "../lib/stores/i18n";
   import { routeStore } from "../lib/stores/route.store";
-  import { authStore } from "../lib/stores/auth.store";
 
   let neuron: NeuronInfo | undefined;
 
@@ -49,7 +48,6 @@
 
     await loadNeuron({
       neuronId: neuronIdMaybe,
-      identity: $authStore.identity,
       setNeuron: (neuronInfo: NeuronInfo) => (neuron = neuronInfo),
       handleError: onError,
     });

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -25,7 +25,7 @@
     }
     try {
       isLoading = true;
-      await listNeurons({ identity: $authStore.identity });
+      await listNeurons();
     } catch (err) {
       toastsStore.error({
         labelKey: "errors.get_neurons",

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -14,7 +14,6 @@
   import VotingCard from "../lib/components/proposal-detail/VotingCard/VotingCard.svelte";
   import IneligibleNeuronsCard from "../lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
   import { i18n } from "../lib/stores/i18n";
-  import { authStore } from "../lib/stores/auth.store";
   import { listNeurons } from "../lib/services/neurons.services";
   import { neuronsStore } from "../lib/stores/neurons.store";
 
@@ -34,7 +33,7 @@
     }
 
     // TODO: catch and error handling -- https://dfinity.atlassian.net/browse/L2-370
-    await listNeurons({ identity: $authStore.identity });
+    await listNeurons();
     neuronsReady = true;
   });
 
@@ -59,7 +58,6 @@
 
     await loadProposal({
       proposalId: proposalIdMaybe,
-      identity: $authStore.identity,
       setProposal: (proposal: ProposalInfo) => (proposalInfo = proposal),
       handleError: onError,
     });

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -22,7 +22,6 @@
     listNextProposals,
     listProposals,
   } from "../lib/services/proposals.services";
-  import { authStore } from "../lib/stores/auth.store";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { routeStore } from "../lib/stores/route.store";
   import { isRoutePath } from "../lib/utils/app-path.utils";
@@ -36,7 +35,6 @@
     try {
       await listNextProposals({
         beforeProposal: lastProposalId($proposalsStore),
-        identity: $authStore.identity,
       });
     } catch (err: unknown) {
       toastsStore.error({
@@ -55,7 +53,6 @@
       // If proposals are already displayed we reset the store first otherwise it might give the user the feeling than the new filters were already applied while the proposals are still being searched.
       await listProposals({
         clearBeforeQuery: !emptyProposals($proposalsStore),
-        identity: $authStore.identity,
       });
     } catch (err: unknown) {
       toastsStore.error({

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -6,7 +6,11 @@ import {
 } from "../../../lib/services/accounts.services";
 import { accountsStore } from "../../../lib/stores/accounts.store";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
-import { mockIdentity } from "../../mocks/auth.store.mock";
+import {
+  mockIdentityErrorMsg,
+  resetIdentity,
+  setNoIdentity,
+} from "../../mocks/auth.store.mock";
 
 describe("accounts-services", () => {
   const mockAccounts = { main: mockMainAccount, subAccounts: [] };
@@ -20,7 +24,7 @@ describe("accounts-services", () => {
     .mockImplementation(() => Promise.resolve());
 
   it("should sync accounts", async () => {
-    await syncAccounts({ identity: mockIdentity });
+    await syncAccounts();
 
     expect(spyLoadAccounts).toHaveBeenCalled();
 
@@ -29,23 +33,28 @@ describe("accounts-services", () => {
   });
 
   it("should add a subaccount", async () => {
-    await addSubAccount({ name: "test subaccount", identity: mockIdentity });
+    await addSubAccount({ name: "test subaccount" });
 
     expect(spyCreateSubAccount).toHaveBeenCalled();
   });
 
   it("should not sync accounts if no identity", async () => {
-    const call = async () => await syncAccounts({ identity: null });
+    setNoIdentity();
 
-    await expect(call).rejects.toThrow(Error("No identity"));
+    const call = async () => await syncAccounts();
+
+    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+    resetIdentity();
   });
 
   it("should not add subaccount if no identity", async () => {
-    const call = async () =>
-      await addSubAccount({ name: "test subaccount", identity: null });
+    setNoIdentity();
 
-    await expect(call).rejects.toThrow(
-      Error("No identity found to create subaccount")
-    );
+    const call = async () => await addSubAccount({ name: "test subaccount" });
+
+    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+    resetIdentity();
   });
 });

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -2,9 +2,12 @@ import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
 import { listCanisters } from "../../../lib/services/canisters.services";
 import { canistersStore } from "../../../lib/stores/canisters.store";
-import { mockIdentity } from "../../mocks/auth.store.mock";
+import {
+  mockIdentityErrorMsg,
+  resetIdentity,
+  setNoIdentity,
+} from "../../mocks/auth.store.mock";
 import { mockCanisters } from "../../mocks/canisters.mock";
-import en from "../../mocks/i18n.mock";
 
 describe("canisters-services", () => {
   const spyQueryCanisters = jest
@@ -12,7 +15,7 @@ describe("canisters-services", () => {
     .mockImplementation(() => Promise.resolve(mockCanisters));
 
   it("should list canisters", async () => {
-    await listCanisters({ identity: mockIdentity });
+    await listCanisters({});
 
     expect(spyQueryCanisters).toHaveBeenCalled();
 
@@ -21,8 +24,12 @@ describe("canisters-services", () => {
   });
 
   it("should not list canisters if no identity", async () => {
-    const call = async () => await listCanisters({ identity: null });
+    setNoIdentity();
 
-    await expect(call).rejects.toThrow(Error(en.error.missing_identity));
+    const call = async () => await listCanisters({});
+
+    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+    resetIdentity();
   });
 });

--- a/frontend/svelte/src/tests/lib/services/knownNeurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/knownNeurons.services.spec.ts
@@ -1,9 +1,12 @@
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/governance.api";
-import * as en from "../../../lib/i18n/en.json";
 import { listKnownNeurons } from "../../../lib/services/knownNeurons.services";
 import { knownNeuronsStore } from "../../../lib/stores/knownNeurons.store";
-import { mockIdentity } from "../../mocks/auth.store.mock";
+import {
+  mockIdentityErrorMsg,
+  resetIdentity,
+  setNoIdentity,
+} from "../../mocks/auth.store.mock";
 import { mockKnownNeuron } from "../../mocks/neurons.mock";
 
 describe("knownNeurons-services", () => {
@@ -12,7 +15,7 @@ describe("knownNeurons-services", () => {
     .mockResolvedValue([mockKnownNeuron]);
 
   it("should list known neurons", async () => {
-    await listKnownNeurons({ identity: mockIdentity });
+    await listKnownNeurons();
 
     expect(spyQueryKnownNeurons).toHaveBeenCalled();
 
@@ -21,8 +24,12 @@ describe("knownNeurons-services", () => {
   });
 
   it("should not list known neurons if no identity", async () => {
-    const call = async () => await listKnownNeurons({ identity: null });
+    setNoIdentity();
 
-    await expect(call).rejects.toThrow(Error(en.error.missing_identity));
+    const call = async () => await listKnownNeurons();
+
+    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+    resetIdentity();
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/api.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/api.spec.ts
@@ -1,5 +1,5 @@
 import { tick } from "svelte";
-import { queryAndUpdate } from "../../../lib/utils/api.utils";
+import { queryAndUpdate } from "../../../lib/services/utils.services";
 
 describe("api-utils", () => {
   describe("queryAndUpdate", () => {
@@ -28,7 +28,7 @@ describe("api-utils", () => {
       const onLoad = jest.fn();
       const onError = jest.fn();
 
-      queryAndUpdate<number, unknown>({
+      await queryAndUpdate<number, unknown>({
         request,
         onLoad,
         onError,

--- a/frontend/svelte/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/auth.store.mock.ts
@@ -2,6 +2,7 @@ import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
 import type { AuthStore } from "../../lib/stores/auth.store";
+import en from "./i18n.mock";
 
 export const mockPrincipal = Principal.fromText(
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
@@ -10,6 +11,21 @@ export const mockPrincipal = Principal.fromText(
 export const mockIdentity = {
   getPrincipal: () => mockPrincipal,
 } as unknown as Identity;
+
+export const mockIdentityErrorMsg = en.error.missing_identity;
+
+let testIdentity: Identity | null = mockIdentity;
+
+export const setNoIdentity = () => (testIdentity = null);
+export const resetIdentity = () => (testIdentity = mockIdentity);
+
+export const mockGetIdentity = () => {
+  if (!testIdentity) {
+    throw new Error(mockIdentityErrorMsg);
+  }
+
+  return mockIdentity;
+};
 
 /**
  * A static mock of the auth store. The component that uses it will be rendered for test with a value that is already defined on mount.


### PR DESCRIPTION
# Motivation

- Refactor the way services access the identity - i.e. instead of passing the identity all the way down from the component, access to the identity on a `services` level.

- Solve the many todo that were open to display properly the error message for the edge case of the identity becoming null or undefined

- With the same approach of an auth becoming idle, logout the user automatically if a function of a service is queried but for some reason no identity was provided

# Note

This is an edge case. The auth - i.e. the identity - is guarded both in terms of session timeout and storage changes. Therefore in a normal behavior mode the automatic signout should already happen even before any call to a service.

# Changes

- add new function `getIdentity` that either return a valid `Identity` or proceed with a `logout`
- remove all `// TODO !identity throw error`
- remove usage of `$authStore.identity` for the services in the component
- refactor and rename `api.utils.ts` to `utils.services.ts` (see next point)
- get the identity from the store directly within `queryAndUpdate` function 
- use `getIdentity` for the update calls (that are not read operations)

# Tests

This new `getIdentity` function is now mocked globally, so it might be possible that we would be able to spare some mocks for the components. There are already quite some changes in this PR, therefore did not dig deeper on that matter.

I did no provided particular test for `getIdentity` because it is already covered by existing test and `logout` itself is already covered by its corresponding tests too.

# Screenshots

Simulated edge case UX.

![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/16886711/159724246-30881fc6-4bfb-4e6d-b78f-f8d284ae32ee.gif)

