### PR TITLE
fix: filters have no effect after back from detail page

### DIFF
--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -90,7 +90,7 @@
       isReferrerProposalDetail
     ) {
       initDebounceFindProposals();
-
+      initialized = true;
       return;
     }
 


### PR DESCRIPTION
# Motivation

PR [#698](https://github.com/dfinity/nns-dapp/pull/698) had a missing flow. It indeed did not reset the list of proposals but had for effect to make the changes of the filters ignored after navigating back from the proposal detail page.

This PR resolves the issue.

# Changes

- if we don't reset the filter and list explicitly, we can consider the component as `initialized`