### PR TITLE
Sanitise screenshot filenames+count separately for each suite

### DIFF
--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -5,17 +5,23 @@ export const config: WebdriverIO.Config = {
   baseUrl: NNS_DAPP_URL,
 
   before: (_capabilities, _spec) => {
-    browser["screenshot-count"] = 0;
     browser["screenshots-taken"] = new Set();
+    browser["screenshot-prefix"] = "before";
+    browser["screenshot-count"] = 0;
 
     browser.addCommand("screenshot", async (name) => {
-      const countStr: string = browser["screenshots-taken"].size
+      const countStr: string = (browser["screenshot-count"]++)
         .toFixed()
         .padStart(2, "0");
-      if (true === browser["screenshots-taken"].has(name)) {
-        throw Error(`A screenshot with this name was already taken: '${name}'`);
+      const unsafeFilename = `${browser["screenshot-prefix"]}_${countStr}_${name}`;
+      // Filesystem-safe characters: ASCII alnum and hyphen.
+      // Underscore may be used to separate the components of the path.
+      const filename = unsafeFilename.replace(/[^a-zA-Z0-9_]+/g, "-");
+
+      if (true === browser["screenshots-taken"].has(filename)) {
+        throw Error(`A screenshot with this name was already taken: '${filename}'`);
       }
-      browser["screenshots-taken"].add(name);
+      browser["screenshots-taken"].add(filename);
 
       const SCREENSHOTS_DIR = "screenshots";
       if (!(existsSync(SCREENSHOTS_DIR) as boolean)) {
@@ -23,12 +29,17 @@ export const config: WebdriverIO.Config = {
       }
 
       await browser.saveScreenshot(
-        `${SCREENSHOTS_DIR}/${countStr}-${name}.png`
+        `${SCREENSHOTS_DIR}/${filename}.png`
       );
     });
   },
 
-  afterTest: function (test, context, { error }) {
+  beforeSuite: (suite) => {
+    browser["screenshot-prefix"] = suite.fullTitle;
+    browser["screenshot-count"] = 0;
+  },
+
+  afterTest: function (test, context, {error}) {
     // Take a screenshot anytime a test fails and throws an error.
     // Note: We could also use `result !== 0` or `passed === true`.
     //       The reason for conditioning on an error is that if
@@ -39,7 +50,7 @@ export const config: WebdriverIO.Config = {
     if (undefined !== error) {
       // Filenames containing spaces are painful to work with on the command line,
       // so we replace any spaces in the test name when we create the screenshot.
-      browser["screenshot"](`test-fail-${test.title.replace(/ /g, "-")}`);
+      browser["screenshot"](`test-fail_${test.title}`);
     }
   },
 


### PR DESCRIPTION
# Motivation
- Screenshot filenames are not being sanitized.  This means that if an exception were thrown in a test with funny characters in its name, e.g. `Redirects /#/canisters -> /v2/#/canisters`, the screenshot code would try to write a file incorporating that string in its name.  This could go wrong.
- The screenshot counter was global, which meant that if a subset of specs were run, the counter would not match.

# Changes
- Sanitize filenames
- Restart the counter with each test suite.

# Tests
- I added `throw Error("Foo")` into the first line of the redirects test.
- I chose this test as it has non-alphanumeric characters in the test name.
- Running that test suite with: `LOG_LEVEL=warn ./scripts/test-winning` yielded these screenshots:
  ```
  landing-page_00_landing-page.png
  landing-page_01_home-page.png
  redirects_00_test-fail_goes-to-accounts-page-after-registration.png
  redirects_01_test-fail_Redirects-accounts-v2-accounts.png
  redirects_02_test-fail_Redirects-neurons-v2-neurons.png
  redirects_03_test-fail_Redirects-proposals-v2-proposals.png
  etc
  ```