### PR TITLE
Update dfx to 0.9.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
-      DFX_VERSION: 0.8.3
+      DFX_VERSION: 0.9.2
       RUSTC_VERSION: 1.58.1
       FLUTTER_VERSION: 2.2.3
       IC_CDK_OPTIMIZER_VERSION: 0.3.1
@@ -92,13 +92,13 @@ jobs:
       - name: Start replica
         run: |
           dfx start --background
-          dfx canister --no-wallet create --all
+          dfx canister create --all
 
       # IDENTITY_SERVICE_URL needs to match `e2e-tests/test.js`
       # REDIRECT_TO_LEGACY=svelte builds and deploys only Svelte
       - name: Deploy
         run: |
-          REDIRECT_TO_LEGACY=svelte DEPLOY_ENV=local IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
+          REDIRECT_TO_LEGACY=svelte DEPLOY_ENV=local IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --network local --argument '(null)'
 
       - name: Build proxy
         working-directory: proxy

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To deploy the NNS Dapp canister to the testnet, run the following:
 
 You can now access the frontend using:
 
-    open "https://$(dfx canister --no-wallet --network testnet id nns-dapp).nnsdapp.dfinity.network"
+    open "https://$(dfx canister --network testnet id nns-dapp).nnsdapp.dfinity.network"
 
 To work on the UI locally, either use your IDE, or run the following:
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,5 +8,5 @@ NETWORK=$1
 #        to deploy these other canisters as well, but you probbaly don't.
 CANISTER_NAME=nns-dapp
 echo "Deploying $CANISTER_NAME to $NETWORK..."
-DEPLOY_ENV=$NETWORK dfx deploy --no-wallet --network "$NETWORK" "$CANISTER_NAME"
+DEPLOY_ENV=$NETWORK dfx deploy --network "$NETWORK" "$CANISTER_NAME"
 echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.8.4",
+  "dfx": "0.9.2",
   "canisters": {
     "nns-dapp": {
       "type": "custom",

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -22,7 +22,7 @@ dfx start
 
 # in another shell, deploy the canister
 # in the repo root
-DEPLOY_ENV=nobuild dfx deploy --no-wallet --network local
+DEPLOY_ENV=nobuild dfx deploy --network local
 ```
 
 Install all the dependencies for the test suite, and run the tests:

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -47,11 +47,11 @@ wait_for_url() {
 wait_for_url "$NETWORK_URL"
 
 : "Creating and deploying canisters..."
-dfx canister --no-wallet create --all || echo Canisters may have been created already. Proceeding...
-REDIRECT_TO_LEGACY=svelte DEPLOY_ENV="$DEPLOY_ENV" IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
+dfx canister create --all || echo Canisters may have been created already. Proceeding...
+REDIRECT_TO_LEGACY=svelte DEPLOY_ENV="$DEPLOY_ENV" IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --network local --argument '(null)'
 
 : "Waiting for the canister to return with HTTP code 200..."
-NNS_DAPP_CANISTER_ID="$(dfx canister --no-wallet --network local id nns-dapp)"
+NNS_DAPP_CANISTER_ID="$(dfx canister --network local id nns-dapp)"
 NNS_DAPP_CANISTER_URL="${NNS_DAPP_CANISTER_ID}.${NETWORK_URL}"
 wait_for_url "$NNS_DAPP_CANISTER_URL" 10 --fail
 

--- a/scripts/deploy-ci-to-testnet
+++ b/scripts/deploy-ci-to-testnet
@@ -33,6 +33,6 @@ unzip "$DOWNLOAD_FILENAME"
 popd
 mv "$UNZIP_TMPDIR/$WASM_FILENAME" "$WASM_PATH"
 rm -fr "${UNZIP_TMPDIR}"
-DEPLOY_ENV=nobuild dfx deploy --no-wallet --network testnet
+DEPLOY_ENV=nobuild dfx deploy --network testnet
 
 echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"

--- a/scripts/deploy-docker-build-to-testnet
+++ b/scripts/deploy-docker-build-to-testnet
@@ -4,7 +4,7 @@ cd "$(dirname "$(realpath "$0")")/.." || exit
 
 ./scripts/docker-build
 
-DEPLOY_ENV=nobuild dfx deploy --no-wallet --network testnet
+DEPLOY_ENV=nobuild dfx deploy --network testnet
 
 set +x
 echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"

--- a/update_config.sh
+++ b/update_config.sh
@@ -10,7 +10,7 @@ fi
 
 if [[ $DEPLOY_ENV = "testnet" ]]; then
   # testnet config
-  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --no-wallet --network testnet id nns-dapp)}"
+  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --network testnet id nns-dapp)}"
   cat >frontend/ts/src/config.json <<EOF
 {
     "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network/",
@@ -36,7 +36,7 @@ EOF
 
 else
   # local config
-  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --no-wallet --network local id nns-dapp)}"
+  OWN_CANISTER_ID="${OWN_CANISTER_ID:-$(dfx canister --network local id nns-dapp)}"
   cat >frontend/ts/src/config.json <<EOF
 {
     "IDENTITY_SERVICE_URL": "",


### PR DESCRIPTION
# Motivation
The dfx version 0.8.4 is now well behind the default version (0.9.2).  It is generally sensible to stay reasonably up to date.  Also, looking at the changelog, there are changes that would help us clean up our code.  Examples:

- `DFX_NETWORK` is available as an environment variable to the build command.
- There is [a standardized location](https://github.com/dfinity/sdk/blob/master/CHANGELOG.adoc#feat-remote-canister-support) for external canister IDs, such as governance, ledger and II.

# Changes
- Update dfx from 0.8.4 to 0.9.2
- Removed `--no-wallet` everywhere as it is now the default and using it throws an error.

# Blast radius
These may be affected:

- Local development environments
- Deployment to testnets
- CI
- Production is not deployed with dfx but it is built with dfx.


# Tests
See CI

### TODO: Test Production upgrade.
- Deploy nns-dapp to a testnet with dfx 0.8.4
- Upgrade with dfx 0.9.2 (verify that this works)
- Verify that the upgraded canister works.

# Release
As updating dfx is something we do rarely, I associate quite a lot of risk with it.  As such, I would consider doing a release with just this change.