### PR TITLE
refactor: style padding calc

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/Address.svelte
+++ b/frontend/svelte/src/lib/components/accounts/Address.svelte
@@ -29,8 +29,8 @@
 
 <style lang="scss">
   article {
-    margin-bottom: calc(2 * var(--padding));
-    padding: 0 0 calc(2 * var(--padding));
+    margin-bottom: var(--padding-2x);
+    padding: 0 0 var(--padding-2x);
   }
 
   form {

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
@@ -27,7 +27,7 @@
   }
 
   p {
-    margin: 0 0 calc(var(--padding) / 2);
+    margin: 0 0 var(--padding-half);
     word-wrap: break-word;
   }
 </style>

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -28,6 +28,6 @@
   .amount {
     display: inline-flex;
     justify-content: center;
-    padding: var(--padding) 0 calc(2 * var(--padding));
+    padding: var(--padding) 0 var(--padding-2x);
   }
 </style>

--- a/frontend/svelte/src/lib/components/common/Layout.svelte
+++ b/frontend/svelte/src/lib/components/common/Layout.svelte
@@ -24,7 +24,7 @@
     position: absolute;
     top: calc(
       var(--header-offset, 0px) + var(--header-height) + var(--nav-height) +
-        (2 * var(--padding))
+        var(--padding-2x)
     );
     left: 0;
     right: 0;

--- a/frontend/svelte/src/lib/components/common/Nav.svelte
+++ b/frontend/svelte/src/lib/components/common/Nav.svelte
@@ -34,7 +34,7 @@
     left: 0;
     right: 0;
 
-    margin: var(--padding) calc(2 * var(--padding));
+    margin: var(--padding) var(--padding-2x);
 
     height: var(--nav-height);
 

--- a/frontend/svelte/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/svelte/src/lib/components/ic/GetICPs.svelte
@@ -92,17 +92,17 @@
   }
 
   .how-much {
-    margin-bottom: calc(var(--padding) / 2);
+    margin-bottom: var(--padding-half);
   }
 
   form {
     display: flex;
     flex-direction: column;
 
-    padding: calc(2 * var(--padding));
+    padding: var(--padding-2x);
 
     button {
-      margin-top: calc(var(--padding) / 2);
+      margin-top: var(--padding-half);
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
@@ -44,7 +44,7 @@
   .title {
     display: flex;
     align-items: center;
-    gap: calc(0.5 * var(--padding));
+    gap: var(--padding-half);
   }
 
   .actions {

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -122,7 +122,7 @@
   .voting-power {
     display: flex;
     align-items: center;
-    gap: calc(0.5 * var(--padding));
+    gap: var(--padding-half);
 
     span {
       display: flex;

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -91,7 +91,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: calc(3 * var(--padding));
+    padding: var(--padding-3x);
   }
 
   .voting-power {

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -114,7 +114,7 @@
   article {
     :global(.collapsible-expand-icon) {
       align-items: start;
-      padding-top: calc(3 * var(--padding));
+      padding-top: var(--padding-3x);
       color: var(--background-contrast);
     }
   }
@@ -123,7 +123,7 @@
     display: flex;
     align-items: start;
     justify-content: space-between;
-    gap: calc(2 * var(--padding));
+    gap: var(--padding-2x);
   }
 
   .subtitle {
@@ -134,9 +134,9 @@
     display: flex;
     align-items: center;
     justify-content: space-around;
-    gap: calc(2 * var(--padding));
-    margin-top: calc(2 * var(--padding));
-    margin-right: calc(2 * var(--padding));
+    gap: var(--padding-2x);
+    margin-top: var(--padding-2x);
+    margin-right: var(--padding-2x);
   }
 
   .badge {
@@ -144,8 +144,8 @@
     color: var(--background);
     border-radius: 50%;
     padding: var(--padding);
-    width: calc(2 * var(--padding));
-    height: calc(2 * var(--padding));
+    width: var(--padding-2x);
+    height: var(--padding-2x);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -161,7 +161,7 @@
 
     ul {
       list-style-type: none;
-      padding: 0 calc(3 * var(--padding));
+      padding: 0 var(--padding-3x);
     }
 
     li {

--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -111,7 +111,7 @@
 
     :global {
       svg {
-        margin-left: calc(var(--padding) / 2);
+        margin-left: var(--padding-half);
       }
     }
   }

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -212,7 +212,7 @@
   .wrapper {
     :global(article) {
       flex-grow: 1;
-      margin: 0 0 calc(2 * var(--padding));
+      margin: 0 0 var(--padding-2x);
     }
   }
 </style>

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -111,7 +111,7 @@
     --input-width: 100%;
 
     small {
-      margin-top: calc(2 * var(--padding));
+      margin-top: var(--padding-2x);
     }
 
     button[type="submit"] {

--- a/frontend/svelte/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -40,7 +40,7 @@
   @use "../../themes/mixins/media";
 
   p {
-    margin: 0 0 calc(2 * var(--padding));
+    margin: 0 0 var(--padding-2x);
     font-size: var(--font-size-h5);
   }
 
@@ -58,7 +58,7 @@
     font-size: var(--font-size-h5);
 
     @include media.min-width(small) {
-      margin: calc(0.5 * var(--padding)) 0;
+      margin: var(--padding-half) 0;
       flex-direction: row;
       align-items: center;
     }

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
@@ -42,7 +42,7 @@
     @include text.clamp(3);
 
     @include media.min-width(medium) {
-      margin-top: calc(0.5 * var(--padding));
+      margin-top: var(--padding-half);
       padding-right: var(--padding);
       font-size: var(--font-size-h3);
     }

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
@@ -51,13 +51,13 @@
   @use "../../../themes/mixins/media";
 
   div {
-    margin: calc(3 * var(--padding)) 0;
+    margin: var(--padding-3x) 0;
 
     a,
     p,
     button {
       display: block;
-      margin: 0 0 calc(0.5 * var(--padding));
+      margin: 0 0 var(--padding-half);
       padding: 0;
 
       font-size: var(--font-size-h5);

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -50,8 +50,8 @@
   @use "../../../themes/mixins/media";
 
   .headline {
-    padding: calc(0.5 * var(--padding)) var(--padding)
-      calc(0.5 * var(--padding)) calc(4.25 * var(--padding));
+    padding: var(--padding-half) var(--padding) var(--padding-half)
+      calc(4.25 * var(--padding));
     display: flex;
     justify-content: space-between;
 
@@ -81,7 +81,7 @@
       margin-left: 0;
     }
     :global(label) {
-      margin-left: calc(0.5 * var(--padding));
+      margin-left: var(--padding-half);
 
       display: flex;
       flex-direction: column;

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -76,7 +76,7 @@
     @include text.clamp(3);
 
     @include media.min-width(small) {
-      margin: 0 calc(2 * var(--padding)) 0 0;
+      margin: 0 var(--padding-2x) 0 0;
     }
   }
 

--- a/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
@@ -80,7 +80,7 @@
   .filters {
     display: flex;
     flex-wrap: wrap;
-    padding: calc(2 * var(--padding)) 0 var(--padding);
+    padding: var(--padding-2x) 0 var(--padding);
 
     --select-flex-direction: row-reverse;
 

--- a/frontend/svelte/src/lib/components/ui/Card.svelte
+++ b/frontend/svelte/src/lib/components/ui/Card.svelte
@@ -33,7 +33,7 @@
     color: var(--gray-50);
 
     padding: calc(2.5 * var(--padding));
-    margin: calc(2 * var(--padding)) 0;
+    margin: var(--padding-2x) 0;
     border-radius: var(--border-radius);
 
     box-shadow: 0 4px 16px 0 rgba(var(--background-rgb), 0.3);

--- a/frontend/svelte/src/lib/components/ui/CardBlock.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardBlock.svelte
@@ -70,7 +70,7 @@
   }
 
   .content {
-    margin: calc(2 * var(--padding)) 0 var(--padding);
+    margin: var(--padding-2x) 0 var(--padding);
 
     &.limit-height {
       max-height: 300px;

--- a/frontend/svelte/src/lib/components/ui/Chip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Chip.svelte
@@ -11,8 +11,8 @@
     background: var(--gray-800);
     color: var(--gray-50);
 
-    padding: calc(var(--padding) / 2) var(--padding);
-    margin: calc(var(--padding) / 2);
+    padding: var(--padding-half) var(--padding);
+    margin: var(--padding-half);
 
     border-radius: calc(2 * var(--border-radius));
   }

--- a/frontend/svelte/src/lib/components/ui/Collapsible.svelte
+++ b/frontend/svelte/src/lib/components/ui/Collapsible.svelte
@@ -103,7 +103,7 @@
 
     .header-content {
       flex: 1;
-      margin-right: calc(3 * var(--padding));
+      margin-right: var(--padding-3x);
     }
 
     @include media.min-width(medium) {
@@ -114,7 +114,7 @@
           display: flex;
           align-items: center;
           justify-content: center;
-          margin-left: calc(3 * var(--padding));
+          margin-left: var(--padding-3x);
         }
       }
     }
@@ -171,7 +171,7 @@
 
   .content {
     // to not stick the content to the bottom
-    padding-bottom: calc(2 * var(--padding));
+    padding-bottom: var(--padding-2x);
     // to respect children margins in contentHeight calculation
     overflow: auto;
     // scrollbar

--- a/frontend/svelte/src/lib/components/ui/FiltersButton.svelte
+++ b/frontend/svelte/src/lib/components/ui/FiltersButton.svelte
@@ -24,11 +24,11 @@
     align-items: center;
 
     :global(svg) {
-      margin-right: calc(var(--padding) / 2);
+      margin-right: var(--padding-half);
     }
   }
 
   small {
-    margin: 0 calc(var(--padding) / 2);
+    margin: 0 var(--padding-half);
   }
 </style>

--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -53,7 +53,7 @@
   .input-block {
     position: relative;
 
-    margin: calc(2 * var(--padding)) 0;
+    margin: var(--padding-2x) 0;
 
     display: flex;
     align-items: center;
@@ -62,7 +62,7 @@
 
     :global(button) {
       position: absolute;
-      right: calc(2 * var(--padding));
+      right: var(--padding-2x);
     }
 
     --disabled-color: var(--gray-100);
@@ -109,7 +109,7 @@
   input {
     width: 100%;
 
-    padding: var(--padding) calc(2 * var(--padding));
+    padding: var(--padding) var(--padding-2x);
     box-sizing: border-box;
 
     border-radius: calc(4 * var(--border-radius));
@@ -118,7 +118,7 @@
     outline: none;
 
     @include media.min-width(medium) {
-      padding: calc(2 * var(--padding));
+      padding: var(--padding-2x);
       font-size: var(--font-size-h3);
     }
   }
@@ -126,7 +126,7 @@
   .placeholder {
     position: absolute;
     top: 50%;
-    left: calc(2 * var(--padding));
+    left: var(--padding-2x);
     transform: translate(0, -50%);
 
     transition: all var(--animation-time-normal);
@@ -145,7 +145,7 @@
     transform: scale(0.8) translate(0, calc(-50% - 30px));
     background: #ffffff;
 
-    padding: 0 calc(var(--padding) / 2);
+    padding: 0 var(--padding-half);
 
     @include media.min-width(medium) {
       transform: scale(0.8) translate(0, calc(-50% - 43px));

--- a/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
@@ -14,7 +14,7 @@
     width: 100%;
     height: inherit;
 
-    margin: calc(var(--padding) / 2) 0;
+    margin: var(--padding-half) 0;
 
     --skeleton-text-background: rgba(var(--light-background-rgb), 0.065);
     --skeleton-text-background-animated: rgba(

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -49,7 +49,7 @@
     align-items: center;
 
     position: fixed;
-    bottom: calc(2 * var(--padding));
+    bottom: var(--padding-2x);
     left: 50%;
     transform: translate(-50%, 0);
 
@@ -60,7 +60,7 @@
 
     width: calc(100% - (8 * var(--padding)));
 
-    padding: var(--padding) calc(var(--padding) * 2);
+    padding: var(--padding) var(--padding-2x);
     box-sizing: border-box;
 
     z-index: calc(var(--z-index) + 999);

--- a/frontend/svelte/src/lib/components/ui/Toolbar.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toolbar.svelte
@@ -12,7 +12,7 @@
     // enable scrolling
     pointer-events: none;
 
-    margin: 0 auto calc(2 * var(--padding));
+    margin: 0 auto var(--padding-2x);
 
     display: flex;
     justify-content: center;
@@ -24,7 +24,7 @@
     }
 
     @include media.min-width(medium) {
-      margin-bottom: calc(3 * var(--padding));
+      margin-bottom: var(--padding-3x);
     }
 
     // buttons
@@ -32,11 +32,11 @@
       pointer-events: all;
 
       flex: 1 1;
-      margin: 0 calc(0.5 * var(--padding));
+      margin: 0 var(--padding-half);
       max-width: 60%;
 
       @include media.min-width(medium) {
-        margin: 0 calc(2 * var(--padding));
+        margin: 0 var(--padding-2x);
         max-width: 406px;
       }
     }

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -22,7 +22,7 @@
     display: inline-block;
 
     left: 50%;
-    bottom: calc(var(--padding) / 2);
+    bottom: var(--padding-half);
     transform: translate(-50%, 100%);
 
     opacity: 0;

--- a/frontend/svelte/src/lib/modals/ConfirmationModal.svelte
+++ b/frontend/svelte/src/lib/modals/ConfirmationModal.svelte
@@ -26,7 +26,7 @@
 
 <style lang="scss">
   article {
-    padding: calc(2 * var(--padding));
+    padding: var(--padding-2x);
   }
 
   [role="toolbar"] {

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -140,7 +140,7 @@
     width: var(--modal-small-width);
     height: fit-content;
     max-width: calc(100vw - (4 * var(--padding)));
-    max-height: calc(100vh - (2 * var(--padding)));
+    max-height: calc(100vh - var(--padding-2x));
 
     --modal-min-height: 100px;
     --modal-toolbar-height: 35px;
@@ -158,7 +158,7 @@
   }
 
   .toolbar {
-    padding: var(--padding) calc(2 * var(--padding));
+    padding: var(--padding) var(--padding-2x);
 
     background: var(--gray-100);
     color: var(--gray-800);

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -124,12 +124,12 @@
 
 <style lang="scss">
   main {
-    padding: calc(3 * var(--padding));
+    padding: var(--padding-3x);
 
     --input-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: calc(2 * var(--padding));
+    gap: var(--padding-2x);
   }
 
   form {

--- a/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposerModal.svelte
@@ -45,6 +45,6 @@
 
 <style lang="scss">
   .content {
-    padding: calc(2 * var(--padding));
+    padding: var(--padding-2x);
   }
 </style>

--- a/frontend/svelte/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -38,7 +38,7 @@
   @use "../../themes/mixins/text";
 
   div {
-    padding: calc(2 * var(--padding)) 0;
+    padding: var(--padding-2x) 0;
 
     display: flex;
     flex-direction: column;

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -32,7 +32,7 @@ button {
 
     vertical-align: bottom;
 
-    padding: calc(var(--padding) / 2);
+    padding: var(--padding-half);
 
     border-radius: 50%;
 
@@ -59,7 +59,7 @@ button {
     &.small {
       min-height: inherit;
       font-size: inherit;
-      padding: calc(var(--padding) / 2) var(--padding);
+      padding: var(--padding-half) var(--padding);
     }
   }
 
@@ -112,12 +112,12 @@ button {
   }
 
   &.input-button {
-    padding: calc(0.5 * var(--padding)) calc(1.5 * var(--padding));
+    padding: var(--padding-half) calc(1.5 * var(--padding));
 
     font-size: var(--font-size-ultra-small);
 
     @include media.min-width(medium) {
-      padding: calc(0.5 * var(--padding)) calc(2 * var(--padding));
+      padding: var(--padding-half) var(--padding-2x);
 
       font-size: var(--font-size-small);
       font-weight: bold;

--- a/frontend/svelte/src/lib/themes/fonts.scss
+++ b/frontend/svelte/src/lib/themes/fonts.scss
@@ -33,11 +33,11 @@ h4,
 h5 {
   font-weight: 700;
   line-height: var(--line-height-title);
-  margin: 0 0 calc(var(--padding) / 2);
+  margin: 0 0 var(--padding-half);
 }
 
 p {
-  margin: 0 0 calc(3 * var(--padding));
+  margin: 0 0 var(--padding-3x);
 }
 
 input,

--- a/frontend/svelte/src/lib/themes/mixins/_confirmation-modal.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_confirmation-modal.scss
@@ -1,5 +1,5 @@
 @mixin wrapper {
-  padding-bottom: calc(2 * var(--padding));
+  padding-bottom: var(--padding-2x);
 
   display: flex;
   flex-direction: column;

--- a/frontend/svelte/src/lib/themes/mixins/_modal.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_modal.scss
@@ -1,6 +1,6 @@
 @mixin section {
-  height: min(500px, calc(100vh - 156px - (2 * var(--padding))));
+  height: min(500px, calc(100vh - 156px - var(--padding-2x)));
   margin: 0;
-  padding: calc(2 * var(--padding));
+  padding: var(--padding-2x);
   max-width: 100%;
 }

--- a/frontend/svelte/src/lib/themes/mixins/_select.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_select.scss
@@ -6,7 +6,7 @@
   align-items: center;
   flex-direction: var(--select-flex-direction);
 
-  padding: calc(2 * var(--padding));
+  padding: var(--padding-2x);
 
   color: var(--select-color);
 
@@ -22,7 +22,7 @@
 
   --select-input-size: 20px;
   --select-input-border: 2px;
-  --select-input-margin: calc(var(--padding) / 2);
+  --select-input-margin: var(--padding-half);
 }
 
 @mixin label {

--- a/frontend/svelte/src/lib/themes/theme.scss
+++ b/frontend/svelte/src/lib/themes/theme.scss
@@ -41,7 +41,7 @@ button {
   cursor: pointer;
   user-select: none;
 
-  padding: 0 calc(var(--padding) / 2);
+  padding: 0 var(--padding-half);
 }
 
 main {
@@ -50,8 +50,7 @@ main {
 }
 
 section {
-  padding: calc(2 * var(--padding)) calc(2.5 * var(--padding))
-    var(--footer-height);
+  padding: var(--padding-2x) calc(2.5 * var(--padding)) var(--footer-height);
   max-width: var(--section-max-width);
   margin: 0 auto;
 }
@@ -69,7 +68,7 @@ p {
 }
 
 ul {
-  padding-inline-start: calc(2 * var(--padding));
+  padding-inline-start: var(--padding-2x);
   margin: 0;
 }
 

--- a/frontend/svelte/src/lib/themes/variables.scss
+++ b/frontend/svelte/src/lib/themes/variables.scss
@@ -5,6 +5,11 @@
   --icon-width: 24px;
 
   --padding: 10px;
+
+  --padding-half: calc(var(--padding) / 2);
+  --padding-2x: calc(2 * var(--padding));
+  --padding-3x: calc(3 * var(--padding));
+
   --border-radius: 10px;
 
   --z-index: 1;
@@ -15,7 +20,7 @@
   --footer-height: 20vh;
 
   --modal-small-width: calc(100% - (8 * var(--padding)));
-  --modal-medium-width: calc(100% - (2 * var(--padding)));
+  --modal-medium-width: calc(100% - var(--padding-2x));
 
   --animation-time-normal: 0.2s;
 

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -111,7 +111,7 @@
     display: block;
     width: 100%;
 
-    margin-bottom: calc(2 * var(--padding));
+    margin-bottom: var(--padding-2x);
 
     --icp-font-size: var(--font-size-h1);
 

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -90,6 +90,6 @@
 
 <style lang="scss">
   p:last-of-type {
-    margin-bottom: calc(3 * var(--padding));
+    margin-bottom: var(--padding-3x);
   }
 </style>

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -160,11 +160,11 @@
     position: relative;
     display: flex;
 
-    padding: calc(2 * var(--padding)) 0;
+    padding: var(--padding-2x) 0;
   }
 
   .no-proposals {
     text-align: center;
-    margin: calc(var(--padding) * 2) 0;
+    margin: var(--padding-2x) 0;
   }
 </style>


### PR DESCRIPTION
# Motivation

We often got the exact same `calc(... * var(-padding))` values in the code. We can spare some style duplication.

# Changes

- refactor common padding style
