### PR TITLE
feat: add keyboard navigation for card and modal

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Card.svelte
+++ b/frontend/svelte/src/lib/components/ui/Card.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
   export let role: "link" | "button" | "checkbox" | undefined = undefined;
   export let ariaLabel: string | undefined = undefined;
   export let selected: boolean = false;
   export let disabled: boolean | undefined = undefined;
   export let testId: string = "card";
 
-  let clickable: boolean = false;
+  const dispatch = createEventDispatcher();
 
   $: clickable =
     role !== undefined ? ["button", "link", "checkbox"].includes(role) : false;
@@ -15,15 +17,28 @@
 
   let ariaChecked: boolean | undefined = undefined;
   $: ariaChecked = role === "checkbox" ? selected : undefined;
+
+  // Simulate click event on pressing "space" key (https://www.w3.org/WAI/GL/wiki/Making_actions_keyboard_accessible_by_using_keyboard_event_handlers_with_WAI-ARIA_controls)
+  const keydown = (event: KeyboardEvent) => {
+    if (
+      event.key === " " &&
+      (event.target as HTMLElement).tagName === "ARTICLE"
+    ) {
+      dispatch("click");
+      event.stopPropagation();
+    }
+  };
 </script>
 
 <article
   data-tid={testId}
   {role}
   on:click
+  on:keydown={keydown}
   class:clickable
   class:selected
   class:disabled
+  tabindex={role === undefined ? undefined : 0}
   aria-disabled={disabled}
   aria-checked={ariaChecked}
   aria-label={ariaLabel}

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -17,13 +17,40 @@
   // Please do not use `showBackButton` without listening on `nnsBack`
   export let showBackButton: boolean = false;
 
+  let contentContainer: HTMLDivElement | undefined;
   let showToolbar: boolean;
   $: showToolbar = $$slots.title ?? showBackButton;
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
   const back = () => dispatch("nnsBack");
+  const keydown = (ev: KeyboardEvent) => {
+    if (visible && ev.key === "Escape") {
+      ev.stopPropagation();
+      close();
+    }
+  };
+
+  // TODO: do we need a visible feedback
+  $: visible &&
+    (() => {
+      if (contentContainer === undefined) {
+        return;
+      }
+
+      const firstFocus: HTMLElement | null = contentContainer.querySelector(
+        `[tabindex="0"],button,a,input`
+      );
+
+      if (firstFocus === null) {
+        return;
+      }
+
+      firstFocus.focus();
+    })();
 </script>
+
+<svelte:window on:keydown={keydown} />
 
 {#if visible}
   <div
@@ -66,7 +93,12 @@
         </div>
       {/if}
 
-      <div class="content" id="modalContent" class:small={size === "small"}>
+      <div
+        class="content"
+        id="modalContent"
+        class:small={size === "small"}
+        bind:this={contentContainer}
+      >
         <slot />
       </div>
 

--- a/frontend/svelte/src/lib/themes/theme.scss
+++ b/frontend/svelte/src/lib/themes/theme.scss
@@ -101,3 +101,8 @@ input::-webkit-inner-spin-button {
 input[type="number"] {
   -moz-appearance: textfield;
 }
+
+:focus-visible {
+  outline: 2px solid var(--blue-600);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
# Motivation

Provide basic keyboard navigation for the voting tab -- 

# Changes

Current state:
- focus visibility
- card click
- modal 
  - close on Esc
  - autofocus of first available content

# Screens


https://user-images.githubusercontent.com/98811342/169397061-61818a76-1bc5-45ec-9a93-f14cde4c0c0b.mov


