### PR TITLE
feat: init new transaction

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/Address.svelte
+++ b/frontend/svelte/src/lib/components/accounts/Address.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import Input from "../ui/Input.svelte";
+  import { i18n } from "../../stores/i18n";
+
+  export let address: number | undefined;
+
+  // TODO(L2-430): to be implemented
+  const submitAddress = () => console.log("submitAddress");
+
+  // TODO(L2-430): Input validation rules - max 40 characters?
+</script>
+
+<article>
+  <form on:submit|preventDefault={submitAddress}>
+    <Input
+      inputType="number"
+      placeholderLabelKey="accounts.address"
+      name="transaction-address"
+      bind:value={address}
+      theme="dark"
+    />
+    <button
+      class="primary small"
+      type="submit"
+      disabled={address === undefined || address === 0}
+    >
+      {$i18n.core.continue}
+    </button>
+  </form>
+</article>
+
+<style lang="scss">
+  article {
+    margin-bottom: calc(2 * var(--padding));
+    padding: 0 0 calc(2 * var(--padding));
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/accounts/Address.svelte
+++ b/frontend/svelte/src/lib/components/accounts/Address.svelte
@@ -7,7 +7,9 @@
   // TODO(L2-430): to be implemented
   const submitAddress = () => console.log("submitAddress");
 
+  // TODO(L2-430): Input is of type number?
   // TODO(L2-430): Input validation rules - max 40 characters?
+  // TODO(L2-430): tests
 </script>
 
 <article>

--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -29,7 +29,7 @@
 <div class="wizard-list" class:disabled={disableSelection}>
   {#if mainAccount}
     {#if displayTitle}
-      <h4>{$i18n.neurons.my_accounts}</h4>
+      <h4>{$i18n.accounts.my_accounts}</h4>
     {/if}
     <!-- Needed mainAccount && because TS didn't learn that `mainAccount` is present in the click listener -->
     <AccountCard

--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -7,6 +7,9 @@
   import type { Account } from "../../types/account";
   import type { Unsubscriber } from "svelte/types/runtime/store";
 
+  export let displayTitle = false;
+  export let disableSelection: boolean = false;
+
   const dispatch = createEventDispatcher();
   const chooseAccount = (selectedAccount: Account) => {
     dispatch("nnsSelectAccount", { selectedAccount });
@@ -23,9 +26,11 @@
   onDestroy(unsubscribeAccounts);
 </script>
 
-<div class="wizard-list">
+<div class="wizard-list" class:disabled={disableSelection}>
   {#if mainAccount}
-    <h4>{$i18n.neurons.my_accounts}</h4>
+    {#if displayTitle}
+      <h4>{$i18n.neurons.my_accounts}</h4>
+    {/if}
     <!-- Needed mainAccount && because TS didn't learn that `mainAccount` is present in the click listener -->
     <AccountCard
       role="button"
@@ -46,3 +51,22 @@
     <Spinner />
   {/if}
 </div>
+
+<style lang="scss">
+  :global(article:first-of-type) {
+    margin-top: var(--padding);
+  }
+
+  .disabled {
+    --disabled-card-opacity: 0.2;
+
+    h4 {
+      opacity: var(--disabled-card-opacity);
+    }
+
+    :global(article) {
+      pointer-events: none;
+      opacity: var(--disabled-card-opacity);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/accounts/SelectDestination.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectDestination.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import Address from "./Address.svelte";
+  import SelectAccount from "./SelectAccount.svelte";
+  import { onMount } from "svelte";
+
+  let address: number | undefined;
+  let mounted: boolean = false;
+
+  onMount(() => (mounted = true));
+
+  // TODO(L2-430): continue implementation of the wizard
+</script>
+
+<div>
+  <p>{$i18n.accounts.enter_address_or_select}</p>
+
+  <Address bind:address />
+
+  <!-- Prevent the component to be presented with a scroll offset when navigating between wizard steps -->
+  {#if mounted}
+    <SelectAccount
+      displayTitle={true}
+      disableSelection={address !== undefined && address !== 0}
+    />
+  {/if}
+</div>
+
+<style lang="scss">
+  p {
+    margin-bottom: calc(1.5 * var(--padding));
+  }
+</style>

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -77,7 +77,7 @@
         <button
           type="button"
           on:click|preventDefault={stakeMaximum}
-          class="primary small"
+          class="secondary small"
           slot="button">{$i18n.neurons.max}</button
         >
       </Input>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -10,7 +10,8 @@
     "confirm": "Confirm",
     "yes": "Yes",
     "no": "No",
-    "unspecified": "Unspecified"
+    "unspecified": "Unspecified",
+    "continue": "Continue"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -71,14 +72,17 @@
     "attach_hardware_subtitle": "Link a hardware wallet to this account",
     "new_linked_account_title": "New Linked Account",
     "new_linked_account_placeholder": "Account Name",
-    "linked_account": "LINKED ACCOUNT"
+    "linked_account": "LINKED ACCOUNT",
+    "select_source": "Select Source Account",
+    "select_destination": "Select destination",
+    "address": "Address",
+    "enter_address_or_select": "Enter a destination address or select an account."
   },
   "neurons": {
     "title": "Neurons",
     "text": "Earn rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by voting on Network Nervous System (NNS) proposals.",
     "principal_is": "Your principal id is",
     "stake_neurons": "Stake Neurons",
-    "select_source": "Select Source Account",
     "set_dissolve_delay": "Set Dissolve Delay",
     "confirm_dissolve_delay": "Confirm Dissolve Delay",
     "follow_neurons_screen": "Follow neurons",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -76,7 +76,8 @@
     "select_source": "Select Source Account",
     "select_destination": "Select destination",
     "address": "Address",
-    "enter_address_or_select": "Enter a destination address or select an account."
+    "enter_address_or_select": "Enter a destination address or select an account.",
+    "my_accounts": "My Accounts"
   },
   "neurons": {
     "title": "Neurons",
@@ -86,7 +87,6 @@
     "set_dissolve_delay": "Set Dissolve Delay",
     "confirm_dissolve_delay": "Confirm Dissolve Delay",
     "follow_neurons_screen": "Follow neurons",
-    "my_accounts": "My Accounts",
     "stake_neuron": "Stake Neuron",
     "source": "Source",
     "transaction_fee": "Transaction Fee",

--- a/frontend/svelte/src/lib/modals/WizardModal.svelte
+++ b/frontend/svelte/src/lib/modals/WizardModal.svelte
@@ -9,14 +9,11 @@
   let stepState: StepsState;
   $: stepState = new StepsState(steps);
 
-  let currentStep: Step | undefined;
+  export let currentStep: Step | undefined;
   $: ({ currentStep } = stepState);
 
   let transition: { diff: number };
   $: transition = { diff: stepState.diff };
-
-  export let currentStepName: string | undefined;
-  $: currentStepName = currentStep?.name;
 
   export const next = () => (stepState = stepState.next());
   export const back = () => (stepState = stepState.back());

--- a/frontend/svelte/src/lib/modals/accounts/AddAccountModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/AddAccountModal.svelte
@@ -29,7 +29,9 @@
 </script>
 
 <WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
-  <svelte:fragment slot="title">{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment>
+  <svelte:fragment slot="title"
+    >{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment
+  >
 
   <svelte:fragment>
     {#if currentStep?.name === "SelectAccount"}

--- a/frontend/svelte/src/lib/modals/accounts/AddAccountModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/AddAccountModal.svelte
@@ -4,16 +4,22 @@
   import WizardModal from "../WizardModal.svelte";
   import { i18n } from "../../stores/i18n";
   import type { Steps } from "../../stores/steps.state";
+  import type { Step } from "../../stores/steps.state";
 
   const steps: Steps = [
     {
       name: "SelectAccount",
+      title: $i18n.accounts.add_account,
       showBackButton: false,
     },
-    { name: "AddNewAccount", showBackButton: true },
+    {
+      name: "AddNewAccount",
+      title: $i18n.accounts.add_account,
+      showBackButton: true,
+    },
   ];
 
-  let currentStepName: string | undefined;
+  let currentStep: Step | undefined;
   let modal: WizardModal;
 
   const handleSelectType = () => {
@@ -22,14 +28,14 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStepName bind:this={modal} on:nnsClose>
-  <svelte:fragment slot="title">{$i18n.accounts.add_account}</svelte:fragment>
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title">{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment>
 
   <svelte:fragment>
-    {#if currentStepName === "SelectAccount"}
+    {#if currentStep?.name === "SelectAccount"}
       <SelectTypeAccount on:nnsSelect={handleSelectType} />
     {/if}
-    {#if currentStepName === "AddNewAccount"}
+    {#if currentStep?.name === "AddNewAccount"}
       <AddNewAccount on:nnsClose />
     {/if}
   </svelte:fragment>

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -17,7 +17,7 @@
             title: $i18n.accounts.select_source,
           },
         ]
-      : [{}]),
+      : []) as Steps,
     {
       name: "SelectDestination",
       showBackButton: canSelectAccount,

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import WizardModal from "../WizardModal.svelte";
+  import type { Step, Steps } from "../../stores/steps.state";
+  import SelectAccount from "../../components/accounts/SelectAccount.svelte";
+  import { i18n } from "../../stores/i18n";
+  import type { Account } from "../../types/account";
+  import SelectDestination from "../../components/accounts/SelectDestination.svelte";
+
+  export let canSelectAccount: boolean;
+
+  const steps: Steps = [
+    ...(canSelectAccount
+      ? [
+          {
+            name: "SelectAccount",
+            showBackButton: false,
+            title: $i18n.accounts.select_source,
+          },
+        ]
+      : [{}]),
+    {
+      name: "SelectDestination",
+      showBackButton: canSelectAccount,
+      title: $i18n.accounts.select_destination,
+    },
+  ];
+
+  let selectedAccount: Account | undefined;
+
+  const chooseAccount = ({
+    detail,
+  }: CustomEvent<{ selectedAccount: Account }>) => {
+    selectedAccount = detail.selectedAccount;
+    modal.next();
+  };
+
+  let currentStep: Step | undefined;
+  let modal: WizardModal;
+</script>
+
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title"
+    >{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment
+  >
+
+  <svelte:fragment>
+    {#if currentStep?.name === "SelectAccount"}
+      <SelectAccount on:nnsSelectAccount={chooseAccount} />
+    {/if}
+    {#if currentStep?.name === "SelectDestination"}
+      <SelectDestination />
+    {/if}
+  </svelte:fragment>
+</WizardModal>

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -9,7 +9,7 @@
   export let canSelectAccount: boolean;
 
   const steps: Steps = [
-    ...(canSelectAccount
+    ...((canSelectAccount
       ? [
           {
             name: "SelectAccount",
@@ -17,7 +17,7 @@
             title: $i18n.accounts.select_source,
           },
         ]
-      : []) as Steps,
+      : []) as Steps),
     {
       name: "SelectDestination",
       showBackButton: canSelectAccount,

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -11,18 +11,38 @@
   import ConfirmDissolveDelay from "../../components/neurons/ConfirmDissolveDelay.svelte";
   import EditFollowNeurons from "../../components/neurons/EditFollowNeurons.svelte";
   import WizardModal from "../WizardModal.svelte";
-  import type { Steps } from "../../stores/steps.state";
+  import type { Step, Steps } from "../../stores/steps.state";
   import { stepIndex } from "../../utils/step.utils";
 
   const steps: Steps = [
-    { name: "SelectAccount", showBackButton: false },
-    { name: "StakeNeuron", showBackButton: true },
-    { name: "SetDissolveDelay", showBackButton: false },
-    { name: "ConfirmDissolveDelay", showBackButton: true },
-    { name: "EditFollowNeurons", showBackButton: false },
+    {
+      name: "SelectAccount",
+      showBackButton: false,
+      title: $i18n.accounts.select_source,
+    },
+    {
+      name: "StakeNeuron",
+      showBackButton: true,
+      title: $i18n.neurons.stake_neuron,
+    },
+    {
+      name: "SetDissolveDelay",
+      showBackButton: false,
+      title: $i18n.neurons.set_dissolve_delay,
+    },
+    {
+      name: "ConfirmDissolveDelay",
+      showBackButton: true,
+      title: $i18n.neurons.confirm_dissolve_delay,
+    },
+    {
+      name: "EditFollowNeurons",
+      showBackButton: false,
+      title: $i18n.neurons.follow_neurons_screen,
+    },
   ];
 
-  let currentStepName: string | undefined;
+  let currentStep: Step | undefined;
   let modal: WizardModal;
 
   let selectedAccount: Account | undefined;
@@ -53,27 +73,19 @@
   const goEditFollowers = () => {
     modal.set(stepIndex({ name: "EditFollowNeurons", steps }));
   };
-
-  const titleMapper: Record<string, string> = {
-    SelectAccount: "select_source",
-    StakeNeuron: "stake_neuron",
-    SetDissolveDelay: "set_dissolve_delay",
-    ConfirmDissolveDelay: "confirm_dissolve_delay",
-    EditFollowNeurons: "follow_neurons_screen",
-  };
-  let titleKey: string = titleMapper[0];
-  $: titleKey = titleMapper[currentStepName ?? "SelectAccount"];
 </script>
 
-<WizardModal {steps} bind:currentStepName bind:this={modal} on:nnsClose>
-  <svelte:fragment slot="title">{$i18n.neurons?.[titleKey]}</svelte:fragment>
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title"
+    >{currentStep?.title ?? $i18n.accounts.select_source}</svelte:fragment
+  >
 
   <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-  {#if currentStepName === "SelectAccount"}
+  {#if currentStep?.name === "SelectAccount"}
     <SelectAccount on:nnsSelectAccount={chooseAccount} />
   {/if}
   <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-  {#if currentStepName === "StakeNeuron"}
+  {#if currentStep?.name === "StakeNeuron"}
     <!-- we spare a spinner for the selectedAccount within StakeNeuron because we reach this step once the selectedAccount has been selected -->
     {#if selectedAccount !== undefined}
       <StakeNeuron
@@ -83,7 +95,7 @@
     {/if}
   {/if}
   <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-  {#if currentStepName === "SetDissolveDelay"}
+  {#if currentStep?.name === "SetDissolveDelay"}
     <SetDissolveDelay
       neuron={newNeuron}
       on:nnsSkipDelay={goEditFollowers}
@@ -92,7 +104,7 @@
     />
   {/if}
   <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-  {#if currentStepName === "ConfirmDissolveDelay"}
+  {#if currentStep?.name === "ConfirmDissolveDelay"}
     <ConfirmDissolveDelay
       neuron={newNeuron}
       {delayInSeconds}
@@ -101,7 +113,7 @@
     />
   {/if}
   <!-- TODO: Manage edge case: https://dfinity.atlassian.net/browse/L2-329 -->
-  {#if currentStepName === "EditFollowNeurons"}
+  {#if currentStep?.name === "EditFollowNeurons"}
     <EditFollowNeurons neuron={newNeuron} />
   {/if}
 </WizardModal>

--- a/frontend/svelte/src/lib/stores/steps.state.ts
+++ b/frontend/svelte/src/lib/stores/steps.state.ts
@@ -1,5 +1,6 @@
 export interface Step {
   readonly name: string;
+  readonly title: string;
   readonly showBackButton: boolean;
 }
 

--- a/frontend/svelte/src/lib/themes/modal.scss
+++ b/frontend/svelte/src/lib/themes/modal.scss
@@ -11,7 +11,7 @@ div.modal {
     gap: var(--padding);
     height: 100%;
     min-height: inherit;
-    padding: 0 calc(2 * var(--padding));
+    padding: 0;
   }
 
   .wizard-list {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -86,6 +86,7 @@ interface I18nAccounts {
   select_destination: string;
   address: string;
   enter_address_or_select: string;
+  my_accounts: string;
 }
 
 interface I18nNeurons {
@@ -96,7 +97,6 @@ interface I18nNeurons {
   set_dissolve_delay: string;
   confirm_dissolve_delay: string;
   follow_neurons_screen: string;
-  my_accounts: string;
   stake_neuron: string;
   source: string;
   transaction_fee: string;

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -14,6 +14,7 @@ interface I18nCore {
   yes: string;
   no: string;
   unspecified: string;
+  continue: string;
 }
 
 interface I18nError {
@@ -81,6 +82,10 @@ interface I18nAccounts {
   new_linked_account_title: string;
   new_linked_account_placeholder: string;
   linked_account: string;
+  select_source: string;
+  select_destination: string;
+  address: string;
+  enter_address_or_select: string;
 }
 
 interface I18nNeurons {
@@ -88,7 +93,6 @@ interface I18nNeurons {
   text: string;
   principal_is: string;
   stake_neurons: string;
-  select_source: string;
   set_dissolve_delay: string;
   confirm_dissolve_delay: string;
   follow_neurons_screen: string;

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -17,6 +17,7 @@
   import AddAcountModal from "../lib/modals/accounts/AddAccountModal.svelte";
   import { ICP } from "@dfinity/nns";
   import { sumICPs } from "../lib/utils/icp.utils";
+  import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
 
   // TODO: To be removed once this page has been implemented
   onMount(() => {
@@ -31,17 +32,15 @@
     async (storeData: AccountsStore) => (accounts = storeData)
   );
 
-  // TODO: TBD https://dfinity.atlassian.net/browse/L2-225
-  const createNewTransaction = () => alert("New Transaction");
-
   const cardClick = (identifier: string) =>
     routeStore.navigate({ path: `${AppPath.Wallet}/${identifier}` });
 
   onDestroy(unsubscribe);
 
-  let showAddAccountModal: boolean = false;
-  const openAddAccountModal = () => (showAddAccountModal = true);
-  const closeModal = () => (showAddAccountModal = false);
+  let modal: "AddAccountModal" | "NewTransaction" | undefined = undefined;
+  const openAddAccountModal = () => (modal = "AddAccountModal");
+  const openNewTransaction = () => (modal = "NewTransaction");
+  const closeModal = () => (modal = undefined);
 
   let totalBalance: ICP;
   const zeroICPs = ICP.fromE8s(BigInt(0));
@@ -87,7 +86,7 @@
     <svelte:fragment slot="footer">
       {#if accounts}
         <Toolbar>
-          <button class="primary" on:click={createNewTransaction}
+          <button class="primary" on:click={openNewTransaction}
             >{$i18n.accounts.new_transaction}</button
           >
           <button class="primary" on:click={openAddAccountModal}
@@ -96,8 +95,11 @@
         </Toolbar>
       {/if}
     </svelte:fragment>
-    {#if showAddAccountModal}
+    {#if modal === "AddAccountModal"}
       <AddAcountModal on:nnsClose={closeModal} />
+    {/if}
+    {#if modal === "NewTransaction"}
+      <NewTransactionModal on:nnsClose={closeModal} canSelectAccount={true} />
     {/if}
   </Layout>
 {/if}

--- a/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
@@ -8,7 +8,7 @@ import en from "../../../mocks/i18n.mock";
 
 describe("Address", () => {
   it("should render a form to enter an address", () => {
-    const { container } = render(Address);
+    const { container } = render(Address, { props: { address: undefined } });
 
     expect(container.querySelector("input")).not.toBeNull();
     expect(container.querySelector("form")).not.toBeNull();

--- a/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import Address from "../../../../lib/components/accounts/Address.svelte";
+import en from "../../../mocks/i18n.mock";
+
+describe("Address", () => {
+  it("should render a form to enter an address", () => {
+    const { container } = render(Address);
+
+    expect(container.querySelector("input")).not.toBeNull();
+    expect(container.querySelector("form")).not.toBeNull();
+
+    const button = container.querySelector('button[type="submit"]');
+    expect(button).not.toBeNull();
+    expect(button?.innerHTML).toEqual(en.core.continue);
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -9,6 +9,7 @@ import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
 } from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
 
 describe("SelectAccount", () => {
   it("should render a spinner until accounts loaded", () => {
@@ -27,5 +28,19 @@ describe("SelectAccount", () => {
     expect(
       getByText(mockMainAccount.identifier, { exact: false })
     ).toBeInTheDocument();
+  });
+
+  it("should render no title per default", () => {
+    const { queryByText } = render(SelectAccount);
+
+    expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
+  });
+
+  it("should render a title", () => {
+    const { queryByText } = render(SelectAccount, {
+      props: { displayTitle: true },
+    });
+
+    expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectDestination.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectDestination.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import SelectDestination from "../../../../lib/components/accounts/SelectDestination.svelte";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import {
+  mockAccountsStoreSubscribe,
+  mockMainAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+
+describe("SelectDestination", () => {
+  jest
+    .spyOn(accountsStore, "subscribe")
+    .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+
+  it("should render an explanation text", () => {
+    const { queryByText } = render(SelectDestination);
+
+    expect(
+      queryByText(en.accounts.enter_address_or_select)
+    ).toBeInTheDocument();
+  });
+
+  it("should render an input to enter an address", () => {
+    const { container } = render(SelectDestination);
+
+    expect(container.querySelector("input")).not.toBeNull();
+    expect(container.querySelector("form")).not.toBeNull();
+  });
+
+  it("should render a list of accounts", () => {
+    const { getByText } = render(SelectDestination);
+
+    expect(
+      getByText(mockMainAccount.identifier, { exact: false })
+    ).toBeInTheDocument();
+
+    expect(
+      getByText(mockSubAccount.identifier, { exact: false })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/CreateNeuronModal.spec.ts
@@ -60,7 +60,7 @@ describe("CreateNeuronModal", () => {
       .mockImplementation(() => mock<GovernanceCanister>());
   });
 
-  const modalTitleSelector = "h4";
+  const modalSelector = "div.toolbar";
 
   it("should display modal", () => {
     const { container } = render(CreateNeuronModal);
@@ -72,7 +72,7 @@ describe("CreateNeuronModal", () => {
     const modal = render(CreateNeuronModal);
 
     const { container } = modal;
-    await waitModalIntroEnd({ container, selector: modalTitleSelector });
+    await waitModalIntroEnd({ container, selector: modalSelector });
 
     return modal;
   };

--- a/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -2,12 +2,11 @@
  * @jest-environment jsdom
  */
 import { fireEvent } from "@testing-library/dom";
-import type { RenderResult } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
 import AddAccountModal from "../../../../lib/modals/accounts/AddAccountModal.svelte";
 import { addSubAccount } from "../../../../lib/services/accounts.services";
 import en from "../../../mocks/i18n.mock";
-import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+import { renderModal } from "../../../mocks/modal.mock";
 
 // This is the way to mock when we import in a destructured manner
 // and we want to mock the imported function
@@ -24,26 +23,15 @@ describe("AddAccountModal", () => {
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
-  const modalTitleSelector = "h4";
-
-  const renderModal = async (): Promise<RenderResult> => {
-    const modal = render(AddAccountModal);
-
-    const { container } = modal;
-    await waitModalIntroEnd({ container, selector: modalTitleSelector });
-
-    return modal;
-  };
-
   it("should display two button cards", async () => {
-    const { container } = await renderModal();
+    const { container } = await renderModal(AddAccountModal);
 
     const buttons = container.querySelectorAll('div[role="button"]');
     expect(buttons.length).toEqual(2);
   });
 
   it("should be able to select new account ", async () => {
-    const { queryByText } = await renderModal();
+    const { queryByText } = await renderModal(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -56,7 +44,7 @@ describe("AddAccountModal", () => {
   });
 
   it("should have disabled Add Account button", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -70,7 +58,7 @@ describe("AddAccountModal", () => {
   });
 
   it("should have enabled Add Account button when entering name", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -89,7 +77,7 @@ describe("AddAccountModal", () => {
   });
 
   const testSubaccount = async (): Promise<{ container: HTMLElement }> => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(AddAccountModal);
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import type { RenderResult } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
+import NewTransactionModal from "../../../../lib/modals/accounts/NewTransactionModal.svelte";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import {
+  mockAccountsStoreSubscribe,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+
+describe("NewTransactionModal", () => {
+  jest
+    .spyOn(accountsStore, "subscribe")
+    .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+
+  const modalSelector = "div.toolbar";
+
+  it("should display modal", () => {
+    const { container } = render(NewTransactionModal);
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  const renderModal = async (): Promise<RenderResult> => {
+    const modal = render(NewTransactionModal, {
+      props: { canSelectAccount: true },
+    });
+
+    const { container } = modal;
+    await waitModalIntroEnd({ container, selector: modalSelector });
+
+    return modal;
+  };
+
+  it("should navigate back and forth between step SelectAccount and SelectDestination", async () => {
+    const { container, getByText } = await renderModal();
+
+    expect(
+      getByText(en.accounts.select_source, { exact: false })
+    ).toBeInTheDocument();
+
+    const mainAccount = container.querySelector(
+      'article[role="button"]:first-of-type'
+    ) as HTMLButtonElement;
+    fireEvent.click(mainAccount);
+
+    await waitFor(() =>
+      expect(
+        getByText(en.accounts.select_destination, { exact: false })
+      ).toBeInTheDocument()
+    );
+
+    const back = container.querySelector("button.back") as HTMLButtonElement;
+    fireEvent.click(back);
+
+    await waitFor(() =>
+      expect(
+        getByText(en.accounts.select_source, { exact: false })
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -3,8 +3,7 @@
  */
 
 import { fireEvent } from "@testing-library/dom";
-import type { RenderResult } from "@testing-library/svelte";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 import NewTransactionModal from "../../../../lib/modals/accounts/NewTransactionModal.svelte";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import {
@@ -12,34 +11,21 @@ import {
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
-import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+import { renderModal } from "../../../mocks/modal.mock";
 
 describe("NewTransactionModal", () => {
   jest
     .spyOn(accountsStore, "subscribe")
     .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
 
-  const modalSelector = "div.toolbar";
-
   it("should display modal", async () => {
-    const { container } = await renderModal();
+    const { container } = await renderModal(NewTransactionModal);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
-  const renderModal = async (): Promise<RenderResult> => {
-    const modal = render(NewTransactionModal, {
-      props: { canSelectAccount: true },
-    });
-
-    const { container } = modal;
-    await waitModalIntroEnd({ container, selector: modalSelector });
-
-    return modal;
-  };
-
   it("should navigate back and forth between step SelectAccount and SelectDestination", async () => {
-    const { container, getByText } = await renderModal();
+    const { container, getByText } = await renderModal(NewTransactionModal);
 
     expect(
       getByText(en.accounts.select_source, { exact: false })

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -21,8 +21,8 @@ describe("NewTransactionModal", () => {
 
   const modalSelector = "div.toolbar";
 
-  it("should display modal", () => {
-    const { container } = render(NewTransactionModal);
+  it("should display modal", async () => {
+    const { container } = await renderModal();
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -4,8 +4,7 @@
 
 import type { NeuronInfo } from "@dfinity/nns";
 import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
-import type { RenderResult } from "@testing-library/svelte";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 import { E8S_PER_ICP } from "../../../../lib/constants/icp.constants";
 import CreateNeuronModal from "../../../../lib/modals/neurons/CreateNeuronModal.svelte";
@@ -22,7 +21,7 @@ import {
 } from "../../../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
-import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+import { renderModal } from "../../../mocks/modal.mock";
 import {
   buildMockNeuronsStoreSubscribe,
   mockFullNeuron,
@@ -60,31 +59,20 @@ describe("CreateNeuronModal", () => {
       .mockImplementation(() => mock<GovernanceCanister>());
   });
 
-  const modalSelector = "div.toolbar";
-
-  it("should display modal", () => {
-    const { container } = render(CreateNeuronModal);
+  it("should display modal", async () => {
+    const { container } = await renderModal(CreateNeuronModal);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
-  const renderModal = async (): Promise<RenderResult> => {
-    const modal = render(CreateNeuronModal);
-
-    const { container } = modal;
-    await waitModalIntroEnd({ container, selector: modalSelector });
-
-    return modal;
-  };
-
   it("should display accounts as cards", async () => {
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     expect(container.querySelector('article[role="button"]')).not.toBeNull();
   });
 
   it("should be able to select an account and move to the next view", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -95,7 +83,7 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should be able to select a subaccount and move to the next view", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(CreateNeuronModal);
 
     const accountCards = container.querySelectorAll('article[role="button"]');
     expect(accountCards.length).toBe(2);
@@ -111,7 +99,7 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should have disabled Create neuron button", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -125,7 +113,7 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should have enabled Create neuron button when entering amount", async () => {
-    const { container, queryByText } = await renderModal();
+    const { container, queryByText } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -144,7 +132,7 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should be able to create a new neuron", async () => {
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -167,7 +155,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -194,7 +182,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -225,7 +213,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -269,7 +257,7 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([newNeuron]));
 
-    const { container, getByText } = await renderModal();
+    const { container, getByText } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -297,7 +285,7 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
 
-    const { container } = await renderModal();
+    const { container } = await renderModal(CreateNeuronModal);
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -350,7 +338,7 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
 
-    const { container, queryByTestId } = await renderModal();
+    const { container, queryByTestId } = await renderModal(CreateNeuronModal);
 
     // SCREEN: Select Account
     const accountCard = container.querySelector('article[role="button"]');

--- a/frontend/svelte/src/tests/lib/stores/steps.state.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/steps.state.spec.ts
@@ -4,9 +4,9 @@ import { stepIndex } from "../../../lib/utils/step.utils";
 
 describe("StepsState", () => {
   const steps: Steps = [
-    { name: "FirstStep", showBackButton: false },
-    { name: "SecondStep", showBackButton: true },
-    { name: "ThirdStep", showBackButton: true },
+    { name: "FirstStep", showBackButton: false, title: 'FirstStep' },
+    { name: "SecondStep", showBackButton: true, title: 'SecondStep' },
+    { name: "ThirdStep", showBackButton: true, title: 'ThirdStep' },
   ];
 
   it("initialize state to 0", () => {

--- a/frontend/svelte/src/tests/lib/stores/steps.state.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/steps.state.spec.ts
@@ -4,9 +4,9 @@ import { stepIndex } from "../../../lib/utils/step.utils";
 
 describe("StepsState", () => {
   const steps: Steps = [
-    { name: "FirstStep", showBackButton: false, title: 'FirstStep' },
-    { name: "SecondStep", showBackButton: true, title: 'SecondStep' },
-    { name: "ThirdStep", showBackButton: true, title: 'ThirdStep' },
+    { name: "FirstStep", showBackButton: false, title: "FirstStep" },
+    { name: "SecondStep", showBackButton: true, title: "SecondStep" },
+    { name: "ThirdStep", showBackButton: true, title: "ThirdStep" },
   ];
 
   it("initialize state to 0", () => {

--- a/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
@@ -17,7 +17,7 @@ export const mockMainAccount: Account = {
 
 export const mockSubAccount: Account = {
   identifier:
-    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+    "aaaa5b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
   balance: ICP.fromString("1234567.8901") as ICP,
   name: "test subaccount",
 };

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -1,6 +1,8 @@
-import { waitFor } from "@testing-library/svelte";
+import type { RenderResult } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
+import type { SvelteComponent } from "svelte";
 
-export const waitModalIntroEnd = async ({
+const waitModalIntroEnd = async ({
   container,
   selector,
 }: {
@@ -12,4 +14,19 @@ export const waitModalIntroEnd = async ({
   container.querySelector('div[role="dialog"]')?.dispatchEvent(event);
 
   await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
+};
+
+const modalToolbarSelector = "div.toolbar";
+
+export const renderModal = async (
+  component: typeof SvelteComponent
+): Promise<RenderResult> => {
+  const modal = render(component, {
+    props: { canSelectAccount: true },
+  });
+
+  const { container } = modal;
+  await waitModalIntroEnd({ container, selector: modalToolbarSelector });
+
+  return modal;
 };

--- a/frontend/svelte/src/tests/routes/Neurons.spec.ts
+++ b/frontend/svelte/src/tests/routes/Neurons.spec.ts
@@ -70,10 +70,10 @@ describe("Neurons", () => {
 
     const toolbarButton = container.querySelector('[role="toolbar"] button');
     expect(toolbarButton).not.toBeNull();
-    expect(queryByText(en.neurons.select_source)).toBeNull();
+    expect(queryByText(en.accounts.select_source)).toBeNull();
 
     toolbarButton !== null && (await fireEvent.click(toolbarButton));
 
-    expect(queryByText(en.neurons.select_source)).not.toBeNull();
+    expect(queryByText(en.accounts.select_source)).not.toBeNull();
   });
 });


### PR DESCRIPTION
# Motivation

Init "New transaction" modal and two first steps to select account and destination (without any logic here).

# Changes

- init new modal `NewTransaction`
- refactor step to define `title` per step
- several UI improvements discussed with Mischa (display of title "My Accounts", "Max" color and texts on "Select destination" and modal wrapper spacing)

# Screenshots

<img width="1513" alt="Capture d’écran 2022-04-05 à 08 50 50" src="https://user-images.githubusercontent.com/16886711/161696145-b2262968-f2be-4e14-867a-f694f5870e82.png">
<img width="1513" alt="Capture d’écran 2022-04-05 à 08 50 55" src="https://user-images.githubusercontent.com/16886711/161696154-5d96421e-7202-43aa-920e-0a5a8865ef77.png">
<img width="1513" alt="Capture d’écran 2022-04-05 à 08 51 05" src="https://user-images.githubusercontent.com/16886711/161696160-c00e75de-8608-45b3-970a-c762bc7d3cf1.png">
<img width="1513" alt="Capture d’écran 2022-04-05 à 08 51 09" src="https://user-images.githubusercontent.com/16886711/161696164-525bbacb-b21e-4155-b49e-a10f3dca9e2e.png">

