### PR TITLE
feat: add "new transaction" feature to wallet page

### DIFF
--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -13,10 +13,15 @@
   import NewTransactionAmount from "../../components/accounts/NewTransactionAmount.svelte";
   import { NEW_TRANSACTION_CONTEXT_KEY } from "../../stores/transaction.store";
   import NewTransactionReview from "../../components/accounts/NewTransactionReview.svelte";
+  import type { Account } from "../../types/account";
 
-  export let canSelectAccount: boolean;
+  export let selectedAccount: Account | undefined = undefined;
 
-  const steps: Steps = [
+  let canSelectAccount: boolean;
+  $: canSelectAccount = selectedAccount === undefined;
+
+  let steps: Steps;
+  $: steps = [
     ...((canSelectAccount
       ? [
           {
@@ -44,7 +49,7 @@
   ];
 
   const newTransactionStore = writable<TransactionStore>({
-    selectedAccount: undefined,
+    selectedAccount,
     destinationAddress: undefined,
     amount: undefined,
   });
@@ -53,6 +58,12 @@
     store: newTransactionStore,
     next: () => modal?.next(),
   });
+
+  // Update store with selectedAccount in case the property would be set after the component is initialized
+  $: newTransactionStore.update((data) => ({
+    ...data,
+    selectedAccount,
+  }));
 
   let currentStep: Step | undefined;
   let modal: WizardModal | undefined;

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -1,4 +1,5 @@
 import type { Identity } from "@dfinity/agent";
+import { get } from "svelte/store";
 import { createSubAccount, loadAccounts } from "../api/accounts.api";
 import { sendICP } from "../api/ledger.api";
 import { toSubAccountId } from "../api/utils.api";
@@ -6,6 +7,8 @@ import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { TransactionStore } from "../stores/transaction.store";
+import type { Account } from "../types/account";
+import { getLastPathDetail } from "../utils/app-path.utils";
 import { errorToString } from "../utils/error.utils";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
@@ -100,4 +103,31 @@ const transferError = ({
   });
 
   return { success: false, err: labelKey };
+};
+
+export const routePathAccountIdentifier = (
+  path: string | undefined
+): string | undefined => {
+  const accountIdentifier: string | undefined = getLastPathDetail(path);
+  return accountIdentifier !== undefined && accountIdentifier !== ""
+    ? accountIdentifier
+    : undefined;
+};
+
+export const getAccountFromStore = (
+  identifier: string | undefined
+): Account | undefined => {
+  if (identifier === undefined) {
+    return undefined;
+  }
+
+  const { main, subAccounts }: AccountsStore = get(accountsStore);
+
+  if (main?.identifier === identifier) {
+    return main;
+  }
+
+  return subAccounts?.find(
+    (account: Account) => account.identifier === identifier
+  );
 };

--- a/frontend/svelte/src/lib/utils/app-path.utils.ts
+++ b/frontend/svelte/src/lib/utils/app-path.utils.ts
@@ -26,7 +26,7 @@ export const isRoutePath: ({
 );
 
 export const getLastPathDetailId = (path: string): bigint | undefined => {
-  const pathDetail = path.split("/").pop();
+  const pathDetail = getLastPathDetail(path);
   if (pathDetail === undefined) {
     return undefined;
   }
@@ -38,3 +38,7 @@ export const getLastPathDetailId = (path: string): bigint | undefined => {
     return undefined;
   }
 };
+
+export const getLastPathDetail = (
+  path: string | undefined
+): string | undefined => path?.split("/").pop();

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -86,10 +86,16 @@
     <svelte:fragment slot="footer">
       {#if accounts}
         <Toolbar>
-          <button class="primary" on:click={openNewTransaction}
+          <button
+            class="primary"
+            on:click={openNewTransaction}
+            data-tid="open-new-transaction"
             >{$i18n.accounts.new_transaction}</button
           >
-          <button class="primary" on:click={openAddAccountModal}
+          <button
+            class="primary"
+            on:click={openAddAccountModal}
+            data-tid="open-add-account-modal"
             >{$i18n.accounts.add_account}</button
           >
         </Toolbar>
@@ -99,7 +105,7 @@
       <AddAcountModal on:nnsClose={closeModal} />
     {/if}
     {#if modal === "NewTransaction"}
-      <NewTransactionModal on:nnsClose={closeModal} canSelectAccount={true} />
+      <NewTransactionModal on:nnsClose={closeModal} />
     {/if}
   </Layout>
 {/if}

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -8,6 +8,14 @@
     AppPath,
     SHOW_ACCOUNTS_ROUTE,
   } from "../lib/constants/routes.constants";
+  import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
+  import {
+    getAccountFromStore,
+    routePathAccountIdentifier,
+  } from "../lib/services/accounts.services";
+  import type { Account } from "../lib/types/account";
+  import { accountsStore } from "../lib/stores/accounts.store";
+  import Spinner from "../lib/components/ui/Spinner.svelte";
 
   onMount(() => {
     if (!SHOW_ACCOUNTS_ROUTE) {
@@ -15,31 +23,52 @@
     }
   });
 
-  const goBack = () => {
+  const goBack = () =>
     routeStore.navigate({
       path: AppPath.Accounts,
     });
-  };
 
-  // TODO: TBD https://dfinity.atlassian.net/browse/L2-225
-  const createNewTransaction = () => alert("New Transaction");
+  let showNewTransactionModal = false;
+
+  let accountIdentifier: string | undefined;
+  $: accountIdentifier = routePathAccountIdentifier($routeStore.path);
+
+  let mainAccount: Account | undefined;
+  $: mainAccount = $accountsStore?.main;
+
+  // TODO(L2-429): context and store for selectedAccount
+  let selectedAccount: Account | undefined;
+  $: accountIdentifier,
+    $accountsStore,
+    (() => (selectedAccount = getAccountFromStore(accountIdentifier)))();
 </script>
 
 {#if SHOW_ACCOUNTS_ROUTE}
   <HeadlessLayout on:nnsBack={goBack}>
     <svelte:fragment slot="header">{$i18n.wallet.title}</svelte:fragment>
 
-    <section>TBD</section>
+    {#if mainAccount}
+      <section>TBD - TODO(L2-429)</section>
+    {:else}
+      <Spinner />
+    {/if}
 
     <svelte:fragment slot="footer">
       <Toolbar>
-        <button class="primary" on:click={createNewTransaction}
+        <button
+          class="primary"
+          on:click={() => (showNewTransactionModal = true)}
+          disabled={selectedAccount === undefined || !mainAccount}
           >{$i18n.accounts.new_transaction}</button
         >
       </Toolbar>
     </svelte:fragment>
   </HeadlessLayout>
-{/if}
 
-<style lang="scss">
-</style>
+  {#if showNewTransactionModal}
+    <NewTransactionModal
+      on:nnsClose={() => (showNewTransactionModal = false)}
+      {selectedAccount}
+    />
+  {/if}
+{/if}

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -40,7 +40,6 @@ describe("NewTransactionModal", () => {
   it("should display modal", async () => {
     const { container } = await renderModal({
       component: NewTransactionModal,
-      props: { canSelectAccount: true },
     });
 
     expect(container.querySelector("div.modal")).not.toBeNull();
@@ -115,7 +114,6 @@ describe("NewTransactionModal", () => {
   it("should navigate back and forth between steps", async () => {
     const { container, getByText } = await renderModal({
       component: NewTransactionModal,
-      props: { canSelectAccount: true },
     });
 
     // Is step 1 active?
@@ -173,7 +171,6 @@ describe("NewTransactionModal", () => {
   it("should close wizard once transaction executed", async () => {
     const { container, getByText, component } = await renderModal({
       component: NewTransactionModal,
-      props: { canSelectAccount: true },
     });
 
     await goToStep2({ container, getByText });

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -4,6 +4,8 @@ import * as accountsApi from "../../../lib/api/accounts.api";
 import * as ledgerApi from "../../../lib/api/ledger.api";
 import {
   addSubAccount,
+  getAccountFromStore,
+  routePathAccountIdentifier,
   syncAccounts,
   transferICP,
 } from "../../../lib/services/accounts.services";
@@ -20,99 +22,148 @@ import {
 } from "../../mocks/auth.store.mock";
 
 describe("accounts-services", () => {
-  const mockAccounts = { main: mockMainAccount, subAccounts: [] };
+  describe("services", () => {
+    const mockAccounts = { main: mockMainAccount, subAccounts: [] };
 
-  const spyLoadAccounts = jest
-    .spyOn(accountsApi, "loadAccounts")
-    .mockImplementation(() => Promise.resolve(mockAccounts));
+    const spyLoadAccounts = jest
+      .spyOn(accountsApi, "loadAccounts")
+      .mockImplementation(() => Promise.resolve(mockAccounts));
 
-  const spyCreateSubAccount = jest
-    .spyOn(accountsApi, "createSubAccount")
-    .mockImplementation(() => Promise.resolve());
+    const spyCreateSubAccount = jest
+      .spyOn(accountsApi, "createSubAccount")
+      .mockImplementation(() => Promise.resolve());
 
-  const spySendICP = jest
-    .spyOn(ledgerApi, "sendICP")
-    .mockImplementation(() => Promise.resolve(BigInt(0)));
+    const spySendICP = jest
+      .spyOn(ledgerApi, "sendICP")
+      .mockImplementation(() => Promise.resolve(BigInt(0)));
 
-  beforeAll(() => jest.spyOn(console, "error").mockImplementation(jest.fn));
+    beforeAll(() => jest.spyOn(console, "error").mockImplementation(jest.fn));
 
-  afterAll(() => jest.clearAllMocks());
+    afterAll(() => jest.clearAllMocks());
 
-  it("should sync accounts", async () => {
-    await syncAccounts();
+    it("should sync accounts", async () => {
+      await syncAccounts();
 
-    expect(spyLoadAccounts).toHaveBeenCalled();
+      expect(spyLoadAccounts).toHaveBeenCalled();
 
-    const accounts = get(accountsStore);
-    expect(accounts).toEqual(mockAccounts);
-  });
-
-  it("should add a subaccount", async () => {
-    await addSubAccount({ name: "test subaccount" });
-
-    expect(spyCreateSubAccount).toHaveBeenCalled();
-  });
-
-  it("should not sync accounts if no identity", async () => {
-    setNoIdentity();
-
-    const call = async () => await syncAccounts();
-
-    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
-
-    resetIdentity();
-  });
-
-  it("should not add subaccount if no identity", async () => {
-    setNoIdentity();
-
-    const call = async () => await addSubAccount({ name: "test subaccount" });
-
-    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
-
-    resetIdentity();
-  });
-
-  const transferICPParams: TransactionStore = {
-    selectedAccount: mockMainAccount,
-    destinationAddress: mockSubAccount.identifier,
-    amount: ICP.fromE8s(BigInt(1)),
-  };
-
-  it("should transfer ICP", async () => {
-    await transferICP(transferICPParams);
-
-    expect(spySendICP).toHaveBeenCalled();
-  });
-
-  it("should sync accounts after transfer ICP", async () => {
-    await transferICP(transferICPParams);
-
-    expect(spyLoadAccounts).toHaveBeenCalled();
-  });
-
-  it("should throw errors if transfer params not provided", async () => {
-    const { err: errSelectedAccount } = await transferICP({
-      ...transferICPParams,
-      selectedAccount: undefined,
+      const accounts = get(accountsStore);
+      expect(accounts).toEqual(mockAccounts);
     });
 
-    expect(errSelectedAccount).toEqual("error.transaction_no_source_account");
+    it("should add a subaccount", async () => {
+      await addSubAccount({ name: "test subaccount" });
 
-    const { err: errDestinationAddress } = await transferICP({
-      ...transferICPParams,
-      destinationAddress: undefined,
+      expect(spyCreateSubAccount).toHaveBeenCalled();
     });
 
-    expect(errDestinationAddress).toEqual(
-      "error.transaction_no_destination_address"
+    it("should not sync accounts if no identity", async () => {
+      setNoIdentity();
+
+      const call = async () => await syncAccounts();
+
+      await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+      resetIdentity();
+    });
+
+    it("should not add subaccount if no identity", async () => {
+      setNoIdentity();
+
+      const call = async () => await addSubAccount({ name: "test subaccount" });
+
+      await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+      resetIdentity();
+    });
+
+    const transferICPParams: TransactionStore = {
+      selectedAccount: mockMainAccount,
+      destinationAddress: mockSubAccount.identifier,
+      amount: ICP.fromE8s(BigInt(1)),
+    };
+
+    it("should transfer ICP", async () => {
+      await transferICP(transferICPParams);
+
+      expect(spySendICP).toHaveBeenCalled();
+    });
+
+    it("should sync accounts after transfer ICP", async () => {
+      await transferICP(transferICPParams);
+
+      expect(spyLoadAccounts).toHaveBeenCalled();
+    });
+
+    it("should throw errors if transfer params not provided", async () => {
+      const { err: errSelectedAccount } = await transferICP({
+        ...transferICPParams,
+        selectedAccount: undefined,
+      });
+
+      expect(errSelectedAccount).toEqual("error.transaction_no_source_account");
+
+      const { err: errDestinationAddress } = await transferICP({
+        ...transferICPParams,
+        destinationAddress: undefined,
+      });
+
+      expect(errDestinationAddress).toEqual(
+        "error.transaction_no_destination_address"
+      );
+
+      const { err: errAmount } = await transferICP({
+        ...transferICPParams,
+        amount: undefined,
+      });
+
+      expect(errAmount).toEqual("error.transaction_invalid_amount");
+    });
+  });
+
+  describe("details", () => {
+    beforeAll(() => {
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterAll(() => jest.clearAllMocks());
+
+    it("should get account identifier from valid path", () => {
+      expect(
+        routePathAccountIdentifier(`/#/wallet/${mockMainAccount.identifier}`)
+      ).toEqual(mockMainAccount.identifier);
+    });
+
+    it("should not get account identifier from invalid path", () => {
+      expect(routePathAccountIdentifier("/#/wallet/")).toBeUndefined();
+      expect(routePathAccountIdentifier(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("get-account", () => {
+    beforeAll(() =>
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+      })
     );
 
-    const { err: errAmount } = await transferICP({
-      ...transferICPParams,
-      amount: undefined,
+    afterAll(() => accountsStore.reset());
+
+    it("should not return an account if no identifier is provided", () => {
+      expect(getAccountFromStore(undefined)).toBeUndefined();
     });
 
-    expect(errAmount).toEqual("error.transaction_invalid_amount");
+    it("should find no account if not matches", () => {
+      expect(getAccountFromStore("aaa")).toBeUndefined();
+    });
+
+    it("should return corresponding account", () => {
+      expect(getAccountFromStore(mockMainAccount.identifier)).toEqual(
+        mockMainAccount
+      );
+      expect(getAccountFromStore(mockSubAccount.identifier)).toEqual(
+        mockSubAccount
+      );
+    });
   });
 });

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -153,12 +153,12 @@ describe("proposals-services", () => {
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
     afterAll(() => jest.clearAllMocks());
-    it("should get proposalId from valid path", async () => {
+    it("should get proposalId from valid path", () => {
       expect(getProposalId("/#/proposal/123")).toBe(BigInt(123));
       expect(getProposalId("/#/proposal/0")).toBe(BigInt(0));
     });
 
-    it("should not get proposalId from invalid path", async () => {
+    it("should not get proposalId from invalid path", () => {
       expect(getProposalId("/#/proposal/")).toBeUndefined();
       expect(getProposalId("/#/proposal/1.5")).toBeUndefined();
       expect(getProposalId("/#/proposal/123n")).toBeUndefined();

--- a/frontend/svelte/src/tests/lib/utils/app-path.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/app-path.utils.spec.ts
@@ -1,5 +1,6 @@
 import { AppPath } from "../../../lib/constants/routes.constants";
 import {
+  getLastPathDetail,
   getLastPathDetailId,
   isAppPath,
   isRoutePath,
@@ -26,7 +27,7 @@ describe("routes", () => {
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
     afterAll(() => jest.clearAllMocks());
-    it("should get id from valid path", async () => {
+    it("should get id from valid path", () => {
       expect(getLastPathDetailId("/#/neuron/123")).toBe(BigInt(123));
       expect(getLastPathDetailId("/neuron/123")).toBe(BigInt(123));
       expect(getLastPathDetailId("/proposal/123")).toBe(BigInt(123));
@@ -34,12 +35,37 @@ describe("routes", () => {
       expect(getLastPathDetailId("/1234")).toBe(BigInt(1234));
     });
 
-    it("should not get neuronId from invalid path", async () => {
+    it("should not get neuronId from invalid path", () => {
       expect(getLastPathDetailId("/#/neuron/")).toBeUndefined();
       expect(getLastPathDetailId("/#/neuron/1.5")).toBeUndefined();
       expect(getLastPathDetailId("/neuron/1.5")).toBeUndefined();
       expect(getLastPathDetailId("/")).toBeUndefined();
       expect(getLastPathDetailId("/#/neuron/123n")).toBeUndefined();
+    });
+  });
+
+  describe("getLastPathDetail", () => {
+    beforeAll(() => {
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterAll(() => jest.clearAllMocks());
+    it("should get detail from valid path", () => {
+      expect(getLastPathDetail("/#/neuron/123_abc")).toBe("123_abc");
+      expect(getLastPathDetail("/neuron/123_abc")).toBe("123_abc");
+      expect(getLastPathDetail("/proposal/123_abc")).toBe("123_abc");
+      expect(getLastPathDetail("/#/neuron/0")).toBe("0");
+      expect(getLastPathDetail("/123_abc")).toBe("123_abc");
+    });
+
+    it("should get empty detail for an invalid path", () => {
+      expect(getLastPathDetail("/#/neuron/")).toEqual("");
+      expect(getLastPathDetail("/neuron/")).toEqual("");
+      expect(getLastPathDetail("/")).toEqual("");
+    });
+
+    it("should not get detail for an undefined path", () => {
+      expect(getLastPathDetail(undefined)).toBeUndefined();
     });
   });
 

--- a/frontend/svelte/src/tests/routes/Accounts.spec.ts
+++ b/frontend/svelte/src/tests/routes/Accounts.spec.ts
@@ -134,11 +134,9 @@ describe("Accounts", () => {
   });
 
   it("should open add account modal", async () => {
-    const { container, getByText } = render(Accounts);
+    const { container, getByTestId, getByText } = render(Accounts);
 
-    const button = container.querySelector(
-      '[data-tid="open-add-account-modal"]'
-    ) as HTMLButtonElement;
+    const button = getByTestId("open-add-account-modal") as HTMLButtonElement;
     await fireEvent.click(button);
 
     await waitFor(() => {

--- a/frontend/svelte/src/tests/routes/Accounts.spec.ts
+++ b/frontend/svelte/src/tests/routes/Accounts.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { accountsStore } from "../../lib/stores/accounts.store";
 import { authStore } from "../../lib/stores/auth.store";
 import { formatICP } from "../../lib/utils/icp.utils";
@@ -13,6 +13,7 @@ import {
   mockSubAccount,
 } from "../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
+import en from "../mocks/i18n.mock";
 
 describe("Accounts", () => {
   let accountsStoreMock: jest.SpyInstance;
@@ -113,5 +114,39 @@ describe("Accounts", () => {
       .spyOn(accountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe());
     expect(accountsStoreMock).toHaveBeenCalled();
+  });
+
+  it("should open transaction modal", async () => {
+    const { container, getByText } = render(Accounts);
+
+    const button = container.querySelector(
+      '[data-tid="open-new-transaction"]'
+    ) as HTMLButtonElement;
+    await fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(container.querySelector("div.modal")).not.toBeNull();
+
+      expect(
+        getByText(en.accounts.select_source, { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should open add account modal", async () => {
+    const { container, getByText } = render(Accounts);
+
+    const button = container.querySelector(
+      '[data-tid="open-add-account-modal"]'
+    ) as HTMLButtonElement;
+    await fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(container.querySelector("div.modal")).not.toBeNull();
+
+      expect(
+        getByText(en.accounts.new_linked_title, { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/svelte/src/tests/routes/Wallet.spec.ts
+++ b/frontend/svelte/src/tests/routes/Wallet.spec.ts
@@ -46,9 +46,9 @@ describe("Wallet", () => {
     });
 
     it("should render a spinner while loading", () => {
-      const { container } = render(Wallet);
+      const { getByTestId } = render(Wallet);
 
-      expect(container.querySelector('[data-tid="spinner"]')).not.toBeNull();
+      expect(getByTestId("spinner")).not.toBeNull();
     });
 
     it("new transaction action should be disabled while loading", () => {

--- a/frontend/svelte/src/tests/routes/Wallet.spec.ts
+++ b/frontend/svelte/src/tests/routes/Wallet.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { accountsStore } from "../../lib/stores/accounts.store";
+import { authStore } from "../../lib/stores/auth.store";
+import { routeStore } from "../../lib/stores/route.store";
+import Wallet from "../../routes/Wallet.svelte";
+import {
+  mockAccountsStoreSubscribe,
+  mockMainAccount,
+} from "../mocks/accounts.store.mock";
+import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
+import en from "../mocks/i18n.mock";
+import { mockRouteStoreSubscibe } from "../mocks/route.store.mock";
+
+describe("Wallet", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
+  const testToolbarButton = ({
+    container,
+    disabled,
+  }: {
+    container: HTMLElement;
+    disabled: boolean;
+  }) => {
+    const button = container.querySelector("div.toolbar button");
+
+    expect(button).not.toBeNull();
+    expect((button as HTMLButtonElement).hasAttribute("disabled")).toEqual(
+      disabled
+    );
+  };
+
+  describe("loading", () => {
+    it("should render title", async () => {
+      const { getAllByText } = render(Wallet);
+
+      expect(getAllByText(en.wallet.title).length).toBeGreaterThan(0);
+    });
+
+    it("should render a spinner while loading", () => {
+      const { container } = render(Wallet);
+
+      expect(container.querySelector('[data-tid="spinner"]')).not.toBeNull();
+    });
+
+    it("new transaction action should be disabled while loading", () => {
+      const { container } = render(Wallet);
+
+      testToolbarButton({ container, disabled: true });
+    });
+  });
+
+  describe("no accounts", () => {
+    beforeAll(() => {
+      jest
+        .spyOn(routeStore, "subscribe")
+        .mockImplementation(
+          mockRouteStoreSubscibe(`/#/wallet/${mockMainAccount.identifier}`)
+        );
+    });
+
+    afterAll(() => jest.clearAllMocks());
+
+    it("new transaction should remain disabled if route is valid but store is not loaded", async () => {
+      const { container } = render(Wallet);
+
+      // init
+      testToolbarButton({ container, disabled: true });
+
+      await tick();
+
+      // route set triggers get account
+      testToolbarButton({ container, disabled: true });
+    });
+  });
+
+  describe("accounts loaded", () => {
+    beforeAll(() => {
+      jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+
+      jest
+        .spyOn(routeStore, "subscribe")
+        .mockImplementation(
+          mockRouteStoreSubscibe(`/#/wallet/${mockMainAccount.identifier}`)
+        );
+    });
+
+    afterAll(() => jest.clearAllMocks());
+
+    it("should hide spinner when accounts are loaded", async () => {
+      const { container } = render(Wallet);
+
+      await waitFor(() =>
+        expect(container.querySelector('[data-tid="spinner"]')).toBeNull()
+      );
+    });
+
+    it("should enable new transaction action for route and store", async () => {
+      const { container } = render(Wallet);
+
+      await waitFor(() => testToolbarButton({ container, disabled: false }));
+    });
+
+    const testModal = async (container: HTMLElement) => {
+      const button = container.querySelector(
+        "div.toolbar button"
+      ) as HTMLButtonElement;
+      await fireEvent.click(button);
+
+      await waitFor(() =>
+        expect(container.querySelector("div.modal")).not.toBeNull()
+      );
+    };
+
+    it("should open transaction modal", async () => {
+      const { container } = render(Wallet);
+
+      await testModal(container);
+    });
+
+    it("should open transaction modal on step select destination because selected account is current account", async () => {
+      const { container, getByText } = render(Wallet);
+
+      await testModal(container);
+
+      expect(
+        getByText(en.accounts.select_destination, { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/svelte/src/tests/routes/Wallet.spec.ts
+++ b/frontend/svelte/src/tests/routes/Wallet.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
 import en from "../mocks/i18n.mock";
-import { mockRouteStoreSubscibe } from "../mocks/route.store.mock";
+import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
 
 describe("Wallet", () => {
   beforeEach(() => {
@@ -63,7 +63,7 @@ describe("Wallet", () => {
       jest
         .spyOn(routeStore, "subscribe")
         .mockImplementation(
-          mockRouteStoreSubscibe(`/#/wallet/${mockMainAccount.identifier}`)
+          mockRouteStoreSubscribe(`/#/wallet/${mockMainAccount.identifier}`)
         );
     });
 
@@ -91,7 +91,7 @@ describe("Wallet", () => {
       jest
         .spyOn(routeStore, "subscribe")
         .mockImplementation(
-          mockRouteStoreSubscibe(`/#/wallet/${mockMainAccount.identifier}`)
+          mockRouteStoreSubscribe(`/#/wallet/${mockMainAccount.identifier}`)
         );
     });
 


### PR DESCRIPTION
# Motivation

Access "New transaction" feature / modal from the "Wallet" page with the selected account prefilled to current account (the account displayed on the detail page).

# Changes

- path `selectedAccount` to `NewTransactionModal`
- resolve identifier from route path
- get account for identifier from store
- add utils to resolve last detail of path as `string`
- display spinner while loading accounts on wallet page
- enabled - disabled action on wallet page until data are loaded
- bind "new transaction" action modal with button

# Screenshots

<img width="1248" alt="Capture d’écran 2022-04-25 à 10 48 48" src="https://user-images.githubusercontent.com/16886711/165055382-ad2d1c5a-af67-4cb4-b3c4-c417b8fcedb8.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 10 48 56" src="https://user-images.githubusercontent.com/16886711/165055393-5b999c53-1c58-4930-a3ae-98be83b6d450.png">
<img width="1248" alt="Capture d’écran 2022-04-25 à 10 49 02" src="https://user-images.githubusercontent.com/16886711/165055398-4a66e1c3-2bd0-48ce-b78c-5c90ab553213.png">

