### PR TITLE
feat: implement transaction step "enter amount" and init step "review"

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
+++ b/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
@@ -8,7 +8,7 @@
 
   let balance: ICPType;
 
-  $: ({ balance } = account ?? ({ balance: 0 } as unknown as Account));
+  $: ({ balance } = account ?? ({ balance: ICPType.fromString('0') } as unknown as Account));
 </script>
 
 <div>

--- a/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
+++ b/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import ICP from "../ic/ICP.svelte";
+  import { ICP as ICPType } from "@dfinity/nns";
+  import type { Account } from "../../types/account";
+  import { i18n } from "../../stores/i18n";
+
+  export let account: Account | undefined;
+
+  let balance: ICPType;
+
+  $: ({ balance } = account ?? ({ balance: 0 } as unknown as Account));
+</script>
+
+<div>
+  <p>{$i18n.accounts.current_balance}:</p>
+  <ICP inline={true} icp={balance} />
+</div>
+
+<style lang="scss">
+  div {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
+++ b/frontend/svelte/src/lib/components/accounts/CurrentBalance.svelte
@@ -8,7 +8,8 @@
 
   let balance: ICPType;
 
-  $: ({ balance } = account ?? ({ balance: ICPType.fromString('0') } as unknown as Account));
+  $: ({ balance } =
+    account ?? ({ balance: ICPType.fromString("0") } as unknown as Account));
 </script>
 
 <div>

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -17,7 +17,7 @@
   const { store }: TransactionContext = context;
 
   let amount: number | undefined = $store.amount
-    ? Number($store.amount)
+    ? Number($store.amount.toE8s()) / E8S_PER_ICP
     : undefined;
 
   let max: number = 0;

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -24,7 +24,7 @@
   $: max = Number($store.selectedAccount?.balance.toE8s() ?? 0) / E8S_PER_ICP;
 
   let validForm: boolean;
-  $: validForm = amount > 0 && amount < max;
+  $: validForm = amount !== undefined && amount > 0 && amount < max;
 
   const onMax = () => (amount = max);
   const onSubmit = () => {

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -24,7 +24,7 @@
   $: max = Number($store.selectedAccount?.balance.toE8s() ?? 0) / E8S_PER_ICP;
 
   let validForm: boolean;
-  $: validForm = amount !== undefined && amount > 0 && amount < max;
+  $: validForm = amount !== undefined && amount > 0 && amount <= max;
 
   const onMax = () => (amount = max);
   const onSubmit = () => {

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -1,36 +1,74 @@
 <script lang="ts">
   import { getContext } from "svelte";
-  import { formattedTransactionFeeICP } from "../../utils/icp.utils";
   import { i18n } from "../../stores/i18n";
   import type { TransactionContext } from "../../stores/transaction.store";
   import { NEW_TRANSACTION_CONTEXT_KEY } from "../../stores/transaction.store";
+  import CurrentBalance from "./CurrentBalance.svelte";
+  import AmountInput from "../ui/AmountInput.svelte";
+  import { E8S_PER_ICP } from "../../constants/icp.constants";
+  import { toastsStore } from "../../stores/toasts.store";
+  import NewTransactionInfo from "./NewTransactionInfo.svelte";
+  import { ICP } from "@dfinity/nns";
+  import type { FromICPStringError } from "@dfinity/nns";
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
   );
   const { store }: TransactionContext = context;
+
+  let amount: number | undefined = $store.amount
+    ? Number($store.amount)
+    : undefined;
+
+  let max: number = 0;
+  $: max = Number($store.selectedAccount?.balance.toE8s() ?? 0) / E8S_PER_ICP;
+
+  let validForm: boolean;
+  $: validForm = amount > 0 && amount < max;
+
+  const onMax = () => (amount = max);
+  const onSubmit = () => {
+    if (!validForm) {
+      toastsStore.error({
+        labelKey: "error.transaction_invalid_amount",
+      });
+      return;
+    }
+
+    const icp: ICP | FromICPStringError = ICP.fromString(`${amount}`);
+
+    if (!(icp instanceof ICP)) {
+      toastsStore.error({
+        labelKey: "error.amount_not_valid",
+      });
+      return;
+    }
+
+    const { store, next }: TransactionContext = context;
+
+    store.update((data) => ({
+      ...data,
+      amount: icp,
+    }));
+
+    next?.();
+  };
 </script>
 
-<div class="wizard-wrapper">
-  <p>// TODO(L2-430): amount input</p>
+<form on:submit|preventDefault={onSubmit} class="wizard-wrapper">
+  <CurrentBalance account={$store.selectedAccount} />
 
-  <h5>{$i18n.accounts.source}</h5>
-  <p>{$store.selectedAccount?.identifier ?? ""}</p>
+  <AmountInput bind:amount on:nnsMax={onMax} {max} />
 
-  <h5>{$i18n.accounts.destination}</h5>
-  <p>{$store.destinationAddress ?? ""}</p>
+  <NewTransactionInfo />
 
-  <h5>{$i18n.accounts.transaction_fee}</h5>
-  <p>{formattedTransactionFeeICP()} ICP</p>
-</div>
+  <button class="primary full-width" type="submit" disabled={!validForm}>
+    {$i18n.accounts.review_transaction}
+  </button>
+</form>
 
 <style lang="scss">
-  h5 {
-    margin: 0;
-  }
-
-  p {
-    margin: 0 0 var(--padding);
-    word-wrap: break-word;
+  button {
+    margin-top: var(--padding);
   }
 </style>

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionDestination.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionDestination.svelte
@@ -18,12 +18,12 @@
   onMount(() => (mounted = true));
 
   // TODO(L2-430): do we need the identifier or another information of the account for the next function of the wizard?
-  const chooseAccount = ({
+  const onSelectAccount = ({
     detail,
   }: CustomEvent<{ selectedAccount: Account }>) =>
     chooseDestinationAddress(detail.selectedAccount.identifier);
 
-  const chooseAddress = () => chooseDestinationAddress(address);
+  const onEnterAddress = () => chooseDestinationAddress(address);
 
   const chooseDestinationAddress = (destinationAddress: string) => {
     const { store, next }: TransactionContext = context;
@@ -35,18 +35,20 @@
 
     next?.();
   };
+
+  // TODO(L2-430): SelectAccount should be filtered with source account - i.e. source account should not be displayed and if only one account the all section should not be displayed
 </script>
 
 <div>
   <p>{$i18n.accounts.enter_address_or_select}</p>
 
-  <Address bind:address on:submit={chooseAddress} />
+  <Address bind:address on:submit={onEnterAddress} />
 
   <!-- Prevent the component to be presented with a scroll offset when navigating between wizard steps -->
   <!-- note about disableSelection: if user is entering an address with the input field, the address is not empty and therefore no account shall be selected -->
   {#if mounted}
     <SelectAccount
-      on:nnsSelectAccount={chooseAccount}
+      on:nnsSelectAccount={onSelectAccount}
       displayTitle={true}
       disableSelection={!emptyAddress(address)}
     />

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import { NEW_TRANSACTION_CONTEXT_KEY } from "../../stores/transaction.store";
+  import type { TransactionContext } from "../../stores/transaction.store";
+  import { getContext } from "svelte";
+  import { formattedTransactionFeeICP } from "../../utils/icp.utils";
+
+  const context: TransactionContext = getContext<TransactionContext>(
+    NEW_TRANSACTION_CONTEXT_KEY
+  );
+  const { store }: TransactionContext = context;
+</script>
+
+<h5>{$i18n.accounts.source}</h5>
+<p>{$store.selectedAccount?.identifier ?? ""}</p>
+
+<h5>{$i18n.accounts.destination}</h5>
+<p>{$store.destinationAddress ?? ""}</p>
+
+<h5>{$i18n.accounts.transaction_fee}</h5>
+
+<p>{formattedTransactionFeeICP()} ICP</p>
+
+<style lang="scss">
+  h5 {
+    margin: 0;
+  }
+
+  p {
+    margin: 0 0 calc(var(--padding) / 2);
+    word-wrap: break-word;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import NewTransactionInfo from "./NewTransactionInfo.svelte";
+  import ICP from "../ic/ICP.svelte";
+  import { ICP as ICPType } from "@dfinity/nns";
+  import { NEW_TRANSACTION_CONTEXT_KEY } from "../../stores/transaction.store";
+  import type { TransactionContext } from "../../stores/transaction.store";
+  import { getContext } from "svelte";
+
+  const context: TransactionContext = getContext<TransactionContext>(
+    NEW_TRANSACTION_CONTEXT_KEY
+  );
+  const { store }: TransactionContext = context;
+
+  let amount: ICPType = $store.amount ?? ICPType.fromE8s(BigInt(0));
+</script>
+
+<div class="wizard-wrapper">
+  <div class="amount">
+    <ICP inline={true} icp={amount} />
+  </div>
+
+  <NewTransactionInfo />
+
+  <p>// TODO(L2-430): effectively create transaction</p>
+</div>
+
+<style lang="scss">
+  .amount {
+    display: inline-flex;
+    justify-content: center;
+    padding: var(--padding) 0 calc(2 * var(--padding));
+  }
+</style>

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionSource.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionSource.svelte
@@ -9,7 +9,7 @@
     NEW_TRANSACTION_CONTEXT_KEY
   );
 
-  const chooseAccount = ({
+  const onSelectAccount = ({
     detail,
   }: CustomEvent<{ selectedAccount: Account }>) => {
     const { store, next }: TransactionContext = context;
@@ -23,4 +23,4 @@
   };
 </script>
 
-<SelectAccount on:nnsSelectAccount={chooseAccount} />
+<SelectAccount on:nnsSelectAccount={onSelectAccount} />

--- a/frontend/svelte/src/lib/components/ic/ICP.svelte
+++ b/frontend/svelte/src/lib/components/ic/ICP.svelte
@@ -5,10 +5,11 @@
 
   export let icp: ICP;
   export let label: string = $i18n.core.icp;
+  export let inline: boolean = false;
 </script>
 
 {#if icp}
-  <div>
+  <div class:inline>
     <span data-tid="icp-value">{`${formatICP(icp.toE8s())}`}</span>
     <span>{label}</span>
   </div>
@@ -29,12 +30,14 @@
       color: var(--gray-50);
     }
 
-    @include media.min-width(medium) {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-end;
-      justify-content: flex-end;
-      grid-gap: 0;
+    &:not(.inline) {
+      @include media.min-width(medium) {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        justify-content: flex-end;
+        grid-gap: 0;
+      }
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import Input from "../ui/Input.svelte";
   import Spinner from "../ui/Spinner.svelte";
   import {
     E8S_PER_ICP,
@@ -12,6 +11,7 @@
   import type { Account } from "../../types/account";
   import { startBusy, stopBusy } from "../../stores/busy.store";
   import { formatICP, formattedTransactionFeeICP } from "../../utils/icp.utils";
+  import AmountInput from "../ui/AmountInput.svelte";
 
   export let account: Account;
   let amount: number;
@@ -37,10 +37,11 @@
     stopBusy("stake-neuron");
   };
 
-  const stakeMaximum = () => {
-    amount =
-      (Number(account.balance.toE8s()) - TRANSACTION_FEE_E8S) / E8S_PER_ICP;
-  };
+  let max: number = 0;
+  $: max =
+    (Number(account.balance.toE8s()) - TRANSACTION_FEE_E8S) / E8S_PER_ICP;
+
+  const stakeMaximum = () => (amount = max);
 </script>
 
 <div class="wizard-wrapper">
@@ -61,20 +62,8 @@
       {`${formatICP(account.balance.toE8s())}`}
     </h4>
     <form on:submit|preventDefault={createNeuron}>
-      <Input
-        placeholderLabelKey="neurons.amount"
-        name="amount"
-        bind:value={amount}
-        theme="dark"
-        inputType="number"
-      >
-        <button
-          type="button"
-          on:click|preventDefault={stakeMaximum}
-          class="secondary small"
-          slot="button">{$i18n.neurons.max}</button
-        >
-      </Input>
+      <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} />
+
       <small>{$i18n.neurons.may_take_while}</small>
       <!-- TODO: L2-252 -->
       <button

--- a/frontend/svelte/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/svelte/src/lib/components/ui/AmountInput.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Input from "./Input.svelte";
+  import { i18n } from "../../stores/i18n";
+  import { createEventDispatcher } from "svelte";
+
+  export let amount: number | undefined = undefined;
+  export let max: number | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
+  const setMax = () => dispatch("nnsMax");
+</script>
+
+<Input
+  placeholderLabelKey="core.amount"
+  name="amount"
+  bind:value={amount}
+  {max}
+  theme="dark"
+  inputType="number"
+>
+  <button
+    type="button"
+    on:click|preventDefault={setMax}
+    class="secondary small"
+    slot="button">{$i18n.core.max}</button
+  >
+</Input>

--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -7,6 +7,7 @@
   export let step: number | "any" | undefined = undefined;
   export let disabled: boolean = false;
   export let minLength: number | undefined = undefined;
+  export let max: number | undefined = undefined;
 
   export let value: string | number | undefined = undefined;
 
@@ -35,6 +36,7 @@
     {value}
     {minLength}
     {placeholder}
+    {max}
     on:input={handleInput}
   />
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -11,7 +11,9 @@
     "yes": "Yes",
     "no": "No",
     "unspecified": "Unspecified",
-    "continue": "Continue"
+    "continue": "Continue",
+    "amount": "Amount",
+    "max": "Max"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -43,7 +45,8 @@
     "unknown": "Sorry, there was an unexpected error. Please try again later.",
     "amount_not_valid": "Sorry, the amount is not valid",
     "amount_not_enough": "Sorry, the amount is not large enough. You need a minimum of 1 ICP to stake a neuron",
-    "stake_neuron": "Sorry, there was an unexpected error staking the neuron. Please try again later."
+    "stake_neuron": "Sorry, there was an unexpected error staking the neuron. Please try again later.",
+    "transaction_invalid_amount": "The amount is less than zero or exceeds the amount of available funds for the selected account."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."
@@ -86,7 +89,9 @@
     "enter_icp_amount": "Enter ICP amount",
     "source": "Source",
     "destination": "Destination",
-    "transaction_fee": "Transaction Fee (billed to source)"
+    "transaction_fee": "Transaction Fee (billed to source)",
+    "review_transaction": "Review transaction",
+    "current_balance": "Current balance"
   },
   "neurons": {
     "title": "Neurons",
@@ -101,8 +106,6 @@
     "transaction_fee": "Transaction Fee",
     "current_balance": "Current Balance",
     "may_take_while": "(This may take up to 1 minute)",
-    "amount": "Amount",
-    "max": "Max",
     "create": "Create",
     "status_locked": "Locked",
     "status_unspecified": "",

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -12,6 +12,7 @@
   } from "../../stores/transaction.store";
   import NewTransactionAmount from "../../components/accounts/NewTransactionAmount.svelte";
   import { NEW_TRANSACTION_CONTEXT_KEY } from "../../stores/transaction.store";
+  import NewTransactionReview from "../../components/accounts/NewTransactionReview.svelte";
 
   export let canSelectAccount: boolean;
 
@@ -35,11 +36,17 @@
       showBackButton: true,
       title: $i18n.accounts.enter_icp_amount,
     },
+    {
+      name: "Review",
+      showBackButton: true,
+      title: $i18n.accounts.review_transaction,
+    },
   ];
 
   const newTransactionStore = writable<TransactionStore>({
     selectedAccount: undefined,
     destinationAddress: undefined,
+    amount: undefined,
   });
 
   setContext<TransactionContext>(NEW_TRANSACTION_CONTEXT_KEY, {
@@ -65,6 +72,9 @@
     {/if}
     {#if currentStep?.name === "SelectAmount"}
       <NewTransactionAmount />
+    {/if}
+    {#if currentStep?.name === "Review"}
+      <NewTransactionReview />
     {/if}
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/stores/transaction.store.ts
+++ b/frontend/svelte/src/lib/stores/transaction.store.ts
@@ -1,3 +1,4 @@
+import type { ICP } from "@dfinity/nns";
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
 import type { Account } from "../types/account";
@@ -5,6 +6,7 @@ import type { Account } from "../types/account";
 export interface TransactionStore {
   selectedAccount: Account | undefined;
   destinationAddress: string | undefined;
+  amount: ICP | undefined;
 }
 
 export interface TransactionContext {
@@ -24,4 +26,5 @@ export const NEW_TRANSACTION_CONTEXT_KEY = Symbol("new-transaction");
 export const transactionStore = writable<TransactionStore>({
   selectedAccount: undefined,
   destinationAddress: undefined,
+  amount: undefined,
 });

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -15,6 +15,8 @@ interface I18nCore {
   no: string;
   unspecified: string;
   continue: string;
+  amount: string;
+  max: string;
 }
 
 interface I18nError {
@@ -48,6 +50,7 @@ interface I18nError {
   amount_not_valid: string;
   amount_not_enough: string;
   stake_neuron: string;
+  transaction_invalid_amount: string;
 }
 
 interface I18nWarning {
@@ -96,6 +99,8 @@ interface I18nAccounts {
   source: string;
   destination: string;
   transaction_fee: string;
+  review_transaction: string;
+  current_balance: string;
 }
 
 interface I18nNeurons {
@@ -111,8 +116,6 @@ interface I18nNeurons {
   transaction_fee: string;
   current_balance: string;
   may_take_while: string;
-  amount: string;
-  max: string;
   create: string;
   status_locked: string;
   status_unspecified: string;

--- a/frontend/svelte/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import CurrentBalance from "../../../../lib/components/accounts/CurrentBalance.svelte";
+import { formatICP } from "../../../../lib/utils/icp.utils";
+import { mockMainAccount } from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+
+describe("CurrentBalance", () => {
+  const props = { account: mockMainAccount };
+
+  it("should render a title", () => {
+    const { getByText } = render(CurrentBalance, { props });
+
+    expect(
+      getByText(en.accounts.current_balance, { exact: false })
+    ).toBeTruthy();
+  });
+
+  it("should render a balance in ICP", () => {
+    const { getByText, container } = render(CurrentBalance, { props });
+
+    const icp: HTMLSpanElement | null = container.querySelector(
+      '[data-tid="icp-value"]'
+    );
+
+    expect(icp?.innerHTML).toEqual(
+      `${formatICP(mockMainAccount.balance.toE8s())}`
+    );
+    expect(getByText(`ICP`)).toBeTruthy();
+  });
+
+  it("should render a zero balance as fallback", () => {
+    const { container } = render(CurrentBalance, {
+      props: { account: undefined },
+    });
+
+    const icp: HTMLSpanElement | null = container.querySelector(
+      '[data-tid="icp-value"]'
+    );
+
+    expect(icp?.innerHTML).toEqual("0.00000000");
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -20,11 +20,9 @@ describe("CurrentBalance", () => {
   });
 
   it("should render a balance in ICP", () => {
-    const { getByText, container } = render(CurrentBalance, { props });
+    const { getByText, queryByTestId } = render(CurrentBalance, { props });
 
-    const icp: HTMLSpanElement | null = container.querySelector(
-      '[data-tid="icp-value"]'
-    );
+    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
 
     expect(icp?.innerHTML).toEqual(
       `${formatICP(mockMainAccount.balance.toE8s())}`
@@ -33,13 +31,11 @@ describe("CurrentBalance", () => {
   });
 
   it("should render a zero balance as fallback", () => {
-    const { container } = render(CurrentBalance, {
+    const { queryByTestId } = render(CurrentBalance, {
       props: { account: undefined },
     });
 
-    const icp: HTMLSpanElement | null = container.querySelector(
-      '[data-tid="icp-value"]'
-    );
+    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
 
     expect(icp?.innerHTML).toEqual("0.00000000");
   });

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -43,11 +43,9 @@ describe("NewTransactionAmount", () => {
   });
 
   it("should render current balance", () => {
-    const { container } = render(NewTransactionTest, { props });
+    const { queryByTestId } = render(NewTransactionTest, { props });
 
-    const icp: HTMLSpanElement | null = container.querySelector(
-      '[data-tid="icp-value"]'
-    );
+    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
 
     expect(icp?.innerHTML).toEqual(
       `${formatICP(mockMainAccount.balance.toE8s())}`

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -15,6 +15,7 @@ describe("NewTransactionAmount", () => {
     transactionStore.set({
       selectedAccount: mockMainAccount,
       destinationAddress: mockSubAccount.identifier,
+      amount: undefined,
     });
 
     const { getByText } = render(NewTransactionAmountTest);

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -2,36 +2,140 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { ICP } from "@dfinity/nns";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import NewTransactionAmount from "../../../../lib/components/accounts/NewTransactionAmount.svelte";
+import { E8S_PER_ICP } from "../../../../lib/constants/icp.constants";
 import { transactionStore } from "../../../../lib/stores/transaction.store";
+import { formatICP } from "../../../../lib/utils/icp.utils";
 import {
   mockMainAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
-import NewTransactionAmountTest from "./NewTransactionAmountTest.svelte";
+import en from "../../../mocks/i18n.mock";
+import NewTransactionTest from "./NewTransactionTest.svelte";
 
 describe("NewTransactionAmount", () => {
-  it("should render transaction store information", () => {
+  const props = { testComponent: NewTransactionAmount };
+
+  beforeAll(() => {
     transactionStore.set({
       selectedAccount: mockMainAccount,
       destinationAddress: mockSubAccount.identifier,
-      amount: undefined,
+      amount: ICP.fromString("10.25") as ICP,
     });
-
-    const { getByText } = render(NewTransactionAmountTest);
-
-    expect(
-      getByText(mockMainAccount.identifier, { exact: false })
-    ).toBeInTheDocument();
-
-    expect(
-      getByText(mockSubAccount.identifier, { exact: false })
-    ).toBeInTheDocument();
   });
 
-  it("should render transaction fee information", () => {
-    const { getByText } = render(NewTransactionAmountTest);
+  afterAll(() => {
+    transactionStore.set({
+      selectedAccount: undefined,
+      destinationAddress: undefined,
+      amount: undefined,
+    });
+  });
 
-    expect(getByText("0.00010000 ICP", { exact: false })).toBeInTheDocument();
+  it("should render a source transaction", () => {
+    const { getByText } = render(NewTransactionTest, { props });
+
+    // More tests about details are provided in NewTransactionInfo.spec.ts
+    expect(getByText(en.accounts.source)).toBeTruthy();
+  });
+
+  it("should render current balance", () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const icp: HTMLSpanElement | null = container.querySelector(
+      '[data-tid="icp-value"]'
+    );
+
+    expect(icp?.innerHTML).toEqual(
+      `${formatICP(mockMainAccount.balance.toE8s())}`
+    );
+  });
+
+  it("should render an input for the amount", () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+  });
+
+  it("should render an input for the amount that has a max value equals to the source account available funds", () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input?.getAttribute("max")).toEqual(
+      `${Number(mockMainAccount.balance.toE8s()) / E8S_PER_ICP}`
+    );
+  });
+
+  it("form should be disabled per default", () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      'button[type="submit"]'
+    );
+    expect(button?.getAttribute("disabled")).not.toBeNull();
+  });
+
+  it("form should become enabled if correct amount is entered", async () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const input: HTMLInputElement = container.querySelector(
+      "input"
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "1" } });
+
+    await waitFor(() => {
+      const button: HTMLButtonElement | null = container.querySelector(
+        'button[type="submit"]'
+      );
+      expect(button?.getAttribute("disabled")).toBeNull();
+    });
+  });
+
+  it("form should remain disabled if amount surpasses max funds", async () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const input: HTMLInputElement = container.querySelector(
+      "input"
+    ) as HTMLInputElement;
+    await fireEvent.input(input, {
+      target: {
+        value: `${(Number(mockMainAccount.balance.toE8s()) + 1) / E8S_PER_ICP}`,
+      },
+    });
+
+    await waitFor(() => {
+      const button: HTMLButtonElement | null = container.querySelector(
+        'button[type="submit"]'
+      );
+      expect(button?.getAttribute("disabled")).not.toBeNull();
+    });
+  });
+
+  it("form submit should update store", async () => {
+    const testValue = "1.123";
+
+    const { container } = render(NewTransactionTest, { props });
+
+    const input: HTMLInputElement = container.querySelector(
+      "input"
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: testValue } });
+
+    const button: HTMLButtonElement = container.querySelector(
+      'button[type="submit"]'
+    ) as HTMLButtonElement;
+
+    await waitFor(() => {
+      expect(button?.getAttribute("disabled")).toBeNull();
+    });
+
+    fireEvent.click(button);
+
+    const { amount } = get(transactionStore);
+    expect(amount).toEqual(ICP.fromString(testValue));
   });
 });

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -23,7 +23,7 @@ describe("NewTransactionAmount", () => {
     transactionStore.set({
       selectedAccount: mockMainAccount,
       destinationAddress: mockSubAccount.identifier,
-      amount: ICP.fromString("10.25") as ICP,
+      amount: undefined,
     });
   });
 

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionInfo.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionInfo.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ICP } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NewTransactionInfo from "../../../../lib/components/accounts/NewTransactionInfo.svelte";
+import { transactionStore } from "../../../../lib/stores/transaction.store";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+import NewTransactionTest from "./NewTransactionTest.svelte";
+
+describe("NewTransactionInfo", () => {
+  const props = { testComponent: NewTransactionInfo };
+
+  beforeAll(() => {
+    transactionStore.set({
+      selectedAccount: mockMainAccount,
+      destinationAddress: mockSubAccount.identifier,
+      amount: ICP.fromString("10.25") as ICP,
+    });
+  });
+
+  afterAll(() => {
+    transactionStore.set({
+      selectedAccount: undefined,
+      destinationAddress: undefined,
+      amount: undefined,
+    });
+  });
+
+  it("should render a source transaction", () => {
+    const { getByText } = render(NewTransactionTest, { props });
+
+    expect(getByText(en.accounts.source)).toBeTruthy();
+    expect(
+      getByText(mockMainAccount.identifier, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render a destination for the transaction", () => {
+    const { getByText } = render(NewTransactionTest, { props });
+
+    expect(getByText(en.accounts.destination)).toBeTruthy();
+    expect(
+      getByText(mockSubAccount.identifier, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render transaction fee information", () => {
+    const { getByText } = render(NewTransactionTest, { props });
+
+    expect(getByText(en.accounts.transaction_fee)).toBeTruthy();
+    expect(getByText("0.00010000 ICP", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ICP } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NewTransactionReview from "../../../../lib/components/accounts/NewTransactionReview.svelte";
+import { transactionStore } from "../../../../lib/stores/transaction.store";
+import { formatICP } from "../../../../lib/utils/icp.utils";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+import NewTransactionTest from "./NewTransactionTest.svelte";
+
+describe("NewTransactionReview", () => {
+  const props = { testComponent: NewTransactionReview };
+
+  const amount = ICP.fromString("10.666") as ICP;
+
+  beforeAll(() => {
+    transactionStore.set({
+      selectedAccount: mockMainAccount,
+      destinationAddress: mockSubAccount.identifier,
+      amount,
+    });
+  });
+
+  afterAll(() => {
+    transactionStore.set({
+      selectedAccount: undefined,
+      destinationAddress: undefined,
+      amount: undefined,
+    });
+  });
+
+  it("should render a source transaction", () => {
+    const { getByText } = render(NewTransactionTest, { props });
+
+    // More tests about details are provided in NewTransactionInfo.spec.ts
+    expect(getByText(en.accounts.source)).toBeTruthy();
+  });
+
+  it("should render the amount the user has entered", () => {
+    const { container } = render(NewTransactionTest, { props });
+
+    const icp: HTMLSpanElement | null = container.querySelector(
+      '[data-tid="icp-value"]'
+    );
+
+    expect(icp?.innerHTML).toEqual(`${formatICP(amount.toE8s())}`);
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
@@ -43,12 +43,9 @@ describe("NewTransactionReview", () => {
   });
 
   it("should render the amount the user has entered", () => {
-    const { container } = render(NewTransactionTest, { props });
+    const { queryByTestId } = render(NewTransactionTest, { props });
 
-    const icp: HTMLSpanElement | null = container.querySelector(
-      '[data-tid="icp-value"]'
-    );
-
+    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
     expect(icp?.innerHTML).toEqual(`${formatICP(amount.toE8s())}`);
   });
 });

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionTest.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { setContext } from "svelte";
+  import { setContext, SvelteComponent } from "svelte";
   import {
     NEW_TRANSACTION_CONTEXT_KEY,
     TransactionContext,
     transactionStore,
   } from "../../../../lib/stores/transaction.store";
-  import NewTransactionAmount from "../../../../lib/components/accounts/NewTransactionAmount.svelte";
+
+  export let testComponent: typeof SvelteComponent;
 
   setContext<TransactionContext>(NEW_TRANSACTION_CONTEXT_KEY, {
     store: transactionStore,
@@ -15,4 +16,4 @@
   });
 </script>
 
-<NewTransactionAmount />
+<svelte:component this={testComponent} />

--- a/frontend/svelte/src/tests/lib/components/ui/AmountInput.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/AmountInput.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import AmountInput from "../../../../lib/components/ui/AmountInput.svelte";
+import en from "../../../mocks/i18n.mock";
+
+describe("AmountInput", () => {
+  const props = { amount: 10.25, max: 11 };
+
+  it("should render an input", () => {
+    const { container } = render(AmountInput, { props });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input?.getAttribute("max")).toEqual("11");
+    expect(input?.value).toBe("10.25");
+  });
+
+  it("should render a max button", () => {
+    const { container } = render(AmountInput, { props });
+
+    const button: HTMLButtonElement | null = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.innerHTML).toEqual(en.core.max);
+  });
+
+  it("should trigger max value", (done) => {
+    const { container, component } = render(AmountInput, { props });
+    component.$on("nnsMax", () => done());
+
+    const button: HTMLButtonElement = container.querySelector(
+      "button"
+    ) as HTMLButtonElement;
+    fireEvent.click(button);
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
@@ -130,6 +130,14 @@ describe("Input", () => {
     testGetAttribute({ container, attribute: "minLength", expected: "10" });
   });
 
+  it("should render an input with a max attribute", () => {
+    const { container } = render(Input, {
+      props: { ...props, max: 10 },
+    });
+
+    testGetAttribute({ container, attribute: "max", expected: "10" });
+  });
+
   it("should render an input with a particular step attribute", () => {
     const { container } = render(Input, {
       props: {

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -53,6 +53,37 @@ describe("NewTransactionModal", () => {
     );
   };
 
+  const goToStep4 = async ({
+    container,
+    getByText,
+    enterAmount,
+  }: {
+    container: HTMLElement;
+    getByText;
+    enterAmount: boolean;
+  }) => {
+    if (enterAmount) {
+      const input: HTMLInputElement = container.querySelector(
+        "input"
+      ) as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: "1" } });
+    }
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      'button[type="submit"]'
+    );
+
+    await waitFor(() => expect(button?.getAttribute("disabled")).toBeNull());
+
+    fireEvent.click(button as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(
+        getByText(en.accounts.review_transaction, { exact: false })
+      ).toBeInTheDocument()
+    );
+  };
+
   const goBack = async ({ container, getByText, title }) => {
     const back = container.querySelector("button.back") as HTMLButtonElement;
     fireEvent.click(back);
@@ -92,5 +123,31 @@ describe("NewTransactionModal", () => {
       getByText,
       title: en.accounts.select_destination,
     });
+
+    // Go to step 3.
+    await goToStep3({ container, getByText });
+
+    // Go to step 4.
+    await goToStep4({ container, getByText, enterAmount: true });
+
+    // Go back to step 3.
+    await goBack({
+      container,
+      getByText,
+      title: en.accounts.enter_icp_amount,
+    });
+
+    // Go back to step 2.
+    await goBack({
+      container,
+      getByText,
+      title: en.accounts.select_destination,
+    });
+
+    // Go to step 3.
+    await goToStep3({ container, getByText });
+
+    // Go to step 4 without entering the amount again as it should be kept in store - input should be set with previous value
+    await goToStep4({ container, getByText, enterAmount: false });
   });
 });

--- a/frontend/svelte/src/tests/lib/stores/transaction.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/transaction.store.spec.ts
@@ -9,6 +9,7 @@ describe("transaction-store", () => {
   const mock = {
     selectedAccount: mockMainAccount,
     destinationAddress: mockSubAccount.identifier,
+    amount: undefined,
   };
 
   it("should set transaction", () => {
@@ -24,6 +25,7 @@ describe("transaction-store", () => {
     const clearMock = {
       selectedAccount: undefined,
       destinationAddress: undefined,
+      amount: undefined,
     };
 
     transactionStore.set(clearMock);


### PR DESCRIPTION
# Motivation

Follow-up of the "New transaction" wizard that implements the step to enter the amount of the transaction and initialize the review step.

# Changes

- implement "New transaction - Enter amount" step
- init "New transaction - Review" step
- new component `CurrentBalance`
- new component `NewTransactionInfo` to display information (source, dest and amount) in multiple steps
- new prop `inline` to display ICP on one line ("value ICP" or "value \n ICP")
- add option `max` to `Input` component
- use `max` option in `StakeNeuron`
- refactor `StakeNeuron` input to enter "amount" to a new component `AmountInput`
- add new step to new transaction modal wizard
- add "amount" field to contextual transaction store

# Screenshots
<img width="1246" alt="Capture d’écran 2022-04-06 à 14 56 58" src="https://user-images.githubusercontent.com/16886711/161981977-297148bd-5aa7-4748-b232-2af562d1984e.png">
<img width="1246" alt="Capture d’écran 2022-04-06 à 14 57 01" src="https://user-images.githubusercontent.com/16886711/161981989-ffd08045-6cd2-40eb-accb-e332d12ec7e2.png">
<img width="1246" alt="Capture d’écran 2022-04-06 à 14 57 07" src="https://user-images.githubusercontent.com/16886711/161981993-81a6a184-1d26-47dd-aa4d-26e942c8a28f.png">


