### PR TITLE
E2e tidy

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -208,6 +208,32 @@ jobs:
       - name: Run linter
         run: npm run check
 
+  e2e-lint:
+    needs: formatting
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEPLOY_ENV: mainnet
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Provide a config
+        run: ./config.sh
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./e2e-tests
+
+      - name: Run e2e linter
+        run: npm run lint
+        working-directory: ./e2e-tests
+
+
+
   shell-checks:
     needs: formatting
     name: ShellCheck

--- a/e2e-tests/.eslintrc.js
+++ b/e2e-tests/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
   plugins: ["@typescript-eslint", "eslint-plugin-wdio"],
   ignorePatterns: ["node_modules", ".eslintrc.js"],
   rules: {
+    "@typescript-eslint/explicit-function-return-type": "warn",
     // https://typescript-eslint.io/rules/no-inferrable-types/
     "@typescript-eslint/no-inferrable-types": 0,
     // This allows to use `async` functions also in function types that expect `void`.

--- a/e2e-tests/common/navigator.ts
+++ b/e2e-tests/common/navigator.ts
@@ -16,7 +16,7 @@ export class MyNavigator {
     selector: string,
     description: string,
     options?: { timeout?: number }
-  ) {
+  ): Promise<WebdriverIO.Element> {
     // Sadly typescript does not prevent undefined from being provided as a selector.
     if (undefined === selector) {
       throw new Error(`Cannot get undefined selector for "${description}".`);
@@ -36,7 +36,7 @@ export class MyNavigator {
     selector: string,
     description: string,
     options?: { timeout?: number; screenshot?: boolean }
-  ) {
+  ): Promise<void> {
     // Sadly typescript does not prevent undefined from being provided as a selector.
     if (undefined === selector) {
       throw new Error(`Cannot click undefined selector for "${description}".`);
@@ -59,7 +59,7 @@ export class MyNavigator {
     selector: string,
     description: string,
     options?: { timeout?: number }
-  ) {
+  ): Promise<void> {
     if (undefined === selector) {
       throw new Error(`Cannot click undefined selector for "${description}".`);
     }
@@ -85,7 +85,7 @@ export class MyNavigator {
     selector: string,
     description: string,
     options?: { timeout?: number }
-  ) {
+  ): Promise<void> {
     if (undefined === selector) {
       throw new Error(
         `Cannot wait for undefined selector to be removed for "${description}".`

--- a/e2e-tests/common/waitForImages.ts
+++ b/e2e-tests/common/waitForImages.ts
@@ -1,4 +1,6 @@
-export const waitForImages = async (browser: WebdriverIO.Browser) =>
+export const waitForImages = async (
+  browser: WebdriverIO.Browser
+): Promise<true | void> =>
   // Wait for all images to be "complete", i.e. loaded
   browser.waitUntil(
     function (): boolean {

--- a/e2e-tests/common/waitForLoad.ts
+++ b/e2e-tests/common/waitForLoad.ts
@@ -3,7 +3,7 @@
  * we have a service worker that can load completely before
  * the actual page loads and we don't want that.
  */
-export const waitForLoad = (browser) => {
+export const waitForLoad = (browser: WebdriverIO.Browser) => {
   // Check that the page has completely loaded, and we are not in the intermediate service worker bootstrap page:
   return browser.waitUntil(
     () =>

--- a/e2e-tests/common/waitForLoad.ts
+++ b/e2e-tests/common/waitForLoad.ts
@@ -3,7 +3,9 @@
  * we have a service worker that can load completely before
  * the actual page loads and we don't want that.
  */
-export const waitForLoad = (browser: WebdriverIO.Browser) => {
+export const waitForLoad = (
+  browser: WebdriverIO.Browser
+): Promise<true | void> => {
   // Check that the page has completely loaded, and we are not in the intermediate service worker bootstrap page:
   return browser.waitUntil(
     () =>

--- a/e2e-tests/components/accounts-tab.ts
+++ b/e2e-tests/components/accounts-tab.ts
@@ -3,6 +3,10 @@ import { MyNavigator } from "../common/navigator";
 export class AccountsTab extends MyNavigator {
   static readonly SELECTOR: string = `[data-tid="accounts-body"]`; // This should be used to verify that we are on the accounts tab.
 
+  constructor(browser: WebdriverIO.Browser) {
+    super(browser);
+  }
+
   /**
    * Gets an account by account title.
    */
@@ -10,7 +14,7 @@ export class AccountsTab extends MyNavigator {
     name: string,
     description: string,
     options?: { timeout?: number }
-  ) {
+  ): Promise<WebdriverIO.Element> {
     const element = await this.browser
       .$(`${AccountsTab.SELECTOR} [data-tid="account-card"]`)
       .$(`.title=${name}`);
@@ -18,9 +22,5 @@ export class AccountsTab extends MyNavigator {
     const timeoutMsg = `Timeout after ${timeout.toLocaleString()}ms waiting for "${description}" with account "${name}"i.`;
     await element.waitForExist({ timeout, timeoutMsg });
     return element;
-  }
-
-  constructor(browser: WebdriverIO.Browser) {
-    super(browser);
   }
 }

--- a/e2e-tests/components/header.ts
+++ b/e2e-tests/components/header.ts
@@ -17,7 +17,7 @@ export class Header extends MyNavigator {
     super(browser);
   }
 
-  async getIcp(howMuch: number) {
+  async getIcp(howMuch: number): Promise<void> {
     // WARNING: If we start before the accounts have loaded this fails.  Why?  No idea.
     // Waiting later does not help, it seems as if the wait has to be before we open the getIcp modal.
     // TODO: The getICP button should not be clickable until it works.

--- a/e2e-tests/components/neurons-tab.ts
+++ b/e2e-tests/components/neurons-tab.ts
@@ -21,7 +21,10 @@ export class NeuronsTab extends MyNavigator {
 
   // TODO: There is no good way to make sure that the browser has displayed the expected modal.  The text can change due to internationalisation.
   // Ideally the modal body would have a specific data-tid so that we can be sure that we have the expected modal and are sure that any further selectors are inside that expected modal.
-  async waitForModalWithTitle(title: string, options?: { timeout?: number }) {
+  async waitForModalWithTitle(
+    title: string,
+    options?: { timeout?: number }
+  ): Promise<void> {
     const timeout = options?.timeout ?? 5_000;
     const timeoutMsg = `Timeout after ${timeout.toLocaleString()}ms waiting for modal with title "${title}".`;
     await this.browser.waitUntil(

--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -109,7 +109,7 @@ const waitForHash = async (
   browser: WebdriverIO.Browser,
   hash: string,
   options?: { timeout?: number }
-) => {
+): Promise<void> => {
   let currentHash = "";
   try {
     await browser.waitUntil(async () => {
@@ -135,7 +135,7 @@ const waitForPath = async (
   browser: WebdriverIO.Browser,
   path: string,
   options?: { timeout?: number }
-) => {
+): Promise<true | void> => {
   const timeout = options?.timeout;
   const timeoutMsg = `Timed out waiting for path to be: '${path}'`;
   return browser.waitUntil(
@@ -152,7 +152,7 @@ const waitForPath = async (
 /**
  * Describes the redirect, if any, that should occur from a given path+hash.
  */
-const redirectTestTitle = (fromPath: FrontendPath, hash: RouteHash) => {
+const redirectTestTitle = (fromPath: FrontendPath, hash: RouteHash): string => {
   const toPath = REDIRECTS[hash][fromPath];
   if (fromPath === toPath) {
     return `Remains on ${fromPath}${hash}`;
@@ -168,7 +168,7 @@ const redirectTest = async (
   browser: WebdriverIO.Browser,
   fromPath: FrontendPath,
   hash: RouteHash
-) => {
+): Promise<void> => {
   const toPath = REDIRECTS[hash][fromPath];
   await browser.url(`${fromPath}${hash}`);
   await waitForPath(browser, `${toPath}${hash}`, { timeout: 20_000 });


### PR DESCRIPTION
# Motivation
Keeping the e2e code in good shape.

# Changes
- Added the e2e linter to CI.  This did not cause any errors but it would catch errors if a contributor was careless or unaware of the linter.
- Added a rule to require function signatures, and added missing signatures.
- Minor rearrangement of code.

# Tests
I have carefully resisted making any changes to the the code, to avoid having lint and code changes in the same PR, so this PR should change nothing in the way the e2e tests are run.