### PR TITLE
Fix: Don't guess if commands are specified

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -111,6 +111,7 @@ while (($# > 0)); do
     CREATE_USERS="true"
     ;;
   --open)
+    GUESS="false"
     OPEN_NNS_DAPP="true"
     ;;
   --dry-run)


### PR DESCRIPTION
# Motivation
If individual steps are specified in deploy.sh, guessing what is required should be disabled.  This is already true for most steps.

However `./deploy.sh --open` should just open the nns-dapp in a browser.  But because the `GUESS=false` that is set for all other similar flags is omitted for `--open`, this tries to deploy as well.

# Changes
- Set `GUESS=false` for `--open` in `deploy.sh`.

# Tests
- With this fix, if I run:
```
./deploy.sh --open
```
a browser opens with the nns.