### PR TITLE
mobile button supports 2 lines of text

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Toolbar.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toolbar.svelte
@@ -39,6 +39,10 @@
         margin: 0 var(--padding-2x);
         max-width: 406px;
       }
+
+      @media (max-width: 450px) {
+        height: 70px;
+      }
     }
   }
 </style>


### PR DESCRIPTION
# Motivation
- Buttons on mobile should support 2 lines of text
 
<img width="504" alt="Screen Shot 2022-05-25 at 12 39 30 PM" src="https://user-images.githubusercontent.com/38238542/170353936-bf7b1f5b-4ecc-4f86-8532-5c69b31828f1.png">


# Changes
- Enabled specific height of 70px, at breakpoint 450px
- Did not specify mixin media, since this breakpoint was specifically for this use case only
