### PR TITLE
Display error message if user tries to merge hardware wallet neurons

### DIFF
--- a/frontend/dart/lib/ic_api/web/web_ic_api.dart
+++ b/frontend/dart/lib/ic_api/web/web_ic_api.dart
@@ -235,6 +235,12 @@ class PlatformICApi extends AbstractPlatformICApi {
         return Result.err(Exception("The neurons being merged must both have the same controller"));
       }
 
+      // TODO remove this check once hardware wallets are supported
+      final currentUserPrincipal = this.getPrincipal();
+      if (neuron1.controller != currentUserPrincipal || neuron2.controller != currentUserPrincipal) {
+        return Result.err(Exception("Unable to merge neurons. Merging of neurons controlled via hardware wallet is not yet supported"));
+      }
+
       // To ensure any built up age bonus is always preserved, if one neuron is
       // locked and the other is not, then we merge the neuron which is not
       // locked into the locked neuron.


### PR DESCRIPTION
# Motivation

Currently merging neurons which are controlled via hardware wallet is not supported, so this PR makes the NNS Dapp display an error message if trying to merge hardware wallet controlled neurons, rather than failing and displaying an obscure message containing minified code.

# Changes

- Display error message if trying to merge hardware wallet controlled neurons.

# Tests

This version is deployed here - https://wqmuk-5qaaa-aaaaa-aaaqq-cai.nnsdapp.dfinity.network/
On this version, neurons controlled by the user's NNS Dapp principal can still be merged and now the error message displays when trying to merge hardware wallet neurons.
![image](https://user-images.githubusercontent.com/4965315/170256196-a54ba4c2-a0c4-452f-ad82-dbfd7b2a9b3d.png)