### PR TITLE
Feat: Merge neurons functionality

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/agent": "^0.11.0",
         "@dfinity/auth-client": "^0.11.0",
-        "@dfinity/nns": "^0.4.0-nightly-2022-04-14"
+        "@dfinity/nns": "^0.4.0-nightly-2022-04-19"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.0-nightly-2022-04-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-04-14.tgz",
-      "integrity": "sha512-uwSzvJL+gndLkBbsZBbEDBO/unP1G+NXhXz8a/7MlGnkFWA3cplVLeUBgqj9YEPfL3cjPZEM+RSYYUmeJjn+TQ==",
+      "version": "0.4.0-nightly-2022-04-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-04-19.tgz",
+      "integrity": "sha512-Nrh3zZBg5za9y+9ocbcYaxZ1Bo2PmxIYUgd9LSipkLylhnPCcBavYxesq5QiZhZMg0MUU2EMwuCSF/kmgkcX7Q==",
       "dependencies": {
         "@dfinity/agent": "^0.11.0",
         "@dfinity/candid": "^0.11.0",
@@ -8572,9 +8572,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.0-nightly-2022-04-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-04-14.tgz",
-      "integrity": "sha512-uwSzvJL+gndLkBbsZBbEDBO/unP1G+NXhXz8a/7MlGnkFWA3cplVLeUBgqj9YEPfL3cjPZEM+RSYYUmeJjn+TQ==",
+      "version": "0.4.0-nightly-2022-04-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-04-19.tgz",
+      "integrity": "sha512-Nrh3zZBg5za9y+9ocbcYaxZ1Bo2PmxIYUgd9LSipkLylhnPCcBavYxesq5QiZhZMg0MUU2EMwuCSF/kmgkcX7Q==",
       "requires": {
         "@dfinity/agent": "^0.11.0",
         "@dfinity/candid": "^0.11.0",

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -98,6 +98,23 @@ export const splitNeuron = async ({
   return response;
 };
 
+export const mergeNeurons = async ({
+  sourceNeuronId,
+  targetNeuronId,
+  identity,
+}: {
+  sourceNeuronId: NeuronId;
+  targetNeuronId: NeuronId;
+  identity: Identity;
+}): Promise<NeuronId> => {
+  const { canister } = await governanceCanister({ identity });
+
+  return canister.mergeNeurons({
+    sourceNeuronId,
+    targetNeuronId,
+  });
+};
+
 export const startDissolving = async ({
   neuronId,
   identity,

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -106,7 +106,7 @@ export const mergeNeurons = async ({
   sourceNeuronId: NeuronId;
   targetNeuronId: NeuronId;
   identity: Identity;
-}): Promise<NeuronId> => {
+}): Promise<void> => {
   const { canister } = await governanceCanister({ identity });
 
   return canister.mergeNeurons({

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -107,12 +107,24 @@ export const mergeNeurons = async ({
   targetNeuronId: NeuronId;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(
+    `Merging neurons (${hashCode(sourceNeuronId)}, ${hashCode(
+      targetNeuronId
+    )}) call...`
+  );
   const { canister } = await governanceCanister({ identity });
 
-  return canister.mergeNeurons({
+  const response = await canister.mergeNeurons({
     sourceNeuronId,
     targetNeuronId,
   });
+  logWithTimestamp(
+    `Merging neurons (${hashCode(sourceNeuronId)}, ${hashCode(
+      targetNeuronId
+    )}) complete.`
+  );
+
+  return response;
 };
 
 export const startDissolving = async ({

--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -23,7 +23,7 @@
   );
 
   // Display the "My Accounts" title only when we filter the list
-  let displayTitle;
+  let displayTitle: boolean;
   $: displayTitle = filterIdentifier !== undefined;
 </script>
 

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -39,7 +39,7 @@
         level: "info",
       });
     }
-    loading = true;
+    loading = false;
     dispatcher("nnsClose");
     stopBusy("merge-neurons");
   };

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -2,6 +2,8 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
+  import { mergeNeurons } from "../../services/neurons.services";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
@@ -24,9 +26,22 @@
 
   let loading: boolean = false;
 
-  const mergeNeurons = () => {
-    // TODO: Implement Functionality in next PR
-    console.log("Merging");
+  const merge = async () => {
+    loading = true;
+    startBusy("merge-neurons");
+    const id = await mergeNeurons({
+      targetNeuronId: neurons[0].neuronId,
+      sourceNeuronId: neurons[1].neuronId,
+    });
+    if (id !== undefined) {
+      toastsStore.show({
+        labelKey: "neuron_detail.merge_neurons_success",
+        level: "info",
+      });
+    }
+    loading = true;
+    dispatcher("nnsClose");
+    stopBusy("merge-neurons");
   };
 
   const sectionTitleMapper = [
@@ -59,7 +74,7 @@
     <button
       class="primary full-width"
       data-tid="confirm-merge-neurons-button"
-      on:click={mergeNeurons}
+      on:click={merge}
     >
       {#if loading}
         <Spinner />
@@ -69,7 +84,7 @@
     </button>
   </div>
   <div class="disclaimer">
-    <p>This action is irreversible.</p>
+    <p>{$i18n.neurons.irreversible_action}</p>
   </div>
 </div>
 

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -29,6 +29,8 @@
   const merge = async () => {
     loading = true;
     startBusy("merge-neurons");
+    // We know that neurons has 2 neurons.
+    // We have a check above that closes the modal if not.
     const id = await mergeNeurons({
       targetNeuronId: neurons[0].neuronId,
       sourceNeuronId: neurons[1].neuronId,

--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -22,6 +22,7 @@
   export let role: undefined | "link" | "button" | "checkbox" = undefined;
   export let ariaLabel: string | undefined = undefined;
   export let selected: boolean = false;
+  export let disabled: boolean | undefined = undefined;
 
   // TODO: https://dfinity.atlassian.net/browse/L2-366
   let stateInfo: StateInfo;
@@ -39,7 +40,7 @@
   $: dissolvingTime = getDissolvingTimeInSeconds(neuron);
 </script>
 
-<Card {role} {selected} on:click {ariaLabel}>
+<Card {role} {selected} {disabled} on:click {ariaLabel}>
   <div slot="start" class="lock" data-tid="neuron-card-title">
     <h3>{neuron.neuronId}</h3>
 

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -33,7 +33,7 @@
       return;
     }
     // We only allow the selection of two neurons.
-    if (selectedNeuronIds.length < MAX_NEURONS_MERGED) {
+    if (!isMaxSelection) {
       selectedNeuronIds = [...selectedNeuronIds, neuronId];
     }
   };
@@ -53,27 +53,28 @@
     selectedNeuronIds: NeuronId[],
     neuronId: NeuronId
   ): boolean => selectedNeuronIds.indexOf(neuronId) > -1;
-  const isMaxSelection = (selectedNeuronIds: NeuronId[]) =>
-    selectedNeuronIds.length === MAX_NEURONS_MERGED;
+  let isMaxSelection: boolean;
+  $: isMaxSelection = selectedNeuronIds.length >= MAX_NEURONS_MERGED;
 </script>
 
 <div class="wrapper">
   <ul class="items">
     {#each neuronsData as { neuron, mergeable, messageKey }}
+      {@const isSelected = isNeuronSelected(selectedNeuronIds, neuron.neuronId)}
       <!-- We have four possibilities: -->
       <!-- 1. Maximum number selected and neuron is one of the selected -->
       <!-- 2. Maximum number selected and neuron is NOT one of the selected -->
       <!-- 3. User can still select and neuron is mergeable -->
       <!-- 4. User can still select and neuron is NOT mergeable -->
       <li>
-        {#if isMaxSelection(selectedNeuronIds) && isNeuronSelected(selectedNeuronIds, neuron.neuronId)}
+        {#if isMaxSelection && isSelected}
           <NeuronCard
             on:click={() => toggleNeuronId(neuron.neuronId)}
             role="checkbox"
             selected
             {neuron}
           />
-        {:else if isMaxSelection(selectedNeuronIds) && !isNeuronSelected(selectedNeuronIds, neuron.neuronId)}
+        {:else if isMaxSelection && !isSelected}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
             text={$i18n.neurons.only_merge_two}

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -12,33 +12,19 @@
   import Tooltip from "../ui/Tooltip.svelte";
   import NeuronCard from "./NeuronCard.svelte";
 
-  export let neurons: MergeableNeuron[];
-  //
-  let renderedNeurons = neurons;
-  $: {
-    if (selectedNeuronIds.length === MAX_NEURONS_MERGED) {
-      renderedNeurons = renderedNeurons.map(({ neuron }) => ({
-        neuron,
-        mergeable: selectedNeuronIds.indexOf(neuron.neuronId) > -1,
-        messageKey: "neurons.only_merge_two",
-      }));
-    } else {
-      renderedNeurons = neurons;
-    }
-  }
+  export let neuronsData: MergeableNeuron[];
 
   const dispatcher = createEventDispatcher();
   const confirmSelection = () => {
     dispatcher("nnsSelect", {
       neurons: mapNeuronIds({
         neuronIds: selectedNeuronIds,
-        neurons: neurons.map(({ neuron }) => neuron),
+        neurons: neuronsData.map(({ neuron }) => neuron),
       }),
     });
   };
 
   let selectedNeuronIds: NeuronId[] = [];
-  // We only allow the selection of two neurons.
   const toggleNeuronId = (neuronId: NeuronId): void => {
     if (selectedNeuronIds.includes(neuronId)) {
       selectedNeuronIds = selectedNeuronIds.filter(
@@ -46,6 +32,7 @@
       );
       return;
     }
+    // We only allow the selection of two neurons.
     if (selectedNeuronIds.length < MAX_NEURONS_MERGED) {
       selectedNeuronIds = [...selectedNeuronIds, neuronId];
     }
@@ -56,7 +43,7 @@
     const { isValid, messageKey } = canBeMerged(
       mapNeuronIds({
         neuronIds: selectedNeuronIds,
-        neurons: neurons.map(({ neuron }) => neuron),
+        neurons: neuronsData.map(({ neuron }) => neuron),
       })
     );
     validSelection = isValid;
@@ -72,7 +59,7 @@
 
 <div class="wrapper">
   <ul class="items">
-    {#each renderedNeurons as { neuron, mergeable, messageKey }}
+    {#each neuronsData as { neuron, mergeable, messageKey }}
       <!-- We have four possibilities: -->
       <!-- 1. Maximum number selected and neuron is one of the selected -->
       <!-- 2. Maximum number selected and neuron is NOT one of the selected -->
@@ -103,7 +90,7 @@
         {:else}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
-            text={translate({ labelKey: messageKey })}
+            text={translate({ labelKey: messageKey ?? "error.cannot_merge" })}
           >
             <NeuronCard disabled role="checkbox" {neuron} />
           </Tooltip>

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -64,7 +64,7 @@
       <!-- 1. Maximum number selected and neuron is one of the selected -->
       <!-- 2. Maximum number selected and neuron is NOT one of the selected -->
       <!-- 3. User can still select and neuron is mergeable -->
-      <!-- 4. User can still select but neuron is NOT mergeable -->
+      <!-- 4. User can still select and neuron is NOT mergeable -->
       <li>
         {#if isMaxSelection(selectedNeuronIds) && isNeuronSelected(selectedNeuronIds, neuron.neuronId)}
           <NeuronCard

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -74,7 +74,8 @@
             selected
             {neuron}
           />
-        {:else if isMaxSelection && !isSelected}
+          <!-- Eslint does not understand that `isSelected` is a boolean -->
+        {:else if isMaxSelection && isSelected === false}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
             text={$i18n.neurons.only_merge_two}

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -59,7 +59,7 @@
 
 <div class="wrapper">
   <ul class="items">
-    {#each neuronsData as { neuron, mergeable, messageKey }}
+    {#each neuronsData as { neuron, mergeable, messageKey } (neuron.neuronId)}
       {@const isSelected = isNeuronSelected(selectedNeuronIds, neuron.neuronId)}
       <!-- We have four possibilities: -->
       <!-- 1. Maximum number selected and neuron is one of the selected -->

--- a/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeurons.svelte
@@ -90,7 +90,7 @@
         {:else}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
-            text={translate({ labelKey: messageKey ?? "error.cannot_merge" })}
+            text={translate({ labelKey: messageKey ?? "error.not_mergeable" })}
           >
             <NeuronCard disabled role="checkbox" {neuron} />
           </Tooltip>
@@ -109,7 +109,9 @@
     <!-- Show the error only when there are two selected neurons -->
     {#if !validSelection && selectedNeuronIds.length === MAX_NEURONS_MERGED}
       <p>
-        {translate({ labelKey: errorLabelKey ?? "error.cannot_merge" })}
+        {translate({
+          labelKey: errorLabelKey ?? "error.cannot_merge_check_article",
+        })}
         <a
           href="https://medium.com/dfinity/internet-computer-nns-neurons-can-now-be-merged-8b4e44584dc2"
           target="_blank"

--- a/frontend/svelte/src/lib/components/ui/Card.svelte
+++ b/frontend/svelte/src/lib/components/ui/Card.svelte
@@ -2,6 +2,7 @@
   export let role: "link" | "button" | "checkbox" | undefined = undefined;
   export let ariaLabel: string | undefined = undefined;
   export let selected: boolean = false;
+  export let disabled: boolean | undefined = undefined;
 
   let clickable: boolean = false;
 
@@ -21,6 +22,8 @@
   on:click
   class:clickable
   class:selected
+  class:disabled
+  aria-disabled={disabled}
   aria-checked={ariaChecked}
   aria-label={ariaLabel}
 >
@@ -55,10 +58,18 @@
     &.selected {
       border: 2px solid var(--blue-500);
     }
+
+    &.disabled {
+      background: var(--background-hover);
+    }
   }
 
   .clickable {
     @include interaction.tappable;
+
+    &.disabled {
+      @include interaction.disabled;
+    }
 
     &:focus,
     &:hover {

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -48,15 +48,18 @@
     "transaction_no_destination_address": "No destination address has been selected to execute the transaction.",
     "transaction_error": "Sorry, there was an error trying to execute the transaction.",
     "unexpected_number_neurons_merge": "Sorry, the number of neurons to merge should be only 2. Please try selecting again.",
-    "cannot_merge": "Those two neurons cannot be merged. Check the article: ",
+    "cannot_merge": "Those two neurons cannot be merged.",
+    "cannot_merge_check_article": "Those two neurons cannot be merged. Check the article: ",
     "split_neuron": "Sorry, there was an unexpected error splitting the neuron. Please try again later.",
     "not_authorized": "Sorry, you are not authorized to perform this action.",
     "invalid_sender": "Sorry, you can't send funds from this account.",
     "insufficient_funds": "Sorry, there are not enough funds in this account",
     "transfer_error": "Sorry, there was an error with the transaction. Please try again later.",
+    "governance_error": "Sorry, there was an error. Please try again later.",
     "merge_neurons_same_id": "Two neurons with same id can't be merged. Check the article for more: ",
     "merge_neurons_not_same_controller": "Two neurons need to have the same controller. Check the article for more: ",
-    "merge_neurons_not_same_manage_neuron_followees": "Two neurons need to have the same followees on the topic of \"Manage Neuron\". Check the article for more: "
+    "merge_neurons_not_same_manage_neuron_followees": "Two neurons need to have the same followees on the topic of \"Manage Neuron\". Check the article for more: ",
+    "not_mergeable": "This neuron can't be merged."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."
@@ -150,7 +153,8 @@
     "split_neuron_success": "Neuron successfully splitted.",
     "cannot_merge_neuron_community": "Neurons that joined the Community Fund can't be merged.",
     "cannot_merge_neuron_hotkey": "You cannot merge neurons controlled by hotkey",
-    "only_merge_two": "You can only merge two neurons at a time."
+    "only_merge_two": "You can only merge two neurons at a time.",
+    "irreversible_action": "This action is irreversible."
   },
   "new_followee": {
     "title": "Enter New Followee",
@@ -296,8 +300,9 @@
     "follow_neurons": "Follow Neurons",
     "no_ballots": "No recent ballots",
     "split_neuron_confirm": "Confirm Split",
-    "split_neuron_success": "Your neuron has successfully been splitted.",
-    "split_neuron_disabled_tooltip": "Neuron needs a minimum stake of $amount ICP to be splittable."
+    "split_neuron_success": "Your neuron has been successfully splitted.",
+    "split_neuron_disabled_tooltip": "Neuron needs a minimum stake of $amount ICP to be splittable.",
+    "merge_neurons_success": "Your neurons have been successfully merged."
   },
   "time": {
     "year": "year",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -53,7 +53,10 @@
     "not_authorized": "Sorry, you are not authorized to perform this action.",
     "invalid_sender": "Sorry, you can't send funds from this account.",
     "insufficient_funds": "Sorry, there are not enough funds in this account",
-    "transfer_error": "Sorry, there was an error with the transaction. Please try again later."
+    "transfer_error": "Sorry, there was an error with the transaction. Please try again later.",
+    "merge_neurons_same_id": "Two neurons with same id can't be merged. Check the article for more: ",
+    "merge_neurons_not_same_controller": "Two neurons need to have the same controller. Check the article for more: ",
+    "merge_neurons_not_same_manage_neuron_followees": "Two neurons need to have the same followees on the topic of \"Manage Neuron\". Check the article for more: "
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."
@@ -144,7 +147,9 @@
     "confirm_delay": "Confirm and Update Delay",
     "dissolve_delay_success": "Dissolve delay successfully updated.",
     "merge_neurons_article_title": "IC NNS Neurons Can Now Be Merged",
-    "split_neuron_success": "Neuron successfully splitted."
+    "split_neuron_success": "Neuron successfully splitted.",
+    "cannot_merge_neuron_community": "Neurons that joined the Community Fund can't be merged.",
+    "only_merge_two": "You can only merge two neurons at a time."
   },
   "new_followee": {
     "title": "Enter New Followee",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -149,6 +149,7 @@
     "merge_neurons_article_title": "IC NNS Neurons Can Now Be Merged",
     "split_neuron_success": "Neuron successfully splitted.",
     "cannot_merge_neuron_community": "Neurons that joined the Community Fund can't be merged.",
+    "cannot_merge_neuron_hotkey": "You cannot merge neurons controlled by hotkey",
     "only_merge_two": "You can only merge two neurons at a time."
   },
   "new_followee": {

--- a/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -79,7 +79,7 @@
   {/if}
   {#if currentStep?.name === "ConfirmMerge"}
     {#if selectedNeurons !== undefined}
-      <ConfirmNeuronsMerge neurons={selectedNeurons} />
+      <ConfirmNeuronsMerge neurons={selectedNeurons} on:nnsClose />
     {/if}
   {/if}
 </WizardModal>

--- a/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -7,17 +7,18 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { definedNeuronsStore } from "../../stores/neurons.store";
   import {
-    mergeableNeurons,
+    mapMergeableNeurons,
     checkInvalidState,
     type InvalidState,
+    type MergeableNeuron,
   } from "../../utils/neuron.utils";
   import { toastsStore } from "../../stores/toasts.store";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
 
-  let neurons: NeuronInfo[];
+  let neurons: MergeableNeuron[];
   // TODO: Add type wrapper to tell whether neuron is mergeable or not.
-  $: neurons = mergeableNeurons($definedNeuronsStore);
+  $: neurons = mapMergeableNeurons($definedNeuronsStore);
 
   let selectedNeurons: NeuronInfo[] | undefined;
 

--- a/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -15,10 +15,13 @@
   import { toastsStore } from "../../stores/toasts.store";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
+  import { authStore } from "../../stores/auth.store";
 
   let neurons: MergeableNeuron[];
-  // TODO: Add type wrapper to tell whether neuron is mergeable or not.
-  $: neurons = mapMergeableNeurons($definedNeuronsStore);
+  $: neurons = mapMergeableNeurons({
+    neurons: $definedNeuronsStore,
+    identity: $authStore.identity,
+  });
 
   let selectedNeurons: NeuronInfo[] | undefined;
 
@@ -72,7 +75,7 @@
       $i18n.neurons.merge_neurons_modal_title}</svelte:fragment
   >
   {#if currentStep?.name === "SelectNeurons"}
-    <SelectNeurons {neurons} on:nnsSelect={handleNeuronSelection} />
+    <SelectNeurons neuronsData={neurons} on:nnsSelect={handleNeuronSelection} />
   {/if}
   {#if currentStep?.name === "ConfirmMerge"}
     {#if selectedNeurons !== undefined}

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -400,6 +400,7 @@ export const mergeNeurons = async ({
   sourceNeuronId: NeuronId;
   targetNeuronId: NeuronId;
 }): Promise<NeuronId | undefined> => {
+  let success = false;
   try {
     const { neuron: neuron1 } = await getIdentityAndNeuronHelper(
       sourceNeuronId
@@ -416,6 +417,7 @@ export const mergeNeurons = async ({
     const identity: Identity = await getIdentityByNeuron(targetNeuronId);
 
     await mergeNeuronsApi({ sourceNeuronId, targetNeuronId, identity });
+    success = true;
 
     await listNeurons({ skipCheck: true });
 
@@ -424,7 +426,7 @@ export const mergeNeurons = async ({
     toastsStore.show(mapNeuronErrorToToastMessage(err));
 
     // To inform there was an error
-    return undefined;
+    return success ? targetNeuronId : undefined;
   }
 };
 

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -12,7 +12,9 @@ export type BusyStateInitiator =
   | "add-followee"
   | "remove-followee"
   | "reload-neurons"
-  | "reload-proposal";
+  | "reload-proposal"
+  | "merge-neurons"
+  | "remove-followee";
 
 /**
  * Store that reflects the app busy state.

--- a/frontend/svelte/src/lib/themes/mixins/_interaction.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_interaction.scss
@@ -7,3 +7,8 @@
   touch-action: initial;
   cursor: initial;
 }
+
+@mixin disabled {
+  cursor: not-allowed;
+  touch-action: none;
+}

--- a/frontend/svelte/src/lib/themes/mixins/_interaction.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_interaction.scss
@@ -11,4 +11,5 @@
 @mixin disabled {
   cursor: not-allowed;
   touch-action: none;
+  pointer-events: none;
 }

--- a/frontend/svelte/src/lib/types/errors.ts
+++ b/frontend/svelte/src/lib/types/errors.ts
@@ -5,3 +5,5 @@ export class NotAuthorizedError extends Error {}
 export class InvalidAmountError extends Error {}
 
 export class InsufficientAmountError extends Error {}
+
+export class CannotBeMerged extends Error {}

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -58,6 +58,9 @@ interface I18nError {
   invalid_sender: string;
   insufficient_funds: string;
   transfer_error: string;
+  merge_neurons_same_id: string;
+  merge_neurons_not_same_controller: string;
+  merge_neurons_not_same_manage_neuron_followees: string;
 }
 
 interface I18nWarning {
@@ -155,6 +158,8 @@ interface I18nNeurons {
   dissolve_delay_success: string;
   merge_neurons_article_title: string;
   split_neuron_success: string;
+  cannot_merge_neuron_community: string;
+  only_merge_two: string;
 }
 
 interface I18nNew_followee {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -159,6 +159,7 @@ interface I18nNeurons {
   merge_neurons_article_title: string;
   split_neuron_success: string;
   cannot_merge_neuron_community: string;
+  cannot_merge_neuron_hotkey: string;
   only_merge_two: string;
 }
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -53,14 +53,17 @@ interface I18nError {
   transaction_error: string;
   unexpected_number_neurons_merge: string;
   cannot_merge: string;
+  cannot_merge_check_article: string;
   split_neuron: string;
   not_authorized: string;
   invalid_sender: string;
   insufficient_funds: string;
   transfer_error: string;
+  governance_error: string;
   merge_neurons_same_id: string;
   merge_neurons_not_same_controller: string;
   merge_neurons_not_same_manage_neuron_followees: string;
+  not_mergeable: string;
 }
 
 interface I18nWarning {
@@ -161,6 +164,7 @@ interface I18nNeurons {
   cannot_merge_neuron_community: string;
   cannot_merge_neuron_hotkey: string;
   only_merge_two: string;
+  irreversible_action: string;
 }
 
 interface I18nNew_followee {
@@ -320,6 +324,7 @@ interface I18nNeuron_detail {
   split_neuron_confirm: string;
   split_neuron_success: string;
   split_neuron_disabled_tooltip: string;
+  merge_neurons_success: string;
 }
 
 interface I18nTime {

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -7,11 +7,13 @@ import {
   TransferError,
 } from "@dfinity/nns";
 import {
+  CannotBeMerged,
   InsufficientAmountError,
   InvalidAmountError,
   NotAuthorizedError,
   NotFoundError,
 } from "../types/errors";
+import type { ToastMsg } from "../types/toast";
 
 export const errorToString = (err?: unknown): string | undefined =>
   typeof err === "string"
@@ -22,7 +24,7 @@ export const errorToString = (err?: unknown): string | undefined =>
     ? (err as Error).message
     : undefined;
 
-export const mapNeuronErrorToToastMessage = (error: Error): string => {
+export const mapNeuronErrorToToastMessage = (error: Error): ToastMsg => {
   /* eslint-disable-next-line @typescript-eslint/ban-types */
   const collection: Array<[Function, string]> = [
     [NotFoundError, "error.neuron_not_found"],
@@ -33,11 +35,13 @@ export const mapNeuronErrorToToastMessage = (error: Error): string => {
     [InsufficientAmountNNSError, "error.amount_not_enough"],
     [InvalidSenderError, "error.invalid_sender"],
     [InsufficientFundsError, "error.insufficient_funds"],
+    [GovernanceError, "error.governance_error"],
     [TransferError, "error.transfer_error"],
+    [CannotBeMerged, "error.cannot_merge"],
   ];
   const pair = collection.find(([classType]) => error instanceof classType);
   if (pair === undefined) {
-    return "error.unknown";
+    return { labelKey: "error.unknown", level: "error" };
   }
-  return pair[1];
+  return { labelKey: pair[1], detail: errorToString(error), level: "error" };
 };

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -323,24 +323,8 @@ const sameId = (neurons: NeuronInfo[]): boolean =>
  */
 export const allHaveSameFollowees = (
   sortedFolloweesLists: NeuronId[][]
-): boolean => {
-  // If lengths of followes are different, return false
-  const lengths = sortedFolloweesLists.map(({ length }) => length);
-  if (new Set(lengths).size > 1) {
-    return false;
-  }
-  // Compare first list with others lists
-  const firstList = sortedFolloweesLists[0];
-  for (let i = 0; i < firstList.length; i++) {
-    const currentIndexFollowees = sortedFolloweesLists.map(
-      (followees) => followees[i]
-    );
-    if (new Set(currentIndexFollowees).size !== 1) {
-      return false;
-    }
-  }
-  return true;
-};
+): boolean =>
+  new Set(sortedFolloweesLists.map((list) => list.join())).size === 1;
 
 const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
   const fullNeurons: Neuron[] = neurons
@@ -355,8 +339,7 @@ const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
       followees.find(({ topic }) => topic === Topic.ManageNeuron)
     )
     .filter(isDefined)
-    .map(({ followees }) => followees)
-    .sort();
+    .map(({ followees }) => followees.sort());
   // If no neuron has ManageNeuron followees, return true
   if (sortedFollowees.length === 0) {
     return true;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -310,6 +310,38 @@ const sameController = (neurons: NeuronInfo[]): boolean =>
 const sameId = (neurons: NeuronInfo[]): boolean =>
   new Set(neurons.map(({ neuronId }) => neuronId)).size === 1;
 
+/**
+ * Receives multiple lists of followees sorted by id.
+ *
+ * Compares that the followees are all the same.
+ *
+ * @param sortedFolloweesLists NeuronId[][].
+ * For example:
+ *  [[2, 4, 5], [1, 2, 3]] returns `false`
+ *  [[2, 5, 6], [2, 5, 6]] returns `true`
+ * @returns boolean
+ */
+export const allHaveSameFollowees = (
+  sortedFolloweesLists: NeuronId[][]
+): boolean => {
+  // If lengths of followes are different, return false
+  const lengths = sortedFolloweesLists.map(({ length }) => length);
+  if (new Set(lengths).size > 1) {
+    return false;
+  }
+  // Compare first list with others lists
+  const firstList = sortedFolloweesLists[0];
+  for (let i = 0; i < firstList.length; i++) {
+    const currentIndexFollowees = sortedFolloweesLists.map(
+      (followees) => followees[i]
+    );
+    if (new Set(currentIndexFollowees).size !== 1) {
+      return false;
+    }
+  }
+  return true;
+};
+
 const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
   const fullNeurons: Neuron[] = neurons
     .map(({ fullNeuron }) => fullNeuron)
@@ -329,22 +361,8 @@ const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
   if (sortedFollowees.length === 0) {
     return true;
   }
-  // If lengths of followes are different, return false
-  const lengths = sortedFollowees.map(({ length }) => length);
-  if (new Set(lengths).size > 1) {
-    return false;
-  }
-  const firstList = sortedFollowees[0];
-  for (let i = 0; i < firstList.length; i++) {
-    const currentIndexFollowees = sortedFollowees.map(
-      (followees) => followees[i]
-    );
-    if (new Set(currentIndexFollowees).size !== 1) {
-      return false;
-    }
-  }
-  // If we haven't returned is because all sorted lists of followees are the same.
-  return true;
+  // Check that all neurons have same followees
+  return allHaveSameFollowees(sortedFollowees);
 };
 
 export const canBeMerged = (

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -254,7 +254,7 @@ export const isEnoughToStakeNeuron = ({
   stake: ICP;
   withTransactionFee?: boolean;
 }): boolean =>
-  stake.toE8s() > E8S_PER_ICP + (withTransactionFee ? TRANSACTION_FEE_E8S : 0);
+  stake.toE8s() >= E8S_PER_ICP + (withTransactionFee ? TRANSACTION_FEE_E8S : 0);
 
 const isMergeableNeuron = ({
   neuron,

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -258,16 +258,36 @@ export const isEnoughToStakeNeuron = ({
 
 export type MergeableNeuron = {
   mergeable: boolean;
-  messageKey: string;
+  messageKey?: string;
   neuron: NeuronInfo;
 };
-// TODO: use hotkey util when merged
-export const mapMergeableNeurons = (neurons: NeuronInfo[]): MergeableNeuron[] =>
-  neurons.map((neuron: NeuronInfo) => ({
-    neuron,
-    mergeable: !hasJoinedCommunityFund(neuron),
-    messageKey: "neurons.cannot_merge_neuron_community",
-  }));
+export const mapMergeableNeurons = ({
+  neurons,
+  identity,
+}: {
+  neurons: NeuronInfo[];
+  identity?: Identity | null;
+}): MergeableNeuron[] =>
+  neurons
+    .map((neuron: NeuronInfo) => ({
+      neuron,
+      mergeable: !hasJoinedCommunityFund(neuron),
+      messageKey: hasJoinedCommunityFund(neuron)
+        ? "neurons.cannot_merge_neuron_community"
+        : undefined,
+    }))
+    .map(({ neuron, mergeable, messageKey }: MergeableNeuron) => ({
+      neuron,
+      mergeable: !mergeable
+        ? mergeable
+        : !isHotKeyControllable({ neuron, identity }),
+      messageKey:
+        messageKey !== undefined
+          ? messageKey
+          : isHotKeyControllable({ neuron, identity })
+          ? "neurons.cannot_merge_neuron_hotkey"
+          : undefined,
+    }));
 
 const sameController = (neurons: NeuronInfo[]): boolean =>
   new Set(

--- a/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/governance.api.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "jest-mock-extended";
 import {
   increaseDissolveDelay,
   joinCommunityFund,
+  mergeNeurons,
   queryKnownNeurons,
   queryNeuron,
   queryNeurons,
@@ -175,6 +176,39 @@ describe("neurons-api", () => {
         joinCommunityFund({
           identity: mockIdentity,
           neuronId: BigInt(10),
+        });
+      await expect(call).rejects.toThrow(error);
+    });
+  });
+
+  describe("merge", () => {
+    it("merges neurons successfully", async () => {
+      mockGovernanceCanister.mergeNeurons.mockImplementation(
+        jest.fn().mockResolvedValue(undefined)
+      );
+
+      await mergeNeurons({
+        identity: mockIdentity,
+        sourceNeuronId: BigInt(10),
+        targetNeuronId: BigInt(11),
+      });
+
+      expect(mockGovernanceCanister.mergeNeurons).toBeCalled();
+    });
+
+    it("throws error when setting followees fails", async () => {
+      const error = new Error();
+      mockGovernanceCanister.mergeNeurons.mockImplementation(
+        jest.fn(() => {
+          throw error;
+        })
+      );
+
+      const call = () =>
+        mergeNeurons({
+          identity: mockIdentity,
+          sourceNeuronId: BigInt(10),
+          targetNeuronId: BigInt(11),
         });
       await expect(call).rejects.toThrow(error);
     });

--- a/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -144,7 +144,7 @@ describe("MergeNeuronsModal", () => {
   });
 
   it("allows user to select two neurons and merge them", async () => {
-    const { queryAllByTestId, queryByTestId, queryByText, queryAllByText } =
+    const { queryAllByTestId, queryByTestId, queryAllByText } =
       await renderMergeModal(mergeableNeurons);
 
     await selectAndTestTwoNeurons({ queryAllByTestId });

--- a/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -6,17 +6,32 @@ import type { NeuronInfo } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import type { RenderResult } from "@testing-library/svelte";
 import MergeNeuronsModal from "../../../../lib/modals/neurons/MergeNeuronsModal.svelte";
+import { authStore } from "../../../../lib/stores/auth.store";
 import { neuronsStore } from "../../../../lib/stores/neurons.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import {
   buildMockNeuronsStoreSubscribe,
+  mockFullNeuron,
   mockNeuron,
 } from "../../../mocks/neurons.mock";
 
 describe("MergeNeuronsModal", () => {
-  const mergeableNeuron1 = { ...mockNeuron, neuronId: BigInt(10) };
-  const mergeableNeuron2 = { ...mockNeuron, neuronId: BigInt(11) };
+  const controller = mockIdentity.getPrincipal().toText();
+  const mergeableNeuron1 = {
+    ...mockNeuron,
+    neuronId: BigInt(10),
+    fullNeuron: { ...mockFullNeuron, controller },
+  };
+  const mergeableNeuron2 = {
+    ...mockNeuron,
+    neuronId: BigInt(11),
+    fullNeuron: { ...mockFullNeuron, controller },
+  };
   const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
   const renderMergeModal = async (
     neurons: NeuronInfo[]
@@ -24,6 +39,9 @@ describe("MergeNeuronsModal", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe(neurons));
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
     return renderModal({
       component: MergeNeuronsModal,
     });
@@ -32,6 +50,28 @@ describe("MergeNeuronsModal", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  const selectAndTestTwoNeurons = async ({ queryAllByTestId }) => {
+    const neuronCardElements = queryAllByTestId("card");
+    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
+
+    let [neuronElement1, neuronElement2] = neuronCardElements;
+
+    expect(neuronElement2.classList.contains("selected")).toBe(false);
+    expect(neuronElement1.classList.contains("selected")).toBe(false);
+
+    await fireEvent.click(neuronElement1);
+    // Elements might change after every click
+    [neuronElement1, neuronElement2] = queryAllByTestId("card");
+
+    expect(neuronElement1.classList.contains("selected")).toBe(true);
+
+    await fireEvent.click(neuronElement2);
+    // Elements might change after every click
+    [neuronElement1, neuronElement2] = queryAllByTestId("card");
+
+    expect(neuronElement2.classList.contains("selected")).toBe(true);
+  };
 
   it("renders title", async () => {
     const { queryByText } = await renderMergeModal([mockNeuron]);
@@ -58,19 +98,7 @@ describe("MergeNeuronsModal", () => {
   it("allows user to select two neurons", async () => {
     const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
 
-    const neuronCardElements = queryAllByTestId("card");
-    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
-
-    const [neuronElement1, neuronElement2] = neuronCardElements;
-
-    expect(neuronElement1.classList.contains("selected")).toBe(false);
-    expect(neuronElement2.classList.contains("selected")).toBe(false);
-
-    await fireEvent.click(neuronElement1);
-    expect(neuronElement1.classList.contains("selected")).toBe(true);
-
-    await fireEvent.click(neuronElement2);
-    expect(neuronElement2.classList.contains("selected")).toBe(true);
+    await selectAndTestTwoNeurons({ queryAllByTestId });
   });
 
   it("allows user to unselect after selecting a neuron", async () => {
@@ -94,24 +122,14 @@ describe("MergeNeuronsModal", () => {
     const { queryAllByTestId, queryByTestId, queryByText, queryAllByText } =
       await renderMergeModal(mergeableNeurons);
 
-    const neuronCardElements = queryAllByTestId("card");
-    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
-
-    const [neuronElement1, neuronElement2] = neuronCardElements;
-
-    expect(neuronElement1.classList.contains("selected")).toBe(false);
-    expect(neuronElement2.classList.contains("selected")).toBe(false);
-
-    await fireEvent.click(neuronElement1);
-    expect(neuronElement1.classList.contains("selected")).toBe(true);
-
-    await fireEvent.click(neuronElement2);
-    expect(neuronElement2.classList.contains("selected")).toBe(true);
+    await selectAndTestTwoNeurons({ queryAllByTestId });
 
     const button = queryByTestId("merge-neurons-confirm-selection-button");
     expect(button).not.toBeNull();
 
     button && (await fireEvent.click(button));
+
+    // Confirm Screen
     expect(
       queryAllByText(en.neurons.merge_neurons_modal_confirm).length
     ).toBeGreaterThan(0);

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -348,10 +348,10 @@ describe("neurons-services", () => {
   describe("mergeNeurons", () => {
     afterEach(() => {
       jest.clearAllMocks();
-      neuronsStore.setNeurons([]);
+      neuronsStore.setNeurons({ neurons: [], certified: true });
     });
     it("should update neuron", async () => {
-      neuronsStore.pushNeurons(neurons);
+      neuronsStore.pushNeurons({ neurons, certified: true });
       await mergeNeurons({
         sourceNeuronId: neurons[0].neuronId,
         targetNeuronId: neurons[1].neuronId,
@@ -383,7 +383,10 @@ describe("neurons-services", () => {
           controller: "another",
         },
       };
-      neuronsStore.pushNeurons([notControlledNeuron, neuron]);
+      neuronsStore.pushNeurons({
+        neurons: [notControlledNeuron, neuron],
+        certified: true,
+      });
 
       await mergeNeurons({
         sourceNeuronId: notControlledNeuron.neuronId,
@@ -617,7 +620,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if no identity", async () => {
-      neuronsStore.setNeurons([neuronFollowing]);
+      neuronsStore.setNeurons({ neurons: [neuronFollowing], certified: true });
 
       setNoIdentity();
 

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -59,6 +59,14 @@ describe("neurons-services", () => {
       controller: mockIdentity.getPrincipal().toText(),
     },
   };
+  const sameControlledNeuron = {
+    ...mockNeuron,
+    neuronId: BigInt(1234555),
+    fullNeuron: {
+      ...mockFullNeuron,
+      controller: mockIdentity.getPrincipal().toText(),
+    },
+  };
 
   const spyStakeNeuron = jest
     .spyOn(api, "stakeNeuron")
@@ -68,7 +76,7 @@ describe("neurons-services", () => {
     .spyOn(api, "queryNeuron")
     .mockImplementation(() => Promise.resolve(mockNeuron));
 
-  const neurons = [mockNeuron, controlledNeuron];
+  const neurons = [sameControlledNeuron, controlledNeuron];
 
   const spyQueryNeurons = jest
     .spyOn(api, "queryNeurons")
@@ -84,7 +92,7 @@ describe("neurons-services", () => {
 
   const spyMergeNeurons = jest
     .spyOn(api, "mergeNeurons")
-    .mockImplementation(() => Promise.resolve(BigInt(10)));
+    .mockImplementation(() => Promise.resolve());
 
   const spySplitNeuron = jest
     .spyOn(api, "splitNeuron")
@@ -277,7 +285,7 @@ describe("neurons-services", () => {
         dissolveDelayInSeconds: 12000,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyIncreaseDissolveDelay).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -294,7 +302,7 @@ describe("neurons-services", () => {
         dissolveDelayInSeconds: 12000,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyIncreaseDissolveDelay).not.toHaveBeenCalled();
 
       neuronsStore.setNeurons({ neurons: [], certified: true });
@@ -318,7 +326,7 @@ describe("neurons-services", () => {
 
       await joinCommunityFund(BigInt(10));
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyJoinCommunityFund).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -332,7 +340,7 @@ describe("neurons-services", () => {
 
       await joinCommunityFund(notControlledNeuron.neuronId);
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyJoinCommunityFund).not.toHaveBeenCalled();
     });
   });
@@ -360,7 +368,7 @@ describe("neurons-services", () => {
         targetNeuronId: neurons[1].neuronId,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyMergeNeurons).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -382,7 +390,7 @@ describe("neurons-services", () => {
         targetNeuronId: neuron.neuronId,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyMergeNeurons).not.toHaveBeenCalled();
     });
   });
@@ -404,7 +412,7 @@ describe("neurons-services", () => {
 
       await startDissolving(BigInt(10));
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyStartDissolving).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -418,7 +426,7 @@ describe("neurons-services", () => {
 
       await startDissolving(notControlledNeuron.neuronId);
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyStartDissolving).not.toHaveBeenCalled();
     });
   });
@@ -440,7 +448,7 @@ describe("neurons-services", () => {
 
       await stopDissolving(BigInt(10));
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyStopDissolving).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -454,7 +462,7 @@ describe("neurons-services", () => {
 
       await stopDissolving(notControlledNeuron.neuronId);
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spyStopDissolving).not.toHaveBeenCalled();
     });
   });
@@ -483,7 +491,7 @@ describe("neurons-services", () => {
         amount: 2.2,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySplitNeuron).not.toHaveBeenCalled();
 
       resetIdentity();
@@ -500,7 +508,7 @@ describe("neurons-services", () => {
         amount: 2.2,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySplitNeuron).not.toHaveBeenCalled();
 
       neuronsStore.setNeurons({ neurons: [], certified: true });
@@ -544,7 +552,7 @@ describe("neurons-services", () => {
         followee,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySetFollowees).not.toHaveBeenCalled();
       resetIdentity();
     });
@@ -563,7 +571,7 @@ describe("neurons-services", () => {
         followee,
       });
 
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySetFollowees).not.toHaveBeenCalled();
     });
   });
@@ -573,6 +581,15 @@ describe("neurons-services", () => {
       jest.clearAllMocks();
       neuronsStore.setNeurons({ neurons: [], certified: true });
     });
+    const followee = BigInt(8);
+    const topic = Topic.ExchangeRate;
+    const neuronFollowing = {
+      ...controlledNeuron,
+      fullNeuron: {
+        ...controlledNeuron.fullNeuron,
+        followees: [{ topic, followees: [followee] }],
+      },
+    };
     it("should remove the followee to next call", async () => {
       const followee = BigInt(8);
       const topic = Topic.ExchangeRate;
@@ -600,9 +617,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if no identity", async () => {
-      const followee = BigInt(8);
-      neuronsStore.setNeurons({ neurons, certified: true });
-      const topic = Topic.ExchangeRate;
+      neuronsStore.setNeurons([neuronFollowing]);
 
       setNoIdentity();
 
@@ -611,26 +626,33 @@ describe("neurons-services", () => {
         topic,
         followee,
       });
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySetFollowees).not.toHaveBeenCalled();
 
       resetIdentity();
     });
 
     it("should not call api if user not controller nor hotkey", async () => {
-      neuronsStore.pushNeurons({
-        neurons: [notControlledNeuron],
-        certified: true,
-      });
       const followee = BigInt(8);
       const topic = Topic.ExchangeRate;
+      const notControlled = {
+        ...notControlledNeuron,
+        fullNeuron: {
+          ...notControlledNeuron.fullNeuron,
+          followees: [{ topic, followees: [followee] }],
+        },
+      };
+      neuronsStore.pushNeurons({
+        neurons: [notControlled],
+        certified: true,
+      });
 
       await removeFollowee({
-        neuronId: notControlledNeuron.neuronId,
+        neuronId: notControlled.neuronId,
         topic,
         followee,
       });
-      expect(toastsStore.error).toHaveBeenCalled();
+      expect(toastsStore.show).toHaveBeenCalled();
       expect(spySetFollowees).not.toHaveBeenCalled();
     });
   });

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -12,6 +12,7 @@ import { InvalidAmountError } from "../../../lib/types/errors";
 import {
   ageMultiplier,
   ballotsWithDefinedProposal,
+  canBeMerged,
   checkInvalidState,
   convertNumberToICP,
   dissolveDelayMultiplier,
@@ -25,6 +26,7 @@ import {
   isIdentityController,
   isNeuronControllable,
   isValidInputAmount,
+  mapMergeableNeurons,
   mapNeuronIds,
   maturityByStake,
   neuronCanBeSplit,
@@ -691,6 +693,166 @@ describe("neuron-utils", () => {
       expect(isIdentityController({ neuron: mockNeuron, identity: null })).toBe(
         false
       );
+    });
+  });
+
+  describe("mapMergeableNeurons", () => {
+    it("wraps mergeable neurons with true if mergeable", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          hasJoinedCommunityFund: undefined,
+          hotKeys: [],
+        },
+      };
+      const neuron2 = {
+        ...neuron,
+        neuronId: BigInt(444),
+      };
+      const wrappedNeurons = mapMergeableNeurons({
+        neurons: [neuron, neuron2],
+      });
+      expect(wrappedNeurons[0].mergeable).toBe(true);
+      expect(wrappedNeurons[1].mergeable).toBe(true);
+    });
+
+    it("wraps mergeable neurons with false if controlled by hotkey or joined community fund", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          hasJoinedCommunityFund: undefined,
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        neuronId: BigInt(444),
+        joinedCommunityFundTimestampSeconds: BigInt(1234),
+        fullNeuron: {
+          ...mockFullNeuron,
+          hotKeys: [],
+        },
+      };
+      const wrappedNeurons = mapMergeableNeurons({
+        neurons: [neuron, neuron2],
+        identity: mockIdentity,
+      });
+      expect(wrappedNeurons[0].mergeable).toBe(false);
+      expect(wrappedNeurons[1].mergeable).toBe(false);
+    });
+  });
+
+  describe("canBeMerged", () => {
+    it("return valid if two neurons can be merged", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "same",
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        neuronId: BigInt(444),
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "same",
+        },
+      };
+      expect(canBeMerged([neuron, neuron2]).isValid).toBe(true);
+    });
+
+    it("return invalid if two neurons have same id", () => {
+      const neuron = {
+        ...mockNeuron,
+      };
+      const neuron2 = {
+        ...mockNeuron,
+      };
+      expect(canBeMerged([neuron, neuron2]).isValid).toBe(false);
+    });
+
+    it("return invalid if two neurons do not have same controller", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller-1",
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        neuronId: BigInt(444),
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller-2",
+        },
+      };
+      expect(canBeMerged([neuron, neuron2]).isValid).toBe(false);
+    });
+
+    it("return invalid if two neurons do not have same followees on Manage Neuron", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller",
+          followees: [
+            {
+              topic: Topic.ManageNeuron,
+              followees: [BigInt(10), BigInt(40)],
+            },
+          ],
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        neuronId: BigInt(444),
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller",
+          followees: [
+            {
+              topic: Topic.ManageNeuron,
+              followees: [BigInt(10)],
+            },
+          ],
+        },
+      };
+      expect(canBeMerged([neuron, neuron2]).isValid).toBe(false);
+    });
+
+    it("return invalid if two neurons have same followees on Manage Neuron", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller",
+          followees: [
+            {
+              topic: Topic.ManageNeuron,
+              followees: [BigInt(10), BigInt(40)],
+            },
+          ],
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        neuronId: BigInt(444),
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: "controller",
+          followees: [
+            {
+              topic: Topic.ManageNeuron,
+              followees: [BigInt(10), BigInt(40)],
+            },
+          ],
+        },
+      };
+      expect(canBeMerged([neuron, neuron2]).isValid).toBe(true);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -729,11 +729,16 @@ describe("neuron-utils", () => {
         ...neuron,
         neuronId: BigInt(444),
       };
+      const neuron3 = {
+        ...neuron,
+        neuronId: BigInt(445),
+      };
       const wrappedNeurons = mapMergeableNeurons({
-        neurons: [neuron, neuron2],
+        neurons: [neuron, neuron2, neuron3],
       });
       expect(wrappedNeurons[0].mergeable).toBe(true);
       expect(wrappedNeurons[1].mergeable).toBe(true);
+      expect(wrappedNeurons[2].mergeable).toBe(true);
     });
 
     it("wraps mergeable neurons with false if controlled by hotkey or joined community fund", () => {
@@ -843,7 +848,7 @@ describe("neuron-utils", () => {
       expect(canBeMerged([neuron, neuron2]).isValid).toBe(false);
     });
 
-    it("return invalid if two neurons have same followees on Manage Neuron", () => {
+    it("return valid if two neurons have same followees on Manage Neuron", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -852,7 +857,7 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(10), BigInt(40)],
+              followees: [BigInt(40), BigInt(10)],
             },
           ],
         },

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -11,6 +11,7 @@ import type { Step } from "../../../lib/stores/steps.state";
 import { InvalidAmountError } from "../../../lib/types/errors";
 import {
   ageMultiplier,
+  allHaveSameFollowees,
   ballotsWithDefinedProposal,
   canBeMerged,
   checkInvalidState,
@@ -693,6 +694,24 @@ describe("neuron-utils", () => {
       expect(isIdentityController({ neuron: mockNeuron, identity: null })).toBe(
         false
       );
+    });
+  });
+
+  describe("allHaveSameFollowees", () => {
+    it("returns true if same followees", () => {
+      const followees = [BigInt(4), BigInt(6), BigInt(9)];
+      expect(allHaveSameFollowees([followees, [...followees]])).toBe(true);
+    });
+
+    it("returns false if not same followees", () => {
+      const followees1 = [BigInt(4), BigInt(6), BigInt(9)];
+      const followees2 = [BigInt(1), BigInt(6), BigInt(9)];
+      expect(allHaveSameFollowees([followees1, followees2])).toBe(false);
+    });
+
+    it("returns false if not the same amount", () => {
+      const followees = [BigInt(4), BigInt(6), BigInt(9)];
+      expect(allHaveSameFollowees([followees, followees.slice(1)])).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

User can merge neurons.

There are two types of checks. Individual and in pairs.

* Neurons might not be mergeable for their attributes (ex: joined community fund).
* Pairs of neurons might not be mergeable by the combination of their attributes (ex: both have different controller).

# Changes

* Add Functionality to the MergeNeuronsModal to check if neurons are mergeable or not and perform action.
* Add util "canBeMerged" to check if neurons can be merged
* Add governance api "mergeNeurons"
* Add prop "disabled" to NeuronCard and Card.
* Add util "mapMergeableNeurons" to wrap NeuronInfo with information about mergeability.
* Add neuron service "mergeNeurons".

# Tests

* Test new functionality in the MergeNeuronsModal.
* New tests for "mergeNeurons" governance api.
* New tests for "mergeNeurons" service.
* New tests for new utils.
