### PR TITLE
fix: remove from selection neurons w/o votingPower

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -15,26 +15,28 @@
 
   export let proposalInfo: ProposalInfo;
 
-  const notVotedNeurons = () =>
+  const votableNeurons = () =>
     getNotVotedNeurons({
       neurons: $neuronsStore,
       proposal: proposalInfo,
-    });
+    })
+      // fix selection of neurons witout votingPower
+      .filter(({ votingPower }) => votingPower > 0);
   let visible: boolean = false;
   /** Signals that the initial checkbox preselection was done. To avoid removing of user selection after second queryAndUpdate callback. */
   let initialSelectionDone = false;
 
   $: visible =
-    notVotedNeurons().length > 0 &&
+    votableNeurons().length > 0 &&
     proposalInfo.status === ProposalStatus.PROPOSAL_STATUS_OPEN;
 
   const unsubcribe = neuronsStore.subscribe(() => {
     if (!initialSelectionDone) {
       initialSelectionDone = true;
-      votingNeuronSelectStore.set(notVotedNeurons());
+      votingNeuronSelectStore.set(votableNeurons());
     } else {
       // preserve user selection after neurons update (e.g. queryAndUpdate second callback)
-      votingNeuronSelectStore.updateNeurons(notVotedNeurons());
+      votingNeuronSelectStore.updateNeurons(votableNeurons());
     }
   });
   const vote = async ({ detail }: { detail: { voteType: Vote } }) =>


### PR DESCRIPTION
# Motivation

Not sure it's important for prod but locally it's possible to have a neuron w/o voting power.
1. stake a neuron w/ amount === 1
2. make dummy proposals (not enough for all but at least one should be created)

As result:
- the neuron has cachedNeuronStake === neuronFees => 0
- votingPower === 0

And the user is able to select the neuron but it doesn't update the total. In case of multiple neurons in theory user could still try vote using this neuron.

# Changes

- filter out from selections neurons w/o votingPower

# Screenshots


## Before


https://user-images.githubusercontent.com/98811342/162806652-1292cdae-9282-4537-be0e-04c870d89eee.mov


## After

<img width="945" alt="image" src="https://user-images.githubusercontent.com/98811342/162806404-4289b543-454f-48ce-95d3-b1572766b1d0.png">


