### PR TITLE
feat: close accounts action modal on error too

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddNewAccount.svelte
@@ -15,26 +15,15 @@
   let dispatcher = createEventDispatcher();
 
   const createNewAccount = async () => {
-    try {
-      startBusy("accounts");
-      await addSubAccount({
-        name: newAccountName,
-      });
-      dispatcher("nnsClose");
-    } catch (err) {
-      const labelKey =
-        err instanceof NameTooLongError
-          ? "create_subaccount_too_long"
-          : err instanceof SubAccountLimitExceededError
-          ? "create_subaccount_limit_exceeded"
-          : "create_subaccount";
-      toastsStore.error({
-        labelKey,
-        err,
-      });
-    } finally {
-      stopBusy("accounts");
-    }
+    startBusy("accounts");
+
+    await addSubAccount({
+      name: newAccountName,
+    });
+
+    stopBusy("accounts");
+
+    dispatcher("nnsClose");
   };
 </script>
 

--- a/frontend/svelte/src/lib/components/accounts/AddNewAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddNewAccount.svelte
@@ -3,11 +3,6 @@
   import { i18n } from "../../stores/i18n";
   import { createEventDispatcher } from "svelte";
   import { addSubAccount } from "../../services/accounts.services";
-  import {
-    NameTooLongError,
-    SubAccountLimitExceededError,
-  } from "../../canisters/nns-dapp/nns-dapp.errors";
-  import { toastsStore } from "../../stores/toasts.store";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
 
   let newAccountName: string = "";

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -21,13 +21,9 @@
   const executeTransaction = async () => {
     startBusy("accounts");
 
-    const { success } = await transferICP($store);
+    await transferICP($store);
 
     stopBusy("accounts");
-
-    if (!success) {
-      return;
-    }
 
     dispatcher("nnsClose");
   };

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -2,6 +2,10 @@ import type { Identity } from "@dfinity/agent";
 import { createSubAccount, loadAccounts } from "../api/accounts.api";
 import { sendICP } from "../api/ledger.api";
 import { toSubAccountId } from "../api/utils.api";
+import {
+  NameTooLongError,
+  SubAccountLimitExceededError,
+} from "../canisters/nns-dapp/nns-dapp.errors";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
 import { toastsStore } from "../stores/toasts.store";
@@ -42,11 +46,25 @@ export const addSubAccount = async ({
 }: {
   name: string;
 }): Promise<void> => {
-  const identity: Identity = await getIdentity();
+  try {
+    const identity: Identity = await getIdentity();
 
-  await createSubAccount({ name, identity });
+    await createSubAccount({ name, identity });
 
-  await syncAccounts();
+    await syncAccounts();
+  } catch (err: unknown) {
+    const labelKey =
+      err instanceof NameTooLongError
+        ? "create_subaccount_too_long"
+        : err instanceof SubAccountLimitExceededError
+        ? "create_subaccount_limit_exceeded"
+        : "create_subaccount";
+
+    toastsStore.error({
+      labelKey,
+      err,
+    });
+  }
 };
 
 export const transferICP = async ({

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -8,6 +8,7 @@ import {
   transferICP,
 } from "../../../lib/services/accounts.services";
 import { accountsStore } from "../../../lib/stores/accounts.store";
+import { toastsStore } from "../../../lib/stores/toasts.store";
 import type { TransactionStore } from "../../../lib/stores/transaction.store";
 import {
   mockMainAccount,
@@ -18,6 +19,7 @@ import {
   resetIdentity,
   setNoIdentity,
 } from "../../mocks/auth.store.mock";
+import en from "../../mocks/i18n.mock";
 
 describe("accounts-services", () => {
   const mockAccounts = { main: mockMainAccount, subAccounts: [] };
@@ -64,11 +66,17 @@ describe("accounts-services", () => {
   });
 
   it("should not add subaccount if no identity", async () => {
+    const spyToastError = jest.spyOn(toastsStore, "error");
+
     setNoIdentity();
 
-    const call = async () => await addSubAccount({ name: "test subaccount" });
+    await addSubAccount({ name: "test subaccount" });
 
-    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+    expect(spyToastError).toBeCalled();
+    expect(spyToastError).toBeCalledWith({
+      labelKey: "create_subaccount",
+      err: new Error(en.error.missing_identity),
+    });
 
     resetIdentity();
   });


### PR DESCRIPTION
# Motivation

Follow defined UX rule "actions modals should be closed on action error"

# Changes

- close modal "add sub account" in case of submit error
- close modal "transfer icp" in case of submit error