### PR TITLE
feat: attach hardware wallet

### DIFF
--- a/frontend/svelte/src/lib/api/accounts.api.ts
+++ b/frontend/svelte/src/lib/api/accounts.api.ts
@@ -1,19 +1,14 @@
 import type { Identity } from "@dfinity/agent";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
-import { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
 import type {
   AccountDetails,
   SubAccountDetails,
 } from "../canisters/nns-dapp/nns-dapp.types";
-import {
-  LEDGER_CANISTER_ID,
-  OWN_CANISTER_ID,
-} from "../constants/canister-ids.constants";
+import { LEDGER_CANISTER_ID } from "../constants/canister-ids.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
-import { createAgent } from "../utils/agent.utils";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
-import { host } from "./constants.api";
+import { nnsDappCanister } from "./nns-dapp.api";
 
 export const loadAccounts = async ({
   identity,
@@ -24,18 +19,14 @@ export const loadAccounts = async ({
 }): Promise<AccountsStore> => {
   logWithTimestamp(`Loading Accounts certified:${certified} call...`);
 
-  const agent = await createAgent({ identity, host });
-  // ACCOUNTS
-  const nnsDapp: NNSDappCanister = NNSDappCanister.create({
-    agent,
-    canisterId: OWN_CANISTER_ID,
-  });
+  const { canister, agent } = await nnsDappCanister({ identity });
+
   // Ensure account exists in NNSDapp Canister
   // https://github.com/dfinity/nns-dapp/blob/main/rs/src/accounts_store.rs#L271
   // https://github.com/dfinity/nns-dapp/blob/main/rs/src/accounts_store.rs#L232
-  await nnsDapp.addAccount();
+  await canister.addAccount();
 
-  const mainAccount: AccountDetails = await nnsDapp.getAccount({ certified });
+  const mainAccount: AccountDetails = await canister.getAccount({ certified });
 
   // ACCOUNT BALANCES
   const ledger: LedgerCanister = LedgerCanister.create({
@@ -62,6 +53,8 @@ export const loadAccounts = async ({
     };
   };
 
+  // TODO(L2-433): map hardware_wallet_accounts
+
   const [main, ...subAccounts] = await Promise.all([
     mapAccount(mainAccount),
     ...mainAccount.sub_accounts.map(mapAccount),
@@ -84,13 +77,11 @@ export const createSubAccount = async ({
 }): Promise<void> => {
   logWithTimestamp(`Creating SubAccount ${hashCode(name)} call...`);
 
-  const nnsDapp: NNSDappCanister = NNSDappCanister.create({
-    agent: await createAgent({ identity, host }),
-    canisterId: OWN_CANISTER_ID,
-  });
+  const { canister } = await nnsDappCanister({ identity });
 
-  await nnsDapp.createSubAccount({
+  await canister.createSubAccount({
     subAccountName: name,
   });
+
   logWithTimestamp(`Creating SubAccount ${hashCode(name)} complete.`);
 };

--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -1,10 +1,7 @@
 import type { Identity } from "@dfinity/agent";
-import { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
 import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
-import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
-import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
-import { host } from "./constants.api";
+import { nnsDappCanister } from "./nns-dapp.api";
 
 export const queryCanisters = async ({
   identity,
@@ -14,14 +11,11 @@ export const queryCanisters = async ({
   certified: boolean;
 }): Promise<CanisterDetails[]> => {
   logWithTimestamp(`Querying Canisters certified:${certified} call...`);
-  const agent = await createAgent({ identity, host });
+  const { canister } = await nnsDappCanister({ identity });
 
-  const nnsDapp: NNSDappCanister = NNSDappCanister.create({
-    agent,
-    canisterId: OWN_CANISTER_ID,
-  });
+  const response = await canister.getCanisters({ certified });
 
-  const response = await nnsDapp.getCanisters({ certified });
   logWithTimestamp(`Querying Canisters certified:${certified} complete.`);
+
   return response;
 };

--- a/frontend/svelte/src/lib/api/nns-dapp.api.ts
+++ b/frontend/svelte/src/lib/api/nns-dapp.api.ts
@@ -1,0 +1,26 @@
+import type { HttpAgent, Identity } from "@dfinity/agent";
+import { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
+import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
+import { createAgent } from "../utils/agent.utils";
+import { host } from "./constants.api";
+
+export const nnsDappCanister = async ({
+  identity,
+}: {
+  identity: Identity;
+}): Promise<{
+  canister: NNSDappCanister;
+  agent: HttpAgent;
+}> => {
+  const agent = await createAgent({ identity, host });
+
+  const canister: NNSDappCanister = NNSDappCanister.create({
+    agent,
+    canisterId: OWN_CANISTER_ID,
+  });
+
+  return {
+    canister,
+    agent,
+  };
+};

--- a/frontend/svelte/src/lib/api/nns-dapp.api.ts
+++ b/frontend/svelte/src/lib/api/nns-dapp.api.ts
@@ -1,8 +1,8 @@
 import type { HttpAgent, Identity } from "@dfinity/agent";
 import { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
 import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
+import { HOST } from "../constants/environment.constants";
 import { createAgent } from "../utils/agent.utils";
-import {HOST} from '../constants/environment.constants';
 
 export const nnsDappCanister = async ({
   identity,

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -55,21 +55,21 @@ export class NNSDappCanister {
    *
    * @returns Promise<void>
    */
-  public addAccount = async (): Promise<AccountIdentifier> => {
+  public async addAccount(): Promise<AccountIdentifier> {
     const identifierText = await this.certifiedService.add_account();
     return AccountIdentifier.fromHex(identifierText);
-  };
+  }
 
   /**
    * Get Account Details
    *
    * @returns Promise<void>
    */
-  public getAccount = async ({
+  public async getAccount({
     certified,
   }: {
     certified: boolean;
-  }): Promise<AccountDetails> => {
+  }): Promise<AccountDetails> {
     const { AccountNotFound, Ok } = await this.getNNSDappService(
       certified
     ).get_account();
@@ -83,16 +83,16 @@ export class NNSDappCanister {
 
     // We should never reach here. Some of the previous properties should be present.
     throw new Error("Error getting account details");
-  };
+  }
 
   /**
    * Creates a subaccount with the name and returns the Subaccount details
    */
-  public createSubAccount = async ({
+  public async createSubAccount({
     subAccountName,
   }: {
     subAccountName: string;
-  }): Promise<SubAccountDetails> => {
+  }): Promise<SubAccountDetails> {
     const {
       AccountNotFound,
       NameTooLong,
@@ -124,11 +124,11 @@ export class NNSDappCanister {
 
     // We should never reach here. Some of the previous properties should be present.
     throw new Error("Error creating subaccount");
-  };
+  }
 
-  public registerHardwareWallet = async (
+  public async registerHardwareWallet(
     request: RegisterHardwareWalletRequest
-  ): Promise<void> => {
+  ): Promise<void> {
     const response: RegisterHardwareWalletResponse =
       await this.certifiedService.register_hardware_wallet(request);
 
@@ -144,7 +144,9 @@ export class NNSDappCanister {
       "HardwareWalletAlreadyRegistered" in response &&
       response.HardwareWalletAlreadyRegistered === null
     ) {
-      throw new HardwareWalletAttachError("error_attach_wallet.already_registered");
+      throw new HardwareWalletAttachError(
+        "error_attach_wallet.already_registered"
+      );
     }
 
     if (
@@ -153,7 +155,7 @@ export class NNSDappCanister {
     ) {
       throw new HardwareWalletAttachError("error_attach_wallet.limit_exceeded");
     }
-  };
+  }
 
   public getCanisters = async ({
     certified,

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -15,3 +15,9 @@ export class NameTooLongError extends Error {
     super(message);
   }
 }
+
+export class HardwareWalletAttachError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -8,9 +8,9 @@
     ADD_ACCOUNT_CONTEXT_KEY,
     type AddAccountContext,
   } from "../../stores/add-account.store";
-  import {createEventDispatcher, getContext} from "svelte";
+  import { createEventDispatcher, getContext } from "svelte";
   import type { LedgerIdentity } from "../../identities/ledger.identity";
-  import {busy, startBusy, stopBusy} from '../../stores/busy.store';
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
 
   let connectionState: LedgerConnectionState =
     LedgerConnectionState.NOT_CONNECTED;

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -2,13 +2,35 @@
   import { i18n } from "../../stores/i18n";
   import { LedgerConnectionState } from "../../constants/ledger.constants";
   import HardwareWalletConnectAction from "./HardwareWalletConnectAction.svelte";
+  import {toastsStore} from '../../stores/toasts.store';
+  import {registerHardwareWalletProxy} from '../../proxy/ledger.services.proxy';
+  import {ADD_ACCOUNT_CONTEXT_KEY, type AddAccountContext} from '../../stores/add-account.store';
+  import {getContext} from 'svelte';
+  import type {LedgerIdentity} from '../../identities/ledger.identity';
 
   let connectionState: LedgerConnectionState =
     LedgerConnectionState.NOT_CONNECTED;
 
-  const onSubmit = () => {
-    // TODO(L2-433): Attach wallet
-    alert("TODO(L2-433): Attach wallet");
+  let ledgerIdentity: LedgerIdentity | undefined = undefined;
+
+  const context: AddAccountContext = getContext<AddAccountContext>(
+          ADD_ACCOUNT_CONTEXT_KEY
+  );
+
+  const { store, next }: AddAccountContext = context;
+
+  const onSubmit = async () => {
+    if (disabled) {
+      toastsStore.error({
+        labelKey: "error_attach_wallet.connect",
+      });
+      return;
+    }
+
+    await registerHardwareWalletProxy({
+      name: $store.hardwareWalletName,
+      ledgerIdentity
+    });
   };
 
   let disabled: boolean;
@@ -17,7 +39,7 @@
 
 <form on:submit|preventDefault={onSubmit} class="wizard-wrapper">
   <div>
-    <HardwareWalletConnectAction bind:connectionState />
+    <HardwareWalletConnectAction bind:connectionState bind:ledgerIdentity />
   </div>
 
   <button

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -2,11 +2,14 @@
   import { i18n } from "../../stores/i18n";
   import { LedgerConnectionState } from "../../constants/ledger.constants";
   import HardwareWalletConnectAction from "./HardwareWalletConnectAction.svelte";
-  import {toastsStore} from '../../stores/toasts.store';
-  import {registerHardwareWalletProxy} from '../../proxy/ledger.services.proxy';
-  import {ADD_ACCOUNT_CONTEXT_KEY, type AddAccountContext} from '../../stores/add-account.store';
-  import {getContext} from 'svelte';
-  import type {LedgerIdentity} from '../../identities/ledger.identity';
+  import { toastsStore } from "../../stores/toasts.store";
+  import { registerHardwareWalletProxy } from "../../proxy/ledger.services.proxy";
+  import {
+    ADD_ACCOUNT_CONTEXT_KEY,
+    type AddAccountContext,
+  } from "../../stores/add-account.store";
+  import { getContext } from "svelte";
+  import type { LedgerIdentity } from "../../identities/ledger.identity";
 
   let connectionState: LedgerConnectionState =
     LedgerConnectionState.NOT_CONNECTED;
@@ -14,10 +17,10 @@
   let ledgerIdentity: LedgerIdentity | undefined = undefined;
 
   const context: AddAccountContext = getContext<AddAccountContext>(
-          ADD_ACCOUNT_CONTEXT_KEY
+    ADD_ACCOUNT_CONTEXT_KEY
   );
 
-  const { store, next }: AddAccountContext = context;
+  const { store }: AddAccountContext = context;
 
   const onSubmit = async () => {
     if (disabled) {
@@ -29,7 +32,7 @@
 
     await registerHardwareWalletProxy({
       name: $store.hardwareWalletName,
-      ledgerIdentity
+      ledgerIdentity,
     });
   };
 

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnectAction.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnectAction.svelte
@@ -9,7 +9,7 @@
   export let connectionState: LedgerConnectionState =
     LedgerConnectionState.NOT_CONNECTED;
 
-  let ledgerIdentity: LedgerIdentity | undefined = undefined;
+  export let ledgerIdentity: LedgerIdentity | undefined = undefined;
 
   const connect = async () =>
     await connectToHardwareWalletProxy(

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -353,5 +353,13 @@
     "connect_not_supported": "Either you have other wallet applications open (e.g. Ledger Live), or your browser doesn't support WebHID, which is necessary to communicate with your Ledger hardware wallet. Supported browsers: Chrome (Desktop) v89+, Edge v89+, Opera v76+. Error: $err",
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right wallet?",
     "user_cancel": "User denied the access to use the ledger device."
+  },
+  "error_attach_wallet": {
+    "unexpected": "There was an error trying to attach the hardware wallet.",
+    "connect": "You need to connect your hardware wallet first.",
+    "no_name": "No account name provided.",
+    "no_identity": "No identity connected to your hardware wallet.",
+    "already_registered": "The hardware wallet is already registered with another account.",
+    "limit_exceeded": "The limit of hardware wallet that can be attached has been reached."
   }
 }

--- a/frontend/svelte/src/lib/proxy/ledger.services.proxy.ts
+++ b/frontend/svelte/src/lib/proxy/ledger.services.proxy.ts
@@ -1,4 +1,7 @@
-import type { ConnectToHardwareWalletParams } from "../services/ledger.services";
+import type {
+  ConnectToHardwareWalletParams,
+  RegisterHardwareWalletParams,
+} from "../services/ledger.services";
 
 export const connectToHardwareWalletProxy = async (
   callback: (params: ConnectToHardwareWalletParams) => void
@@ -8,4 +11,14 @@ export const connectToHardwareWalletProxy = async (
   );
 
   return connectToHardwareWallet(callback);
+};
+
+export const registerHardwareWalletProxy = async (
+  params: RegisterHardwareWalletParams
+): Promise<void> => {
+  const { registerHardwareWallet } = await import(
+    "../services/ledger.services"
+  );
+
+  return registerHardwareWallet(params);
 };

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -1,11 +1,22 @@
+import type { Identity } from "@dfinity/agent";
+import { nnsDappCanister } from "../api/nns-dapp.api";
 import { LedgerConnectionState } from "../constants/ledger.constants";
 import { LedgerErrorKey } from "../errors/ledger.errors";
 import { LedgerIdentity } from "../identities/ledger.identity";
 import { toastsStore } from "../stores/toasts.store";
+import { hashCode, logWithTimestamp } from "../utils/dev.utils";
+import { syncAccounts } from "./accounts.services";
+import { getIdentity } from "./auth.services";
+import {HardwareWalletAttachError} from '../canisters/nns-dapp/nns-dapp.errors';
 
 export interface ConnectToHardwareWalletParams {
   connectionState: LedgerConnectionState;
   ledgerIdentity?: LedgerIdentity;
+}
+
+export interface RegisterHardwareWalletParams {
+  name: string | undefined;
+  ledgerIdentity: LedgerIdentity | undefined;
 }
 
 /**
@@ -34,5 +45,50 @@ export const connectToHardwareWallet = async (
     });
 
     callback({ connectionState: LedgerConnectionState.NOT_CONNECTED });
+  }
+};
+
+export const registerHardwareWallet = async ({
+  name,
+  ledgerIdentity,
+}: RegisterHardwareWalletParams): Promise<void> => {
+  if (name === undefined) {
+    toastsStore.error({
+      labelKey: "error_attach_wallet.no_name",
+    });
+    return;
+  }
+
+  if (ledgerIdentity === undefined) {
+    toastsStore.error({
+      labelKey: "error_attach_wallet.no_identity",
+    });
+    return;
+  }
+
+  logWithTimestamp(`Register hardware wallet ${hashCode(name)}...`);
+
+  const identity: Identity = await getIdentity();
+
+  try {
+    const { canister } = await nnsDappCanister({ identity });
+
+    await canister.registerHardwareWallet({
+      name,
+      principal: ledgerIdentity.getPrincipal(),
+    });
+
+    logWithTimestamp(`Register hardware wallet ${hashCode(name)} complete.`);
+
+    await syncAccounts();
+  } catch (err: unknown) {
+    const ledgerErrorKey: boolean = err instanceof HardwareWalletAttachError;
+
+    toastsStore.error({
+      labelKey: ledgerErrorKey
+          ? (err as HardwareWalletAttachError).message
+          : "error_attach_wallet.unexpected",
+      ...(!ledgerErrorKey && { err }),
+    });
   }
 };

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -1,5 +1,6 @@
 import type { Identity } from "@dfinity/agent";
 import { nnsDappCanister } from "../api/nns-dapp.api";
+import { HardwareWalletAttachError } from "../canisters/nns-dapp/nns-dapp.errors";
 import { LedgerConnectionState } from "../constants/ledger.constants";
 import { LedgerErrorKey } from "../errors/ledger.errors";
 import { LedgerIdentity } from "../identities/ledger.identity";
@@ -7,7 +8,6 @@ import { toastsStore } from "../stores/toasts.store";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
-import {HardwareWalletAttachError} from '../canisters/nns-dapp/nns-dapp.errors';
 
 export interface ConnectToHardwareWalletParams {
   connectionState: LedgerConnectionState;
@@ -86,8 +86,8 @@ export const registerHardwareWallet = async ({
 
     toastsStore.error({
       labelKey: ledgerErrorKey
-          ? (err as HardwareWalletAttachError).message
-          : "error_attach_wallet.unexpected",
+        ? (err as HardwareWalletAttachError).message
+        : "error_attach_wallet.unexpected",
       ...(!ledgerErrorKey && { err }),
     });
   }

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -379,6 +379,15 @@ interface I18nError__ledger {
   user_cancel: string;
 }
 
+interface I18nError_attach_wallet {
+  unexpected: string;
+  connect: string;
+  no_name: string;
+  no_identity: string;
+  already_registered: string;
+  limit_exceeded: string;
+}
+
 interface I18n {
   lang: Languages;
   core: I18nCore;
@@ -403,4 +412,5 @@ interface I18n {
   neuron_detail: I18nNeuron_detail;
   time: I18nTime;
   error__ledger: I18nError__ledger;
+  error_attach_wallet: I18nError_attach_wallet;
 }

--- a/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
@@ -1,66 +1,173 @@
+import type { HttpAgent } from "@dfinity/agent";
+import { mock } from "jest-mock-extended";
+import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import { LedgerConnectionState } from "../../../lib/constants/ledger.constants";
 import { LedgerIdentity } from "../../../lib/identities/ledger.identity";
-import { connectToHardwareWallet } from "../../../lib/services/ledger.services";
+import * as accountsServices from "../../../lib/services/accounts.services";
+import * as authServices from "../../../lib/services/auth.services";
+import {
+  connectToHardwareWallet,
+  registerHardwareWallet,
+} from "../../../lib/services/ledger.services";
+import { authStore } from "../../../lib/stores/auth.store";
 import { toastsStore } from "../../../lib/stores/toasts.store";
+import * as agent from "../../../lib/utils/agent.utils";
+import {
+  mockAuthStoreSubscribe,
+  mockGetIdentity,
+  mockIdentityErrorMsg,
+  resetIdentity,
+  setNoIdentity,
+} from "../../mocks/auth.store.mock";
 import { MockLedgerIdentity } from "../../mocks/ledger.identity.mock";
+import { MockNNSDappCanister } from "../../mocks/nns-dapp.canister.mock";
 
 describe("ledger-services", () => {
-  const callback = jest.fn();
+  describe("connect hardware wallet", () => {
+    const callback = jest.fn();
 
-  describe("connection success", () => {
-    const mockLedgerIdentity: MockLedgerIdentity = new MockLedgerIdentity();
+    describe("success", () => {
+      const mockLedgerIdentity: MockLedgerIdentity = new MockLedgerIdentity();
 
-    beforeAll(() =>
+      beforeAll(() =>
+        jest
+          .spyOn(LedgerIdentity, "create")
+          .mockImplementation(
+            async (): Promise<LedgerIdentity> => mockLedgerIdentity
+          )
+      );
+
+      afterAll(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+      });
+
+      it("should set connecting state before connecting", async () => {
+        await connectToHardwareWallet(callback);
+
+        expect(callback).toHaveBeenCalledWith({
+          connectionState: LedgerConnectionState.CONNECTING,
+        });
+      });
+
+      it("should set connected state and identity once ledger connected", async () => {
+        await connectToHardwareWallet(callback);
+
+        expect(callback).toHaveBeenCalledWith({
+          connectionState: LedgerConnectionState.CONNECTED,
+          ledgerIdentity: mockLedgerIdentity,
+        });
+      });
+    });
+
+    describe("error", () => {
+      it("should set not connected state on error", async () => {
+        await connectToHardwareWallet(callback);
+
+        expect(callback).toHaveBeenNthCalledWith(2, {
+          connectionState: LedgerConnectionState.NOT_CONNECTED,
+        });
+      });
+
+      it("should display a toast for the error assuming the user has cancelled the process", async () => {
+        const spyToastError = jest.spyOn(toastsStore, "error");
+
+        await connectToHardwareWallet(callback);
+
+        expect(spyToastError).toBeCalled();
+        expect(spyToastError).toBeCalledWith({
+          labelKey: "error__ledger.user_cancel",
+        });
+
+        spyToastError.mockRestore();
+      });
+    });
+  });
+
+  describe("register hardware wallet", () => {
+    const mockNNSDappCanister: MockNNSDappCanister = new MockNNSDappCanister();
+
+    const ledgerIdentity = new MockLedgerIdentity();
+
+    let spySyncAccounts;
+
+    beforeAll(() => {
       jest
-        .spyOn(LedgerIdentity, "create")
-        .mockImplementation(
-          async (): Promise<LedgerIdentity> => mockLedgerIdentity
-        )
-    );
+        .spyOn(NNSDappCanister, "create")
+        .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
+
+      spySyncAccounts = jest
+        .spyOn(accountsServices, "syncAccounts")
+        .mockImplementation(jest.fn());
+
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreSubscribe);
+
+      const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
+      jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
+
+      jest
+        .spyOn(authServices, "getIdentity")
+        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+    });
 
     afterAll(() => {
       jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 
-    it("should set connecting state before connecting", async () => {
-      await connectToHardwareWallet(callback);
+    describe("success", () => {
+      it("should sync accounts after register", async () => {
+        await registerHardwareWallet({ name: "test", ledgerIdentity });
 
-      expect(callback).toHaveBeenCalledWith({
-        connectionState: LedgerConnectionState.CONNECTING,
+        expect(spySyncAccounts).toHaveBeenCalled();
       });
     });
 
-    it("should set connected state and identity once ledger connected", async () => {
-      await connectToHardwareWallet(callback);
+    describe("error", () => {
+      it("should throw an error if no name provided", async () => {
+        const spyToastError = jest.spyOn(toastsStore, "error");
 
-      expect(callback).toHaveBeenCalledWith({
-        connectionState: LedgerConnectionState.CONNECTED,
-        ledgerIdentity: mockLedgerIdentity,
-      });
-    });
-  });
+        await registerHardwareWallet({ name: undefined, ledgerIdentity });
 
-  describe("connection error", () => {
-    it("should set not connected state on error", async () => {
-      await connectToHardwareWallet(callback);
+        expect(spyToastError).toBeCalled();
+        expect(spyToastError).toBeCalledWith({
+          labelKey: "error_attach_wallet.no_name",
+        });
 
-      expect(callback).toHaveBeenNthCalledWith(2, {
-        connectionState: LedgerConnectionState.NOT_CONNECTED,
-      });
-    });
-
-    it("should display a toast for the error assuming the user has cancelled the process", async () => {
-      const spyToastError = jest.spyOn(toastsStore, "error");
-
-      await connectToHardwareWallet(callback);
-
-      expect(spyToastError).toBeCalled();
-      expect(spyToastError).toBeCalledWith({
-        labelKey: "error__ledger.user_cancel",
+        spyToastError.mockRestore();
       });
 
-      spyToastError.mockRestore();
+      it("should throw an error if no ledger identity provided", async () => {
+        const spyToastError = jest.spyOn(toastsStore, "error");
+
+        await registerHardwareWallet({
+          name: "test",
+          ledgerIdentity: undefined,
+        });
+
+        expect(spyToastError).toBeCalled();
+        expect(spyToastError).toBeCalledWith({
+          labelKey: "error_attach_wallet.no_identity",
+        });
+
+        spyToastError.mockRestore();
+      });
+
+      it("should not register and sync accounts if no identity", async () => {
+        setNoIdentity();
+
+        const call = async () =>
+          await registerHardwareWallet({
+            name: "test",
+            ledgerIdentity,
+          });
+
+        await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+        resetIdentity();
+      });
     });
   });
 });

--- a/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -40,6 +40,7 @@ export class MockNNSDappCanister extends NNSDappCanister {
   }
 
   public async registerHardwareWallet(
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     request: RegisterHardwareWalletRequest
   ): Promise<void> {
     // Do nothing

--- a/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -9,7 +9,7 @@ import {
   mockMainAccount,
   mockSubAccountDetails,
 } from "./accounts.store.mock";
-import {RegisterHardwareWalletRequest} from '../../lib/canisters/nns-dapp/nns-dapp.types';
+import type {RegisterHardwareWalletRequest} from '../../lib/canisters/nns-dapp/nns-dapp.types';
 
 // eslint-disable-next-line
 // @ts-ignore: test file

--- a/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -22,21 +22,19 @@ export class MockNNSDappCanister extends NNSDappCanister {
     return this;
   }
 
-  public addAccount = async (): Promise<AccountIdentifier> => {
+  public async addAccount(): Promise<AccountIdentifier> {
     return AccountIdentifier.fromHex(mockMainAccount.identifier);
-  };
+  }
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  public getAccount = async (_: {
-    certified: boolean;
-  }): Promise<AccountDetails> => {
+  public async getAccount(_: { certified: boolean }): Promise<AccountDetails> {
     return mockAccountDetails;
-  };
+  }
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  public createSubAccount = async (_: {
+  public async createSubAccount(_: {
     subAccountName: string;
-  }): Promise<SubAccountDetails> => {
+  }): Promise<SubAccountDetails> {
     return mockSubAccountDetails;
-  };
+  }
 }

--- a/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -9,6 +9,7 @@ import {
   mockMainAccount,
   mockSubAccountDetails,
 } from "./accounts.store.mock";
+import {RegisterHardwareWalletRequest} from '../../lib/canisters/nns-dapp/nns-dapp.types';
 
 // eslint-disable-next-line
 // @ts-ignore: test file
@@ -36,5 +37,11 @@ export class MockNNSDappCanister extends NNSDappCanister {
     subAccountName: string;
   }): Promise<SubAccountDetails> {
     return mockSubAccountDetails;
+  }
+
+  public async registerHardwareWallet(
+      request: RegisterHardwareWalletRequest
+  ): Promise<void> {
+      // Do nothing
   }
 }

--- a/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/svelte/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -2,6 +2,7 @@ import { AccountIdentifier } from "@dfinity/nns";
 import { NNSDappCanister } from "../../lib/canisters/nns-dapp/nns-dapp.canister";
 import type {
   AccountDetails,
+  RegisterHardwareWalletRequest,
   SubAccountDetails,
 } from "../../lib/canisters/nns-dapp/nns-dapp.types";
 import {
@@ -9,7 +10,6 @@ import {
   mockMainAccount,
   mockSubAccountDetails,
 } from "./accounts.store.mock";
-import type {RegisterHardwareWalletRequest} from '../../lib/canisters/nns-dapp/nns-dapp.types';
 
 // eslint-disable-next-line
 // @ts-ignore: test file
@@ -40,8 +40,8 @@ export class MockNNSDappCanister extends NNSDappCanister {
   }
 
   public async registerHardwareWallet(
-      request: RegisterHardwareWalletRequest
+    request: RegisterHardwareWalletRequest
   ): Promise<void> {
-      // Do nothing
+    // Do nothing
   }
 }


### PR DESCRIPTION
# Motivation

Attach hardware wallet - i.e. create an account for the selected hardware wallet.

Follows PR [connect](https://github.com/dfinity/nns-dapp/pull/785) hardware wallet.

# Changes

- refactor duplicate code to instantiate nns-dapp canister agent
- add `registerHardwareWallet` to nns-dapp canister
- uses previous function and add `registerHardwareWallet` in `ledger.service`
- add function to proxy for lazy loading / chunking reason
- implement feature in component
- call busy store and close modal in the component as well

# Screenshot

Note: even if I would not have used my hw before the account would not have been displayed in the list of accounts anyway, this is something that will be solve in next PR. There is a TODO within code / this PR about it.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/16886711/166940734-304b77d1-b6f6-4c56-8fb5-91e191e87ffe.gif)

