### PR TITLE
feat: "Loading your neurons..." spinner

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -252,7 +252,8 @@
     "confirm_adopt_headline": "Adopt Proposal",
     "confirm_adopt_text": "You are about to cast $votingPower votes for this proposal, are you sure you want to proceed?",
     "confirm_reject_headline": "Reject Proposal",
-    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?"
+    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?",
+    "loading_neurons": "Loading your neurons..."
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -240,7 +240,8 @@
     "proposer_prefix": "Proposer:",
     "adopt": "Adopt",
     "reject": "Reject",
-    "my_votes": "My Votes"
+    "my_votes": "My Votes",
+    "loading_neurons": "Loading your neurons..."
   },
   "proposal_detail__vote": {
     "headline": "Cast Vote",
@@ -252,8 +253,7 @@
     "confirm_adopt_headline": "Adopt Proposal",
     "confirm_adopt_text": "You are about to cast $votingPower votes for this proposal, are you sure you want to proceed?",
     "confirm_reject_headline": "Reject Proposal",
-    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?",
-    "loading_neurons": "Loading your neurons..."
+    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?"
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -273,6 +273,7 @@ interface I18nProposal_detail__vote {
   confirm_adopt_text: string;
   confirm_reject_headline: string;
   confirm_reject_text: string;
+  loading_neurons: string;
 }
 
 interface I18nProposal_detail__ineligible {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -260,6 +260,7 @@ interface I18nProposal_detail {
   adopt: string;
   reject: string;
   my_votes: string;
+  loading_neurons: string;
 }
 
 interface I18nProposal_detail__vote {
@@ -273,7 +274,6 @@ interface I18nProposal_detail__vote {
   confirm_adopt_text: string;
   confirm_reject_headline: string;
   confirm_reject_text: string;
-  loading_neurons: string;
 }
 
 interface I18nProposal_detail__ineligible {

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -126,7 +126,7 @@
               <Spinner />
             </div>
 
-            <span><small>{$i18n.proposal_detail__vote.loading_neurons}</small></span>
+            <span><small>{$i18n.proposal_detail.loading_neurons}</small></span>
           </div>
         {/if}
       {:else}

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -110,17 +110,42 @@
     >
 
     <section>
-      {#if $proposalInfoStore && neuronsReady}
+      {#if $proposalInfoStore}
         <ProposalDetailCard proposalInfo={$proposalInfoStore} />
-        <VotesCard proposalInfo={$proposalInfoStore} />
-        <VotingCard proposalInfo={$proposalInfoStore} />
-        <IneligibleNeuronsCard
-          proposalInfo={$proposalInfoStore}
-          neurons={$definedNeuronsStore}
-        />
+
+        {#if neuronsReady}
+          <VotesCard proposalInfo={$proposalInfoStore} />
+          <VotingCard proposalInfo={$proposalInfoStore} />
+          <IneligibleNeuronsCard
+            proposalInfo={$proposalInfoStore}
+            neurons={$definedNeuronsStore}
+          />
+        {:else}
+          <div class="loader">
+            <div class="spinner">
+              <Spinner />
+            </div>
+
+            <span><small>{$i18n.proposal_detail__vote.loading_neurons}</small></span>
+          </div>
+        {/if}
       {:else}
         <Spinner />
       {/if}
     </section>
   </HeadlessLayout>
 {/if}
+
+<style lang="scss">
+  .loader {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .spinner {
+    position: relative;
+    padding: var(--padding-2x) 0;
+  }
+</style>

--- a/frontend/svelte/src/tests/mocks/neurons.mock.ts
+++ b/frontend/svelte/src/tests/mocks/neurons.mock.ts
@@ -41,8 +41,8 @@ export const mockKnownNeuron: KnownNeuron = {
 };
 
 export const buildMockNeuronsStoreSubscribe =
-  (neurons: NeuronInfo[] = []) =>
+  (neurons: NeuronInfo[] = [], certified = true) =>
   (run: Subscriber<NeuronsStore>): (() => void) => {
-    run({ neurons, certified: true });
+    run({ neurons, certified });
     return () => undefined;
   };

--- a/frontend/svelte/src/tests/routes/ProposalDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/ProposalDetail.spec.ts
@@ -20,7 +20,7 @@ import {
 } from "../mocks/proposals.store.mock";
 import { mockRouteStoreSubscibe } from "../mocks/route.store.mock";
 
-describe("NeuronDetail", () => {
+describe("ProposalDetail", () => {
   const mockGovernanceCanister: MockGovernanceCanister =
     new MockGovernanceCanister(mockProposals);
 

--- a/frontend/svelte/src/tests/routes/ProposalDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/ProposalDetail.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
+import { render, waitFor } from "@testing-library/svelte";
+import { authStore } from "../../lib/stores/auth.store";
+import { neuronsStore } from "../../lib/stores/neurons.store";
+import { proposalsStore } from "../../lib/stores/proposals.store";
+import { routeStore } from "../../lib/stores/route.store";
+import ProposalDetail from "../../routes/ProposalDetail.svelte";
+import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../mocks/governance.canister.mock";
+import en from "../mocks/i18n.mock";
+import { MockLedgerCanister } from "../mocks/ledger.canister.mock";
+import { buildMockNeuronsStoreSubscribe } from "../mocks/neurons.mock";
+import {
+  mockEmptyProposalsStoreSubscribe,
+  mockProposals,
+} from "../mocks/proposals.store.mock";
+import { mockRouteStoreSubscibe } from "../mocks/route.store.mock";
+
+describe("NeuronDetail", () => {
+  const mockGovernanceCanister: MockGovernanceCanister =
+    new MockGovernanceCanister(mockProposals);
+
+  const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+
+    jest
+      .spyOn(routeStore, "subscribe")
+      .mockImplementation(
+        mockRouteStoreSubscibe(`/#/proposal/${mockProposals[0].id}`)
+      );
+
+    jest
+      .spyOn(proposalsStore, "subscribe")
+      .mockImplementation(mockEmptyProposalsStoreSubscribe);
+
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    jest
+      .spyOn(LedgerCanister, "create")
+      .mockImplementation((): LedgerCanister => mockLedgerCanister);
+
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscribe([], false));
+  });
+
+  it("should render title", async () => {
+    const { getAllByText } = render(ProposalDetail);
+
+    expect(getAllByText(en.proposal_detail.title).length).toBeGreaterThan(0);
+  });
+
+  it("should render loading neurons", async () => {
+    const { getByText } = render(ProposalDetail);
+
+    await waitFor(() =>
+      expect(
+        getByText(en.proposal_detail.loading_neurons, { exact: false })
+      ).toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

We want to voting feature to be available only when the neurons store has been fully initialized but we also want to provide a smooth UI. That's why instead of hiding the all proposal detail page while we load the information we need we can display the static content - i.e. the proposal detail - as fast as we can and display another spinner dedicated to the loading of the neurons.

Worth to note that the store is now loaded only once, therefore user should only face this spinner the first time the store is loaded.

# Changes

- split `ProposalDetail` checks for `proposalInfoStore` and `neuronsReady` to display two distinct spinner - i.e. display the `ProposalDetailCard` as fast as possible

# Screenshot

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/16886711/164054047-adfd9e98-1874-448c-b745-37f76d98ed53.gif)

