### PR TITLE
L2-483: Lazy load voted proposals in Neuron Voting History

### DIFF
--- a/frontend/svelte/src/lib/api/proposals.api.ts
+++ b/frontend/svelte/src/lib/api/proposals.api.ts
@@ -7,7 +7,7 @@ import type {
   Vote,
 } from "@dfinity/nns";
 import { GovernanceCanister, Topic } from "@dfinity/nns";
-import { LIST_PAGINATION_LIMIT } from "../constants/constants";
+import { DEFAULT_LIST_PAGINATION_LIMIT } from "../constants/constants";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import { createAgent } from "../utils/agent.utils";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
@@ -42,7 +42,7 @@ export const queryProposals = async ({
 
   const { proposals }: ListProposalsResponse = await governance.listProposals({
     request: {
-      limit: LIST_PAGINATION_LIMIT,
+      limit: DEFAULT_LIST_PAGINATION_LIMIT,
       beforeProposal,
       excludeTopic: enumsExclude<Topic>({
         obj: Topic as unknown as Topic,

--- a/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
@@ -3,11 +3,20 @@
   import BallotSummary from "./BallotSummary.svelte";
   import { i18n } from "../../../stores/i18n";
   import { ballotsWithDefinedProposal } from "../../../utils/neuron.utils";
+  import InfiniteScroll from "../../ui/InfiniteScroll.svelte";
 
   export let neuron: NeuronInfo | undefined;
 
+  const PAGE_LIMIT = 5;
+
   let ballots: Required<BallotInfo>[] = [];
+  let ballotsToShow: Required<BallotInfo>[] = [];
+  let ballotsIndex: number = PAGE_LIMIT;
   $: ballots = neuron === undefined ? [] : ballotsWithDefinedProposal(neuron);
+  $: ballotsToShow = ballots.slice(0, ballotsIndex);
+  const showMore = () => {
+    ballotsIndex += PAGE_LIMIT;
+  };
 </script>
 
 {#if neuron !== undefined}
@@ -19,13 +28,17 @@
       <span>{$i18n.neuron_detail.vote}</span>
     </h4>
 
-    <ul>
-      {#each ballots as ballot}
+    <InfiniteScroll
+      pageLimit={PAGE_LIMIT}
+      containerElement="ul"
+      on:nnsIntersect={showMore}
+    >
+      {#each ballotsToShow as ballot}
         <li>
           <BallotSummary {ballot} />
         </li>
       {/each}
-    </ul>
+    </InfiniteScroll>
   {/if}
 {/if}
 
@@ -34,12 +47,6 @@
     display: flex;
     justify-content: space-between;
     line-height: var(--line-height-standard);
-  }
-
-  ul {
-    margin: 0;
-    padding: 0;
-    list-style: none;
   }
 
   li {

--- a/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
@@ -4,18 +4,32 @@
   import { i18n } from "../../../stores/i18n";
   import { ballotsWithDefinedProposal } from "../../../utils/neuron.utils";
   import InfiniteScroll from "../../ui/InfiniteScroll.svelte";
+  import { debounce } from "../../../utils/utils";
 
   export let neuron: NeuronInfo | undefined;
 
   const PAGE_LIMIT = 5;
 
   let ballots: Required<BallotInfo>[] = [];
+  // Each `BallotSummary` fetches the proposal from the canister.
+  // We want to avoid making too many calls, since a neuron can vote in many proposals.
   let ballotsToShow: Required<BallotInfo>[] = [];
   let ballotsIndex: number = PAGE_LIMIT;
   $: ballots = neuron === undefined ? [] : ballotsWithDefinedProposal(neuron);
   $: ballotsToShow = ballots.slice(0, ballotsIndex);
-  const showMore = () => {
+
+  // We fake fetching the next `PAGE_LIMIT` ballots.
+  const nextPage = debounce(() => {
     ballotsIndex += PAGE_LIMIT;
+    fakeLoading = false;
+  });
+  let fakeLoading: boolean = false;
+  const showMore = () => {
+    if (fakeLoading) {
+      return;
+    }
+    fakeLoading = true;
+    nextPage();
   };
 </script>
 

--- a/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/Ballots/Ballots.svelte
@@ -28,6 +28,9 @@
     if (fakeLoading) {
       return;
     }
+    if (ballotsIndex >= ballots.length) {
+      return;
+    }
     fakeLoading = true;
     nextPage();
   };
@@ -42,11 +45,7 @@
       <span>{$i18n.neuron_detail.vote}</span>
     </h4>
 
-    <InfiniteScroll
-      pageLimit={PAGE_LIMIT}
-      containerElement="ul"
-      on:nnsIntersect={showMore}
-    >
+    <InfiniteScroll pageLimit={PAGE_LIMIT} on:nnsIntersect={showMore}>
       {#each ballotsToShow as ballot}
         <li>
           <BallotSummary {ballot} />

--- a/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalCard.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <!-- We hide the card but keep an element in DOM to preserve the infinite scroll feature -->
-<div class:hidden>
+<li class:hidden>
   {#if !hide}
     <Card role="link" on:click={showProposal}>
       <div slot="start" class="title-container">
@@ -58,14 +58,14 @@
       <ProposalMeta {proposalInfo} size="small" link={false} />
     </Card>
   {/if}
-</div>
+</li>
 
 <style lang="scss">
   @use "../../themes/mixins/text";
   @use "../../themes/mixins/card";
   @use "../../themes/mixins/media.scss";
 
-  div.hidden {
+  li.hidden {
     visibility: hidden;
   }
 

--- a/frontend/svelte/src/lib/components/proposals/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposals/ProposalMeta.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { NeuronId, ProposalId, ProposalInfo } from "@dfinity/nns";
+  import type { ProposalId, ProposalInfo } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
   import Proposer from "./Proposer.svelte";
   import { mapProposalInfo } from "../../utils/proposals.utils";
@@ -8,12 +8,11 @@
   export let size: "small" | "normal" = "normal";
   export let link: boolean = true;
 
-  let proposer: NeuronId | undefined;
   let id: ProposalId | undefined;
   let topic: string | undefined;
   let url: string | undefined;
 
-  $: ({ proposer, id, url, topic } = mapProposalInfo(proposalInfo));
+  $: ({ id, url, topic } = mapProposalInfo(proposalInfo));
 </script>
 
 {#if link && url}

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -2,8 +2,11 @@
   import { afterUpdate, createEventDispatcher, onDestroy } from "svelte";
   import {
     INFINITE_SCROLL_OFFSET,
-    LIST_PAGINATION_LIMIT,
+    DEFAULT_LIST_PAGINATION_LIMIT,
   } from "../../constants/constants";
+
+  export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
+  export let containerElement: "ul" | "div" = "div";
 
   /**
    * The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance from the bottom or top of the page.
@@ -19,7 +22,7 @@
     threshold: 0,
   };
 
-  let container: HTMLDivElement;
+  let container: HTMLDivElement | HTMLUListElement;
 
   const dispatch = createEventDispatcher();
 
@@ -56,9 +59,7 @@
       return;
     }
 
-    const pageIndex: number =
-      container.children.length / LIST_PAGINATION_LIMIT - 1;
-
+    const pageIndex: number = container.children.length / pageLimit - 1;
     // If the pageIndex is not an integer the all page was not fetched - e.g. 50 elements instead of 100 - therefore there is no more elements to fetch
     if (!Number.isInteger(pageIndex)) {
       return;
@@ -68,6 +69,7 @@
      * The infinite scroll observe an element that finds place after x % of last page.
      *
      * For example given following list of elements:
+     *
      * [0-100]
      * [101-200]
      *
@@ -87,8 +89,7 @@
      * Infinite scroll does not observe because all data are fetched.
      */
     const element: Element | undefined = Array.from(container.children)[
-      pageIndex * LIST_PAGINATION_LIMIT +
-        Math.round(LIST_PAGINATION_LIMIT * INFINITE_SCROLL_OFFSET)
+      pageIndex * pageLimit + Math.round(pageLimit * INFINITE_SCROLL_OFFSET)
     ];
 
     if (element === undefined) {
@@ -101,6 +102,20 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-<div bind:this={container}>
-  <slot />
-</div>
+{#if containerElement === "ul"}
+  <ul bind:this={container}>
+    <slot />
+  </ul>
+{:else}
+  <div bind:this={container}>
+    <slot />
+  </div>
+{/if}
+
+<style lang="scss">
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -21,7 +21,7 @@
     threshold: 0,
   };
 
-  let container: HTMLDivElement | HTMLUListElement;
+  let container: HTMLUListElement;
 
   const dispatch = createEventDispatcher();
 

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -6,7 +6,6 @@
   } from "../../constants/constants";
 
   export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
-  export let containerElement: "ul" | "div" = "div";
 
   /**
    * The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance from the bottom or top of the page.

--- a/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfiniteScroll.svelte
@@ -102,15 +102,9 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-{#if containerElement === "ul"}
-  <ul bind:this={container}>
-    <slot />
-  </ul>
-{:else}
-  <div bind:this={container}>
-    <slot />
-  </div>
-{/if}
+<ul bind:this={container}>
+  <slot />
+</ul>
 
 <style lang="scss">
   ul {

--- a/frontend/svelte/src/lib/constants/constants.ts
+++ b/frontend/svelte/src/lib/constants/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_LIST_PAGINATION_LIMIT = 3;
+export const DEFAULT_LIST_PAGINATION_LIMIT = 100;
 
 /**
  * The infinite scroll observe an element that finds place after x % of last page.

--- a/frontend/svelte/src/lib/constants/constants.ts
+++ b/frontend/svelte/src/lib/constants/constants.ts
@@ -1,4 +1,4 @@
-export const LIST_PAGINATION_LIMIT = 100;
+export const DEFAULT_LIST_PAGINATION_LIMIT = 3;
 
 /**
  * The infinite scroll observe an element that finds place after x % of last page.

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -156,7 +156,9 @@
 
       <InfiniteScroll on:nnsIntersect={findNextProposals}>
         {#each $proposalsStore.proposals as proposalInfo (proposalInfo.id)}
-          <ProposalCard {hidden} {proposalInfo} />
+          <li>
+            <ProposalCard {hidden} {proposalInfo} />
+          </li>
         {/each}
       </InfiniteScroll>
 

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -156,9 +156,7 @@
 
       <InfiniteScroll on:nnsIntersect={findNextProposals}>
         {#each $proposalsStore.proposals as proposalInfo (proposalInfo.id)}
-          <li>
-            <ProposalCard {hidden} {proposalInfo} />
-          </li>
+          <ProposalCard {hidden} {proposalInfo} />
         {/each}
       </InfiniteScroll>
 

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -5,8 +5,8 @@
 import { render } from "@testing-library/svelte";
 import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
 import {
+  DEFAULT_LIST_PAGINATION_LIMIT,
   INFINITE_SCROLL_OFFSET,
-  LIST_PAGINATION_LIMIT,
 } from "../../../../lib/constants/constants";
 import {
   IntersectionObserverActive,
@@ -27,11 +27,38 @@ describe("InfiniteScroll", () => {
     expect(container.querySelector("div")).not.toBeNull();
   });
 
+  it("should render the expected container", () => {
+    const { container } = render(InfiniteScroll, {
+      props: {
+        containerElement: "ul",
+      },
+    });
+
+    expect(container.querySelector("ul")).not.toBeNull();
+  });
+
   it("should trigger an intersect event", () => {
     const spyIntersect = jest.fn();
 
     render(InfiniteScrollTest, {
-      props: { elements: new Array(LIST_PAGINATION_LIMIT), spy: spyIntersect },
+      props: {
+        elements: new Array(DEFAULT_LIST_PAGINATION_LIMIT),
+        spy: spyIntersect,
+      },
+    });
+
+    expect(spyIntersect).toHaveBeenCalled();
+  });
+
+  it("should trigger an intersect event with custom page limit", () => {
+    const spyIntersect = jest.fn();
+
+    render(InfiniteScrollTest, {
+      props: {
+        pageLimit: 5,
+        elements: new Array(5),
+        spy: spyIntersect,
+      },
     });
 
     expect(spyIntersect).toHaveBeenCalled();
@@ -42,7 +69,7 @@ describe("InfiniteScroll", () => {
 
     render(InfiniteScrollTest, {
       props: {
-        elements: new Array(LIST_PAGINATION_LIMIT + 1),
+        elements: new Array(DEFAULT_LIST_PAGINATION_LIMIT + 1),
         spy: spyIntersect,
       },
     });
@@ -53,11 +80,17 @@ describe("InfiniteScroll", () => {
   it("should not trigger an intersect event if more elements than offset but less than page", () => {
     const spyIntersect = jest.fn();
 
+    /**
+     * [0-100]
+     * [101-121]
+     *
+     * Infinite scroll does not observe because all data are fetched.
+     */
     render(InfiniteScrollTest, {
       props: {
         elements: new Array(
-          LIST_PAGINATION_LIMIT -
-            Math.round(LIST_PAGINATION_LIMIT * INFINITE_SCROLL_OFFSET) +
+          DEFAULT_LIST_PAGINATION_LIMIT +
+            Math.round(DEFAULT_LIST_PAGINATION_LIMIT * INFINITE_SCROLL_OFFSET) +
             1
         ),
         spy: spyIntersect,

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -27,16 +27,6 @@ describe("InfiniteScroll", () => {
     expect(container.querySelector("div")).not.toBeNull();
   });
 
-  it("should render the expected container", () => {
-    const { container } = render(InfiniteScroll, {
-      props: {
-        containerElement: "ul",
-      },
-    });
-
-    expect(container.querySelector("ul")).not.toBeNull();
-  });
-
   it("should trigger an intersect event", () => {
     const spyIntersect = jest.fn();
 

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -24,7 +24,7 @@ describe("InfiniteScroll", () => {
   it("should render a container", () => {
     const { container } = render(InfiniteScroll);
 
-    expect(container.querySelector("div")).not.toBeNull();
+    expect(container.querySelector("ul")).not.toBeNull();
   });
 
   it("should trigger an intersect event", () => {

--- a/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InfiniteScrollTest.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import InfiniteScroll from "../../../../lib/components/ui/InfiniteScroll.svelte";
+  import { DEFAULT_LIST_PAGINATION_LIMIT } from "../../../../lib/constants/constants";
 
   export let elements: number[];
+  export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
   export let spy: () => void;
-
-  const intersect = () => spy();
 </script>
 
-<InfiniteScroll on:nnsIntersect={intersect}>
+<InfiniteScroll on:nnsIntersect={spy} {pageLimit}>
   {#each elements as element, i}
     <div>Test {i}</div>
   {/each}


### PR DESCRIPTION
# Motivation

Do not fetch from the backend the proposal for each ballot that the neuron has voted, until the user needs to see it.

# Changes

* Use the `InfiniteScroll` in the `Ballots` components to load ballots per page.
* Add two props in `InfiinteScroll` for new use case: `pageLimit` and `containerElement`.

# Tests

* New test cases in InfiniteScroll
