### PR TITLE
fix: proposal filters counter

### DIFF
--- a/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalsFilters.svelte
@@ -5,7 +5,7 @@
   import { i18n } from "../../stores/i18n";
   import { ProposalStatus, ProposalRewardStatus, Topic } from "@dfinity/nns";
   import { proposalsFiltersStore } from "../../stores/proposals.store";
-  import { enumSize } from "../../utils/enum.utils";
+  import { enumsExclude } from "../../utils/enum.utils";
   import FiltersButton from "../ui/FiltersButton.svelte";
 
   let modalFilters: ProposalsFilterModalProps | undefined = undefined;
@@ -21,12 +21,25 @@
 
   $: ({ topics, rewards, status, excludeVotedProposals } =
     $proposalsFiltersStore);
+
+  let totalFiltersTopic = enumsExclude({
+    obj: Topic as unknown as Topic,
+    values: [Topic.Unspecified],
+  }).length;
+  let totalFiltersProposalRewardStatus = enumsExclude({
+    obj: ProposalRewardStatus as unknown as ProposalRewardStatus,
+    values: [ProposalRewardStatus.PROPOSAL_REWARD_STATUS_UNKNOWN],
+  }).length;
+  let totalFiltersProposalStatus = enumsExclude({
+    obj: ProposalStatus as unknown as ProposalStatus,
+    values: [ProposalStatus.PROPOSAL_STATUS_UNKNOWN],
+  }).length;
 </script>
 
 <div class="filters">
   <FiltersButton
     testId="filters-by-topics"
-    totalFilters={enumSize(Topic)}
+    totalFilters={totalFiltersTopic}
     activeFilters={topics.length}
     on:nnsFilter={() =>
       openModal({
@@ -38,7 +51,7 @@
 
   <FiltersButton
     testId="filters-by-rewards"
-    totalFilters={enumSize(ProposalRewardStatus)}
+    totalFilters={totalFiltersProposalRewardStatus}
     activeFilters={rewards.length}
     on:nnsFilter={() =>
       openModal({
@@ -50,7 +63,7 @@
 
   <FiltersButton
     testId="filters-by-status"
-    totalFilters={enumSize(ProposalStatus)}
+    totalFilters={totalFiltersProposalStatus}
     activeFilters={status.length}
     on:nnsFilter={() =>
       openModal({

--- a/frontend/svelte/src/lib/utils/enum.utils.ts
+++ b/frontend/svelte/src/lib/utils/enum.utils.ts
@@ -1,5 +1,3 @@
-import { Topic } from "@dfinity/nns";
-
 /**
  * Return the values of a number-based Enum
  *
@@ -50,9 +48,9 @@ export const enumsExclude = <T>({
     values,
   });
 
-  return enumKeys(Topic)
+  return enumKeys(obj)
     .filter((key: string) => !keys.includes(key))
-    .map((key: string) => Topic[key]);
+    .map((key: string) => obj[key]);
 };
 
 /**

--- a/frontend/svelte/src/tests/lib/components/proposals/ProposalsFilters.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposals/ProposalsFilters.spec.ts
@@ -36,7 +36,7 @@ describe("ProposalsFilters", () => {
     shouldRenderFilter({
       container,
       activeFilters: DEFAULT_PROPOSALS_FILTERS.topics.length,
-      totalFilters: enumSize(Topic),
+      totalFilters: enumSize(Topic) - 1,
       text: en.voting.topics,
     });
   });
@@ -47,7 +47,7 @@ describe("ProposalsFilters", () => {
     shouldRenderFilter({
       container,
       activeFilters: DEFAULT_PROPOSALS_FILTERS.rewards.length,
-      totalFilters: enumSize(ProposalRewardStatus),
+      totalFilters: enumSize(ProposalRewardStatus) - 1,
       text: en.voting.rewards,
     });
   });
@@ -58,7 +58,7 @@ describe("ProposalsFilters", () => {
     shouldRenderFilter({
       container,
       activeFilters: DEFAULT_PROPOSALS_FILTERS.status.length,
-      totalFilters: enumSize(ProposalStatus),
+      totalFilters: enumSize(ProposalStatus) - 1,
       text: en.voting.status,
     });
   });


### PR DESCRIPTION
# Motivation

Because we removed the "Unspecified" options of the proposal filters, the counter total was not displaying the correct total value anymore - e.g. 5/11 instead of 5/10 filters.

In addition, found out that `Topic` was used in a generic utils that was fortunately only used so far for such filter.

# Changes

- fix counter without "Unspecified" value
- fix generic utils

# Screenshot

Counters are now correct:

<img width="1440" alt="Capture d’écran 2022-04-19 à 19 10 30" src="https://user-images.githubusercontent.com/16886711/164058877-d7f12876-0c97-4f14-8cc8-acbbb068f57c.png">


<!-- Please provide any information or screenshots about the tests that have been done -->
