### PR TITLE
merge and spawn neuron maturity sliders have label which shows ICP 

### DIFF
--- a/frontend/dart/lib/ui/neurons/detail/neuron_rewards_card.dart
+++ b/frontend/dart/lib/ui/neurons/detail/neuron_rewards_card.dart
@@ -274,6 +274,7 @@ class _NeuronMergeMaturityState extends State<NeuronMergeMaturity> {
                     child: Column(
                       children: [
                         StakeRewardsWidget(
+                          neuronMaturityICPEquivalent: widget.neuron.maturityICPEquivalent,
                           sliderValue: sliderValue.currentValue,
                           onUpdate: (value) {
                             setState(() {
@@ -359,11 +360,12 @@ class _NeuronMergeMaturityState extends State<NeuronMergeMaturity> {
 }
 
 class StakeRewardsWidget extends StatelessWidget {
+  final ICP neuronMaturityICPEquivalent;
   final int sliderValue;
   final Function(int) onUpdate;
 
   const StakeRewardsWidget(
-      {Key? key, required this.sliderValue, required this.onUpdate})
+      {Key? key, required this.neuronMaturityICPEquivalent , required this.sliderValue, required this.onUpdate})
       : super(key: key);
 
   @override
@@ -393,12 +395,13 @@ class StakeRewardsWidget extends StatelessWidget {
           height: 10,
         ),
         Slider(
+          label: (((neuronMaturityICPEquivalent.asE8s()) * BigInt.from(sliderValue))/(BigInt.from(100)* BigInt.from(E8S_PER_ICP))).toString() + ' ICP',
           activeColor: AppColors.white,
           inactiveColor: AppColors.gray600,
           value: sliderValue.toDouble(),
           min: 0,
           max: 100,
-          label: sliderValue.toString(),
+          divisions: 100,
           onChanged: (double value) {
             onUpdate(value.toInt());
           },

--- a/frontend/dart/lib/ui/neurons/detail/neuron_spawn_neuron.dart
+++ b/frontend/dart/lib/ui/neurons/detail/neuron_spawn_neuron.dart
@@ -1,3 +1,4 @@
+import 'package:nns_dapp/data/icp.dart';
 import 'package:nns_dapp/ui/_components/confirm_dialog.dart';
 import 'package:nns_dapp/ui/_components/form_utils.dart';
 import 'package:nns_dapp/ui/_components/responsive.dart';
@@ -76,6 +77,7 @@ class _SpawnNeuronState extends State<SpawnNeuron> {
                     child: Column(
                       children: [
                         SpawnNeuronStake(
+                          neuronMaturityICPEquivalent : widget.neuron.maturityICPEquivalent,
                           sliderValue: sliderValue.currentValue,
                           onUpdate: (value) {
                             setState(() {
@@ -161,10 +163,11 @@ class _SpawnNeuronState extends State<SpawnNeuron> {
 }
 
 class SpawnNeuronStake extends StatelessWidget {
+  final ICP neuronMaturityICPEquivalent;
   final int sliderValue;
   final Function(int) onUpdate;
 
-  const SpawnNeuronStake({Key? key, required this.sliderValue, required this.onUpdate}) : super(key: key);
+  const SpawnNeuronStake({Key? key, required this.neuronMaturityICPEquivalent,required this.sliderValue, required this.onUpdate}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -190,12 +193,13 @@ class SpawnNeuronStake extends StatelessWidget {
           height: 10,
         ),
         Slider(
+          label: (((neuronMaturityICPEquivalent.asE8s()) * BigInt.from(sliderValue))/(BigInt.from(100)* BigInt.from(E8S_PER_ICP))).toString() + ' ICP',
           activeColor: AppColors.white,
           inactiveColor: AppColors.gray600,
           value: sliderValue.toDouble(),
           min: 0,
           max: 100,
-          label: sliderValue.toString(),
+          divisions: 100,
           onChanged: (double value) {
             onUpdate(value.toInt());
           },


### PR DESCRIPTION


# Motivation

merge and spawn neuron maturity sliders will now show the maturity ICP equivalent as label. 
So that users can make out how much of the of their maturity ICP is being used,

# Changes

![IMG_20220524_113447](https://user-images.githubusercontent.com/58399007/170013775-1585f6df-4bbf-4915-869b-54a1bd27279d.jpg)


