### PR TITLE
Debug store trigger

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -8,7 +8,7 @@
   import Canisters from "./routes/Canisters.svelte";
   import Auth from "./routes/Auth.svelte";
   import type { Unsubscriber } from "svelte/types/runtime/store";
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import { authStore } from "./lib/stores/auth.store";
   import type { AuthStore } from "./lib/stores/auth.store";
   import Wallet from "./routes/Wallet.svelte";
@@ -20,7 +20,6 @@
   import NeuronDetail from "./routes/NeuronDetail.svelte";
   import BusyScreen from "./lib/components/ui/BusyScreen.svelte";
   import { worker } from "./lib/services/worker.services";
-  import { bindDebugGenerator } from "./lib/utils/dev.utils";
 
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
@@ -48,9 +47,6 @@
       routeStore.replace({ path: AppPath.Accounts });
     }
   );
-
-  // bind the debug trigger after app initialization
-  onMount(bindDebugGenerator);
 
   onDestroy(() => {
     unsubscribeAuth();

--- a/frontend/svelte/src/lib/components/common/Header.svelte
+++ b/frontend/svelte/src/lib/components/common/Header.svelte
@@ -3,6 +3,7 @@
   import { i18n } from "../../stores/i18n";
   import GetICPs from "../ic/GetICPs.svelte";
   import { IS_TESTNET } from "../../constants/environment.constants";
+  import { triggerDebugReport } from "../../utils/dev.utils";
 </script>
 
 <header>
@@ -10,7 +11,7 @@
     <GetICPs />
   {/if}
 
-  <h4>{$i18n.header.title}</h4>
+  <h4 use:triggerDebugReport>{$i18n.header.title}</h4>
   <Logout />
 </header>
 

--- a/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
+++ b/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
@@ -5,6 +5,7 @@
   import Tooltip from "../ui/Tooltip.svelte";
   import Footer from "./Footer.svelte";
   import Banner from "./Banner.svelte";
+  import { triggerDebugReport } from "../../utils/dev.utils";
 
   export let showFooter = true;
 
@@ -21,7 +22,7 @@
       aria-label={$i18n.core.back}><IconBackIosNew /></button
     >
   </Tooltip>
-  <h2><slot name="header" /></h2>
+  <h2 use:triggerDebugReport><slot name="header" /></h2>
 </header>
 <main>
   <slot />

--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
   import { busy, busyMessageKey } from "../../stores/busy.store";
+  import { triggerDebugReport } from "../../utils/dev.utils";
   import { translate } from "../../utils/i18n.utils";
   import Spinner from "./Spinner.svelte";
 </script>
@@ -12,7 +13,7 @@
       {#if $busyMessageKey !== undefined}
         <p>{translate({ labelKey: $busyMessageKey })}</p>
       {/if}
-      <span>
+      <span use:triggerDebugReport>
         <Spinner inline />
       </span>
     </div>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -15,7 +15,8 @@
     "amount": "Amount",
     "max": "Max",
     "principal": "Principal",
-    "toggle": "toggle"
+    "toggle": "toggle",
+    "save_log_file": "Save the app state to the file"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -6,6 +6,7 @@
   import IconBackIosNew from "../icons/IconBackIosNew.svelte";
   import { i18n } from "../stores/i18n";
   import { busy } from "../stores/busy.store";
+  import { triggerDebugReport } from "../utils/dev.utils";
 
   export let visible: boolean = true;
   export let theme: "dark" | "light" = "light";
@@ -56,7 +57,7 @@
               disabled={$busy}><IconBackIosNew /></button
             >
           {/if}
-          <h3 id="modalTitle"><slot name="title" /></h3>
+          <h3 id="modalTitle" use:triggerDebugReport><slot name="title" /></h3>
           <button
             data-tid="close-modal"
             on:click|stopPropagation={close}

--- a/frontend/svelte/src/lib/proxy/debug.services.proxy.ts
+++ b/frontend/svelte/src/lib/proxy/debug.services.proxy.ts
@@ -1,7 +1,9 @@
 const importDebugServices = () => import("../services/debug.services");
 
-export const generateDebugLogProxy = async (): Promise<void> => {
+export const generateDebugLogProxy = async (
+  safeToFile: boolean
+): Promise<void> => {
   const { generateDebugLog } = await importDebugServices();
 
-  return generateDebugLog();
+  return generateDebugLog(safeToFile);
 };

--- a/frontend/svelte/src/lib/services/debug.services.ts
+++ b/frontend/svelte/src/lib/services/debug.services.ts
@@ -19,7 +19,7 @@ import { mapPromises, stringifyJson } from "../utils/utils";
  * 2. log it in the dev console
  * 3. generates a json file with logged context
  */
-export const generateDebugLog = async () => {
+export const generateDebugLog = async (safeToFile: boolean) => {
   const debugStore = initDebugStore();
   const {
     route,
@@ -99,10 +99,13 @@ export const generateDebugLog = async () => {
   const anonymizedStateAsText = stringifyJson(anonymizedState, {
     indentation: 2,
   });
+
   console.log(date, anonymizedStateAsText);
-  // saveToFile(anonymizedStateAsText, `${date}_nns-local-state.json`);
-  saveToJSONFile({
-    blob: new Blob([anonymizedStateAsText]),
-    filename: `${date}_nns-local-state.json`,
-  });
+
+  if (safeToFile) {
+    saveToJSONFile({
+      blob: new Blob([anonymizedStateAsText]),
+      filename: `${date}_nns-local-state.json`,
+    });
+  }
 };

--- a/frontend/svelte/src/lib/stores/debug.store.ts
+++ b/frontend/svelte/src/lib/stores/debug.store.ts
@@ -44,6 +44,7 @@ export const debugSelectedAccountStore = (
 export const initDebugStore = () =>
   derived(
     [
+      // TODO (L2-611): anonymise wallet id and neuron ids
       routeStore,
       accountsStore,
       sortedNeuronStore,

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -19,6 +19,7 @@ interface I18nCore {
   max: string;
   principal: string;
   toggle: string;
+  save_log_file: string;
 }
 
 interface I18nError {

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -72,7 +72,6 @@ export function triggerDebugReport(node: HTMLElement) {
 
   return {
     destroy() {
-      stop();
       node.style.touchAction = originalTouchActionValue;
       node.removeEventListener("click", click, false);
     },

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -1,4 +1,6 @@
+import { get } from "svelte/store";
 import { generateDebugLogProxy } from "../proxy/debug.services.proxy";
+import { i18n } from "../stores/i18n";
 
 export const isNode = (): boolean =>
   typeof process !== "undefined" &&
@@ -59,7 +61,7 @@ export function triggerDebugReport(node: HTMLElement) {
       count++;
 
       if (count === 5) {
-        generateDebugLogProxy(confirm("Save the app state to the file"));
+        generateDebugLogProxy(confirm(get(i18n).core.save_log_file));
       }
     } else {
       startTime = now;

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -47,7 +47,7 @@ export const digestText = async (text: string): Promise<string> => {
  */
 export function triggerDebugReport(node: HTMLElement) {
   const TWO_SECONDS = 2 * 1000;
-  const originalUserSelectValue: string = node.style.userSelect;
+  const originalTouchActionValue: string = node.style.touchAction;
 
   let startTime: number = 0;
   let count = 0;
@@ -59,7 +59,7 @@ export function triggerDebugReport(node: HTMLElement) {
       count++;
 
       if (count === 5) {
-        generateDebugLogProxy(confirm("Save the app state to the file")).then();
+        generateDebugLogProxy(confirm("Save the app state to the file"));
       }
     } else {
       startTime = now;
@@ -67,17 +67,14 @@ export function triggerDebugReport(node: HTMLElement) {
     }
   };
 
-  node.addEventListener("click", click, true);
-
-  // disable text selection
-  node.style.userSelect = "none";
+  node.style.touchAction = "manipulation";
+  node.addEventListener("click", click, { passive: true });
 
   return {
     destroy() {
       stop();
-      node.removeEventListener("click", click, true);
-      // restore user selection
-      node.style.userSelect = originalUserSelectValue;
+      node.style.touchAction = originalTouchActionValue;
+      node.removeEventListener("click", click, false);
     },
   };
 }


### PR DESCRIPTION
# Motivation

To be able to get the debug log also on mobile devices the trigger was added to the headlines and the busy spinner (see [descriptions](https://www.notion.so/Debug-state-trigger-99c2bcdd972c48fbbcdcea98965ba76b))

# Changes

- `triggerDebugReport` directive
- confirm dialog before log

# Tests

only manual