### PR TITLE
fix: filter have no effect after proposal detail page back action

### DIFF
--- a/frontend/svelte/src/lib/api/proposals.api.ts
+++ b/frontend/svelte/src/lib/api/proposals.api.ts
@@ -107,15 +107,15 @@ export const registerVote = async ({
     agent: await createAgent({ identity, host: process.env.HOST }),
   });
 
-  const response = await governance.registerVote({
+  await governance.registerVote({
     neuronId,
     vote,
     proposalId,
   });
+
   logWithTimestamp(
     `Registering Vote (${hashCode(proposalId)}, ${hashCode(
       neuronId
     )}) complete.`
   );
-  return response;
 };

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -90,7 +90,7 @@
       isReferrerProposalDetail
     ) {
       initDebounceFindProposals();
-
+      initialized = true;
       return;
     }
 

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -387,7 +387,7 @@ describe("proposals-services", () => {
         });
       };
 
-    let lastToastMessage: ToastMsg, spyToastShow;
+    let spyToastShow;
 
     beforeEach(() => {
       jest
@@ -396,7 +396,7 @@ describe("proposals-services", () => {
 
       spyToastShow = jest
         .spyOn(toastsStore, "show")
-        .mockImplementation((params) => (lastToastMessage = params));
+        .mockImplementation(jest.fn());
     });
 
     afterAll(() => jest.clearAllMocks());


### PR DESCRIPTION
# Motivation

PR [#698](https://github.com/dfinity/nns-dapp/pull/698) had a missing flow. It indeed did not reset the list of proposals but had for effect to make the changes of the filters ignored after navigating back from the proposal detail page.

This PR resolves the issue.

# Changes

- if we don't reset the filter and list explicitly, we can consider the component as `initialized`

