### PR TITLE
Feat/request and response logs

### DIFF
--- a/frontend/svelte/src/lib/api/accounts.api.ts
+++ b/frontend/svelte/src/lib/api/accounts.api.ts
@@ -13,6 +13,7 @@ import { identityServiceURL } from "../constants/identity.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
 import { createAgent } from "../utils/agent.utils";
+import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 
 export const loadAccounts = async ({
   identity,
@@ -21,6 +22,8 @@ export const loadAccounts = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<AccountsStore> => {
+  logWithTimestamp(`Loading Accounts certified:${certified} call...`);
+
   const agent = await createAgent({ identity, host: identityServiceURL });
   // ACCOUNTS
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
@@ -64,6 +67,8 @@ export const loadAccounts = async ({
     ...mainAccount.sub_accounts.map(mapAccount),
   ]);
 
+  logWithTimestamp(`Loading Accounts certified:${certified} complete.`);
+
   return {
     main,
     subAccounts,
@@ -77,6 +82,8 @@ export const createSubAccount = async ({
   name: string;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(`Creating SubAccount ${hashCode(name)} call...`);
+
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
     agent: await createAgent({ identity, host: identityServiceURL }),
     canisterId: OWN_CANISTER_ID,
@@ -85,4 +92,5 @@ export const createSubAccount = async ({
   await nnsDapp.createSubAccount({
     subAccountName: name,
   });
+  logWithTimestamp(`Creating SubAccount ${hashCode(name)} complete.`);
 };

--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -4,6 +4,7 @@ import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 import { identityServiceURL } from "../constants/identity.constants";
 import { createAgent } from "../utils/agent.utils";
+import { logWithTimestamp } from "../utils/dev.utils";
 
 export const queryCanisters = async ({
   identity,
@@ -12,6 +13,7 @@ export const queryCanisters = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<CanisterDetails[]> => {
+  logWithTimestamp(`Querying Canisters certified:${certified} call...`);
   const agent = await createAgent({ identity, host: identityServiceURL });
 
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
@@ -19,5 +21,7 @@ export const queryCanisters = async ({
     canisterId: OWN_CANISTER_ID,
   });
 
-  return nnsDapp.getCanisters({ certified });
+  const response = await nnsDapp.getCanisters({ certified });
+  logWithTimestamp(`Querying Canisters certified:${certified} complete.`);
+  return response;
 };

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -7,6 +7,7 @@ import {
   LEDGER_CANISTER_ID,
 } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
+import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { dfinityNeuron, icNeuron } from "./constants.api";
 import { toSubAccountId } from "./utils.api";
 
@@ -19,12 +20,19 @@ export const queryNeuron = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<NeuronInfo | undefined> => {
+  logWithTimestamp(
+    `Querying Neuron(${hashCode(neuronId)}) certified:${certified} call...`
+  );
   const { canister } = await governanceCanister({ identity });
 
-  return canister.getNeuron({
+  const response = await canister.getNeuron({
     certified,
     neuronId,
   });
+  logWithTimestamp(
+    `Querying Neuron(${hashCode(neuronId)}) certified:${certified} complete.`
+  );
+  return response;
 };
 
 export const increaseDissolveDelay = async ({
@@ -36,12 +44,23 @@ export const increaseDissolveDelay = async ({
   dissolveDelayInSeconds: number;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(
+    `Increasing Dissolve Delay(${hashCode(neuronId)}, ${hashCode(
+      dissolveDelayInSeconds
+    )}) call...`
+  );
   const { canister } = await governanceCanister({ identity });
 
-  return canister.increaseDissolveDelay({
+  const response = await canister.increaseDissolveDelay({
     neuronId,
     additionalDissolveDelaySeconds: dissolveDelayInSeconds,
   });
+  logWithTimestamp(
+    `Increasing Dissolve Delay(${hashCode(neuronId)}, ${hashCode(
+      dissolveDelayInSeconds
+    )}) complete.`
+  );
+  return response;
 };
 
 export const joinCommunityFund = async ({
@@ -51,9 +70,12 @@ export const joinCommunityFund = async ({
   neuronId: NeuronId;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(`Joining Community Fund (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.joinCommunityFund(neuronId);
+  const response = await canister.joinCommunityFund(neuronId);
+  logWithTimestamp(`Joining Community Fund (${hashCode(neuronId)}) complete.`);
+  return response;
 };
 
 export const splitNeuron = async ({
@@ -65,12 +87,15 @@ export const splitNeuron = async ({
   amount: ICP;
   identity: Identity;
 }): Promise<NeuronId> => {
+  logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.splitNeuron({
+  const response = await canister.splitNeuron({
     neuronId,
     amount,
   });
+  logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) complete.`);
+  return response;
 };
 
 export const startDissolving = async ({
@@ -80,9 +105,12 @@ export const startDissolving = async ({
   neuronId: NeuronId;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(`Starting Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.startDissolving(neuronId);
+  const response = await canister.startDissolving(neuronId);
+  logWithTimestamp(`Starting Dissolving (${hashCode(neuronId)}) complete.`);
+  return response;
 };
 
 export const stopDissolving = async ({
@@ -92,9 +120,12 @@ export const stopDissolving = async ({
   neuronId: NeuronId;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.stopDissolving(neuronId);
+  const response = await canister.stopDissolving(neuronId);
+  logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) complete.`);
+  return response;
 };
 
 export const setFollowees = async ({
@@ -108,13 +139,16 @@ export const setFollowees = async ({
   topic: Topic;
   followees: NeuronId[];
 }): Promise<void> => {
+  logWithTimestamp(`Setting Followees (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.setFollowees({
+  const response = await canister.setFollowees({
     neuronId,
     topic,
     followees,
   });
+  logWithTimestamp(`Setting Followees (${hashCode(neuronId)}) complete.`);
+  return response;
 };
 
 export const queryNeurons = async ({
@@ -124,11 +158,14 @@ export const queryNeurons = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<NeuronInfo[]> => {
+  logWithTimestamp(`Querying Neurons certified:${certified} call...`);
   const { canister } = await governanceCanister({ identity });
 
-  return canister.listNeurons({
+  const response = await canister.listNeurons({
     certified,
   });
+  logWithTimestamp(`Querying Neurons certified:${certified} complete.`);
+  return response;
 };
 
 /**
@@ -143,6 +180,7 @@ export const stakeNeuron = async ({
   identity: Identity;
   fromSubAccount?: SubAccountArray;
 }): Promise<NeuronId> => {
+  logWithTimestamp(`Staking Neuron call...`);
   const { canister, agent } = await governanceCanister({ identity });
 
   const ledgerCanister: LedgerCanister = LedgerCanister.create({
@@ -153,12 +191,14 @@ export const stakeNeuron = async ({
   const fromSubAccountId =
     fromSubAccount !== undefined ? toSubAccountId(fromSubAccount) : undefined;
 
-  return canister.stakeNeuron({
+  const response = await canister.stakeNeuron({
     stake,
     principal: identity.getPrincipal(),
     fromSubAccountId,
     ledgerCanister,
   });
+  logWithTimestamp(`Staking Neuron complete.`);
+  return response;
 };
 
 export const queryKnownNeurons = async ({
@@ -168,6 +208,7 @@ export const queryKnownNeurons = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<KnownNeuron[]> => {
+  logWithTimestamp(`Querieng Known Neurons certified:${certified} call...`);
   const { canister } = await governanceCanister({ identity });
 
   const knownNeurons = await canister.listKnownNeurons(certified);
@@ -180,7 +221,9 @@ export const queryKnownNeurons = async ({
     knownNeurons.push(icNeuron);
   }
 
-  return knownNeurons;
+  const response = await knownNeurons;
+  logWithTimestamp(`Querieng Known Neurons certified:${certified} complete.`);
+  return response;
 };
 
 export const claimOrRefreshNeuron = async ({
@@ -190,12 +233,19 @@ export const claimOrRefreshNeuron = async ({
   neuronId: NeuronId;
   identity: Identity;
 }): Promise<NeuronId | undefined> => {
+  logWithTimestamp(
+    `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) call...`
+  );
   const { canister } = await governanceCanister({ identity });
 
-  return canister.claimOrRefreshNeuron({
+  const response = await canister.claimOrRefreshNeuron({
     neuronId,
     by: { NeuronIdOrSubaccount: {} },
   });
+  logWithTimestamp(
+    `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) complete.`
+  );
+  return response;
 };
 
 // TODO: Apply pattern to other canister instantiation L2-371
@@ -207,6 +257,7 @@ export const governanceCanister = async ({
   canister: GovernanceCanister;
   agent: HttpAgent;
 }> => {
+  logWithTimestamp(`GC call...`);
   const agent = await createAgent({
     identity,
     host: process.env.HOST,
@@ -217,6 +268,7 @@ export const governanceCanister = async ({
     canisterId: GOVERNANCE_CANISTER_ID,
   });
 
+  logWithTimestamp(`GC complete.`);
   return {
     canister,
     agent,

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -257,7 +257,6 @@ export const governanceCanister = async ({
   canister: GovernanceCanister;
   agent: HttpAgent;
 }> => {
-  logWithTimestamp(`GC call...`);
   const agent = await createAgent({
     identity,
     host: process.env.HOST,
@@ -268,7 +267,6 @@ export const governanceCanister = async ({
     canisterId: GOVERNANCE_CANISTER_ID,
   });
 
-  logWithTimestamp(`GC complete.`);
   return {
     canister,
     agent,

--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -8,6 +8,7 @@ import {
 } from "@dfinity/nns";
 import { LEDGER_CANISTER_ID } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
+import { logWithTimestamp } from "../utils/dev.utils";
 
 export const getNeuronBalance = async ({
   neuron,
@@ -18,11 +19,14 @@ export const getNeuronBalance = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<ICP> => {
+  logWithTimestamp(`Getting Neuron Balance certified:${certified} call...`);
   const { canister } = await ledgerCanister({ identity });
-  return canister.accountBalance({
+  const response = await canister.accountBalance({
     accountIdentifier: AccountIdentifier.fromHex(neuron.accountIdentifier),
     certified,
   });
+  logWithTimestamp(`Getting Neuron Balance certified:${certified} complete.`);
+  return response;
 };
 
 /**
@@ -45,13 +49,16 @@ export const sendICP = async ({
   amount: ICP;
   fromSubAccountId?: number | undefined;
 }): Promise<BlockHeight> => {
+  logWithTimestamp(`Sending icp call...`);
   const { canister } = await ledgerCanister({ identity });
 
-  return canister.transfer({
+  const response = await canister.transfer({
     to: AccountIdentifier.fromHex(to),
     amount,
     fromSubAccountId,
   });
+  logWithTimestamp(`Sending icp complete.`);
+  return response;
 };
 
 const ledgerCanister = async ({
@@ -62,6 +69,7 @@ const ledgerCanister = async ({
   canister: LedgerCanister;
   agent: HttpAgent;
 }> => {
+  logWithTimestamp(`LC call...`);
   const agent = await createAgent({
     identity,
     host: process.env.HOST,
@@ -71,6 +79,8 @@ const ledgerCanister = async ({
     agent,
     canisterId: LEDGER_CANISTER_ID,
   });
+
+  logWithTimestamp(`LC complete.`);
 
   return {
     canister,

--- a/frontend/svelte/src/lib/api/proposals.api.ts
+++ b/frontend/svelte/src/lib/api/proposals.api.ts
@@ -10,6 +10,7 @@ import { GovernanceCanister, Topic } from "@dfinity/nns";
 import { LIST_PAGINATION_LIMIT } from "../constants/constants";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import { createAgent } from "../utils/agent.utils";
+import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { enumsExclude } from "../utils/enum.utils";
 
 export const queryProposals = async ({
@@ -23,6 +24,12 @@ export const queryProposals = async ({
   filters: ProposalsFiltersStore;
   certified: boolean;
 }): Promise<ProposalInfo[]> => {
+  logWithTimestamp(
+    `Querying Proposals (${
+      beforeProposal === undefined ? "start" : hashCode(beforeProposal)
+    }) certified:${certified} call...`
+  );
+
   const governance: GovernanceCanister = GovernanceCanister.create({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
@@ -47,6 +54,12 @@ export const queryProposals = async ({
     certified,
   });
 
+  logWithTimestamp(
+    `Querying Proposals (${
+      beforeProposal === undefined ? "start" : hashCode(beforeProposal)
+    }) certified:${certified} complete.`
+  );
+
   return proposals;
 };
 
@@ -59,11 +72,20 @@ export const queryProposal = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<ProposalInfo | undefined> => {
+  logWithTimestamp(
+    `Querying Proposal (${hashCode(proposalId)}) certified:${certified} call...`
+  );
   const governance: GovernanceCanister = GovernanceCanister.create({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
 
-  return governance.getProposal({ proposalId, certified });
+  const response = await governance.getProposal({ proposalId, certified });
+  logWithTimestamp(
+    `Querying Proposal (${hashCode(
+      proposalId
+    )}) certified:${certified} complete.`
+  );
+  return response;
 };
 
 export const registerVote = async ({
@@ -77,13 +99,23 @@ export const registerVote = async ({
   vote: Vote;
   identity: Identity;
 }): Promise<void> => {
+  logWithTimestamp(
+    `Registering Vote (${hashCode(proposalId)}, ${hashCode(neuronId)}) call...`
+  );
+
   const governance: GovernanceCanister = GovernanceCanister.create({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
 
-  return governance.registerVote({
+  const response = await governance.registerVote({
     neuronId,
     vote,
     proposalId,
   });
+  logWithTimestamp(
+    `Registering Vote (${hashCode(proposalId)}, ${hashCode(
+      neuronId
+    )}) complete.`
+  );
+  return response;
 };

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -33,6 +33,7 @@ export const syncAccounts = (): Promise<void> => {
         detail: errorToString(error),
       });
     },
+    logMessage: "Syncing Accounts",
   });
 };
 

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -33,5 +33,6 @@ export const listCanisters = async ({
         detail: errorToString(error),
       });
     },
+    logMessage: "Syncing Canisters",
   });
 };

--- a/frontend/svelte/src/lib/services/knownNeurons.services.ts
+++ b/frontend/svelte/src/lib/services/knownNeurons.services.ts
@@ -25,5 +25,6 @@ export const listKnownNeurons = (): Promise<void> => {
         detail: errorToString(error),
       });
     },
+    logMessage: "Syncing Known Neurons",
   });
 };

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -247,15 +247,11 @@ export const registerVotes = async ({
   // <test_log>
   // https://forum.dfinity.org/t/potentially-serious-nns-error-nns-app-ui-shows-error-when-voting-every-time/12212
   try {
-    // naive test of BigInts in Set
-    const stringifiedNeuronIds = Array.from(
-      new Set(neuronIds.map((id) => id.toString()))
-    );
-    if (stringifiedNeuronIds.length !== neuronIds.length) {
+    if (uniqueNeuronIds.length !== neuronIds.length) {
       console.error(
-        "registerVotes/TL(neuronIds, stringifiedNeuronIds)",
+        "registerVotes/TL(ids, ids_text)",
         neuronIds.map(hashCode),
-        stringifiedNeuronIds.map(hashCode)
+        uniqueNeuronIds.map(hashCode)
       );
     }
   } catch (err) {
@@ -377,12 +373,14 @@ const requestRegisterVotes = async ({
         })
     )
   );
+  const rejectedResponses = responses.filter(
+    ({ status }) => status === "rejected"
+  );
   const details: string[] = responses
     .map((response, i) => errorDetail(neuronIds[i], response))
     .filter(isDefined);
-
-  if (details.length > 0) {
-    console.error("vote", details);
+  if (rejectedResponses.length > 0) {
+    console.error("vote", rejectedResponses);
 
     toastsStore.show({
       labelKey: "error.register_vote",

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -20,13 +20,14 @@ import {
 } from "../stores/proposals.store";
 import { toastsStore } from "../stores/toasts.store";
 import { getLastPathDetailId } from "../utils/app-path.utils";
+import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { errorToString } from "../utils/error.utils";
 import { replacePlaceholders } from "../utils/i18n.utils";
 import {
   excludeProposals,
   proposalsHaveSameIds,
 } from "../utils/proposals.utils";
-import { hashCode, isDefined, logWithTimestamp } from "../utils/utils";
+import { isDefined } from "../utils/utils";
 import { getIdentity } from "./auth.services";
 import { listNeurons } from "./neurons.services";
 import {
@@ -142,6 +143,9 @@ const findProposals = async ({
       onLoad({ response: proposals, certified });
     },
     onError,
+    logMessage: `Syncing proposals ${
+      beforeProposal === undefined ? "" : `from: ${hashCode(beforeProposal)}`
+    }`,
   });
 };
 
@@ -215,6 +219,7 @@ const getProposal = async ({
       queryProposal({ proposalId, identity, certified }),
     onLoad,
     onError,
+    logMessage: `Syncing Proposal ${hashCode(proposalId)}`,
   });
 };
 
@@ -259,12 +264,16 @@ export const registerVotes = async ({
   // </test_log>
 
   try {
+    logWithTimestamp(`Registering [${neuronIds.map(hashCode)}] votes call...`);
     await requestRegisterVotes({
       neuronIds: uniqueNeuronIds,
       proposalId,
       identity,
       vote,
     });
+    logWithTimestamp(
+      `Registering [${neuronIds.map(hashCode)}] votes complete.`
+    );
   } catch (error: unknown) {
     console.error("vote unknown:", error);
 

--- a/frontend/svelte/src/lib/services/utils.services.ts
+++ b/frontend/svelte/src/lib/services/utils.services.ts
@@ -27,13 +27,13 @@ export const queryAndUpdate = async <R, E>({
 }: {
   request: (options: { certified: boolean; identity: Identity }) => Promise<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
-  logMessage: string;
+  logMessage?: string;
   onError?: QueryAndUpdateOnError<E>;
 }): Promise<void> => {
   let certifiedDone = false;
-  const logPrefix = `[${lastIndex++}] ${logMessage}`;
   const identity: Identity = await getIdentity();
 
+  const logPrefix = `[${lastIndex++}] ${logMessage ?? ""}`;
   logWithTimestamp(`${logPrefix} calls...`);
 
   return Promise.race([

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -14,7 +14,7 @@ export const logWithTimestamp = (...args): void => {
 
 // Insecure but fast
 // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
-const seed = Math.round(Math.random() * 99999);
+const seed = Math.round(Math.random() * 1e6);
 export const hashCode = (value: string | bigint | number): string =>
   (
     Array.from(`${value}`).reduce(

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -2,3 +2,25 @@ export const isNode = (): boolean =>
   typeof process !== "undefined" &&
   process.versions != null &&
   process.versions.node != null;
+
+/**
+ *
+ * console.log with time prefix (e.g. "[15:22:55.438] message text")
+ */
+export const logWithTimestamp = (...args): void => {
+  const time = `[${new Date().toISOString().split("T")[1].replace("Z", "")}]`;
+  console.log.call(console, ...[time, ...args]);
+};
+
+// Insecure but fast
+// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+const seed = Math.round(Math.random() * 99999);
+export const hashCode = (value: string | bigint | number): string =>
+  (
+    Array.from(`${value}`).reduce(
+      (s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0,
+      0
+    ) + seed
+  )
+    .toString(36)
+    .toUpperCase();

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -8,6 +8,8 @@ export const isNode = (): boolean =>
  * console.log with time prefix (e.g. "[15:22:55.438] message text")
  */
 export const logWithTimestamp = (...args): void => {
+  if (isNode() === true) return;
+
   const time = `[${new Date().toISOString().split("T")[1].replace("Z", "")}]`;
   console.log.call(console, ...[time, ...args]);
 };

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -83,20 +83,3 @@ export const createChunks = <T>(
   }
   return chunks;
 };
-
-/**
- *
- * console.log with time prefix (e.g. "[15:22:55.438] message text")
- */
-export const logWithTimestamp = (...args): void => {
-  const time = `[${new Date().toISOString().split("T")[1].replace("Z", "")}]`;
-  console.log.call(console, ...[time, ...args]);
-};
-
-// Unreliable but fast
-// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
-export const hashCode = (value: string | bigint | number): number =>
-  Array.from(`${value}`).reduce(
-    (s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0,
-    0
-  );

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -83,3 +83,20 @@ export const createChunks = <T>(
   }
   return chunks;
 };
+
+/**
+ *
+ * console.log with time prefix (e.g. "[15:22:55.438] message text")
+ */
+export const logWithTimestamp = (...args): void => {
+  const time = `[${new Date().toISOString().split("T")[1].replace("Z", "")}]`;
+  console.log.call(console, ...[time, ...args]);
+};
+
+// Unreliable but fast
+// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+export const hashCode = (value: string | bigint | number): number =>
+  Array.from(`${value}`).reduce(
+    (s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0,
+    0
+  );

--- a/frontend/svelte/src/tests/lib/utils/api.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/api.spec.ts
@@ -14,6 +14,7 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
+        logMessage: "",
       });
 
       expect(request).toHaveBeenCalledTimes(2);
@@ -32,6 +33,7 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
+        logMessage: "",
       });
 
       await tick();
@@ -54,6 +56,7 @@ describe("api-utils", () => {
       await queryAndUpdate<number, unknown>({
         request,
         onLoad,
+        logMessage: "",
       });
 
       expect(requestCertified.sort()).toEqual([false, true]);
@@ -70,6 +73,7 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
+        logMessage: "",
       });
 
       expect(onLoad).not.toBeCalled();
@@ -98,6 +102,7 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
+        logMessage: "",
       });
       await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -134,9 +139,26 @@ describe("api-utils", () => {
       await queryAndUpdate<number, unknown>({
         request,
         onLoad,
+        logMessage: "",
       });
       expect(updateDone).toBeTruthy();
       expect(queryDone).toBeFalsy();
+    });
+
+    it.only("should log", async () => {
+      const log = jest.spyOn(console, "log").mockImplementation((text) => {
+        console.error(text);
+      });
+      const request = jest.fn().mockImplementation(() => Promise.resolve());
+      const onLoad = jest.fn();
+
+      await queryAndUpdate<number, unknown>({
+        request,
+        onLoad,
+        logMessage: "test-log",
+      });
+
+      expect(log).toBeCalled();
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/api.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/api.spec.ts
@@ -1,5 +1,6 @@
 import { tick } from "svelte";
 import { queryAndUpdate } from "../../../lib/services/utils.services";
+import * as devUtils from "../../../lib/utils/dev.utils";
 
 describe("api-utils", () => {
   describe("queryAndUpdate", () => {
@@ -140,9 +141,7 @@ describe("api-utils", () => {
     });
 
     it("should log", async () => {
-      const log = jest.spyOn(console, "log").mockImplementation((text) => {
-        console.error(text);
-      });
+      const log = jest.spyOn(devUtils, "logWithTimestamp");
       const request = jest.fn().mockImplementation(() => Promise.resolve());
       const onLoad = jest.fn();
 

--- a/frontend/svelte/src/tests/lib/utils/api.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/api.spec.ts
@@ -145,7 +145,7 @@ describe("api-utils", () => {
       expect(queryDone).toBeFalsy();
     });
 
-    it.only("should log", async () => {
+    it("should log", async () => {
       const log = jest.spyOn(console, "log").mockImplementation((text) => {
         console.error(text);
       });

--- a/frontend/svelte/src/tests/lib/utils/api.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/api.spec.ts
@@ -14,7 +14,6 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
-        logMessage: "",
       });
 
       expect(request).toHaveBeenCalledTimes(2);
@@ -33,7 +32,6 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
-        logMessage: "",
       });
 
       await tick();
@@ -56,7 +54,6 @@ describe("api-utils", () => {
       await queryAndUpdate<number, unknown>({
         request,
         onLoad,
-        logMessage: "",
       });
 
       expect(requestCertified.sort()).toEqual([false, true]);
@@ -73,7 +70,6 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
-        logMessage: "",
       });
 
       expect(onLoad).not.toBeCalled();
@@ -102,7 +98,6 @@ describe("api-utils", () => {
         request,
         onLoad,
         onError,
-        logMessage: "",
       });
       await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -139,7 +134,6 @@ describe("api-utils", () => {
       await queryAndUpdate<number, unknown>({
         request,
         onLoad,
-        logMessage: "",
       });
       expect(updateDone).toBeTruthy();
       expect(queryDone).toBeFalsy();

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -496,7 +496,7 @@ describe("neuron-utils", () => {
     });
   });
 
-  describe.only("followeesNeurons", () => {
+  describe("followeesNeurons", () => {
     it("should transform followees", () => {
       const neuron = {
         ...mockNeuron,


### PR DESCRIPTION
# Motivation

To get more information from user side the log messages were added.

# Changes

- added logWithTimestamp
- requests log their status with some details (e.g. neuronId)
  - to not disturb people with raw data in dev.console all IDs are converted into hashes (see `hashCode`)
- to be sure that the app doesn't try to vote w/ duplications `registerVotes` does extra step to be sure neuronIds are unique with extra console.error if not.
- voting error handling was updated to rely on all rejected requests (not only with human readable message

# Tests

- queryAndUpdate should log

# Notes

- Probably it's better to replace `hashCode` with something random based...

# Screenshots

https://user-images.githubusercontent.com/98811342/164051948-1e830e94-8b46-4d31-a4e4-0bda830404e9.mov


