### PR TITLE
feat: &ndash; for question separator

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -272,7 +272,7 @@
     "confirm_adopt_text": "You are about to cast $votingPower votes for this proposal, are you sure you want to proceed?",
     "confirm_reject_headline": "Reject Proposal",
     "confirm_reject_text": "You are about to cast $votingPower votes against this proposal, are you sure you want to proceed?",
-    "accept_or_reject": "Do you want to adopt or reject Proposal <strong>$id</strong> - <strong>$title</strong> for <strong>$topic</strong>?"
+    "accept_or_reject": "Do you want to adopt or reject Proposal <strong>$id</strong> &ndash; <strong>$title</strong> for <strong>$topic</strong>?"
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",


### PR DESCRIPTION
# Motivation

> That’s good. A minor thing: can you use “&ndash;” for the dash between the id and the title. a dash is not the same character as a “-” (minus). Just a minor thing…

Mischa

# Screenshot

<img width="1513" alt="Capture d’écran 2022-05-02 à 16 07 52" src="https://user-images.githubusercontent.com/16886711/166247870-09f297b8-5164-4744-9616-c3f4763deed1.png">

