### PR TITLE
feat: ignore error "Neuron already voted on proposal."

### DIFF
--- a/frontend/svelte/src/lib/api/proposals.api.ts
+++ b/frontend/svelte/src/lib/api/proposals.api.ts
@@ -107,15 +107,15 @@ export const registerVote = async ({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
 
-  const response = await governance.registerVote({
+  await governance.registerVote({
     neuronId,
     vote,
     proposalId,
   });
+
   logWithTimestamp(
     `Registering Vote (${hashCode(proposalId)}, ${hashCode(
       neuronId
     )}) complete.`
   );
-  return response;
 };

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -387,7 +387,7 @@ describe("proposals-services", () => {
         });
       };
 
-    let lastToastMessage: ToastMsg, spyToastShow;
+    let spyToastShow;
 
     beforeEach(() => {
       jest
@@ -396,7 +396,7 @@ describe("proposals-services", () => {
 
       spyToastShow = jest
         .spyOn(toastsStore, "show")
-        .mockImplementation((params) => (lastToastMessage = params));
+        .mockImplementation(jest.fn());
     });
 
     afterAll(() => jest.clearAllMocks());


### PR DESCRIPTION
# Motivation

If user has for example two neurons with one neuron (B) following another neuron (A). Then if user select both A and B to cast a vote on a proposal, A will first vote for itself and then vote for the followee B. Then our function `Promise.allSettled` that register all votes process next neuron B and try to vote again. This leads to an error `"Neuron already voted on proposal."` thrown by the [Governance canister](https://github.com/dfinity/ic/blob/936d234f2e6179cbaf6e5628df0f77e594e03505/rs/nns/governance/src/governance.rs#L5264) because it has indeed already been registered by A.

Vote are correctly cast therefore we can safely ignore this particular error.

# Note

This has been thankfully found by [justmythoughts](https://forum.dfinity.org/u/justmythoughts) on the [forum](https://forum.dfinity.org/t/nns-voting-error-nns-app-ui-shows-error-when-voting-every-time/12212/12).

# Why this solution

After some more research, we noticed that this error was not new and already existed in the Flutter version of the app. However, the error was ignored, therefore not presented to the user and silent. As it was not explicitly coded that way, we couldn't have noticed it in our reverse engineering that served the development of the Svelte rewrite.

We discussed  different way to process the neurons tree on the frontend side to query the backend with only unique neurons but any solution also need some UX improvements as user somehow should also be made aware of the relations between the neurons on the proposal detail's page - voting card.

That's why we decided to postpone such a tasky enhancements for the future as we aim to improve the overall UX and for now on, to ignore safely the error message that is actually an information.

# Changes

- ignore "Neuron already voted on proposal." when processing the responses of the register of all votes
- remove debugging information and workaround that made the selected neuron ids unique

# Screenshots

Flutter:

<img width="1513" alt="Capture d’écran 2022-04-20 à 08 30 19" src="https://user-images.githubusercontent.com/16886711/164190143-809c1410-b679-40ad-83a7-ff4b40b116e4.png">

