### PR TITLE
feat: display title in proposal question

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -16,7 +16,7 @@
 
   let id: ProposalId | undefined;
   let topic: string | undefined;
-  $: ({ id, topic } = mapProposalInfo(proposalInfo));
+  $: ({ id, topic, title } = mapProposalInfo(proposalInfo));
 
   let total: bigint;
   let disabled: boolean = true;
@@ -49,6 +49,7 @@
 <p class="question">
   {@html replacePlaceholders($i18n.proposal_detail__vote.accept_or_reject, {
     $id: `${id ?? ""}`,
+    $title: `${title ?? ""}`,
     $topic: topic ?? "",
   })}
 </p>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -272,7 +272,7 @@
     "confirm_adopt_text": "You are about to cast $votingPower votes for this proposal, are you sure you want to proceed?",
     "confirm_reject_headline": "Reject Proposal",
     "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?",
-    "accept_or_reject": "Do you want to adopt or reject Proposal <strong>$id</strong> for <strong>$topic</strong>?"
+    "accept_or_reject": "Do you want to adopt or reject Proposal <strong>$id</strong> - <strong>$title</strong> for <strong>$topic</strong>?"
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { Topic, Vote } from "@dfinity/nns";
+import type { Proposal } from "@dfinity/nns/dist/types/types/governance_converters";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import VotingConfirmationToolbar from "../../../../../lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte";
@@ -134,6 +135,7 @@ describe("VotingConfirmationToolbar", () => {
       en.proposal_detail__vote.accept_or_reject,
       {
         $id: `${mockProposalInfo.id}`,
+        $title: `${(mockProposalInfo.proposal as Proposal).title}`,
         $topic: en.topics[Topic[mockProposalInfo.topic]],
       }
     )


### PR DESCRIPTION
# Motivation

Display the title of the proposal in the question "accept / reject voting" as well.

Follow-up of #774

# Changes

- display `title` in question

# Screenshot

<img width="1513" alt="Capture d’écran 2022-05-02 à 15 02 56" src="https://user-images.githubusercontent.com/16886711/166238281-3f255de2-b978-44ec-9203-beaaa9d1117f.png">


<img width="1513" alt="Capture d’écran 2022-05-02 à 15 05 04" src="https://user-images.githubusercontent.com/16886711/166238380-3e1702e0-b714-4303-a83e-cd1315d27412.png">
