### PR TITLE
EXC-1030: Users can specify the subaccount in the CLI tool.

### DIFF
--- a/frontend/ts/ic-hardware-wallet-cli.ts
+++ b/frontend/ts/ic-hardware-wallet-cli.ts
@@ -249,7 +249,7 @@ async function stopDissolving(neuronId: string) {
 }
 
 async function getLedgerIdentity(): Promise<LedgerIdentity> {
-  const subaccountId = Number.parseInt(program.opts().subaccount ?? 0);
+  const subaccountId = tryParseInt(program.opts().subaccount);
   if (subaccountId < 0 || subaccountId > 255) {
     throw new InvalidArgumentError("Subaccount must be between 0 and 255 inclusive.");
   }

--- a/frontend/ts/ic-hardware-wallet-cli.ts
+++ b/frontend/ts/ic-hardware-wallet-cli.ts
@@ -182,9 +182,8 @@ async function disburseNeuron(
   neuronId: string,
   to?: AccountIdentifier,
   amount?: string,
-  subaccount?: string
 ) {
-  const identity = await getLedgerIdentity(subaccount);
+  const identity = await getLedgerIdentity();
   const governance = await getGovernanceService(identity);
 
   const response = await governance.disburse({
@@ -249,8 +248,11 @@ async function stopDissolving(neuronId: string) {
   log(response);
 }
 
-async function getLedgerIdentity(subaccount?: string): Promise<LedgerIdentity> {
-  const subaccountId = subaccount ? Number.parseInt(subaccount) : 0;
+async function getLedgerIdentity(): Promise<LedgerIdentity> {
+  const subaccountId = Number.parseInt(program.opts().subaccount ?? 0);
+  if (subaccountId < 0 || subaccountId > 255) {
+    throw new InvalidArgumentError("Subaccount must be between 0 and 255 inclusive.");
+  }
   return await LedgerIdentity.create(`m/44'/223'/0'/0/${subaccountId}`);
 }
 
@@ -417,6 +419,10 @@ async function main() {
       new Option("--network <network>", "The IC network to talk to.")
         .default("https://ic0.app")
         .env("IC_NETWORK")
+    )
+    .addOption(
+      new Option("--subaccount <subaccount>", "The subaccount to use.")
+        .default(0)
     )
     .addCommand(
       new Command("info")

--- a/frontend/ts/ic-hardware-wallet-cli.ts
+++ b/frontend/ts/ic-hardware-wallet-cli.ts
@@ -181,7 +181,7 @@ async function removeHotkey(neuronId: string, principal: string) {
 async function disburseNeuron(
   neuronId: string,
   to?: AccountIdentifier,
-  amount?: string,
+  amount?: string
 ) {
   const identity = await getLedgerIdentity();
   const governance = await getGovernanceService(identity);
@@ -251,7 +251,9 @@ async function stopDissolving(neuronId: string) {
 async function getLedgerIdentity(): Promise<LedgerIdentity> {
   const subaccountId = tryParseInt(program.opts().subaccount);
   if (subaccountId < 0 || subaccountId > 255) {
-    throw new InvalidArgumentError("Subaccount must be between 0 and 255 inclusive.");
+    throw new InvalidArgumentError(
+      "Subaccount must be between 0 and 255 inclusive."
+    );
   }
   return await LedgerIdentity.create(`m/44'/223'/0'/0/${subaccountId}`);
 }
@@ -421,8 +423,9 @@ async function main() {
         .env("IC_NETWORK")
     )
     .addOption(
-      new Option("--subaccount <subaccount>", "The subaccount to use.")
-        .default(0)
+      new Option("--subaccount <subaccount>", "The subaccount to use.").default(
+        0
+      )
     )
     .addCommand(
       new Command("info")

--- a/ic-hardware-wallet-cli/ic-hardware-wallet-cli
+++ b/ic-hardware-wallet-cli/ic-hardware-wallet-cli
@@ -7,7 +7,7 @@ if [ ! -d "node_modules" ]; then
 fi
 
 # This isn't needed by the CLI, but is done to keep the TS compiler happy.
-DEPLOY_ENV=mainnet ../../update_config.sh
+DEPLOY_ENV=mainnet ../../update_config.sh > /dev/null
 
 npm run ic-hardware-wallet-cli --silent -- "${@}"
 popd || exit >/dev/null

--- a/ic-hardware-wallet-cli/ic-hardware-wallet-cli
+++ b/ic-hardware-wallet-cli/ic-hardware-wallet-cli
@@ -7,7 +7,7 @@ if [ ! -d "node_modules" ]; then
 fi
 
 # This isn't needed by the CLI, but is done to keep the TS compiler happy.
-DEPLOY_ENV=mainnet ../../update_config.sh > /dev/null
+DEPLOY_ENV=mainnet ../../update_config.sh >/dev/null
 
 npm run ic-hardware-wallet-cli --silent -- "${@}"
 popd || exit >/dev/null


### PR DESCRIPTION
We always assumed that the user wants to use subaccount `0`. This PR
expands the scope of the CLI tool to allow specifying any subaccount.

Example command:

```
./ic-hardware-wallet-cli --subaccount 1 info
```