### PR TITLE
button disabled hover state

### DIFF
--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -2,7 +2,8 @@
 @use "mixins/media";
 
 button {
-  &[disabled] {
+  &[disabled],
+  &[disabled]:hover {
     pointer-events: none;
   }
 
@@ -65,7 +66,8 @@ button {
 
   &.primary,
   &.input-button {
-    &[disabled] {
+    &[disabled],
+    &[disabled]:hover {
       background: var(--gray-400);
       color: var(--gray-600);
     }
@@ -90,7 +92,8 @@ button {
   }
 
   &.secondary {
-    &[disabled] {
+    &[disabled],
+    &[disabled]:hover {
       background: var(--gray-400);
       color: var(--gray-600);
     }
@@ -135,7 +138,8 @@ button {
     background: var(--gray-600);
     color: var(--gray-50);
 
-    &[disabled] {
+    &[disabled],
+    &[disabled]:hover {
       background: rgba(var(--gray-600-rgb), 0.8);
       color: var(--gray-800);
     }
@@ -176,7 +180,8 @@ button {
       font-size: var(--font-size-h3);
     }
 
-    &[disabled] {
+    &[disabled],
+    &[disabled]:hover {
       background: var(--gray-400);
       color: var(--gray-600);
     }


### PR DESCRIPTION
# Motivation
Button when disabled should not be changing colors, or cursor change when hovered over.

- Added [disabled]:hover attribute that behaves the same as disabled when button is hovered over.
- Note: The primary buttons in the footer of pages such as `Merge Neurons`, `Stake Neurons`, `Add Transaction`, and `Add Account` are not disabled by default, but a modal pop-up will show instead -- blocking interaction with the buttons. 
- It may not be necessary to change these footer buttons to disabled, unless you want to guard against when page is somehow lagging and paused.

https://dfinity.atlassian.net/jira/software/c/projects/L2/boards/182?modal=detail&selectedIssue=L2-534&assignee=617f8802e79ff6006ffac7cc
