### PR TITLE
Build patched CMC canister and deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Create initial state
         run: |
-          ./deploy.sh --users
+          ./deploy.sh --populate
 
       - name: Build proxy
         working-directory: proxy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ env:
       FLUTTER_VERSION: 2.2.3
       IC_CDK_OPTIMIZER_VERSION: 0.3.1
       IC_COMMIT: 6dc5e2dcb50569e20891af02b846a7d9a58e3489
+      NNS_CACHING_KEY: dv-0004
 
 jobs:
   nns_canisters:
@@ -32,7 +33,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0003"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-${{ env.NNS_CACHING_KEY }}"
 
       - name: Download prebuilt nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
@@ -70,7 +71,9 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0003"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-${{ env.NNS_CACHING_KEY }}"
+      - name: Show canister versions
+        run: sha256sum target/ic/*.wasm
 
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( e2e-tests/scripts/nns-canister.* )}}-dv-0002"
 
       - name: Download prebuilt nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
@@ -67,7 +67,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( e2e-tests/scripts/nns-canister.* )}}-dv-0002"
 
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,16 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get cached nns canisters
-        id: create_nns_canister_cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-${{ env.NNS_CACHING_KEY }}"
-      - name: Show canister versions
-        run: sha256sum target/ic/*.wasm
-
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no
       # "restore-keys"-style matching). Because (in case of an exact match)
@@ -117,6 +107,15 @@ jobs:
         run: |
           dfx start --background --clean
 
+      - name: Get cached nns canisters
+        id: create_nns_canister_cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            target/ic
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-${{ env.NNS_CACHING_KEY }}"
+      - name: Show canister versions
+        run: sha256sum target/ic/*.wasm
       # IDENTITY_SERVICE_URL needs to match `e2e-tests/test.js`
       # REDIRECT_TO_LEGACY=svelte builds and deploys only Svelte
       - name: Deploy NNS canisters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0001"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0002"
 
       - name: Download prebuilt nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
@@ -67,7 +67,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0001"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-dv-0002"
 
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0003"
 
       - name: Download prebuilt nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
@@ -54,6 +54,9 @@ jobs:
           cache-to: type=gha,scope=cached-stage,mode=max
           outputs: target/ic
 
+      - name: Show canister versions
+        run: sha256sum target/ic/*.wasm
+
   build:
     needs: [nns_canisters]
     runs-on: ubuntu-20.04
@@ -67,7 +70,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0003"
 
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( e2e-tests/scripts/nns-canister.* )}}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0002"
 
       - name: Download prebuilt nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
@@ -67,7 +67,7 @@ jobs:
         with:
           path: |
             target/ic
-          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( e2e-tests/scripts/nns-canister.* )}}-dv-0002"
+          key: "nns-canisters-${{ env.IC_COMMIT }}-${{hashFiles( 'e2e-tests/scripts/nns-canister.*' )}}-dv-0002"
 
       # Cache based on the Cargo.lock
       # The cache key is always an exact match or no match (i.e. no

--- a/deploy.sh
+++ b/deploy.sh
@@ -208,9 +208,13 @@ if [[ "$POPULATE" == "true" ]]; then
   # Set the cycles exchange rate - needs a patched cycles minting canister.
   ./scripts/set-xdr-conversion-rate
 
+  # Allow the cmc canister to create canisters anywhere.
+  # Note: The proposal is acepted and executed immediately because there are no neurons apart from the test user.
+  ./scripts/propose --to set-authorized-subnetworks --dfx-network "$DFX_NETWORK"
+
+  # Create users and neurons
   pushd e2e-tests
   npm ci
-  
   printf '%s\n' user-N01-neuron-created.e2e.ts |
     SCREENSHOT=1 xargs -I {} npm run test -- --spec "./specs/{}"
   popd

--- a/deploy.sh
+++ b/deploy.sh
@@ -60,7 +60,7 @@ help_text() {
 	--nns-dapp
 	  Depoy the NNS dapp.
 
-	--users
+	--populate
 	  Create sample users with ICP, neurons and follow relationships.
 
 	--open
@@ -79,7 +79,7 @@ START_DFX="false"
 DEPLOY_NNS_BACKEND="false"
 DEPLOY_II="false"
 DEPLOY_NNS_DAPP="false"
-CREATE_USERS="false"
+POPULATE="false"
 OPEN_NNS_DAPP="false"
 
 while (($# > 0)); do
@@ -106,9 +106,9 @@ while (($# > 0)); do
     GUESS="false"
     DEPLOY_NNS_DAPP="true"
     ;;
-  --users)
+  --populate)
     GUESS="false"
-    CREATE_USERS="true"
+    POPULATE="true"
     ;;
   --open)
     GUESS="false"
@@ -132,7 +132,7 @@ if [[ "$GUESS" == "true" ]]; then
     DEPLOY_NNS_BACKEND=true
     DEPLOY_II=true
     DEPLOY_NNS_DAPP=true
-    CREATE_USERS=true
+    POPULATE=true
     ;;
   *)
     { # Can we find an existing II?
@@ -143,7 +143,7 @@ if [[ "$GUESS" == "true" ]]; then
       DEPLOY_II=true
     }
     DEPLOY_NNS_DAPP=true
-    CREATE_USERS=true
+    POPULATE=true
     ;;
   esac
 fi
@@ -153,7 +153,7 @@ echo START_DFX=$START_DFX
 echo DEPLOY_NNS_BACKEND=$DEPLOY_NNS_BACKEND
 echo DEPLOY_II=$DEPLOY_II
 echo DEPLOY_NNS_DAPP=$DEPLOY_NNS_DAPP
-echo CREATE_USERS=$CREATE_USERS
+echo POPULATE=$POPULATE
 echo OPEN_NNS_DAPP=$OPEN_NNS_DAPP
 [[ "$DRY_RUN" != "true" ]] || exit 0
 [[ "$GUESS" != "true" ]] || {
@@ -204,7 +204,7 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
   echo "Deployed to: $OWN_CANISTER_URL"
 fi
 
-if [[ "$CREATE_USERS" == "true" ]]; then
+if [[ "$POPULATE" == "true" ]]; then
   pushd e2e-tests
   npm ci
   printf '%s\n' user-N01-neuron-created.e2e.ts |

--- a/deploy.sh
+++ b/deploy.sh
@@ -210,7 +210,10 @@ if [[ "$POPULATE" == "true" ]]; then
 
   # Allow the cmc canister to create canisters anywhere.
   # Note: The proposal is acepted and executed immediately because there are no neurons apart from the test user.
-  ./scripts/propose --to set-authorized-subnetworks --dfx-network "$DFX_NETWORK"
+  # Note: Local dfx has no subnets.
+  [[ "$DFX_NETWORK" == "local" ]] || {
+    ./scripts/propose --to set-authorized-subnetworks --dfx-network "$DFX_NETWORK" --jfdi
+  }
 
   # Create users and neurons
   pushd e2e-tests

--- a/deploy.sh
+++ b/deploy.sh
@@ -205,13 +205,15 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
 fi
 
 if [[ "$POPULATE" == "true" ]]; then
-  # Set the cycles exchange rate - needs a patched cycles minting canister.
+  echo Setting the cycles exchange rate...
+  echo Note: This needs a patched cycles minting canister.
   ./scripts/set-xdr-conversion-rate --dfx-network "$DFX_NETWORK"
 
   # Allow the cmc canister to create canisters anywhere.
   # Note: The proposal is acepted and executed immediately because there are no neurons apart from the test user.
   # Note: Local dfx has no subnets.
   [[ "$DFX_NETWORK" == "local" ]] || {
+    echo Setting the list of subnets CMC is authorized to create canisters in...
     ./scripts/propose --to set-authorized-subnetworks --dfx-network "$DFX_NETWORK" --jfdi
   }
 
@@ -220,6 +222,7 @@ if [[ "$POPULATE" == "true" ]]; then
   REDIRECT_TO_LEGACY="$(jq -re .REDIRECT_TO_LEGACY frontend/ts/src/config.json)"
   [[ "$REDIRECT_TO_LEGACY" == "prod" ]] ||
     [[ "$REDIRECT_TO_LEGACY" == "flutter" ]] || {
+    echo Creating users and neurons...
     pushd e2e-tests
     npm ci
     printf '%s\n' user-N01-neuron-created.e2e.ts |

--- a/deploy.sh
+++ b/deploy.sh
@@ -205,8 +205,12 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
 fi
 
 if [[ "$POPULATE" == "true" ]]; then
+  # Set the cycles exchange rate - needs a patched cycles minting canister.
+  ./scripts/set-xdr-conversion-rate
+
   pushd e2e-tests
   npm ci
+  
   printf '%s\n' user-N01-neuron-created.e2e.ts |
     SCREENSHOT=1 xargs -I {} npm run test -- --spec "./specs/{}"
   popd

--- a/deploy.sh
+++ b/deploy.sh
@@ -206,7 +206,7 @@ fi
 
 if [[ "$POPULATE" == "true" ]]; then
   # Set the cycles exchange rate - needs a patched cycles minting canister.
-  ./scripts/set-xdr-conversion-rate
+  ./scripts/set-xdr-conversion-rate --dfx-network "$DFX_NETWORK"
 
   # Allow the cmc canister to create canisters anywhere.
   # Note: The proposal is acepted and executed immediately because there are no neurons apart from the test user.

--- a/deploy.sh
+++ b/deploy.sh
@@ -216,11 +216,16 @@ if [[ "$POPULATE" == "true" ]]; then
   }
 
   # Create users and neurons
-  pushd e2e-tests
-  npm ci
-  printf '%s\n' user-N01-neuron-created.e2e.ts |
-    SCREENSHOT=1 xargs -I {} npm run test -- --spec "./specs/{}"
-  popd
+  # Note: Cannot be used with flutter.
+  REDIRECT_TO_LEGACY="$(jq -re .REDIRECT_TO_LEGACY frontend/ts/src/config.json)"
+  [[ "$REDIRECT_TO_LEGACY" == "prod" ]] ||
+    [[ "$REDIRECT_TO_LEGACY" == "flutter" ]] || {
+    pushd e2e-tests
+    npm ci
+    printf '%s\n' user-N01-neuron-created.e2e.ts |
+      SCREENSHOT=1 xargs -I {} npm run test -- --spec "./specs/{}"
+    popd
+  }
 fi
 
 if [[ "$OPEN_NNS_DAPP" == "true" ]]; then

--- a/e2e-tests/common/constants.ts
+++ b/e2e-tests/common/constants.ts
@@ -23,3 +23,4 @@ export const REDIRECT_TO_LEGACY: RedirectToLegacy = getRequiredEnvEnum(
   RedirectToLegacy
 );
 export const NNS_DAPP_URL: string = getRequiredEnvVar("OWN_CANISTER_URL");
+export const DFX_NETWORK: string = getRequiredEnvVar("DFX_NETWORK");

--- a/e2e-tests/components/proposals-tab.ts
+++ b/e2e-tests/components/proposals-tab.ts
@@ -1,5 +1,6 @@
 import { MyNavigator } from "../common/navigator";
 import { execFile } from "node:child_process";
+import { DFX_NETWORK } from "../common/constants";
 
 export class ProposalsTab extends MyNavigator {
   static readonly SELECTOR: string = `[data-tid="proposals-tab"]`;
@@ -18,7 +19,7 @@ export class ProposalsTab extends MyNavigator {
     const proposalId: number = await new Promise((yay, nay) =>
       execFile(
         "../scripts/propose",
-        ["--to", proposalName, "--jfdi"],
+        ["--to", proposalName, "--dfx-network", DFX_NETWORK, "--jfdi"],
         {},
         (error, stdout, stderr) => {
           if (error) {

--- a/e2e-tests/scripts/nns-canister-install
+++ b/e2e-tests/scripts/nns-canister-install
@@ -79,6 +79,9 @@ if { curl -sL "$(./e2e-tests/scripts/nns-dashboard)" | grep -q "$FIRST_POSSIBLE_
   }
 fi
 
+echo "Canister hashes:"
+sha256sum "${DOWNLOAD_DIR}"/*.wasm
+
 NNS_URL="$(./e2e-tests/scripts/nns-dashboard)"
 
 "${DOWNLOAD_DIR}/ic-nns-init" \

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -48,6 +48,12 @@ RUN binary="governance-canister" && \
     features="test" && \
     ic-cdk-optimizer -o "$CARGO_TARGET_DIR/${binary}_${features}.wasm" "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/${binary}.wasm"
 
+RUN binary="cycles-minting-canister" && \
+    cargo build --target wasm32-unknown-unknown --release -p "$binary"
+RUN binary="cycles-minting-canister" && \
+    ic-cdk-optimizer -o "$CARGO_TARGET_DIR/${binary}.wasm" "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/${binary}.wasm"
+
+
 FROM scratch AS scratch
 COPY --from=builder /ic/rs/rosetta-api/ledger.did /ledger.private.did
 COPY --from=builder /ic/rs/rosetta-api/ledger_canister/ledger.did /ledger.public.did


### PR DESCRIPTION
# Motivation
The CMC canister needs to be patched in order for cycle creation commands to work on a testnet.  The patch allows the exchange rate for buying the initial canister cycles to be set directly.

# Changes
- Commit 1: Build the patched canister in Docker, with the other patched NNS canisters.
- Commit 2: Rename `--users` in deploy.sh to `--populate`
- Commit 3: Set the exchange rate as part of `--populate`
- Commit 4: Make a proposal to allow CMC to create canisters; do this as part of `--populate`
- Cleanup:
  - Run only relevant parts of `--populate`:
    -  On local `dfx` networks, there are no subnets so don't try to authorize subnets.  It will fail.
    - If the network uses flutter, don't try to use e2e tests to create users and neurons.  It will fail.
  - Bust the NNS canister cache, as otherwise the old artifacts without the CMC patch are used.

# Tests
Running:
```
./deploy.sh nnsdapp_both
```
yielded this: https://tmxop-wyaaa-aaaaa-aaapa-cai.nnsdapp.dfinity.network/#/canister/wxns6-qiaaa-aaaaa-aaaqa-cai

I verified that I can create canisters there:
![Screenshot from 2022-05-25 05-31-12](https://user-images.githubusercontent.com/5982633/170173920-6350f1b6-9e40-43e3-bd55-6e5a15fde405.png)

