### PR TITLE
fix: neuron utils wildcard import

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMaturityCard.svelte
@@ -4,13 +4,14 @@
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
   import { formatPercentage } from "../../utils/format.utils";
-  import * as utils from "../../utils/neuron.utils";
   import Card from "../ui/Card.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
   import MergeMaturityButton from "./actions/MergeMaturityButton.svelte";
   import SpawnNeuronButton from "./actions/SpawnNeuronButton.svelte";
-
-  const { isCurrentUserController, maturityByStake } = utils;
+  import {
+    isCurrentUserController,
+    maturityByStake,
+  } from "../../utils/neuron.utils";
 
   export let neuron: NeuronInfo;
   let userControlled: boolean;

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -6,7 +6,6 @@
   import { secondsToDate } from "../../utils/date.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formatICP } from "../../utils/icp.utils";
-  import * as utils from "../../utils/neuron.utils";
   import NeuronCard from "../neurons/NeuronCard.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
   import IncreaseDissolveDelayButton from "./actions/IncreaseDissolveDelayButton.svelte";
@@ -16,14 +15,13 @@
   import DissolveActionButton from "./actions/DissolveActionButton.svelte";
   import DisburseButton from "./actions/DisburseButton.svelte";
   import { authStore } from "../../stores/auth.store";
-
-  const {
+  import {
     ageMultiplier,
     dissolveDelayMultiplier,
     formatVotingPower,
     hasJoinedCommunityFund,
     isCurrentUserController,
-  } = utils;
+  } from "../../utils/neuron.utils";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronMetaInfoCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronMetaInfoCard.spec.ts
@@ -73,7 +73,7 @@ describe("NeuronMetaInfoCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders actions", async () => {
+  it("renders actions", () => {
     // Each action button is tested separately
     const { queryByText } = render(NeuronMetaInfoCard, {
       props,

--- a/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronMetaInfoCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronMetaInfoCard.spec.ts
@@ -4,25 +4,35 @@
 
 import { render } from "@testing-library/svelte";
 import NeuronMetaInfoCard from "../../../../lib/components/neuron-detail/NeuronMetaInfoCard.svelte";
-import * as utils from "../../../../lib/utils/neuron.utils";
+import { authStore } from "../../../../lib/stores/auth.store";
+import { formatVotingPower } from "../../../../lib/utils/neuron.utils";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
-import { mockNeuron } from "../../../mocks/neurons.mock";
+import { mockFullNeuron, mockNeuron } from "../../../mocks/neurons.mock";
 
 describe("NeuronMetaInfoCard", () => {
-  beforeEach(() => {
+  const props = {
+    neuron: {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        controller: mockIdentity.getPrincipal().toText(),
+      },
+    },
+  };
+
+  beforeAll(() =>
     jest
-      .spyOn(utils, "isCurrentUserController")
-      .mockImplementation((): boolean => true);
-    jest
-      .spyOn(utils, "hasJoinedCommunityFund")
-      .mockImplementation((): boolean => false);
-  });
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe)
+  );
+
   it("renders neuron id", () => {
     const { queryByText } = render(NeuronMetaInfoCard, {
-      neuron: mockNeuron,
+      props,
     });
 
     expect(queryByText(mockNeuron.neuronId.toString())).toBeInTheDocument();
@@ -31,7 +41,7 @@ describe("NeuronMetaInfoCard", () => {
   it("renders a NeuronCard", () => {
     // We can skip many edge cases tested in the NeuronCard
     const { queryByTestId } = render(NeuronMetaInfoCard, {
-      neuron: mockNeuron,
+      props,
     });
 
     expect(queryByTestId("neuron-card-title")).toBeInTheDocument();
@@ -39,14 +49,14 @@ describe("NeuronMetaInfoCard", () => {
 
   it("renders voting power", () => {
     const { queryByText } = render(NeuronMetaInfoCard, {
-      neuron: mockNeuron,
+      props,
     });
 
     expect(
       queryByText(en.neurons.voting_power, { exact: false })
     ).toBeInTheDocument();
     expect(
-      queryByText(utils.formatVotingPower(mockNeuron.votingPower))
+      queryByText(formatVotingPower(mockNeuron.votingPower))
     ).toBeInTheDocument();
   });
 
@@ -63,10 +73,10 @@ describe("NeuronMetaInfoCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders actions", () => {
+  it("renders actions", async () => {
     // Each action button is tested separately
     const { queryByText } = render(NeuronMetaInfoCard, {
-      neuron: mockNeuron,
+      props,
     });
 
     expect(
@@ -81,11 +91,18 @@ describe("NeuronMetaInfoCard", () => {
   });
 
   it("renders no actions if user is not controller", () => {
-    jest
-      .spyOn(utils, "isCurrentUserController")
-      .mockImplementation((): boolean => false);
+    const props = {
+      neuron: {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "not-controller",
+        },
+      },
+    };
+
     const { queryByText } = render(NeuronMetaInfoCard, {
-      neuron: mockNeuron,
+      props,
     });
 
     expect(


### PR DESCRIPTION
# Motivation

Follow up PR #670 to fix wildcard import.

# Changes

- es6 naming import instead of wildcard to helps bundler chunking process (if we ever use chunking)
