### PR TITLE
refactor: ledger error label key with two underscores

### DIFF
--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -145,7 +145,7 @@ export class NNSDappCanister {
       response.HardwareWalletAlreadyRegistered === null
     ) {
       throw new HardwareWalletAttachError(
-        "error_attach_wallet.already_registered"
+        "error__attach_wallet.already_registered"
       );
     }
 
@@ -153,7 +153,9 @@ export class NNSDappCanister {
       "HardwareWalletLimitExceeded" in response &&
       response.HardwareWalletLimitExceeded === null
     ) {
-      throw new HardwareWalletAttachError("error_attach_wallet.limit_exceeded");
+      throw new HardwareWalletAttachError(
+        "error__attach_wallet.limit_exceeded"
+      );
     }
   }
 

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -28,7 +28,7 @@
   const onSubmit = async () => {
     if (disabled) {
       toastsStore.error({
-        labelKey: "error_attach_wallet.connect",
+        labelKey: "error__attach_wallet.connect",
       });
       return;
     }

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -356,7 +356,7 @@
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right wallet?",
     "user_cancel": "User denied the access to use the ledger device."
   },
-  "error_attach_wallet": {
+  "error__attach_wallet": {
     "unexpected": "There was an error trying to attach the hardware wallet.",
     "connect": "You need to connect your hardware wallet first.",
     "no_name": "No account name provided.",

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -54,14 +54,14 @@ export const registerHardwareWallet = async ({
 }: RegisterHardwareWalletParams): Promise<void> => {
   if (name === undefined) {
     toastsStore.error({
-      labelKey: "error_attach_wallet.no_name",
+      labelKey: "error__attach_wallet.no_name",
     });
     return;
   }
 
   if (ledgerIdentity === undefined) {
     toastsStore.error({
-      labelKey: "error_attach_wallet.no_identity",
+      labelKey: "error__attach_wallet.no_identity",
     });
     return;
   }
@@ -87,7 +87,7 @@ export const registerHardwareWallet = async ({
     toastsStore.error({
       labelKey: ledgerErrorKey
         ? (err as HardwareWalletAttachError).message
-        : "error_attach_wallet.unexpected",
+        : "error__attach_wallet.unexpected",
       ...(!ledgerErrorKey && { err }),
     });
   }

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -381,7 +381,7 @@ interface I18nError__ledger {
   user_cancel: string;
 }
 
-interface I18nError_attach_wallet {
+interface I18nError__attach_wallet {
   unexpected: string;
   connect: string;
   no_name: string;
@@ -414,5 +414,5 @@ interface I18n {
   neuron_detail: I18nNeuron_detail;
   time: I18nTime;
   error__ledger: I18nError__ledger;
-  error_attach_wallet: I18nError_attach_wallet;
+  error__attach_wallet: I18nError__attach_wallet;
 }

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -206,7 +206,7 @@ describe("NNSDapp", () => {
         {
           HardwareWalletAlreadyRegistered: null,
         },
-        new HardwareWalletAttachError("error_attach_wallet.already_registered")
+        new HardwareWalletAttachError("error__attach_wallet.already_registered")
       ));
 
     it("should throw register hardware wallet error limit exceeded", async () =>
@@ -214,7 +214,7 @@ describe("NNSDapp", () => {
         {
           HardwareWalletLimitExceeded: null,
         },
-        new HardwareWalletAttachError("error_attach_wallet.limit_exceeded")
+        new HardwareWalletAttachError("error__attach_wallet.limit_exceeded")
       ));
   });
 });

--- a/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
@@ -133,7 +133,7 @@ describe("ledger-services", () => {
 
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
-          labelKey: "error_attach_wallet.no_name",
+          labelKey: "error__attach_wallet.no_name",
         });
 
         spyToastError.mockRestore();
@@ -149,7 +149,7 @@ describe("ledger-services", () => {
 
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
-          labelKey: "error_attach_wallet.no_identity",
+          labelKey: "error__attach_wallet.no_identity",
         });
 
         spyToastError.mockRestore();


### PR DESCRIPTION
# Motivation

Follow label pattern for errors

# Changes

- two underscores instead of one in i18n label `error__attach_wallet`
