### PR TITLE
style: sort stake neuron information

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -6,12 +6,9 @@
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { startBusy, stopBusy } from "../../stores/busy.store";
-  import {
-    formatICP,
-    formattedTransactionFeeICP,
-    maxICP,
-  } from "../../utils/icp.utils";
+  import { formattedTransactionFeeICP, maxICP } from "../../utils/icp.utils";
   import AmountInput from "../ui/AmountInput.svelte";
+  import CurrentBalance from "../accounts/CurrentBalance.svelte";
 
   export let account: Account;
   let amount: number;
@@ -43,7 +40,13 @@
   const stakeMaximum = () => (amount = max);
 </script>
 
-<div class="wizard-wrapper">
+<form on:submit|preventDefault={createNeuron} class="wizard-wrapper">
+  <div class="head">
+    <CurrentBalance balance={account.balance} />
+
+    <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} />
+  </div>
+
   <div>
     <h5>{$i18n.neurons.source}</h5>
     <small class="identifier">{account.identifier}</small>
@@ -55,67 +58,33 @@
       <span>ICP</span>
     </small>
   </div>
-  <div class="form">
-    <p class="title">{$i18n.neurons.current_balance}</p>
-    <h4 class="balance">
-      {`${formatICP(account.balance.toE8s())}`}
-    </h4>
-    <form on:submit|preventDefault={createNeuron}>
-      <AmountInput bind:amount on:nnsMax={stakeMaximum} {max} />
 
-      <small>{$i18n.neurons.may_take_while}</small>
-      <!-- TODO: L2-252 -->
-      <button
-        class="primary full-width"
-        type="submit"
-        data-tid="create-neuron-button"
-        disabled={amount === undefined || amount <= 0 || creating}
-      >
-        {#if creating}
-          <Spinner />
-        {:else}
-          {$i18n.neurons.create}
-        {/if}
-      </button>
-    </form>
-  </div>
-</div>
+  <small>{$i18n.neurons.may_take_while}</small>
+  <!-- TODO: L2-252 -->
+  <button
+    class="primary full-width"
+    type="submit"
+    data-tid="create-neuron-button"
+    disabled={amount === undefined || amount <= 0 || creating}
+  >
+    {#if creating}
+      <Spinner />
+    {:else}
+      {$i18n.neurons.create}
+    {/if}
+  </button>
+</form>
 
 <style lang="scss">
+  @use "../../themes/mixins/modal";
+
+  .head {
+    @include modal.header;
+  }
+
   small {
     word-break: break-all;
-  }
-
-  .form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    .title {
-      color: var(--gray-400);
-      font-size: var(--font-size-h3);
-    }
-
-    .balance {
-      font-size: var(--font-size-h1);
-    }
-  }
-
-  form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    width: 100%;
-    --input-width: 100%;
-
-    small {
-      margin-top: var(--padding-2x);
-    }
-
-    button[type="submit"] {
-      margin-top: var(--padding);
-    }
+    text-align: center;
   }
 
   .transaction-fee {


### PR DESCRIPTION
# Motivation

Unify display of current balance and input field to enter amount on "New transaction" and "Create neuron" wizard modal.

Discussed with Mischa: balance and field comes first, therefore this PR sort the elements of the "Stake neuron" step accordingly.

# Changes

- sort elements and remove unused div

# Screenshots

Before:

<img width="1271" alt="Capture d’écran 2022-04-13 à 17 13 40" src="https://user-images.githubusercontent.com/16886711/163213191-bdb0f213-1f5a-4921-9f9c-af267b9a0d3b.png">

After:

<img width="1271" alt="Capture d’écran 2022-04-13 à 17 13 20" src="https://user-images.githubusercontent.com/16886711/163213227-cd4527a5-b17d-49a9-a022-630a79be74f7.png">
