### PR TITLE
Fix: change II curl URL

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -11,7 +11,7 @@
       "type": "custom",
       "wasm": "internet_identity.wasm",
       "candid": "internet_identity.did",
-      "build": "curl -sSL https://github.com/dfinity/internet-identity/releases/download/release-initial/internet_identity_dev.wasm -o internet_identity.wasm"
+      "build": "curl -sSL https://github.com/dfinity/internet-identity/releases/download/release-2022-03-15/internet_identity_dev.wasm -o internet_identity.wasm"
     }
   },
   "networks": {


### PR DESCRIPTION
# Motivation

URL used to get II wasm for e2e test is returning 404.

# Changes

* Change URL where we get II wasm.

# Tests

No extra tests
