### PR TITLE
Fix: Style variable instead of prop for Input

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -16,7 +16,6 @@
   export let placeholderLabelKey: string;
 
   export let theme: "dark" | "light" = "light";
-  export let withErrorMessage: boolean = false;
 
   const handleInput = ({ currentTarget }: InputEventHandler) =>
     (value =
@@ -29,7 +28,7 @@
   $: placeholder = translate({ labelKey: placeholderLabelKey });
 </script>
 
-<div class={`input-block ${theme} `} class:disabled class:withErrorMessage>
+<div class={`input-block ${theme} `} class:disabled>
   <input
     data-tid="input-ui-element"
     type={inputType}
@@ -60,7 +59,10 @@
   .input-block {
     position: relative;
 
-    margin: var(--padding-2x) 0;
+    margin-top: var(--padding-2x);
+    margin-bottom: var(--input-margin-bottom, var(--padding-2x));
+    margin-left: 0;
+    margin-right: 0;
 
     display: flex;
     align-items: center;
@@ -73,10 +75,6 @@
     }
 
     --disabled-color: var(--gray-100);
-
-    &.withErrorMessage {
-      margin-bottom: 0;
-    }
 
     &.disabled {
       color: var(--disabled-color);

--- a/frontend/svelte/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/svelte/src/lib/components/ui/InputWithError.svelte
@@ -34,7 +34,6 @@
     {placeholderLabelKey}
     {max}
     {autocomplete}
-    withErrorMessage={error}
     bind:value
     on:blur
     on:input
@@ -42,7 +41,7 @@
     <slot name="button" slot="button" />
   </Input>
 
-  {#if errorMessage !== undefined}
+  {#if error}
     <p class={`error-message ${theme}`} data-tid="input-error-message">
       <IconInfo />
       <span>
@@ -61,6 +60,7 @@
   }
 
   .error {
+    --input-margin-bottom: 0;
     --input-error-color: var(--error);
   }
 


### PR DESCRIPTION
# Motivation

Refactor `Input` and remove the prop `withErrorMessage`.

# Changes

* Use a css variable instead of a prop to change Input style.

# Tests

No test changes.
