### PR TITLE
feat: increase the number of paginated proposals to 500

### DIFF
--- a/frontend/svelte/src/lib/constants/constants.ts
+++ b/frontend/svelte/src/lib/constants/constants.ts
@@ -1,4 +1,4 @@
-export const LIST_PAGINATION_LIMIT = 100;
+export const LIST_PAGINATION_LIMIT = 500;
 
 /**
  * The infinite scroll observe an element that finds place after x % of last page.


### PR DESCRIPTION
# Motivation

Increase the number of paginated proposals to 500 requested by user with long history.

# Changes

- update constant `LIST_PAGINATION_LIMIT`

