### PR TITLE
L2-527: Disable Confirm Spawn if not enough

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -12,6 +12,7 @@
   export let neuron: NeuronInfo;
   export let percentage: number;
   export let buttonText: string;
+  export let disabled: boolean = false;
 
   let neuronICP: bigint;
   $: neuronICP = neuronStake(neuron);
@@ -60,7 +61,7 @@
     data-tid="select-maturity-percentage-button"
     class="primary full-width"
     on:click={selectPercentage}
-    disabled={percentage === 0}
+    disabled={percentage === 0 || disabled}
   >
     {buttonText}
   </button>

--- a/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -61,7 +61,7 @@
     data-tid="select-maturity-percentage-button"
     class="primary full-width"
     on:click={selectPercentage}
-    disabled={percentage === 0 || disabled}
+    {disabled}
   >
     {buttonText}
   </button>

--- a/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
@@ -66,6 +66,7 @@
       buttonText={$i18n.neuron_detail.merge}
       on:nnsSelectPercentage={goToConfirm}
       bind:percentage={percentageToMerge}
+      disabled={percentageToMerge === 0}
     >
       <svelte:fragment slot="text">
         <h5>{$i18n.neuron_detail.merge_maturity_modal_title}</h5>

--- a/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import type { NeuronInfo } from "@dfinity/nns";
+  import { ICP, type NeuronInfo } from "@dfinity/nns";
   import SelectPercentage from "../../components/neuron-detail/SelectPercentage.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
   import WizardModal from "../WizardModal.svelte";
@@ -11,6 +11,7 @@
   import { spawnNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
+  import { isEnoughToStakeNeuron } from "../../utils/neuron.utils";
 
   export let neuron: NeuronInfo;
 
@@ -32,6 +33,24 @@
 
   let percentageToSpawn: number = 0;
   let loading: boolean;
+
+  let notEnoughMaturityToSpawn: boolean;
+  $: {
+    const maturitySelected: number =
+      neuron.fullNeuron === undefined
+        ? 0
+        : Math.floor(
+            (Number(neuron.fullNeuron.maturityE8sEquivalent) *
+              percentageToSpawn) /
+              100
+          );
+    notEnoughMaturityToSpawn =
+      neuron.fullNeuron === undefined
+        ? false
+        : isEnoughToStakeNeuron({
+            stake: ICP.fromE8s(BigInt(maturitySelected)),
+          });
+  }
 
   const dispatcher = createEventDispatcher();
   const spawnNeuronFromMaturity = async () => {
@@ -66,6 +85,7 @@
       buttonText={$i18n.neuron_detail.spawn}
       on:nnsSelectPercentage={goToConfirm}
       bind:percentage={percentageToSpawn}
+      disabled={!notEnoughMaturityToSpawn}
     >
       <svelte:fragment slot="text">
         <h5>{$i18n.neuron_detail.spawn_maturity_modal_title}</h5>

--- a/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import { ICP, type NeuronInfo } from "@dfinity/nns";
+  import type { NeuronInfo } from "@dfinity/nns";
   import SelectPercentage from "../../components/neuron-detail/SelectPercentage.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
   import WizardModal from "../WizardModal.svelte";
@@ -11,7 +11,7 @@
   import { spawnNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { isEnoughToStakeNeuron } from "../../utils/neuron.utils";
+  import { isEnoughMaturityToSpawn } from "../../utils/neuron.utils";
 
   export let neuron: NeuronInfo;
 
@@ -35,19 +35,10 @@
   let loading: boolean;
 
   let enoughMaturityToSpawn: boolean;
-  $: {
-    if (neuron.fullNeuron !== undefined) {
-      const maturitySelected: number = Math.floor(
-        (Number(neuron.fullNeuron.maturityE8sEquivalent) * percentageToSpawn) /
-          100
-      );
-      enoughMaturityToSpawn = isEnoughToStakeNeuron({
-        stake: ICP.fromE8s(BigInt(maturitySelected)),
-      });
-    } else {
-      enoughMaturityToSpawn = false;
-    }
-  }
+  $: enoughMaturityToSpawn = isEnoughMaturityToSpawn({
+    neuron,
+    percentage: percentageToSpawn,
+  });
 
   const dispatcher = createEventDispatcher();
   const spawnNeuronFromMaturity = async () => {

--- a/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -34,22 +34,19 @@
   let percentageToSpawn: number = 0;
   let loading: boolean;
 
-  let notEnoughMaturityToSpawn: boolean;
+  let enoughMaturityToSpawn: boolean;
   $: {
-    const maturitySelected: number =
-      neuron.fullNeuron === undefined
-        ? 0
-        : Math.floor(
-            (Number(neuron.fullNeuron.maturityE8sEquivalent) *
-              percentageToSpawn) /
-              100
-          );
-    notEnoughMaturityToSpawn =
-      neuron.fullNeuron === undefined
-        ? false
-        : isEnoughToStakeNeuron({
-            stake: ICP.fromE8s(BigInt(maturitySelected)),
-          });
+    if (neuron.fullNeuron !== undefined) {
+      const maturitySelected: number = Math.floor(
+        (Number(neuron.fullNeuron.maturityE8sEquivalent) * percentageToSpawn) /
+          100
+      );
+      enoughMaturityToSpawn = isEnoughToStakeNeuron({
+        stake: ICP.fromE8s(BigInt(maturitySelected)),
+      });
+    } else {
+      enoughMaturityToSpawn = false;
+    }
   }
 
   const dispatcher = createEventDispatcher();
@@ -85,7 +82,7 @@
       buttonText={$i18n.neuron_detail.spawn}
       on:nnsSelectPercentage={goToConfirm}
       bind:percentage={percentageToSpawn}
-      disabled={!notEnoughMaturityToSpawn}
+      disabled={!enoughMaturityToSpawn}
     >
       <svelte:fragment slot="text">
         <h5>{$i18n.neuron_detail.spawn_maturity_modal_title}</h5>

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -261,6 +261,24 @@ export const isEnoughToStakeNeuron = ({
   stake.toE8s() >=
   MIN_NEURON_STAKE + (withTransactionFee ? TRANSACTION_FEE_E8S : 0);
 
+export const isEnoughMaturityToSpawn = ({
+  neuron: { fullNeuron },
+  percentage,
+}: {
+  neuron: NeuronInfo;
+  percentage: number;
+}): boolean => {
+  if (fullNeuron === undefined) {
+    return false;
+  }
+  const maturitySelected: number = Math.floor(
+    (Number(fullNeuron.maturityE8sEquivalent) * percentage) / 100
+  );
+  return isEnoughToStakeNeuron({
+    stake: ICP.fromE8s(BigInt(maturitySelected)),
+  });
+};
+
 const isMergeableNeuron = ({
   neuron,
   identity,

--- a/frontend/svelte/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -21,7 +21,7 @@ describe("SpawnNeuronModal", () => {
     ...mockNeuron,
     fullNeuron: {
       ...mockFullNeuron,
-      maturityE8sEquivalent: BigInt(1_000_000),
+      maturityE8sEquivalent: BigInt(10_000_000),
     },
   };
 
@@ -49,6 +49,32 @@ describe("SpawnNeuronModal", () => {
     expect(
       queryByText(formatPercentage(maturityByStake(neuron)))
     ).toBeInTheDocument();
+  });
+
+  it("should have disabled button if percentage is not enought to spawn a new neuron", async () => {
+    const { queryByTestId } = await renderModal({
+      component: SpawnNeuronModal,
+      props: {
+        neuron: {
+          ...neuron,
+          fullNeuron: {
+            ...neuron.fullNeuron,
+            maturityE8sEquivalent: BigInt(1_000_000),
+          },
+        },
+      },
+    });
+
+    const rangeElement = queryByTestId("input-range");
+    expect(rangeElement).toBeInTheDocument();
+    rangeElement &&
+      (await fireEvent.input(rangeElement, { target: { value: 50 } }));
+
+    const selectMaturityButton = queryByTestId(
+      "select-maturity-percentage-button"
+    );
+    expect(selectMaturityButton).toBeInTheDocument();
+    expect(selectMaturityButton?.getAttribute("disabled")).not.toBeNull();
   });
 
   it("should call spawnNeuron service on confirm click", async () => {


### PR DESCRIPTION
# Motivation

User should not be able to confirm spawning a neuron if amount is not enough for a new neuron.

# Changes

* Calculate if percentageToSpawn is enough to create new neuron.
* Add disabled prop in SelectPercentage.

# Tests

* Add test for new use case.
