### PR TITLE
L2-474: Follow neuron validations

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -39,13 +39,9 @@
           }
         : { neuronId };
     };
-    if (followesPerTopic !== undefined) {
-      followees = followesPerTopic.followees.map(mapToKnownNeuron);
-    } else {
-      // If we remove the last followee of that topic, followesPerTopic is undefined.
-      // and we need to reset the followees array
-      followees = [];
-    }
+    // If we remove the last followee of that topic, followesPerTopic is undefined.
+    // and we need to reset the followees array
+    followees = followesPerTopic?.map(mapToKnownNeuron) ?? [];
   }
 
   const openNewFolloweeModal = () => (showNewFolloweeModal = true);

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -34,7 +34,7 @@
     "register_vote_unknown": "Sorry, there was an unexpected error while registering the vote. Please try again later.",
     "add_followee": "Sorry, there was an unexpected error while adding the followee. Please try again later.",
     "remove_followee": "Sorry, there was an unexpected error while removing the followee. Please try again later.",
-    "followee_does_not_exist": "Sorry, followee already removed, refresh the page to have the latest data.",
+    "followee_does_not_exist": "Sorry, this neuron is not followed in that topic, refresh the page to have the latest data.",
     "accounts_not_found": "An error occurred while loading the accounts information.",
     "fail": "fail",
     "join_community_fund": "Sorry, there was an error joining the community fund. Please try again later.",
@@ -171,7 +171,9 @@
     "follow": "Follow",
     "unfollow": "Unfollow",
     "success_add_followee": "Followee added successfully",
-    "success_remove_followee": "Followee removed successfully"
+    "success_remove_followee": "Followee removed successfully",
+    "same_neuron": "You can't add the same neuron as followee.",
+    "already_followed": "You are already following this neuron."
   },
   "follow_neurons": {
     "description": "Follow neurons to automate your voting, and receive the maximum voting rewards. You can follow neurons on specific topics or all topics.",

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -42,10 +42,7 @@
   let loadingAddress: boolean = false;
   let loading: boolean = false;
   let topicFollowees: NeuronId[];
-  $: {
-    const topicInfo = followeesByTopic({ neuron, topic });
-    topicFollowees = topicInfo?.followees ?? [];
-  }
+  $: topicFollowees = followeesByTopic({ neuron, topic }) ?? [];
 
   onMount(() => listKnownNeurons());
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -658,7 +658,7 @@ export const addFollowee = async ({
 
   const topicFollowees = followeesByTopic({ neuron, topic });
   // Do not allow to add a neuron id who is already followed
-  if (topicFollowees !== undefined && topicFollowees.indexOf(followee) > -1) {
+  if (topicFollowees !== undefined && topicFollowees.includes(followee)) {
     toastsStore.error({
       labelKey: "new_followee.already_followed",
     });

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -183,6 +183,8 @@ interface I18nNew_followee {
   unfollow: string;
   success_add_followee: string;
   success_remove_followee: string;
+  same_neuron: string;
+  already_followed: string;
 }
 
 interface I18nFollow_neurons {

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -4,7 +4,6 @@ import {
   NeuronState,
   Topic,
   type BallotInfo,
-  type Followees,
   type Neuron,
   type NeuronId,
   type NeuronInfo,
@@ -436,10 +435,10 @@ export const followeesByTopic = ({
 }: {
   neuron: NeuronInfo | undefined;
   topic: Topic;
-}): Followees | undefined =>
+}): NeuronId[] | undefined =>
   neuron?.fullNeuron?.followees.find(
     ({ topic: followedTopic }) => topic === followedTopic
-  );
+  )?.followees;
 
 /**
  * NeuronManagement proposals are not public so we hide this topic

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -764,6 +764,42 @@ describe("neurons-services", () => {
       expect(spySetFollowees).toHaveBeenCalledWith(expectedArgument);
     });
 
+    it("should not call api if trying follow itself", async () => {
+      neuronsStore.setNeurons({ neurons, certified: true });
+      const topic = Topic.ExchangeRate;
+
+      await addFollowee({
+        neuronId: controlledNeuron.neuronId,
+        topic,
+        followee: controlledNeuron.neuronId,
+      });
+
+      expect(toastsStore.error).toHaveBeenCalled();
+      expect(spySetFollowees).not.toHaveBeenCalled();
+    });
+
+    it("should not call api if trying follow a neuron already added", async () => {
+      const topic = Topic.ExchangeRate;
+      const followee = BigInt(10);
+      const neuron = {
+        ...controlledNeuron,
+        fullNeuron: {
+          ...controlledNeuron.fullNeuron,
+          followees: [{ topic, followees: [followee] }],
+        },
+      };
+      neuronsStore.setNeurons({ neurons: [neuron], certified: true });
+
+      await addFollowee({
+        neuronId: neuron.neuronId,
+        topic,
+        followee: followee,
+      });
+
+      expect(toastsStore.error).toHaveBeenCalled();
+      expect(spySetFollowees).not.toHaveBeenCalled();
+    });
+
     it("should not call api if no identity", async () => {
       const followee = BigInt(8);
       neuronsStore.setNeurons({ neurons, certified: true });

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -953,13 +953,13 @@ describe("neuron-utils", () => {
 
     it("should return followees by topic", () => {
       expect(followeesByTopic({ neuron, topic: followees[0].topic })).toEqual(
-        followees[0]
+        followees[0].followees
       );
       expect(followeesByTopic({ neuron, topic: followees[1].topic })).toEqual(
-        followees[1]
+        followees[1].followees
       );
       expect(followeesByTopic({ neuron, topic: followees[2].topic })).toEqual(
-        followees[2]
+        followees[2].followees
       );
     });
 


### PR DESCRIPTION
# Motivation

Neuron can't follow another neuron twice on the same topic, nor can follow itself. These validations are done in the frontend.

# Changes

* Add the validations in the neuron service addFollowee.
* Change return type of neuron util "followeesByTopic" to "NeuronId[]".
* Clean up some code.

# Tests

* New tests for new validations.
* Change test in neuron util "followeesByTopic".
