### PR TITLE
Proposals tab is shown in prod

### DIFF
--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -32,8 +32,8 @@ const REDIRECTS = {
       [FrontendPath.Svelte]: FrontendPath.Flutter,
     },
     [RouteHash.Neurons]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Proposals]: {
       [FrontendPath.Flutter]: FrontendPath.Svelte,

--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -18,8 +18,8 @@ const REDIRECTS = {
       [FrontendPath.Svelte]: FrontendPath.Flutter,
     },
     [RouteHash.Proposals]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Canisters]: {
       [FrontendPath.Flutter]: FrontendPath.Flutter,

--- a/frontend/dart/lib/data/env.dart
+++ b/frontend/dart/lib/data/env.dart
@@ -1,5 +1,5 @@
 const REDIRECT_TO_LEGACY = String.fromEnvironment('REDIRECT_TO_LEGACY');
 bool showAccountsRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }
 bool showNeuronsRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }
-bool showProposalsRoute() { return ["flutter", "both", "prod"].contains(REDIRECT_TO_LEGACY); }
+bool showProposalsRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }
 bool showCanistersRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }

--- a/frontend/dart/lib/data/env.dart
+++ b/frontend/dart/lib/data/env.dart
@@ -1,5 +1,5 @@
 const REDIRECT_TO_LEGACY = String.fromEnvironment('REDIRECT_TO_LEGACY');
 bool showAccountsRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }
-bool showNeuronsRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }
+bool showNeuronsRoute() { return ["flutter", "both", "prod"].contains(REDIRECT_TO_LEGACY); }
 bool showProposalsRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }
 bool showCanistersRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -13,7 +13,7 @@ export enum AppPath {
 export const SHOW_ACCOUNTS_ROUTE = ["svelte", "both"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );
-export const SHOW_NEURONS_ROUTE = ["svelte", "both"].includes(
+export const SHOW_NEURONS_ROUTE = ["svelte", "both", "staging"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );
 export const SHOW_PROPOSALS_ROUTE = [

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -16,9 +16,12 @@ export const SHOW_ACCOUNTS_ROUTE = ["svelte", "both"].includes(
 export const SHOW_NEURONS_ROUTE = ["svelte", "both"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );
-export const SHOW_PROPOSALS_ROUTE = ["svelte", "both", "prod", "staging"].includes(
-  process.env.REDIRECT_TO_LEGACY as string
-);
+export const SHOW_PROPOSALS_ROUTE = [
+  "svelte",
+  "both",
+  "prod",
+  "staging",
+].includes(process.env.REDIRECT_TO_LEGACY as string);
 export const SHOW_CANISTERS_ROUTE = ["svelte", "both"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -16,7 +16,7 @@ export const SHOW_ACCOUNTS_ROUTE = ["svelte", "both"].includes(
 export const SHOW_NEURONS_ROUTE = ["svelte", "both"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );
-export const SHOW_PROPOSALS_ROUTE = ["svelte", "both", "staging"].includes(
+export const SHOW_PROPOSALS_ROUTE = ["svelte", "both", "prod", "staging"].includes(
   process.env.REDIRECT_TO_LEGACY as string
 );
 export const SHOW_CANISTERS_ROUTE = ["svelte", "both"].includes(


### PR DESCRIPTION
# Motivation
The proposals tab will now be deployed in production using svelte.

# Changes
- Update the svelte and flutter values:
  - showProposalsRoute now uses svelte for production
  - showNeuronsRoute now uses svelte for staging
- Update redirect test.

# Tests
```
REDIRECT_TO_LEGACY=prod ./scripts/test-winning --spec /specs/redirect-to-legacy.e2e.ts
```
![Screenshot from 2022-04-11 09-56-54](https://user-images.githubusercontent.com/5982633/162691201-d4d6b563-2f90-45f4-99c4-f047e355573d.png)

