### PR TITLE
Markdown img to link

### DIFF
--- a/frontend/svelte/src/lib/utils/markdown.utils.ts
+++ b/frontend/svelte/src/lib/utils/markdown.utils.ts
@@ -11,13 +11,42 @@ export const targetBlankLinkRenderer = (
     href === null || href === undefined
       ? ""
       : ` target="_blank" rel="noopener noreferrer" href="${href}"`
-  }${
-    title === null || title === undefined ? "" : ` title="${title}"`
-  }>${text}</a>`;
+  }${title === null || title === undefined ? "" : ` title="${title}"`}>${
+    text.length === 0 ? href ?? title : text
+  }</a>`;
+
+/**
+ * Based on https://github.com/markedjs/marked/blob/master/src/Renderer.js#L186
+ * @returns <a> tag to image
+ */
+export const imageToLinkRenderer = (
+  href: string | null | undefined,
+  title: string | null | undefined,
+  alt: string
+): string => {
+  if (href === undefined || href === null || href?.length === 0) {
+    return alt;
+  }
+  const fileExtention = href.includes(".")
+    ? (href.split(".").pop() as string)
+    : "";
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type
+  const typeProp =
+    fileExtention === "" ? undefined : ` type="image/${fileExtention}"`;
+  const titleDefined = title !== undefined && title !== null;
+  const titleProp = titleDefined ? ` title="${title}"` : undefined;
+  const text = alt === "" ? (titleDefined ? title : href) : alt;
+
+  return `<a href="${href}" target="_blank" rel="noopener noreferrer"${
+    typeProp === undefined ? "" : typeProp
+  }${titleProp === undefined ? "" : titleProp}>${text}</a>`;
+};
 
 export const renderer = (marked: Marked): Renderer => {
   const renderer = new marked.Renderer();
   // custom link renderer
   renderer.link = targetBlankLinkRenderer;
+  renderer.image = imageToLinkRenderer;
+
   return renderer;
 };

--- a/frontend/svelte/src/lib/utils/markdown.utils.ts
+++ b/frontend/svelte/src/lib/utils/markdown.utils.ts
@@ -20,26 +20,26 @@ export const targetBlankLinkRenderer = (
  * @returns <a> tag to image
  */
 export const imageToLinkRenderer = (
-  href: string | null | undefined,
+  src: string | null | undefined,
   title: string | null | undefined,
   alt: string
 ): string => {
-  if (href === undefined || href === null || href?.length === 0) {
+  if (src === undefined || src === null || src?.length === 0) {
     return alt;
   }
-  const fileExtention = href.includes(".")
-    ? (href.split(".").pop() as string)
+  const fileExtention = src.includes(".")
+    ? (src.split(".").pop() as string)
     : "";
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type
   const typeProp =
     fileExtention === "" ? undefined : ` type="image/${fileExtention}"`;
   const titleDefined = title !== undefined && title !== null;
   const titleProp = titleDefined ? ` title="${title}"` : undefined;
-  const text = alt === "" ? (titleDefined ? title : href) : alt;
+  const text = alt === "" ? (titleDefined ? title : src) : alt;
 
-  return `<a href="${href}" target="_blank" rel="noopener noreferrer"${
-    typeProp === undefined ? "" : typeProp
-  }${titleProp === undefined ? "" : titleProp}>${text}</a>`;
+  return `<a href="${src}" target="_blank" rel="noopener noreferrer"${
+    typeProp ?? ""
+  }${titleProp ?? ""}>${text}</a>`;
 };
 
 export const renderer = (marked: Marked): Renderer => {

--- a/frontend/svelte/src/tests/lib/components/ui/Markdown.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Markdown.spec.ts
@@ -5,7 +5,10 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import Markdown from "../../../../lib/components/ui/Markdown.svelte";
-import { targetBlankLinkRenderer } from "../../../../lib/utils/markdown.utils";
+import {
+  imageToLinkRenderer,
+  targetBlankLinkRenderer,
+} from "../../../../lib/utils/markdown.utils";
 
 const HTML_TEXT = "<p>demo<p>";
 
@@ -61,13 +64,23 @@ describe("Markdown", () => {
     expect(getByText(HTML_TEXT)).toBeInTheDocument();
   });
 
+  it("should be called with custom renderers", async () => {
+    render(Markdown, {
+      props: { text: "" },
+    });
+    await tick();
+    expect(globalThis.marked.parse).toBeCalledWith("", {
+      renderer: { link: targetBlankLinkRenderer, image: imageToLinkRenderer },
+    });
+  });
+
   it('should "sanitize" the text', async () => {
     render(Markdown, {
       props: { text: "<script>alert('hack')</script>" },
     });
     await tick();
     expect(globalThis.marked.parse).toBeCalledWith("alert('hack')", {
-      renderer: { link: targetBlankLinkRenderer },
+      renderer: { link: targetBlankLinkRenderer, image: imageToLinkRenderer },
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/markdown.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/markdown.utils.spec.ts
@@ -1,4 +1,7 @@
-import { targetBlankLinkRenderer } from "../../../lib/utils/markdown.utils";
+import {
+  imageToLinkRenderer,
+  targetBlankLinkRenderer,
+} from "../../../lib/utils/markdown.utils";
 
 describe("markdown.utils", () => {
   describe("targetBlankLinkRenderer", () => {
@@ -24,6 +27,67 @@ describe("markdown.utils", () => {
       expect(targetBlankLinkRenderer(undefined, "title", "text")).toEqual(
         `<a title="title">text</a>`
       );
+    });
+
+    it("should render href of title if no text", () => {
+      expect(targetBlankLinkRenderer("/", "title", "")).toEqual(
+        `<a target="_blank" rel="noopener noreferrer" href="/" title="title">/</a>`
+      );
+      expect(targetBlankLinkRenderer(null, "title", "")).toEqual(
+        `<a title="title">title</a>`
+      );
+    });
+  });
+
+  describe("imageToLinkRenderer", () => {
+    it("should render link instead of image", () => {
+      expect(imageToLinkRenderer("image.png", "title", "alt")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png" title="title">alt</a>`
+      );
+    });
+
+    it("should render link without alt", () => {
+      expect(imageToLinkRenderer("image.png", "title", "")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png" title="title">title</a>`
+      );
+    });
+
+    it("should render link without title", () => {
+      expect(imageToLinkRenderer("image.png", undefined, "alt")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png">alt</a>`
+      );
+      expect(imageToLinkRenderer("image.png", null, "alt")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png">alt</a>`
+      );
+    });
+
+    it("should render link without alt and title", () => {
+      expect(imageToLinkRenderer("image.png", undefined, "")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png">image.png</a>`
+      );
+      expect(imageToLinkRenderer("image.png", null, "")).toEqual(
+        `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png">image.png</a>`
+      );
+    });
+
+    it("should not render mime type withoug file extention", () => {
+      expect(imageToLinkRenderer("/image", undefined, "")).toEqual(
+        `<a href="/image" target="_blank" rel="noopener noreferrer">/image</a>`
+      );
+    });
+
+    it("should render empty string w/o href", () => {
+      expect(imageToLinkRenderer("", undefined, "")).toEqual(``);
+      expect(imageToLinkRenderer(null, null, "")).toEqual(``);
+      expect(imageToLinkRenderer("", "title", "")).toEqual(``);
+      expect(imageToLinkRenderer(undefined, "title", "")).toEqual(``);
+    });
+
+    it("should render alt w/o href", () => {
+      expect(imageToLinkRenderer("", undefined, "alt")).toEqual(`alt`);
+      expect(imageToLinkRenderer(undefined, null, "alt")).toEqual(`alt`);
+      expect(imageToLinkRenderer(null, null, "alt")).toEqual(`alt`);
+      expect(imageToLinkRenderer("", "", "alt")).toEqual(`alt`);
     });
   });
 });


### PR DESCRIPTION
# Motivation

To have the same behavior as in the dashboard-app all the summary images should be rendered as images.

https://dfinity.slack.com/archives/C01EWN833KN/p1649311351785469?thread_ts=1649163857.576849&cid=C01EWN833KN


# Changes

- added imageToLinkRenderer

# Tests

- tests for imageToLinkRenderer

# Screen

<img width="1367" alt="Screenshot 2022-04-07 at 12 39 33" src="https://user-images.githubusercontent.com/98811342/162181205-9b2c2938-3732-4556-8720-0f797c4fc56f.png">
