### PR TITLE
L2-335: List CanisterCards

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -22,6 +22,7 @@
   import { worker } from "./lib/services/worker.services";
   import { bindDebugGenerator } from "./lib/utils/dev.utils";
   import { listNeurons } from "./lib/services/neurons.services";
+  import CanisterDetail from "./routes/CanisterDetail.svelte";
 
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
@@ -68,6 +69,7 @@
   <PrivateRoute path={AppPath.Wallet} component={Wallet} />
   <PrivateRoute path={AppPath.ProposalDetail} component={ProposalDetail} />
   <PrivateRoute path={AppPath.NeuronDetail} component={NeuronDetail} />
+  <PrivateRoute path={AppPath.CanisterDetail} component={CanisterDetail} />
 </Guard>
 
 <Toasts />

--- a/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
+  import Card from "../ui/Card.svelte";
+
+  export let canister: CanisterDetails;
+  export let role: undefined | "link" | "button" | "checkbox" = undefined;
+  export let ariaLabel: string | undefined = undefined;
+
+  let canisterId: string;
+  $: canisterId = canister.canister_id.toText();
+  let title: string;
+  $: title = canister.name.length > 0 ? canister.name : canisterId;
+</script>
+
+<Card {role} {ariaLabel} on:click testId="canister-card">
+  <h3 slot="start">{title}</h3>
+  <p>{canisterId}</p>
+</Card>

--- a/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
@@ -8,11 +8,13 @@
 
   let canisterId: string;
   $: canisterId = canister.canister_id.toText();
-  let title: string;
-  $: title = canister.name.length > 0 ? canister.name : canisterId;
+  let validName: boolean;
+  $: validName = canister.name.length > 0;
 </script>
 
 <Card {role} {ariaLabel} on:click testId="canister-card">
-  <h3 slot="start">{title}</h3>
-  <p>{canisterId}</p>
+  <h3 slot="start">{validName ? canister.name : canisterId}</h3>
+  {#if validName}
+    <p>{canisterId}</p>
+  {/if}
 </Card>

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -7,6 +7,7 @@ export enum AppPath {
   Wallet = "/#/wallet",
   ProposalDetail = "/#/proposal",
   NeuronDetail = "/#/neuron",
+  CanisterDetail = "/#/canister",
 }
 
 // See the [README.md](../../../../../README.md) for when each tab should be shown in svelte.

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -251,7 +251,11 @@
     "step2": "Link canisters to your account",
     "step3": "Send cycles to canisters",
     "principal_is": "Your principal id is",
-    "create_or_link": "Create or Link Canister"
+    "create_or_link": "Create or Link Canister",
+    "empty": "No canisters yet."
+  },
+  "canister_detail": {
+    "title": "Canister"
   },
   "topics": {
     "Unspecified": "Unspecified",

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -10,12 +10,13 @@ export const listCanisters = async ({
   clearBeforeQuery?: boolean;
 }) => {
   if (clearBeforeQuery === true) {
-    canistersStore.setCanisters([]);
+    canistersStore.setCanisters({ canisters: [], certified: true });
   }
 
   return queryAndUpdate<CanisterDetails[], unknown>({
     request: (options) => queryCanisters(options),
-    onLoad: ({ response: canisters }) => canistersStore.setCanisters(canisters),
+    onLoad: ({ response: canisters, certified }) =>
+      canistersStore.setCanisters({ canisters, certified }),
     onError: ({ error: err, certified }) => {
       console.error(err);
 
@@ -24,7 +25,7 @@ export const listCanisters = async ({
       }
 
       // Explicitly handle only UPDATE errors
-      canistersStore.setCanisters([]);
+      canistersStore.setCanisters({ canisters: [], certified: true });
 
       toastsStore.error({
         labelKey: "error.list_canisters",

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -10,7 +10,7 @@ export const listCanisters = async ({
   clearBeforeQuery?: boolean;
 }) => {
   if (clearBeforeQuery === true) {
-    canistersStore.setCanisters({ canisters: [], certified: true });
+    canistersStore.setCanisters({ canisters: undefined, certified: true });
   }
 
   return queryAndUpdate<CanisterDetails[], unknown>({

--- a/frontend/svelte/src/lib/services/debug.services.ts
+++ b/frontend/svelte/src/lib/services/debug.services.ts
@@ -51,7 +51,7 @@ export const generateDebugLog = async () => {
     },
     sortedNeuron: await mapPromises(sortedNeuron, anonymizeNeuronInfo),
     knownNeurons: await mapPromises(knownNeurons, anonymizeKnownNeuron),
-    canisters: await mapPromises(canisters, anonymizeCanister),
+    canisters: await mapPromises(canisters.canisters, anonymizeCanister),
     proposals: {
       proposals: await mapPromises(proposals?.proposals, anonymizeProposal),
       certified: proposals?.certified,

--- a/frontend/svelte/src/lib/stores/canisters.store.ts
+++ b/frontend/svelte/src/lib/stores/canisters.store.ts
@@ -1,8 +1,8 @@
 import { writable } from "svelte/store";
-import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
+import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
 
 export interface CanistersStore {
-  canisters: CanisterDetails[] | undefined;
+  canisters: CanisterInfo[] | undefined;
   certified: boolean | undefined;
 }
 
@@ -21,7 +21,7 @@ const initCanistersStore = () => {
     subscribe,
 
     setCanisters({ canisters, certified }: CanistersStore) {
-      set({ canisters: [...(canisters || [])], certified });
+      set({ canisters, certified });
     },
   };
 };

--- a/frontend/svelte/src/lib/stores/canisters.store.ts
+++ b/frontend/svelte/src/lib/stores/canisters.store.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 
 export interface CanistersStore {
-  canisters: CanisterDetails[];
+  canisters: CanisterDetails[] | undefined;
   certified: boolean | undefined;
 }
 
@@ -13,7 +13,7 @@ export interface CanistersStore {
  */
 const initCanistersStore = () => {
   const { subscribe, set } = writable<CanistersStore>({
-    canisters: [],
+    canisters: undefined,
     certified: undefined,
   });
 
@@ -21,7 +21,7 @@ const initCanistersStore = () => {
     subscribe,
 
     setCanisters({ canisters, certified }: CanistersStore) {
-      set({ canisters: [...canisters], certified });
+      set({ canisters: [...(canisters || [])], certified });
     },
   };
 };

--- a/frontend/svelte/src/lib/stores/canisters.store.ts
+++ b/frontend/svelte/src/lib/stores/canisters.store.ts
@@ -1,19 +1,27 @@
 import { writable } from "svelte/store";
 import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 
+export interface CanistersStore {
+  canisters: CanisterDetails[];
+  certified: boolean | undefined;
+}
+
 /**
  * A store that contains the canisters of the users
  *
  * - setCanisters: replace the current list of canisters with a new list (can be the effective list of canisters or empty)
  */
 const initCanistersStore = () => {
-  const { subscribe, set } = writable<CanisterDetails[]>([]);
+  const { subscribe, set } = writable<CanistersStore>({
+    canisters: [],
+    certified: undefined,
+  });
 
   return {
     subscribe,
 
-    setCanisters(canisters: CanisterDetails[]) {
-      set([...canisters]);
+    setCanisters({ canisters, certified }: CanistersStore) {
+      set({ canisters: [...canisters], certified });
     },
   };
 };

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -266,6 +266,11 @@ interface I18nCanisters {
   step3: string;
   principal_is: string;
   create_or_link: string;
+  empty: string;
+}
+
+interface I18nCanister_detail {
+  title: string;
 }
 
 interface I18nTopics {
@@ -471,6 +476,7 @@ interface I18n {
   follow_neurons: I18nFollow_neurons;
   voting: I18nVoting;
   canisters: I18nCanisters;
+  canister_detail: I18nCanister_detail;
   topics: I18nTopics;
   rewards: I18nRewards;
   status: I18nStatus;

--- a/frontend/svelte/src/lib/utils/app-path.utils.ts
+++ b/frontend/svelte/src/lib/utils/app-path.utils.ts
@@ -6,6 +6,7 @@ const mapper: Record<string, string> = {
   [AppPath.Wallet]: `${AppPath.Wallet}/[a-zA-Z0-9]+`,
   [AppPath.ProposalDetail]: `${AppPath.ProposalDetail}/[0-9]+`,
   [AppPath.NeuronDetail]: `${AppPath.NeuronDetail}/[0-9]+`,
+  [AppPath.CanisterDetail]: `${AppPath.CanisterDetail}/[a-zA-Z0-9-]+`,
 };
 
 const pathValidation = (path: AppPath): string => mapper[path] ?? path;

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import HeadlessLayout from "../lib/components/common/HeadlessLayout.svelte";
+  import {
+    AppPath,
+    SHOW_CANISTERS_ROUTE,
+  } from "../lib/constants/routes.constants";
+  import { i18n } from "../lib/stores/i18n";
+  import { routeStore } from "../lib/stores/route.store";
+
+  onMount(async () => {
+    if (!SHOW_CANISTERS_ROUTE) {
+      window.location.replace("/#/canisters");
+    }
+  });
+
+  const goBack = () => {
+    routeStore.navigate({
+      path: AppPath.Canisters,
+    });
+  };
+  // TODO: setup details page: https://dfinity.atlassian.net/browse/L2-334
+  // TODO: canister details card UI: https://dfinity.atlassian.net/browse/L2-599
+</script>
+
+{#if SHOW_CANISTERS_ROUTE}
+  <HeadlessLayout on:nnsBack={goBack}>
+    <svelte:fragment slot="header"
+      >{$i18n.canister_detail.title}</svelte:fragment
+    >
+    <section />
+  </HeadlessLayout>
+{/if}

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -16,11 +16,7 @@
   import type { CanisterId } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import { routeStore } from "../lib/stores/route.store";
 
-  let loading: boolean = false;
-
   const loadCanisters = async () => {
-    loading = true;
-
     try {
       await listCanisters({
         clearBeforeQuery: true,
@@ -31,8 +27,6 @@
         err,
       });
     }
-
-    loading = false;
   };
 
   onMount(async () => {
@@ -49,10 +43,10 @@
     });
   };
 
+  let loading: boolean;
+  $: loading = $canistersStore.canisters === undefined;
   let noCanisters: boolean;
-  $: loading,
-    $canistersStore,
-    (noCanisters = !loading && $canistersStore.canisters.length === 0);
+  $: noCanisters = !loading && $canistersStore.canisters?.length === 0;
 
   // TODO: TBD https://dfinity.atlassian.net/browse/L2-227
   const createOrLink = () => alert("Create or Link");
@@ -72,7 +66,7 @@
         {$authStore.identity?.getPrincipal().toText()}
       </p>
 
-      {#each $canistersStore.canisters as canister}
+      {#each $canistersStore.canisters ?? [] as canister}
         <CanisterCard
           role="link"
           ariaLabel={$i18n.neurons.aria_label_neuron_card}

--- a/frontend/svelte/src/tests/lib/components/canisters/CanisterCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/CanisterCard.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import CanisterCard from "../../../../lib/components/canisters/CanisterCard.svelte";
+import { mockCanister } from "../../../mocks/canisters.mock";
+
+describe("CanisterCard", () => {
+  it("renders a Card", () => {
+    const { queryByTestId } = render(CanisterCard, {
+      props: { canister: mockCanister },
+    });
+
+    const element = queryByTestId("canister-card");
+    expect(element).toBeInTheDocument();
+  });
+
+  it("is clickable", async () => {
+    const spyClick = jest.fn();
+    const { container, component } = render(CanisterCard, {
+      props: { canister: mockCanister },
+    });
+    component.$on("click", spyClick);
+
+    const articleElement = container.querySelector("article");
+
+    articleElement && (await fireEvent.click(articleElement));
+
+    expect(spyClick).toBeCalled();
+  });
+
+  it("renders role and aria-label passed", async () => {
+    const role = "link";
+    const ariaLabel = "test label";
+    const { container } = render(CanisterCard, {
+      props: {
+        canister: mockCanister,
+        role,
+        ariaLabel,
+      },
+    });
+
+    const articleElement = container.querySelector("article");
+
+    expect(articleElement?.getAttribute("role")).toBe(role);
+    expect(articleElement?.getAttribute("aria-label")).toBe(ariaLabel);
+  });
+
+  it("renders the canister name if present", async () => {
+    const canisterName = "Da best Canister";
+    const { getByText } = render(CanisterCard, {
+      props: {
+        canister: { ...mockCanister, name: canisterName },
+      },
+    });
+    expect(getByText(canisterName)).toBeInTheDocument();
+  });
+
+  it("renders the canister id in text if name is empty string", async () => {
+    const { queryAllByText } = render(CanisterCard, {
+      props: {
+        canister: { ...mockCanister, name: "" },
+      },
+    });
+    expect(
+      queryAllByText(mockCanister.canister_id.toText()).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the canister id", async () => {
+    const { queryAllByText } = render(CanisterCard, {
+      props: {
+        canister: mockCanister,
+      },
+    });
+    expect(
+      queryAllByText(mockCanister.canister_id.toText()).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -19,8 +19,8 @@ describe("canisters-services", () => {
 
     expect(spyQueryCanisters).toHaveBeenCalled();
 
-    const canisters = get(canistersStore);
-    expect(canisters).toEqual(mockCanisters);
+    const store = get(canistersStore);
+    expect(store.canisters).toEqual(mockCanisters);
   });
 
   it("should not list canisters if no identity", async () => {

--- a/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
@@ -12,9 +12,9 @@ describe("canisters-store", () => {
 
   it("should reset canisters", () => {
     canistersStore.setCanisters({ canisters: mockCanisters, certified: true });
-    canistersStore.setCanisters({ canisters: [], certified: true });
+    canistersStore.setCanisters({ canisters: undefined, certified: true });
 
     const store = get(canistersStore);
-    expect(store.canisters).toEqual([]);
+    expect(store.canisters).toBeUndefined();
   });
 });

--- a/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
@@ -4,17 +4,17 @@ import { mockCanisters } from "../../mocks/canisters.mock";
 
 describe("canisters-store", () => {
   it("should set canisters", () => {
-    canistersStore.setCanisters(mockCanisters);
+    canistersStore.setCanisters({ canisters: mockCanisters, certified: true });
 
-    const canisters = get(canistersStore);
-    expect(canisters).toEqual(mockCanisters);
+    const store = get(canistersStore);
+    expect(store.canisters).toEqual(mockCanisters);
   });
 
   it("should reset canisters", () => {
-    canistersStore.setCanisters(mockCanisters);
-    canistersStore.setCanisters([]);
+    canistersStore.setCanisters({ canisters: mockCanisters, certified: true });
+    canistersStore.setCanisters({ canisters: [], certified: true });
 
-    const canisters = get(canistersStore);
-    expect(canisters).toEqual([]);
+    const store = get(canistersStore);
+    expect(store.canisters).toEqual([]);
   });
 });

--- a/frontend/svelte/src/tests/mocks/canisters.mock.ts
+++ b/frontend/svelte/src/tests/mocks/canisters.mock.ts
@@ -1,17 +1,23 @@
 import { Principal } from "@dfinity/principal";
+import type { Subscriber } from "svelte/store";
 import {
   CanisterStatus,
   type CanisterDetails,
 } from "../../lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "../../lib/canisters/nns-dapp/nns-dapp.types";
+import type { CanistersStore } from "../../lib/stores/canisters.store";
 import { mockIdentity } from "./auth.store.mock";
 
+export const mockCanister = {
+  name: "",
+  canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+};
 export const mockCanisters: CanisterInfo[] = [
   {
     name: "test1",
     canister_id: Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai"),
   },
-  { name: "", canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai") },
+  mockCanister,
 ];
 
 export const mockCanisterDetails: CanisterDetails = {
@@ -25,4 +31,12 @@ export const mockCanisterDetails: CanisterDetails = {
     memoryAllocation: BigInt(1000),
     computeAllocation: BigInt(2000),
   },
+};
+
+export const mockCanistersStoreSubscribe = (
+  run: Subscriber<CanistersStore>
+): (() => void) => {
+  run({ canisters: mockCanisters, certified: true });
+
+  return () => undefined;
 };

--- a/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import CanisterDetail from "../../routes/CanisterDetail.svelte";
+import en from "../mocks/i18n.mock";
+
+describe("CanisterDetail", () => {
+  it("should render title", () => {
+    const { getByText } = render(CanisterDetail);
+
+    expect(getByText(en.canister_detail.title)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Motivation

User can see the attached canisters in a list of cards.

# Changes

* New component "CanisterCard".
* New route "CanisterDetails". Empty for now with TODOs inside.
* Add new route to the accepted routes.
* Change in the canisters store to also keep whether the data is "certified" or not. Following the other store patterns.

# Tests

* Test for the new components: CanisterCard and route CanisterDetails.
* Extend route Canisters testing.
* Fix canisters store tests.
