### PR TITLE
feat: display question "accept reject proposal"

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
@@ -8,7 +8,7 @@
   import ProposalMeta from "./ProposalMeta.svelte";
   import ProposalActions from "./ProposalActions.svelte";
   import ProposalSummaryCardBlock from "./ProposalSummaryCardBlock.svelte";
-  import {mapProposalInfo} from '../../../utils/proposals.utils';
+  import { mapProposalInfo } from "../../../utils/proposals.utils";
 
   export let proposalInfo: ProposalInfo;
 

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
@@ -4,11 +4,11 @@
   import Badge from "../../ui/Badge.svelte";
   import Card from "../../ui/Card.svelte";
   import type { ProposalColor } from "../../../../lib/constants/proposals.constants";
-  import { PROPOSAL_COLOR } from "../../../../lib/constants/proposals.constants";
   import { i18n } from "../../../../lib/stores/i18n";
   import ProposalMeta from "./ProposalMeta.svelte";
   import ProposalActions from "./ProposalActions.svelte";
   import ProposalSummaryCardBlock from "./ProposalSummaryCardBlock.svelte";
+  import {mapProposalInfo} from '../../../utils/proposals.utils';
 
   export let proposalInfo: ProposalInfo;
 
@@ -17,9 +17,7 @@
   let status: ProposalStatus = ProposalStatus.PROPOSAL_STATUS_UNKNOWN;
   let color: ProposalColor;
 
-  $: ({ proposal, status } = proposalInfo);
-  $: title = proposal?.title ?? "";
-  $: color = PROPOSAL_COLOR[status];
+  $: ({ proposal, status, title, color } = mapProposalInfo(proposalInfo));
 </script>
 
 <Card>

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
@@ -5,21 +5,18 @@
     ProposalId,
     ProposalInfo,
   } from "@dfinity/nns";
-  import { Topic } from "@dfinity/nns";
   import { i18n } from "../../../../lib/stores/i18n";
   import VotingHistoryModal from "../../../modals/neurons/VotingHistoryModal.svelte";
+  import { mapProposalInfo } from "../../../utils/proposals.utils";
 
   export let proposalInfo: ProposalInfo;
 
-  let proposal: Proposal | undefined;
   let proposer: NeuronId | undefined;
   let id: ProposalId | undefined;
   let topic: string | undefined;
   let url: string | undefined;
 
-  $: ({ proposal, proposer, id } = proposalInfo);
-  $: topic = $i18n.topics[Topic[proposalInfo?.topic]];
-  $: url = proposal?.url;
+  $: ({ proposer, id, url, topic } = mapProposalInfo(proposalInfo));
 
   let modalOpen = false;
 </script>

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import type {
-    NeuronId,
-    ProposalId,
-    ProposalInfo,
-  } from "@dfinity/nns";
+  import type { NeuronId, ProposalId, ProposalInfo } from "@dfinity/nns";
   import { i18n } from "../../../../lib/stores/i18n";
   import VotingHistoryModal from "../../../modals/neurons/VotingHistoryModal.svelte";
   import { mapProposalInfo } from "../../../utils/proposals.utils";

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type {
     NeuronId,
-    Proposal,
     ProposalId,
     ProposalInfo,
   } from "@dfinity/nns";

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -54,6 +54,6 @@
   <Card>
     <h3 slot="start">{$i18n.proposal_detail__vote.headline}</h3>
     <CastVoteCardNeuronSelect />
-    <VotingConfirmationToolbar on:nnsConfirm={vote} />
+    <VotingConfirmationToolbar {proposalInfo} on:nnsConfirm={vote} />
   </Card>
 {/if}

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -48,8 +48,8 @@
 
 <p class="question">
   {@html replacePlaceholders($i18n.proposal_detail__vote.accept_or_reject, {
-    $id: id,
-    $topic: topic,
+    $id: `${id ?? ""}`,
+    $topic: topic ?? "",
   })}
 </p>
 

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
-  import { Vote } from "@dfinity/nns";
+  import { type ProposalId, type ProposalInfo, Vote } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import VoteConfirmationModal from "../../../modals/proposals/VoteConfirmationModal.svelte";
   import { i18n } from "../../../stores/i18n";
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
-  import { selectedNeuronsVotingPower } from "../../../utils/proposals.utils";
+  import {
+    mapProposalInfo,
+    selectedNeuronsVotingPower,
+  } from "../../../utils/proposals.utils";
+  import { replacePlaceholders } from "../../../utils/i18n.utils";
 
   const dispatch = createEventDispatcher();
+
+  export let proposalInfo: ProposalInfo;
+
+  let id: ProposalId | undefined;
+  let topic: string | undefined;
+  $: ({ id, topic } = mapProposalInfo(proposalInfo));
 
   let total: bigint;
   let disabled: boolean = true;
@@ -35,6 +45,13 @@
     });
   };
 </script>
+
+<p class="question">
+  {@html replacePlaceholders($i18n.proposal_detail__vote.accept_or_reject, {
+    $id: id,
+    $topic: topic,
+  })}
+</p>
 
 <div role="toolbar">
   <button
@@ -66,5 +83,9 @@
 
     display: flex;
     gap: var(--padding);
+  }
+
+  .question {
+    margin: 0 0 var(--padding-2x);
   }
 </style>

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -6,25 +6,21 @@
   import { i18n } from "../../stores/i18n";
   import { routeStore } from "../../stores/route.store";
   import { AppPath } from "../../constants/routes.constants";
-  import { PROPOSAL_COLOR } from "../../constants/proposals.constants";
   import type { ProposalColor } from "../../constants/proposals.constants";
   import { proposalsFiltersStore } from "../../stores/proposals.store";
-  import { hideProposal } from "../../utils/proposals.utils";
+  import {mapProposalInfo, hideProposal} from "../../utils/proposals.utils";
   import type { ProposalId } from "@dfinity/nns";
   import Proposer from "./Proposer.svelte";
 
   export let proposalInfo: ProposalInfo;
   export let hidden: boolean = false;
 
-  let proposal: Proposal | undefined;
   let status: ProposalStatus = ProposalStatus.PROPOSAL_STATUS_UNKNOWN;
   let id: ProposalId | undefined;
   let title: string | undefined;
   let color: ProposalColor | undefined;
 
-  $: ({ proposal, status, id } = proposalInfo);
-  $: title = proposal?.title ?? "";
-  $: color = PROPOSAL_COLOR[status];
+  $: ({ status, id, title, color } = mapProposalInfo(proposalInfo));
 
   const showProposal = () => {
     routeStore.navigate({

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -8,7 +8,7 @@
   import { AppPath } from "../../constants/routes.constants";
   import type { ProposalColor } from "../../constants/proposals.constants";
   import { proposalsFiltersStore } from "../../stores/proposals.store";
-  import {mapProposalInfo, hideProposal} from "../../utils/proposals.utils";
+  import { mapProposalInfo, hideProposal } from "../../utils/proposals.utils";
   import type { ProposalId } from "@dfinity/nns";
   import Proposer from "./Proposer.svelte";
 

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Card from "../ui/Card.svelte";
-  import type { Proposal, ProposalInfo } from "@dfinity/nns";
+  import type { ProposalInfo } from "@dfinity/nns";
   import { ProposalStatus } from "@dfinity/nns";
   import Badge from "../ui/Badge.svelte";
   import { i18n } from "../../stores/i18n";

--- a/frontend/svelte/src/lib/components/proposals/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalMeta.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import type {
-    NeuronId,
-    ProposalId,
-    ProposalInfo,
-  } from "@dfinity/nns";
+  import type { NeuronId, ProposalId, ProposalInfo } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
   import Proposer from "./Proposer.svelte";
-  import {mapProposalInfo} from '../../utils/proposals.utils';
+  import { mapProposalInfo } from "../../utils/proposals.utils";
 
   export let proposalInfo: ProposalInfo;
   export let size: "small" | "normal" = "normal";

--- a/frontend/svelte/src/lib/components/proposals/Proposer.svelte
+++ b/frontend/svelte/src/lib/components/proposals/Proposer.svelte
@@ -3,13 +3,14 @@
   import type { NeuronId } from "@dfinity/nns";
   import VotingHistoryModal from "../../modals/neurons/VotingHistoryModal.svelte";
   import { i18n } from "../../stores/i18n";
+  import {mapProposalInfo} from '../../utils/proposals.utils';
 
   export let proposalInfo: ProposalInfo;
 
   let modalOpen = false;
 
   let proposer: NeuronId | undefined;
-  $: ({ proposer } = proposalInfo);
+  $: ({ proposer } = mapProposalInfo(proposalInfo));
 </script>
 
 {#if proposer !== undefined}

--- a/frontend/svelte/src/lib/components/proposals/Proposer.svelte
+++ b/frontend/svelte/src/lib/components/proposals/Proposer.svelte
@@ -3,7 +3,7 @@
   import type { NeuronId } from "@dfinity/nns";
   import VotingHistoryModal from "../../modals/neurons/VotingHistoryModal.svelte";
   import { i18n } from "../../stores/i18n";
-  import {mapProposalInfo} from '../../utils/proposals.utils';
+  import { mapProposalInfo } from "../../utils/proposals.utils";
 
   export let proposalInfo: ProposalInfo;
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -271,7 +271,8 @@
     "confirm_adopt_headline": "Adopt Proposal",
     "confirm_adopt_text": "You are about to cast $votingPower votes for this proposal, are you sure you want to proceed?",
     "confirm_reject_headline": "Reject Proposal",
-    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?"
+    "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?",
+    "accept_or_reject": "Do you want to adopt or reject Proposal <strong>$id</strong> for <strong>$topic</strong>?"
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -292,6 +292,7 @@ interface I18nProposal_detail__vote {
   confirm_adopt_text: string;
   confirm_reject_headline: string;
   confirm_reject_text: string;
+  accept_or_reject: string;
 }
 
 interface I18nProposal_detail__ineligible {

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -283,7 +283,7 @@ export const mapProposalInfo = (
 } => {
   const { proposal, proposer, id, status } = proposalInfo;
 
-  const {topics} = get(i18n);
+  const { topics } = get(i18n);
 
   return {
     id,

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -283,14 +283,14 @@ export const mapProposalInfo = (
 } => {
   const { proposal, proposer, id, status } = proposalInfo;
 
-  const labels = get(i18n);
+  const {topics} = get(i18n);
 
   return {
     id,
     proposer,
     proposal,
     title: proposal?.title,
-    topic: labels.topics[Topic[proposalInfo?.topic]],
+    topic: topics[Topic[proposalInfo?.topic]],
     url: proposal?.url,
     color: PROPOSAL_COLOR[status],
     status,

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -277,7 +277,7 @@ export const mapProposalInfo = (
   proposer: NeuronId | undefined;
   title: string | undefined;
   url: string | undefined;
-  topic: string;
+  topic: string | undefined;
   color: ProposalColor | undefined;
   status: ProposalStatus;
 } => {

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -5,7 +5,13 @@ import type {
   ProposalId,
   ProposalInfo,
 } from "@dfinity/nns";
-import { ProposalStatus, Vote } from "@dfinity/nns";
+import { ProposalStatus, Topic, Vote } from "@dfinity/nns";
+import { get } from "svelte/store";
+import {
+  PROPOSAL_COLOR,
+  type ProposalColor,
+} from "../constants/proposals.constants";
+import { i18n } from "../stores/i18n";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import { isDefined, stringifyJson } from "./utils";
 
@@ -261,4 +267,32 @@ export const excludeProposals = ({
 }): ProposalInfo[] => {
   const excludeIds = proposalIdSet(exclusion);
   return proposals.filter(({ id }) => !excludeIds.has(id as ProposalId));
+};
+
+export const mapProposalInfo = (
+  proposalInfo: ProposalInfo
+): {
+  id: ProposalId | undefined;
+  proposal: Proposal | undefined;
+  proposer: NeuronId | undefined;
+  title: string | undefined;
+  url: string | undefined;
+  topic: string;
+  color: ProposalColor | undefined;
+  status: ProposalStatus;
+} => {
+  const { proposal, proposer, id, status } = proposalInfo;
+
+  const labels = get(i18n);
+
+  return {
+    id,
+    proposer,
+    proposal,
+    title: proposal?.title,
+    topic: labels.topics[Topic[proposalInfo?.topic]],
+    url: proposal?.url,
+    color: PROPOSAL_COLOR[status],
+    status,
+  };
 };

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -2,13 +2,15 @@
  * @jest-environment jsdom
  */
 
-import { Vote } from "@dfinity/nns";
+import { Topic, Vote } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import VotingConfirmationToolbar from "../../../../../lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte";
 import { E8S_PER_ICP } from "../../../../../lib/constants/icp.constants";
 import { votingNeuronSelectStore } from "../../../../../lib/stores/proposals.store";
+import { replacePlaceholders } from "../../../../../lib/utils/i18n.utils";
 import { formatVotingPower } from "../../../../../lib/utils/neuron.utils";
+import en from "../../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
 
@@ -121,5 +123,27 @@ describe("VotingConfirmationToolbar", () => {
     );
     expect(onConfirm).toBeCalled();
     expect(calledVoteType).toBe(Vote.NO);
+  });
+
+  it("should display a question that repeats id and topic", () => {
+    const { container } = render(VotingConfirmationToolbar, {
+      props,
+    });
+
+    const testLabel = replacePlaceholders(
+      en.proposal_detail__vote.accept_or_reject,
+      {
+        $id: `${mockProposalInfo.id}`,
+        $topic: en.topics[Topic[mockProposalInfo.topic]],
+      }
+    )
+      .replace(/<strong>/g, "")
+      .replace(/<\/strong>/g, "");
+
+    const { textContent }: HTMLParagraphElement = container.querySelector(
+      ".question"
+    ) as HTMLParagraphElement;
+
+    expect(textContent).toEqual(testLabel);
   });
 });

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -10,6 +10,7 @@ import { E8S_PER_ICP } from "../../../../../lib/constants/icp.constants";
 import { votingNeuronSelectStore } from "../../../../../lib/stores/proposals.store";
 import { formatVotingPower } from "../../../../../lib/utils/neuron.utils";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
+import { mockProposalInfo } from "../../../../mocks/proposal.mock";
 
 describe("VotingConfirmationToolbar", () => {
   const votingPower = BigInt(100 * E8S_PER_ICP);
@@ -19,12 +20,16 @@ describe("VotingConfirmationToolbar", () => {
     votingPower,
   };
 
+  const props = {
+    proposalInfo: mockProposalInfo,
+  };
+
   beforeEach(() => {
     votingNeuronSelectStore.set([neuron]);
   });
 
   it("should disable buttons if nothing is selected", async () => {
-    const { container } = render(VotingConfirmationToolbar);
+    const { container } = render(VotingConfirmationToolbar, { props });
     votingNeuronSelectStore.toggleSelection(neuron.neuronId);
     await waitFor(() =>
       expect(
@@ -39,7 +44,7 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it("should display Vote.YES modal", async () => {
-    const { container } = render(VotingConfirmationToolbar);
+    const { container } = render(VotingConfirmationToolbar, { props });
     fireEvent.click(
       container.querySelector('[data-tid="vote-yes"]') as Element
     );
@@ -51,7 +56,7 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it("should display Vote.NO modal", async () => {
-    const { container } = render(VotingConfirmationToolbar);
+    const { container } = render(VotingConfirmationToolbar, { props });
     fireEvent.click(container.querySelector('[data-tid="vote-no"]') as Element);
     await waitFor(() =>
       expect(
@@ -61,7 +66,9 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it('should display "total" in modal', async () => {
-    const { getByText, container } = render(VotingConfirmationToolbar);
+    const { getByText, container } = render(VotingConfirmationToolbar, {
+      props,
+    });
     fireEvent.click(
       container.querySelector('[data-tid="vote-yes"]') as Element
     );
@@ -73,7 +80,7 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it("should hide confirmation on cancel", async () => {
-    const { container } = render(VotingConfirmationToolbar);
+    const { container } = render(VotingConfirmationToolbar, { props });
     fireEvent.click(
       container.querySelector('[data-tid="vote-yes"]') as Element
     );
@@ -93,7 +100,9 @@ describe("VotingConfirmationToolbar", () => {
   });
 
   it("should hide confirmation and dispatch on confirm", async () => {
-    const { component, container } = render(VotingConfirmationToolbar);
+    const { component, container } = render(VotingConfirmationToolbar, {
+      props,
+    });
     let calledVoteType: Vote = Vote.UNSPECIFIED;
     const onConfirm = jest.fn((ev) => (calledVoteType = ev?.detail?.voteType));
     component.$on("nnsConfirm", onConfirm);


### PR DESCRIPTION
# Motivation

Some users find themselves lost on the proposal detail page after some scroll and might not be sure on what proposal they are about to vote. That's why we add a sentence next to the vote actions that display the proposal id and topic again.

# Changes

- refactor proposal info destruction that is shared in various component
- display sentence “Do you want to adopt or reject Proposal 56789 for Governance?” with related proposal id and topic

# Screenshot

<img width="1513" alt="Capture d’écran 2022-05-02 à 10 39 20" src="https://user-images.githubusercontent.com/16886711/166210154-8963c79c-e5c8-4c29-b47e-eb85600d7859.png">

