### PR TITLE
Fix: Close After New Followee change

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
+++ b/frontend/svelte/src/lib/components/neurons/KnownNeuronFollowItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { KnownNeuron, NeuronId, Topic } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
   import { addFollowee, removeFollowee } from "../../services/neurons.services";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
@@ -9,6 +10,7 @@
   export let neuronId: NeuronId;
   export let isFollowed: boolean = false;
 
+  const dispatcher = createEventDispatcher();
   const toggleKnownNeuronFollowee = async () => {
     startBusy({ initiator: "add-followee" });
 
@@ -20,6 +22,7 @@
     });
 
     stopBusy("add-followee");
+    dispatcher("nnsUpdated");
   };
 </script>
 

--- a/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
-  import { onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import KnownNeuronFollowItem from "../../components/neurons/KnownNeuronFollowItem.svelte";
   import Input from "../../components/ui/Input.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
@@ -53,6 +53,10 @@
     knownNeuronId: NeuronId;
   }): boolean => followees.find((id) => id === knownNeuronId) !== undefined;
 
+  const dispatcher = createEventDispatcher();
+  const close = () => {
+    dispatcher("nnsClose");
+  };
   const addFolloweeByAddress = async () => {
     let followee: bigint;
     if (followeeAddress.length === 0) {
@@ -76,6 +80,7 @@
     });
 
     stopBusy("add-followee");
+    close();
 
     followeeAddress = "";
   };
@@ -112,6 +117,7 @@
           {#each $sortedknownNeuronsStore as knownNeuron}
             <li data-tid="known-neuron-item">
               <KnownNeuronFollowItem
+                on:nnsUpdated={close}
                 {knownNeuron}
                 neuronId={neuron.neuronId}
                 {topic}

--- a/frontend/svelte/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -4,7 +4,7 @@
 
 import { Topic } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import NewFolloweeModal from "../../../../lib/modals/neurons/NewFolloweeModal.svelte";
 import {
   addFollowee,
@@ -69,7 +69,7 @@ describe("NewFolloweeModal", () => {
   });
 
   it("adds a followee from a valid address", async () => {
-    const { container } = render(NewFolloweeModal, {
+    const { container, component } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
     });
 
@@ -84,9 +84,13 @@ describe("NewFolloweeModal", () => {
     const formElement = container.querySelector("form");
     expect(formElement).toBeInTheDocument();
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+
     formElement && (await fireEvent.submit(formElement));
 
     expect(addFollowee).toBeCalled();
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 
   it("renders known neurons", async () => {
@@ -120,7 +124,7 @@ describe("NewFolloweeModal", () => {
 
   it("follow known neurons", async () => {
     knownNeuronsStore.setNeurons([mockKnownNeuron]);
-    const { queryAllByTestId } = render(NewFolloweeModal, {
+    const { queryAllByTestId, component } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },
     });
 
@@ -133,16 +137,20 @@ describe("NewFolloweeModal", () => {
 
     expect(followButton).toBeInTheDocument();
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+
     followButton && (await fireEvent.click(followButton));
 
     expect(addFollowee).toBeCalled();
     expect(removeFollowee).not.toBeCalled();
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 
   it("unfollow known neurons", async () => {
     knownNeuronsStore.setNeurons([mockKnownNeuron]);
 
-    const { queryByTestId } = render(NewFolloweeModal, {
+    const { queryByTestId, component } = render(NewFolloweeModal, {
       props: { neuron: followingNeuron, topic: Topic.Unspecified },
     });
 
@@ -152,6 +160,9 @@ describe("NewFolloweeModal", () => {
 
     expect(knownNeuronElement).toBeInTheDocument();
 
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+
     const knownNeuronButton = knownNeuronElement?.querySelector("button");
     expect(knownNeuronButton).toBeInTheDocument();
 
@@ -159,5 +170,6 @@ describe("NewFolloweeModal", () => {
 
     expect(removeFollowee).toBeCalled();
     expect(addFollowee).not.toBeCalled();
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 });


### PR DESCRIPTION
# Motivation

Modal to add new followee or unfollow known neurons closes after action (like in Flutter).

# Changes

* Dispatch the "nnsClose" action in NewFolloweeModal after followee action.
* Dispatch "nnsUpdate" from KnownNeuronFollowItem and listen for it in NewFolloweeModal to close modal.

# Tests

* Expect that the modal closes in the tests.
