### PR TITLE
Add CSP for the web worker

### DIFF
--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -52,6 +52,7 @@ const updateCSP = (content) => {
         content="default-src 'none';
         connect-src 'self' ${cspConnectSrc()};
         img-src 'self' https://nns.raw.ic0.app/;
+        child-src 'self';
         manifest-src 'self';
         script-src 'unsafe-eval' 'strict-dynamic' 'nonce-bundle-369ac6c9-8078-4625-82f7-f37a9ca8fb16';
         base-uri 'self';


### PR DESCRIPTION
# Motivation
Current main does not load on iOS.  The console gives the error:

<img width="1679" alt="Screenshot 2022-04-06 at 14 14 45" src="https://user-images.githubusercontent.com/5982633/161972255-dfcf4858-482e-49d3-91a2-6b88a10d8b34.png">

With this PR the page loads in Safari and there are no console errors.

Note:  There is a "worker-src" directive but it is [not supported by Safari](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src).

# Changes
- Added `child-src: 'self'` to the CSP.

# Tests
With this PR the page loads in Safari and there are no console errors.