### PR TITLE
fix: max new transaction value

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -10,6 +10,7 @@
   import NewTransactionInfo from "./NewTransactionInfo.svelte";
   import { ICP } from "@dfinity/nns";
   import type { FromICPStringError } from "@dfinity/nns";
+  import { maxICP } from "../../utils/icp.utils";
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
@@ -21,7 +22,7 @@
     : undefined;
 
   let max: number = 0;
-  $: max = Number($store.selectedAccount?.balance.toE8s() ?? 0) / E8S_PER_ICP;
+  $: max = maxICP($store.selectedAccount?.balance);
 
   let validForm: boolean;
   $: validForm = amount !== undefined && amount > 0 && amount <= max;

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import Spinner from "../ui/Spinner.svelte";
-  import {
-    E8S_PER_ICP,
-    TRANSACTION_FEE_E8S,
-  } from "../../constants/icp.constants";
   import { syncAccounts } from "../../services/accounts.services";
   import { stakeAndLoadNeuron } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { startBusy, stopBusy } from "../../stores/busy.store";
-  import { formatICP, formattedTransactionFeeICP } from "../../utils/icp.utils";
+  import {
+    formatICP,
+    formattedTransactionFeeICP,
+    maxICP,
+  } from "../../utils/icp.utils";
   import AmountInput from "../ui/AmountInput.svelte";
 
   export let account: Account;
@@ -38,8 +38,7 @@
   };
 
   let max: number = 0;
-  $: max =
-    (Number(account.balance.toE8s()) - TRANSACTION_FEE_E8S) / E8S_PER_ICP;
+  $: max = maxICP(account.balance);
 
   const stakeMaximum = () => (amount = max);
 </script>

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -14,3 +14,6 @@ export const sumICPs = (...icps: ICP[]): ICP =>
 
 export const formattedTransactionFeeICP = () =>
   formatICP(ICP.fromE8s(BigInt(TRANSACTION_FEE_E8S)).toE8s());
+
+export const maxICP = (icp: ICP | undefined): number =>
+  Math.max((Number(icp?.toE8s() ?? 0) - TRANSACTION_FEE_E8S) / E8S_PER_ICP, 0);

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -6,7 +6,10 @@ import { ICP } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import NewTransactionAmount from "../../../../lib/components/accounts/NewTransactionAmount.svelte";
-import { E8S_PER_ICP } from "../../../../lib/constants/icp.constants";
+import {
+  E8S_PER_ICP,
+  TRANSACTION_FEE_E8S,
+} from "../../../../lib/constants/icp.constants";
 import { transactionStore } from "../../../../lib/stores/transaction.store";
 import { formatICP } from "../../../../lib/utils/icp.utils";
 import {
@@ -59,12 +62,15 @@ describe("NewTransactionAmount", () => {
     expect(input).not.toBeNull();
   });
 
-  it("should render an input for the amount that has a max value equals to the source account available funds", () => {
+  it("should render an input for the amount that has a max value equals to the source account available funds minus the transaction fee", () => {
     const { container } = render(NewTransactionTest, { props });
 
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input?.getAttribute("max")).toEqual(
-      `${Number(mockMainAccount.balance.toE8s()) / E8S_PER_ICP}`
+      `${
+        (Number(mockMainAccount.balance.toE8s()) - TRANSACTION_FEE_E8S) /
+        E8S_PER_ICP
+      }`
     );
   });
 

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,7 +1,7 @@
 import { ICP } from "@dfinity/nns";
 import {
   formatICP,
-  formattedTransactionFeeICP,
+  formattedTransactionFeeICP, maxICP,
   sumICPs,
 } from "../../../lib/utils/icp.utils";
 
@@ -39,4 +39,12 @@ describe("icp-utils", () => {
 
   it("should format a specific transaction fee", () =>
     expect(formattedTransactionFeeICP()).toEqual("0.00010000"));
+
+  it("should max ICP value", () => {
+    expect(maxICP(undefined)).toEqual(0);
+    expect(maxICP(ICP.fromString("0") as ICP)).toEqual(0);
+    expect(maxICP(ICP.fromString("0.0001") as ICP)).toEqual(0);
+    expect(maxICP(ICP.fromString("0.00011") as ICP)).toEqual(0.00001);
+    expect(maxICP(ICP.fromString("1") as ICP)).toEqual(0.9999);
+  });
 });


### PR DESCRIPTION
# Motivation

The "max" button in the transaction fee did not take in account the transaction fee that are added at the top of the transaction.

# Changes

- reduce transaction fee from max value of the transaction
- extract utility function to compute max value
