### PR TITLE
L2-329: Manage errors stake neuron

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -7,7 +7,11 @@
   import { secondsToDuration } from "../../utils/date.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formatICP } from "../../utils/icp.utils";
-  import { votingPower } from "../../utils/neuron.utils";
+  import {
+    formatVotingPower,
+    neuronStake,
+    votingPower,
+  } from "../../utils/neuron.utils";
   import { startBusy, stopBusy } from "../../stores/busy.store";
 
   export let delayInSeconds: number;
@@ -16,18 +20,20 @@
 
   const dispatcher = createEventDispatcher();
   let neuronICP: bigint;
-  $: neuronICP = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
+  $: neuronICP = neuronStake(neuron);
 
   const updateNeuron = async () => {
     startBusy("update-delay");
     loading = true;
-    await updateDelay({
+    const neuronId = await updateDelay({
       neuronId: neuron.neuronId,
       dissolveDelayInSeconds: delayInSeconds,
     });
     stopBusy("update-delay");
-    dispatcher("nnsNext");
     loading = false;
+    if (neuronId !== undefined) {
+      dispatcher("nnsNext");
+    }
   };
 </script>
 
@@ -50,10 +56,12 @@
   <div class="voting-power">
     <h5>{$i18n.neurons.voting_power}</h5>
     <p>
-      {votingPower({
-        stake: neuronICP,
-        dissolveDelayInSeconds: delayInSeconds,
-      }).toFixed(2)}
+      {formatVotingPower(
+        votingPower({
+          stake: neuronICP,
+          dissolveDelayInSeconds: delayInSeconds,
+        })
+      )}
     </p>
   </div>
   <div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -8,81 +8,68 @@
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formatICP } from "../../utils/icp.utils";
   import { votingPower } from "../../utils/neuron.utils";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
 
   export let delayInSeconds: number;
-  export let neuron: NeuronInfo | undefined;
+  export let neuron: NeuronInfo;
   let loading: boolean = false;
 
   const dispatcher = createEventDispatcher();
   let neuronICP: bigint;
-  $: neuronICP = neuron?.fullNeuron?.cachedNeuronStake ?? BigInt(0);
+  $: neuronICP = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
 
   const updateNeuron = async () => {
-    if (neuron === undefined) {
-      // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-329
-      console.error("Neuron is not defined");
-      return;
-    }
-
+    startBusy("update-delay");
     loading = true;
-    try {
-      await updateDelay({
-        neuronId: neuron.neuronId,
-        dissolveDelayInSeconds: delayInSeconds,
-      });
-      dispatcher("nnsNext");
-    } catch (error) {
-      // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-329
-      console.error(error);
-    } finally {
-      loading = false;
-    }
+    await updateDelay({
+      neuronId: neuron.neuronId,
+      dissolveDelayInSeconds: delayInSeconds,
+    });
+    stopBusy("update-delay");
+    dispatcher("nnsNext");
+    loading = false;
   };
 </script>
 
 <div class="wizard-wrapper" data-tid="confirm-dissolve-delay-container">
-  {#if neuron !== undefined}
-    <div class="main-info">
-      <h3>{secondsToDuration(BigInt(delayInSeconds))}</h3>
-    </div>
-    <div>
-      <h5>{$i18n.neurons.neuron_id}</h5>
-      <p>{neuron.neuronId}</p>
-    </div>
-    <div>
-      <h5>{$i18n.neurons.neuron_balance}</h5>
-      <p>
-        {replacePlaceholders($i18n.neurons.icp_stake, {
-          $amount: formatICP(neuronICP),
-        })}
-      </p>
-    </div>
-    <div class="voting-power">
-      <h5>{$i18n.neurons.voting_power}</h5>
-      <p>
-        {votingPower({
-          stake: neuronICP,
-          dissolveDelayInSeconds: delayInSeconds,
-        }).toFixed(2)}
-      </p>
-    </div>
-    <div>
-      <button
-        class="primary full-width"
-        data-tid="confirm-delay-button"
-        disabled={loading}
-        on:click={updateNeuron}
-      >
-        {#if loading}
-          <Spinner />
-        {:else}
-          {$i18n.neurons.confirm_delay}
-        {/if}
-      </button>
-    </div>
-  {:else}
-    <Spinner />
-  {/if}
+  <div class="main-info">
+    <h3>{secondsToDuration(BigInt(delayInSeconds))}</h3>
+  </div>
+  <div>
+    <h5>{$i18n.neurons.neuron_id}</h5>
+    <p>{neuron.neuronId}</p>
+  </div>
+  <div>
+    <h5>{$i18n.neurons.neuron_balance}</h5>
+    <p>
+      {replacePlaceholders($i18n.neurons.icp_stake, {
+        $amount: formatICP(neuronICP),
+      })}
+    </p>
+  </div>
+  <div class="voting-power">
+    <h5>{$i18n.neurons.voting_power}</h5>
+    <p>
+      {votingPower({
+        stake: neuronICP,
+        dissolveDelayInSeconds: delayInSeconds,
+      }).toFixed(2)}
+    </p>
+  </div>
+  <div>
+    <button
+      class="primary full-width"
+      data-tid="confirm-delay-button"
+      disabled={loading}
+      on:click={updateNeuron}
+    >
+      {#if loading}
+        <Spinner />
+      {:else}
+        {$i18n.neurons.confirm_delay}
+      {/if}
+    </button>
+  </div>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/neurons/EditFollowNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/EditFollowNeurons.svelte
@@ -4,11 +4,10 @@
   import FollowTopicSection from "./FollowTopicSection.svelte";
   import { i18n } from "../../stores/i18n";
   import { enumValues } from "../../utils/enum.utils";
-  import Spinner from "../ui/Spinner.svelte";
   import { onMount } from "svelte";
   import { listKnownNeurons } from "../../services/knownNeurons.services";
 
-  export let neuron: NeuronInfo | undefined;
+  export let neuron: NeuronInfo;
 
   // Load KnownNeurons which are used in the FollowTopicSections
   onMount(() => listKnownNeurons());
@@ -17,16 +16,12 @@
 </script>
 
 <div class="wizard-list" data-tid="edit-followers-screen">
-  {#if neuron !== undefined}
-    <p>{$i18n.follow_neurons.description}</p>
-    <div>
-      {#each topics as topic}
-        <FollowTopicSection {neuron} {topic} />
-      {/each}
-    </div>
-  {:else}
-    <Spinner />
-  {/if}
+  <p>{$i18n.follow_neurons.description}</p>
+  <div>
+    {#each topics as topic}
+      <FollowTopicSection {neuron} {topic} />
+    {/each}
+  </div>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -14,7 +14,7 @@
   import { votingPower } from "../../utils/neuron.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
 
-  export let neuron: NeuronInfo | undefined;
+  export let neuron: NeuronInfo;
   export let delayInSeconds: number = 0;
 
   let loading: boolean = false;
@@ -36,7 +36,7 @@
     dispatcher("nnsSkipDelay");
   };
   let neuronICP: bigint;
-  $: neuronICP = neuron?.fullNeuron?.cachedNeuronStake ?? BigInt(0);
+  $: neuronICP = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
 
   const goToConfirmation = async () => {
     dispatcher("nnsConfirmDelay");

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -11,7 +11,11 @@
   import { i18n } from "../../stores/i18n";
   import { secondsToDuration } from "../../utils/date.utils";
   import { formatICP } from "../../utils/icp.utils";
-  import { votingPower } from "../../utils/neuron.utils";
+  import {
+    formatVotingPower,
+    neuronStake,
+    votingPower,
+  } from "../../utils/neuron.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
 
   export let neuron: NeuronInfo;
@@ -36,7 +40,7 @@
     dispatcher("nnsSkipDelay");
   };
   let neuronICP: bigint;
-  $: neuronICP = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
+  $: neuronICP = neuronStake(neuron);
 
   const goToConfirmation = async () => {
     dispatcher("nnsConfirmDelay");
@@ -44,85 +48,83 @@
 </script>
 
 <div class="wizard-wrapper wrapper">
-  {#if neuron !== undefined}
-    <div>
-      <h5>{$i18n.neurons.neuron_id}</h5>
-      <p>{neuron.neuronId}</p>
-    </div>
-    <div>
-      <h5>{$i18n.neurons.neuron_balance}</h5>
-      <p data-tid="neuron-stake">
-        {replacePlaceholders($i18n.neurons.icp_stake, {
-          $amount: formatICP(neuronICP),
-        })}
+  <div>
+    <h5>{$i18n.neurons.neuron_id}</h5>
+    <p>{neuron.neuronId}</p>
+  </div>
+  <div>
+    <h5>{$i18n.neurons.neuron_balance}</h5>
+    <p data-tid="neuron-stake">
+      {replacePlaceholders($i18n.neurons.icp_stake, {
+        $amount: formatICP(neuronICP),
+      })}
+    </p>
+  </div>
+  <div>
+    {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
+      <h5>{$i18n.neurons.current_dissolve_delay}</h5>
+      <p class="duration">
+        {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons
+          .staked}
       </p>
+    {/if}
+  </div>
+  <Card>
+    <div slot="start">
+      <h5>{$i18n.neurons.dissolve_delay_title}</h5>
+      <p>{$i18n.neurons.dissolve_delay_description}</p>
     </div>
-    <div>
-      {#if neuron.state === NeuronState.LOCKED && neuron.dissolveDelaySeconds}
-        <h5>{$i18n.neurons.current_dissolve_delay}</h5>
-        <p class="duration">
-          {secondsToDuration(neuron.dissolveDelaySeconds)} - {$i18n.neurons
-            .staked}
-        </p>
-      {/if}
-    </div>
-    <Card>
-      <div slot="start">
-        <h5>{$i18n.neurons.dissolve_delay_title}</h5>
-        <p>{$i18n.neurons.dissolve_delay_description}</p>
-      </div>
-      <div class="select-delay-container">
-        <input
-          min={0}
-          max={SECONDS_IN_EIGHT_YEARS}
-          type="range"
-          bind:value={delayInSeconds}
-          style={`background-image: ${backgroundStyle};`}
-        />
-        <div class="details">
-          <div>
-            <h5>
-              {votingPower({
+    <div class="select-delay-container">
+      <input
+        min={0}
+        max={SECONDS_IN_EIGHT_YEARS}
+        type="range"
+        bind:value={delayInSeconds}
+        style={`background-image: ${backgroundStyle};`}
+      />
+      <div class="details">
+        <div>
+          <h5>
+            {formatVotingPower(
+              votingPower({
                 stake: neuronICP,
                 dissolveDelayInSeconds: delayInSeconds,
-              }).toFixed(2)}
-            </h5>
-            <p>{$i18n.neurons.voting_power}</p>
-          </div>
-          <div>
-            {#if delayInSeconds > 0}
-              <h5>{secondsToDuration(BigInt(delayInSeconds))}</h5>
-            {:else}
-              <h5>{$i18n.neurons.no_delay}</h5>
-            {/if}
-            <p>{$i18n.neurons.dissolve_delay_title}</p>
-          </div>
+              })
+            )}
+          </h5>
+          <p>{$i18n.neurons.voting_power}</p>
+        </div>
+        <div>
+          {#if delayInSeconds > 0}
+            <h5>{secondsToDuration(BigInt(delayInSeconds))}</h5>
+          {:else}
+            <h5>{$i18n.neurons.no_delay}</h5>
+          {/if}
+          <p>{$i18n.neurons.dissolve_delay_title}</p>
         </div>
       </div>
-    </Card>
-    <div class="buttons">
-      <button
-        on:click={skipDelay}
-        data-tid="skip-neuron-delay"
-        class="secondary full-width"
-        disabled={loading}>{$i18n.neurons.skip}</button
-      >
-      <button
-        class="primary full-width"
-        disabled={disableUpdate || loading}
-        on:click={goToConfirmation}
-        data-tid="go-confirm-delay-button"
-      >
-        {#if loading}
-          <Spinner />
-        {:else}
-          {$i18n.neurons.update_delay}
-        {/if}
-      </button>
     </div>
-  {:else}
-    <Spinner />
-  {/if}
+  </Card>
+  <div class="buttons">
+    <button
+      on:click={skipDelay}
+      data-tid="skip-neuron-delay"
+      class="secondary full-width"
+      disabled={loading}>{$i18n.neurons.skip}</button
+    >
+    <button
+      class="primary full-width"
+      disabled={disableUpdate || loading}
+      on:click={goToConfirmation}
+      data-tid="go-confirm-delay-button"
+    >
+      {#if loading}
+        <Spinner />
+      {:else}
+        {$i18n.neurons.update_delay}
+      {/if}
+    </button>
+  </div>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -12,6 +12,7 @@
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { formatICP } from "../../utils/icp.utils";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
 
   export let account: Account;
   const transactionIcp: ICP = ICP.fromE8s(BigInt(TRANSACTION_FEE_E8S)) as ICP;
@@ -20,27 +21,22 @@
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
+    startBusy("stake-neuron");
     creating = true;
-    try {
-      const neuronId = await stakeAndLoadNeuron({
-        amount,
-        fromSubAccount:
-          "subAccount" in account ? account.subAccount : undefined,
-      });
-
+    const neuronId = await stakeAndLoadNeuron({
+      amount,
+      fromSubAccount: "subAccount" in account ? account.subAccount : undefined,
+    });
+    if (neuronId !== undefined) {
       // We don't wait for `syncAccounts` to finish to give a better UX to the user.
       // `syncAccounts` might be slow since it loads all accounts and balances.
       // in the neurons page there are no balances nor accounts
-      // TODO: L2-329 Manage edge cases
       syncAccounts();
 
       dispatcher("nnsNeuronCreated", { neuronId });
-    } catch (err) {
-      // TODO: L2-329 Manage errors
-      console.error(err);
-    } finally {
-      creating = false;
     }
+    creating = false;
+    stopBusy("stake-neuron");
   };
 
   const stakeMaximum = () => {

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -38,7 +38,12 @@
     "suspicious_response": "Suspicious response detected. Page reload suggested.",
     "start_dissolving": "Sorry, there was an error dissolving the neuron. Please try again later.",
     "stop_dissolving": "Sorry, there was an error stopping the dissolve process of the neuron. Please try again later.",
-    "dummy_proposal": "There was an error creating the proposals. Check the console for more details."
+    "dummy_proposal": "There was an error creating the proposals. Check the console for more details.",
+    "update_delay": "Sorry, there was an error updating the delay of the neuron",
+    "unknown": "Sorry, there was an unexpected error. Please try again later.",
+    "amount_not_valid": "Sorry, the amount is not valid",
+    "amount_not_enough": "Sorry, the amount is not large enough. You need a minimum of 1 ICP to stake a neuron",
+    "stake_neuron": "Sorry, there was an unexpected error staking the neuron. Please try again later."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -81,8 +81,8 @@
       ({ stepName, isNeuronInvalid, isAccountInvalid }) => {
         return (
           stepName === currentStep?.name &&
-          ((isNeuronInvalid && isNeuronInvalid(newNeuron)) ||
-            (isAccountInvalid && isAccountInvalid(selectedAccount)))
+          ((isNeuronInvalid?.(newNeuron) ?? false) ||
+            (isAccountInvalid?.(selectedAccount) ?? false))
         );
       }
     );

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -54,24 +54,38 @@
   const dispatcher = createEventDispatcher();
   type InvalidState = {
     stepName: string;
-    neuron?: null;
-    account?: null;
+    isNeuronInvalid?: (n?: NeuronInfo) => boolean;
+    isAccountInvalid?: (a?: Account) => boolean;
   };
   const invalidStates: InvalidState[] = [
-    { stepName: "StakeNeuron", account: null },
-    { stepName: "SetDissolveDelay", neuron: null },
-    { stepName: "ConfirmDissolveDelay", neuron: null },
-    { stepName: "EditFollowNeurons", neuron: null },
+    {
+      stepName: "StakeNeuron",
+      isAccountInvalid: (account?: Account) => account === undefined,
+    },
+    {
+      stepName: "SetDissolveDelay",
+      isNeuronInvalid: (neuron?: NeuronInfo) => neuron === undefined,
+    },
+    {
+      stepName: "ConfirmDissolveDelay",
+      isNeuronInvalid: (neuron?: NeuronInfo) => neuron === undefined,
+    },
+    {
+      stepName: "EditFollowNeurons",
+      isNeuronInvalid: (neuron?: NeuronInfo) => neuron === undefined,
+    },
   ];
   $: {
     newNeuron = $neuronsStore.find(({ neuronId }) => newNeuronId === neuronId);
-    const invalidState = invalidStates.find(({ stepName, neuron, account }) => {
-      return (
-        stepName === currentStep?.name &&
-        ((neuron === null && newNeuron === undefined) ||
-          (account === null && selectedAccount === undefined))
-      );
-    });
+    const invalidState = invalidStates.find(
+      ({ stepName, isNeuronInvalid, isAccountInvalid }) => {
+        return (
+          stepName === currentStep?.name &&
+          ((isNeuronInvalid && isNeuronInvalid(newNeuron)) ||
+            (isAccountInvalid && isAccountInvalid(selectedAccount)))
+        );
+      }
+    );
     if (invalidState !== undefined) {
       toastsStore.error({
         labelKey: "error.unknown",

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -13,6 +13,8 @@
   import WizardModal from "../WizardModal.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
   import { stepIndex } from "../../utils/step.utils";
+  import { createEventDispatcher } from "svelte";
+  import { toastsStore } from "../../stores/toasts.store";
 
   const steps: Steps = [
     {
@@ -49,7 +51,34 @@
 
   let newNeuronId: NeuronId | undefined;
   let newNeuron: NeuronInfo | undefined;
-  $: newNeuron = $neuronsStore.find(({ neuronId }) => newNeuronId === neuronId);
+  const dispatcher = createEventDispatcher();
+  type InvalidState = {
+    stepName: string;
+    neuron?: null;
+    account?: null;
+  };
+  const invalidStates: InvalidState[] = [
+    { stepName: "StakeNeuron", account: null },
+    { stepName: "SetDissolveDelay", neuron: null },
+    { stepName: "ConfirmDissolveDelay", neuron: null },
+    { stepName: "EditFollowNeurons", neuron: null },
+  ];
+  $: {
+    newNeuron = $neuronsStore.find(({ neuronId }) => newNeuronId === neuronId);
+    const invalidState = invalidStates.find(({ stepName, neuron, account }) => {
+      return (
+        stepName === currentStep?.name &&
+        ((neuron === null && newNeuron === undefined) ||
+          (account === null && selectedAccount === undefined))
+      );
+    });
+    if (invalidState !== undefined) {
+      toastsStore.error({
+        labelKey: "error.unknown",
+      });
+      dispatcher("nnsClose");
+    }
+  }
   let delayInSeconds: number = 0;
 
   const chooseAccount = ({
@@ -79,12 +108,9 @@
   <svelte:fragment slot="title"
     >{currentStep?.title ?? $i18n.accounts.select_source}</svelte:fragment
   >
-
-  <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
   {#if currentStep?.name === "SelectAccount"}
     <SelectAccount on:nnsSelectAccount={chooseAccount} />
   {/if}
-  <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
   {#if currentStep?.name === "StakeNeuron"}
     <!-- we spare a spinner for the selectedAccount within StakeNeuron because we reach this step once the selectedAccount has been selected -->
     {#if selectedAccount !== undefined}
@@ -94,26 +120,29 @@
       />
     {/if}
   {/if}
-  <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
   {#if currentStep?.name === "SetDissolveDelay"}
-    <SetDissolveDelay
-      neuron={newNeuron}
-      on:nnsSkipDelay={goEditFollowers}
-      on:nnsConfirmDelay={goNext}
-      bind:delayInSeconds
-    />
+    {#if newNeuron !== undefined}
+      <SetDissolveDelay
+        neuron={newNeuron}
+        on:nnsSkipDelay={goEditFollowers}
+        on:nnsConfirmDelay={goNext}
+        bind:delayInSeconds
+      />
+    {/if}
   {/if}
-  <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
   {#if currentStep?.name === "ConfirmDissolveDelay"}
-    <ConfirmDissolveDelay
-      neuron={newNeuron}
-      {delayInSeconds}
-      on:back={goBack}
-      on:nnsNext={goNext}
-    />
+    {#if newNeuron !== undefined}
+      <ConfirmDissolveDelay
+        neuron={newNeuron}
+        {delayInSeconds}
+        on:back={goBack}
+        on:nnsNext={goNext}
+      />
+    {/if}
   {/if}
-  <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
   {#if currentStep?.name === "EditFollowNeurons"}
-    <EditFollowNeurons neuron={newNeuron} />
+    {#if newNeuron !== undefined}
+      <EditFollowNeurons neuron={newNeuron} />
+    {/if}
   {/if}
 </WizardModal>

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -209,18 +209,23 @@ export const updateDelay = async ({
 }: {
   neuronId: NeuronId;
   dissolveDelayInSeconds: number;
-}): Promise<void> => {
+}): Promise<NeuronId | undefined> => {
   const identity: Identity = await getIdentity();
 
   try {
     await increaseDissolveDelay({ neuronId, dissolveDelayInSeconds, identity });
 
     await getAndLoadNeuronHelper({ neuronId, identity });
+
+    return neuronId;
   } catch (err) {
     toastsStore.error({
       labelKey: "error.unknown",
       err,
     });
+
+    // To inform there was an error
+    return undefined;
   }
 };
 

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -2,6 +2,8 @@ import type { Readable } from "svelte/store";
 import { derived, writable } from "svelte/store";
 
 export type BusyStateInitiator =
+  | "stake-neuron"
+  | "update-delay"
   | "vote"
   | "accounts"
   | "join-community-fund"

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -43,6 +43,11 @@ interface I18nError {
   start_dissolving: string;
   stop_dissolving: string;
   dummy_proposal: string;
+  update_delay: string;
+  unknown: string;
+  amount_not_valid: string;
+  amount_not_enough: string;
+  stake_neuron: string;
 }
 
 interface I18nWarning {

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -55,12 +55,17 @@ export const votingPower = ({
   stake: bigint;
   dissolveDelayInSeconds: number;
   ageSeconds?: number;
-}): number =>
+}): bigint =>
   dissolveDelayInSeconds > SECONDS_IN_HALF_YEAR
-    ? (Number(stake) / E8S_PER_ICP) *
-      dissolveDelayMultiplier(dissolveDelayInSeconds) *
-      ageMultiplier(ageSeconds)
-    : 0;
+    ? BigInt(
+        Math.round(
+          (Number(stake) / E8S_PER_ICP) *
+            dissolveDelayMultiplier(dissolveDelayInSeconds) *
+            ageMultiplier(ageSeconds) *
+            E8S_PER_ICP
+        )
+      )
+    : BigInt(0);
 
 export const hasValidStake = (neuron: NeuronInfo): boolean =>
   // Ignore if we can't validate the stake

--- a/frontend/svelte/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
@@ -1,16 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-
 import { render } from "@testing-library/svelte";
-import ConfirmDissolveDelay from "../../../../lib/components/neurons/ConfirmDissolveDelay.svelte";
+import ConfirmDisolveDelay from "../../../../lib/components/neurons/ConfirmDissolveDelay.svelte";
+import { mockNeuron } from "../../../mocks/neurons.mock";
 
 describe("ConfirmDissolveDelay", () => {
-  it("should render a spinner until neuron loaded", () => {
-    const { container } = render(ConfirmDissolveDelay, {
-      props: { neuron: undefined, delayInSeconds: 0 },
+  // Tested in CreateNeuronModal.spec.ts
+  it("is not tested in isolation", () => {
+    render(ConfirmDisolveDelay, {
+      props: { neuron: mockNeuron, delayInSeconds: 10_000 },
     });
-
-    expect(container.querySelector('[data-tid="spinner"]')).toBeInTheDocument();
+    expect(true).toBeTruthy();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -1,22 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-
 import { render } from "@testing-library/svelte";
 import EditFollowNeurons from "../../../../lib/components/neurons/EditFollowNeurons.svelte";
+import { mockNeuron } from "../../../mocks/neurons.mock";
 
-jest.mock("../../../../lib/services/knownNeurons.services", () => {
-  return {
-    listKnownNeurons: jest.fn(),
-  };
-});
-
-describe("SetDissolveDelay", () => {
-  it("should render a spinner until neuron loaded", () => {
-    const { container } = render(EditFollowNeurons, {
-      props: { neuron: undefined },
+describe("EditFollowNeurons", () => {
+  // Tested in FollowNeuronsModal.spec.ts
+  it("is not tested in isolation", () => {
+    render(EditFollowNeurons, {
+      props: { neuron: mockNeuron },
     });
-
-    expect(container.querySelector('[data-tid="spinner"]')).toBeInTheDocument();
+    expect(true).toBeTruthy();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -1,16 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-
 import { render } from "@testing-library/svelte";
 import SetDissolveDelay from "../../../../lib/components/neurons/SetDissolveDelay.svelte";
+import { mockNeuron } from "../../../mocks/neurons.mock";
 
 describe("SetDissolveDelay", () => {
-  it("should render a spinner until neuron loaded", () => {
-    const { container } = render(SetDissolveDelay, {
-      props: { neuron: undefined },
+  // Tested in CreateNeuronModal.spec.ts
+  it("is not tested in isolation", () => {
+    render(SetDissolveDelay, {
+      props: { neuron: mockNeuron },
     });
-
-    expect(container.querySelector('[data-tid="spinner"]')).toBeInTheDocument();
+    expect(true).toBeTruthy();
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -15,6 +15,7 @@ import {
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import { authStore } from "../../../../lib/stores/auth.store";
 import { neuronsStore } from "../../../../lib/stores/neurons.store";
+import { toastsStore } from "../../../../lib/stores/toasts.store";
 import {
   mockAccountsStoreSubscribe,
   mockSubAccount,
@@ -40,6 +41,15 @@ jest.mock("../../../../lib/services/neurons.services", () => {
 jest.mock("../../../../lib/services/accounts.services", () => {
   return {
     syncAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("../../../../lib/stores/toasts.store", () => {
+  return {
+    toastsStore: {
+      error: jest.fn(),
+      show: jest.fn(),
+    },
   };
 });
 
@@ -184,6 +194,42 @@ describe("CreateNeuronModal", () => {
         container.querySelector("[data-tid='go-confirm-delay-button']")
       ).not.toBeNull()
     );
+  });
+
+  it("should close modal if it finds an invalid state", async () => {
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscribe([]));
+    const { container, component } = await renderModal(CreateNeuronModal);
+
+    const accountCard = container.querySelector('article[role="button"]');
+    expect(accountCard).not.toBeNull();
+
+    accountCard && (await fireEvent.click(accountCard));
+
+    const input = container.querySelector('input[name="amount"]');
+    // Svelte generates code for listening to the `input` event
+    // https://github.com/testing-library/svelte-testing-library/issues/29#issuecomment-498055823
+    input && (await fireEvent.input(input, { target: { value: 22 } }));
+
+    const createButton = container.querySelector('button[type="submit"]');
+
+    createButton && (await fireEvent.click(createButton));
+
+    // Confirm Delay is not rendered.
+    expect(
+      container.querySelector("[data-tid='go-confirm-delay-button']")
+    ).toBeNull();
+
+    // cannost use `done` callback with async
+    let closed = false;
+    component.$on("nnsClose", async () => {
+      closed = true;
+    });
+
+    expect(toastsStore.error).toBeCalled();
+
+    await waitFor(() => closed);
   });
 
   it("should have the update delay button disabled", async () => {

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -16,6 +16,7 @@ import { accountsStore } from "../../../../lib/stores/accounts.store";
 import { authStore } from "../../../../lib/stores/auth.store";
 import { neuronsStore } from "../../../../lib/stores/neurons.store";
 import { toastsStore } from "../../../../lib/stores/toasts.store";
+import { formatVotingPower } from "../../../../lib/utils/neuron.utils";
 import {
   mockAccountsStoreSubscribe,
   mockSubAccount,
@@ -302,11 +303,12 @@ describe("CreateNeuronModal", () => {
 
   it("should be able to create a neuron and see the stake of the new neuron in the dissolve modal", async () => {
     const neuronStake = 2.2;
+    const neuronStakeE8s = BigInt(Math.round(neuronStake * E8S_PER_ICP));
     const newNeuron: NeuronInfo = {
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
-        cachedNeuronStake: BigInt(Math.round(neuronStake * E8S_PER_ICP)),
+        cachedNeuronStake: neuronStakeE8s,
       },
     };
     jest
@@ -335,7 +337,9 @@ describe("CreateNeuronModal", () => {
       expect(container.querySelector('input[type="range"]')).not.toBeNull()
     );
 
-    expect(getByText(neuronStake, { exact: false })).not.toBeNull();
+    expect(
+      getByText(formatVotingPower(neuronStakeE8s), { exact: false })
+    ).not.toBeNull();
   });
 
   it("should be able to change dissolve delay in the confirmation screen", async () => {

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -200,7 +200,9 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([]));
-    const { container, component } = await renderModal(CreateNeuronModal);
+    const { container, component } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -85,27 +85,40 @@ describe("neurons-services", () => {
       expect(neuron).toEqual(mockNeuron);
     });
 
-    it(`stakeNeuron should raise an error if amount less than ${
+    it(`stakeNeuron return undefined if amount less than ${
       E8S_PER_ICP / E8S_PER_ICP
     } ICP`, async () => {
       jest
         .spyOn(LedgerCanister, "create")
         .mockImplementation(() => mock<LedgerCanister>());
 
-      const call = () =>
-        stakeAndLoadNeuron({
-          amount: 0.1,
-        });
+      const response = await stakeAndLoadNeuron({
+        amount: 0.1,
+      });
 
-      await expect(call).rejects.toThrow(Error);
+      expect(response).toBeUndefined();
+    });
+
+    it("stake neuron should return undefined if amount not valid", async () => {
+      jest
+        .spyOn(LedgerCanister, "create")
+        .mockImplementation(() => mock<LedgerCanister>());
+
+      const response = await stakeAndLoadNeuron({
+        amount: NaN,
+      });
+
+      expect(response).toBeUndefined();
     });
 
     it("should not stake neuron if no identity", async () => {
       setNoIdentity();
 
-      const call = async () => await stakeAndLoadNeuron({ amount: 10 });
+      const response = await stakeAndLoadNeuron({
+        amount: 10,
+      });
 
-      await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+      expect(response).toBeUndefined();
 
       resetIdentity();
     });

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -28,7 +28,7 @@ describe("neuron-utils", () => {
     it("should return zero for delays less than six months", () => {
       expect(
         votingPower({ stake: BigInt(2), dissolveDelayInSeconds: 100 })
-      ).toBe(0);
+      ).toBe(BigInt(0));
     });
 
     it("should return more than stake when delay more than six months", () => {
@@ -39,7 +39,7 @@ describe("neuron-utils", () => {
           stake: icp.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
         })
-      ).toBeGreaterThan(Number(stake));
+      ).toBeGreaterThan(icp.toE8s());
     });
 
     it("should return the double when delay is eight years", () => {
@@ -50,7 +50,7 @@ describe("neuron-utils", () => {
           stake: icp.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
         })
-      ).toBe(Number(stake) * 2);
+      ).toBe(icp.toE8s() * BigInt(2));
     });
 
     it("should add age multiplier", () => {

--- a/frontend/svelte/src/tests/mocks/neurons.mock.ts
+++ b/frontend/svelte/src/tests/mocks/neurons.mock.ts
@@ -14,7 +14,7 @@ export const mockFullNeuron: Neuron = {
   createdTimestampSeconds: BigInt(10),
   maturityE8sEquivalent: BigInt(10),
   agingSinceTimestampSeconds: BigInt(10),
-  neuronFees: BigInt(10000000),
+  neuronFees: BigInt(0),
   hotKeys: [],
   accountIdentifier: "account-identifier-text",
   joinedCommunityFundTimestampSeconds: undefined,


### PR DESCRIPTION
# Motivation

Stake Neuron flow: manage edge cases, show errors gracefully and give a better UX on errors.

# Changes

* Add "invalidStates" array in the CreateNeuronModal. Error should be shown and modal closed on unexpected edge cases.
* Show busy screen when updating delay and staking neuron.
* Manage errors in services instead of component during the flow.
* Components ConfirmDissolveDelay, SetDissolveDelay and EditFollowNeurons are not rendered without a neuron.