### PR TITLE
L2 369 switch to promise all settled for the cast vote function

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -4,7 +4,7 @@
   import VoteConfirmationModal from "../../../modals/proposals/VoteConfirmationModal.svelte";
   import { i18n } from "../../../stores/i18n";
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
-  import { selectedNeuronsVotingPover } from "../../../utils/proposals.utils";
+  import { selectedNeuronsVotingPower } from "../../../utils/proposals.utils";
 
   const dispatch = createEventDispatcher();
 
@@ -12,7 +12,7 @@
   let showConfirmationModal: boolean = false;
   let selectedVoteType: Vote = Vote.YES;
 
-  $: total = selectedNeuronsVotingPover({
+  $: total = selectedNeuronsVotingPower({
     neurons: $votingNeuronSelectStore.neurons,
     selectedIds: $votingNeuronSelectStore.selectedIds,
   });

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -3,13 +3,13 @@
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
   import {
     formatVotingPower,
-    selectedNeuronsVotingPover,
+    selectedNeuronsVotingPower,
   } from "../../../utils/proposals.utils";
   import Checkbox from "../../ui/Checkbox.svelte";
 
   let total: bigint;
 
-  $: total = selectedNeuronsVotingPover({
+  $: total = selectedNeuronsVotingPower({
     neurons: $votingNeuronSelectStore.neurons,
     selectedIds: $votingNeuronSelectStore.selectedIds,
   });

--- a/frontend/svelte/src/lib/components/ui/Markdown.svelte
+++ b/frontend/svelte/src/lib/components/ui/Markdown.svelte
@@ -28,7 +28,7 @@
     on:nnsError={onError}
   />
 {:else if parse !== undefined && text !== undefined}
-  {@html parse(removeHTMLTags(text))}
+  {@html parse(removeHTMLTags(text) ?? "")}
 {:else}
   <!-- fallback text content -->
   <p data-tid="markdown-text">{text}</p>

--- a/frontend/svelte/src/lib/components/ui/Markdown.svelte
+++ b/frontend/svelte/src/lib/components/ui/Markdown.svelte
@@ -7,7 +7,7 @@
 
   // do not load the lib if available
   /* eslint-disable-next-line no-undef */
-  let parse: (string) => string | undefined = globalThis?.marked?.parse;
+  let parse: (value: string) => string | undefined = globalThis?.marked?.parse;
   let loading: boolean = parse === undefined;
 
   const onLoad = () => {

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -25,11 +25,13 @@
     "get_neurons": "There was an unexpected issue while searching for the neurons.",
     "get_known_neurons": "There was an unexpected issue while searching for the known neurons.",
     "register_vote": "Sorry, there was an error while registering the vote. Please try again.",
+    "register_vote_neuron": "$neuronId: $reason",
     "register_vote_unknown": "Sorry, there was an unexpectedf error while registering the vote. Please try again later.",
     "add_followee": "Sorry, there was an unexpectedf error while adding the followee. Please try again later.",
     "remove_followee": "Sorry, there was an unexpectedf error while removing the followee. Please try again later.",
     "followee_does_not_exist": "Sorry, followee already removed, refresh the page to have the latest data.",
-    "accounts_not_found": "An error occurred while loading the accounts information."
+    "accounts_not_found": "An error occurred while loading the accounts information.",
+    "fail": "fail"
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -225,7 +225,7 @@ const requestRegisterVotes = async ({
   }> = responses
     // add neuronId
     .map((result, i) => ({ neuronId: neuronIds[i], result }))
-    // use only not empty errors
+    // handle only not-empty errors
     .filter(
       ({ result }) =>
         result.status === "rejected" && result.reason instanceof Error
@@ -242,7 +242,6 @@ const requestRegisterVotes = async ({
     const detail: string = errors
       .map(({ neuronId, error }) => {
         const reason = errorToString(error);
-        console.log(typeof reason, error?.["message"], get(i18n).error.fail);
         return replacePlaceholders(get(i18n).error.register_vote_neuron, {
           $neuronId: neuronId.toString(),
           $reason:

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -180,11 +180,8 @@ export const registerVotes = async ({
       identity,
     });
   } catch (error) {
-    // TODO: replace w/ console.error mock
-    if (!isNode()) {
-      // preserve in unit-test
-      console.error("vote unknown:", error);
-    }
+    console.error("vote unknown:", error);
+
     toastsStore.show({
       labelKey: "error.register_vote_unknown",
       level: "error",

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -199,9 +199,10 @@ const requestRegisterVotes = async ({
   );
   const errors: Array<{
     neuronId: bigint;
+    // TODO: replace Error with NNSJsError
     error: Error;
   }> = responses
-    // add neuronId
+    // map neuronId
     .map((result, i) => ({ neuronId: neuronIds[i], result }))
     // handle only not-empty errors
     .filter(

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -184,7 +184,15 @@ export const registerVotes = async ({
     });
   }
 
-  await listNeurons({ identity });
+  try {
+    await listNeurons({ identity });
+  } catch (err) {
+    console.error(err);
+    toastsStore.error({
+      labelKey: "error.list_proposals",
+      err,
+    });
+  }
 
   busyStore.stop("vote");
 };

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -7,6 +7,7 @@ import {
   registerVote,
 } from "../api/proposals.api";
 import { busyStore } from "../stores/busy.store";
+import { i18n } from "../stores/i18n";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import {
   proposalsFiltersStore,
@@ -16,7 +17,6 @@ import { toastsStore } from "../stores/toasts.store";
 import { getLastPathDetailId } from "../utils/app-path.utils";
 import { errorToString } from "../utils/error.utils";
 import { replacePlaceholders } from "../utils/i18n.utils";
-import { stringifyJson, uniqueObjects } from "../utils/utils";
 import { getIdentity } from "./auth.services";
 import { listNeurons } from "./neurons.services";
 

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -1,10 +1,5 @@
 import type { Identity } from "@dfinity/agent";
-import {
-  type NeuronId,
-  type ProposalId,
-  type ProposalInfo,
-  type Vote,
-} from "@dfinity/nns";
+import type { NeuronId, ProposalId, ProposalInfo, Vote } from "@dfinity/nns";
 import { get } from "svelte/store";
 import {
   queryProposal,

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -29,11 +29,13 @@ interface I18nError {
   get_neurons: string;
   get_known_neurons: string;
   register_vote: string;
+  register_vote_neuron: string;
   register_vote_unknown: string;
   add_followee: string;
   remove_followee: string;
   followee_does_not_exist: string;
   accounts_not_found: string;
+  fail: string;
 }
 
 interface I18nWarning {

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -1,6 +1,10 @@
+import { GovernanceError } from "@dfinity/nns";
+
 export const errorToString = (err?: unknown): string | undefined =>
   typeof err === "string"
     ? (err as string)
+    : err instanceof GovernanceError
+    ? (err as GovernanceError)?.detail?.error_message
     : err instanceof Error
     ? (err as Error).message
     : undefined;

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -113,7 +113,7 @@ export const hasMatchingProposals = ({
   );
 };
 
-export const selectedNeuronsVotingPover = ({
+export const selectedNeuronsVotingPower = ({
   neurons,
   selectedIds,
 }: {

--- a/frontend/svelte/src/lib/utils/security.utils.ts
+++ b/frontend/svelte/src/lib/utils/security.utils.ts
@@ -3,7 +3,9 @@ let decoder: HTMLDivElement | undefined;
  * Simple but fast string sanitizer (does NOT escape but removes HTML tags)
  * https://github.com/vuejs/vue/blob/dev/src/compiler/parser/entity-decoder.js
  */
-export const removeHTMLTags = (text?: string): string | null | undefined => {
+export const removeHTMLTags = (
+  text?: string | undefined
+): string | null | undefined => {
   if (text === undefined) return text;
 
   decoder = decoder || document.createElement("div");

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -53,3 +53,7 @@ export const uniqueObjects = <T>(list: T[]): T[] => {
   }
   return result;
 };
+
+// https://stackoverflow.com/questions/43010737/way-to-tell-typescript-compiler-array-prototype-filter-removes-certain-types-fro#answer-54318054
+export const isDefined = <T>(argument: T | undefined): argument is T =>
+  argument !== undefined;

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -21,7 +21,7 @@ export const debounce = (func: Function, timeout?: number) => {
  * devMode transforms 123n -> "BigInt(123)"
  */
 export const stringifyJson = (
-  value,
+  value: unknown,
   options?: {
     indentation?: number;
     devMode?: boolean;

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -33,7 +33,6 @@
       return;
     }
 
-    // TODO: catch and error handling -- https://dfinity.atlassian.net/browse/L2-370
     await listNeurons({ identity: $authStore.identity });
     neuronsReady = true;
   });

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.spec.ts
@@ -9,6 +9,8 @@ import en from "../../../../mocks/i18n.mock";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
 
 describe("ProposalMeta", () => {
+  jest.spyOn(console, "error").mockImplementation(jest.fn);
+
   const props = {
     proposalInfo: mockProposalInfo,
   };

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -222,6 +222,28 @@ describe("proposals-services", () => {
         });
         expect(spyOnListNeurons).toBeCalledTimes(1);
       });
+
+      it("should show 'error.list_proposals' on refetch neurons error", async () => {
+        jest.spyOn(api, "registerVote").mockImplementation(mockRegisterVote);
+        const err = new Error("test");
+        const spyToastError = jest.spyOn(toastsStore, "error");
+        // .mockImplementation((params) => (lastToastMessage = params));
+        const spyOnListNeurons = jest
+          .spyOn(neuronsServices, "listNeurons")
+          .mockImplementation(() => Promise.reject(err));
+
+        await registerVotes({
+          neuronIds,
+          proposalId,
+          vote: Vote.YES,
+          identity,
+        });
+        expect(spyOnListNeurons).toBeCalled();
+        expect(spyToastError).toBeCalledWith({
+          err,
+          labelKey: "error.list_proposals",
+        });
+      });
     });
 
     describe("register vote errors", () => {

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -14,8 +14,6 @@ import { busyStore } from "../../../lib/stores/busy.store";
 import { proposalsStore } from "../../../lib/stores/proposals.store";
 import { toastsStore } from "../../../lib/stores/toasts.store";
 import type { ToastMsg } from "../../../lib/types/toast";
-import { mockIdentity } from "../../mocks/auth.store.mock";
-import en from "../../mocks/i18n.mock";
 import {
   mockIdentityErrorMsg,
   resetIdentity,
@@ -289,7 +287,6 @@ describe("proposals-services", () => {
           neuronIds,
           proposalId,
           vote: Vote.NO,
-          identity,
         });
         expect(spyToastShow).toBeCalled();
         expect(lastToastMessage.labelKey).toBe("error.register_vote");
@@ -318,7 +315,6 @@ describe("proposals-services", () => {
           neuronIds,
           proposalId,
           vote: Vote.NO,
-          identity,
         });
         expect(lastToastMessage?.detail?.split(/governance-error/).length).toBe(
           neuronIds.length + 1

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -1,5 +1,4 @@
-import type { Identity } from "@dfinity/agent";
-import type { ProposalInfo } from "@dfinity/nns";
+import type { NeuronId, ProposalInfo } from "@dfinity/nns";
 import { GovernanceError, Vote } from "@dfinity/nns";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/proposals.api";
@@ -14,6 +13,7 @@ import {
 import { busyStore } from "../../../lib/stores/busy.store";
 import { proposalsStore } from "../../../lib/stores/proposals.store";
 import { toastsStore } from "../../../lib/stores/toasts.store";
+import type { ToastMsg } from "../../../lib/types/toast";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockProposals } from "../../mocks/proposals.store.mock";
@@ -224,106 +224,90 @@ describe("proposals-services", () => {
       });
     });
 
-    describe("multiple errors nns-js", () => {
+    describe("register vote errors", () => {
       jest
         .spyOn(neuronsServices, "listNeurons")
         .mockImplementation(() => Promise.resolve());
 
-      afterAll(() => jest.clearAllMocks());
-
-      const mockRegisterVote = async ({
-        neuronId,
-      }: {
-        neuronId: bigint;
-        vote: Vote;
-        proposalId: bigint;
-        identity: Identity;
-      }): Promise<void> => {
-        throw new GovernanceError({
-          error_message: `${neuronId}`,
-          error_type: 0,
-        });
-      };
-
-      it("should show multiple nns-js errors in details", async () => {
-        jest.spyOn(api, "registerVote").mockImplementation(mockRegisterVote);
-
-        const spyToastShow = jest.spyOn(toastsStore, "show");
-        await registerVotes({
-          neuronIds,
-          proposalId,
-          vote: Vote.NO,
-          identity,
-        });
-        expect(spyToastShow).toBeCalledTimes(1);
-        expect(spyToastShow).toBeCalledWith({
-          labelKey: "error.register_vote",
-          level: "error",
-          detail: "\n" + neuronIds.map((id) => `"${id}"`).join("\n"),
-        });
-      });
-    });
-
-    describe("unique errors nns-js", () => {
-      jest
-        .spyOn(neuronsServices, "listNeurons")
-        .mockImplementation(() => Promise.resolve());
-
-      afterAll(() => jest.clearAllMocks());
-
-      let registerVoteCallCount = 0;
-
-      const mockRegisterVote = async (): Promise<void> => {
-        throw new GovernanceError({
-          error_message: registerVoteCallCount++ === 0 ? "error0" : "error1",
-          error_type: 0,
-        });
-      };
-
-      it("should show only unique nns-js errors", async () => {
-        jest.spyOn(api, "registerVote").mockImplementation(mockRegisterVote);
-
-        const spyToastShow = jest.spyOn(toastsStore, "show");
-        await registerVotes({
-          neuronIds,
-          proposalId,
-          vote: Vote.NO,
-          identity,
-        });
-        expect(spyToastShow).toBeCalledWith({
-          labelKey: "error.register_vote",
-          level: "error",
-          detail: `\n"error0"\n"error1"`,
-        });
-      });
-    });
-
-    describe("unknow errors", () => {
-      jest
-        .spyOn(neuronsServices, "listNeurons")
-        .mockImplementation(() => Promise.resolve());
-
-      afterAll(() => jest.clearAllMocks());
-
-      const mockRegisterVote = async (): Promise<void> => {
+      const mockRegisterVoteError = async (): Promise<void> => {
         throw new Error("test");
       };
+      const mockRegisterVoteGovernanceError = async (): Promise<void> => {
+        throw new GovernanceError({
+          error_message: "governance-error",
+          error_type: 0,
+        });
+      };
 
-      it("should show register_vote_unknown on not nns-js-based error", async () => {
-        jest.spyOn(api, "registerVote").mockImplementation(mockRegisterVote);
+      let lastToastMessage: ToastMsg;
+      const spyToastShow = jest
+        .spyOn(toastsStore, "show")
+        .mockImplementation((params) => (lastToastMessage = params));
 
-        const spyToastShow = jest.spyOn(toastsStore, "show");
+      beforeEach(
+        () =>
+          (lastToastMessage = {
+            labelKey: "",
+            level: "info",
+          })
+      );
+
+      afterAll(() => jest.clearAllMocks());
+
+      it("should show error.register_vote_unknown on not nns-js-based error", async () => {
+        await registerVotes({
+          neuronIds: null as unknown as NeuronId[],
+          proposalId,
+          vote: Vote.NO,
+          identity,
+        });
+        expect(lastToastMessage.labelKey).toBe("error.register_vote_unknown");
+        expect(lastToastMessage.level).toBe("error");
+      });
+
+      it("should show error.register_vote on nns-js-based errors", async () => {
+        jest
+          .spyOn(api, "registerVote")
+          .mockImplementation(mockRegisterVoteError);
         await registerVotes({
           neuronIds,
           proposalId,
           vote: Vote.NO,
           identity,
         });
-        expect(spyToastShow).toBeCalledWith({
-          labelKey: "error.register_vote_unknown",
-          level: "error",
-          detail: "test",
+        expect(spyToastShow).toBeCalled();
+        expect(lastToastMessage.labelKey).toBe("error.register_vote");
+        expect(lastToastMessage.level).toBe("error");
+      });
+
+      it("should show reason per neuron Error in detail", async () => {
+        jest
+          .spyOn(api, "registerVote")
+          .mockImplementation(mockRegisterVoteError);
+        await registerVotes({
+          neuronIds,
+          proposalId,
+          vote: Vote.NO,
+          identity,
         });
+        expect(lastToastMessage?.detail?.split(/test/).length).toBe(
+          neuronIds.length + 1
+        );
+      });
+
+      it("should show reason per neuron GovernanceError in detail", async () => {
+        jest
+          .spyOn(api, "registerVote")
+          .mockImplementation(mockRegisterVoteGovernanceError);
+        await registerVotes({
+          neuronIds,
+          proposalId,
+          vote: Vote.NO,
+          identity,
+        });
+        expect(lastToastMessage?.detail?.split(/governance-error/).length).toBe(
+          neuronIds.length + 1
+        );
       });
     });
   });

--- a/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
@@ -8,7 +8,7 @@ import {
   lastProposalId,
   proposalActionFields,
   proposalFirstActionKey,
-  selectedNeuronsVotingPover,
+  selectedNeuronsVotingPower,
 } from "../../../lib/utils/proposals.utils";
 import { mockNeuron } from "../../mocks/neurons.mock";
 import { mockProposalInfo } from "../../mocks/proposal.mock";
@@ -309,7 +309,7 @@ describe("proposals-utils", () => {
     });
   });
 
-  describe("selectedNeuronsVotingPover", () => {
+  describe("selectedNeuronsVotingPower", () => {
     const neuron = (id: number, votingPower: number): NeuronInfo =>
       ({
         ...mockNeuron,
@@ -319,14 +319,14 @@ describe("proposals-utils", () => {
 
     it("should calculate total", () => {
       expect(
-        selectedNeuronsVotingPover({
+        selectedNeuronsVotingPower({
           neurons: [neuron(1, 1), neuron(2, 3), neuron(3, 5)],
           selectedIds: [1, 2, 3].map(BigInt),
         })
       ).toBe(BigInt(9));
 
       expect(
-        selectedNeuronsVotingPover({
+        selectedNeuronsVotingPower({
           neurons: [neuron(1, 1), neuron(2, 3), neuron(3, 5)],
           selectedIds: [1, 3].map(BigInt),
         })
@@ -335,7 +335,7 @@ describe("proposals-utils", () => {
 
     it("should return 0 if no selection", () => {
       expect(
-        selectedNeuronsVotingPover({
+        selectedNeuronsVotingPower({
           neurons: [neuron(1, 1), neuron(2, 3), neuron(3, 5)],
           selectedIds: [],
         })

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   debounce,
+  isDefined,
   stringifyJson,
   uniqueObjects,
 } from "../../../lib/utils/utils";
@@ -103,5 +104,18 @@ describe("utils", () => {
     ]);
     expect(uniqueObjects([1, 2, 3, 1, 2, 3])).toEqual([1, 2, 3]);
     expect(uniqueObjects([])).toEqual([]);
+  });
+
+  describe("isDefined", () => {
+    it("should return true if not undefined", () => {
+      expect(isDefined(true)).toBeTruthy();
+      expect(isDefined(1)).toBeTruthy();
+      expect(isDefined("")).toBeTruthy();
+      expect(isDefined(null)).toBeTruthy();
+    });
+
+    it("should return false if undefined", () => {
+      expect(isDefined(undefined)).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
# Motivation

To improve error handling we switch from Promise.all to Promise.allSettled. Display individual errors (one per failure neuron update) in detail of the error message.
[L2-369](https://dfinity.atlassian.net/browse/L2-369)

# Changes

- display individual neuron errors (in detail)
- listNeurons error handling (refresh)
- reorganisation of register vote tests (error blocks are combined in single describe block)

# Tests

- proposal service

# Notes

@peterpeterparker Probably it makes sense to change the detail rendering style. So it doesn't look like a part of the error message.

# Screenshots

![image](https://user-images.githubusercontent.com/98811342/159910886-1251b175-a37f-4576-8a51-f2da7088fef3.png)

**empty error message fallback**
![image](https://user-images.githubusercontent.com/98811342/159910623-7eeb8204-a78a-4b6d-bedd-10a93fdb6a20.png)
