### PR TITLE
feat: load neurons after sign-in

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -21,6 +21,7 @@
   import BusyScreen from "./lib/components/ui/BusyScreen.svelte";
   import { worker } from "./lib/services/worker.services";
   import { bindDebugGenerator } from "./lib/utils/dev.utils";
+  import { listNeurons } from "./lib/services/neurons.services";
 
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
@@ -35,7 +36,7 @@
         return;
       }
 
-      await syncAccounts();
+      await Promise.all([syncAccounts(), listNeurons()]);
     }
   );
 

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -9,8 +9,7 @@
   import NeuronCard from "../lib/components/neurons/NeuronCard.svelte";
   import CreateNeuronModal from "../lib/modals/neurons/CreateNeuronModal.svelte";
   import type { NeuronId } from "@dfinity/nns";
-  import { listNeurons } from "../lib/services/neurons.services";
-  import { sortedNeuronStore } from "../lib/stores/neurons.store";
+  import {neuronsStore, sortedNeuronStore} from "../lib/stores/neurons.store";
   import { routeStore } from "../lib/stores/route.store";
   import {
     AppPath,
@@ -20,14 +19,13 @@
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
 
   let isLoading: boolean = false;
+  $: isLoading = $neuronsStore.neurons === undefined;
+
   onMount(async () => {
     // TODO: To be removed once this page has been implemented
     if (!SHOW_NEURONS_ROUTE) {
       window.location.replace("/#/neurons");
     }
-    isLoading = true;
-    await listNeurons();
-    isLoading = false;
   });
 
   let principalText: string = "";

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -9,7 +9,7 @@
   import NeuronCard from "../lib/components/neurons/NeuronCard.svelte";
   import CreateNeuronModal from "../lib/modals/neurons/CreateNeuronModal.svelte";
   import type { NeuronId } from "@dfinity/nns";
-  import {neuronsStore, sortedNeuronStore} from "../lib/stores/neurons.store";
+  import { neuronsStore, sortedNeuronStore } from "../lib/stores/neurons.store";
   import { routeStore } from "../lib/stores/route.store";
   import {
     AppPath,

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { ICP, LedgerCanister } from "@dfinity/nns";
+import { GovernanceCanister, ICP, LedgerCanister } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 import App from "../App.svelte";
@@ -15,6 +15,7 @@ import {
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "./mocks/auth.store.mock";
+import { mockNeuron } from "./mocks/neurons.mock";
 
 jest.mock("../lib/services/worker.services", () => ({
   worker: {
@@ -25,8 +26,9 @@ jest.mock("../lib/services/worker.services", () => ({
 describe("App", () => {
   const mockLedgerCanister = mock<LedgerCanister>();
   const mockNNSDappCanister = mock<NNSDappCanister>();
+  const mockGovernanceCanister = mock<GovernanceCanister>();
 
-  beforeEach(() => {
+  beforeAll(() => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mutableMockAuthStoreSubscribe);
@@ -38,18 +40,27 @@ describe("App", () => {
     jest
       .spyOn(NNSDappCanister, "create")
       .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
+
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    mockCanisters();
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
+  afterAll(() => {
+    jest.clearAllMocks();
   });
 
-  it("should synchronize the accounts after sign in", async () => {
+  const mockCanisters = () => {
     mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
     mockLedgerCanister.accountBalance.mockResolvedValue(
       ICP.fromString("1") as ICP
     );
+    mockGovernanceCanister.listNeurons.mockResolvedValue([mockNeuron]);
+  };
 
+  it("should synchronize the accounts after sign in", async () => {
     render(App);
 
     authStoreMock.next({
@@ -58,6 +69,8 @@ describe("App", () => {
 
     // query + update calls
     const numberOfCalls = 2;
+
+    const numberOfCheckNeuronsBalance = 1;
 
     await waitFor(() =>
       expect(mockNNSDappCanister.addAccount).toHaveBeenCalledTimes(
@@ -73,17 +86,29 @@ describe("App", () => {
 
     await waitFor(() =>
       expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(
+        numberOfCalls + numberOfCheckNeuronsBalance
+      )
+    );
+  });
+
+  it("should synchronize the neurons after sign in", async () => {
+    render(App);
+
+    authStoreMock.next({
+      identity: mockIdentity,
+    });
+
+    // query + update calls
+    const numberOfCalls = 2;
+
+    await waitFor(() =>
+      expect(mockGovernanceCanister.listNeurons).toHaveBeenCalledTimes(
         numberOfCalls
       )
     );
   });
 
   it("should register auth worker sync after sign in", async () => {
-    mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
-    mockLedgerCanister.accountBalance.mockResolvedValue(
-      ICP.fromString("1") as ICP
-    );
-
     render(App);
 
     authStoreMock.next({


### PR DESCRIPTION
# Motivation

Some users feel like voting is currently a bit slow because the neurons have to be loaded. This behavior happens because most user jump in the "Voting" tab in svelte from the other tabs that are still written with "Flutter".

e.g. user sign in -> flutter -> load neurons in the background -> go to "voting" tab -> select proposal -> neurons have to be loaded again

It will be improved once we will have launch the other tabs rewritten in Svelte. However, in current implementation, the neurons - unlike the accounts - are not loaded after each sign-in but "only" when user access the "Neurons" tab.

This PR change this behavior by loading the neurons after each sign-in. This behavior is identical to what Flutter does and has for end effect to make feel that the proposal detail page is faster because often the neurons would have been already loaded when accessed the page.

e.g. user sign in -> svelte -> load neurons -> go to "voting" tab -> select proposal -> neurons are most probably already loaded or needs few time to finish to be loaded

# Changes

- call `listNeurons()` from `App` after sign-in
