### PR TITLE
Fix flaky tests: Wait for canister to be ready

### DIFF
--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -8,7 +8,8 @@ while (($# > 0)); do
   arg="$1"
   shift 1
   case "$arg" in
-  --help) cat <<-EOF
+  --help)
+    cat <<-EOF
 
 	Deploys nns-dapp and required canisters to localhost.
 
@@ -19,7 +20,8 @@ while (($# > 0)); do
 	  --nobuild == set DEPLOY_ENV=nobuild so that the existing wasm is used.
 
 	EOF
-        exit 0 ;;
+    exit 0
+    ;;
   --nobuild) DEPLOY_ENV=nobuild ;;
   esac
 done

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -8,6 +8,18 @@ while (($# > 0)); do
   arg="$1"
   shift 1
   case "$arg" in
+  --help) cat <<-EOF
+
+	Deploys nns-dapp and required canisters to localhost.
+
+	Usage: "$0 [--nobuild] [--help]"
+
+	Flags:
+	  --help == print this help
+	  --nobuild == set DEPLOY_ENV=nobuild so that the existing wasm is used.
+
+	EOF
+        exit 0 ;;
   --nobuild) DEPLOY_ENV=nobuild ;;
   esac
 done

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -17,9 +17,10 @@ wait_for_url() {
   local seconds="${2:-10}"
   local options="${3:-}"
   for ((i = 0; i < seconds; i++)); do
-    if curl ${options:+${options}} -so /dev/null "$url"
-    then return 0
-    else sleep 1
+    if curl ${options:+${options}} -so /dev/null "$url"; then
+      return 0
+    else
+      sleep 1
     fi
   done
   echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/../.."
+
+wait_for_url() {
+	local url="$1"
+	local seconds="${2:-10}"
+	local options="${3:-}"
+	for ((i = 0; i < seconds; i++)); do if curl ${options:+${options}} -so /dev/null "$url"; then return 0; else sleep 1; fi; done
+	echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
+	return 1
+}
+
+DEPLOY_ENV="local"
+NETWORK_URL="localhost:8080"
+wait_for_url "$NETWORK_URL"
+
+while (($# > 0)); do
+	arg="$1"
+	shift 1
+	case "$arg" in
+	--nobuild) DEPLOY_ENV=nobuild ;;
+	esac
+done
+
+set -x
 dfx canister --no-wallet create --all || echo Canisters may have been created already. Proceeding...
-REDIRECT_TO_LEGACY=svelte DEPLOY_ENV=local IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
+REDIRECT_TO_LEGACY=svelte DEPLOY_ENV="$DEPLOY_ENV" IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
+
+NNS_DAPP_CANISTER_ID="$(dfx canister --no-wallet --network local id nns-dapp)"
+NNS_DAPP_CANISTER_URL="${NNS_DAPP_CANISTER_ID}.${NETWORK_URL}"
+wait_for_url "$NNS_DAPP_CANISTER_URL" 10 --fail
+
+echo OK

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -13,6 +13,7 @@ while (($# > 0)); do
 done
 
 wait_for_url() {
+  : "Waiting up to ${seconds} seconds for: ${url}"
   local url="$1"
   local seconds="${2:-10}"
   local options="${3:-}"
@@ -23,19 +24,19 @@ wait_for_url() {
       sleep 1
     fi
   done
-  echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
+  echo "URL not ready after ${seconds}s: curl ${options:+${options}} -so /dev/null $url" >&2
   return 1
 }
 
-: "Checking that the network is present at the expected location..."
-: "Note: The network is expected to complain that we haven't specified the canister ID."
+: "Waiting for the network to be present at: ${NETWORK_URL}"
+: "Note: The network is expected to complain, with a non-200 response, that we haven't specified the canister ID."
 wait_for_url "$NETWORK_URL"
 
 : "Creating and deploying canisters..."
 dfx canister --no-wallet create --all || echo Canisters may have been created already. Proceeding...
 REDIRECT_TO_LEGACY=svelte DEPLOY_ENV="$DEPLOY_ENV" IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
 
-: "Checking that the canister returns with HTTP code 200..."
+: "Waiting for the canister to return with HTTP code 200..."
 NNS_DAPP_CANISTER_ID="$(dfx canister --no-wallet --network local id nns-dapp)"
 NNS_DAPP_CANISTER_URL="${NNS_DAPP_CANISTER_ID}.${NETWORK_URL}"
 wait_for_url "$NNS_DAPP_CANISTER_URL" 10 --fail

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -2,7 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-DEPLOY_ENV="local"
+DEPLOY_ENV="${DEPLOY_ENV:-local}"
 NETWORK_URL="localhost:8080"
 while (($# > 0)); do
   arg="$1"

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -2,19 +2,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-wait_for_url() {
-  local url="$1"
-  local seconds="${2:-10}"
-  local options="${3:-}"
-  for ((i = 0; i < seconds; i++)); do if curl ${options:+${options}} -so /dev/null "$url"; then return 0; else sleep 1; fi; done
-  echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
-  return 1
-}
-
 DEPLOY_ENV="local"
 NETWORK_URL="localhost:8080"
-wait_for_url "$NETWORK_URL"
-
 while (($# > 0)); do
   arg="$1"
   shift 1
@@ -23,10 +12,29 @@ while (($# > 0)); do
   esac
 done
 
-set -x
+wait_for_url() {
+  local url="$1"
+  local seconds="${2:-10}"
+  local options="${3:-}"
+  for ((i = 0; i < seconds; i++)); do
+    if curl ${options:+${options}} -so /dev/null "$url"
+    then return 0
+    else sleep 1
+    fi
+  done
+  echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
+  return 1
+}
+
+: "Checking that the network is present at the expected location..."
+: "Note: The network is expected to complain that we haven't specified the canister ID."
+wait_for_url "$NETWORK_URL"
+
+: "Creating and deploying canisters..."
 dfx canister --no-wallet create --all || echo Canisters may have been created already. Proceeding...
 REDIRECT_TO_LEGACY=svelte DEPLOY_ENV="$DEPLOY_ENV" IDENTITY_SERVICE_URL=http://localhost:8087 dfx deploy --no-wallet --network local --argument '(null)'
 
+: "Checking that the canister returns with HTTP code 200..."
 NNS_DAPP_CANISTER_ID="$(dfx canister --no-wallet --network local id nns-dapp)"
 NNS_DAPP_CANISTER_URL="${NNS_DAPP_CANISTER_ID}.${NETWORK_URL}"
 wait_for_url "$NNS_DAPP_CANISTER_URL" 10 --fail

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -3,12 +3,12 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 wait_for_url() {
-	local url="$1"
-	local seconds="${2:-10}"
-	local options="${3:-}"
-	for ((i = 0; i < seconds; i++)); do if curl ${options:+${options}} -so /dev/null "$url"; then return 0; else sleep 1; fi; done
-	echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
-	return 1
+  local url="$1"
+  local seconds="${2:-10}"
+  local options="${3:-}"
+  for ((i = 0; i < seconds; i++)); do if curl ${options:+${options}} -so /dev/null "$url"; then return 0; else sleep 1; fi; done
+  echo "URL not ready after ${seconds}s: curl ${options} -so /dev/null $url" >&2
+  return 1
 }
 
 DEPLOY_ENV="local"
@@ -16,11 +16,11 @@ NETWORK_URL="localhost:8080"
 wait_for_url "$NETWORK_URL"
 
 while (($# > 0)); do
-	arg="$1"
-	shift 1
-	case "$arg" in
-	--nobuild) DEPLOY_ENV=nobuild ;;
-	esac
+  arg="$1"
+  shift 1
+  case "$arg" in
+  --nobuild) DEPLOY_ENV=nobuild ;;
+  esac
 done
 
 set -x

--- a/e2e-tests/scripts/deploy-local-canisters
+++ b/e2e-tests/scripts/deploy-local-canisters
@@ -27,10 +27,10 @@ while (($# > 0)); do
 done
 
 wait_for_url() {
-  : "Waiting up to ${seconds} seconds for: ${url}"
   local url="$1"
   local seconds="${2:-10}"
   local options="${3:-}"
+  : "Waiting up to ${seconds} seconds for: ${url}"
   for ((i = 0; i < seconds; i++)); do
     if curl ${options:+${options}} -so /dev/null "$url"; then
       return 0


### PR DESCRIPTION
# Motivation
Sometimes tests fail because the canister installation wasn't ready:
```
2022-04-10T05:44:35.8392589Z [0-0]   Code: 404 (Not Found)
2022-04-10T05:44:35.8393240Z [0-0]   Body: Requested canister does not exist
2022-04-10T05:44:35.8394445Z [0-0] " class="svelte-ksskaf">An error occurred while loading the accounts information. Server returned an error:
2022-04-10T05:44:35.8397503Z [0-0]   Code: 404 (Not Found)
2022-04-10T05:44:35.8397996Z [0-0]   Body: Requested canister does not exist
```

Note: I checked whether the installation had failed; the installation was fine, some later checks worked, it just took a while for the canister to be ready.

# Changes
- Support `nobuild` for faster testing.
- Wait for the local network to be ready before deploying canisters.
- Wait for the nns-dapp canister to be ready before running tests.

# Tests
Running tests repeatedly on CI:  Success: 2/2
Actually, I can just do this and see the results below:
```
seq 10 | while read line ; do git pull ; git commit -m bump-$line --allow-empty ; git push ; sleep 30m ; done
```