### PR TITLE
Add CODEOWNERS file (#647)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The codebase is owned by the Governance & Identity Experience team at DFINITY
+*   @dfinity/gix


### PR DESCRIPTION
The CODEOWNERS is required by @dfinity/idx in order for this repo to
accept external contributions.