### PR TITLE
L2-361: Neuron detail dissolve delay

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -80,7 +80,7 @@
         {/if}
       </p>
       <div class="buttons">
-        <IncreaseDissolveDelayButton />
+        <IncreaseDissolveDelayButton {neuron} />
         {#if neuron.state === NeuronState.DISSOLVED}
           <DisburseButton />
         {:else if neuron.state === NeuronState.DISSOLVING || neuron.state === NeuronState.LOCKED}

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
@@ -1,7 +1,19 @@
-<script>
+<script lang="ts">
+  import IncreaseDissolveDelayModal from "../../../modals/neurons/IncreaseDissolveDelayModal.svelte";
   import { i18n } from "../../../stores/i18n";
+  import type { NeuronInfo } from "@dfinity/nns";
+
+  export let neuron: NeuronInfo;
+
+  let showModal: boolean = false;
+  const openModal = () => (showModal = true);
+  const closeModal = () => (showModal = false);
 </script>
 
-<button class="primary small"
+<button class="primary small" on:click={openModal}
   >{$i18n.neuron_detail.increase_dissolve_delay}</button
 >
+
+{#if showModal}
+  <IncreaseDissolveDelayModal {neuron} on:nnsClose={closeModal} />
+{/if}

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -33,7 +33,7 @@
     stopBusy("update-delay");
     loading = false;
     if (neuronId !== undefined) {
-      dispatcher("nnsNext");
+      dispatcher("nnsUpdated");
       toastsStore.show({
         labelKey: "neurons.dissolve_delay_success",
         level: "info",

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -13,6 +13,7 @@
     votingPower,
   } from "../../utils/neuron.utils";
   import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { toastsStore } from "../../stores/toasts.store";
 
   export let delayInSeconds: number;
   export let neuron: NeuronInfo;
@@ -33,6 +34,10 @@
     loading = false;
     if (neuronId !== undefined) {
       dispatcher("nnsNext");
+      toastsStore.show({
+        labelKey: "neurons.dissolve_delay_success",
+        level: "info",
+      });
     }
   };
 </script>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -28,7 +28,8 @@
     loading = true;
     const neuronId = await updateDelay({
       neuronId: neuron.neuronId,
-      dissolveDelayInSeconds: delayInSeconds,
+      dissolveDelayInSeconds:
+        delayInSeconds - Number(neuron.dissolveDelaySeconds),
     });
     stopBusy("update-delay");
     loading = false;

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -116,26 +116,6 @@
         </div>
       </div>
     </div>
-    <div class="buttons">
-      <button
-        on:click={cancel}
-        data-tid="skip-neuron-delay"
-        class="secondary full-width"
-        disabled={loading}>{secondaryButtonText}</button
-      >
-      <button
-        class="primary full-width"
-        disabled={disableUpdate || loading}
-        on:click={goToConfirmation}
-        data-tid="go-confirm-delay-button"
-      >
-        {#if loading}
-          <Spinner />
-        {:else}
-          {$i18n.neurons.update_delay}
-        {/if}
-      </button>
-    </div>
   </Card>
   <div class="buttons">
     <button

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -44,7 +44,7 @@
   let disableUpdate: boolean;
   $: disableUpdate =
     delayInSeconds < SECONDS_IN_HALF_YEAR ||
-    delayInSeconds === minDelayInSeconds;
+    delayInSeconds <= minDelayInSeconds;
   const dispatcher = createEventDispatcher();
   const cancel = (): void => {
     dispatcher("nnsCancel");

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -20,7 +20,7 @@
 
   export let neuron: NeuronInfo;
   export let delayInSeconds: number = 0;
-  export let secondaryButtonText: string;
+  export let cancelButtonText: string;
   export let minDelayInSeconds: number = 0;
 
   let loading: boolean = false;
@@ -120,9 +120,9 @@
   <div class="buttons">
     <button
       on:click={cancel}
-      data-tid="skip-neuron-delay"
+      data-tid="cancel-neuron-delay"
       class="secondary full-width"
-      disabled={loading}>{secondaryButtonText}</button
+      disabled={loading}>{cancelButtonText}</button
     >
     <button
       class="primary full-width"

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -42,7 +42,9 @@
   };
 
   let disableUpdate: boolean;
-  $: disableUpdate = delayInSeconds < SECONDS_IN_HALF_YEAR;
+  $: disableUpdate =
+    delayInSeconds < SECONDS_IN_HALF_YEAR ||
+    delayInSeconds === minDelayInSeconds;
   const dispatcher = createEventDispatcher();
   const cancel = (): void => {
     dispatcher("nnsCancel");

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -119,7 +119,8 @@
     "voting_power": "Voting Power",
     "skip": "Skip",
     "update_delay": "Update Delay",
-    "confirm_delay": "Confirm and Update Delay"
+    "confirm_delay": "Confirm and Update Delay",
+    "dissolve_delay_success": "Dissolve delay successfully updated."
   },
   "new_followee": {
     "title": "Enter New Followee",

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -101,9 +101,6 @@
     selectedAccount = detail.selectedAccount;
     modal.next();
   };
-  const goBack = () => {
-    modal.back();
-  };
   const goNext = () => {
     modal.next();
   };
@@ -137,7 +134,7 @@
   {#if currentStep?.name === "SetDissolveDelay"}
     {#if newNeuron !== undefined}
       <SetDissolveDelay
-        secondaryButtonText={$i18n.neurons.skip}
+        cancelButtonText={$i18n.neurons.skip}
         neuron={newNeuron}
         on:nnsCancel={goEditFollowers}
         on:nnsConfirmDelay={goNext}
@@ -150,8 +147,7 @@
       <ConfirmDissolveDelay
         neuron={newNeuron}
         {delayInSeconds}
-        on:back={goBack}
-        on:nnsNext={goNext}
+        on:nnsUpdated={goNext}
       />
     {/if}
   {/if}

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -137,8 +137,9 @@
   {#if currentStep?.name === "SetDissolveDelay"}
     {#if newNeuron !== undefined}
       <SetDissolveDelay
+        secondaryButtonText={$i18n.neurons.skip}
         neuron={newNeuron}
-        on:nnsSkipDelay={goEditFollowers}
+        on:nnsCancel={goEditFollowers}
         on:nnsConfirmDelay={goNext}
         bind:delayInSeconds
       />

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import SetDissolveDelay from "../../components/neurons/SetDissolveDelay.svelte";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import ConfirmDissolveDelay from "../../components/neurons/ConfirmDissolveDelay.svelte";
+  import WizardModal from "../WizardModal.svelte";
+  import type { Steps } from "../../stores/steps.state";
+  import { createEventDispatcher } from "svelte";
+
+  export let neuron: NeuronInfo;
+
+  const steps: Steps = [
+    { name: "SetDissolveDelay", showBackButton: false },
+    { name: "ConfirmDissolveDelay", showBackButton: true },
+  ];
+
+  let currentStepName: string | undefined;
+  let modal: WizardModal;
+
+  let delayInSeconds: number = Number(neuron.dissolveDelaySeconds);
+
+  const dispatcher = createEventDispatcher();
+  const goBack = () => {
+    modal.back();
+  };
+  const goNext = () => {
+    modal.next();
+  };
+  const closeModal = () => {
+    dispatcher("nnsClose");
+  };
+
+  const titleMapper: Record<string, string> = {
+    SetDissolveDelay: "set_dissolve_delay",
+    ConfirmDissolveDelay: "confirm_dissolve_delay",
+  };
+  let titleKey: string = titleMapper[0];
+  $: titleKey = titleMapper[currentStepName ?? "SetDissolveDelay"];
+</script>
+
+<WizardModal {steps} bind:currentStepName bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title">{$i18n.neurons?.[titleKey]}</svelte:fragment>
+  {#if currentStepName === "SetDissolveDelay"}
+    <SetDissolveDelay
+      {neuron}
+      secondaryButtonText={$i18n.core.confirm_no}
+      minDelayInSeconds={Number(neuron.dissolveDelaySeconds)}
+      on:nnsSkipDelay={closeModal}
+      on:nnsConfirmDelay={goNext}
+      bind:delayInSeconds
+    />
+  {/if}
+  {#if currentStepName === "ConfirmDissolveDelay"}
+    <ConfirmDissolveDelay
+      {neuron}
+      {delayInSeconds}
+      on:back={goBack}
+      on:nnsUpdated={closeModal}
+    />
+  {/if}
+</WizardModal>

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -4,17 +4,25 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import ConfirmDissolveDelay from "../../components/neurons/ConfirmDissolveDelay.svelte";
   import WizardModal from "../WizardModal.svelte";
-  import type { Steps } from "../../stores/steps.state";
+  import type { Step, Steps } from "../../stores/steps.state";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: NeuronInfo;
 
   const steps: Steps = [
-    { name: "SetDissolveDelay", showBackButton: false },
-    { name: "ConfirmDissolveDelay", showBackButton: true },
+    {
+      name: "SetDissolveDelay",
+      showBackButton: false,
+      title: $i18n.neurons.set_dissolve_delay,
+    },
+    {
+      name: "ConfirmDissolveDelay",
+      showBackButton: true,
+      title: $i18n.neurons.confirm_dissolve_delay,
+    },
   ];
 
-  let currentStepName: string | undefined;
+  let currentStep: Step;
   let modal: WizardModal;
 
   let delayInSeconds: number = Number(neuron.dissolveDelaySeconds);
@@ -29,28 +37,21 @@
   const closeModal = () => {
     dispatcher("nnsClose");
   };
-
-  const titleMapper: Record<string, string> = {
-    SetDissolveDelay: "set_dissolve_delay",
-    ConfirmDissolveDelay: "confirm_dissolve_delay",
-  };
-  let titleKey: string = titleMapper[0];
-  $: titleKey = titleMapper[currentStepName ?? "SetDissolveDelay"];
 </script>
 
-<WizardModal {steps} bind:currentStepName bind:this={modal} on:nnsClose>
-  <svelte:fragment slot="title">{$i18n.neurons?.[titleKey]}</svelte:fragment>
-  {#if currentStepName === "SetDissolveDelay"}
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
+  {#if currentStep.name === "SetDissolveDelay"}
     <SetDissolveDelay
       {neuron}
       secondaryButtonText={$i18n.core.confirm_no}
       minDelayInSeconds={Number(neuron.dissolveDelaySeconds)}
-      on:nnsSkipDelay={closeModal}
+      on:nnsCancel={closeModal}
       on:nnsConfirmDelay={goNext}
       bind:delayInSeconds
     />
   {/if}
-  {#if currentStepName === "ConfirmDissolveDelay"}
+  {#if currentStep.name === "ConfirmDissolveDelay"}
     <ConfirmDissolveDelay
       {neuron}
       {delayInSeconds}

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -28,9 +28,6 @@
   let delayInSeconds: number = Number(neuron.dissolveDelaySeconds);
 
   const dispatcher = createEventDispatcher();
-  const goBack = () => {
-    modal.back();
-  };
   const goNext = () => {
     modal.next();
   };
@@ -44,7 +41,7 @@
   {#if currentStep.name === "SetDissolveDelay"}
     <SetDissolveDelay
       {neuron}
-      secondaryButtonText={$i18n.core.confirm_no}
+      cancelButtonText={$i18n.core.confirm_no}
       minDelayInSeconds={Number(neuron.dissolveDelaySeconds)}
       on:nnsCancel={closeModal}
       on:nnsConfirmDelay={goNext}
@@ -55,7 +52,6 @@
     <ConfirmDissolveDelay
       {neuron}
       {delayInSeconds}
-      on:back={goBack}
       on:nnsUpdated={closeModal}
     />
   {/if}

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -130,6 +130,7 @@ interface I18nNeurons {
   skip: string;
   update_delay: string;
   confirm_delay: string;
+  dissolve_delay_success: string;
 }
 
 interface I18nNew_followee {

--- a/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -9,7 +9,7 @@ describe("SetDissolveDelay", () => {
   // Tested in CreateNeuronModal.spec.ts
   it("is not tested in isolation", () => {
     render(SetDissolveDelay, {
-      props: { neuron: mockNeuron },
+      props: { neuron: mockNeuron, cancelButtonText: "Cancel" },
     });
     expect(true).toBeTruthy();
   });

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -23,49 +23,49 @@ describe("VotingConfirmationToolbar", () => {
     votingNeuronSelectStore.set([neuron]);
   });
 
-  it("should disable buttons if nothing is selected", () => {
+  it("should disable buttons if nothing is selected", async () => {
     const { container } = render(VotingConfirmationToolbar);
     votingNeuronSelectStore.toggleSelection(neuron.neuronId);
-    waitFor(() =>
+    await waitFor(() =>
       expect(
-        container.querySelectorAll('[data-tid="vote-yes"][disabled]')
+        container.querySelector('[data-tid="vote-yes"][disabled]')
       ).toBeInTheDocument()
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
-        container.querySelectorAll('[data-tid="vote-no"][disabled]')
+        container.querySelector('[data-tid="vote-no"][disabled]')
       ).toBeInTheDocument()
     );
   });
 
-  it("should display Vote.YES modal", () => {
+  it("should display Vote.YES modal", async () => {
     const { container } = render(VotingConfirmationToolbar);
     fireEvent.click(
       container.querySelector('[data-tid="vote-yes"]') as Element
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         container.querySelector('[data-tid="thumb-up"]')
       ).toBeInTheDocument()
     );
   });
 
-  it("should display Vote.NO modal", () => {
+  it("should display Vote.NO modal", async () => {
     const { container } = render(VotingConfirmationToolbar);
     fireEvent.click(container.querySelector('[data-tid="vote-no"]') as Element);
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         container.querySelector('[data-tid="thumb-down"]')
       ).toBeInTheDocument()
     );
   });
 
-  it('should display "total" in modal', () => {
+  it('should display "total" in modal', async () => {
     const { getByText, container } = render(VotingConfirmationToolbar);
     fireEvent.click(
       container.querySelector('[data-tid="vote-yes"]') as Element
     );
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         getByText(formatVotingPower(votingPower), { exact: false })
       ).toBeInTheDocument()
@@ -82,7 +82,7 @@ describe("VotingConfirmationToolbar", () => {
         container.querySelector('[data-tid="confirm-no"]')
       ).toBeInTheDocument()
     );
-    fireEvent.click(
+    await fireEvent.click(
       container.querySelector('[data-tid="confirm-no"]') as Element
     );
     await waitFor(() =>
@@ -98,9 +98,11 @@ describe("VotingConfirmationToolbar", () => {
     const onConfirm = jest.fn((ev) => (calledVoteType = ev?.detail?.voteType));
     component.$on("nnsConfirm", onConfirm);
 
-    fireEvent.click(container.querySelector('[data-tid="vote-no"]') as Element);
+    await fireEvent.click(
+      container.querySelector('[data-tid="vote-no"]') as Element
+    );
     await waitFor(() => container.querySelector('[data-tid="confirm-yes"]'));
-    fireEvent.click(
+    await fireEvent.click(
       container.querySelector('[data-tid="confirm-yes"]') as Element
     );
     await waitFor(() =>

--- a/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
@@ -92,7 +92,7 @@ describe("Toasts", () => {
     const button: HTMLButtonElement | null = container.querySelector(
       'button[aria-label="Close"]'
     );
-    button && fireEvent.click(button);
+    button && (await fireEvent.click(button));
 
     await waitFor(() =>
       expect(container.querySelector("div.toast")).toBeNull()

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -425,7 +425,7 @@ describe("CreateNeuronModal", () => {
       expect(container.querySelector('input[type="range"]')).not.toBeNull()
     );
 
-    const skipButton = queryByTestId("skip-neuron-delay");
+    const skipButton = queryByTestId("cancel-neuron-delay");
 
     skipButton && (await fireEvent.click(skipButton));
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { NeuronInfo } from "@dfinity/nns";
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor, type RenderResult } from "@testing-library/svelte";
+import { SECONDS_IN_YEAR } from "../../../../lib/constants/constants";
+import IncreaseDissolveDelayModal from "../../../../lib/modals/neurons/IncreaseDissolveDelayModal.svelte";
+import { updateDelay } from "../../../../lib/services/neurons.services";
+import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+import { mockNeuron } from "../../../mocks/neurons.mock";
+
+jest.mock("../../../../lib/services/neurons.services", () => {
+  return {
+    updateDelay: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("IncreaseDissolveDelayModal", () => {
+  const modalTitleSelector = "h3";
+
+  const renderModal = async (neuron: NeuronInfo): Promise<RenderResult> => {
+    const modal = render(IncreaseDissolveDelayModal, { neuron });
+
+    const { container } = modal;
+    await waitModalIntroEnd({ container, selector: modalTitleSelector });
+
+    return modal;
+  };
+
+  it("should display modal", async () => {
+    const { container } = await renderModal(mockNeuron);
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should have the update delay button disabled by default", async () => {
+    const { container } = await renderModal(mockNeuron);
+
+    const updateDelayButton = container.querySelector(
+      '[data-tid="go-confirm-delay-button"]'
+    );
+    expect(updateDelayButton?.getAttribute("disabled")).not.toBeNull();
+  });
+
+  it("should be able to change dissolve delay in the confirmation screen", async () => {
+    const editableNeuron = {
+      ...mockNeuron,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+    };
+    const { container } = await renderModal(editableNeuron);
+
+    await waitFor(() =>
+      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+    );
+    const inputRange = container.querySelector('input[type="range"]');
+    expect(inputRange).not.toBeNull();
+
+    inputRange &&
+      (await fireEvent.input(inputRange, {
+        target: { value: SECONDS_IN_YEAR * 2 },
+      }));
+
+    const goToConfirmDelayButton = container.querySelector(
+      '[data-tid="go-confirm-delay-button"]'
+    );
+    await waitFor(() =>
+      expect(goToConfirmDelayButton?.getAttribute("disabled")).toBeNull()
+    );
+
+    goToConfirmDelayButton && (await fireEvent.click(goToConfirmDelayButton));
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-tid="confirm-dissolve-delay-container"]')
+      ).not.toBeNull()
+    );
+
+    const confirmButton = container.querySelector(
+      '[data-tid="confirm-delay-button"]'
+    );
+    confirmButton && (await fireEvent.click(confirmButton));
+
+    await waitFor(() => expect(updateDelay).toBeCalled());
+  });
+
+  it("should not be able to change dissolve delay below current value", async () => {
+    const editableNeuron = {
+      ...mockNeuron,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+    };
+    const { container } = await renderModal(editableNeuron);
+
+    await waitFor(() =>
+      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+    );
+    const inputRange = container.querySelector<HTMLInputElement>(
+      'input[type="range"]'
+    );
+    expect(inputRange).not.toBeNull();
+
+    inputRange &&
+      (await fireEvent.input(inputRange, {
+        target: { value: SECONDS_IN_YEAR / 2 },
+      }));
+
+    const goToConfirmDelayButton = container.querySelector(
+      '[data-tid="go-confirm-delay-button"]'
+    );
+    await waitFor(() =>
+      expect(goToConfirmDelayButton?.getAttribute("disabled")).not.toBeNull()
+    );
+    inputRange &&
+      (await waitFor(() =>
+        expect(inputRange.value).toBe(String(SECONDS_IN_YEAR))
+      ));
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -4,11 +4,11 @@
 
 import type { NeuronInfo } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor, type RenderResult } from "@testing-library/svelte";
+import { waitFor, type RenderResult } from "@testing-library/svelte";
 import { SECONDS_IN_YEAR } from "../../../../lib/constants/constants";
 import IncreaseDissolveDelayModal from "../../../../lib/modals/neurons/IncreaseDissolveDelayModal.svelte";
 import { updateDelay } from "../../../../lib/services/neurons.services";
-import { waitModalIntroEnd } from "../../../mocks/modal.mock";
+import { renderModal } from "../../../mocks/modal.mock";
 import { mockNeuron } from "../../../mocks/neurons.mock";
 
 jest.mock("../../../../lib/services/neurons.services", () => {
@@ -18,25 +18,23 @@ jest.mock("../../../../lib/services/neurons.services", () => {
 });
 
 describe("IncreaseDissolveDelayModal", () => {
-  const modalTitleSelector = "h3";
-
-  const renderModal = async (neuron: NeuronInfo): Promise<RenderResult> => {
-    const modal = render(IncreaseDissolveDelayModal, { neuron });
-
-    const { container } = modal;
-    await waitModalIntroEnd({ container, selector: modalTitleSelector });
-
-    return modal;
+  const renderIncreaseDelayModal = async (
+    neuron: NeuronInfo
+  ): Promise<RenderResult> => {
+    return renderModal({
+      component: IncreaseDissolveDelayModal,
+      props: { neuron },
+    });
   };
 
   it("should display modal", async () => {
-    const { container } = await renderModal(mockNeuron);
+    const { container } = await renderIncreaseDelayModal(mockNeuron);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
   it("should have the update delay button disabled by default", async () => {
-    const { container } = await renderModal(mockNeuron);
+    const { container } = await renderIncreaseDelayModal(mockNeuron);
 
     const updateDelayButton = container.querySelector(
       '[data-tid="go-confirm-delay-button"]'
@@ -49,7 +47,7 @@ describe("IncreaseDissolveDelayModal", () => {
       ...mockNeuron,
       dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
     };
-    const { container } = await renderModal(editableNeuron);
+    const { container } = await renderIncreaseDelayModal(editableNeuron);
 
     await waitFor(() =>
       expect(container.querySelector('input[type="range"]')).not.toBeNull()
@@ -90,7 +88,7 @@ describe("IncreaseDissolveDelayModal", () => {
       ...mockNeuron,
       dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
     };
-    const { container } = await renderModal(editableNeuron);
+    const { container } = await renderIncreaseDelayModal(editableNeuron);
 
     await waitFor(() =>
       expect(container.querySelector('input[type="range"]')).not.toBeNull()

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -2,7 +2,7 @@ import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-const waitModalIntroEnd = async ({
+export const waitModalIntroEnd = async ({
   container,
   selector,
 }: {

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -23,7 +23,8 @@ export const renderModal = async ({
   props,
 }: {
   component: typeof SvelteComponent;
-  props?: Record<string, string | boolean>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props?: Record<string, any>;
 }): Promise<RenderResult> => {
   const modal = render(component, {
     props,

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -2,7 +2,7 @@ import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
-export const waitModalIntroEnd = async ({
+const waitModalIntroEnd = async ({
   container,
   selector,
 }: {


### PR DESCRIPTION
# Motivation

Modal in neuron details to increase the dissolve delay.

# Changes

* New modal IncreaseDissolveDelayModal that uses SetDissolveDelay and ConfirmDissolveDelay screens.
* Minor changes in SetDissolveDelay and ConfirmDissolveDelay to adapt for different use cases.
* IncreaseDissolveDelayButton opens IncreaseDissolveDelayModal.

# Tests

* Test flow for IncreaseDissolveDelayModal.
