### PR TITLE
docs: fix jsdoc params definition

### DIFF
--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -183,8 +183,10 @@ export const stakeAndLoadNeuron = async ({
 
 /**
  * This gets all neurons linked to the current user's principal, even those with a stake of 0. And adds them to the store
- * @param skipCheck it true, the neurons' balance won't be checked and those that are not synced won't be refreshed. Useful because the function `checkNeuronBalances` that does this check might ultimately call the current function `listNeurons` again.
- * @param callback an optional callback that can be called when the data are successfully loaded (certified or not). Useful for example to close synchronously a busy spinner once all data have been fetched.
+ *
+ * @param {Object} params
+ * @param {skipCheck} params.skipCheck it true, the neurons' balance won't be checked and those that are not synced won't be refreshed. Useful because the function `checkNeuronBalances` that does this check might ultimately call the current function `listNeurons` again.
+ * @param {callback} params.callback an optional callback that can be called when the data are successfully loaded (certified or not). Useful for example to close synchronously a busy spinner once all data have been fetched.
  */
 export const listNeurons = async ({
   skipCheck = false,


### PR DESCRIPTION
# Motivation

eslint warning "JSDoc '@param' tag has name 'callback', but there is no parameter with that name. "

# Changes

- declare first the param object and then the param variables in jsdoc
