### PR TITLE
feat: do not provide "Unspecified" as proposal filter option

### DIFF
--- a/frontend/svelte/src/lib/modals/proposals/ProposalsFilterModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposalsFilterModal.svelte
@@ -14,7 +14,7 @@
     ProposalStatus,
     Topic,
   } from "@dfinity/nns";
-  import { PROPOSAL_FILTER_UNDEFINED_VALUE } from "../../types/proposals";
+  import { PROPOSAL_FILTER_UNSPECIFIED_VALUE } from "../../types/proposals";
 
   export let props: ProposalsFilterModalProps | undefined;
 
@@ -29,7 +29,7 @@
   $: filters = props?.filters;
   $: filtersValues = filters
     ? enumValues(filters).filter(
-        (value) => value !== PROPOSAL_FILTER_UNDEFINED_VALUE
+        (value) => value !== PROPOSAL_FILTER_UNSPECIFIED_VALUE
       )
     : [];
   $: selectedFilters = props?.selectedFilters || [];

--- a/frontend/svelte/src/lib/modals/proposals/ProposalsFilterModal.svelte
+++ b/frontend/svelte/src/lib/modals/proposals/ProposalsFilterModal.svelte
@@ -14,17 +14,24 @@
     ProposalStatus,
     Topic,
   } from "@dfinity/nns";
+  import { PROPOSAL_FILTER_UNDEFINED_VALUE } from "../../types/proposals";
 
   export let props: ProposalsFilterModalProps | undefined;
 
   let visible: boolean;
   let category: string;
   let filters: ProposalsFilters | undefined;
+  let filtersValues: number[];
   let selectedFilters: (Topic | ProposalRewardStatus | ProposalStatus)[];
 
   $: visible = props !== undefined;
   $: category = props?.category ?? "uncategorized";
   $: filters = props?.filters;
+  $: filtersValues = filters
+    ? enumValues(filters).filter(
+        (value) => value !== PROPOSAL_FILTER_UNDEFINED_VALUE
+      )
+    : [];
   $: selectedFilters = props?.selectedFilters || [];
 
   const dispatch = createEventDispatcher();
@@ -75,7 +82,7 @@
   <span slot="title">{$i18n.voting?.[category] ?? ""}</span>
 
   {#if filters}
-    {#each enumValues(filters) as key (key)}
+    {#each filtersValues as key (key)}
       <Checkbox
         inputId={`${key}`}
         checked={selectedFilters.includes(key)}

--- a/frontend/svelte/src/lib/types/proposals.ts
+++ b/frontend/svelte/src/lib/types/proposals.ts
@@ -10,3 +10,5 @@ export interface ProposalsFilterModalProps {
   filters: ProposalsFilters;
   selectedFilters: (Topic | ProposalRewardStatus | ProposalStatus)[];
 }
+
+export const PROPOSAL_FILTER_UNDEFINED_VALUE = 0;

--- a/frontend/svelte/src/lib/types/proposals.ts
+++ b/frontend/svelte/src/lib/types/proposals.ts
@@ -11,4 +11,4 @@ export interface ProposalsFilterModalProps {
   selectedFilters: (Topic | ProposalRewardStatus | ProposalStatus)[];
 }
 
-export const PROPOSAL_FILTER_UNDEFINED_VALUE = 0;
+export const PROPOSAL_FILTER_UNSPECIFIED_VALUE = 0;

--- a/frontend/svelte/src/tests/lib/modals/proposals/ProposalsFilterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/proposals/ProposalsFilterModal.spec.ts
@@ -42,9 +42,19 @@ describe("ProposalsFilterModal", () => {
       props,
     });
 
-    enumKeys(Topic).forEach((key: string) =>
-      expect(getByText(en.topics[key])).toBeInTheDocument()
-    );
+    enumKeys(Topic)
+      .filter((key: string) => key !== "Unspecified")
+      .forEach((key: string) =>
+        expect(getByText(en.topics[key])).toBeInTheDocument()
+      );
+  });
+
+  it("should not render filter Unspecified", () => {
+    const { getByText } = render(ProposalsFilterModal, {
+      props,
+    });
+
+    expect(() => getByText(en.topics.Unspecified)).toThrow();
   });
 
   it("should forward close modal event", (done) => {
@@ -86,6 +96,7 @@ describe("ProposalsFilterModal", () => {
     button && (await fireEvent.click(button));
 
     const selectedTopics = get(proposalsFiltersStore).topics;
-    expect(selectedTopics).toEqual([...DEFAULT_PROPOSALS_FILTERS.topics, 0, 1]);
+
+    expect(selectedTopics).toEqual([...DEFAULT_PROPOSALS_FILTERS.topics, 1, 2]);
   });
 });


### PR DESCRIPTION
# Motivation

We shouldn't include Unknown or Unspecified as options for the filters, since those values should never appear on proposal fields.

# Changes

- do not provide `Unspecified` respectively `0` value as option for the proposal filters
