### PR TITLE
fix: replace exponential format for ICP amount

### DIFF
--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -275,7 +275,7 @@ export const isValidInputAmount = ({
 }): boolean => amount !== undefined && amount > 0 && amount <= max;
 
 export const convertNumberToICP = (amount: number): ICP => {
-  const stake = ICP.fromString(String(amount));
+  const stake = ICP.fromString(amount.toFixed(8));
 
   if (!(stake instanceof ICP) || stake === undefined) {
     throw new InvalidAmountError();

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -660,6 +660,7 @@ describe("neuron-utils", () => {
       expect(convertNumberToICP(10)?.toE8s()).toBe(BigInt(1_000_000_000));
       expect(convertNumberToICP(10.1234)?.toE8s()).toBe(BigInt(1_012_340_000));
       expect(convertNumberToICP(0.004)?.toE8s()).toBe(BigInt(400_000));
+      expect(convertNumberToICP(0.00000001)?.toE8s()).toBe(BigInt(1));
     });
 
     it("raises error on negative numbers", () => {


### PR DESCRIPTION
# Motivation

ICP class doesn't support exponential format (e.g. "1e-8").
icp.d.ts
```ts
    /**
     * Initialize from a string. Accepted formats:
     *
     * 1234567.8901
     * 1'234'567.8901
     * 1,234,567.8901
     */
    static fromString(amount: string): ICP | FromICPStringError;
```

### Note
Refactoring suggestions are welcome.

## Before
https://user-images.githubusercontent.com/98811342/169790101-edc7935f-3262-4adc-8f4c-ab7f44f55176.mov

## After
https://user-images.githubusercontent.com/98811342/169790340-5519db02-4e39-4df0-8024-0120fc061397.mov

# Changes

- String() -->  toFixed(8) (According to validation and display formatting 8 is enough precision)

# Tests

- neuron.utils.spec `expect(convertNumberToICP(0.00000001)?.toE8s()).toBe(BigInt(1));`
