### PR TITLE
Use subdomains for e2e tests

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "wdio": "wdio run ./wdio.conf.ts",
-    "test": "tsc test.ts && node test.js",
+    "test": "wdio run ./wdio.conf.ts",
     "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },


### PR DESCRIPTION
# Motivation
e2e tests have been using a proxy, using ports to distinguish between canisters.  This is not standard for the IC and is not actually needed.

# Changes
- Use localhost subdomains directly in ee2 tests, rather than the proxy.

# Future
- It may be that the proxy turns out to be needed after all.  Let us wait for quiet and if there are no contra-indications, delete the proxy.  That will mean less code to maintain and save about 16 seconds from every CI run.

# Tests
See the e2e tests run in CI