### PR TITLE
Disable shfmt

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install shfmt
-        run: sudo snap install --classic shfmt
+      # Disabled due to temporary installation problems.
+      #- name: Install shfmt
+      #  run: sudo snap install --classic shfmt
 
       - name: Install Rust
         run: |
@@ -30,8 +31,9 @@ jobs:
       - name: Format rust
         run: cargo fmt
 
-      - name: Format shell scripts
-        run: ./scripts/fmt-sh
+      # Disabled due to temporary installation problems.
+      #- name: Format shell scripts
+      #  run: ./scripts/fmt-sh
 
       - name: Install ts dependencies
         run: npm ci


### PR DESCRIPTION
# Motivation
PRs are blocked because shfmt cannot be installed at the moment.

# Changes
- Comment out shfmt.  To be reinstated when installations work again.

Note: A PR can be created that reverts this PR.  When that PR passes CI, it can be merged.