### PR TITLE
Feat/proposals qu error handling

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
@@ -16,6 +16,7 @@
       await loadProposal({
         proposalId: ballot.proposalId as ProposalId,
         setProposal: (proposalInfo: ProposalInfo) => (proposal = proposalInfo),
+        silentErrorMessages: true,
       })
   );
 </script>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -37,7 +37,6 @@
     "accounts_not_found": "An error occurred while loading the accounts information.",
     "fail": "fail",
     "join_community_fund": "Sorry, there was an error joining the community fund. Please try again later.",
-    "suspicious_response": "Suspicious response detected. Page reload suggested.",
     "dummy_proposal": "There was an error creating the proposals. Check the console for more details.",
     "update_delay": "Sorry, there was an error updating the delay of the neuron",
     "unknown": "Sorry, there was an unexpected error. Please try again later.",

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -108,11 +108,7 @@ const findProposals = async ({
       return;
     }
 
-    console.error("suspisious u->t", untrustedProposals, trustedProposals);
-    toastsStore.show({
-      labelKey: "error.suspicious_response",
-      level: "error",
-    });
+    console.error("query != update", untrustedProposals, trustedProposals);
 
     // Remove proven untrusted proposals (in query but not in update)
     const proposalsToRemove = excludeProposals({

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -149,19 +149,23 @@ export const loadProposal = async ({
   proposalId,
   setProposal,
   handleError,
+  silentErrorMessages,
 }: {
   proposalId: ProposalId;
   setProposal: (proposal: ProposalInfo) => void;
   handleError?: () => void;
+  silentErrorMessages?: boolean;
 }): Promise<void> => {
   const catchError = (error: unknown) => {
     console.error(error);
 
-    toastsStore.show({
-      labelKey: "error.proposal_not_found",
-      level: "error",
-      detail: `id: "${proposalId}"`,
-    });
+    if (silentErrorMessages !== true) {
+      toastsStore.show({
+        labelKey: "error.proposal_not_found",
+        level: "error",
+        detail: `id: "${proposalId}"`,
+      });
+    }
 
     handleError?.();
   };

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -41,7 +41,6 @@ interface I18nError {
   accounts_not_found: string;
   fail: string;
   join_community_fund: string;
-  suspicious_response: string;
   dummy_proposal: string;
   update_delay: string;
   unknown: string;

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -375,30 +375,6 @@ describe("proposals-services", () => {
     });
   });
 
-  describe("suspisious responses", () => {
-    beforeAll(() => {
-      jest.clearAllMocks();
-    });
-
-    it("should display suspicious_response error", async () => {
-      let requestIndex = 0;
-      const spyQueryProposals = jest
-        .spyOn(api, "queryProposals")
-        .mockImplementation(() =>
-          Promise.resolve(mockProposals.slice(requestIndex++))
-        );
-      const spyToastShow = jest.spyOn(toastsStore, "show");
-
-      await listProposals();
-
-      expect(spyQueryProposals).toBeCalled();
-      expect(spyToastShow).toBeCalledWith({
-        labelKey: "error.suspicious_response",
-        level: "error",
-      });
-    });
-  });
-
   describe("filter", () => {
     const spySetProposals = jest.spyOn(proposalsStore, "setProposals");
     const spyPushProposals = jest.spyOn(proposalsStore, "pushProposals");


### PR DESCRIPTION
# Motivation

To not confuse user w/ not critical errors some error messages was hidden.

# Changes

- remove suspicious message (still in dev console)
- To minimize the display of the error "An error occurred while loading proposal id: 55672" we concluded that in a first step we are "just" going to silent the error - i.e. the display of the toast - on the proposer modal. (clarified w/ @peterpeterparker  and Mischa)

# Tests

- remove suspicious message

# Screens

## removed suspicious message
![image](https://user-images.githubusercontent.com/98811342/163377485-1c8cbe31-31e9-4d40-8640-fa560dd62c87.png)
