### PR TITLE
Fix CSP domains

### DIFF
--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -40,9 +40,9 @@ const OWN_CANISTER_ID =
   process.env.OWN_CANISTER_ID ||
   (development ? "qaa6y-5yaaa-aaaaa-aaafa-cai" : "qoctq-giaaa-aaaaa-aaaea-cai");
 
-const GOVERNANCE_CANISTER_URL = `https://${GOVERNANCE_CANISTER_ID}${domain}/`;
-const LEDGER_CANISTER_URL = `https://${LEDGER_CANISTER_ID}${domain}/`;
-const OWN_CANISTER_URL = `https://${OWN_CANISTER_ID}${domain}/`;
+const GOVERNANCE_CANISTER_URL = `https://${GOVERNANCE_CANISTER_ID}.${domain}/`;
+const LEDGER_CANISTER_URL = `https://${LEDGER_CANISTER_ID}.${domain}/`;
+const OWN_CANISTER_URL = `https://${OWN_CANISTER_ID}.${domain}/`;
 
 // For values, see the [README](../../README.md).
 // The default should match production.  Except during local development.


### PR DESCRIPTION
# Motivation
Some domains are malformed on main.  Here are the env vars used by svelte:
```
  "svelteEnvironmentVariables": {
    "ENVIRONMENT": "mainnet",
    "DEPLOY_ENV": "mainnet",
    "FETCH_ROOT_KEY": false,
    "REDIRECT_TO_LEGACY": "prod",
    "MAINNET": "https://ic0.app/",
    "HOST": "https://ic0.app/",
    "OWN_CANISTER_ID": "qoctq-giaaa-aaaaa-aaaea-cai",
    "OWN_CANISTER_URL": "https://qoctq-giaaa-aaaaa-aaaea-caiic0.app/", <---
    "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
    "GOVERNANCE_CANISTER_ID": "rrkah-fqaaa-aaaaa-aaaaq-cai",
    "LEDGER_CANISTER_ID": "ryjl3-tyaaa-aaaaa-aaaba-cai",
    "GOVERNANCE_CANISTER_URL": "https://rrkah-fqaaa-aaaaa-aaaaq-caiic0.app/", <-----
    "LEDGER_CANISTER_URL": "https://ryjl3-tyaaa-aaaaa-aaaba-caiic0.app/", <-----
    "ROLLUP_WATCH": false
  }
```
The cause for this is this code, which is missing the dot separator:
```
const domainTestnet = "nnsdapp.dfinity.network";
const domainMainnet = "ic0.app";
const domain = development ? domainTestnet : domainMainnet;
...
const GOVERNANCE_CANISTER_URL = `https://${GOVERNANCE_CANISTER_ID}${domain}/`;
const LEDGER_CANISTER_URL = `https://${LEDGER_CANISTER_ID}${domain}/`;
const OWN_CANISTER_URL = `https://${OWN_CANISTER_ID}${domain}/`;
```
Those domains are used in the content security policy.  Looking at production, those broken entries are in the CSP.  As far as I can tell they are not needed anyway as the agent always uses https://ic0.app/.  Maybe it should be using https://nns.ic0.app/  If https://ic0.app/ is there, then a response from ANY canister will pass the CSP.  So I think we need to tighten that.

Let's fix these domains first.

# Changes
- Add the missing "." separators.

# Tests
Running `DEPLOY_ENV=mainnet ./build.sh` now shows these environment variables for mainnet:
```
{
  "svelteEnvironmentVariables": {
    "ENVIRONMENT": "mainnet",
    "DEPLOY_ENV": "mainnet",
    "FETCH_ROOT_KEY": false,
    "REDIRECT_TO_LEGACY": "prod",
    "MAINNET": "https://ic0.app",
    "HOST": "https://ic0.app",
    "OWN_CANISTER_ID": "qoctq-giaaa-aaaaa-aaaea-cai",
    "OWN_CANISTER_URL": "https://qoctq-giaaa-aaaaa-aaaea-cai.ic0.app/",
    "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
    "GOVERNANCE_CANISTER_ID": "rrkah-fqaaa-aaaaa-aaaaq-cai",
    "LEDGER_CANISTER_ID": "ryjl3-tyaaa-aaaaa-aaaba-cai",
    "GOVERNANCE_CANISTER_URL": "https://rrkah-fqaaa-aaaaa-aaaaq-cai.ic0.app/",
    "LEDGER_CANISTER_URL": "https://ryjl3-tyaaa-aaaaa-aaaba-cai.ic0.app/",
    "ROLLUP_WATCH": false
  }
}
```
In particular the canister URLs are now correct.