### PR TITLE
test: fix warnings "<FiltersButton> was created with unknown prop 'data-tid'"

### DIFF
--- a/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
@@ -25,7 +25,6 @@
 
 <div class="filters">
   <FiltersButton
-    data-tid="filters-by-topics"
     totalFilters={enumSize(Topic)}
     activeFilters={topics.length}
     on:nnsFilter={() =>


### PR DESCRIPTION
# Motivation

Clear "<FiltersButton> was created with unknown prop 'data-tid'" throw while testing

# Changes

- remove unused `data-tid` incorrectly set to a cmp

# Screenshot

Warning used to be:

<img width="1410" alt="Capture d’écran 2022-04-05 à 07 43 33" src="https://user-images.githubusercontent.com/16886711/161686648-2238f4a8-0021-4f91-bea3-3dce21699578.png">


