### PR TITLE
Fix docker builds of the flutter frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN echo "REDIRECT_TO_LEGACY: '$REDIRECT_TO_LEGACY'"
 COPY . /build
 WORKDIR /build
 RUN find . -type f | sed 's/^..//g' > ../build-inputs.txt
+RUN git config --global --add safe.directory /flutter
 RUN ./build.sh
 
 RUN ls -sh nns-dapp.wasm; sha256sum nns-dapp.wasm


### PR DESCRIPTION
# Motivation
Flutter builds in docker are failing.

Notes:
- Builds started failing at about 8pm last night.  See:  https://github.com/dfinity/nns-dapp/actions/workflows/docker-build.yaml
- Builds failed equally in CI and on local docker
- Non-docker builds still work.
- Several new errors were observed in docker.  One was:
```
    #30 28.24 fatal: unsafe repository ('/flutter' is owned by someone else)
    #30 28.24 To add an exception for this directory, call:
   #30 28.24
   #30 28.24 	git config --global --add safe.directory /flutter
```
- Taking this suggestion seems to work.

# Changes
- Added a git config line to the dockerfile.

# Tests
- See CI
- Local (non-CI) docker builds work.