### PR TITLE
L2-486: Neurons functionality compatible with hardware wallet

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/agent": "^0.11.1",
         "@dfinity/auth-client": "^0.11.1",
-        "@dfinity/nns": "^0.4.0-nightly-2022-05-13",
+        "@dfinity/nns": "^0.4.0-nightly-2022-05-16",
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
         "@ledgerhq/hw-transport-webhid": "^6.27.1",
         "@zondax/ledger-icp": "^0.6.0"
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.0-nightly-2022-05-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-05-13.tgz",
-      "integrity": "sha512-glrtE4JQRnoLcDSIcgmmlhcATuLdLlCDEF4Pd7hrcqXDx1+FKjm97aBv8JJhXETAs1JppewxW/5WPtisBIHbJw==",
+      "version": "0.4.0-nightly-2022-05-16",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-05-16.tgz",
+      "integrity": "sha512-1HlGRtM/xcBqKVD+FIPiCErv1bHafNSocR6ror3Su4QT2wxHeBaLHZWxEcAhnw8AH5rWUQlgZ5IJQjOUHZj6OA==",
       "dependencies": {
         "@dfinity/agent": "^0.11.1",
         "@dfinity/candid": "^0.11.1",
@@ -9310,9 +9310,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.0-nightly-2022-05-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-05-13.tgz",
-      "integrity": "sha512-glrtE4JQRnoLcDSIcgmmlhcATuLdLlCDEF4Pd7hrcqXDx1+FKjm97aBv8JJhXETAs1JppewxW/5WPtisBIHbJw==",
+      "version": "0.4.0-nightly-2022-05-16",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.0-nightly-2022-05-16.tgz",
+      "integrity": "sha512-1HlGRtM/xcBqKVD+FIPiCErv1bHafNSocR6ror3Su4QT2wxHeBaLHZWxEcAhnw8AH5rWUQlgZ5IJQjOUHZj6OA==",
       "requires": {
         "@dfinity/agent": "^0.11.1",
         "@dfinity/candid": "^0.11.1",

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -22,6 +22,7 @@
     hasJoinedCommunityFund,
     isHotKeyControllable,
     isNeuronControllable,
+    isNeuronControllableByUser,
   } from "../../utils/neuron.utils";
   import { accountsStore } from "../../stores/accounts.store";
 
@@ -29,6 +30,11 @@
 
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
+  let isControlledByUser: boolean;
+  $: isControlledByUser = isNeuronControllableByUser({
+    neuron,
+    identity: $authStore.identity,
+  });
   let isControllable: boolean;
   $: isControllable = isNeuronControllable({
     neuron,
@@ -49,7 +55,7 @@
         {secondsToDate(Number(neuron.createdTimestampSeconds))} - {$i18n.neurons
           .staked}
       </p>
-      {#if !isCommunityFund && isControllable}
+      {#if !isCommunityFund && isControlledByUser}
         <JoinCommunityFundButton neuronId={neuron.neuronId} />
       {/if}
     </div>
@@ -101,7 +107,7 @@
       {#if isControllable || hotkeyControlled}
         <IncreaseStakeButton {neuron} />
       {/if}
-      {#if isControllable}
+      {#if isControlledByUser}
         <SplitNeuronButton {neuron} />
       {/if}
     </div>

--- a/frontend/svelte/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -2,7 +2,7 @@
   import type { NeuronId } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
-  import { authStore } from "../../stores/auth.store";
+  import { accountsStore } from "../../stores/accounts.store";
   import { i18n } from "../../stores/i18n";
   import { definedNeuronsStore } from "../../stores/neurons.store";
   import { translate } from "../../utils/i18n.utils";
@@ -19,7 +19,7 @@
   let neurons: MergeableNeuron[];
   $: neurons = mapMergeableNeurons({
     neurons: $definedNeuronsStore,
-    identity: $authStore.identity,
+    accounts: $accountsStore,
     selectedNeurons: mapNeuronIds({
       neuronIds: selectedNeuronIds,
       neurons: $definedNeuronsStore,

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -189,11 +189,10 @@ export const getAccountIdentityByPrincipal = async (
     principal: principalString,
     accounts,
   });
-  if (account?.type === "hardwareWallet") {
-    return getLedgerIdentityProxy(account.identifier);
+  if (account === undefined) {
+    throw new Error(`Account with principal ${principalString} not found!`);
   }
-
-  return getIdentity();
+  return getAccountIdentity(account.identifier);
 };
 
 export const renameSubAccount = async ({

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -18,6 +18,7 @@ import { accountsStore } from "../stores/accounts.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { TransactionStore } from "../stores/transaction.store";
 import type { Account } from "../types/account";
+import { getAccountByPrincipal } from "../utils/accounts.utils";
 import { getLastPathDetail } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
 import { getIdentity } from "./auth.services";
@@ -175,6 +176,21 @@ export const getAccountIdentity = async (
 
   if (account?.type === "hardwareWallet") {
     return getLedgerIdentityProxy(identifier);
+  }
+
+  return getIdentity();
+};
+
+export const getAccountIdentityByPrincipal = async (
+  principalString: string
+): Promise<Identity | LedgerIdentity> => {
+  const accounts = get(accountsStore);
+  const account = getAccountByPrincipal({
+    principal: principalString,
+    accounts,
+  });
+  if (account?.type === "hardwareWallet") {
+    return getLedgerIdentityProxy(account.identifier);
   }
 
   return getIdentity();

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -410,13 +410,9 @@ const checkNeuronBalances = async (neurons: NeuronInfo[]): Promise<void> => {
   return listNeurons({ skipCheck: true });
 };
 
-const getAndLoadNeuronHelper = async ({
-  neuronId,
-  identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}) => {
+// We always want to call this with the user identity
+const getAndLoadNeuronHelper = async (neuronId: NeuronId) => {
+  const identity = await getIdentity();
   const neuron: NeuronInfo | undefined = await getNeuron({
     neuronId,
     identity,
@@ -444,8 +440,7 @@ export const updateDelay = async ({
       identity: neuronIdentity,
     });
 
-    const identity: Identity = await getIdentity();
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -465,7 +460,7 @@ export const joinCommunityFund = async (
 
     await joinCommunityFundApi({ neuronId, identity });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -507,6 +502,8 @@ export const mergeNeurons = async ({
     return targetNeuronId;
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
+    console.log("in da error");
+    console.log(err);
 
     // To inform there was an error
     return success ? targetNeuronId : undefined;
@@ -551,7 +548,7 @@ export const addHotkey = async ({
 
     await addHotkeyApi({ neuronId, identity, principal });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -583,11 +580,13 @@ export const removeHotkey = async ({
 
     await removeHotkeyApi({ neuronId, identity, principal });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
+    console.log("in da error");
+    console.log(err);
 
     // To inform there was an error
     return undefined;
@@ -615,7 +614,7 @@ export const splitNeuron = async ({
       labelKey: "neuron_detail.split_neuron_success",
     });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -658,11 +657,13 @@ export const mergeMaturity = async ({
 
     await mergeMaturityApi({ neuronId, percentageToMerge, identity });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return { success: true };
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
+    console.log("in da error");
+    console.log(err);
 
     return { success: false };
   }
@@ -680,7 +681,7 @@ export const spawnNeuron = async ({
 
     await spawnNeuronApi({ neuronId, percentageToSpawn, identity });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return { success: true };
   } catch (err) {
@@ -698,7 +699,7 @@ export const startDissolving = async (
 
     await startDissolvingApi({ neuronId, identity });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -716,7 +717,7 @@ export const stopDissolving = async (
 
     await stopDissolvingApi({ neuronId, identity });
 
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
 
     return neuronId;
   } catch (err) {
@@ -737,10 +738,11 @@ const setFolloweesHelper = async ({
 }) => {
   try {
     // ManageNeuron topic followes can only be handled by controllers
+    // The other topics can be handled by hotkey user
     const identity: Identity =
       topic === Topic.ManageNeuron
         ? await getIdentityByNeuron(neuronId)
-        : await getIdentityByNeuronOrHotkey(neuronId);
+        : await getIdentity();
 
     await setFollowees({
       identity,
@@ -748,7 +750,7 @@ const setFolloweesHelper = async ({
       topic,
       followees,
     });
-    await getAndLoadNeuronHelper({ neuronId, identity });
+    await getAndLoadNeuronHelper(neuronId);
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
   }

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -133,6 +133,8 @@ const getIdentityOfControllerByNeuronId = async (
   const neuronIdentity = await getAccountIdentityByPrincipal(
     neuron.fullNeuron.controller
   );
+  // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a hardware wallet.
+  // If we enable visiting neurons which are not ours, we will need this service to throw `NotAuthorizedError`.
   if (isIdentityController({ neuron, identity: neuronIdentity })) {
     return neuronIdentity;
   }

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -118,7 +118,7 @@ const getNeuronHW = async ({
 const getNeuronFromStore = (neuronId: NeuronId): NeuronInfo | undefined =>
   get(definedNeuronsStore).find((neuron) => neuron.neuronId === neuronId);
 
-const getIdentityOfNeuronController = async (
+const getIdentityOfControllerByNeuronId = async (
   neuronId: NeuronId
 ): Promise<Identity> => {
   const { neuron } = await getIdentityAndNeuronHelper(neuronId);
@@ -145,7 +145,7 @@ export const getIdentityOfNeuronControllerOrHotkey = async (
 ): Promise<Identity> => {
   try {
     // No `await` no `catch`
-    return await getIdentityOfNeuronController(neuronId);
+    return await getIdentityOfControllerByNeuronId(neuronId);
   } catch (_) {
     // Check if hotkey
     const { identity, neuron } = await getIdentityAndNeuronHelper(neuronId);
@@ -436,7 +436,7 @@ export const updateDelay = async ({
   dissolveDelayInSeconds: number;
 }): Promise<NeuronId | undefined> => {
   try {
-    const neuronIdentity: Identity = await getIdentityOfNeuronController(
+    const neuronIdentity: Identity = await getIdentityOfControllerByNeuronId(
       neuronId
     );
     await increaseDissolveDelay({
@@ -459,7 +459,9 @@ export const joinCommunityFund = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await joinCommunityFundApi({ neuronId, identity });
 
@@ -495,7 +497,7 @@ export const mergeNeurons = async ({
         translate({ labelKey: messageKey ?? "error.governance_error" })
       );
     }
-    const identity: Identity = await getIdentityOfNeuronController(
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
       targetNeuronId
     );
 
@@ -547,7 +549,9 @@ export const addHotkey = async ({
   principal: Principal;
 }): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await addHotkeyApi({ neuronId, identity, principal });
 
@@ -579,7 +583,9 @@ export const removeHotkey = async ({
     return;
   }
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await removeHotkeyApi({ neuronId, identity, principal });
 
@@ -602,7 +608,9 @@ export const splitNeuron = async ({
   amount: number;
 }): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     const stake = convertNumberToICP(amount);
 
@@ -632,7 +640,9 @@ export const disburse = async ({
   toAccountId: string;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await disburseApi({ neuronId, toAccountId, identity });
 
@@ -654,7 +664,9 @@ export const mergeMaturity = async ({
   percentageToMerge: number;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await mergeMaturityApi({ neuronId, percentageToMerge, identity });
 
@@ -676,7 +688,9 @@ export const spawnNeuron = async ({
   percentageToSpawn?: number;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await spawnNeuronApi({ neuronId, percentageToSpawn, identity });
 
@@ -694,7 +708,9 @@ export const startDissolving = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await startDissolvingApi({ neuronId, identity });
 
@@ -712,7 +728,9 @@ export const stopDissolving = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
 
     await stopDissolvingApi({ neuronId, identity });
 
@@ -744,11 +762,11 @@ const setFolloweesHelper = async ({
     // We try to control by hotkey by default
     let identity: Identity = await getIdentity();
     if (!isHotKeyControllable({ neuron, identity })) {
-      identity = await getIdentityOfNeuronController(neuron.neuronId);
+      identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
     }
     // ManageNeuron topic followes can only be handled by controllers
     if (topic === Topic.ManageNeuron) {
-      identity = await getIdentityOfNeuronController(neuron.neuronId);
+      identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
     }
     await setFollowees({
       identity,
@@ -887,7 +905,9 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     return;
   }
   try {
-    const identity: Identity = await getIdentityOfNeuronController(neuronId);
+    const identity: Identity = await getIdentityOfControllerByNeuronId(
+      neuronId
+    );
     await makeDummyProposalsApi({
       neuronId,
       identity,

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -52,6 +52,7 @@ import {
   convertNumberToICP,
   followeesByTopic,
   isEnoughToStakeNeuron,
+  isHotKeyControllable,
   isIdentityController,
 } from "../utils/neuron.utils";
 import { createChunks, isDefined } from "../utils/utils";
@@ -117,7 +118,9 @@ const getNeuronHW = async ({
 const getNeuronFromStore = (neuronId: NeuronId): NeuronInfo | undefined =>
   get(definedNeuronsStore).find((neuron) => neuron.neuronId === neuronId);
 
-const getIdentityByNeuron = async (neuronId: NeuronId): Promise<Identity> => {
+const getIdentityOfNeuronController = async (
+  neuronId: NeuronId
+): Promise<Identity> => {
   const { neuron } = await getIdentityAndNeuronHelper(neuronId);
 
   if (
@@ -137,12 +140,12 @@ const getIdentityByNeuron = async (neuronId: NeuronId): Promise<Identity> => {
   throw new NotAuthorizedError();
 };
 
-export const getIdentityByNeuronOrHotkey = async (
+export const getIdentityOfNeuronControllerOrHotkey = async (
   neuronId: NeuronId
 ): Promise<Identity> => {
   try {
     // No `await` no `catch`
-    return await getIdentityByNeuron(neuronId);
+    return await getIdentityOfNeuronController(neuronId);
   } catch (_) {
     // Check if hotkey
     const { identity, neuron } = await getIdentityAndNeuronHelper(neuronId);
@@ -433,7 +436,9 @@ export const updateDelay = async ({
   dissolveDelayInSeconds: number;
 }): Promise<NeuronId | undefined> => {
   try {
-    const neuronIdentity: Identity = await getIdentityByNeuron(neuronId);
+    const neuronIdentity: Identity = await getIdentityOfNeuronController(
+      neuronId
+    );
     await increaseDissolveDelay({
       neuronId,
       dissolveDelayInSeconds,
@@ -445,8 +450,6 @@ export const updateDelay = async ({
     return neuronId;
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
-    console.log("in da error");
-    console.log(err);
     // To inform there was an error
     return undefined;
   }
@@ -456,7 +459,7 @@ export const joinCommunityFund = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await joinCommunityFundApi({ neuronId, identity });
 
@@ -492,7 +495,9 @@ export const mergeNeurons = async ({
         translate({ labelKey: messageKey ?? "error.governance_error" })
       );
     }
-    const identity: Identity = await getIdentityByNeuron(targetNeuronId);
+    const identity: Identity = await getIdentityOfNeuronController(
+      targetNeuronId
+    );
 
     await mergeNeuronsApi({ sourceNeuronId, targetNeuronId, identity });
     success = true;
@@ -502,8 +507,6 @@ export const mergeNeurons = async ({
     return targetNeuronId;
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
-    console.log("in da error");
-    console.log(err);
 
     // To inform there was an error
     return success ? targetNeuronId : undefined;
@@ -544,7 +547,7 @@ export const addHotkey = async ({
   principal: Principal;
 }): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await addHotkeyApi({ neuronId, identity, principal });
 
@@ -576,7 +579,7 @@ export const removeHotkey = async ({
     return;
   }
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await removeHotkeyApi({ neuronId, identity, principal });
 
@@ -585,8 +588,6 @@ export const removeHotkey = async ({
     return neuronId;
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
-    console.log("in da error");
-    console.log(err);
 
     // To inform there was an error
     return undefined;
@@ -601,7 +602,7 @@ export const splitNeuron = async ({
   amount: number;
 }): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     const stake = convertNumberToICP(amount);
 
@@ -631,7 +632,7 @@ export const disburse = async ({
   toAccountId: string;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await disburseApi({ neuronId, toAccountId, identity });
 
@@ -653,7 +654,7 @@ export const mergeMaturity = async ({
   percentageToMerge: number;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await mergeMaturityApi({ neuronId, percentageToMerge, identity });
 
@@ -662,8 +663,6 @@ export const mergeMaturity = async ({
     return { success: true };
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
-    console.log("in da error");
-    console.log(err);
 
     return { success: false };
   }
@@ -677,7 +676,7 @@ export const spawnNeuron = async ({
   percentageToSpawn?: number;
 }): Promise<{ success: boolean }> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await spawnNeuronApi({ neuronId, percentageToSpawn, identity });
 
@@ -695,7 +694,7 @@ export const startDissolving = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await startDissolvingApi({ neuronId, identity });
 
@@ -713,7 +712,7 @@ export const stopDissolving = async (
   neuronId: NeuronId
 ): Promise<NeuronId | undefined> => {
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
 
     await stopDissolvingApi({ neuronId, identity });
 
@@ -728,29 +727,36 @@ export const stopDissolving = async (
 };
 
 const setFolloweesHelper = async ({
-  neuronId,
+  neuron,
   topic,
   followees,
 }: {
-  neuronId: NeuronId;
+  neuron: NeuronInfo | undefined;
   topic: Topic;
   followees: NeuronId[];
 }) => {
   try {
+    if (neuron === undefined) {
+      throw new NotFoundError(
+        "Neuron not found in store. We can't check authorization to set followees."
+      );
+    }
+    // We try to control by hotkey by default
+    let identity: Identity = await getIdentity();
+    if (!isHotKeyControllable({ neuron, identity })) {
+      identity = await getIdentityOfNeuronController(neuron.neuronId);
+    }
     // ManageNeuron topic followes can only be handled by controllers
-    // The other topics can be handled by hotkey user
-    const identity: Identity =
-      topic === Topic.ManageNeuron
-        ? await getIdentityByNeuron(neuronId)
-        : await getIdentity();
-
+    if (topic === Topic.ManageNeuron) {
+      identity = await getIdentityOfNeuronController(neuron.neuronId);
+    }
     await setFollowees({
       identity,
-      neuronId,
+      neuronId: neuron.neuronId,
       topic,
       followees,
     });
-    await getAndLoadNeuronHelper(neuronId);
+    await getAndLoadNeuronHelper(neuron.neuronId);
   } catch (err) {
     toastsStore.show(mapNeuronErrorToToastMessage(err));
   }
@@ -787,7 +793,7 @@ export const addFollowee = async ({
     topicFollowees === undefined ? [followee] : [...topicFollowees, followee];
 
   await setFolloweesHelper({
-    neuronId,
+    neuron,
     topic,
     followees: newFollowees,
   });
@@ -819,7 +825,7 @@ export const removeFollowee = async ({
     (id) => id !== followee
   );
   await setFolloweesHelper({
-    neuronId,
+    neuron,
     topic,
     followees: newFollowees,
   });
@@ -881,7 +887,7 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     return;
   }
   try {
-    const identity: Identity = await getIdentityByNeuron(neuronId);
+    const identity: Identity = await getIdentityOfNeuronController(neuronId);
     await makeDummyProposalsApi({
       neuronId,
       identity,

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -46,7 +46,11 @@ export const mapNeuronErrorToToastMessage = (error: Error): ToastMsg => {
   ];
   const pair = collection.find(([classType]) => error instanceof classType);
   if (pair === undefined) {
-    return { labelKey: "error.unknown", level: "error" };
+    return {
+      labelKey: "error.unknown",
+      level: "error",
+      detail: errorToString(error),
+    };
   }
   return { labelKey: pair[1], detail: errorToString(error), level: "error" };
 };

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -311,25 +311,24 @@ export const isEnoughMaturityToSpawn = ({
 
 const isMergeableNeuron = ({
   neuron,
-  identity,
+  accounts,
 }: {
   neuron: NeuronInfo;
-  identity?: Identity | null;
+  accounts: AccountsStore;
 }): boolean =>
-  !hasJoinedCommunityFund(neuron) &&
-  !isHotKeyControllable({ neuron, identity });
+  !hasJoinedCommunityFund(neuron) && isNeuronControllable({ neuron, accounts });
 
 const getMergeableNeuronMessageKey = ({
   neuron,
-  identity,
+  accounts,
 }: {
   neuron: NeuronInfo;
-  identity?: Identity | null;
+  accounts: AccountsStore;
 }): string | undefined => {
   if (hasJoinedCommunityFund(neuron)) {
     return "neurons.cannot_merge_neuron_community";
   }
-  if (isHotKeyControllable({ neuron, identity })) {
+  if (!isNeuronControllable({ neuron, accounts })) {
     return "neurons.cannot_merge_neuron_hotkey";
   }
 };
@@ -350,11 +349,11 @@ export type MergeableNeuron = {
  */
 export const mapMergeableNeurons = ({
   neurons,
-  identity,
+  accounts,
   selectedNeurons,
 }: {
   neurons: NeuronInfo[];
-  identity?: Identity | null;
+  accounts: AccountsStore;
   selectedNeurons: NeuronInfo[];
 }): MergeableNeuron[] =>
   neurons
@@ -364,8 +363,8 @@ export const mapMergeableNeurons = ({
       selected: selectedNeurons
         .map(({ neuronId }) => neuronId)
         .includes(neuron.neuronId),
-      mergeable: isMergeableNeuron({ neuron, identity }),
-      messageKey: getMergeableNeuronMessageKey({ neuron, identity }),
+      mergeable: isMergeableNeuron({ neuron, accounts }),
+      messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
     }))
     // Then we calculate the neuron with the current selection
     .map(({ mergeable, selected, messageKey, neuron }: MergeableNeuron) => {

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -145,6 +145,19 @@ export const sortNeuronsByCreatedTimestamp = (
   );
 
 /*
+ * Returns true if the neuron can be controlled by current user
+ */
+export const isNeuronControllableByUser = ({
+  neuron: { fullNeuron },
+  identity,
+}: {
+  neuron: NeuronInfo;
+  identity?: Identity | null;
+}): boolean =>
+  fullNeuron?.controller !== undefined &&
+  fullNeuron.controller === identity?.getPrincipal().toText();
+
+/*
  * Returns true if the neuron can be controlled. A neuron can be controlled if:
  *
  *  1. The user is the controller

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -309,6 +309,7 @@ export const isEnoughMaturityToSpawn = ({
   });
 };
 
+// Tested with `mapMergeableNeurons`
 const isMergeableNeuron = ({
   neuron,
   accounts,
@@ -343,7 +344,7 @@ export type MergeableNeuron = {
  * Returns neuron data wrapped with extra information about mergeability.
  *
  * @neurons NeuronInfo[]
- * @identity Identity | null
+ * @accounts AccountsStore
  * @selectedNeuronIds NeuronId[]
  * @returns MergeableNeuron[]
  */

--- a/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -7,12 +7,13 @@ import { fireEvent } from "@testing-library/dom";
 import type { RenderResult } from "@testing-library/svelte";
 import MergeNeuronsModal from "../../../../lib/modals/neurons/MergeNeuronsModal.svelte";
 import { mergeNeurons } from "../../../../lib/services/neurons.services";
-import { authStore } from "../../../../lib/stores/auth.store";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
 import { neuronsStore } from "../../../../lib/stores/neurons.store";
+import type { Account } from "../../../../lib/types/account";
 import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "../../../mocks/auth.store.mock";
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import {
@@ -28,39 +29,9 @@ jest.mock("../../../../lib/services/neurons.services", () => {
 });
 
 describe("MergeNeuronsModal", () => {
-  const controller = mockIdentity.getPrincipal().toText();
-  const mergeableNeuron1 = {
-    ...mockNeuron,
-    neuronId: BigInt(10),
-    fullNeuron: { ...mockFullNeuron, controller },
-  };
-  const mergeableNeuron2 = {
-    ...mockNeuron,
-    neuronId: BigInt(11),
-    fullNeuron: { ...mockFullNeuron, controller },
-  };
-  const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
-  const renderMergeModal = async (
-    neurons: NeuronInfo[]
-  ): Promise<RenderResult> => {
-    jest
-      .spyOn(neuronsStore, "subscribe")
-      .mockImplementation(buildMockNeuronsStoreSubscribe(neurons));
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-    return renderModal({
-      component: MergeNeuronsModal,
-    });
-  };
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  const selectAndTestTwoNeurons = async ({ queryAllByTestId }) => {
+  const selectAndTestTwoNeurons = async ({ queryAllByTestId, neurons }) => {
     const neuronCardElements = queryAllByTestId("card");
-    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
+    expect(neuronCardElements.length).toBe(neurons.length);
 
     let [neuronElement1, neuronElement2] = neuronCardElements;
 
@@ -79,90 +50,214 @@ describe("MergeNeuronsModal", () => {
 
     expect(neuronElement2.classList.contains("selected")).toBe(true);
   };
+  const renderMergeModal = async (
+    neurons: NeuronInfo[],
+    hardwareWalletAccounts: Account[] = []
+  ): Promise<RenderResult> => {
+    accountsStore.set({
+      main: mockMainAccount,
+      hardwareWallets: hardwareWalletAccounts,
+    });
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(buildMockNeuronsStoreSubscribe(neurons));
+    return renderModal({
+      component: MergeNeuronsModal,
+    });
+  };
+  describe("when mergeable neurons by user", () => {
+    const controller = mockMainAccount.principal?.toText() as string;
+    const mergeableNeuron1 = {
+      ...mockNeuron,
+      neuronId: BigInt(10),
+      fullNeuron: { ...mockFullNeuron, controller },
+    };
+    const mergeableNeuron2 = {
+      ...mockNeuron,
+      neuronId: BigInt(11),
+      fullNeuron: { ...mockFullNeuron, controller },
+    };
+    const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
 
-  it("renders title", async () => {
-    const { queryByText } = await renderMergeModal([mockNeuron]);
+    afterEach(() => {
+      jest.clearAllMocks();
+      accountsStore.reset();
+    });
 
-    const element = queryByText(en.neurons.merge_neurons_modal_title);
-    expect(element).not.toBeNull();
+    it("renders title", async () => {
+      const { queryByText } = await renderMergeModal([mockNeuron]);
+
+      const element = queryByText(en.neurons.merge_neurons_modal_title);
+      expect(element).not.toBeNull();
+    });
+
+    it("renders disabled button", async () => {
+      const { queryByTestId } = await renderMergeModal([mockNeuron]);
+
+      const button = queryByTestId("merge-neurons-confirm-selection-button");
+      expect(button).not.toBeNull();
+      expect(button?.hasAttribute("disabled")).toBeTruthy();
+    });
+
+    it("renders mergeable neurons", async () => {
+      const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+
+      const neuronCardElements = queryAllByTestId("neuron-card-title");
+      expect(neuronCardElements.length).toBe(mergeableNeurons.length);
+    });
+
+    it("allows user to select two neurons", async () => {
+      const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        queryAllByTestId,
+        neurons: mergeableNeurons,
+      });
+    });
+
+    it("allows user to unselect after selecting a neuron", async () => {
+      const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+
+      const neuronCardElements = queryAllByTestId("card");
+      expect(neuronCardElements.length).toBe(mergeableNeurons.length);
+
+      const [neuronElement1] = neuronCardElements;
+
+      expect(neuronElement1.classList.contains("selected")).toBe(false);
+
+      await fireEvent.click(neuronElement1);
+      expect(neuronElement1.classList.contains("selected")).toBe(true);
+
+      await fireEvent.click(neuronElement1);
+      expect(neuronElement1.classList.contains("selected")).toBe(false);
+    });
+
+    it("allows user to select two neurons and move to confirmation screen", async () => {
+      const { queryAllByTestId, queryByTestId, queryByText, queryAllByText } =
+        await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        queryAllByTestId,
+        neurons: mergeableNeurons,
+      });
+
+      const button = queryByTestId("merge-neurons-confirm-selection-button");
+      expect(button).not.toBeNull();
+
+      button && (await fireEvent.click(button));
+
+      // Confirm Merge Screen
+      expect(
+        queryAllByText(en.neurons.merge_neurons_modal_confirm).length
+      ).toBeGreaterThan(0);
+      expect(queryByText(mergeableNeuron1.neuronId.toString())).not.toBeNull();
+    });
+
+    it("allows user to select two neurons and merge them", async () => {
+      const { queryAllByTestId, queryByTestId, queryAllByText } =
+        await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        queryAllByTestId,
+        neurons: mergeableNeurons,
+      });
+
+      const button = queryByTestId("merge-neurons-confirm-selection-button");
+      expect(button).not.toBeNull();
+
+      button && (await fireEvent.click(button));
+
+      // Confirm Merge Screen
+      expect(
+        queryAllByText(en.neurons.merge_neurons_modal_confirm).length
+      ).toBeGreaterThan(0);
+
+      const confirmMergeButton = queryByTestId("confirm-merge-neurons-button");
+
+      confirmMergeButton && (await fireEvent.click(confirmMergeButton));
+
+      expect(mergeNeurons).toBeCalled();
+    });
   });
 
-  it("renders disabled button", async () => {
-    const { queryByTestId } = await renderMergeModal([mockNeuron]);
+  describe("when mergeable neurons by hardware wallet", () => {
+    const controller = mockHardwareWalletAccount.principal?.toText() as string;
+    const mergeableNeuron1 = {
+      ...mockNeuron,
+      neuronId: BigInt(10),
+      fullNeuron: { ...mockFullNeuron, controller },
+    };
+    const mergeableNeuron2 = {
+      ...mockNeuron,
+      neuronId: BigInt(11),
+      fullNeuron: { ...mockFullNeuron, controller },
+    };
+    const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
+    it("allows user to select two neurons and merge them", async () => {
+      const { queryAllByTestId, queryByTestId, queryAllByText } =
+        await renderMergeModal(mergeableNeurons, [mockHardwareWalletAccount]);
 
-    const button = queryByTestId("merge-neurons-confirm-selection-button");
-    expect(button).not.toBeNull();
-    expect(button?.hasAttribute("disabled")).toBeTruthy();
+      await selectAndTestTwoNeurons({
+        queryAllByTestId,
+        neurons: mergeableNeurons,
+      });
+
+      const button = queryByTestId("merge-neurons-confirm-selection-button");
+      expect(button).not.toBeNull();
+
+      button && (await fireEvent.click(button));
+
+      // Confirm Merge Screen
+      expect(
+        queryAllByText(en.neurons.merge_neurons_modal_confirm).length
+      ).toBeGreaterThan(0);
+
+      const confirmMergeButton = queryByTestId("confirm-merge-neurons-button");
+
+      confirmMergeButton && (await fireEvent.click(confirmMergeButton));
+
+      expect(mergeNeurons).toBeCalled();
+    });
   });
 
-  it("renders mergeable neurons", async () => {
-    const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+  describe("when neurons from main user and hardware wallet", () => {
+    const neuronHW = {
+      ...mockNeuron,
+      neuronId: BigInt(10),
+      fullNeuron: {
+        ...mockFullNeuron,
+        controller: mockHardwareWalletAccount.principal?.toText() as string,
+      },
+    };
+    const neuronMain = {
+      ...mockNeuron,
+      neuronId: BigInt(11),
+      fullNeuron: {
+        ...mockFullNeuron,
+        controller: mockMainAccount.principal?.toText() as string,
+      },
+    };
+    const neurons = [neuronHW, neuronMain];
+    it("does not allow to select two neurons with different controller", async () => {
+      const { queryAllByTestId } = await renderMergeModal(neurons, [
+        mockHardwareWalletAccount,
+      ]);
 
-    const neuronCardElements = queryAllByTestId("neuron-card-title");
-    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
-  });
+      const neuronCardElements = queryAllByTestId("card");
+      expect(neuronCardElements.length).toBe(neurons.length);
 
-  it("allows user to select two neurons", async () => {
-    const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+      const [neuronElement1] = neuronCardElements;
 
-    await selectAndTestTwoNeurons({ queryAllByTestId });
-  });
+      expect(neuronElement1.classList.contains("selected")).toBe(false);
 
-  it("allows user to unselect after selecting a neuron", async () => {
-    const { queryAllByTestId } = await renderMergeModal(mergeableNeurons);
+      await fireEvent.click(neuronElement1);
+      expect(neuronElement1.classList.contains("selected")).toBe(true);
 
-    const neuronCardElements = queryAllByTestId("card");
-    expect(neuronCardElements.length).toBe(mergeableNeurons.length);
+      // We need to query again because the elements have changed because of the Tooltip.
+      const neuronCardElementsAfterSelection = queryAllByTestId("card");
+      const [, neuronElement2] = neuronCardElementsAfterSelection;
 
-    const [neuronElement1] = neuronCardElements;
-
-    expect(neuronElement1.classList.contains("selected")).toBe(false);
-
-    await fireEvent.click(neuronElement1);
-    expect(neuronElement1.classList.contains("selected")).toBe(true);
-
-    await fireEvent.click(neuronElement1);
-    expect(neuronElement1.classList.contains("selected")).toBe(false);
-  });
-
-  it("allows user to select two neurons and move to confirmation screen", async () => {
-    const { queryAllByTestId, queryByTestId, queryByText, queryAllByText } =
-      await renderMergeModal(mergeableNeurons);
-
-    await selectAndTestTwoNeurons({ queryAllByTestId });
-
-    const button = queryByTestId("merge-neurons-confirm-selection-button");
-    expect(button).not.toBeNull();
-
-    button && (await fireEvent.click(button));
-
-    // Confirm Merge Screen
-    expect(
-      queryAllByText(en.neurons.merge_neurons_modal_confirm).length
-    ).toBeGreaterThan(0);
-    expect(queryByText(mergeableNeuron1.neuronId.toString())).not.toBeNull();
-  });
-
-  it("allows user to select two neurons and merge them", async () => {
-    const { queryAllByTestId, queryByTestId, queryAllByText } =
-      await renderMergeModal(mergeableNeurons);
-
-    await selectAndTestTwoNeurons({ queryAllByTestId });
-
-    const button = queryByTestId("merge-neurons-confirm-selection-button");
-    expect(button).not.toBeNull();
-
-    button && (await fireEvent.click(button));
-
-    // Confirm Merge Screen
-    expect(
-      queryAllByText(en.neurons.merge_neurons_modal_confirm).length
-    ).toBeGreaterThan(0);
-
-    const confirmMergeButton = queryByTestId("confirm-merge-neurons-button");
-
-    confirmMergeButton && (await fireEvent.click(confirmMergeButton));
-
-    expect(mergeNeurons).toBeCalled();
+      expect(neuronElement2.classList.contains("disabled")).toBe(true);
+    });
   });
 });

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -2,9 +2,12 @@ import { ICP } from "@dfinity/nns";
 import { get } from "svelte/store";
 import * as accountsApi from "../../../lib/api/accounts.api";
 import * as ledgerApi from "../../../lib/api/ledger.api";
+import { getLedgerIdentityProxy } from "../../../lib/proxy/ledger.services.proxy";
 import {
   addSubAccount,
   getAccountFromStore,
+  getAccountIdentity,
+  getAccountIdentityByPrincipal,
   renameSubAccount,
   routePathAccountIdentifier,
   syncAccounts,
@@ -14,15 +17,25 @@ import { accountsStore } from "../../../lib/stores/accounts.store";
 import { toastsStore } from "../../../lib/stores/toasts.store";
 import type { TransactionStore } from "../../../lib/stores/transaction.store";
 import {
+  mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
 } from "../../mocks/accounts.store.mock";
 import {
+  mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
 } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
+
+jest.mock("../../../lib/proxy/ledger.services.proxy", () => {
+  return {
+    getLedgerIdentityProxy: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockIdentity)),
+  };
+});
 
 describe("accounts-services", () => {
   describe("services", () => {
@@ -268,6 +281,72 @@ describe("accounts-services", () => {
       expect(getAccountFromStore(mockSubAccount.identifier)).toEqual(
         mockSubAccount
       );
+    });
+  });
+
+  describe("getAccountIdentity", () => {
+    it("returns user identity if main account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+      });
+      const expectedIdentity = await getAccountIdentity(
+        mockMainAccount.identifier
+      );
+      expect(expectedIdentity).toBe(mockIdentity);
+      accountsStore.reset();
+    });
+
+    it("returns user identity if main account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+      });
+      const expectedIdentity = await getAccountIdentity(
+        mockMainAccount.identifier
+      );
+      expect(expectedIdentity).toBe(mockIdentity);
+      accountsStore.reset();
+    });
+
+    it("returns calls for hardware walleet identity if hardware wallet account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+      const expectedIdentity = await getAccountIdentity(
+        mockHardwareWalletAccount.identifier
+      );
+      expect(expectedIdentity).toBe(mockIdentity);
+      expect(getLedgerIdentityProxy).toBeCalled();
+      accountsStore.reset();
+    });
+  });
+
+  describe("getAccountIdentityByPrincipal", () => {
+    it("returns user identity if main account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+      });
+      const expectedIdentity = await getAccountIdentityByPrincipal(
+        mockMainAccount.principal?.toText() as string
+      );
+      expect(expectedIdentity).toBe(mockIdentity);
+      accountsStore.reset();
+    });
+
+    it("returns calls for hardware walleet identity if hardware wallet account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+      const expectedIdentity = await getAccountIdentityByPrincipal(
+        mockHardwareWalletAccount.principal?.toText() as string
+      );
+      expect(expectedIdentity).toBe(mockIdentity);
+      expect(getLedgerIdentityProxy).toBeCalled();
+      accountsStore.reset();
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -59,6 +59,9 @@ const resetAccountIdentity = () => (testIdentity = mockIdentity);
 jest.mock("../../../lib/services/accounts.services", () => {
   return {
     syncAccounts: jest.fn(),
+    getAccountIdentityByPrincipal: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(testIdentity)),
     getAccountIdentity: jest
       .fn()
       .mockImplementation(() => Promise.resolve(testIdentity)),


### PR DESCRIPTION
# Motivation

User is able to manage a neuron from a Hardware Wallet.

# Changes

* Get the identity based on the neuron controller where suited.
* Prefer the user identity if the functionality can be managed by a hotkey.
* Split and Join Community Fund only available for neurons whose controller is the nns dapp user. Like in Svelte.
* New neuron util "getIdentityByPrincipal" and "isNeuronControllableByUser".
* Helper "getAndLoadNeuron" uses user principal.

# Tests

* Fix broken tests.
* Add tests for HW cases in Merge Neurons Modal and "mapMergeable" util.
* Tests for "getIdentity" helpers.
