### PR TITLE
Use deploy.sh in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,21 +138,8 @@ jobs:
         run: |
           dfx start --background --clean
 
-      # IDENTITY_SERVICE_URL needs to match `e2e-tests/test.js`
-      # REDIRECT_TO_LEGACY=svelte builds and deploys only Svelte
-      - name: Deploy NNS canisters
-        run: |
-          ./e2e-tests/scripts/nns-canister-install
-
-      - name: Deploy
-        run: |
-          ./e2e-tests/scripts/deploy-local-canisters
-
-      - name: Build proxy
-        working-directory: proxy
-        run: |
-          npm ci
-          npm run build
+      - name: Deploy canisters and state
+        run: ./deploy.sh --nns-backend --ii --nns-dapp --users
 
       - name: prepare and run the test suite
         working-directory: e2e-tests

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "wdio": "wdio run ./wdio.conf.ts",
-    "test": "tsc test.ts && node test.js",
+    "test": "wdio run ./wdio.conf.ts",
     "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },


### PR DESCRIPTION
# Motivation
We now have `deploy.sh` able to create all required local canisters and state.  It would be good if it kept working.  Using it in CI is a way of checking that it works, at least on AMD64 Linux.  It also reduces the risk of our development environment and CI diverging.

Note: GitHub does not offer CI runners equivalent to an M1 mac.  It may do in future, there seems to be plenty of demand.  If and when it does, we could also run the build on there.

# Changes
* Use deploy.sh rather than the underlying commands in CI.

# Tests
*  See the CI test results! :-)