### PR TITLE
refactor: use selected account context

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -3,7 +3,6 @@
   import HardwareWalletListNeuronsModal from "../../modals/accounts/HardwareWalletListNeuronsModal.svelte";
   import { listNeuronsHardwareWalletProxy } from "../../proxy/ledger.services.proxy";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
-  import type { Account } from "../../types/account";
   import { writable } from "svelte/store";
   import { getContext, setContext } from "svelte";
   import type {
@@ -14,16 +13,6 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { mapHardwareWalletNeuronInfo } from "../../utils/hardware-wallet-neurons.utils";
   import { authStore } from "../../stores/auth.store";
-  import {
-    SELECTED_ACCOUNT_CONTEXT_KEY,
-    type SelectedAccountContext,
-  } from "../../types/selected-account.context";
-
-  const { store } = getContext<SelectedAccountContext>(
-    SELECTED_ACCOUNT_CONTEXT_KEY
-  );
-  let selectedAccount: Account | undefined;
-  $: selectedAccount = $store.account;
 
   let modalOpen = false;
 
@@ -32,7 +21,6 @@
    * We notably need a store because the user can add hotkeys to the neurons that are not yet controlled by NNS-dapp and need to update dynamically the UI accordingly.
    */
   const hardwareWalletNeuronsStore = writable<HardwareWalletNeuronsStore>({
-    selectedAccount,
     neurons: [],
   });
 

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -5,7 +5,7 @@
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import type { Account } from "../../types/account";
   import { writable } from "svelte/store";
-  import { setContext } from "svelte";
+  import { getContext, setContext } from "svelte";
   import type {
     HardwareWalletNeuronsContext,
     HardwareWalletNeuronsStore,
@@ -14,8 +14,16 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { mapHardwareWalletNeuronInfo } from "../../utils/hardware-wallet-neurons.utils";
   import { authStore } from "../../stores/auth.store";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    type SelectedAccountContext,
+  } from "../../types/selected-account.context";
 
-  export let selectedAccount: Account | undefined;
+  const { store } = getContext<SelectedAccountContext>(
+    SELECTED_ACCOUNT_CONTEXT_KEY
+  );
+  let selectedAccount: Account | undefined;
+  $: selectedAccount = $store.account;
 
   let modalOpen = false;
 

--- a/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -4,7 +4,7 @@
   import { listNeuronsHardwareWalletProxy } from "../../proxy/ledger.services.proxy";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { writable } from "svelte/store";
-  import { getContext, setContext } from "svelte";
+  import { setContext } from "svelte";
   import type {
     HardwareWalletNeuronsContext,
     HardwareWalletNeuronsStore,

--- a/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
+++ b/frontend/svelte/src/lib/components/accounts/RenameSubAccountAction.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import Input from "../ui/Input.svelte";
   import { i18n } from "../../stores/i18n";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, getContext } from "svelte";
   import { renameSubAccount } from "../../services/accounts.services";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import type { Account } from "../../types/account";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    type SelectedAccountContext,
+  } from "../../types/selected-account.context";
 
-  export let selectedAccount: Account | undefined;
+  const { store } = getContext<SelectedAccountContext>(
+    SELECTED_ACCOUNT_CONTEXT_KEY
+  );
+  let selectedAccount: Account | undefined;
+  $: selectedAccount = $store.account;
 
   let newAccountName: string = "";
 

--- a/frontend/svelte/src/lib/components/accounts/RenameSubAccountButton.svelte
+++ b/frontend/svelte/src/lib/components/accounts/RenameSubAccountButton.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import RenameSubAccountModal from "../../modals/accounts/RenameSubAccountModal.svelte";
-  import type { Account } from "../../types/account";
   import { i18n } from "../../stores/i18n";
-
-  export let selectedAccount: Account | undefined;
 
   let modalOpen = false;
 </script>
@@ -18,8 +15,5 @@
 </button>
 
 {#if modalOpen}
-  <RenameSubAccountModal
-    {selectedAccount}
-    on:nnsClose={() => (modalOpen = false)}
-  />
+  <RenameSubAccountModal on:nnsClose={() => (modalOpen = false)} />
 {/if}

--- a/frontend/svelte/src/lib/components/accounts/WalletActions.svelte
+++ b/frontend/svelte/src/lib/components/accounts/WalletActions.svelte
@@ -19,11 +19,11 @@
 
 <div role="menubar">
   {#if type === "subAccount"}
-    <RenameSubAccountButton selectedAccount={$store.account} />
+    <RenameSubAccountButton />
   {/if}
 
   {#if type === "hardwareWallet"}
-    <HardwareWalletListNeuronsButton selectedAccount={$store.account} />
+    <HardwareWalletListNeuronsButton />
     <HardwareWalletShowActionButton />
   {/if}
 </div>

--- a/frontend/svelte/src/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.svelte
@@ -13,26 +13,33 @@
     type HardwareWalletNeuronsContext,
   } from "../../types/hardware-wallet-neurons.context";
   import { toastsStore } from "../../stores/toasts.store";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    type SelectedAccountContext,
+  } from "../../types/selected-account.context";
 
   export let neuronId: NeuronId;
 
+  // Get the selected account from the account context - "Wallet" detail page context
+  const { store: storeAccount } = getContext<SelectedAccountContext>(
+    SELECTED_ACCOUNT_CONTEXT_KEY
+  );
+  let selectedAccount: Account | undefined;
+  $: selectedAccount = $storeAccount.account;
+
+  // Get the store for the neurons of the hardware wallet from the dedicated context
   const context: HardwareWalletNeuronsContext =
     getContext<HardwareWalletNeuronsContext>(
       HARDWARE_WALLET_NEURONS_CONTEXT_KEY
     );
   const { store }: HardwareWalletNeuronsContext = context;
 
-  let selectedAccount: Account | undefined = undefined;
-
-  $: ({ selectedAccount } = $store);
-
   const dispatch = createEventDispatcher();
 
   // We do not fetch again all the neurons on the ledger and solely update the UI to replicate the UI/UX that was developed in Flutter and is already in production.
   // i.e. the neuron that has just been added to the hotkey control will be displayed as "Added to NNS dapp"
   const updateContextStoreNeuron = () =>
-    store.update(({ selectedAccount, neurons }) => ({
-      selectedAccount,
+    store.update(({ neurons }) => ({
       neurons: neurons.map((neuron: HardwareWalletNeuronInfo) =>
         neuron.neuronId !== neuronId
           ? neuron

--- a/frontend/svelte/src/lib/modals/accounts/RenameSubAccountModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/RenameSubAccountModal.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-  import RenameSubAccount from "../../components/accounts/RenameSubAccountAction.svelte";
+  import RenameSubAccountAction from "../../components/accounts/RenameSubAccountAction.svelte";
   import WizardModal from "../WizardModal.svelte";
   import { i18n } from "../../stores/i18n";
   import type { Steps } from "../../stores/steps.state";
-  import type { Account } from "../../types/account";
   import type { Step } from "../../stores/steps.state";
-
-  export let selectedAccount: Account | undefined;
 
   let steps: Steps = [
     {
@@ -25,6 +22,6 @@
   >
 
   <svelte:fragment>
-    <RenameSubAccount on:nnsClose {selectedAccount} />
+    <RenameSubAccountAction on:nnsClose />
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/types/hardware-wallet-neurons.context.ts
+++ b/frontend/svelte/src/lib/types/hardware-wallet-neurons.context.ts
@@ -1,13 +1,11 @@
 import type { NeuronInfo } from "@dfinity/nns";
 import type { Writable } from "svelte/store";
-import type { Account } from "./account";
 
 export interface HardwareWalletNeuronInfo extends NeuronInfo {
   controlledByNNSDapp: boolean;
 }
 
 export interface HardwareWalletNeuronsStore {
-  selectedAccount: Account | undefined;
   neurons: HardwareWalletNeuronInfo[];
 }
 

--- a/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte
@@ -5,18 +5,27 @@
     type HardwareWalletNeuronsContext,
   } from "../../../../lib/types/hardware-wallet-neurons.context";
   import {
-    hardwareWalletNeuronsStore,
+    mockHardwareWalletNeuronsStore,
     mockNeuronStake,
   } from "../../../mocks/hardware-wallet-neurons.store.mock";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    SelectedAccountContext,
+  } from "../../../../lib/types/selected-account.context";
+  import { mockSelectedAccountStore } from "../../../mocks/selected-account.store.mock";
 
   export let testComponent: typeof SvelteComponent;
 
   setContext<HardwareWalletNeuronsContext>(
     HARDWARE_WALLET_NEURONS_CONTEXT_KEY,
     {
-      store: hardwareWalletNeuronsStore,
+      store: mockHardwareWalletNeuronsStore,
     }
   );
+
+  setContext<SelectedAccountContext>(SELECTED_ACCOUNT_CONTEXT_KEY, {
+    store: mockSelectedAccountStore,
+  });
 </script>
 
 <svelte:component this={testComponent} neuronId={mockNeuronStake.neuronId} />

--- a/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
@@ -3,9 +3,11 @@
  */
 
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 import HardwareWalletListNeurons from "../../../../lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
 import { listNeuronsHardwareWalletProxy } from "../../../../lib/proxy/ledger.services.proxy";
+import { mockMainAccount } from "../../../mocks/accounts.store.mock";
+import { renderSelectedAccountContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../mocks/neurons.mock";
 
@@ -25,20 +27,26 @@ describe("HardwareWalletListNeuronsButton", () => {
     );
   });
 
+  const renderTestCmp = () =>
+    renderSelectedAccountContext({
+      Component: HardwareWalletListNeurons,
+      account: mockMainAccount,
+    });
+
   it("should contain a closed modal per default", () => {
-    const { getByText } = render(HardwareWalletListNeurons);
+    const { getByText } = renderTestCmp();
     expect(() => getByText(en.neurons.title)).toThrow();
   });
 
   it("should contain an action named list neurons", async () => {
-    const { getByText } = render(HardwareWalletListNeurons);
+    const { getByText } = renderTestCmp();
     expect(
       getByText(en.accounts.attach_hardware_show_neurons)
     ).toBeInTheDocument();
   });
 
   it("should list neurons and open modal", async () => {
-    const { getByText, getByTestId } = render(HardwareWalletListNeurons);
+    const { getByText, getByTestId } = renderTestCmp();
     await fireEvent.click(
       getByTestId("ledger-list-button") as HTMLButtonElement
     );

--- a/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/accounts/HardwareWalletNeuronsTest.svelte
@@ -4,14 +4,14 @@
     HARDWARE_WALLET_NEURONS_CONTEXT_KEY,
     type HardwareWalletNeuronsContext,
   } from "../../../../lib/types/hardware-wallet-neurons.context";
-  import { hardwareWalletNeuronsStore } from "../../../mocks/hardware-wallet-neurons.store.mock";
+  import { mockHardwareWalletNeuronsStore } from "../../../mocks/hardware-wallet-neurons.store.mock";
 
   export let testComponent: typeof SvelteComponent;
 
   setContext<HardwareWalletNeuronsContext>(
     HARDWARE_WALLET_NEURONS_CONTEXT_KEY,
     {
-      store: hardwareWalletNeuronsStore,
+      store: mockHardwareWalletNeuronsStore,
     }
   );
 </script>

--- a/frontend/svelte/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
@@ -3,10 +3,11 @@
  */
 
 import { fireEvent } from "@testing-library/dom";
-import { render } from "@testing-library/svelte";
 import RenameSubAccountAction from "../../../../lib/components/accounts/RenameSubAccountAction.svelte";
 import { renameSubAccount } from "../../../../lib/services/accounts.services";
+import type { Account } from "../../../../lib/types/account";
 import { mockSubAccount } from "../../../mocks/accounts.store.mock";
+import { renderSelectedAccountContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
 
 jest.mock("../../../../lib/services/accounts.services");
@@ -25,10 +26,14 @@ describe("RenameSubAccountAction", () => {
     });
   });
 
-  it("should render a cta text", () => {
-    const { getByText } = render(RenameSubAccountAction, {
-      props: { selectedAccount: undefined },
+  const renderTestCmp = (account: Account | undefined) =>
+    renderSelectedAccountContext({
+      Component: RenameSubAccountAction,
+      account,
     });
+
+  it("should render a cta text", () => {
+    const { getByText } = renderTestCmp(undefined);
 
     expect(
       getByText(en.accounts.rename_account_enter_new_name)
@@ -36,9 +41,7 @@ describe("RenameSubAccountAction", () => {
   });
 
   it("should not enable rename action if no new name", () => {
-    const { getByTestId } = render(RenameSubAccountAction, {
-      props: { selectedAccount: undefined },
-    });
+    const { getByTestId } = renderTestCmp(undefined);
 
     const button = getByTestId("rename-subaccount-button") as HTMLButtonElement;
 
@@ -47,9 +50,7 @@ describe("RenameSubAccountAction", () => {
   });
 
   it("should enable and disable action according input", async () => {
-    const { container, getByTestId } = render(RenameSubAccountAction, {
-      props: { selectedAccount: mockSubAccount },
-    });
+    const { container, getByTestId } = renderTestCmp(mockSubAccount);
 
     const input = container.querySelector("input") as HTMLInputElement;
 
@@ -64,21 +65,18 @@ describe("RenameSubAccountAction", () => {
   });
 
   it("should disable action even if text entered if not account", async () => {
-    const { container, getByTestId } = render(RenameSubAccountAction, {
-      props: { selectedAccount: undefined },
-    });
+    const { container, getByTestId } = renderTestCmp(undefined);
 
     const input = container.querySelector("input") as HTMLInputElement;
     const button = getByTestId("rename-subaccount-button") as HTMLButtonElement;
 
     await fireEvent.input(input, { target: { value: "test" } });
+
     expect(button.getAttribute("disabled")).not.toBeNull();
   });
 
   it("should call rename action", async () => {
-    const { container, getByTestId } = render(RenameSubAccountAction, {
-      props: { selectedAccount: mockSubAccount },
-    });
+    const { container, getByTestId } = renderTestCmp(mockSubAccount);
 
     const input = container.querySelector("input") as HTMLInputElement;
     await fireEvent.input(input, { target: { value: "test" } });

--- a/frontend/svelte/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
@@ -9,23 +9,17 @@ import en from "../../../mocks/i18n.mock";
 
 describe("RenameSubAccountButton", () => {
   it("should contain a closed modal per default", () => {
-    const { getByText } = render(RenameSubAccount, {
-      props: { selectedAccount: undefined },
-    });
+    const { getByText } = render(RenameSubAccount);
     expect(() => getByText(en.accounts.rename_linked_account)).toThrow();
   });
 
   it("should contain an action named rename", async () => {
-    const { getByText } = render(RenameSubAccount, {
-      props: { selectedAccount: undefined },
-    });
+    const { getByText } = render(RenameSubAccount);
     expect(getByText(en.accounts.rename)).toBeInTheDocument();
   });
 
   it("should open modal", async () => {
-    const { getByText, getByTestId } = render(RenameSubAccount, {
-      props: { selectedAccount: undefined },
-    });
+    const { getByText, getByTestId } = render(RenameSubAccount);
     await fireEvent.click(
       getByTestId("open-rename-subaccount-button") as HTMLButtonElement
     );

--- a/frontend/svelte/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
@@ -13,7 +13,7 @@ import {
   mockIdentity,
 } from "../../../mocks/auth.store.mock";
 import {
-  hardwareWalletNeuronsStore,
+  mockHardwareWalletNeuronsStore,
   mockNeuronStake,
 } from "../../../mocks/hardware-wallet-neurons.store.mock";
 import en from "../../../mocks/i18n.mock";
@@ -111,7 +111,7 @@ describe("HardwareWalletNeuronAddHotkeyModal", () => {
     await waitFor(() => expect(spyAddHotkey).toBeCalled());
     await waitFor(() => expect(spyGetNeuron).toBeCalled());
 
-    const store = get(hardwareWalletNeuronsStore);
+    const store = get(mockHardwareWalletNeuronsStore);
     expect(
       store.neurons.find(({ controlledByNNSDapp }) => !controlledByNNSDapp)
     ).toBeUndefined();

--- a/frontend/svelte/src/tests/lib/modals/accounts/RenameSubAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/RenameSubAccountModal.spec.ts
@@ -2,34 +2,40 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
 import RenameSubAccountModal from "../../../../lib/modals/accounts/RenameSubAccountModal.svelte";
+import type { Account } from "../../../../lib/types/account";
 import { mockSubAccount } from "../../../mocks/accounts.store.mock";
+import { renderSelectedAccountContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
-import { renderModal } from "../../../mocks/modal.mock";
+import { renderModalSelectedAccountContextWrapper } from "../../../mocks/modal.mock";
 
 describe("RenameSubAccountModal", () => {
-  it("should display modal", () => {
-    const { container } = render(RenameSubAccountModal, {
-      props: { selectedAccount: undefined },
+  const renderTestCmp = (account: Account | undefined) =>
+    renderSelectedAccountContext({
+      Component: RenameSubAccountModal,
+      account,
     });
+
+  const renderTestModalCmp = (account: Account | undefined) =>
+    renderModalSelectedAccountContextWrapper({
+      Component: RenameSubAccountModal,
+      account,
+    });
+
+  it("should display modal", () => {
+    const { container } = renderTestCmp(undefined);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
   it("should render title", () => {
-    const { getByText } = render(RenameSubAccountModal, {
-      props: { selectedAccount: undefined },
-    });
+    const { getByText } = renderTestCmp(undefined);
 
     expect(getByText(en.accounts.rename_linked_account)).toBeInTheDocument();
   });
 
   it("should render rename action", async () => {
-    const { getByTestId } = await renderModal({
-      component: RenameSubAccountModal,
-      props: { selectedAccount: mockSubAccount },
-    });
+    const { getByTestId } = await renderTestModalCmp(mockSubAccount);
 
     expect(getByTestId("rename-subaccount-button")).not.toBeNull();
   });

--- a/frontend/svelte/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/svelte/src/tests/mocks/context-wrapper.mock.ts
@@ -1,0 +1,45 @@
+import type { RenderResult } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
+import type { SvelteComponent } from "svelte";
+import { writable } from "svelte/store";
+import type { Account } from "../../lib/types/account";
+import {
+  SELECTED_ACCOUNT_CONTEXT_KEY,
+  type SelectedAccountStore,
+} from "../../lib/types/selected-account.context";
+import ContextWrapperTest from "../lib/components/ContextWrapperTest.svelte";
+
+export const renderContextWrapper = <T>({
+  Component,
+  contextKey,
+  contextValue,
+}: {
+  Component: typeof SvelteComponent;
+  contextKey: symbol;
+  contextValue: T;
+}): RenderResult =>
+  render(ContextWrapperTest, {
+    props: {
+      contextKey,
+      contextValue,
+      Component,
+    },
+  });
+
+export const renderSelectedAccountContext = ({
+  Component,
+  account,
+}: {
+  Component: typeof SvelteComponent;
+  account: Account | undefined;
+}): RenderResult =>
+  renderContextWrapper({
+    contextKey: SELECTED_ACCOUNT_CONTEXT_KEY,
+    contextValue: {
+      store: writable<SelectedAccountStore>({
+        account,
+        transactions: undefined,
+      }),
+    },
+    Component,
+  });

--- a/frontend/svelte/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store";
 import type { HardwareWalletNeuronsStore } from "../../lib/types/hardware-wallet-neurons.context";
-import { mockMainAccount } from "./accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "./neurons.mock";
 
 export const mockNeuronStake = {
@@ -12,16 +11,16 @@ export const mockNeuronStake = {
   },
 };
 
-export const hardwareWalletNeuronsStore = writable<HardwareWalletNeuronsStore>({
-  selectedAccount: mockMainAccount,
-  neurons: [
-    {
-      ...mockNeuron,
-      controlledByNNSDapp: true,
-    },
-    {
-      ...mockNeuronStake,
-      controlledByNNSDapp: false,
-    },
-  ],
-});
+export const mockHardwareWalletNeuronsStore =
+  writable<HardwareWalletNeuronsStore>({
+    neurons: [
+      {
+        ...mockNeuron,
+        controlledByNNSDapp: true,
+      },
+      {
+        ...mockNeuronStake,
+        controlledByNNSDapp: false,
+      },
+    ],
+  });

--- a/frontend/svelte/src/tests/mocks/modal.mock.ts
+++ b/frontend/svelte/src/tests/mocks/modal.mock.ts
@@ -1,6 +1,13 @@
 import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
+import { writable } from "svelte/store";
+import type { Account } from "../../lib/types/account";
+import {
+  SELECTED_ACCOUNT_CONTEXT_KEY,
+  type SelectedAccountStore,
+} from "../../lib/types/selected-account.context";
+import ContextWrapperTest from "../lib/components/ContextWrapperTest.svelte";
 
 const waitModalIntroEnd = async ({
   container,
@@ -35,3 +42,44 @@ export const renderModal = async ({
 
   return modal;
 };
+
+export const renderModalContextWrapper = async <T>({
+  Component,
+  contextKey,
+  contextValue,
+}: {
+  Component: typeof SvelteComponent;
+  contextKey: symbol;
+  contextValue: T;
+}): Promise<RenderResult> => {
+  const modal = render(ContextWrapperTest, {
+    props: {
+      contextKey,
+      contextValue,
+      Component,
+    },
+  });
+
+  const { container } = modal;
+  await waitModalIntroEnd({ container, selector: modalToolbarSelector });
+
+  return modal;
+};
+
+export const renderModalSelectedAccountContextWrapper = ({
+  Component,
+  account,
+}: {
+  Component: typeof SvelteComponent;
+  account: Account | undefined;
+}): Promise<RenderResult> =>
+  renderModalContextWrapper({
+    contextKey: SELECTED_ACCOUNT_CONTEXT_KEY,
+    contextValue: {
+      store: writable<SelectedAccountStore>({
+        account,
+        transactions: undefined,
+      }),
+    },
+    Component,
+  });

--- a/frontend/svelte/src/tests/mocks/selected-account.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/selected-account.store.mock.ts
@@ -1,0 +1,8 @@
+import { writable } from "svelte/store";
+import type { SelectedAccountStore } from "../../lib/types/selected-account.context";
+import { mockMainAccount } from "./accounts.store.mock";
+
+export const mockSelectedAccountStore = writable<SelectedAccountStore>({
+  account: mockMainAccount,
+  transactions: undefined,
+});


### PR DESCRIPTION
# Motivation

A dedicated context and store has been introduced for the selected account of the "Wallet -Account" details page. It can be used to avoid passing properties through components and to replace existing store information that duplicate the information.

# Changes

- use selected account context and store instead of passing props
- remove `selectedAccount` from hardware wallet neurons store and use selected account store instead
