### PR TITLE
fix: too long text in the modal title

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -75,6 +75,7 @@
 
 <style lang="scss">
   @use "../themes/mixins/interaction";
+  @use "../themes/mixins/text";
 
   .modal {
     position: fixed;
@@ -174,6 +175,8 @@
     height: var(--modal-toolbar-height);
 
     h3 {
+      @include text.clamp(1);
+
       color: inherit;
       font-weight: 400;
       margin-bottom: 0;


### PR DESCRIPTION
# Motivation

See screenshots

# Screenshots
## Before
<img width="494" alt="image" src="https://user-images.githubusercontent.com/98811342/162731711-37a8f9c9-76a6-414b-b898-13ca34944b85.png">
## After
<img width="465" alt="image" src="https://user-images.githubusercontent.com/98811342/162731613-89f30d9d-8e31-4c4d-9e9c-c1e989386d64.png">
