### PR TITLE
feat: autocomplete to off as default value for input type text

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -22,6 +22,7 @@
       inputType === "number" ? +currentTarget.value : currentTarget.value);
 
   $: step = inputType === "number" ? step ?? "any" : undefined;
+  $: autocomplete = inputType !== "number" ? autocomplete ?? "off" : undefined;
 
   let placeholder: string;
   $: placeholder = translate({ labelKey: placeholderLabelKey });

--- a/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Input.spec.ts
@@ -131,6 +131,7 @@ describe("Input", () => {
     const { container } = render(Input, {
       props: {
         ...props,
+        inputType: "text",
         autocomplete: "off",
       },
     });
@@ -144,6 +145,17 @@ describe("Input", () => {
     });
 
     testGetAttribute({ container, attribute: "step", expected: "any" });
+  });
+
+  it("should render a text input with autocomplete to off as default value", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    testGetAttribute({ container, attribute: "autocomplete", expected: "off" });
   });
 
   it("should render an input with min length", () => {


### PR DESCRIPTION
# Motivation

Per default, we do not want to use the autocomplete feature for `<input />` set as type text. It notably fixes a styling issue on Webkit.

# Changes

- set `autocomplete` to `off` per default

# Screenshots

<img width="1248" alt="Capture d’écran 2022-04-25 à 07 48 50" src="https://user-images.githubusercontent.com/16886711/165040865-adb07c64-2cfe-4e74-8ea6-e231ec78c983.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 07 48 55" src="https://user-images.githubusercontent.com/16886711/165040874-a9a87601-e291-481d-9508-4f16057a881d.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 07 49 08" src="https://user-images.githubusercontent.com/16886711/165040878-149dcc26-ccd5-4df7-99a0-7ce5bd031d58.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 07 49 39" src="https://user-images.githubusercontent.com/16886711/165040882-953c170a-0393-4aaa-bc54-2a57e6f03f6b.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 07 49 42" src="https://user-images.githubusercontent.com/16886711/165040884-c8815185-5af7-4f0e-b56e-724f385d091d.png">

