### PR TITLE
style: busy text as paragraph

### DIFF
--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -10,7 +10,7 @@
   <div data-tid="busy" transition:fade>
     <div class="content">
       {#if $busyMessageKey !== undefined}
-        <h4>{translate({ labelKey: $busyMessageKey })}</h4>
+        <p>{translate({ labelKey: $busyMessageKey })}</p>
       {/if}
       <span>
         <Spinner inline />
@@ -34,5 +34,10 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+  }
+
+  p {
+    padding-bottom: var(--padding);
+    max-width: calc(var(--section-max-width) / 2);
   }
 </style>

--- a/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/busy.services.spec.ts
@@ -17,7 +17,7 @@ describe("busy-services", () => {
     jest.clearAllMocks();
   });
 
-  it("call start busy without message if neuron not controlled by hardware wallet", async () => {
+  it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
     accountsStore.set({
       main: mockMainAccount,
     });


### PR DESCRIPTION
# Motivation

Design is personal but I feel like the text of the busy screen was screaming at me 😂.

# Changes

- display text with `p`
- add spacing
- limit width in case passed text would be really long

# Screenshots

Is:

<img width="1513" alt="Capture d’écran 2022-05-17 à 07 23 44" src="https://user-images.githubusercontent.com/16886711/168735858-90793eca-4616-42e1-8cc0-228e8e3d2b2d.png">


Will be:

<img width="1513" alt="Capture d’écran 2022-05-17 à 07 24 47" src="https://user-images.githubusercontent.com/16886711/168735817-453fd533-eb07-4527-8311-e2f0daa443d1.png">
<img width="1513" alt="Capture d’écran 2022-05-17 à 07 26 43" src="https://user-images.githubusercontent.com/16886711/168735824-5997cc3a-3312-44ca-86b1-4584e974ca56.png">

