### PR TITLE
Fix deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,5 +8,7 @@ NETWORK=$1
 #        to deploy these other canisters as well, but you probbaly don't.
 CANISTER_NAME=nns-dapp
 echo "Deploying $CANISTER_NAME to $NETWORK..."
-DEPLOY_ENV=$NETWORK dfx deploy --network "$NETWORK" "$CANISTER_NAME" --no-wallet
+dfx canister --network "$NETWORK" create "$CANISTER_NAME" || echo "canister may have been created already"
+OWN_CANISTER_ID="$(dfx canister --network "$NETWORK" id "$CANISTER_NAME")"
+DEPLOY_ENV="$NETWORK" OWN_CANISTER_ID="$OWN_CANISTER_ID" dfx deploy --network "$NETWORK" "$CANISTER_NAME" --no-wallet
 echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,5 +8,5 @@ NETWORK=$1
 #        to deploy these other canisters as well, but you probbaly don't.
 CANISTER_NAME=nns-dapp
 echo "Deploying $CANISTER_NAME to $NETWORK..."
-DEPLOY_ENV=$NETWORK dfx deploy --network "$NETWORK" "$CANISTER_NAME"
+DEPLOY_ENV=$NETWORK dfx deploy --network "$NETWORK" "$CANISTER_NAME" --no-wallet
 echo "Deployed to: https://$(jq -jc '.["nns-dapp"].testnet' canister_ids.json).nnsdapp.dfinity.network"


### PR DESCRIPTION
# Motivation
Fix deployments to testnets.

# Changes
* `dfx 0.9.2` removed `--no-wallet` from many commands, so existing commands with `--no-wallet` broke.  So I removed `--no-wallet` from all out `dfx` calls.
* svelte hard-wires a canister ID - something it should never ever do but hey - this includes a quick fix and we can provide a deeper solution later.

# For future PRs
* Remove all hard-wired values for OWN_CANISTER_ID from svelte.

# Tests
Deployed with:
```
REDIRECT_TO_LEGACY=both ./deploy.sh testnet
```
To: https://wzp7w-lyaaa-aaaaa-aaara-cai.nnsdapp.dfinity.network/
and again from scratch to: https://wljip-hiaaa-aaaaa-aaasa-cai.nnsdapp.dfinity.network/v2/
Weirdly, it says:
```
max@sinkpad:~/dfn/nns-dapp/branches/fix-deploy (1:36:28)$ REDIRECT_TO_LEGACY=both ./deploy.sh testnet
Deploying nns-dapp to testnet...
canister may have been created already
```
But it works.  Why should create canister return a non-zero exit code, but as far as I can tell fully succeed and without any messages on stdout or stderr?  Given that the canister is created I will push on regardless.