### PR TITLE
L2-524: New Neuron Flow working for HW

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { getIdentity } from "../../services/auth.services";
-  import {
-    addHotkeyFromHW,
-    getAndLoadNeuron,
-  } from "../../services/neurons.services";
+  import { addHotkeyFromHW } from "../../services/neurons.services";
   import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import Spinner from "../ui/Spinner.svelte";
@@ -28,7 +25,7 @@
     loading = true;
     // This screen is only for hardware wallet.
     startBusy({
-      initiator: "stake-neuron",
+      initiator: "add-hotkey-neuron",
       labelKey: "busy_screen.pending_approval_hw",
     });
     const identity = await getIdentity();
@@ -37,10 +34,6 @@
       principal: identity.getPrincipal(),
       accountIdentifier: account.identifier,
     });
-    if (success !== undefined) {
-      // Now we can fetch and load neuron to neurons store.
-      await getAndLoadNeuron(neuronId);
-    }
     loading = false;
     stopBusy("add-hotkey-neuron");
     if (success !== undefined) {

--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -29,14 +29,14 @@
       labelKey: "busy_screen.pending_approval_hw",
     });
     const identity = await getIdentity();
-    const success = await addHotkeyFromHW({
+    const maybeNeuronId = await addHotkeyFromHW({
       neuronId,
       principal: identity.getPrincipal(),
       accountIdentifier: account.identifier,
     });
     loading = false;
     stopBusy("add-hotkey-neuron");
-    if (success !== undefined) {
+    if (maybeNeuronId !== undefined) {
       toastsStore.success({
         labelKey: "neurons.add_user_as_hotkey_success",
       });

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -66,6 +66,10 @@
   );
 
   const dispatcher = createEventDispatcher();
+  const close = () => {
+    dispatcher("nnsClose");
+  };
+
   type InvalidState = {
     stepName: string;
     isNeuronIdInvalid?: (n?: NeuronId) => boolean;
@@ -110,7 +114,7 @@
       toastsStore.error({
         labelKey: "error.unknown",
       });
-      dispatcher("nnsClose");
+      close();
     }
   }
   let delayInSeconds: number = 0;
@@ -144,9 +148,6 @@
   };
   const goEditFollowers = () => {
     modal.set(stepIndex({ name: "EditFollowNeurons", steps }));
-  };
-  const close = () => {
-    dispatcher("nnsClose");
   };
 </script>
 

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -5,7 +5,7 @@
   import SelectAccount from "../../components/accounts/SelectAccount.svelte";
   import StakeNeuron from "../../components/neurons/StakeNeuron.svelte";
   import SetDissolveDelay from "../../components/neurons/SetDissolveDelay.svelte";
-  import type { NeuronInfo } from "@dfinity/nns";
+  import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import ConfirmDissolveDelay from "../../components/neurons/ConfirmDissolveDelay.svelte";
   import EditFollowNeurons from "../../components/neurons/EditFollowNeurons.svelte";
   import WizardModal from "../WizardModal.svelte";
@@ -15,6 +15,7 @@
   import { toastsStore } from "../../stores/toasts.store";
   import AddUserToHotkeys from "../../components/neurons/AddUserToHotkeys.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
+  import { definedNeuronsStore } from "../../stores/neurons.store";
 
   const lastSteps: Steps = [
     {
@@ -58,10 +59,16 @@
 
   let selectedAccount: Account | undefined;
 
+  let newNeuronId: NeuronId | undefined;
   let newNeuron: NeuronInfo | undefined;
+  $: newNeuron = $definedNeuronsStore.find(
+    ({ neuronId }) => neuronId === newNeuronId
+  );
+
   const dispatcher = createEventDispatcher();
   type InvalidState = {
     stepName: string;
+    isNeuronIdInvalid?: (n?: NeuronId) => boolean;
     isNeuronInvalid?: (n?: NeuronInfo) => boolean;
     isAccountInvalid?: (a?: Account) => boolean;
   };
@@ -73,7 +80,7 @@
     {
       stepName: "AddUserToHotkeys",
       isAccountInvalid: (account?: Account) => account === undefined,
-      isNeuronInvalid: (neuron?: NeuronInfo) => neuron === undefined,
+      isNeuronIdInvalid: (neuronId?: NeuronId) => neuronId === undefined,
     },
     {
       stepName: "SetDissolveDelay",
@@ -90,11 +97,12 @@
   ];
   $: {
     const invalidState = invalidStates.find(
-      ({ stepName, isNeuronInvalid, isAccountInvalid }) => {
+      ({ stepName, isNeuronInvalid, isAccountInvalid, isNeuronIdInvalid }) => {
         return (
           stepName === currentStep?.name &&
           ((isNeuronInvalid?.(newNeuron) ?? false) ||
-            (isAccountInvalid?.(selectedAccount) ?? false))
+            (isAccountInvalid?.(selectedAccount) ?? false) ||
+            (isNeuronIdInvalid?.(newNeuronId) ?? false))
         );
       }
     );
@@ -122,8 +130,10 @@
   const goNext = () => {
     modal.next();
   };
-  const addNeuron = ({ detail }: CustomEvent<{ neuron: NeuronInfo }>) => {
-    newNeuron = detail.neuron;
+  const onNeuronCreated = async ({
+    detail,
+  }: CustomEvent<{ neuronId: NeuronId }>) => {
+    newNeuronId = detail.neuronId;
     if (isAccountHardwareWallet(selectedAccount)) {
       toastsStore.show({
         labelKey: "neurons.neuron_create_success",
@@ -134,6 +144,9 @@
   };
   const goEditFollowers = () => {
     modal.set(stepIndex({ name: "EditFollowNeurons", steps }));
+  };
+  const close = () => {
+    dispatcher("nnsClose");
   };
 </script>
 
@@ -147,16 +160,21 @@
   {#if currentStep?.name === "StakeNeuron"}
     <!-- we spare a spinner for the selectedAccount within StakeNeuron because we reach this step once the selectedAccount has been selected -->
     {#if selectedAccount !== undefined}
-      <StakeNeuron account={selectedAccount} on:nnsNeuronCreated={addNeuron} />
+      <StakeNeuron
+        loadNeuron={!isAccountHardwareWallet(selectedAccount)}
+        account={selectedAccount}
+        on:nnsNeuronCreated={onNeuronCreated}
+      />
     {/if}
   {/if}
   {#if currentStep?.name === "AddUserToHotkeys"}
     <!-- we spare a spinner for the selectedAccount and newNeuron within AddUserToHotkeys -->
-    {#if selectedAccount !== undefined && newNeuron !== undefined}
+    {#if selectedAccount !== undefined && newNeuronId !== undefined}
       <AddUserToHotkeys
-        on:nnsNext={goNext}
+        on:nnsHotkeyAdded={goNext}
+        on:nnsSkip={close}
         account={selectedAccount}
-        neuron={newNeuron}
+        neuronId={newNeuronId}
       />
     {/if}
   {/if}

--- a/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/CreateNeuronModal.svelte
@@ -162,7 +162,6 @@
     <!-- we spare a spinner for the selectedAccount within StakeNeuron because we reach this step once the selectedAccount has been selected -->
     {#if selectedAccount !== undefined}
       <StakeNeuron
-        loadNeuron={!isAccountHardwareWallet(selectedAccount)}
         account={selectedAccount}
         on:nnsNeuronCreated={onNeuronCreated}
       />

--- a/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -234,10 +234,11 @@ describe("AddAccountModal", () => {
 
     const attach = getByTestId("ledger-attach-button") as HTMLButtonElement;
 
-    fireEvent.click(attach);
-
     const onClose = jest.fn();
     component.$on("nnsClose", onClose);
+
+    fireEvent.click(attach);
+
     await waitFor(() => expect(onClose).toBeCalled());
   };
 

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -179,13 +179,13 @@ describe("NewTransactionModal", () => {
 
     await goToStep4({ container, getByText, enterAmount: true });
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
     const button = container.querySelector(
       "button[type='submit']"
     ) as HTMLButtonElement;
     await fireEvent.click(button);
 
-    const onClose = jest.fn();
-    component.$on("nnsClose", onClose);
     await waitFor(() => expect(onClose).toBeCalled());
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -95,11 +95,11 @@ describe("AddHotkeyModal", () => {
     const buttonElement = queryByTestId("add-hotkey-neuron-button");
     expect(buttonElement).not.toBeNull();
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
     buttonElement && (await fireEvent.click(buttonElement));
     expect(addHotkey).toBeCalled();
 
-    const onClose = jest.fn();
-    component.$on("nnsClose", onClose);
     await waitFor(() => expect(onClose).toBeCalled());
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -50,7 +50,6 @@ jest.mock("../../../../lib/services/neurons.services", () => {
     loadNeuron: jest.fn().mockResolvedValue(undefined),
     addHotkeyFromHW: jest.fn().mockResolvedValue(BigInt(10)),
     getNeuronFromStore: jest.fn(),
-    getAndLoadNeuron: jest.fn(),
   };
 });
 

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -4,7 +4,12 @@
 
 import type { NeuronInfo } from "@dfinity/nns";
 import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
-import { fireEvent, waitFor } from "@testing-library/svelte";
+import {
+  fireEvent,
+  waitFor,
+  type BoundFunction,
+  type queries,
+} from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 import { E8S_PER_ICP } from "../../../../lib/constants/icp.constants";
 import CreateNeuronModal from "../../../../lib/modals/neurons/CreateNeuronModal.svelte";
@@ -408,13 +413,16 @@ describe("CreateNeuronModal", () => {
 
     afterEach(() => {
       jest.clearAllMocks();
+      neuronsStore.setNeurons({ neurons: [], certified: true });
     });
 
-    it("should create neuron for hardwareWallet", async () => {
-      const { container, queryByTestId, queryByText } = await renderModal({
-        component: CreateNeuronModal,
-      });
-
+    const createNeuron = async ({
+      queryByText,
+      container,
+    }: {
+      queryByText: BoundFunction<queries.QueryByText>;
+      container: HTMLElement;
+    }) => {
       // SCREEN: Select Hardware Wallet Account
       const hardwareWalletAccount = queryByText(
         mockHardwareWalletAccount.name as string,
@@ -435,19 +443,83 @@ describe("CreateNeuronModal", () => {
       const createButton = container.querySelector('button[type="submit"]');
 
       createButton && (await fireEvent.click(createButton));
+    };
+
+    it("should create neuron for hardwareWallet and close modal if hotkey is not added", async () => {
+      const { container, queryByTestId, queryByText, component } =
+        await renderModal({
+          component: CreateNeuronModal,
+        });
+
+      await createNeuron({ queryByText, container });
+
+      // SCREEN: Add NNS App Principal as Hotkey
+      await waitFor(() =>
+        expect(queryByTestId("add-principal-to-hotkeys-modal")).not.toBeNull()
+      );
+      const onClose = jest.fn();
+      component.$on("nnsClose", onClose);
+
+      const skipButton = queryByTestId("skip-add-principal-to-hotkey-modal");
+
+      skipButton && (await fireEvent.click(skipButton));
+
+      await waitFor(() => expect(onClose).toBeCalled());
+    });
+
+    it("should create neuron for hardwareWallet and add dissolve delay", async () => {
+      neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
+      const { container, queryByTestId, queryByText } = await renderModal({
+        component: CreateNeuronModal,
+      });
+
+      await createNeuron({ queryByText, container });
 
       // SCREEN: Add NNS App Principal as Hotkey
       await waitFor(() =>
         expect(queryByTestId("add-principal-to-hotkeys-modal")).not.toBeNull()
       );
 
-      const skipButton = queryByTestId("confirm-add-principal-to-hotkey-modal");
+      const addHotkeyButton = queryByTestId(
+        "confirm-add-principal-to-hotkey-modal"
+      );
 
-      skipButton && (await fireEvent.click(skipButton));
+      addHotkeyButton && (await fireEvent.click(addHotkeyButton));
 
       expect(addHotkeyFromHW).toBeCalled();
 
-      // TODO: Continue flow https://dfinity.atlassian.net/browse/L2-524
+      await waitFor(() =>
+        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+      );
+      const inputRange = container.querySelector('input[type="range"]');
+
+      const ONE_YEAR = 60 * 60 * 24 * 365;
+      inputRange &&
+        (await fireEvent.input(inputRange, { target: { value: ONE_YEAR } }));
+
+      const goToConfirmDelayButton = container.querySelector(
+        '[data-tid="go-confirm-delay-button"]'
+      );
+      await waitFor(() =>
+        expect(goToConfirmDelayButton?.getAttribute("disabled")).toBeNull()
+      );
+
+      goToConfirmDelayButton && (await fireEvent.click(goToConfirmDelayButton));
+
+      await waitFor(() =>
+        expect(
+          container.querySelector(
+            '[data-tid="confirm-dissolve-delay-container"]'
+          )
+        ).not.toBeNull()
+      );
+
+      const confirmButton = container.querySelector(
+        '[data-tid="confirm-delay-button"]'
+      );
+      confirmButton && (await fireEvent.click(confirmButton));
+
+      await waitFor(() => expect(updateDelay).toBeCalled());
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/CreateNeuronModal.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../../lib/services/neurons.services";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import { authStore } from "../../../../lib/stores/auth.store";
+import { neuronsStore } from "../../../../lib/stores/neurons.store";
 import { formatVotingPower } from "../../../../lib/utils/neuron.utils";
 import {
   mockAccountsStoreSubscribe,
@@ -37,11 +38,14 @@ const newNeuron: NeuronInfo = {
 };
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
-    stakeNeuron: jest.fn().mockImplementation(() => Promise.resolve(newNeuron)),
+    stakeNeuron: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(newNeuron.neuronId)),
     updateDelay: jest.fn().mockResolvedValue(undefined),
     loadNeuron: jest.fn().mockResolvedValue(undefined),
     addHotkeyFromHW: jest.fn().mockResolvedValue(BigInt(10)),
     getNeuronFromStore: jest.fn(),
+    getAndLoadNeuron: jest.fn(),
   };
 });
 
@@ -70,6 +74,7 @@ jest.mock("../../../../lib/stores/toasts.store", () => {
 describe("CreateNeuronModal", () => {
   describe("main account selection", () => {
     beforeEach(() => {
+      neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
       jest
         .spyOn(accountsStore, "subscribe")
         .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
@@ -82,6 +87,10 @@ describe("CreateNeuronModal", () => {
       jest
         .spyOn(GovernanceCanister, "create")
         .mockImplementation(() => mock<GovernanceCanister>());
+    });
+
+    afterEach(() => {
+      neuronsStore.setNeurons({ neurons: [], certified: true });
     });
 
     it("should display modal", async () => {

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -153,13 +153,13 @@ describe("IncreaseNeuronStakeModal", () => {
 
     await goToStep3({ container, getByText, enterAmount: true });
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
     const button = container.querySelector(
       "button[type='submit']"
     ) as HTMLButtonElement;
     await fireEvent.click(button);
 
-    const onClose = jest.fn();
-    component.$on("nnsClose", onClose);
     await waitFor(() => expect(onClose).toBeCalled());
   });
 });

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -191,32 +191,33 @@ describe("neurons-services", () => {
       jest.clearAllMocks();
     });
     it("should stake a neuron from main account", async () => {
-      const newNeuron = await stakeNeuron({
+      const newNeuronId = await stakeNeuron({
         amount: 10,
         account: mockMainAccount,
       });
 
       expect(spyStakeNeuron).toHaveBeenCalled();
-      expect(newNeuron).toEqual(mockNeuron);
+      expect(newNeuronId).toEqual(mockNeuron.neuronId);
     });
 
     it("should stake and load a neuron from subaccount", async () => {
-      const newNeuron = await stakeNeuron({
+      const newNeuronId = await stakeNeuron({
         amount: 10,
         account: mockSubAccount,
       });
 
       expect(spyStakeNeuron).toHaveBeenCalled();
-      expect(newNeuron).toEqual(mockNeuron);
+      expect(newNeuronId).toEqual(mockNeuron.neuronId);
     });
 
     it("should stake neuron from hardware wallet", async () => {
-      await stakeNeuron({
+      const newNeuronId = await stakeNeuron({
         amount: 10,
         account: mockHardwareWalletAccount,
       });
 
       expect(spyStakeNeuron).toHaveBeenCalled();
+      expect(newNeuronId).toEqual(mockNeuron.neuronId);
     });
 
     it(`stakeNeuron return undefined if amount less than ${


### PR DESCRIPTION
# Motivation

User can keep with the New Neuron flow when creating a neuron from a hardware wallet.

# Changes

* Separate staking neuron and loading in store.
* On skipping adding the current user as hotkey, it closes the modal.
* Export the neuron service "getAndLoadNeuron".
* CreateNeuronModal reads neuron from store.

# Tests

* Fix broken tests
* Add test case in CreateNeuronModal for Hardware Wallet.