### PR TITLE
feat: disable confirm button while processing

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -6,7 +6,7 @@
   import type { TransactionContext } from "../../stores/transaction.store";
   import { createEventDispatcher, getContext } from "svelte";
   import { i18n } from "../../stores/i18n";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { transferICP } from "../../services/accounts.services";
 
   const context: TransactionContext = getContext<TransactionContext>(
@@ -40,7 +40,7 @@
 
   <NewTransactionInfo />
 
-  <button class="primary full-width" type="submit">
+  <button class="primary full-width" type="submit" disabled={$busy}>
     {$i18n.accounts.confirm_and_send}
   </button>
 </form>

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
@@ -81,6 +81,7 @@ describe("NewTransactionReview", () => {
     ) as HTMLButtonElement;
     await fireEvent.click(button);
 
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBeTruthy());
     await waitFor(() => expect(spyTransferICP).toHaveBeenCalled());
   });
 


### PR DESCRIPTION
# Motivation

Disable "Confirm transaction" action while processing to prevent misbehavior and to follow pattern of other steps / wizards.

# Changes

- button `disabled` if `busy`

# Screenshot

<img width="1248" alt="Capture d’écran 2022-04-25 à 07 56 55" src="https://user-images.githubusercontent.com/16886711/165030692-9743513a-66eb-4e81-bbae-c550673bd42f.png">

