### PR TITLE
feat: account address input rules

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/Address.svelte
+++ b/frontend/svelte/src/lib/components/accounts/Address.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
   import Input from "../ui/Input.svelte";
   import { i18n } from "../../stores/i18n";
+  import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../constants/accounts.constants";
+  import { invalidAddress } from "../../utils/accounts.utils";
 
-  export let address: number | undefined;
+  export let address: string = "";
 
   // TODO(L2-430): to be implemented
   const submitAddress = () => console.log("submitAddress");
-
-  // TODO(L2-430): Input is of type number?
-  // TODO(L2-430): Input validation rules - max 40 characters?
-  // TODO(L2-430): tests
 </script>
 
 <article>
   <form on:submit|preventDefault={submitAddress}>
     <Input
-      inputType="number"
+      inputType="text"
       placeholderLabelKey="accounts.address"
-      name="transaction-address"
+      name="accounts-address"
       bind:value={address}
+      minLength={ACCOUNT_ADDRESS_MIN_LENGTH}
       theme="dark"
     />
     <button
       class="primary small"
       type="submit"
-      disabled={address === undefined || address === 0}
+      disabled={invalidAddress(address)}
     >
       {$i18n.core.continue}
     </button>

--- a/frontend/svelte/src/lib/components/accounts/SelectDestination.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectDestination.svelte
@@ -3,8 +3,9 @@
   import Address from "./Address.svelte";
   import SelectAccount from "./SelectAccount.svelte";
   import { onMount } from "svelte";
+  import { emptyAddress } from "../../utils/accounts.utils";
 
-  let address: number | undefined;
+  let address: string;
   let mounted: boolean = false;
 
   onMount(() => (mounted = true));
@@ -21,7 +22,7 @@
   {#if mounted}
     <SelectAccount
       displayTitle={true}
-      disableSelection={address !== undefined && address !== 0}
+      disableSelection={!emptyAddress(address)}
     />
   {/if}
 </div>

--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -6,6 +6,7 @@
   export let spellcheck: boolean | undefined = undefined;
   export let step: number | "any" | undefined = undefined;
   export let disabled: boolean = false;
+  export let minLength: number | undefined = undefined;
 
   export let value: string | number | undefined = undefined;
 
@@ -18,6 +19,9 @@
       inputType === "number" ? +currentTarget.value : currentTarget.value);
 
   $: step = inputType === "number" ? step ?? "any" : undefined;
+
+  let placeholder: string;
+  $: placeholder = translate({ labelKey: placeholderLabelKey });
 </script>
 
 <div class={`input-block ${theme}`} class:disabled>
@@ -29,11 +33,13 @@
     {step}
     {disabled}
     {value}
+    {minLength}
+    {placeholder}
     on:input={handleInput}
   />
 
   <span class="placeholder">
-    {translate({ labelKey: placeholderLabelKey })}
+    {placeholder}
   </span>
 
   <slot name="button" />
@@ -87,9 +93,7 @@
         background-color: var(--gray-50-background);
         border: 1px solid var(--black);
 
-        &[disabled] + span.placeholder,
-        &:valid + span.placeholder,
-        &:focus + span.placeholder {
+        &:not(:placeholder-shown) + span.placeholder {
           background-color: var(--gray-50-background);
         }
       }
@@ -130,11 +134,12 @@
 
     font-size: var(--font-size-h4);
     color: var(--gray-600);
+
+    /** Space to display fully the caret if field is focused and empty */
+    margin-left: 4px;
   }
 
-  .input-block input[disabled] + span.placeholder,
-  .input-block input:valid + span.placeholder,
-  .input-block input:focus + span.placeholder {
+  .input-block input:not(:placeholder-shown) + span.placeholder {
     transform: scale(0.8) translate(0, calc(-50% - 30px));
     background: #ffffff;
 
@@ -151,5 +156,9 @@
 
   input[disabled] {
     cursor: text;
+  }
+
+  input::placeholder {
+    visibility: hidden;
   }
 </style>

--- a/frontend/svelte/src/lib/constants/accounts.constants.ts
+++ b/frontend/svelte/src/lib/constants/accounts.constants.ts
@@ -1,0 +1,1 @@
+export const ACCOUNT_ADDRESS_MIN_LENGTH = 40;

--- a/frontend/svelte/src/lib/utils/accounts.utils.ts
+++ b/frontend/svelte/src/lib/utils/accounts.utils.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../constants/accounts.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
 
@@ -20,3 +21,15 @@ export const getAccountByPrincipal = ({
   // TODO: Check also the hardware wallets L2-433
   return undefined;
 };
+
+/**
+ * Is the address a valid entry to proceed with any action such as transferring ICP?
+ */
+export const invalidAddress = (address: string | undefined): boolean =>
+  address === undefined || address.length < ACCOUNT_ADDRESS_MIN_LENGTH;
+
+/**
+ * Is the address an empty value? Useful to detect if user is currently entering an address regardless if valid or invalid
+ */
+export const emptyAddress = (address: string | undefined): boolean =>
+  address === undefined || address.length === 0;

--- a/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/Address.spec.ts
@@ -2,13 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import Address from "../../../../lib/components/accounts/Address.svelte";
+import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../../../lib/constants/accounts.constants";
+import { mockAddressInput } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 
 describe("Address", () => {
+  const props = { props: { address: undefined } };
+
   it("should render a form to enter an address", () => {
-    const { container } = render(Address, { props: { address: undefined } });
+    const { container } = render(Address, props);
 
     expect(container.querySelector("input")).not.toBeNull();
     expect(container.querySelector("form")).not.toBeNull();
@@ -16,5 +20,45 @@ describe("Address", () => {
     const button = container.querySelector('button[type="submit"]');
     expect(button).not.toBeNull();
     expect(button?.innerHTML).toEqual(en.core.continue);
+  });
+
+  it("should render an input with a minimal length of 40", () => {
+    const { container } = render(Address, props);
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute("minlength")).toEqual(
+      `${ACCOUNT_ADDRESS_MIN_LENGTH}`
+    );
+  });
+
+  it("should enable and disable action according input", async () => {
+    const { container } = render(Address, props);
+
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("disabled")).not.toBeNull();
+
+    await fireEvent.input(input, { target: { value: "test" } });
+    expect(button?.getAttribute("disabled")).not.toBeNull();
+
+    await fireEvent.input(input, {
+      target: {
+        value: mockAddressInput(ACCOUNT_ADDRESS_MIN_LENGTH),
+      },
+    });
+
+    expect(button?.getAttribute("disabled")).toBeNull();
+
+    await fireEvent.input(input, {
+      target: {
+        value: mockAddressInput(ACCOUNT_ADDRESS_MIN_LENGTH + 1),
+      },
+    });
+    expect(button?.getAttribute("disabled")).toBeNull();
+
+    await fireEvent.input(input, { target: { value: "" } });
+    expect(button?.getAttribute("disabled")).not.toBeNull();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
@@ -122,6 +122,14 @@ describe("Input", () => {
     testGetAttribute({ container, attribute: "step", expected: "any" });
   });
 
+  it("should render an input with min length", () => {
+    const { container } = render(Input, {
+      props: { ...props, minLength: 10 },
+    });
+
+    testGetAttribute({ container, attribute: "minLength", expected: "10" });
+  });
+
   it("should render an input with a particular step attribute", () => {
     const { container } = render(Input, {
       props: {

--- a/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -24,14 +24,14 @@ describe("AddAccountModal", () => {
   });
 
   it("should display two button cards", async () => {
-    const { container } = await renderModal(AddAccountModal);
+    const { container } = await renderModal({ component: AddAccountModal });
 
     const buttons = container.querySelectorAll('div[role="button"]');
     expect(buttons.length).toEqual(2);
   });
 
   it("should be able to select new account ", async () => {
-    const { queryByText } = await renderModal(AddAccountModal);
+    const { queryByText } = await renderModal({ component: AddAccountModal });
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -44,7 +44,9 @@ describe("AddAccountModal", () => {
   });
 
   it("should have disabled Add Account button", async () => {
-    const { container, queryByText } = await renderModal(AddAccountModal);
+    const { container, queryByText } = await renderModal({
+      component: AddAccountModal,
+    });
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -58,7 +60,9 @@ describe("AddAccountModal", () => {
   });
 
   it("should have enabled Add Account button when entering name", async () => {
-    const { container, queryByText } = await renderModal(AddAccountModal);
+    const { container, queryByText } = await renderModal({
+      component: AddAccountModal,
+    });
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();
@@ -77,7 +81,9 @@ describe("AddAccountModal", () => {
   });
 
   const testSubaccount = async (): Promise<{ container: HTMLElement }> => {
-    const { container, queryByText } = await renderModal(AddAccountModal);
+    const { container, queryByText } = await renderModal({
+      component: AddAccountModal,
+    });
 
     const accountCard = queryByText(en.accounts.new_linked_title);
     expect(accountCard).not.toBeNull();

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -19,13 +19,19 @@ describe("NewTransactionModal", () => {
     .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
 
   it("should display modal", async () => {
-    const { container } = await renderModal(NewTransactionModal);
+    const { container } = await renderModal({
+      component: NewTransactionModal,
+      props: { canSelectAccount: true },
+    });
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
   it("should navigate back and forth between step SelectAccount and SelectDestination", async () => {
-    const { container, getByText } = await renderModal(NewTransactionModal);
+    const { container, getByText } = await renderModal({
+      component: NewTransactionModal,
+      props: { canSelectAccount: true },
+    });
 
     expect(
       getByText(en.accounts.select_source, { exact: false })

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -60,19 +60,21 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should display modal", async () => {
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
   it("should display accounts as cards", async () => {
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     expect(container.querySelector('article[role="button"]')).not.toBeNull();
   });
 
   it("should be able to select an account and move to the next view", async () => {
-    const { container, queryByText } = await renderModal(CreateNeuronModal);
+    const { container, queryByText } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -83,7 +85,9 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should be able to select a subaccount and move to the next view", async () => {
-    const { container, queryByText } = await renderModal(CreateNeuronModal);
+    const { container, queryByText } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCards = container.querySelectorAll('article[role="button"]');
     expect(accountCards.length).toBe(2);
@@ -99,7 +103,9 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should have disabled Create neuron button", async () => {
-    const { container, queryByText } = await renderModal(CreateNeuronModal);
+    const { container, queryByText } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -113,7 +119,9 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should have enabled Create neuron button when entering amount", async () => {
-    const { container, queryByText } = await renderModal(CreateNeuronModal);
+    const { container, queryByText } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -132,7 +140,7 @@ describe("CreateNeuronModal", () => {
   });
 
   it("should be able to create a new neuron", async () => {
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -155,7 +163,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -182,7 +190,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -213,7 +221,7 @@ describe("CreateNeuronModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -257,7 +265,9 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([newNeuron]));
 
-    const { container, getByText } = await renderModal(CreateNeuronModal);
+    const { container, getByText } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -285,7 +295,7 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
 
-    const { container } = await renderModal(CreateNeuronModal);
+    const { container } = await renderModal({ component: CreateNeuronModal });
 
     const accountCard = container.querySelector('article[role="button"]');
     expect(accountCard).not.toBeNull();
@@ -338,7 +348,9 @@ describe("CreateNeuronModal", () => {
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
 
-    const { container, queryByTestId } = await renderModal(CreateNeuronModal);
+    const { container, queryByTestId } = await renderModal({
+      component: CreateNeuronModal,
+    });
 
     // SCREEN: Select Account
     const accountCard = container.querySelector('article[role="button"]');

--- a/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,5 +1,13 @@
-import { getAccountByPrincipal } from "../../../lib/utils/accounts.utils";
-import { mockMainAccount } from "../../mocks/accounts.store.mock";
+import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../../lib/constants/accounts.constants";
+import {
+  emptyAddress,
+  getAccountByPrincipal,
+  invalidAddress,
+} from "../../../lib/utils/accounts.utils";
+import {
+  mockAddressInput,
+  mockMainAccount,
+} from "../../mocks/accounts.store.mock";
 
 describe("accounts-utils", () => {
   describe("getAccountByPrincipal", () => {
@@ -29,5 +37,32 @@ describe("accounts-utils", () => {
       });
       expect(found).toBeUndefined();
     });
+  });
+
+  it("should be a invalid address", () => {
+    expect(invalidAddress(undefined)).toBeTruthy();
+    expect(invalidAddress("test")).toBeTruthy();
+
+    expect(
+      invalidAddress(mockAddressInput(ACCOUNT_ADDRESS_MIN_LENGTH - 1))
+    ).toBeTruthy();
+  });
+
+  it("should be a valid address", () => {
+    expect(
+      invalidAddress(mockAddressInput(ACCOUNT_ADDRESS_MIN_LENGTH))
+    ).toBeFalsy();
+    expect(
+      invalidAddress(mockAddressInput(ACCOUNT_ADDRESS_MIN_LENGTH + 1))
+    ).toBeFalsy();
+  });
+
+  it("should be an empty address", () => {
+    expect(emptyAddress(undefined)).toBeTruthy();
+    expect(emptyAddress("")).toBeTruthy();
+  });
+
+  it("should not be an empty address", () => {
+    expect(emptyAddress("test")).toBeFalsy();
   });
 });

--- a/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
@@ -42,3 +42,8 @@ export const mockAccountsStoreSubscribe =
 
     return () => undefined;
   };
+
+export const mockAddressInput = (length: number): string =>
+  Array.from(Array(length))
+    .map(() => "a")
+    .join("");

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -18,11 +18,15 @@ const waitModalIntroEnd = async ({
 
 const modalToolbarSelector = "div.toolbar";
 
-export const renderModal = async (
-  component: typeof SvelteComponent
-): Promise<RenderResult> => {
+export const renderModal = async ({
+  component,
+  props,
+}: {
+  component: typeof SvelteComponent;
+  props?: Record<string, string | boolean>;
+}): Promise<RenderResult> => {
   const modal = render(component, {
-    props: { canSelectAccount: true },
+    props,
   });
 
   const { container } = modal;


### PR DESCRIPTION
# Motivation

Implement address input rules as in Dart.

# Changes

- input is of type `test` and should be min 40 characters
- modify component `Input` to support `minlength`
