### PR TITLE
Environment argument for controlling the log level

### DIFF
--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -61,7 +61,8 @@ export const config: WebdriverIO.Config = {
       acceptInsecureCerts: true,
     },
   ],
-  logLevel: "info",
+  logLevel:
+    process.env.LOG_LEVEL === undefined ? "info" : process.env.LOG_LEVEL,
   services: ["chromedriver"],
 
   framework: "mocha",


### PR DESCRIPTION
# Motivation
The e2e log level is too noisy for most purposes, it floods the screen with hard-to-read data and by its sheer volume hides errors.  Personally, when developing I use `logLevel: warn` and switch back to `logLevel: info` if I really need the data for debugging.

However, when changing the log level in the code, one ends up with a diff which I have to remove every time I commit or make a PR.  Better to have a default in the code and an external override.

# Changes
- Override the log level with an environment variable.

# Tests
I use this control regularly.  It works.