### PR TITLE
fix: broken summary layout (too wide <pre>)

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
@@ -30,5 +30,10 @@
       line-height: var(--line-height-standard);
       text-decoration: none;
     }
+
+    :global(pre) {
+      // make the <code> scrollable
+      overflow-x: auto;
+    }
   }
 </style>

--- a/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposals/BallotSummary.svelte
@@ -53,5 +53,10 @@
   .summary {
     grid-column-start: 1;
     grid-column-end: 3;
+    // fix broken layout with too long urls in summary
+    word-break: break-word;
+    // Fix too wide <pre> with code-blocks
+    // (By default, flex items won’t shrink below their minimum content size)
+    min-width: 0;
   }
 </style>


### PR DESCRIPTION
# Motivation

Fix broken layout in proposal summary

# Before

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/98811342/162976966-bc1d5cdd-3819-4e36-8167-44b6c9fcdc9f.png">

# After

https://www.loom.com/share/a326ded572f04af9a1e90e587b7707d1