### PR TITLE
refactor: start busy with object params

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/AddSubAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddSubAccount.svelte
@@ -10,7 +10,7 @@
   let dispatcher = createEventDispatcher();
 
   const createNewSubAccount = async () => {
-    startBusy("accounts");
+    startBusy({initiator: "accounts"});
 
     await addSubAccount({
       name: newAccountName,

--- a/frontend/svelte/src/lib/components/accounts/AddSubAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddSubAccount.svelte
@@ -10,7 +10,7 @@
   let dispatcher = createEventDispatcher();
 
   const createNewSubAccount = async () => {
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "accounts" });
 
     await addSubAccount({
       name: newAccountName,

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -33,7 +33,7 @@
       return;
     }
 
-    startBusy("accounts");
+    startBusy({initiator: "accounts"});
 
     await registerHardwareWalletProxy({
       name: $store.hardwareWalletName,

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletConnect.svelte
@@ -33,7 +33,7 @@
       return;
     }
 
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "accounts" });
 
     await registerHardwareWalletProxy({
       name: $store.hardwareWalletName,

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -9,7 +9,7 @@
   let neurons: NeuronInfo[];
 
   const listNeurons = async () => {
-    startBusy("accounts", "busy_screen.pending_approval_hw");
+    startBusy({initiator: "accounts", labelKey: "busy_screen.pending_approval_hw"});
 
     const { neurons: fetchedNeurons, err } =
       await listNeuronsHardwareWalletProxy();

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -9,7 +9,10 @@
   let neurons: NeuronInfo[];
 
   const listNeurons = async () => {
-    startBusy({initiator: "accounts", labelKey: "busy_screen.pending_approval_hw"});
+    startBusy({
+      initiator: "accounts",
+      labelKey: "busy_screen.pending_approval_hw",
+    });
 
     const { neurons: fetchedNeurons, err } =
       await listNeuronsHardwareWalletProxy();

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -20,7 +20,7 @@
   const dispatcher = createEventDispatcher();
 
   const executeTransaction = async () => {
-    startBusy("accounts");
+    startBusy({initiator: "accounts"});
 
     const { success } = await transferICP($store);
 

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -20,7 +20,7 @@
   const dispatcher = createEventDispatcher();
 
   const executeTransaction = async () => {
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "accounts" });
 
     const { success } = await transferICP($store);
 

--- a/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
+++ b/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
@@ -13,7 +13,7 @@
   let dispatcher = createEventDispatcher();
 
   const createNewSubAccount = async () => {
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "accounts" });
 
     await renameSubAccount({
       newName: newAccountName,

--- a/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
+++ b/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
@@ -13,7 +13,7 @@
   let dispatcher = createEventDispatcher();
 
   const createNewSubAccount = async () => {
-    startBusy("accounts");
+    startBusy({initiator: "accounts"});
 
     await renameSubAccount({
       newName: newAccountName,

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
@@ -14,7 +14,7 @@
   const closeModal = () => (isOpen = false);
 
   const joinFund = async () => {
-    startBusy({initiator: "join-community-fund"});
+    startBusy({ initiator: "join-community-fund" });
     const id = await joinCommunityFund(neuronId);
     if (id !== undefined) {
       toastsStore.success({

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundButton.svelte
@@ -14,7 +14,7 @@
   const closeModal = () => (isOpen = false);
 
   const joinFund = async () => {
-    startBusy("join-community-fund");
+    startBusy({initiator: "join-community-fund"});
     const id = await joinCommunityFund(neuronId);
     if (id !== undefined) {
       toastsStore.success({

--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -24,7 +24,7 @@
   const addCurrentUserToHotkey = async () => {
     loading = true;
     // This screen is only for hardware wallet.
-    startBusy("stake-neuron", "busy_screen.pending_approval_hw");
+    startBusy({initiator: "stake-neuron", labelKey: "busy_screen.pending_approval_hw"});
     const identity = await getIdentity();
     const neuronId = await addHotkeyFromHW({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -24,7 +24,10 @@
   const addCurrentUserToHotkey = async () => {
     loading = true;
     // This screen is only for hardware wallet.
-    startBusy({initiator: "stake-neuron", labelKey: "busy_screen.pending_approval_hw"});
+    startBusy({
+      initiator: "stake-neuron",
+      labelKey: "busy_screen.pending_approval_hw",
+    });
     const identity = await getIdentity();
     const neuronId = await addHotkeyFromHW({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -47,7 +47,7 @@
   const closeNewFolloweeModal = () => (showNewFolloweeModal = false);
 
   const removeCurrentFollowee = async (followee: NeuronId) => {
-    startBusy({initiator: "remove-followee"});
+    startBusy({ initiator: "remove-followee" });
     await removeFollowee({
       neuronId: neuron.neuronId,
       topic,

--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -47,7 +47,7 @@
   const closeNewFolloweeModal = () => (showNewFolloweeModal = false);
 
   const removeCurrentFollowee = async (followee: NeuronId) => {
-    startBusy("remove-followee");
+    startBusy({initiator: "remove-followee"});
     await removeFollowee({
       neuronId: neuron.neuronId,
       topic,

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -17,7 +17,7 @@
 
   const toggleKnownNeuronFollowee = async () => {
     loading = true;
-    startBusy({initiator: "add-followee"});
+    startBusy({ initiator: "add-followee" });
     dispatcher("nnsLoading", { loading: true });
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -17,7 +17,7 @@
 
   const toggleKnownNeuronFollowee = async () => {
     loading = true;
-    startBusy("add-followee");
+    startBusy({initiator: "add-followee"});
     dispatcher("nnsLoading", { loading: true });
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -16,7 +16,10 @@
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
-    startBusy({initiator: "stake-neuron", labelKey: "busy_screen.pending_approval_hw"});
+    startBusy({
+      initiator: "stake-neuron",
+      labelKey: "busy_screen.pending_approval_hw",
+    });
     creating = true;
     const neuron = await stakeNeuron({
       amount,

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -16,7 +16,7 @@
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
-    startBusy("stake-neuron", "busy_screen.pending_approval_hw");
+    startBusy({initiator: "stake-neuron", labelKey: "busy_screen.pending_approval_hw"});
     creating = true;
     const neuron = await stakeNeuron({
       amount,

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -76,7 +76,7 @@
 
     loading = true;
     loadingAddress = true;
-    startBusy({initiator: "add-followee"});
+    startBusy({ initiator: "add-followee" });
 
     await addFollowee({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -76,7 +76,7 @@
 
     loading = true;
     loadingAddress = true;
-    startBusy("add-followee");
+    startBusy({initiator: "add-followee"});
 
     await addFollowee({
       neuronId: neuron.neuronId,

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -45,7 +45,7 @@
       });
       return;
     }
-    startBusy({initiator: "split-neuron"});
+    startBusy({ initiator: "split-neuron" });
     const id = await splitNeuron({ neuronId: neuron.neuronId, amount });
     if (id !== undefined) {
       toastsStore.success({

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -45,7 +45,7 @@
       });
       return;
     }
-    startBusy("split-neuron");
+    startBusy({initiator: "split-neuron"});
     const id = await splitNeuron({ neuronId: neuron.neuronId, amount });
     if (id !== undefined) {
       toastsStore.success({

--- a/frontend/svelte/src/lib/services/busy.services.ts
+++ b/frontend/svelte/src/lib/services/busy.services.ts
@@ -14,15 +14,17 @@ export const startBusyNeuron = ({
 }) => {
   const neuron = getNeuronFromStore(neuronId);
   if (neuron?.fullNeuron?.controller === undefined) {
-    startBusy(initiator);
+    startBusy({ initiator });
     return;
   }
   const hardwareWalletNeuron = isNeuronControlledByHardwareWallet({
     neuron,
     accounts: get(accountsStore),
   });
-  startBusy(
+  startBusy({
     initiator,
-    hardwareWalletNeuron ? "busy_screen.pending_approval_hw" : undefined
-  );
+    ...(hardwareWalletNeuron && {
+      labelKey: "busy_screen.pending_approval_hw",
+    }),
+  });
 };

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -255,7 +255,7 @@ export const registerVotes = async ({
   proposalId: ProposalId;
   vote: Vote;
 }): Promise<void> => {
-  startBusy({initiator: "vote"});
+  startBusy({ initiator: "vote" });
 
   const identity: Identity = await getIdentity();
 
@@ -294,7 +294,7 @@ export const registerVotes = async ({
   };
 
   const reloadListNeurons = async () => {
-    startBusy({initiator: "reload-neurons"});
+    startBusy({ initiator: "reload-neurons" });
 
     try {
       await listNeurons({
@@ -313,7 +313,7 @@ export const registerVotes = async ({
   };
 
   const reloadProposal = async () => {
-    startBusy({initiator: "reload-proposal"});
+    startBusy({ initiator: "reload-proposal" });
 
     await loadProposal({
       proposalId,

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -255,7 +255,7 @@ export const registerVotes = async ({
   proposalId: ProposalId;
   vote: Vote;
 }): Promise<void> => {
-  startBusy("vote");
+  startBusy({initiator: "vote"});
 
   const identity: Identity = await getIdentity();
 
@@ -294,7 +294,7 @@ export const registerVotes = async ({
   };
 
   const reloadListNeurons = async () => {
-    startBusy("reload-neurons");
+    startBusy({initiator: "reload-neurons"});
 
     try {
       await listNeurons({
@@ -313,7 +313,7 @@ export const registerVotes = async ({
   };
 
   const reloadProposal = async () => {
-    startBusy("reload-proposal");
+    startBusy({initiator: "reload-proposal"});
 
     await loadProposal({
       proposalId,

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -17,20 +17,19 @@ export type BusyStateInitiatorType =
   | "merge-neurons"
   | "merge-maturity"
   | "spawn-neuron"
-  | "disburse-neuron"
-  | "remove-followee";
+  | "disburse-neuron";
 
-type BusyItem = {
+export interface BusyState {
   initiator: BusyStateInitiatorType;
   labelKey?: string;
-};
+}
 
 /**
  * Store that reflects the app busy state.
- * Is used to show the busy-screen that locks the UI
+ * Is used to show the busy-screen that locks the UI.
  */
 const initBusyStore = () => {
-  const { subscribe, update } = writable<Array<BusyItem>>([]);
+  const { subscribe, update } = writable<Array<BusyState>>([]);
 
   return {
     subscribe,
@@ -38,7 +37,7 @@ const initBusyStore = () => {
     /**
      * Show the busy-screen if not visible
      */
-    startBusy(newInitiator: BusyStateInitiatorType, labelKey?: string) {
+    startBusy({ initiator: newInitiator, labelKey }: BusyState) {
       update((state) => [
         ...state.filter(({ initiator }) => newInitiator !== initiator),
         { initiator: newInitiator, labelKey },

--- a/frontend/svelte/src/tests/lib/components/ui/BusyScreen.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/BusyScreen.spec.ts
@@ -9,7 +9,7 @@ import { startBusy, stopBusy } from "../../../../lib/stores/busy.store";
 describe("BusyScreen", () => {
   it("should show the spinner", async () => {
     const { container } = render(BusyScreen);
-    startBusy("vote");
+    startBusy({initiator: "vote"});
     await waitFor(() =>
       expect(container.querySelector("svg")).toBeInTheDocument()
     );
@@ -17,7 +17,7 @@ describe("BusyScreen", () => {
 
   it("should hide the spinner", async () => {
     const { container } = render(BusyScreen);
-    startBusy("vote");
+    startBusy({initiator: "vote"});
     await waitFor(() =>
       expect(container.querySelector("svg")).toBeInTheDocument()
     );

--- a/frontend/svelte/src/tests/lib/components/ui/BusyScreen.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/BusyScreen.spec.ts
@@ -9,7 +9,7 @@ import { startBusy, stopBusy } from "../../../../lib/stores/busy.store";
 describe("BusyScreen", () => {
   it("should show the spinner", async () => {
     const { container } = render(BusyScreen);
-    startBusy({initiator: "vote"});
+    startBusy({ initiator: "vote" });
     await waitFor(() =>
       expect(container.querySelector("svg")).toBeInTheDocument()
     );
@@ -17,7 +17,7 @@ describe("BusyScreen", () => {
 
   it("should hide the spinner", async () => {
     const { container } = render(BusyScreen);
-    startBusy({initiator: "vote"});
+    startBusy({ initiator: "vote" });
     await waitFor(() =>
       expect(container.querySelector("svg")).toBeInTheDocument()
     );

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -34,7 +34,7 @@ describe("busy-services", () => {
       initiator,
       neuronId: neuron.neuronId,
     });
-    expect(startBusySpy).toBeCalledWith(initiator, undefined);
+    expect(startBusySpy).toBeCalledWith({initiator});
   });
 
   it("call start busy with message if neuron controlled by hardware wallet", async () => {
@@ -55,9 +55,9 @@ describe("busy-services", () => {
       initiator,
       neuronId: neuron.neuronId,
     });
-    expect(startBusySpy).toBeCalledWith(
+    expect(startBusySpy).toBeCalledWith({
       initiator,
-      "busy_screen.pending_approval_hw"
-    );
+      labelKey: "busy_screen.pending_approval_hw",
+    });
   });
 });

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -34,7 +34,7 @@ describe("busy-services", () => {
       initiator,
       neuronId: neuron.neuronId,
     });
-    expect(startBusySpy).toBeCalledWith({initiator});
+    expect(startBusySpy).toBeCalledWith({ initiator });
   });
 
   it("call start busy with message if neuron controlled by hardware wallet", async () => {

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -17,7 +17,7 @@ describe("busy-services", () => {
     jest.clearAllMocks();
   });
 
-  it("call start busy without message if neuron not controlled by hardware wallet", async () => {
+  it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
     accountsStore.set({
       main: mockMainAccount,
     });

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -200,7 +200,7 @@ describe("proposals-services", () => {
           proposalId,
           vote: Vote.YES,
         });
-        expect(spyBusyStart).toBeCalledWith("vote");
+        expect(spyBusyStart).toBeCalledWith({ initiator: "vote" });
         expect(spyBusyStop).toBeCalledWith("vote");
       });
 

--- a/frontend/svelte/src/tests/lib/stores/busy.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/busy.store.spec.ts
@@ -3,19 +3,19 @@ import { busy, startBusy, stopBusy } from "../../../lib/stores/busy.store";
 
 describe("busy.store", () => {
   it("should add initiator", () => {
-    startBusy("vote");
+    startBusy({initiator: "vote"});
     expect(get(busy)).toBe(true);
   });
 
   it("should add initiator only once", () => {
-    startBusy("vote");
-    startBusy("vote");
+    startBusy({initiator: "vote"});
+    startBusy({initiator: "vote"});
     expect(get(busy)).toBe(true);
   });
 
   it("should remove initiator", () => {
-    startBusy("vote");
-    startBusy("accounts");
+    startBusy({initiator: "vote"});
+    startBusy({initiator: "accounts"});
     stopBusy("vote");
     expect(get(busy)).toBe(true);
 
@@ -24,12 +24,12 @@ describe("busy.store", () => {
   });
 
   it("should derive a busy state", () => {
-    startBusy("vote");
+    startBusy({initiator: "vote"});
     expect(get(busy)).toBe(true);
     stopBusy("vote");
     expect(get(busy)).toBe(false);
-    startBusy("vote");
-    startBusy("accounts");
+    startBusy({initiator: "vote"});
+    startBusy({initiator: "accounts"});
     expect(get(busy)).toBe(true);
     stopBusy("vote");
     expect(get(busy)).toBe(true);

--- a/frontend/svelte/src/tests/lib/stores/busy.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/busy.store.spec.ts
@@ -3,19 +3,19 @@ import { busy, startBusy, stopBusy } from "../../../lib/stores/busy.store";
 
 describe("busy.store", () => {
   it("should add initiator", () => {
-    startBusy({initiator: "vote"});
+    startBusy({ initiator: "vote" });
     expect(get(busy)).toBe(true);
   });
 
   it("should add initiator only once", () => {
-    startBusy({initiator: "vote"});
-    startBusy({initiator: "vote"});
+    startBusy({ initiator: "vote" });
+    startBusy({ initiator: "vote" });
     expect(get(busy)).toBe(true);
   });
 
   it("should remove initiator", () => {
-    startBusy({initiator: "vote"});
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "vote" });
+    startBusy({ initiator: "accounts" });
     stopBusy("vote");
     expect(get(busy)).toBe(true);
 
@@ -24,12 +24,12 @@ describe("busy.store", () => {
   });
 
   it("should derive a busy state", () => {
-    startBusy({initiator: "vote"});
+    startBusy({ initiator: "vote" });
     expect(get(busy)).toBe(true);
     stopBusy("vote");
     expect(get(busy)).toBe(false);
-    startBusy({initiator: "vote"});
-    startBusy({initiator: "accounts"});
+    startBusy({ initiator: "vote" });
+    startBusy({ initiator: "accounts" });
     expect(get(busy)).toBe(true);
     stopBusy("vote");
     expect(get(busy)).toBe(true);


### PR DESCRIPTION
# Motivation

Path object to start busy screen.

# Changes

- refactor `startBusy` to provide the state object
- remove double entry `remove-followee` in list of initiator
- rename type to interface `BusyState`