### PR TITLE
chore: missing types for log function

### DIFF
--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -7,7 +7,7 @@ export const isNode = (): boolean =>
  *
  * console.log with time prefix (e.g. "[15:22:55.438] message text")
  */
-export const logWithTimestamp = (...args): void => {
+export const logWithTimestamp = (...args: string[]): void => {
   if (isNode() === true) return;
 
   const time = `[${new Date().toISOString().split("T")[1].replace("Z", "")}]`;


### PR DESCRIPTION
# Motivation

eslint warning "Rest parameter 'args' implicitly has an 'any[]' type, but a better type may be inferred from usage. "

# Changes

- define args as type `string[]`
