### PR TITLE
L2-477 and L2-480: Hotkey manages followees not ManageNeuron

### DIFF
--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -113,9 +113,8 @@ export const getIdentityByNeuronOrHotkey = async (
   neuronId: NeuronId
 ): Promise<Identity> => {
   try {
-    // If we return immediately the error thrown is not caught
-    const identity = await getIdentityByNeuron(neuronId);
-    return identity;
+    // No `await` no `catch`
+    return await getIdentityByNeuron(neuronId);
   } catch (_) {
     // Check if hotkey
     const { identity, neuron } = await getIdentityAndNeuronHelper(neuronId);

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -1,11 +1,11 @@
 import type { Identity } from "@dfinity/agent";
-import type {
-  Followees,
-  ICP,
-  Neuron,
-  NeuronId,
-  NeuronInfo,
+import {
   Topic,
+  type Followees,
+  type ICP,
+  type Neuron,
+  type NeuronId,
+  type NeuronInfo,
 } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
@@ -113,7 +113,9 @@ export const getIdentityByNeuronOrHotkey = async (
   neuronId: NeuronId
 ): Promise<Identity> => {
   try {
-    return getIdentityByNeuron(neuronId);
+    // If we return immediately the error thrown is not caught
+    const identity = await getIdentityByNeuron(neuronId);
+    return identity;
   } catch (_) {
     // Check if hotkey
     const { identity, neuron } = await getIdentityAndNeuronHelper(neuronId);
@@ -616,7 +618,11 @@ const setFolloweesHelper = async ({
   labelKey: "add_followee" | "remove_followee";
 }) => {
   try {
-    const identity: Identity = await getIdentityByNeuronOrHotkey(neuronId);
+    // ManageNeuron topic followes can only be handled by controllers
+    const identity: Identity =
+      topic === Topic.ManageNeuron
+        ? await getIdentityByNeuron(neuronId)
+        : await getIdentityByNeuronOrHotkey(neuronId);
 
     await setFollowees({
       identity,

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -799,6 +799,54 @@ describe("neurons-services", () => {
       expect(toastsStore.show).toHaveBeenCalled();
       expect(spySetFollowees).not.toHaveBeenCalled();
     });
+
+    it("should call api if not controlled by user but controlled by hotkey", async () => {
+      const followee = BigInt(8);
+      const topic = Topic.ExchangeRate;
+      const hotkeyNeuron = {
+        ...notControlledNeuron,
+        fullNeuron: {
+          ...notControlledNeuron.fullNeuron,
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      neuronsStore.pushNeurons({
+        neurons: [hotkeyNeuron],
+        certified: true,
+      });
+
+      await addFollowee({
+        neuronId: hotkeyNeuron.neuronId,
+        topic,
+        followee,
+      });
+
+      expect(spySetFollowees).toHaveBeenCalled();
+    });
+
+    it("should not call api if not controlled by user but controlled by hotkey for topic Manage Neuron", async () => {
+      const followee = BigInt(8);
+      const topic = Topic.ManageNeuron;
+      const hotkeyNeuron = {
+        ...notControlledNeuron,
+        fullNeuron: {
+          ...notControlledNeuron.fullNeuron,
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      neuronsStore.pushNeurons({
+        neurons: [hotkeyNeuron],
+        certified: true,
+      });
+
+      await addFollowee({
+        neuronId: hotkeyNeuron.neuronId,
+        topic,
+        followee,
+      });
+
+      expect(spySetFollowees).not.toHaveBeenCalled();
+    });
   });
 
   describe("remove followee", () => {
@@ -878,6 +926,54 @@ describe("neurons-services", () => {
         followee,
       });
       expect(toastsStore.show).toHaveBeenCalled();
+      expect(spySetFollowees).not.toHaveBeenCalled();
+    });
+
+    it("should call api if user not controller but controlled by hotkey", async () => {
+      const followee = BigInt(8);
+      const topic = Topic.ExchangeRate;
+      const hotkeyNeuron = {
+        ...notControlledNeuron,
+        fullNeuron: {
+          ...notControlledNeuron.fullNeuron,
+          followees: [{ topic, followees: [followee] }],
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      neuronsStore.pushNeurons({
+        neurons: [hotkeyNeuron],
+        certified: true,
+      });
+
+      await removeFollowee({
+        neuronId: hotkeyNeuron.neuronId,
+        topic,
+        followee,
+      });
+      expect(spySetFollowees).toHaveBeenCalled();
+    });
+
+    it("should not call api if user not controller but controlled by hotkey and topic is manage neuron", async () => {
+      const followee = BigInt(8);
+      const topic = Topic.ManageNeuron;
+      const hotkeyNeuron = {
+        ...notControlledNeuron,
+        fullNeuron: {
+          ...notControlledNeuron.fullNeuron,
+          followees: [{ topic, followees: [followee] }],
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      neuronsStore.pushNeurons({
+        neurons: [hotkeyNeuron],
+        certified: true,
+      });
+
+      await removeFollowee({
+        neuronId: hotkeyNeuron.neuronId,
+        topic,
+        followee,
+      });
       expect(spySetFollowees).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
# Motivation

User controlled by Hotkey can manage followees, except ManageNeuron topic.

# Changes

* Logic to get identity for followees actions, depends on topic.
* Disable button to Follow or Unfollow depending on topic and controller.

# Tests

* New test to check hotkeys can control followees.
* New test to check hotkeys can't controll followees on Manage Neuron.
