### PR TITLE
feat: toast display as success instead of info

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
@@ -39,7 +39,7 @@
     if (id !== undefined) {
       toastsStore.show({
         labelKey: successKey,
-        level: "info",
+        level: "success",
       });
     }
     closeModal();

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
@@ -19,7 +19,7 @@
     if (id !== undefined) {
       toastsStore.show({
         labelKey: "neuron_detail.join_community_fund_success",
-        level: "info",
+        level: "success",
       });
     }
     closeModal();

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -37,7 +37,7 @@
       dispatcher("nnsUpdated");
       toastsStore.show({
         labelKey: "neurons.dissolve_delay_success",
-        level: "info",
+        level: "success",
       });
     }
   };

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -38,7 +38,7 @@
     if (id !== undefined) {
       toastsStore.show({
         labelKey: "neuron_detail.merge_neurons_success",
-        level: "info",
+        level: "success",
       });
     }
     loading = false;

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -61,7 +61,7 @@
     });
     toastsStore.show({
       labelKey: "new_followee.success_remove_followee",
-      level: "info",
+      level: "success",
     });
     stopBusy("remove-followee");
   };

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -62,8 +62,8 @@
     transform: translate(-50%, 0);
 
     border-radius: var(--border-radius);
-    background: var(--black);
-    color: var(--black-contrast);
+    background: var(--green-500);
+    color: var(--green-500-contrast);
     box-shadow: 0 4px 16px 0 rgba(var(--background-rgb), 0.3);
 
     width: calc(100% - var(--padding-8x));

--- a/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
@@ -32,7 +32,7 @@
       const response = await addHotkey({ neuronId, principal });
       if (response !== undefined) {
         toastsStore.show({
-          level: "info",
+          level: "success",
           labelKey: "neuron_detail.add_hotkey_success",
         });
       }

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -50,7 +50,7 @@
     if (id !== undefined) {
       toastsStore.show({
         labelKey: "neurons.split_neuron_success",
-        level: "info",
+        level: "success",
       });
     }
     dispatcher("nnsClose");

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -79,7 +79,7 @@ export const displayAndCleanLogoutMsg = () => {
 
   // For simplicity reason we assume the level pass as query params is one of the type ToastLevel
   const level: ToastLevel =
-    (urlParams.get(levelParam) as ToastLevel | null) ?? "info";
+    (urlParams.get(levelParam) as ToastLevel | null) ?? "success";
 
   toastsStore.show({ labelKey: msg, level });
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -474,7 +474,7 @@ export const splitNeuron = async ({
     await splitNeuronApi({ neuronId, identity, amount: stake });
     toastsStore.show({
       labelKey: "neuron_detail.split_neuron_success",
-      level: "info",
+      level: "success",
     });
 
     await getAndLoadNeuronHelper({ neuronId, identity });
@@ -546,7 +546,7 @@ const setFolloweesHelper = async ({
 
     toastsStore.show({
       labelKey: `new_followee.success_${labelKey}`,
-      level: "info",
+      level: "success",
     });
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
@@ -673,7 +673,7 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     });
     toastsStore.show({
       labelKey: "neuron_detail.dummy_proposal_success",
-      level: "info",
+      level: "success",
     });
     return;
   } catch (error) {

--- a/frontend/svelte/src/lib/types/toast.ts
+++ b/frontend/svelte/src/lib/types/toast.ts
@@ -1,4 +1,4 @@
-export type ToastLevel = "info" | "warn" | "error";
+export type ToastLevel = "success" | "warn" | "error";
 
 export interface ToastMsg {
   labelKey: string;

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -9,7 +9,7 @@ import en from "../../../mocks/i18n.mock";
 
 describe("Toast", () => {
   const props: { msg: ToastMsg } = {
-    msg: { labelKey: "core.close", level: "info", detail: "more details" },
+    msg: { labelKey: "core.close", level: "success", detail: "more details" },
   };
 
   it("should render a text", async () => {

--- a/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toasts.spec.ts
@@ -21,7 +21,7 @@ describe("Toasts", () => {
   it("should display a toast", async () => {
     const { container } = render(Toasts);
 
-    toastsStore.show({ labelKey: "test.test", level: "info" });
+    toastsStore.show({ labelKey: "test.test", level: "success" });
 
     await waitForDialog(container);
 
@@ -31,7 +31,7 @@ describe("Toasts", () => {
   it("should display an informative toast", async () => {
     const { container } = render(Toasts);
 
-    toastsStore.show({ labelKey: "test.test", level: "info" });
+    toastsStore.show({ labelKey: "test.test", level: "success" });
 
     await waitForDialog(container);
 
@@ -85,7 +85,7 @@ describe("Toasts", () => {
   it("should close toast", async () => {
     const { container } = render(Toasts);
 
-    toastsStore.show({ labelKey: "test.test", level: "info" });
+    toastsStore.show({ labelKey: "test.test", level: "success" });
 
     await waitForDialog(container);
 

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -288,7 +288,7 @@ describe("proposals-services", () => {
         () =>
           (lastToastMessage = {
             labelKey: "",
-            level: "info",
+            level: "success",
           })
       );
 


### PR DESCRIPTION
# Motivation

The toast is actually used to display "success" messages and not information. Therefore this PR makes its color matching its purpose.

# Changes

- toast message `info` refactored to `success`
- colors from dark to "green" success color

# Screenshot

Was:

<img width="1248" alt="Capture d’écran 2022-04-25 à 11 47 46" src="https://user-images.githubusercontent.com/16886711/165065953-d33677d3-d131-4c73-9b93-7f4e25183156.png">

Suggestion:

<img width="1248" alt="Capture d’écran 2022-04-25 à 11 46 56" src="https://user-images.githubusercontent.com/16886711/165065992-495579ce-fcb8-472f-8959-4d64782518b3.png">

