### PR TITLE
feat: display fee only on amount step

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -72,7 +72,7 @@
     <AmountInput bind:amount on:nnsMax={onMax} {max} />
   </div>
 
-  <NewTransactionInfo />
+  <NewTransactionInfo feeOnly={true} />
 
   <button class="primary full-width" type="submit" disabled={!validForm}>
     {$i18n.accounts.review_transaction}

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionInfo.svelte
@@ -9,17 +9,21 @@
     NEW_TRANSACTION_CONTEXT_KEY
   );
   const { store }: TransactionContext = context;
+
+  export let feeOnly: boolean = false;
 </script>
 
-<h5>{$i18n.accounts.source}</h5>
-<p>{$store.selectedAccount?.identifier ?? ""}</p>
+{#if !feeOnly}
+  <h5>{$i18n.accounts.source}</h5>
+  <p>{$store.selectedAccount?.identifier ?? ""}</p>
 
-<h5>{$i18n.accounts.destination}</h5>
-<p>{$store.destinationAddress ?? ""}</p>
+  <h5>{$i18n.accounts.destination}</h5>
+  <p>{$store.destinationAddress ?? ""}</p>
+{/if}
 
 <h5>{$i18n.accounts.transaction_fee}</h5>
 
-<p>{formattedTransactionFeeICP()} ICP</p>
+<p class="fee">{formattedTransactionFeeICP()} ICP</p>
 
 <style lang="scss">
   h5 {
@@ -29,5 +33,9 @@
   p {
     margin: 0 0 var(--padding-0_5x);
     word-wrap: break-word;
+  }
+
+  .fee {
+    flex-grow: 1;
   }
 </style>

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -38,11 +38,10 @@ describe("NewTransactionAmount", () => {
     });
   });
 
-  it("should render a source transaction", () => {
+  it("should not render a source transaction", () => {
     const { getByText } = render(NewTransactionTest, { props });
 
-    // More tests about details are provided in NewTransactionInfo.spec.ts
-    expect(getByText(en.accounts.source)).toBeTruthy();
+    expect(() => getByText(en.accounts.source)).toThrow();
   });
 
   it("should render current balance", () => {


### PR DESCRIPTION
# Motivation

In the "New transaction" wizard displaying "source" and "destination" information on the "amount" step does not particularly add much values because the next step is a "review" step that repeat these information.

Discussed wish Mischa.

# Changes

- display only the "fee" on amount step and "fee+source+destination" on "review step"

# Screenshot

Before:

<img width="1271" alt="Capture d’écran 2022-04-13 à 17 16 21" src="https://user-images.githubusercontent.com/16886711/163213826-51d030e3-12d5-41ca-aad6-fb7c8920b05d.png">

After:

<img width="1271" alt="Capture d’écran 2022-04-13 à 17 16 04" src="https://user-images.githubusercontent.com/16886711/163213853-185d72a7-004f-4ffb-bff7-21353e7a5870.png">

