### PR TITLE
feat: re-filter proposals returned by governance canister

### DIFF
--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -32,12 +32,18 @@
     });
   };
 
-  // HACK: the governance canister does not implement a filter to hide proposals where all neurons have voted or are ineligible.
-  // That's why we hide these proposals on the client side only.
+  // HACK:
+  //
+  // 1. the governance canister does not implement a filter to hide proposals where all neurons have voted or are ineligible.
+  // 2. the governance canister interprets queries with empty filter (e.g. topics=[]) has "any" queries and returns proposals anyway. On the contrary, the Flutter app displays nothing if one filter is empty.
+  // 3. the Flutter app does not simply display nothing when a filter is empty but re-filter the results provided by the backend.
+  //
+  // That's why we hide and re-process these proposals delivered by the backend on the client side.
+  //
   // We do not filter these types of proposals from the list but "only" hide these because removing them from the list is not compatible with an infinite scroll feature.
   let hide: boolean;
   $: hide = hideProposal({
-    excludeVotedProposals: $proposalsFiltersStore.excludeVotedProposals,
+    filters: $proposalsFiltersStore,
     proposalInfo,
   });
 </script>

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -36,7 +36,7 @@ const handleFindProposalsError = ({ error, certified }) => {
 
   // Explicitly handle only UPDATE errors
   if (certified === true) {
-    proposalsStore.setProposals([]);
+    proposalsStore.setProposals({ proposals: [], certified });
 
     toastsStore.show({
       labelKey: "error.list_proposals",
@@ -49,7 +49,7 @@ const handleFindProposalsError = ({ error, certified }) => {
 export const listProposals = async (): Promise<void> => {
   return findProposals({
     beforeProposal: undefined,
-    onLoad: ({ response: proposals }) => proposalsStore.setProposals(proposals),
+    onLoad: ({ response: proposals, certified }) => proposalsStore.setProposals({proposals, certified}),
     onError: handleFindProposalsError,
   });
 };

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -6,6 +6,10 @@ import type {
   ProposalInfo,
 } from "@dfinity/nns";
 import { ProposalStatus, Vote } from "@dfinity/nns";
+import type {
+  ProposalsFiltersStore,
+  ProposalsStore,
+} from "../stores/proposals.store";
 import { isDefined, stringifyJson } from "./utils";
 
 export const emptyProposals = ({ length }: ProposalInfo[]): boolean =>
@@ -62,16 +66,53 @@ export const formatProposalSummary = (summary: string): string => {
   );
 };
 
+export const hideProposal = ({
+  proposalInfo,
+  filters,
+}: {
+  proposalInfo: ProposalInfo;
+  filters: ProposalsFiltersStore;
+}): boolean =>
+  !matchFilters({ proposalInfo, filters }) ||
+  isExcludedVotedProposal({ proposalInfo, filters });
+
+/**
+ * Does the proposal returned by the backend really matches the filter selected by the user?
+ */
+const matchFilters = ({
+  proposalInfo,
+  filters,
+}: {
+  proposalInfo: ProposalInfo;
+  filters: ProposalsFiltersStore;
+}): boolean => {
+  const { topics, rewards, status } = filters;
+
+  const {
+    topic: proposalTopic,
+    status: proposalStatus,
+    rewardStatus,
+  } = proposalInfo;
+
+  return (
+    topics.includes(proposalTopic) &&
+    rewards.includes(rewardStatus) &&
+    status.includes(proposalStatus)
+  );
+};
+
 /**
  * Hide a proposal if checkbox "excludeVotedProposals" is selected and the proposal is OPEN and has at least one UNSPECIFIED ballots' vote.
  */
-export const hideProposal = ({
+const isExcludedVotedProposal = ({
   proposalInfo,
-  excludeVotedProposals,
+  filters,
 }: {
   proposalInfo: ProposalInfo;
-  excludeVotedProposals: boolean;
+  filters: ProposalsFiltersStore;
 }): boolean => {
+  const { excludeVotedProposals } = filters;
+
   const { status, ballots } = proposalInfo;
   const containsUnspecifiedBallot = (): boolean =>
     // Sometimes ballots contains all neurons with Vote.UNSPECIFIED
@@ -91,23 +132,18 @@ export const hideProposal = ({
  */
 export const hasMatchingProposals = ({
   proposals,
-  excludeVotedProposals,
+  filters,
 }: {
   proposals: ProposalInfo[];
-  excludeVotedProposals: boolean;
+  filters: ProposalsFiltersStore;
 }): boolean => {
   if (proposals.length === 0) {
     return false;
   }
 
-  if (!excludeVotedProposals) {
-    return true;
-  }
-
   return (
     proposals.find(
-      (proposalInfo: ProposalInfo) =>
-        !hideProposal({ proposalInfo, excludeVotedProposals })
+      (proposalInfo: ProposalInfo) => !hideProposal({ proposalInfo, filters })
     ) !== undefined
   );
 };

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -38,7 +38,7 @@
 
     try {
       await listNextProposals({
-        beforeProposal: lastProposalId($proposalsStore),
+        beforeProposal: lastProposalId($proposalsStore.proposals),
       });
     } catch (err: unknown) {
       toastsStore.error({
@@ -85,7 +85,10 @@
 
     // If the previous page is the proposal detail page and if we have proposals in store, we don't reset and query the proposals after mount.
     // We do this to smoothness the back and forth navigation between this page and the detail page.
-    if (!emptyProposals($proposalsStore) && isReferrerProposalDetail) {
+    if (
+      !emptyProposals($proposalsStore.proposals) &&
+      isReferrerProposalDetail
+    ) {
       initDebounceFindProposals();
 
       return;
@@ -111,7 +114,7 @@
 
       // Show spinner right away avoiding debounce
       loading = true;
-      proposalsStore.setProposals([]);
+      proposalsStore.setProposals({ proposals: [], certified: undefined });
 
       debounceFindProposals?.();
     }
@@ -119,14 +122,23 @@
 
   onDestroy(unsubscribe);
 
+  const updateNothingFound = () => {
+    // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches
+    if ($proposalsStore.certified !== true) {
+      return;
+    }
+
+    nothingFound =
+      initialized &&
+      !loading &&
+      !hasMatchingProposals({
+        proposals: $proposalsStore.proposals,
+        filters: $proposalsFiltersStore,
+      });
+  };
+
   let nothingFound: boolean;
-  $: nothingFound =
-    initialized &&
-    !loading &&
-    !hasMatchingProposals({
-      proposals: $proposalsStore,
-      excludeVotedProposals: $proposalsFiltersStore.excludeVotedProposals,
-    });
+  $: initialized, loading, $proposalsStore, (() => updateNothingFound())();
 </script>
 
 {#if SHOW_PROPOSALS_ROUTE}
@@ -137,7 +149,7 @@
       <ProposalsFilters />
 
       <InfiniteScroll on:nnsIntersect={findNextProposals}>
-        {#each $proposalsStore as proposalInfo (proposalInfo.id)}
+        {#each $proposalsStore.proposals as proposalInfo (proposalInfo.id)}
           <ProposalCard {hidden} {proposalInfo} />
         {/each}
       </InfiniteScroll>


### PR DESCRIPTION
# Motivation

The governance canister interprets queries with empty filter (e.g. topics=[]) has "any" queries and returns proposals anyway. On the contrary, the Flutter app displays nothing if one filter is empty.

The Flutter app does not simply display nothing when a filter is empty but re-filter the results provided by the backend.

This PR aims to reproduce the same behavior as Flutter app.

# Note

We could have implemented a feature that just empty the proposals store if no filters is provided - i.e. no backend query if filter is empty but we cannot be 100% sure it ultimately matches the exact same behavior as Flutter in production.

In addition, since we also implemented certified queries, this can also lead to some glitch if users changes the filters selection often really quickly.

Speaking of, if we stick to update calls, we might someday implement a feature that disable the filters selection until the certified queries are finished. Like "Please wait to update your filters until data are certified". For the future.

# Edge case glitch

An edge case glitch might happen when user search filter X, update calls take long, user modify filter Y meanwhile and returned call is re-processed with filter Y until ultimately the second update calls kicks. Not wrong but user might experience a UX that does "display results -> nothing found -> displayed results". This PR however try to minimize this by updating the "Nothing found" info only if the store is certified.

# Changes

- re-process the returned proposals of the governance canister - i.e. checks if content matches currently selected filters
- add `certified` info to store
- process "nothing found" info only if store is certified
