### PR TITLE
Fix: Propose can load neuron

### DIFF
--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -894,8 +894,7 @@ export const loadNeuron = ({
         ...options,
       }),
     onLoad: ({ response: neuron, certified }) => {
-      // Handle not authorized neurons as if not found.
-      if (neuron === undefined || !userAuthorizedNeuron(neuron)) {
+      if (neuron === undefined) {
         catchError(new NotFoundError(`Neuron with id ${neuronId} not found`));
         return;
       }

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1211,6 +1211,7 @@ describe("neurons-services", () => {
   });
 
   describe("load neuron", () => {
+    afterEach(() => jest.clearAllMocks());
     it("should get neuron from neurons store if presented and not call queryNeuron", async () => {
       neuronsStore.pushNeurons({ neurons: [mockNeuron], certified: true });
       await loadNeuron({
@@ -1230,6 +1231,23 @@ describe("neurons-services", () => {
         setNeuron: jest.fn,
       });
       expect(spyGetNeuron).toBeCalled();
+    });
+
+    it("should call setNeuron even if the neuron doesn't have fullNeuron", async () => {
+      const neuronId = BigInt(333333);
+      const publicInfoNeuron = {
+        ...mockNeuron,
+        neuronId,
+        fullNeuron: undefined,
+      };
+      spyGetNeuron.mockImplementation(() => Promise.resolve(publicInfoNeuron));
+      const setNeuronSpy = jest.fn();
+      await loadNeuron({
+        neuronId,
+        setNeuron: setNeuronSpy,
+      });
+      expect(spyGetNeuron).toBeCalled();
+      expect(setNeuronSpy).toBeCalled();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User can see the proposer modal

# Changes

* `loadNeuron` does not check if the user is authorized or not to see the neuron.

# Tests

* Test for bug.
