### PR TITLE
feat: redesign toasts

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -32,11 +32,16 @@
   in:fly={{ y: 100, duration: 200 }}
   out:fade={{ delay: 100 }}
 >
-  <p title={text}>
+  <p>
     {text}
   </p>
 
-  <button on:click={close} aria-label={$i18n.core.close}><IconClose /></button>
+  <button
+    class="close"
+    class:error={level === "error"}
+    class:warning={level === "warn"}
+    on:click={close}>{$i18n.core.close}</button
+  >
 </div>
 
 <style lang="scss">
@@ -47,6 +52,10 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--padding);
+
+    // (>=3 lines x 1rem) + top/bottom paddings
+    height: calc(8.5 * var(--padding));
 
     position: fixed;
     bottom: var(--padding-2x);
@@ -77,26 +86,25 @@
     &.warn {
       background: var(--yellow-500);
       color: var(--yellow-500-contrast);
+
+      button.close {
+        color: var(--yellow-500-contrast);
+      }
     }
   }
 
   p {
-    @include text.clamp(4);
-
     margin: 0;
-    font-size: 1rem;
-
-    @include media.min-width(medium) {
-      @include text.clamp(2);
-    }
+    max-height: 100%;
+    overflow-y: auto;
   }
 
-  button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-
-    padding: 0;
+  button.close {
+    // rewrite default button styles
+    padding: var(--padding-0_5x) var(--padding);
+    min-height: 0;
+    border: 1px solid;
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-h5);
   }
 </style>

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -2,7 +2,6 @@
   /**
    * A toast - snack-bar to display a short info or error message.
    */
-  import IconClose from "../../icons/IconClose.svelte";
   import { toastsStore } from "../../stores/toasts.store";
   import { fade, fly } from "svelte/transition";
   import { translate } from "../../utils/i18n.utils";

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -5,6 +5,7 @@
 import { render } from "@testing-library/svelte";
 import Toast from "../../../../lib/components/ui/Toast.svelte";
 import type { ToastMsg } from "../../../../lib/types/toast";
+import en from "../../../mocks/i18n.mock";
 
 describe("Toast", () => {
   const props: { msg: ToastMsg } = {
@@ -22,13 +23,13 @@ describe("Toast", () => {
   });
 
   it("should render a close button", async () => {
-    const { getByRole } = render(Toast, {
+    const { getByText } = render(Toast, {
       props,
     });
 
-    const button = getByRole("button");
+    const button = getByText(en.core.close);
 
-    expect(button?.getAttribute("aria-label")).toEqual("Close");
+    expect(button).toBeInTheDocument();
   });
 
   it("should render details", async () => {
@@ -39,15 +40,5 @@ describe("Toast", () => {
     const p: HTMLParagraphElement | null = container.querySelector("p");
 
     expect(p?.textContent).toContain("more details");
-  });
-
-  it("should render title", async () => {
-    const { container } = render(Toast, {
-      props,
-    });
-
-    const elementWithTitle: HTMLParagraphElement | null =
-      container.querySelector('[title="Close more details"]');
-    expect(elementWithTitle).not.toBeNull();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
@@ -89,9 +89,8 @@ describe("Toasts", () => {
 
     await waitForDialog(container);
 
-    const button: HTMLButtonElement | null = container.querySelector(
-      'button[aria-label="Close"]'
-    );
+    const button: HTMLButtonElement | null =
+      container.querySelector("button.close");
     button && (await fireEvent.click(button));
 
     await waitFor(() =>


### PR DESCRIPTION
# Motivation

Users seems to not get that the toast messages are not disappearing automatically. After some discussions w/ Mischa the first solution - to replace the ( x ) with more visible call-to-action.

The tooltip was removed and the message visible area was increased to be always 3 lines with a scroll if needed (aligned w/ Mischa)

# Tests

- Design update only, no tests needed.

# Screenshots

## warning
https://user-images.githubusercontent.com/98811342/163381000-8f3699f7-cb7a-4cf0-a3f6-d595c320ae0c.mov

## error
https://user-images.githubusercontent.com/98811342/163381020-18be7817-a74a-4419-9b15-a21c99f765ec.mov

## default
https://user-images.githubusercontent.com/98811342/163381036-0c7ba437-5a29-4a10-974a-94d40d2690bb.mov


