### PR TITLE
feat: instead of spinner, make buttons disabled if busy

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
+++ b/frontend/svelte/src/lib/components/neurons/AddUserToHotkeys.svelte
@@ -2,15 +2,13 @@
   import { createEventDispatcher } from "svelte";
   import { addHotkeyForHardwareWalletNeuron } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
-  import Spinner from "../ui/Spinner.svelte";
   import type { Account } from "../../types/account";
   import type { NeuronId } from "@dfinity/nns";
   import { authStore } from "../../stores/auth.store";
+  import { busy } from "../../stores/busy.store";
 
   export let account: Account;
   export let neuronId: NeuronId;
-
-  let loading: boolean = false;
 
   const dispatcher = createEventDispatcher();
   const skip = () => {
@@ -19,13 +17,12 @@
 
   // Add the auth identity principal as hotkey
   const addCurrentUserToHotkey = async () => {
-    loading = true;
     // This screen is only for hardware wallet.
     const { success } = await addHotkeyForHardwareWalletNeuron({
       neuronId,
       accountIdentifier: account.identifier,
     });
-    loading = false;
+
     if (success) {
       dispatcher("nnsHotkeyAdded");
     }
@@ -50,13 +47,9 @@
       class="primary full-width"
       on:click={addCurrentUserToHotkey}
       data-tid="confirm-add-principal-to-hotkey-modal"
-      disabled={$authStore.identity?.getPrincipal() === undefined}
+      disabled={$authStore.identity?.getPrincipal() === undefined || $busy}
     >
-      {#if loading}
-        <Spinner />
-      {:else}
-        {$i18n.neuron_detail.add_hotkey}
-      {/if}
+      {$i18n.neuron_detail.add_hotkey}
     </button>
   </div>
 </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
-  import Spinner from "../ui/Spinner.svelte";
   import { updateDelay } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
   import { secondsToDuration } from "../../utils/date.utils";
@@ -12,12 +11,11 @@
     neuronStake,
     votingPower,
   } from "../../utils/neuron.utils";
-  import { stopBusy } from "../../stores/busy.store";
+  import { busy, stopBusy } from "../../stores/busy.store";
   import { startBusyNeuron } from "../../services/busy.services";
 
   export let delayInSeconds: number;
   export let neuron: NeuronInfo;
-  let loading: boolean = false;
 
   const dispatcher = createEventDispatcher();
   let neuronICP: bigint;
@@ -25,14 +23,15 @@
 
   const updateNeuron = async () => {
     startBusyNeuron({ initiator: "update-delay", neuronId: neuron.neuronId });
-    loading = true;
+
     const neuronId = await updateDelay({
       neuronId: neuron.neuronId,
       dissolveDelayInSeconds:
         delayInSeconds - Number(neuron.dissolveDelaySeconds),
     });
+
     stopBusy("update-delay");
-    loading = false;
+
     if (neuronId !== undefined) {
       dispatcher("nnsUpdated");
     }
@@ -70,14 +69,10 @@
     <button
       class="primary full-width"
       data-tid="confirm-delay-button"
-      disabled={loading}
+      disabled={$busy}
       on:click={updateNeuron}
     >
-      {#if loading}
-        <Spinner />
-      {:else}
-        {$i18n.neurons.confirm_delay}
-      {/if}
+      {$i18n.neurons.confirm_delay}
     </button>
   </div>
 </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -4,13 +4,12 @@
   import { MAX_NEURONS_MERGED } from "../../constants/neurons.constants";
   import { startBusyNeuron } from "../../services/busy.services";
   import { mergeNeurons } from "../../services/neurons.services";
-  import { stopBusy } from "../../stores/busy.store";
+  import { busy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { toastsStore } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formatICP } from "../../utils/icp.utils";
   import { neuronStake } from "../../utils/neuron.utils";
-  import Spinner from "../ui/Spinner.svelte";
 
   export let neurons: NeuronInfo[];
 
@@ -25,10 +24,7 @@
     }
   }
 
-  let loading: boolean = false;
-
   const merge = async () => {
-    loading = true;
     startBusyNeuron({
       initiator: "merge-neurons",
       neuronId: neurons[0].neuronId,
@@ -39,12 +35,13 @@
       targetNeuronId: neurons[0].neuronId,
       sourceNeuronId: neurons[1].neuronId,
     });
+
     if (id !== undefined) {
       toastsStore.success({
         labelKey: "neuron_detail.merge_neurons_success",
       });
     }
-    loading = false;
+
     dispatcher("nnsClose");
     stopBusy("merge-neurons");
   };
@@ -79,13 +76,10 @@
     <button
       class="primary full-width"
       data-tid="confirm-merge-neurons-button"
+      disabled={$busy}
       on:click={merge}
     >
-      {#if loading}
-        <Spinner />
-      {:else}
-        {$i18n.neurons.merge_neurons_modal_confirm}
-      {/if}
+      {$i18n.neurons.merge_neurons_modal_confirm}
     </button>
   </div>
   <div class="disclaimer">

--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -1,32 +1,24 @@
 <script lang="ts">
   import type { KnownNeuron, NeuronId, Topic } from "@dfinity/nns";
-  import { createEventDispatcher } from "svelte";
   import { addFollowee, removeFollowee } from "../../services/neurons.services";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
-  import Spinner from "../ui/Spinner.svelte";
 
   export let knownNeuron: KnownNeuron;
   export let topic: Topic;
   export let neuronId: NeuronId;
   export let isFollowed: boolean = false;
-  export let disabled: boolean = false;
-
-  let loading: boolean = false;
-  const dispatcher = createEventDispatcher();
 
   const toggleKnownNeuronFollowee = async () => {
-    loading = true;
     startBusy({ initiator: "add-followee" });
-    dispatcher("nnsLoading", { loading: true });
+
     const toggleFollowee = isFollowed ? removeFollowee : addFollowee;
     await toggleFollowee({
       neuronId,
       topic,
       followee: knownNeuron.id,
     });
-    loading = false;
-    dispatcher("nnsLoading", { loading: false });
+
     stopBusy("add-followee");
   };
 </script>
@@ -35,13 +27,11 @@
   <p>{knownNeuron.name}</p>
   <!-- TODO: Fix style while loading - https://dfinity.atlassian.net/browse/L2-404 -->
   <button
-    class={`secondary small ${loading ? "icon-only" : ""}`}
-    {disabled}
+    class="secondary small"
+    disabled={$busy}
     on:click={toggleKnownNeuronFollowee}
   >
-    {#if loading}
-      <Spinner inline size="small" />
-    {:else if isFollowed}
+    {#if isFollowed}
       {$i18n.new_followee.unfollow}
     {:else}
       {$i18n.new_followee.follow}

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -3,7 +3,6 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import Card from "../ui/Card.svelte";
-  import Spinner from "../ui/Spinner.svelte";
   import {
     SECONDS_IN_EIGHT_YEARS,
     SECONDS_IN_HALF_YEAR,
@@ -23,8 +22,6 @@
   export let delayInSeconds: number = 0;
   export let cancelButtonText: string | undefined = undefined;
   export let minDelayInSeconds: number = 0;
-
-  let loading: boolean = false;
 
   const checkMinimum = () => {
     if (delayInSeconds < minDelayInSeconds) {
@@ -113,21 +110,16 @@
       <button
         on:click={cancel}
         data-tid="cancel-neuron-delay"
-        class="secondary full-width"
-        disabled={loading}>{cancelButtonText}</button
+        class="secondary full-width">{cancelButtonText}</button
       >
     {/if}
     <button
       class="primary full-width"
-      disabled={disableUpdate || loading}
+      disabled={disableUpdate}
       on:click={goToConfirmation}
       data-tid="go-confirm-delay-button"
     >
-      {#if loading}
-        <Spinner />
-      {:else}
-        {$i18n.neurons.update_delay}
-      {/if}
+      {$i18n.neurons.update_delay}
     </button>
   </div>
 </div>

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import Spinner from "../ui/Spinner.svelte";
   import { syncAccounts } from "../../services/accounts.services";
   import { stakeNeuron } from "../../services/neurons.services";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { formattedTransactionFeeICP, maxICP } from "../../utils/icp.utils";
   import AmountInput from "../ui/AmountInput.svelte";
   import CurrentBalance from "../accounts/CurrentBalance.svelte";
@@ -13,7 +12,7 @@
 
   export let account: Account;
   let amount: number;
-  let creating: boolean = false;
+
   const dispatcher = createEventDispatcher();
 
   const createNeuron = async () => {
@@ -24,7 +23,7 @@
         ? "busy_screen.pending_approval_hw"
         : undefined,
     });
-    creating = true;
+
     const neuronId = await stakeNeuron({
       amount,
       account,
@@ -38,7 +37,7 @@
 
       dispatcher("nnsNeuronCreated", { neuronId });
     }
-    creating = false;
+
     stopBusy("stake-neuron");
   };
 
@@ -68,18 +67,14 @@
   </div>
 
   <small>{$i18n.neurons.may_take_while}</small>
-  <!-- TODO: L2-252 -->
+
   <button
     class="primary full-width"
     type="submit"
     data-tid="create-neuron-button"
-    disabled={amount === undefined || amount <= 0 || creating}
+    disabled={amount === undefined || amount <= 0 || $busy}
   >
-    {#if creating}
-      <Spinner />
-    {:else}
-      {$i18n.neurons.create}
-    {/if}
+    {$i18n.neurons.create}
   </button>
 </form>
 

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -9,6 +9,7 @@
     selectedNeuronsVotingPower,
   } from "../../../utils/proposals.utils";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
+  import { busy } from "../../../stores/busy.store";
 
   const dispatch = createEventDispatcher();
 
@@ -28,7 +29,7 @@
     neurons: $votingNeuronSelectStore.neurons,
     selectedIds: $votingNeuronSelectStore.selectedIds,
   });
-  $: disabled = $votingNeuronSelectStore.selectedIds.length === 0;
+  $: disabled = $votingNeuronSelectStore.selectedIds.length === 0 || $busy;
 
   const showAdoptConfirmation = () => {
     selectedVoteType = Vote.YES;

--- a/frontend/svelte/src/lib/components/ui/ConfirmActionScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/ConfirmActionScreen.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import Spinner from "./Spinner.svelte";
-
-  export let loading: boolean = false;
+  import { busy } from "../../stores/busy.store";
 
   const dispatcher = createEventDispatcher();
   const confirm = async () => {
@@ -21,14 +19,10 @@
     <button
       class="primary full-width"
       data-tid="confirm-action-button"
-      disabled={loading}
+      disabled={$busy}
       on:click={confirm}
     >
-      {#if loading}
-        <Spinner />
-      {:else}
-        <slot name="button-content" />
-      {/if}
+      <slot name="button-content" />
     </button>
   </div>
 </div>

--- a/frontend/svelte/src/lib/modals/ConfirmationModal.svelte
+++ b/frontend/svelte/src/lib/modals/ConfirmationModal.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from "svelte";
   import { i18n } from "../stores/i18n";
   import Modal from "./Modal.svelte";
+  import { busy } from "../stores/busy.store";
 
   const dispatch = createEventDispatcher();
 </script>
@@ -12,11 +13,13 @@
     <div role="toolbar">
       <button
         data-tid="confirm-no"
+        disabled={$busy}
         on:click={() => dispatch("nnsClose")}
         class="secondary full-width">{$i18n.core.confirm_no}</button
       >
       <button
         data-tid="confirm-yes"
+        disabled={$busy}
         class="primary full-width"
         on:click={() => dispatch("nnsConfirm")}>{$i18n.core.confirm_yes}</button
       >

--- a/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/MergeMaturityModal.svelte
@@ -32,23 +32,23 @@
   let modal: WizardModal;
 
   let percentageToMerge: number = 0;
-  let loading: boolean;
 
   const dispatcher = createEventDispatcher();
   const mergeNeuronMaturity = async () => {
-    loading = true;
     startBusyNeuron({ initiator: "merge-maturity", neuronId: neuron.neuronId });
+
     const { success } = await mergeMaturity({
       neuronId: neuron.neuronId,
       percentageToMerge,
     });
+
     if (success) {
       toastsStore.success({
         labelKey: "neuron_detail.merge_maturity_success",
       });
       dispatcher("nnsClose");
     }
-    loading = false;
+
     stopBusy("merge-maturity");
   };
   const goToConfirm = () => {
@@ -75,7 +75,7 @@
       </svelte:fragment>
     </SelectPercentage>
   {:else if currentStep.name === "ConfirmMerge"}
-    <ConfirmActionScreen {loading} on:nnsConfirm={mergeNeuronMaturity}>
+    <ConfirmActionScreen on:nnsConfirm={mergeNeuronMaturity}>
       <div class="confirm" slot="main-info">
         <h4>{$i18n.neuron_detail.merge_maturity_confirmation_q}</h4>
         <p class="confirm-answer">

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -8,7 +8,7 @@
   import { addFollowee } from "../../services/neurons.services";
   import { accountsStore } from "../../stores/accounts.store";
   import { authStore } from "../../stores/auth.store";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { sortedknownNeuronsStore } from "../../stores/knownNeurons.store";
   import {
@@ -39,8 +39,7 @@
       : isControllableByUser || isControllableByHotkey;
 
   let followeeAddress: string = "";
-  let loadingAddress: boolean = false;
-  let loading: boolean = false;
+
   let topicFollowees: NeuronId[];
   $: topicFollowees = followeesByTopic({ neuron, topic }) ?? [];
 
@@ -53,12 +52,6 @@
     followees: NeuronId[];
     knownNeuronId: NeuronId;
   }): boolean => followees.find((id) => id === knownNeuronId) !== undefined;
-
-  // We can't edit two followees at the same time.
-  // Canister edits followees by sending the new array of followees.
-  const updateLoading = ({ detail }: CustomEvent<{ loading: boolean }>) => {
-    loading = detail.loading;
-  };
 
   const addFolloweeByAddress = async () => {
     let followee: bigint;
@@ -74,8 +67,6 @@
       return;
     }
 
-    loading = true;
-    loadingAddress = true;
     startBusy({ initiator: "add-followee" });
 
     await addFollowee({
@@ -84,8 +75,6 @@
       followee,
     });
 
-    loading = false;
-    loadingAddress = false;
     stopBusy("add-followee");
 
     followeeAddress = "";
@@ -106,17 +95,11 @@
           theme="dark"
         />
         <button
-          class={`primary small ${loadingAddress ? "icon-only" : ""}`}
+          class="primary small"
           type="submit"
-          disabled={followeeAddress.length === 0 ||
-            loading ||
-            !isUserAuthorized}
+          disabled={followeeAddress.length === 0 || !isUserAuthorized || $busy}
         >
-          {#if loadingAddress}
-            <Spinner inline size="small" />
-          {:else}
-            {$i18n.new_followee.follow_neuron}
-          {/if}
+          {$i18n.new_followee.follow_neuron}
         </button>
       </form>
     </article>
@@ -129,8 +112,6 @@
           {#each $sortedknownNeuronsStore as knownNeuron}
             <li data-tid="known-neuron-item">
               <KnownNeuronFollowItem
-                on:nnsLoading={updateLoading}
-                disabled={loading || !isUserAuthorized}
                 {knownNeuron}
                 neuronId={neuron.neuronId}
                 {topic}

--- a/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -44,7 +44,6 @@
   let modal: WizardModal;
 
   let percentageToSpawn: number = 0;
-  let loading: boolean;
 
   let enoughMaturityToSpawn: boolean;
   $: enoughMaturityToSpawn = isEnoughMaturityToSpawn({
@@ -62,8 +61,8 @@
 
   const dispatcher = createEventDispatcher();
   const spawnNeuronFromMaturity = async () => {
-    loading = true;
     startBusyNeuron({ initiator: "spawn-neuron", neuronId: neuron.neuronId });
+
     const { success } = await spawnNeuron({
       neuronId: neuron.neuronId,
       percentageToSpawn: controlledByHarwareWallet
@@ -76,7 +75,7 @@
       });
       dispatcher("nnsClose");
     }
-    loading = false;
+
     stopBusy("spawn-neuron");
   };
   const goToConfirm = () => {
@@ -103,7 +102,7 @@
       </svelte:fragment>
     </SelectPercentage>
   {:else if currentStep.name === "ConfirmSpawn"}
-    <ConfirmActionScreen {loading} on:nnsConfirm={spawnNeuronFromMaturity}>
+    <ConfirmActionScreen on:nnsConfirm={spawnNeuronFromMaturity}>
       <div class="confirm" slot="main-info">
         <h4>{$i18n.neuron_detail.spawn_maturity_confirmation_q}</h4>
         <p class="confirm-answer">

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -10,7 +10,7 @@
   } from "../../constants/icp.constants";
   import { i18n } from "../../stores/i18n";
   import { formattedTransactionFeeICP } from "../../utils/icp.utils";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { createEventDispatcher } from "svelte";
   import { splitNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
@@ -74,7 +74,7 @@
       data-tid="split-neuron-button"
       class="primary full-width"
       on:click={split}
-      disabled={!validForm}
+      disabled={!validForm || $busy}
     >
       {$i18n.neuron_detail.split_neuron_confirm}
     </button>

--- a/frontend/svelte/src/tests/lib/components/ui/ConfirmActionScreen.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/ConfirmActionScreen.spec.ts
@@ -20,15 +20,6 @@ describe("ConfirmActionScreen", () => {
     expect(element).toBeInTheDocument();
   });
 
-  it("should render spinner when loading", () => {
-    const { queryByTestId } = render(ConfirmActionScreenTest, {
-      props: { loading: true },
-    });
-
-    const element = queryByTestId("spinner");
-    expect(element).toBeInTheDocument();
-  });
-
   it("should trigger nnsConfirm event on click button", async () => {
     const spy = jest.fn();
     const { queryByTestId } = render(ConfirmActionScreenTest, {

--- a/frontend/svelte/src/tests/lib/components/ui/ConfirmActionScreenTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/ConfirmActionScreenTest.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import ConfirmActionScreen from "../../../../lib/components/ui/ConfirmActionScreen.svelte";
 
-  export let loading: boolean = false;
   export let spy: () => void = () => undefined;
 </script>
 
-<ConfirmActionScreen {loading} on:nnsConfirm={spy}>
+<ConfirmActionScreen on:nnsConfirm={spy}>
   <h3 slot="main-info" data-tid="test-main-info">Main information</h3>
   <svelte:fragment slot="button-content">Confirm</svelte:fragment>
 </ConfirmActionScreen>


### PR DESCRIPTION
# Motivation

Instead of spinner replacing buttons when work is in progress, make buttons disabled if `$busy`. This to avoid two display two spinners on screen.

# Changes

- remove `loading` and `spinner`
- make buttons disabled if `$busy`

# Tests

No particular tests were provided because such use case was not tested before anyway.
