### PR TITLE
L2-520: Show message busy screen

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -2,8 +2,9 @@
   import { ICP, type NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { AppPath } from "../../constants/routes.constants";
+  import { startBusyNeuron } from "../../services/busy.services";
   import { disburse } from "../../services/neurons.services";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { routeStore } from "../../stores/route.store";
   import { toastsStore } from "../../stores/toasts.store";
@@ -19,7 +20,10 @@
 
   const dispatcher = createEventDispatcher();
   const executeTransaction = async () => {
-    startBusy("disburse-neuron");
+    startBusyNeuron({
+      initiator: "disburse-neuron",
+      neuronId: neuron.neuronId,
+    });
     loading = true;
     const { success } = await disburse({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronHotkeysCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronHotkeysCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
+  import { startBusyNeuron } from "../../services/busy.services";
   import { removeHotkey } from "../../services/neurons.services";
   import { accountsStore } from "../../stores/accounts.store";
   import { authStore } from "../../stores/auth.store";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { isNeuronControllable } from "../../utils/neuron.utils";
   import Card from "../ui/Card.svelte";
@@ -21,7 +22,10 @@
   $: hotkeys = neuron.fullNeuron?.hotKeys ?? [];
 
   const remove = async (hotkey: string) => {
-    startBusy("remove-hotkey-neuron");
+    startBusyNeuron({
+      initiator: "remove-hotkey-neuron",
+      neuronId: neuron.neuronId,
+    });
     await removeHotkey({
       neuronId: neuron.neuronId,
       principalString: hotkey,

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
@@ -6,8 +6,9 @@
     startDissolving,
     stopDissolving,
   } from "../../../services/neurons.services";
-  import { startBusy, stopBusy } from "../../../stores/busy.store";
+  import { stopBusy } from "../../../stores/busy.store";
   import { i18n } from "../../../stores/i18n";
+  import { startBusyNeuron } from "../../../services/busy.services";
 
   export let neuronId: NeuronId;
   export let neuronState: NeuronState;
@@ -30,7 +31,7 @@
 
   const dissolveAction = async () => {
     const action = isDissolving ? stopDissolving : startDissolving;
-    startBusy("dissolve-action");
+    startBusyNeuron({ initiator: "dissolve-action", neuronId });
     await action(neuronId);
     closeModal();
     stopBusy("dissolve-action");

--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -23,7 +23,8 @@
   // Add the auth identity principal as hotkey
   const addCurrentUserToHotkey = async () => {
     loading = true;
-    startBusy("add-hotkey-neuron");
+    // This screen is only for hardware wallet.
+    startBusy("stake-neuron", $i18n.wallet.pending_approval);
     const identity = await getIdentity();
     const neuronId = await addHotkeyFromHW({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -24,7 +24,7 @@
   const addCurrentUserToHotkey = async () => {
     loading = true;
     // This screen is only for hardware wallet.
-    startBusy("stake-neuron", $i18n.wallet.pending_approval);
+    startBusy("stake-neuron", "busy_screen.pending_approval_hw");
     const identity = await getIdentity();
     const neuronId = await addHotkeyFromHW({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -12,7 +12,8 @@
     neuronStake,
     votingPower,
   } from "../../utils/neuron.utils";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
+  import { startBusyNeuron } from "../../services/busy.services";
 
   export let delayInSeconds: number;
   export let neuron: NeuronInfo;
@@ -23,7 +24,7 @@
   $: neuronICP = neuronStake(neuron);
 
   const updateNeuron = async () => {
-    startBusy("update-delay");
+    startBusyNeuron({ initiator: "update-delay", neuronId: neuron.neuronId });
     loading = true;
     const neuronId = await updateDelay({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -2,8 +2,9 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
+  import { startBusyNeuron } from "../../services/busy.services";
   import { mergeNeurons } from "../../services/neurons.services";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
@@ -28,7 +29,10 @@
 
   const merge = async () => {
     loading = true;
-    startBusy("merge-neurons");
+    startBusyNeuron({
+      initiator: "merge-neurons",
+      neuronId: neurons[0].neuronId,
+    });
     // We know that neurons has 2 neurons.
     // We have a check above that closes the modal if not.
     const id = await mergeNeurons({

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -16,7 +16,7 @@
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
-    startBusy("stake-neuron");
+    startBusy("stake-neuron", $i18n.wallet.pending_approval);
     creating = true;
     const neuron = await stakeNeuron({
       amount,

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -16,7 +16,7 @@
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
-    startBusy("stake-neuron", $i18n.wallet.pending_approval);
+    startBusy("stake-neuron", "busy_screen.pending_approval_hw");
     creating = true;
     const neuron = await stakeNeuron({
       amount,

--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
-  import { busy, firstBusyItem } from "../../stores/busy.store";
+  import { busy, busyMessage } from "../../stores/busy.store";
   import Spinner from "./Spinner.svelte";
 </script>
 
@@ -8,8 +8,8 @@
 {#if $busy}
   <div data-tid="busy" transition:fade>
     <div class="content">
-      {#if $firstBusyItem.message !== undefined}
-        <h4>{$firstBusyItem.message}</h4>
+      {#if $busyMessage !== undefined}
+        <h4>{$busyMessage}</h4>
       {/if}
       <span>
         <Spinner inline />

--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
-  import { busy, busyMessage } from "../../stores/busy.store";
+  import { busy, busyMessageKey } from "../../stores/busy.store";
+  import { translate } from "../../utils/i18n.utils";
   import Spinner from "./Spinner.svelte";
 </script>
 
@@ -8,8 +9,8 @@
 {#if $busy}
   <div data-tid="busy" transition:fade>
     <div class="content">
-      {#if $busyMessage !== undefined}
-        <h4>{$busyMessage}</h4>
+      {#if $busyMessageKey !== undefined}
+        <h4>{translate({ labelKey: $busyMessageKey })}</h4>
       {/if}
       <span>
         <Spinner inline />

--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
-  import { busy } from "../../stores/busy.store";
+  import { busy, firstBusyItem } from "../../stores/busy.store";
   import Spinner from "./Spinner.svelte";
 </script>
 
 <!-- Display spinner and lock UI if busyStore is not empty -->
 {#if $busy}
   <div data-tid="busy" transition:fade>
-    <Spinner />
+    <div class="content">
+      {#if $firstBusyItem.message !== undefined}
+        <h4>{$firstBusyItem.message}</h4>
+      {/if}
+      <span>
+        <Spinner inline />
+      </span>
+    </div>
   </div>
 {/if}
 
@@ -19,5 +26,12 @@
     inset: 0;
 
     background-color: rgba(var(--background-rgb), 0.75);
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
 </style>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -268,7 +268,8 @@
     "PROPOSAL_STATUS_FAILED": "Failed"
   },
   "wallet": {
-    "title": "Account"
+    "title": "Account",
+    "pending_approval": "Please use your hardware wallet to approve."
   },
   "proposal_detail": {
     "title": "Proposal",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -268,8 +268,10 @@
     "PROPOSAL_STATUS_FAILED": "Failed"
   },
   "wallet": {
-    "title": "Account",
-    "pending_approval": "Please use your hardware wallet to approve."
+    "title": "Account"
+  },
+  "busy_screen": {
+    "pending_approval_hw": "Please use your hardware wallet to approve."
   },
   "proposal_detail": {
     "title": "Proposal",

--- a/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
@@ -3,12 +3,13 @@
   import type { Principal } from "@dfinity/principal";
   import type { NeuronId } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { addHotkey } from "../../services/neurons.services";
   import Spinner from "../../components/ui/Spinner.svelte";
   import { createEventDispatcher } from "svelte";
   import { getPrincipalFromString } from "../../utils/accounts.utils";
   import InputWithError from "../../components/ui/InputWithError.svelte";
+  import { startBusyNeuron } from "../../services/busy.services";
 
   export let neuronId: NeuronId;
 
@@ -27,7 +28,7 @@
   const dispatcher = createEventDispatcher();
   const add = async () => {
     if (validPrincipal !== undefined) {
-      startBusy("add-hotkey-neuron");
+      startBusyNeuron({ initiator: "add-hotkey-neuron", neuronId });
       loading = true;
       await addHotkey({ neuronId, principal: validPrincipal });
       loading = false;

--- a/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
@@ -3,7 +3,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { formatPercentage } from "../../utils/format.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { mergeMaturity } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
   import { createEventDispatcher } from "svelte";
@@ -11,6 +11,7 @@
   import WizardModal from "../WizardModal.svelte";
   import SelectPercentage from "../../components/neuron-detail/SelectPercentage.svelte";
   import ConfirmActionScreen from "../../components/ui/ConfirmActionScreen.svelte";
+  import { startBusyNeuron } from "../../services/busy.services";
 
   export let neuron: NeuronInfo;
 
@@ -36,7 +37,7 @@
   const dispatcher = createEventDispatcher();
   const mergeNeuronMaturity = async () => {
     loading = true;
-    startBusy("merge-maturity");
+    startBusyNeuron({ initiator: "merge-maturity", neuronId: neuron.neuronId });
     const { success } = await mergeMaturity({
       neuronId: neuron.neuronId,
       percentageToMerge,

--- a/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -6,12 +6,13 @@
   import WizardModal from "../WizardModal.svelte";
   import ConfirmActionScreen from "../../components/ui/ConfirmActionScreen.svelte";
   import { formatPercentage } from "../../utils/format.utils";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { stopBusy } from "../../stores/busy.store";
   import { createEventDispatcher } from "svelte";
   import { spawnNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { isEnoughMaturityToSpawn } from "../../utils/neuron.utils";
+  import { startBusyNeuron } from "../../services/busy.services";
 
   export let neuron: NeuronInfo;
   export let controlledByHarwareWallet: boolean;
@@ -62,7 +63,7 @@
   const dispatcher = createEventDispatcher();
   const spawnNeuronFromMaturity = async () => {
     loading = true;
-    startBusy("spawn-neuron");
+    startBusyNeuron({ initiator: "spawn-neuron", neuronId: neuron.neuronId });
     const { success } = await spawnNeuron({
       neuronId: neuron.neuronId,
       percentageToSpawn: controlledByHarwareWallet

--- a/frontend/svelte/src/lib/services/busy.services.ts
+++ b/frontend/svelte/src/lib/services/busy.services.ts
@@ -1,5 +1,9 @@
 import type { NeuronId } from "@dfinity/nns";
+import { get } from "svelte/store";
+import { accountsStore } from "../stores/accounts.store";
 import { startBusy, type BusyStateInitiatorType } from "../stores/busy.store";
+import { i18n } from "../stores/i18n";
+import { isNeuronControlledByHardwareWallet } from "../utils/neuron.utils";
 import { getNeuronFromStore } from "./neurons.services";
 
 export const startBusyNeuron = ({
@@ -10,6 +14,17 @@ export const startBusyNeuron = ({
   initiator: BusyStateInitiatorType;
 }) => {
   const neuron = getNeuronFromStore(neuronId);
-  // Check if neuron is controlled by hardware wallet
-  startBusy(initiator);
+  if (neuron?.fullNeuron?.controller === undefined) {
+    startBusy(initiator);
+    return;
+  }
+  const hardwareWalletNeuron = isNeuronControlledByHardwareWallet({
+    neuron,
+    accounts: get(accountsStore),
+  });
+  const labels = get(i18n);
+  startBusy(
+    initiator,
+    hardwareWalletNeuron ? labels.wallet.pending_approval : undefined
+  );
 };

--- a/frontend/svelte/src/lib/services/busy.services.ts
+++ b/frontend/svelte/src/lib/services/busy.services.ts
@@ -1,0 +1,15 @@
+import type { NeuronId } from "@dfinity/nns";
+import { startBusy, type BusyStateInitiatorType } from "../stores/busy.store";
+import { getNeuronFromStore } from "./neurons.services";
+
+export const startBusyNeuron = ({
+  neuronId,
+  initiator,
+}: {
+  neuronId: NeuronId;
+  initiator: BusyStateInitiatorType;
+}) => {
+  const neuron = getNeuronFromStore(neuronId);
+  // Check if neuron is controlled by hardware wallet
+  startBusy(initiator);
+};

--- a/frontend/svelte/src/lib/services/busy.services.ts
+++ b/frontend/svelte/src/lib/services/busy.services.ts
@@ -2,7 +2,6 @@ import type { NeuronId } from "@dfinity/nns";
 import { get } from "svelte/store";
 import { accountsStore } from "../stores/accounts.store";
 import { startBusy, type BusyStateInitiatorType } from "../stores/busy.store";
-import { i18n } from "../stores/i18n";
 import { isNeuronControlledByHardwareWallet } from "../utils/neuron.utils";
 import { getNeuronFromStore } from "./neurons.services";
 
@@ -22,9 +21,8 @@ export const startBusyNeuron = ({
     neuron,
     accounts: get(accountsStore),
   });
-  const labels = get(i18n);
   startBusy(
     initiator,
-    hardwareWalletNeuron ? labels.wallet.pending_approval : undefined
+    hardwareWalletNeuron ? "busy_screen.pending_approval_hw" : undefined
   );
 };

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -115,7 +115,9 @@ const getNeuronHW = async ({
   return neurons.find((currentNeuron) => currentNeuron.neuronId === neuronId);
 };
 
-const getNeuronFromStore = (neuronId: NeuronId): NeuronInfo | undefined =>
+export const getNeuronFromStore = (
+  neuronId: NeuronId
+): NeuronInfo | undefined =>
   get(definedNeuronsStore).find((neuron) => neuron.neuronId === neuronId);
 
 const getIdentityOfControllerByNeuronId = async (

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -9,7 +9,7 @@ import {
 import {
   startBusy,
   stopBusy,
-  type BusyStateInitiator,
+  type BusyStateInitiatorType,
 } from "../stores/busy.store";
 import { i18n } from "../stores/i18n";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
@@ -284,7 +284,7 @@ export const registerVotes = async ({
     initiator,
   }: {
     certified: boolean;
-    initiator: BusyStateInitiator;
+    initiator: BusyStateInitiatorType;
   }) => {
     if (!certified) {
       return;

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -1,5 +1,4 @@
-import type { Readable } from "svelte/store";
-import { derived, writable } from "svelte/store";
+import { derived, writable, type Readable } from "svelte/store";
 
 export type BusyStateInitiatorType =
   | "stake-neuron"
@@ -23,7 +22,7 @@ export type BusyStateInitiatorType =
 
 type BusyItem = {
   initiator: BusyStateInitiatorType;
-  message?: string;
+  labelKey?: string;
 };
 
 /**
@@ -39,10 +38,10 @@ const initBusyStore = () => {
     /**
      * Show the busy-screen if not visible
      */
-    startBusy(newInitiator: BusyStateInitiatorType, message?: string) {
+    startBusy(newInitiator: BusyStateInitiatorType, labelKey?: string) {
       update((state) => [
         ...state.filter(({ initiator }) => newInitiator !== initiator),
-        { initiator: newInitiator, message },
+        { initiator: newInitiator, labelKey },
       ]);
     },
 
@@ -67,8 +66,9 @@ export const busy: Readable<boolean> = derived(
 );
 
 // Returns the newest message that was added to the store
-export const busyMessage: Readable<string | undefined> = derived(
+export const busyMessageKey: Readable<string | undefined> = derived(
   busyStore,
   ($busyStore) =>
-    $busyStore.reverse().find(({ message }) => message !== undefined)?.message
+    $busyStore.reverse().find(({ labelKey }) => labelKey !== undefined)
+      ?.labelKey
 );

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -39,8 +39,11 @@ const initBusyStore = () => {
     /**
      * Show the busy-screen if not visible
      */
-    startBusy(initiator: BusyStateInitiatorType, message?: string) {
-      update((state) => [...state, { initiator, message }]);
+    startBusy(newInitiator: BusyStateInitiatorType, message?: string) {
+      update((state) => [
+        ...state.filter(({ initiator }) => newInitiator !== initiator),
+        { initiator: newInitiator, message },
+      ]);
     },
 
     /**
@@ -63,7 +66,9 @@ export const busy: Readable<boolean> = derived(
   ($busyStore) => $busyStore.length > 0
 );
 
-export const firstBusyItem: Readable<BusyItem> = derived(
+// Returns the newest message that was added to the store
+export const busyMessage: Readable<string | undefined> = derived(
   busyStore,
-  ($busyStore) => $busyStore[0]
+  ($busyStore) =>
+    $busyStore.reverse().find(({ message }) => message !== undefined)?.message
 );

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -287,6 +287,7 @@ interface I18nStatus {
 
 interface I18nWallet {
   title: string;
+  pending_approval: string;
 }
 
 interface I18nProposal_detail {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -287,7 +287,10 @@ interface I18nStatus {
 
 interface I18nWallet {
   title: string;
-  pending_approval: string;
+}
+
+interface I18nBusy_screen {
+  pending_approval_hw: string;
 }
 
 interface I18nProposal_detail {
@@ -440,6 +443,7 @@ interface I18n {
   rewards: I18nRewards;
   status: I18nStatus;
   wallet: I18nWallet;
+  busy_screen: I18nBusy_screen;
   proposal_detail: I18nProposal_detail;
   proposal_detail__vote: I18nProposal_detail__vote;
   proposal_detail__ineligible: I18nProposal_detail__ineligible;

--- a/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronHotkeysCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neuron-detail/NeuronHotkeysCard.spec.ts
@@ -16,6 +16,7 @@ import { mockFullNeuron, mockNeuron } from "../../../mocks/neurons.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     removeHotkey: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -15,6 +15,7 @@ jest.mock("../../../../../lib/services/neurons.services", () => {
   return {
     startDissolving: jest.fn().mockResolvedValue(undefined),
     stopDissolving: jest.fn().mockResolvedValue(undefined),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -11,6 +11,7 @@ import { renderModal } from "../../../mocks/modal.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     addHotkey: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -41,6 +41,7 @@ jest.mock("../../../../lib/services/neurons.services", () => {
     updateDelay: jest.fn().mockResolvedValue(undefined),
     loadNeuron: jest.fn().mockResolvedValue(undefined),
     addHotkeyFromHW: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/DisburseNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/DisburseNeuronModal.spec.ts
@@ -19,6 +19,7 @@ import { mockNeuron } from "../../../mocks/neurons.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     disburse: jest.fn().mockResolvedValue({ success: true }),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -14,6 +14,7 @@ import { mockNeuron } from "../../../mocks/neurons.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     updateDelay: jest.fn().mockResolvedValue(undefined),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/MergeMaturityModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/MergeMaturityModal.spec.ts
@@ -13,6 +13,7 @@ import { mockFullNeuron, mockNeuron } from "../../../mocks/neurons.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     mergeMaturity: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -25,6 +25,7 @@ import {
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     mergeNeurons: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -13,6 +13,7 @@ import { mockFullNeuron, mockNeuron } from "../../../mocks/neurons.mock";
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
     spawnNeuron: jest.fn().mockResolvedValue(BigInt(10)),
+    getNeuronFromStore: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -56,6 +56,9 @@ describe("busy-services", () => {
       initiator,
       neuronId: neuron.neuronId,
     });
-    expect(startBusySpy).toBeCalledWith(initiator, en.wallet.pending_approval);
+    expect(startBusySpy).toBeCalledWith(
+      initiator,
+      en.busy_screen.pending_approval_hw
+    );
   });
 });

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -1,0 +1,61 @@
+import { startBusyNeuron } from "../../../lib/services/busy.services";
+import { accountsStore } from "../../../lib/stores/accounts.store";
+import * as busyStore from "../../../lib/stores/busy.store";
+import { neuronsStore } from "../../../lib/stores/neurons.store";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "../../mocks/accounts.store.mock";
+import en from "../../mocks/i18n.mock";
+import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
+
+describe("busy-services", () => {
+  const startBusySpy = jest
+    .spyOn(busyStore, "startBusy")
+    .mockImplementation(jest.fn());
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("call start busy without message if neuron not controlled by hardware wallet", async () => {
+    accountsStore.set({
+      main: mockMainAccount,
+    });
+    const neuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        controller: mockMainAccount.principal?.toText() as string,
+      },
+    };
+    neuronsStore.setNeurons({ neurons: [neuron], certified: true });
+    const initiator = "add-hotkey-neuron";
+    await startBusyNeuron({
+      initiator,
+      neuronId: neuron.neuronId,
+    });
+    expect(startBusySpy).toBeCalledWith(initiator, undefined);
+  });
+
+  it("call start busy with message if neuron controlled by hardware wallet", async () => {
+    accountsStore.set({
+      main: mockMainAccount,
+      hardwareWallets: [mockHardwareWalletAccount],
+    });
+    const neuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        controller: mockHardwareWalletAccount.principal?.toText() as string,
+      },
+    };
+    neuronsStore.setNeurons({ neurons: [neuron], certified: true });
+    const initiator = "add-hotkey-neuron";
+    await startBusyNeuron({
+      initiator,
+      neuronId: neuron.neuronId,
+    });
+    expect(startBusySpy).toBeCalledWith(initiator, en.wallet.pending_approval);
+  });
+});

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -6,7 +6,6 @@ import {
   mockHardwareWalletAccount,
   mockMainAccount,
 } from "../../mocks/accounts.store.mock";
-import en from "../../mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
 
 describe("busy-services", () => {
@@ -58,7 +57,7 @@ describe("busy-services", () => {
     });
     expect(startBusySpy).toBeCalledWith(
       initiator,
-      en.busy_screen.pending_approval_hw
+      "busy_screen.pending_approval_hw"
     );
   });
 });


### PR DESCRIPTION
# Motivation

Show a message to the user when confirmation from the Hardware Wallet is needed.

# Changes

* Change Busy Store to an array of objects that can take a message.
* BusyScreen component reads and displays message if present.
* Busy service to show the message if the neuron is controlled from hardware wallet.

# Tests

* Fix broken tests.
* Add a test for new busy service.