### PR TITLE
style: fix modal max height

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -9,7 +9,7 @@
 
   export let visible: boolean = true;
   export let theme: "dark" | "light" = "light";
-  export let size: "small" | "medium" = "small";
+  export let size: "small" | "big" = "small";
   export let testId: string | undefined = undefined;
 
   // There is no way to know whether a parent is listening to the "nnsBack" event
@@ -142,13 +142,12 @@
 
     width: var(--modal-small-width);
 
-    &.medium {
-      width: var(--modal-medium-width);
+    &.big {
+      width: var(--modal-big-width);
     }
 
-    height: fit-content;
+    height: min(calc(100% - var(--padding-6x)), var(--modal-max-height));
     max-width: calc(100vw - var(--padding-4x));
-    max-height: calc(100% - var(--padding-6x));
 
     --modal-toolbar-height: 35px;
 
@@ -157,10 +156,6 @@
     border-radius: calc(2 * var(--border-radius));
 
     overflow: hidden;
-
-    &.medium {
-      width: var(--modal-medium-width);
-    }
   }
 
   .light > div.wrapper {
@@ -225,7 +220,7 @@
     display: flex;
     flex-direction: column;
 
-    height: calc(100vh - 100px - var(--modal-toolbar-height));
+    height: calc(100% - var(--modal-toolbar-height));
     overflow-y: auto;
     overflow-x: hidden;
 

--- a/frontend/svelte/src/lib/modals/WizardModal.svelte
+++ b/frontend/svelte/src/lib/modals/WizardModal.svelte
@@ -24,7 +24,7 @@
 
 <Modal
   theme="dark"
-  size="medium"
+  size="big"
   on:nnsClose
   on:introend={() => (presented = true)}
   showBackButton={currentStep?.showBackButton ?? false}

--- a/frontend/svelte/src/lib/modals/accounts/HardwareWalletListNeuronsModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/HardwareWalletListNeuronsModal.svelte
@@ -7,7 +7,7 @@
   export let neurons: NeuronInfo[];
 </script>
 
-<Modal on:nnsClose theme="dark" size="medium">
+<Modal on:nnsClose theme="dark" size="big">
   <span slot="title">{$i18n.neurons.title}</span>
 
   <div>

--- a/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
@@ -41,7 +41,7 @@
   };
 </script>
 
-<Modal on:nnsClose theme="dark" size="medium">
+<Modal on:nnsClose theme="dark" size="big">
   <span slot="title">{$i18n.neuron_detail.add_hotkey_modal_title}</span>
   <form on:submit|preventDefault={add} data-tid="add-hotkey-neuron-modal">
     <div class="input-wrapper">

--- a/frontend/svelte/src/lib/modals/neurons/FollowNeuronsModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/FollowNeuronsModal.svelte
@@ -7,7 +7,7 @@
   export let neuron: NeuronInfo;
 </script>
 
-<Modal theme="dark" size="medium" on:nnsClose>
+<Modal theme="dark" size="big" on:nnsClose>
   <span slot="title">{$i18n.neurons.follow_neurons_screen}</span>
   <section>
     <EditFollowNeurons {neuron} />

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -92,7 +92,7 @@
   };
 </script>
 
-<Modal theme="dark" size="medium" on:nnsClose>
+<Modal theme="dark" size="big" on:nnsClose>
   <span slot="title">{$i18n.new_followee.title}</span>
   <main data-tid="new-followee-modal">
     <article>

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -57,7 +57,7 @@
   };
 </script>
 
-<Modal on:nnsClose theme="dark" size="medium">
+<Modal on:nnsClose theme="dark" size="big">
   <span slot="title">{$i18n.neuron_detail.split_neuron}</span>
   <section data-tid="split-neuron-modal">
     <CurrentBalance {balance} />

--- a/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -34,7 +34,7 @@
   });
 </script>
 
-<Modal testId="voting-history-modal" on:nnsClose theme="dark" size="medium">
+<Modal testId="voting-history-modal" on:nnsClose theme="dark" size="big">
   <span slot="title">{$i18n.neuron_detail.title}</span>
 
   {#if neuron !== undefined}

--- a/frontend/svelte/src/lib/themes/variables.scss
+++ b/frontend/svelte/src/lib/themes/variables.scss
@@ -29,11 +29,12 @@
   --button-min-height: 60px;
 
   --modal-small-width: calc(100% - var(--padding-8x));
-  --modal-medium-width: calc(100% - var(--padding-2x));
+  --modal-big-width: calc(100% - var(--padding-2x));
+  --modal-max-height: 610px;
 
   @include media.min-width(medium) {
     --modal-small-width: 500px;
-    --modal-medium-width: 600px;
+    --modal-big-width: 600px;
   }
 
   // Json colors


### PR DESCRIPTION
# Motivation

I noticed in the demo provided in PR #852 that modal are really big on big screen. This PR limits their `height`.

# Changes

- refactor property value name `medium` to `big` 
- set max height to 610px or screen size minus some spacing

# Screenshots

<img width="1513" alt="Capture d’écran 2022-05-17 à 07 45 39" src="https://user-images.githubusercontent.com/16886711/168738138-a619c395-3858-438b-90c7-9075a783ed82.png">
<img width="1513" alt="Capture d’écran 2022-05-17 à 07 45 52" src="https://user-images.githubusercontent.com/16886711/168738152-59e5d769-cf0c-4a5e-bdab-0038ed86dc4d.png">
<img width="1513" alt="Capture d’écran 2022-05-17 à 07 46 07" src="https://user-images.githubusercontent.com/16886711/168738156-573aad33-5420-4598-b21e-0ed11fd6e38a.png">

