### PR TITLE
Correct agent URL

### DIFF
--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -32,7 +32,7 @@ const IDENTITY_SERVICE_URL =
 
 // The host that nns-js connects to
 const HOST =
-  process.env.HOST || (development ? `https://${domainTestnet}/` : MAINNET);
+  process.env.HOST || (development ? `https://${domainTestnet}/` : "https://nns.ic0.app");
 
 // Canister Ids for testnet and mainnet
 const GOVERNANCE_CANISTER_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai";

--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -32,7 +32,8 @@ const IDENTITY_SERVICE_URL =
 
 // The host that nns-js connects to
 const HOST =
-  process.env.HOST || (development ? `https://${domainTestnet}/` : "https://nns.ic0.app");
+  process.env.HOST ||
+  (development ? `https://${domainTestnet}/` : "https://nns.ic0.app");
 
 // Canister Ids for testnet and mainnet
 const GOVERNANCE_CANISTER_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai";


### PR DESCRIPTION
# Motivation
In production, agent.js should call https://nns.ic0.app not https://ic0.app

In fact, it calls both but it should only be calling https://nns.ic0.app.  The CSP is lax in allowing https://ic0.app.  Tightening the CSP however has to be done with extreme caution so is deferred until we can observe no calls to domains that would be blocked.

There is a second open question: Why we need to provide the host to agent.js at all.  I suspect that once we have completely removed the proxy, we can also omit the host, both from the agent and from the CSP, using `self` in the latter.

# Changes
- Correct the HOST in svelte.

# Tests
Running `DEPLOY_ENV=mainnet ./build.sh` shows this configuration in svelte:
```
{
  "svelteEnvironmentVariables": {
    "ENVIRONMENT": "mainnet",
    "DEPLOY_ENV": "mainnet",
    "FETCH_ROOT_KEY": false,
    "REDIRECT_TO_LEGACY": "prod",
    "MAINNET": "https://ic0.app",  <------------ NOTE: This is used in the CSP.  This is unchanged.
    "HOST": "https://nns.ic0.app", <------------ NOTE: This is the only value that has changed in the config.
    "OWN_CANISTER_ID": "qoctq-giaaa-aaaaa-aaaea-cai",
    "OWN_CANISTER_URL": "https://qoctq-giaaa-aaaaa-aaaea-cai.ic0.app/",
    "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
    "GOVERNANCE_CANISTER_ID": "rrkah-fqaaa-aaaaa-aaaaq-cai",
    "LEDGER_CANISTER_ID": "ryjl3-tyaaa-aaaaa-aaaba-cai",
    "GOVERNANCE_CANISTER_URL": "https://rrkah-fqaaa-aaaaa-aaaaq-cai.ic0.app/",
    "LEDGER_CANISTER_URL": "https://ryjl3-tyaaa-aaaaa-aaaba-cai.ic0.app/",
    "ROLLUP_WATCH": false
  }
}
```