### PR TITLE
Restrict how process.env may be used

### DIFF
--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run import-assets && npm run i18n && BASE_HREF=/ ROLLUP_WATCH=true npm run build:index && rollup -c -w",
     "start": "sirv public",
     "check": "svelte-check --tsconfig ./tsconfig.json && npm run lint",
-    "lint": "eslint --max-warnings 0 './src/**/*.{js,ts,svelte}'",
+    "lint": "./scripts/lint",
     "format": "prettier --write --plugin-search-dir=. .",
     "test": "jest",
     "test:watch": "npm run test -- --watchAll",

--- a/frontend/svelte/scripts/lint
+++ b/frontend/svelte/scripts/lint
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+    cat <<-EOF
+	Checks for conventions not covered by eslint.
+
+	Flags:
+	--help
+	  Prints this help text.
+	EOF
+}
+
+while (( $# > 0 )) ; do
+  arg="$1" ; shift 1
+  case "$arg" in
+  --help)
+    print_help
+    exit 0 ;;
+  *)
+    {
+      printf "ERROR: %s\n" "Unsupported argument: '$arg'" "See --help for usage."
+      exit 1
+    } >&2
+  esac
+done
+
+: Configuration from env vars should be accessed ONLY via constans files
+ENVIRONMENT_CONSTANTS_DIR="src/lib/constants/"
+if git grep -w process.env src/ | grep -vE "^${ENVIRONMENT_CONSTANTS_DIR}"
+then
+  { 
+    echo "ERROR: process.env used outside the environment constants in '${ENVIRONMENT_CONSTANTS_DIR}'."
+    exit 1
+  } >&2
+fi
+
+: Eslint should pass
+eslint --max-warnings 0 './src/**/*.{js,ts,svelte}'

--- a/frontend/svelte/src/lib/api/accounts.api.ts
+++ b/frontend/svelte/src/lib/api/accounts.api.ts
@@ -13,7 +13,7 @@ import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
 import { createAgent } from "../utils/agent.utils";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
-import { host } from "./constants.api";
+import { HOST } from "./environment.constants.api";
 
 export const loadAccounts = async ({
   identity,
@@ -24,7 +24,7 @@ export const loadAccounts = async ({
 }): Promise<AccountsStore> => {
   logWithTimestamp(`Loading Accounts certified:${certified} call...`);
 
-  const agent = await createAgent({ identity, host });
+  const agent = await createAgent({ identity, host: HOST });
   // ACCOUNTS
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
     agent,
@@ -85,7 +85,7 @@ export const createSubAccount = async ({
   logWithTimestamp(`Creating SubAccount ${hashCode(name)} call...`);
 
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
-    agent: await createAgent({ identity, host }),
+    agent: await createAgent({ identity, host: HOST }),
     canisterId: OWN_CANISTER_ID,
   });
 

--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -4,7 +4,7 @@ import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
-import { host } from "./constants.api";
+import { HOST } from "./environment.constants.api";
 
 export const queryCanisters = async ({
   identity,
@@ -14,7 +14,7 @@ export const queryCanisters = async ({
   certified: boolean;
 }): Promise<CanisterDetails[]> => {
   logWithTimestamp(`Querying Canisters certified:${certified} call...`);
-  const agent = await createAgent({ identity, host });
+  const agent = await createAgent({ identity, host: HOST });
 
   const nnsDapp: NNSDappCanister = NNSDappCanister.create({
     agent,

--- a/frontend/svelte/src/lib/api/constants.api.ts
+++ b/frontend/svelte/src/lib/api/constants.api.ts
@@ -9,5 +9,3 @@ export const icNeuron = {
   name: "Internet Computer Association",
   description: undefined,
 };
-
-export const host: string = process.env.HOST as string;

--- a/frontend/svelte/src/lib/api/dev.api.ts
+++ b/frontend/svelte/src/lib/api/dev.api.ts
@@ -3,6 +3,7 @@ import { HttpAgent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
+import { DEPLOY_ENV, HOST } from "../environment.constants.api";
 import { governanceCanister } from "./governance.api";
 
 /*
@@ -32,7 +33,7 @@ export const acquireICPTs = async ({
 
   // If https://nnsdapp.dfinity.network/ is ever used anywhere else, extract or use an environment variable
   const agent: HttpAgent = new HttpAgent({
-    host: "https://nnsdapp.dfinity.network/",
+    host: HOST,
     identity,
   });
   await agent.fetchRootKey();
@@ -66,7 +67,7 @@ export const makeDummyProposals = async ({
 };
 
 const assertTestnet = () => {
-  if (process.env.DEPLOY_ENV !== "testnet") {
+  if (DEPLOY_ENV !== "testnet") {
     throw new Error('The environment is not "testnet"');
   }
 };

--- a/frontend/svelte/src/lib/api/governance.api.ts
+++ b/frontend/svelte/src/lib/api/governance.api.ts
@@ -15,7 +15,8 @@ import {
 } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
-import { dfinityNeuron, host, icNeuron } from "./constants.api";
+import { dfinityNeuron, icNeuron } from "./constants.api";
+import { HOST } from "./environment.constants.api";
 import { toSubAccountId } from "./utils.api";
 
 export const queryNeuron = async ({
@@ -355,7 +356,7 @@ export const governanceCanister = async ({
 }> => {
   const agent = await createAgent({
     identity,
-    host,
+    host: HOST,
   });
 
   const canister = GovernanceCanister.create({

--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -9,7 +9,7 @@ import {
 import { LEDGER_CANISTER_ID } from "../constants/canister-ids.constants";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
-import { host } from "./constants.api";
+import { HOST } from "./environment.constants.api";
 
 export const getNeuronBalance = async ({
   neuron,
@@ -73,7 +73,7 @@ const ledgerCanister = async ({
   logWithTimestamp(`LC call...`);
   const agent = await createAgent({
     identity,
-    host,
+    host: HOST,
   });
 
   const canister = LedgerCanister.create({

--- a/frontend/svelte/src/lib/api/proposals.api.ts
+++ b/frontend/svelte/src/lib/api/proposals.api.ts
@@ -12,7 +12,7 @@ import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import { createAgent } from "../utils/agent.utils";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { enumsExclude } from "../utils/enum.utils";
-import { host } from "./constants.api";
+import { HOST } from "./environment.constants.api";
 
 export const queryProposals = async ({
   beforeProposal,
@@ -32,7 +32,7 @@ export const queryProposals = async ({
   );
 
   const governance: GovernanceCanister = GovernanceCanister.create({
-    agent: await createAgent({ identity, host }),
+    agent: await createAgent({ identity, host: HOST }),
   });
 
   const { rewards, status, topics }: ProposalsFiltersStore = filters;
@@ -77,7 +77,7 @@ export const queryProposal = async ({
     `Querying Proposal (${hashCode(proposalId)}) certified:${certified} call...`
   );
   const governance: GovernanceCanister = GovernanceCanister.create({
-    agent: await createAgent({ identity, host }),
+    agent: await createAgent({ identity, host: HOST }),
   });
 
   const response = await governance.getProposal({ proposalId, certified });
@@ -105,7 +105,7 @@ export const registerVote = async ({
   );
 
   const governance: GovernanceCanister = GovernanceCanister.create({
-    agent: await createAgent({ identity, host }),
+    agent: await createAgent({ identity, host: HOST }),
   });
 
   await governance.registerVote({

--- a/frontend/svelte/src/lib/components/common/Banner.svelte
+++ b/frontend/svelte/src/lib/components/common/Banner.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
   import IconClose from "../../icons/IconClose.svelte";
+  import {
+    IS_TESTNET,
+    ROLLUP_WATCH,
+  } from "../../constants/environment.constants";
 
   export let headless: boolean = false;
 
@@ -10,10 +14,8 @@
     localStorage.getItem(localstorageKey) ?? "true"
   ) as boolean;
 
-  const testnet: boolean = process.env.DEPLOY_ENV === "testnet";
-  const localEnv: boolean = JSON.parse(
-    process.env.ROLLUP_WATCH ?? "false"
-  ) as boolean;
+  const testnet: boolean = IS_TESTNET;
+  const localEnv: boolean = ROLLUP_WATCH;
   const banner: boolean = testnet && !localEnv;
 
   const rootStyle: string = `

--- a/frontend/svelte/src/lib/constants/environment.constants.ts
+++ b/frontend/svelte/src/lib/constants/environment.constants.ts
@@ -1,2 +1,5 @@
-const deployEnvironment: string = String(process.env.DEPLOY_ENV);
-export const IS_TESTNET = deployEnvironment === "testnet";
+export const DEPLOY_ENV: string = String(process.env.DEPLOY_ENV);
+export const IS_TESTNET: boolean = DEPLOY_ENV === "testnet";
+export const HOST: string = process.env.HOST as string;
+export const ROLLUP_WATCH: boolean = process.env.ROLLUP_WATCH === "true";
+export const FETCH_ROOT_KEY: boolean = process.env.FETCH_ROOT_KEY === "true";

--- a/frontend/svelte/src/lib/utils/agent.utils.ts
+++ b/frontend/svelte/src/lib/utils/agent.utils.ts
@@ -1,5 +1,6 @@
 import type { Identity } from "@dfinity/agent";
 import { HttpAgent } from "@dfinity/agent";
+import { FETCH_ROOT_KEY } from "../constants/environment.constants";
 
 export const createAgent = async ({
   identity,
@@ -13,9 +14,7 @@ export const createAgent = async ({
     ...(host !== undefined && { host }),
   });
 
-  // process.env.FETCH_ROOT_KEY is changed to `true`, but we hande nullish/empty cases explicitly
-  // @ts-ignore: rollup substitutes process.env.FETCH_ROOT_KEY for `true`, not a string. TS cannot recognize it as boolean.
-  if (process.env.FETCH_ROOT_KEY === true) {
+  if (FETCH_ROOT_KEY) {
     // Fetch root key for certificate validation during development or on testnet
     await agent.fetchRootKey();
   }


### PR DESCRIPTION
# Motivation
We need better control over environment variable based configuration.  `process.env.` values are accessed across the svelte codebase, making it hard to verify that they are parsed and interpreted consistently.

The control is needed:
- For deploying to new environments, such as localhost without the proxy or new testnets.
- For deploying production-like builds to testnets.

A small goal in this direction is therefore to access the environment only in constants files, ideally in environment.constants.ts unless there are strong compelling reasons to use another constants file.

# Changes
- Defined a lint rule to enforce the policy.
- Moved any direct access of process.env to the environment.constants file.

# Tests
TODO