### PR TITLE
L2-526: Error management neurons with HW

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -390,6 +390,7 @@
     "connect_not_supported": "Either you have other wallet applications open (e.g. Ledger Live), or your browser doesn't support WebHID, which is necessary to communicate with your Ledger hardware wallet. Supported browsers: Chrome (Desktop) v89+, Edge v89+, Opera v76+. Error: $err",
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right wallet?",
     "user_cancel": "User denied the access to use the ledger device.",
+    "user_rejected_transaction": "The transaction was rejected on the ledger device.",
     "incorrect_identifier": "Wallet account identifier doesn't match. Are you sure you connected the right wallet? Expected identifier: $identifier. Wallet identifier: $ledgerIdentifier."
   },
   "error__attach_wallet": {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -415,6 +415,7 @@ interface I18nError__ledger {
   connect_not_supported: string;
   unexpected_wallet: string;
   user_cancel: string;
+  user_rejected_transaction: string;
   incorrect_identifier: string;
 }
 

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -28,6 +28,21 @@ export const errorToString = (err?: unknown): string | undefined =>
     : undefined;
 
 export const mapNeuronErrorToToastMessage = (error: Error): ToastMsg => {
+  // Check toToastError first
+  const fallbackKey = "fallback";
+  const toastError = toToastError({
+    err: error,
+    fallbackErrorLabelKey: fallbackKey,
+  });
+  // Return if error found is not fallback
+  if (toastError.labelKey !== fallbackKey) {
+    return {
+      level: "error",
+      ...toastError,
+    };
+  }
+
+  // Check GovernanceErrors
   /* eslint-disable-next-line @typescript-eslint/ban-types */
   const collection: Array<[Function, string]> = [
     [NotFoundError, "error.neuron_not_found"],

--- a/frontend/svelte/src/lib/utils/ledger.utils.ts
+++ b/frontend/svelte/src/lib/utils/ledger.utils.ts
@@ -54,6 +54,9 @@ export const decodeSignature = ({
 }: ResponseSign): Signature => {
   const labels = get(i18n);
 
+  if (returnCode === LedgerError.TransactionRejected) {
+    throw new LedgerErrorKey("error__ledger.user_rejected_transaction");
+  }
   if (signatureRS === null || signatureRS === undefined) {
     throw new LedgerErrorMessage(
       replacePlaceholders(labels.error__ledger.signature_unexpected, {


### PR DESCRIPTION
# Motivation

Show meaningful error messages to the user when interacts with neurons controlled by a hardware wallet.

# Changes

* Add toToastError in the mapNeuronErrorToToastMessage helper.

# Tests

Not applicable.
