### PR TITLE
Add cycles minting canister ID

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -87,6 +87,7 @@
   "defaults": {
     "network": {
       "config": {
+        "CYCLES_MINTING_CANISTER_ID": "rkp4c-7iaaa-aaaaa-aaaca-cai",
         "GOVERNANCE_CANISTER_ID": "rrkah-fqaaa-aaaaa-aaaaq-cai",
         "LEDGER_CANISTER_ID": "ryjl3-tyaaa-aaaaa-aaaba-cai"
       }


### PR DESCRIPTION
# Motivation
We need to reference the cycles minting canister sometimes, so we need to add the canister ID to the config.

# Changes
* Add the cmc canister ID, using the same name used in the main IC repo.

# Tests
This should cause no changes as it is as yet unused.