### PR TITLE
L2-608: Fix neuron stake update after transaction

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -9,6 +9,10 @@
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { transferICP } from "../../services/accounts.services";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
+  import { toastsStore } from "../../stores/toasts.store";
+
+  export let onTransactionComplete: (() => Promise<void>) | undefined =
+    undefined;
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
@@ -23,6 +27,11 @@
     startBusy({ initiator: "accounts" });
 
     const { success } = await transferICP($store);
+
+    if (success) {
+      await onTransactionComplete?.();
+      toastsStore.success({ labelKey: "accounts.transaction_success" });
+    }
 
     stopBusy("accounts");
 

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -11,13 +11,10 @@
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
   import { toastsStore } from "../../stores/toasts.store";
 
-  export let onTransactionComplete: (() => Promise<void>) | undefined =
-    undefined;
-
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
   );
-  const { store }: TransactionContext = context;
+  const { store, onTransactionComplete }: TransactionContext = context;
 
   let amount: ICPType = $store.amount ?? ICPType.fromE8s(BigInt(0));
 

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -18,6 +18,8 @@
 
   export let selectedAccount: Account | undefined = undefined;
   export let destinationAddress: string | undefined = undefined;
+  export let onTransactionComplete: (() => Promise<void>) | undefined =
+    undefined;
 
   let canSelectAccount: boolean;
   $: canSelectAccount = selectedAccount === undefined;
@@ -107,7 +109,7 @@
       <NewTransactionAmount />
     {/if}
     {#if currentStep?.name === "Review"}
-      <NewTransactionReview on:nnsClose />
+      <NewTransactionReview {onTransactionComplete} on:nnsClose />
     {/if}
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
+++ b/frontend/svelte/src/lib/modals/accounts/NewTransactionModal.svelte
@@ -75,6 +75,7 @@
   setContext<TransactionContext>(NEW_TRANSACTION_CONTEXT_KEY, {
     store: newTransactionStore,
     next: () => modal?.next(),
+    onTransactionComplete,
   });
 
   // Update store with selectedAccount in case the property would be set after the component is initialized
@@ -109,7 +110,7 @@
       <NewTransactionAmount />
     {/if}
     {#if currentStep?.name === "Review"}
-      <NewTransactionReview {onTransactionComplete} on:nnsClose />
+      <NewTransactionReview on:nnsClose />
     {/if}
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -18,7 +18,6 @@
           resolve();
         },
         handleError: () => {
-          console.log("in da error");
           resolve();
         },
       });

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -1,27 +1,11 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { loadNeuron } from "../../services/neurons.services";
-  import { neuronsStore } from "../../stores/neurons.store";
+  import { reloadNeuron } from "../../services/neurons.services";
   import NewTransactionModal from "../accounts/NewTransactionModal.svelte";
 
   export let neuron: NeuronInfo;
 
-  // Not resolve until the neuron has been loaded
-  const fetchUpdatedNeuron = () =>
-    new Promise<void>((resolve) => {
-      loadNeuron({
-        neuronId: neuron.neuronId,
-        forceFetch: true,
-        strategy: "update",
-        setNeuron: ({ neuron, certified }) => {
-          neuronsStore.pushNeurons({ neurons: [neuron], certified });
-          resolve();
-        },
-        handleError: () => {
-          resolve();
-        },
-      });
-    });
+  const fetchUpdatedNeuron = () => reloadNeuron(neuron);
 </script>
 
 <NewTransactionModal

--- a/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -5,7 +5,7 @@
 
   export let neuron: NeuronInfo;
 
-  const fetchUpdatedNeuron = () => reloadNeuron(neuron);
+  const fetchUpdatedNeuron = () => reloadNeuron(neuron.neuronId);
 </script>
 
 <NewTransactionModal

--- a/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -25,6 +25,7 @@
     // The fetched neuron doesn't belong to a user so it should not be added to the neuronsStore
     await loadNeuron({
       neuronId,
+      skipCheck: true,
       setNeuron: ({ neuron: neuronInfo }) => (neuron = neuronInfo),
       handleError: () => {
         neuron = undefined;

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -114,8 +114,6 @@ export const transferICP = async ({
 
     await syncAccounts();
 
-    toastsStore.success({ labelKey: "accounts.transaction_success" });
-
     return { success: true };
   } catch (err) {
     return transferError({ labelKey: "error.transaction_error", err });

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -942,12 +942,13 @@ export const loadNeuron = ({
 };
 
 // Not resolve until the neuron has been loaded
-export const reloadNeuron = (neuron) =>
+export const reloadNeuron = (neuronId: NeuronId) =>
   new Promise<void>((resolve) => {
     loadNeuron({
-      neuronId: neuron.neuronId,
+      neuronId,
       forceFetch: true,
       strategy: "update",
+      skipCheck: false,
       setNeuron: ({ neuron, certified }) => {
         neuronsStore.pushNeurons({ neurons: [neuron], certified });
         resolve();

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -865,7 +865,7 @@ export const removeFollowee = async ({
 export const loadNeuron = ({
   neuronId,
   forceFetch = false,
-  // Check also the Neuro stake when loading only one.
+  // Check also the Neuron's stake when loading only one.
   // Same we do when loading the list of neurons.
   skipCheck = false,
   setNeuron,
@@ -921,6 +921,7 @@ export const loadNeuron = ({
           forceFetch,
           setNeuron,
           handleError,
+          // Avoid an infinite loop skipping check
           skipCheck: true,
           strategy: "query",
         });

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -940,6 +940,23 @@ export const loadNeuron = ({
   });
 };
 
+// Not resolve until the neuron has been loaded
+export const reloadNeuron = (neuron) =>
+  new Promise<void>((resolve) => {
+    loadNeuron({
+      neuronId: neuron.neuronId,
+      forceFetch: true,
+      strategy: "update",
+      setNeuron: ({ neuron, certified }) => {
+        neuronsStore.pushNeurons({ neurons: [neuron], certified });
+        resolve();
+      },
+      handleError: () => {
+        resolve();
+      },
+    });
+  });
+
 export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
   // Only available in testnet
   if (!IS_TESTNET) {

--- a/frontend/svelte/src/lib/types/transaction.context.ts
+++ b/frontend/svelte/src/lib/types/transaction.context.ts
@@ -11,6 +11,7 @@ export interface TransactionStore {
 export interface TransactionContext {
   store: Writable<TransactionStore>;
   next: () => void;
+  onTransactionComplete?: () => Promise<void>;
 }
 
 export const NEW_TRANSACTION_CONTEXT_KEY = Symbol("new-transaction");

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
@@ -94,6 +94,24 @@ describe("NewTransactionReview", () => {
     await waitFor(() => expect(spyTransferICP).toHaveBeenCalled());
   });
 
+  it("should call complete callback", async () => {
+    const spyTransferICP = jest.spyOn(mockLedgerCanister, "transfer");
+
+    const completeTransactionSpy = jest.fn().mockResolvedValue(undefined);
+    const { container } = render(NewTransactionTest, {
+      props: { ...props, onTransactionComplete: completeTransactionSpy },
+    });
+
+    const button = container.querySelector(
+      "button[type='submit']"
+    ) as HTMLButtonElement;
+    await fireEvent.click(button);
+
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBeTruthy());
+    await waitFor(() => expect(spyTransferICP).toHaveBeenCalled());
+    await waitFor(() => expect(completeTransactionSpy).toHaveBeenCalled());
+  });
+
   it("should sync accounts after transaction executed", async () => {
     const spyGetAccount = jest.spyOn(mockNNSDappCanister, "getAccount");
 

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionTest.svelte
@@ -2,16 +2,19 @@
   import { setContext, SvelteComponent } from "svelte";
   import {
     NEW_TRANSACTION_CONTEXT_KEY,
-    TransactionContext,
+    type TransactionContext,
   } from "../../../../lib/types/transaction.context";
   import { mockTransactionStore } from "../../../mocks/transaction.store.mock";
 
   export let testComponent: typeof SvelteComponent;
-  export let nextCallback: () => void | undefined = undefined;
+  export let nextCallback: (() => void) | undefined = undefined;
+  export let onTransactionComplete: (() => Promise<void>) | undefined =
+    undefined;
 
   setContext<TransactionContext>(NEW_TRANSACTION_CONTEXT_KEY, {
     store: mockTransactionStore,
     next: () => nextCallback?.(),
+    onTransactionComplete,
   });
 </script>
 

--- a/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/NewTransactionModal.spec.ts
@@ -8,6 +8,7 @@ import { waitFor } from "@testing-library/svelte";
 import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import NewTransactionModal from "../../../../lib/modals/accounts/NewTransactionModal.svelte";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
+import { toastsStore } from "../../../../lib/stores/toasts.store";
 import {
   mockAccountsStoreSubscribe,
   mockSubAccount,
@@ -21,6 +22,7 @@ describe("NewTransactionModal", () => {
   const mockLedgerCanister: MockLedgerCanister = new MockLedgerCanister();
   const mockNNSDappCanister: MockNNSDappCanister = new MockNNSDappCanister();
 
+  let successSpy;
   beforeAll(() => {
     jest
       .spyOn(accountsStore, "subscribe")
@@ -33,6 +35,8 @@ describe("NewTransactionModal", () => {
     jest
       .spyOn(NNSDappCanister, "create")
       .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
+
+    successSpy = jest.spyOn(toastsStore, "success");
   });
 
   afterAll(() => jest.clearAllMocks());
@@ -187,5 +191,32 @@ describe("NewTransactionModal", () => {
     await fireEvent.click(button);
 
     await waitFor(() => expect(onClose).toBeCalled());
+    expect(successSpy).toBeCalled();
+  });
+
+  it("should call on complete callback if passed when transaction is executed", async () => {
+    const completeTransactionSpy = jest.fn().mockResolvedValue(undefined);
+    const { container, getByText, component } = await renderModal({
+      component: NewTransactionModal,
+      props: {
+        onTransactionComplete: completeTransactionSpy,
+      },
+    });
+
+    await goToStep2({ container, getByText });
+
+    await goToStep3({ container, getByText });
+
+    await goToStep4({ container, getByText, enterAmount: true });
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+    const button = container.querySelector(
+      "button[type='submit']"
+    ) as HTMLButtonElement;
+    await fireEvent.click(button);
+
+    await waitFor(() => expect(onClose).toBeCalled());
+    await waitFor(() => expect(completeTransactionSpy).toHaveBeenCalled());
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -7,7 +7,7 @@ import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
 import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import IncreaseNeuronStakeModal from "../../../../lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
-import { loadNeuron } from "../../../../lib/services/neurons.services";
+import { reloadNeuron } from "../../../../lib/services/neurons.services";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import {
   mockAccountsStoreSubscribe,
@@ -21,11 +21,7 @@ import { MockNNSDappCanister } from "../../../mocks/nns-dapp.canister.mock";
 
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
-    loadNeuron: jest
-      .fn()
-      .mockImplementation(({ setNeuron }) =>
-        setNeuron({ neuron: mockNeuron, certified: false })
-      ),
+    reloadNeuron: jest.fn(),
   };
 });
 
@@ -146,7 +142,7 @@ describe("IncreaseNeuronStakeModal", () => {
     });
   });
 
-  it("should call loadNeuron and close wizard once transaction executed", async () => {
+  it("should call reloadNeuron and close wizard once transaction executed", async () => {
     const { container, getByText, component } = await renderModal({
       component: IncreaseNeuronStakeModal,
       props: {
@@ -166,6 +162,6 @@ describe("IncreaseNeuronStakeModal", () => {
     await fireEvent.click(button);
 
     await waitFor(() => expect(onClose).toBeCalled());
-    expect(loadNeuron).toBeCalled();
+    expect(reloadNeuron).toBeCalled();
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
 import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import IncreaseNeuronStakeModal from "../../../../lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
+import { loadNeuron } from "../../../../lib/services/neurons.services";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import {
   mockAccountsStoreSubscribe,
@@ -20,7 +21,11 @@ import { MockNNSDappCanister } from "../../../mocks/nns-dapp.canister.mock";
 
 jest.mock("../../../../lib/services/neurons.services", () => {
   return {
-    loadNeuron: jest.fn().mockResolvedValue(undefined),
+    loadNeuron: jest
+      .fn()
+      .mockImplementation(({ setNeuron }) =>
+        setNeuron({ neuron: mockNeuron, certified: false })
+      ),
   };
 });
 
@@ -141,7 +146,7 @@ describe("IncreaseNeuronStakeModal", () => {
     });
   });
 
-  it("should close wizard once transaction executed", async () => {
+  it("should call loadNeuron and close wizard once transaction executed", async () => {
     const { container, getByText, component } = await renderModal({
       component: IncreaseNeuronStakeModal,
       props: {
@@ -161,5 +166,6 @@ describe("IncreaseNeuronStakeModal", () => {
     await fireEvent.click(button);
 
     await waitFor(() => expect(onClose).toBeCalled());
+    expect(loadNeuron).toBeCalled();
   });
 });

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -118,14 +118,6 @@ describe("accounts-services", () => {
       expect(spyLoadAccounts).toHaveBeenCalled();
     });
 
-    it("should display a successful toast after transfer ICP", async () => {
-      const spyToastSuccess = jest.spyOn(toastsStore, "success");
-
-      await transferICP(transferICPParams);
-
-      expect(spyToastSuccess).toHaveBeenCalled();
-    });
-
     it("should throw errors if transfer params not provided", async () => {
       const { err: errSelectedAccount } = await transferICP({
         ...transferICPParams,

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1280,12 +1280,12 @@ describe("neurons-services", () => {
       neuronsStore.setNeurons({ neurons: [], certified: true });
     });
     it("should call the api", async () => {
-      await reloadNeuron(mockNeuron);
+      await reloadNeuron(mockNeuron.neuronId);
       expect(spyGetNeuron).toBeCalled();
     });
 
     it("should add neuron to the store", async () => {
-      await reloadNeuron(mockNeuron);
+      await reloadNeuron(mockNeuron.neuronId);
       const store = get(neuronsStore);
       expect(
         store.neurons?.find(({ neuronId }) => neuronId === mockNeuron.neuronId)

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1228,9 +1228,29 @@ describe("neurons-services", () => {
     it("should call the api to get neuron if not in store", async () => {
       await loadNeuron({
         neuronId: mockNeuron.neuronId,
-        setNeuron: jest.fn,
+        setNeuron: jest.fn(),
       });
       expect(spyGetNeuron).toBeCalled();
+    });
+
+    it("should call the api to get neuron and check the balance on update", async () => {
+      const neuronId = BigInt(333333);
+      const controlledNeuron = {
+        ...mockNeuron,
+        neuronId,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: mockIdentity.getPrincipal().toText(),
+        },
+      };
+      spyGetNeuron.mockImplementation(() => Promise.resolve(controlledNeuron));
+      await loadNeuron({
+        neuronId,
+        setNeuron: jest.fn(),
+      });
+      await tick();
+      expect(spyGetNeuron).toBeCalled();
+      expect(spyGetNeuronBalance).toBeCalled();
     });
 
     it("should call setNeuron even if the neuron doesn't have fullNeuron", async () => {

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -43,6 +43,7 @@ const {
   stopDissolving,
   updateDelay,
   mergeNeurons,
+  reloadNeuron,
 } = services;
 
 jest.mock("../../../lib/stores/toasts.store", () => {
@@ -1268,6 +1269,27 @@ describe("neurons-services", () => {
       });
       expect(spyGetNeuron).toBeCalled();
       expect(setNeuronSpy).toBeCalled();
+      // Reset spy implementation
+      spyGetNeuron.mockImplementation(() => Promise.resolve(mockNeuron));
+    });
+  });
+
+  describe("reloadNeuron", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      neuronsStore.setNeurons({ neurons: [], certified: true });
+    });
+    it("should call the api", async () => {
+      await reloadNeuron(mockNeuron);
+      expect(spyGetNeuron).toBeCalled();
+    });
+
+    it("should add neuron to the store", async () => {
+      await reloadNeuron(mockNeuron);
+      const store = get(neuronsStore);
+      expect(
+        store.neurons?.find(({ neuronId }) => neuronId === mockNeuron.neuronId)
+      ).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User sees always new neuron stake after transaction.

# Changes

* "loadNeuron" checks balance when fetching a single neuron, same as when fetching the list of neurons.
* Check in "loadNeuron" can be skipped with `skipCheck` flag.
* "loadNeuron" also accepts the query strategy as param.
* Add a callback in the Transaction modal to be called when transaction is finished.

# Tests

* Test that the new callback in Transaction modal is called.
* Test new flags in "loadNeuron"
