### PR TITLE
fix: display select account title only if accounts are selectable

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -31,7 +31,7 @@
 
 <div class="wizard-list" class:disabled={disableSelection}>
   {#if mainAccount}
-    {#if displayTitle}
+    {#if displayTitle && subAccounts?.length > 0}
       <h4>{$i18n.accounts.my_accounts}</h4>
     {/if}
 

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -8,6 +8,7 @@ import { accountsStore } from "../../../../lib/stores/accounts.store";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
+  mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 
@@ -28,6 +29,9 @@ describe("SelectAccount", () => {
     expect(
       getByText(mockMainAccount.identifier, { exact: false })
     ).toBeInTheDocument();
+
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it("should render no title per default", () => {
@@ -37,9 +41,11 @@ describe("SelectAccount", () => {
   });
 
   it("should render a title", async () => {
-    jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
+    accountsStore.set({
+      main: mockMainAccount,
+      subAccounts: [mockSubAccount],
+      hardwareWallets: undefined,
+    });
 
     const { queryByText } = render(SelectAccount, {
       props: {
@@ -50,6 +56,26 @@ describe("SelectAccount", () => {
     await waitFor(() =>
       expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
     );
+
+    accountsStore.reset();
+  });
+
+  it("should render no title if no accounts listed", async () => {
+    accountsStore.set({
+      main: mockMainAccount,
+      subAccounts: undefined,
+      hardwareWallets: undefined,
+    });
+
+    const { queryByText } = render(SelectAccount, {
+      props: {
+        displayTitle: true,
+      },
+    });
+
+    expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
+
+    accountsStore.reset();
   });
 
   it("should filter an account for a given identifier", () => {


### PR DESCRIPTION
# Motivation

The title "My accounts" was displayed even if no accounts were listed.

# Changes

- display title only if at least one account can be selected
