### PR TITLE
Fix typescript in e2e tests

### DIFF
--- a/e2e-tests/common/constants.ts
+++ b/e2e-tests/common/constants.ts
@@ -18,8 +18,6 @@ export enum RedirectToLegacy {
 
 export const REDIRECT_TO_LEGACY: RedirectToLegacy = ((
   env = RedirectToLegacy.prod
-) => env)(RedirectToLegacy[process.env.REDIRECT_TO_LEGACY]);
+) => env)(RedirectToLegacy[process.env.REDIRECT_TO_LEGACY as string]);
 
-export const NNS_DAPP_URL: string = (process.env.NNS_DAPP_URL as boolean)
-  ? String(process.env.NNS_DAPP_URL)
-  : "http://localhost:8080";
+export const NNS_DAPP_URL: string = process.env.NNS_DAPP_URL ?? "http://localhost:8080";

--- a/e2e-tests/common/constants.ts
+++ b/e2e-tests/common/constants.ts
@@ -20,4 +20,5 @@ export const REDIRECT_TO_LEGACY: RedirectToLegacy = ((
   env = RedirectToLegacy.prod
 ) => env)(RedirectToLegacy[process.env.REDIRECT_TO_LEGACY as string]);
 
-export const NNS_DAPP_URL: string = process.env.NNS_DAPP_URL ?? "http://localhost:8080";
+export const NNS_DAPP_URL: string =
+  process.env.NNS_DAPP_URL ?? "http://localhost:8080";

--- a/e2e-tests/common/navigator.ts
+++ b/e2e-tests/common/navigator.ts
@@ -46,7 +46,7 @@ export class Navigator {
     const timeoutMsg = `Timeout after ${timeout.toLocaleString()}ms waiting to click "${description}" with selector "${selector}".`;
     await button.waitForEnabled({ timeout, timeoutMsg });
     if (Boolean(process.env.SCREENSHOT) || (options?.screenshot ?? false)) {
-      await browser["screenshot"](description);
+      await this.browser["screenshot"](description);
     }
     await button.click();
   }
@@ -68,13 +68,13 @@ export class Navigator {
     const lengthBefore = (await this.browser.getWindowHandles()).length;
     await this.click(selector, description, { timeout });
     // Wait for a new tab to open, then switch to it.
-    await browser.waitUntil(
-      async () => (await browser.getWindowHandles()).length > lengthBefore,
+    await this.browser.waitUntil(
+      async () => (await this.browser.getWindowHandles()).length > lengthBefore,
       { timeout, timeoutMsg }
     );
-    const newWindowHandle = await browser
+    const newWindowHandle = await this.browser
       .getWindowHandles()
       .then((handles) => handles[handles.length - 1]);
-    await browser.switchToWindow(newWindowHandle);
+    await this.browser.switchToWindow(newWindowHandle);
   }
 }

--- a/e2e-tests/common/navigator.ts
+++ b/e2e-tests/common/navigator.ts
@@ -2,6 +2,8 @@
  * Additional functionality for the wdio "browser".
  */
 export class Navigator {
+  browser: WebdriverIO.Browser;
+
   constructor(browser: WebdriverIO.Browser) {
     this.browser = browser;
   }

--- a/e2e-tests/common/register.ts
+++ b/e2e-tests/common/register.ts
@@ -1,7 +1,6 @@
 import { AuthPage } from "../components/auth";
 import { IIWelcomeBackPage } from "../components/ii-welcome-back-page";
 import { IIWelcomePage } from "../components/ii-welcome-page";
-import { IIWelcomePage } from "../components/ii-add-device-page";
 import { IICaptchaPage } from "../components/ii-captcha-page";
 import { IICongratulationsPage } from "../components/ii-congratulations-page";
 import { IIRecoveryMechanismPage } from "../components/ii-recovery-mechanism";
@@ -14,7 +13,7 @@ import { Header } from "../components/header";
 /**
  * Registers a new identity on the Internet Identity.
  */
-export const register = async (browser: WebdriverIO.Browser): string => {
+export const register = async (browser: WebdriverIO.Browser): { identityAnchor: string } => {
   if (undefined === browser) {
     throw new Error("Browser is undefined in 'register(..)'");
   }
@@ -88,7 +87,7 @@ export const register = async (browser: WebdriverIO.Browser): string => {
   );
 
   // Congratulations Page
-  const newIdentity = await navigator
+  const identityAnchor = await navigator
     .getElement(
       IICongratulationsPage.IDENTITY_SELECTOR,
       "registration-ii-new-identity",
@@ -128,6 +127,6 @@ export const register = async (browser: WebdriverIO.Browser): string => {
   );
 
   // Log change of state:
-  console.warn("Created identity", newIdentity);
-  return newIdentity;
+  console.warn("Created identity", identityAnchor);
+  return {identityAnchor};
 };

--- a/e2e-tests/common/register.ts
+++ b/e2e-tests/common/register.ts
@@ -13,7 +13,9 @@ import { Header } from "../components/header";
 /**
  * Registers a new identity on the Internet Identity.
  */
-export const register = async (browser: WebdriverIO.Browser): Promise<{ identityAnchor: string }> => {
+export const register = async (
+  browser: WebdriverIO.Browser
+): Promise<{ identityAnchor: string }> => {
   if (undefined === browser) {
     throw new Error("Browser is undefined in 'register(..)'");
   }
@@ -128,5 +130,5 @@ export const register = async (browser: WebdriverIO.Browser): Promise<{ identity
 
   // Log change of state:
   console.warn("Created identity", identityAnchor);
-  return {identityAnchor};
+  return { identityAnchor };
 };

--- a/e2e-tests/common/register.ts
+++ b/e2e-tests/common/register.ts
@@ -13,7 +13,7 @@ import { Header } from "../components/header";
 /**
  * Registers a new identity on the Internet Identity.
  */
-export const register = async (browser: WebdriverIO.Browser): { identityAnchor: string } => {
+export const register = async (browser: WebdriverIO.Browser): Promise<{ identityAnchor: string }> => {
   if (undefined === browser) {
     throw new Error("Browser is undefined in 'register(..)'");
   }

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "wdio": "wdio run ./wdio.conf.ts",
     "test": "tsc test.ts && node test.js",
-    "build": "npx tsc --project .",
-    "lint": "eslint --max-warnings 0 './**/*.{js,ts}'",
+    "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },
   "devDependencies": {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "wdio": "wdio run ./wdio.conf.ts",
     "test": "tsc test.ts && node test.js",
+    "build": "npx tsc --project .",
     "lint": "eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },

--- a/e2e-tests/specs/home.e2e.ts
+++ b/e2e-tests/specs/home.e2e.ts
@@ -1,6 +1,6 @@
-const { register } = require("../common/register");
-const { waitForImages } = require("../common/waitForImages");
-const { waitForLoad } = require("../common/waitForLoad");
+import { register } from "../common/register";
+import { waitForImages } from "../common/waitForImages";
+import { waitForLoad } from "../common/waitForLoad";
 
 describe("landing page", () => {
   it("loads", async () => {

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -1,5 +1,4 @@
 import { register } from "../common/register";
-import { loginWithIdentity } from "../common/login";
 import { waitForImages } from "../common/waitForImages";
 import { waitForLoad } from "../common/waitForLoad";
 import { Header } from "../components/header.ts";
@@ -11,8 +10,8 @@ import { AuthPage } from "../components/auth";
  * Verifies that the login/logout state is synchronised across tabs.
  */
 describe("multi-tab-auth", () => {
-  const nnsTabs = [];
-  var identityAnchor = undefined;
+  const nnsTabs: Array<string> = [];
+  var identityAnchor: string|undefined = undefined;
   var navigator;
 
   before(() => {

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -10,8 +10,7 @@ import { AuthPage } from "../components/auth";
  */
 describe("multi-tab-auth", () => {
   const nnsTabs: Array<string> = [];
-  var identityAnchor: string|undefined = undefined;
-  var navigator;
+  let navigator;
 
   before(() => {
     navigator = new Navigator(browser);
@@ -30,7 +29,7 @@ describe("multi-tab-auth", () => {
   });
 
   it("registerTabOne", async () => {
-    identityAnchor = (await register(browser)).identityAnchor;
+    await register(browser);
     await waitForImages(browser);
     await browser["screenshot"]("register-tab-one");
   });

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -30,7 +30,7 @@ describe("multi-tab-auth", () => {
   });
 
   it("registerTabOne", async () => {
-    identityAnchor = await register(browser);
+    identityAnchor = (await register(browser)).identityAnchor;
     await waitForImages(browser);
     await browser["screenshot"]("register-tab-one");
   });

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -1,8 +1,7 @@
 import { register } from "../common/register";
 import { waitForImages } from "../common/waitForImages";
 import { waitForLoad } from "../common/waitForLoad";
-import { Header } from "../components/header.ts";
-import { getLoginButton } from "../components/auth";
+import { Header } from "../components/header";
 import { Navigator } from "../common/navigator";
 import { AuthPage } from "../components/auth";
 

--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -1,11 +1,11 @@
 import { register } from "../common/register";
-const { waitForLoad } = require("../common/waitForLoad");
-const {
+import { waitForLoad } from "../common/waitForLoad";
+import {
   RouteHash,
   FrontendPath,
   RedirectToLegacy,
   REDIRECT_TO_LEGACY,
-} = require("../common/constants");
+} from "../common/constants";
 
 const REDIRECTS = {
   [RedirectToLegacy.prod]: {
@@ -121,8 +121,7 @@ const waitForHash = async (
     throw new Error(
       `Expected hash '${hash}' but have: '${currentHash}' with ${JSON.stringify(
         options
-      )}`,
-      { cause: err }
+      )} (caused by ${err})`
     );
   }
 };

--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -1,4 +1,4 @@
-const { register } = require("../common/register");
+import { register } from "../common/register";
 const { waitForLoad } = require("../common/waitForLoad");
 const {
   RouteHash,
@@ -137,7 +137,7 @@ const waitForPath = async (
   path: string,
   options?: { timeout?: number }
 ) => {
-  const { timeout } = options;
+  const timeout = options?.timeout;
   const timeoutMsg = `Timed out waiting for path to be: '${path}'`;
   return browser.waitUntil(
     async () =>

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -6,6 +6,7 @@
       "@wdio/mocha-framework",
       "expect-webdriverio"
     ],
+    "esModuleInterop": true,
     "strictNullChecks": true,
     "target": "ES5"
   }

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -94,12 +94,8 @@ export const config: WebdriverIO.Config = {
       acceptInsecureCerts: true,
     },
   ],
-  logLevel:
-    process.env.LOG_LEVEL === undefined
-      ? "warn"
-      : (process.env.LOG_LEVEL as
-          | WebDriverOptions.WebDriverLogTypes
-          | undefined),
+  logLevel: (process.env.LOG_LEVEL ??
+    "warn") as WebDriverOptions.WebDriverLogTypes,
   services: ["chromedriver"],
 
   framework: "mocha",

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -1,5 +1,6 @@
 const { existsSync, mkdirSync, writeFileSync } = require("fs");
 const { NNS_DAPP_URL } = require("./common/constants");
+import { Options as WebDriverOptions } from '@wdio/types';
 
 export const config: WebdriverIO.Config = {
   baseUrl: NNS_DAPP_URL,
@@ -11,7 +12,7 @@ export const config: WebdriverIO.Config = {
 
     browser.addCommand(
       "screenshot",
-      async (name: string, options?: { saveDom?: boolean } = {}) => {
+      async (name: string, options?: { saveDom?: boolean }) => {
         // Safe increment.  If you see screenshot counts this high, think why.
         browser["screenshot-count"] =
           (Number.isNaN(browser["screenshot-count"])
@@ -94,7 +95,7 @@ export const config: WebdriverIO.Config = {
     },
   ],
   logLevel:
-    process.env.LOG_LEVEL === undefined ? "warn" : process.env.LOG_LEVEL,
+    process.env.LOG_LEVEL === undefined ? "warn" : process.env.LOG_LEVEL as (WebDriverOptions.WebDriverLogTypes|undefined),
   services: ["chromedriver"],
 
   framework: "mocha",

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -1,6 +1,6 @@
 const { existsSync, mkdirSync, writeFileSync } = require("fs");
 const { NNS_DAPP_URL } = require("./common/constants");
-import { Options as WebDriverOptions } from '@wdio/types';
+import { Options as WebDriverOptions } from "@wdio/types";
 
 export const config: WebdriverIO.Config = {
   baseUrl: NNS_DAPP_URL,
@@ -95,7 +95,11 @@ export const config: WebdriverIO.Config = {
     },
   ],
   logLevel:
-    process.env.LOG_LEVEL === undefined ? "warn" : process.env.LOG_LEVEL as (WebDriverOptions.WebDriverLogTypes|undefined),
+    process.env.LOG_LEVEL === undefined
+      ? "warn"
+      : (process.env.LOG_LEVEL as
+          | WebDriverOptions.WebDriverLogTypes
+          | undefined),
   services: ["chromedriver"],
 
   framework: "mocha",


### PR DESCRIPTION
# Motivation
There are a lot of typescript errors in the e2e tests, strangely not caught by eslint.  This makes it easy to write typos and similar mistakes that SHOULD be caught at compile time but that wdio either swallows silently or causes wdio to die with very hard to debug error messages.

So let's catch the typescript errors.

Running tsc on the e2e test code does just that, and actually finds problems.

# Changes
- Run tsc as part of `npm run lint`
- Fix 36 errors.
- Add esModuleInterop due to tsc warnings in third party libraries.

# Tests
The e2e tests pass locally, and should also pass on CI.