### PR TITLE
fix: hidden/cut-off tooltip on mobile

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -18,7 +18,7 @@
   }
 
   .tooltip {
-    z-index: 1;
+    z-index: var(--z-index);
 
     position: absolute;
     display: inline-block;

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -18,6 +18,8 @@
   }
 
   .tooltip {
+    z-index: 1;
+
     position: absolute;
     display: inline-block;
 
@@ -36,7 +38,11 @@
     background: var(--gray-600);
 
     color: var(--gray-600-contrast);
-    white-space: pre;
+
+    // limit width
+    white-space: pre-wrap;
+    max-width: 240px;
+    width: max-content;
 
     &.noWrap {
       white-space: nowrap;


### PR DESCRIPTION
# Motivation

See screenshots

# Screenshots

## Before
~tablet view
<img width="730" alt="image" src="https://user-images.githubusercontent.com/98811342/162760683-e49efa38-30fa-4bfe-90fb-eb0ca42e8dc8.png">
mobile
<img width="435" alt="image" src="https://user-images.githubusercontent.com/98811342/162760775-fdbf5088-2fd6-459e-970e-bfe4e547de0d.png">

## After
<img width="412" alt="Screenshot 2022-04-11 at 16 20 51" src="https://user-images.githubusercontent.com/98811342/162760908-a879676b-2bc5-4b28-8214-f6910219dc29.png">
<img width="447" alt="Screenshot 2022-04-11 at 16 20 36" src="https://user-images.githubusercontent.com/98811342/162760927-7f632aea-b944-4663-891a-b67121eb16d0.png">

