### PR TITLE
build: fix canister id for local development

### DIFF
--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -8,7 +8,7 @@
     "import-assets-for-dev": "cp -R ../dart/assets public/assets && cp ../dart/web/manifest.json public/ && cp ../dart/web/favicon.ico public/",
     "import-assets": "rm -fr public/assets/assets && mkdir -p public/assets && npm run import-assets-for-dev",
     "build": "rm -fr public/assets/assets && npm run i18n && npm run build:config && rollup -c && npm run build:index",
-    "dev": "npm run import-assets && npm run i18n && CANISTER_ID=q4eej-kyaaa-aaaaa-aaaha-cai DEPLOY_ENV=nnsdapp_both npm run build:config && BASE_HREF=/ ROLLUP_WATCH=true npm run build:index && rollup -c -w",
+    "dev": "npm run import-assets && npm run i18n && CANISTER_ID=qsgjb-riaaa-aaaaa-aaaga-cai DEPLOY_ENV=nnsdapp_both npm run build:config && BASE_HREF=/ ROLLUP_WATCH=true npm run build:index && rollup -c -w",
     "build:config": "../../config.sh",
     "start": "sirv public",
     "check": "svelte-check --tsconfig ./tsconfig.json && npm run lint",


### PR DESCRIPTION
# Motivation

Testnet has been redeployed, fix the canister id that has changed.

# Changes

- update nns-both canister id in `package.json`
