### PR TITLE
L2-596: Link existing canister

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
@@ -6,6 +6,7 @@
     ADD_ACCOUNT_CONTEXT_KEY,
     type AddAccountContext,
   } from "../../types/add-account.context";
+  import CardItem from "../ui/CardItem.svelte";
 
   const context: AddAccountContext = getContext<AddAccountContext>(
     ADD_ACCOUNT_CONTEXT_KEY
@@ -17,55 +18,23 @@
 </script>
 
 <div class="wizard-wrapper">
-  <div
-    class="card-item"
-    role="button"
+  <CardItem
     on:click={selectNewSubAccount}
-    data-tid="choose-linked-as-account-type"
-  >
-    <h4>{$i18n.accounts.new_linked_title}</h4>
-    <span>{$i18n.accounts.new_linked_subtitle}</span>
-  </div>
-  <div
-    class="card-item"
-    role="button"
+    title={$i18n.accounts.new_linked_title}
+    subtitle={$i18n.accounts.new_linked_subtitle}
+    testId="choose-linked-as-account-type"
+  />
+  <CardItem
     on:click={selectNewHardwareWallet}
-    data-tid="choose-hardware-wallet-as-account-type"
-  >
-    <h4>{$i18n.accounts.attach_hardware_title}</h4>
-    <span>{$i18n.accounts.attach_hardware_subtitle}</span>
-  </div>
+    title={$i18n.accounts.attach_hardware_title}
+    subtitle={$i18n.accounts.attach_hardware_subtitle}
+    testId="choose-hardware-wallet-as-account-type"
+  />
 </div>
 
 <style lang="scss">
-  @use "../../themes/mixins/interaction";
-  @use "../../themes/mixins/media";
-
   .wizard-wrapper {
-    justify-content: center;
-  }
-
-  .card-item {
-    padding: var(--padding-2x) var(--padding);
-    border-radius: var(--border-radius);
-
-    @include media.min-width(medium) {
-      padding: var(--padding-4x);
-    }
-
-    @include interaction.tappable;
-
-    &:hover {
-      background: var(--background-hover);
-    }
-
-    h4 {
-      line-height: 1;
-      margin-bottom: var(--padding);
-    }
-
-    span {
-      color: var(--gray-200);
-    }
+    // Need to overwrite the default of wizrd-wrapper
+    justify-content: center !important;
   }
 </style>

--- a/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
@@ -20,16 +20,26 @@
 <div class="wizard-wrapper">
   <CardItem
     on:click={selectNewSubAccount}
-    title={$i18n.accounts.new_linked_title}
-    subtitle={$i18n.accounts.new_linked_subtitle}
     testId="choose-linked-as-account-type"
-  />
+  >
+    <svelte:fragment slot="title"
+      >{$i18n.accounts.new_linked_title}</svelte:fragment
+    >
+    <svelte:fragment slot="subtitle"
+      >{$i18n.accounts.new_linked_subtitle}</svelte:fragment
+    >
+  </CardItem>
   <CardItem
     on:click={selectNewHardwareWallet}
-    title={$i18n.accounts.attach_hardware_title}
-    subtitle={$i18n.accounts.attach_hardware_subtitle}
     testId="choose-hardware-wallet-as-account-type"
-  />
+  >
+    <svelte:fragment slot="title"
+      >{$i18n.accounts.attach_hardware_title}</svelte:fragment
+    >
+    <svelte:fragment slot="subtitle"
+      >{$i18n.accounts.attach_hardware_subtitle}</svelte:fragment
+    >
+  </CardItem>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AddAccountType.svelte
@@ -17,7 +17,7 @@
   const selectNewHardwareWallet = async () => await select("hardwareWallet");
 </script>
 
-<div class="wizard-wrapper">
+<div class="wizard-wrapper wrapper">
   <CardItem
     on:click={selectNewSubAccount}
     testId="choose-linked-as-account-type"
@@ -43,8 +43,8 @@
 </div>
 
 <style lang="scss">
-  .wizard-wrapper {
-    // Need to overwrite the default of wizrd-wrapper
-    justify-content: center !important;
+  // Need to overwrite the default of wizrd-wrapper
+  .wizard-wrapper.wrapper {
+    justify-content: center;
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
@@ -1,50 +1,48 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import InputWithError from "../ui/InputWithError.svelte";
   import type { Principal } from "@dfinity/principal";
   import { getPrincipalFromString } from "../../utils/accounts.utils";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { attachCanister } from "../../services/canisters.services";
   import { createEventDispatcher } from "svelte";
   import { toastsStore } from "../../stores/toasts.store";
+  import PrincipalInput from "../ui/PrincipalInput.svelte";
 
   let address: string = "";
   let validPrincipal: Principal | undefined;
   $: validPrincipal = getPrincipalFromString(address);
   let showError: boolean = false;
-
-  const showErrorIfAny = () => {
-    showError = address.length > 0 && validPrincipal === undefined;
-  };
   // Hide error on change
   $: address, (showError = false);
 
   const dispatcher = createEventDispatcher();
   const attach = async () => {
-    // Button is only enabled when validPrincipal is defined
-    if (validPrincipal !== undefined) {
-      startBusy({ initiator: "attach-canister" });
-      await attachCanister(validPrincipal);
+    // Edge case: button is only enabled when validPrincipal is defined
+    if (validPrincipal === undefined) {
+      toastsStore.error({
+        labelKey: "error.principal_not_valid",
+      });
+      return;
+    }
+    startBusy({ initiator: "attach-canister" });
+    const { success } = await attachCanister(validPrincipal);
+    if (success) {
       toastsStore.success({
         labelKey: "canisters.link_canister_success",
       });
-      stopBusy("attach-canister");
-      dispatcher("nnsClose");
     }
+    stopBusy("attach-canister");
+    dispatcher("nnsClose");
   };
 </script>
 
 <form on:submit|preventDefault={attach} data-tid="attach-canister-modal">
   <div class="input-wrapper">
-    <h5>{$i18n.canisters.canister_id}</h5>
-    <InputWithError
-      inputType="text"
+    <h5>{$i18n.canisters.enter_canister_id}</h5>
+    <PrincipalInput
+      bind:validPrincipal
       placeholderLabelKey="canisters.canister_id"
       name="canister-principal"
-      bind:value={address}
-      theme="dark"
-      errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
-      on:blur={showErrorIfAny}
     />
   </div>
 
@@ -52,7 +50,7 @@
     data-tid="attach-canister-button"
     class="primary full-width"
     type="submit"
-    disabled={validPrincipal === undefined}
+    disabled={validPrincipal === undefined || $busy}
   >
     {$i18n.core.confirm}
   </button>
@@ -60,6 +58,10 @@
 
 <style lang="scss">
   @use "../../themes/mixins/modal.scss";
+
+  h5 {
+    text-align: center;
+  }
 
   form {
     @include modal.section;

--- a/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import InputWithError from "../ui/InputWithError.svelte";
+  import type { Principal } from "@dfinity/principal";
+  import { getPrincipalFromString } from "../../utils/accounts.utils";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { attachCanister } from "../../services/canisters.services";
+  import { createEventDispatcher } from "svelte";
+  import { toastsStore } from "../../stores/toasts.store";
+
+  let address: string = "";
+  let validPrincipal: Principal | undefined;
+  $: validPrincipal = getPrincipalFromString(address);
+  let showError: boolean = false;
+
+  const showErrorIfAny = () => {
+    showError = address.length > 0 && validPrincipal === undefined;
+  };
+  // Hide error on change
+  $: address, (showError = false);
+
+  const dispatcher = createEventDispatcher();
+  const attach = async () => {
+    // Button is only enabled when validPrincipal is defined
+    if (validPrincipal !== undefined) {
+      startBusy({ initiator: "attach-canister" });
+      await attachCanister(validPrincipal);
+      toastsStore.success({
+        labelKey: "canisters.link_canister_success",
+      });
+      stopBusy("attach-canister");
+      dispatcher("nnsClose");
+    }
+  };
+</script>
+
+<form on:submit|preventDefault={attach} data-tid="attach-canister-modal">
+  <div class="input-wrapper">
+    <h5>{$i18n.canisters.canister_id}</h5>
+    <InputWithError
+      inputType="text"
+      placeholderLabelKey="canisters.canister_id"
+      name="canister-principal"
+      bind:value={address}
+      theme="dark"
+      errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
+      on:blur={showErrorIfAny}
+    />
+  </div>
+
+  <button
+    data-tid="attach-canister-button"
+    class="primary full-width"
+    type="submit"
+    disabled={validPrincipal === undefined}
+  >
+    {$i18n.core.confirm}
+  </button>
+</form>
+
+<style lang="scss">
+  @use "../../themes/mixins/modal.scss";
+
+  form {
+    @include modal.section;
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+  }
+
+  .input-wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
@@ -1,31 +1,25 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
   import type { Principal } from "@dfinity/principal";
-  import { getPrincipalFromString } from "../../utils/accounts.utils";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { attachCanister } from "../../services/canisters.services";
   import { createEventDispatcher } from "svelte";
   import { toastsStore } from "../../stores/toasts.store";
   import PrincipalInput from "../ui/PrincipalInput.svelte";
 
-  let address: string = "";
-  let validPrincipal: Principal | undefined;
-  $: validPrincipal = getPrincipalFromString(address);
-  let showError: boolean = false;
-  // Hide error on change
-  $: address, (showError = false);
+  let principal: Principal | undefined;
 
   const dispatcher = createEventDispatcher();
   const attach = async () => {
-    // Edge case: button is only enabled when validPrincipal is defined
-    if (validPrincipal === undefined) {
+    // Edge case: button is only enabled when principal is defined
+    if (principal === undefined) {
       toastsStore.error({
         labelKey: "error.principal_not_valid",
       });
       return;
     }
     startBusy({ initiator: "attach-canister" });
-    const { success } = await attachCanister(validPrincipal);
+    const { success } = await attachCanister(principal);
     if (success) {
       toastsStore.success({
         labelKey: "canisters.link_canister_success",
@@ -40,7 +34,7 @@
   <div class="input-wrapper">
     <h5>{$i18n.canisters.enter_canister_id}</h5>
     <PrincipalInput
-      bind:validPrincipal
+      bind:principal
       placeholderLabelKey="canisters.canister_id"
       name="canister-principal"
     />
@@ -50,7 +44,7 @@
     data-tid="attach-canister-button"
     class="primary full-width"
     type="submit"
-    disabled={validPrincipal === undefined || $busy}
+    disabled={principal === undefined || $busy}
   >
     {$i18n.core.confirm}
   </button>

--- a/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
@@ -15,7 +15,7 @@
   };
 </script>
 
-<div class="wizard-wrapper">
+<div class="wizard-wrapper wrapper">
   <CardItem testId="choose-create-as-new-canister" on:click={selectCreate}>
     <svelte:fragment slot="title"
       >{$i18n.canisters.create_canister_title}</svelte:fragment
@@ -35,8 +35,8 @@
 </div>
 
 <style lang="scss">
-  .wizard-wrapper {
-    // Need to overwrite the default of wizrd-wrapper
+  // Need to overwrite the default of wizrd-wrapper
+  .wizard-wrapper.wrapper {
     justify-content: center !important;
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
@@ -35,8 +35,8 @@
 </div>
 
 <style lang="scss">
-  // Need to overwrite the default of wizrd-wrapper
+  // Need to overwrite the default of wizard-wrapper
   .wizard-wrapper.wrapper {
-    justify-content: center !important;
+    justify-content: center;
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
@@ -1,30 +1,37 @@
-<script>
+<script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { i18n } from "../../stores/i18n";
   import CardItem from "../ui/CardItem.svelte";
 
   const dispatcher = createEventDispatcher();
+  const dispatchSelect = (type: "newCanisterCreate" | "newCanisterAttach") => {
+    dispatcher("nnsSelect", { type });
+  };
   const selectCreate = () => {
-    dispatcher("nnsSelect", { type: "newCanisterCreate" });
+    dispatchSelect("newCanisterCreate");
   };
   const selectLink = () => {
-    dispatcher("nnsSelect", { type: "newCanisterAttach" });
+    dispatchSelect("newCanisterAttach");
   };
 </script>
 
 <div class="wizard-wrapper">
-  <CardItem
-    title={$i18n.canisters.create_canister_title}
-    subtitle={$i18n.canisters.create_canister_subtitle}
-    testId="choose-create-as-new-canister"
-    on:click={selectCreate}
-  />
-  <CardItem
-    title={$i18n.canisters.link_canister_title}
-    subtitle={$i18n.canisters.link_canister_subtitle}
-    testId="choose-link-as-new-canister"
-    on:click={selectLink}
-  />
+  <CardItem testId="choose-create-as-new-canister" on:click={selectCreate}>
+    <svelte:fragment slot="title"
+      >{$i18n.canisters.create_canister_title}</svelte:fragment
+    >
+    <svelte:fragment slot="subtitle"
+      >{$i18n.canisters.create_canister_subtitle}</svelte:fragment
+    >
+  </CardItem>
+  <CardItem testId="choose-link-as-new-canister" on:click={selectLink}>
+    <svelte:fragment slot="title"
+      >{$i18n.canisters.link_canister_title}</svelte:fragment
+    >
+    <svelte:fragment slot="subtitle"
+      >{$i18n.canisters.link_canister_subtitle}</svelte:fragment
+    >
+  </CardItem>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import { i18n } from "../../stores/i18n";
+  import CardItem from "../ui/CardItem.svelte";
+
+  const dispatcher = createEventDispatcher();
+  const selectCreate = () => {
+    dispatcher("nnsSelect", { type: "newCanisterCreate" });
+  };
+  const selectLink = () => {
+    dispatcher("nnsSelect", { type: "newCanisterAttach" });
+  };
+</script>
+
+<div class="wizard-wrapper">
+  <CardItem
+    title={$i18n.canisters.create_canister_title}
+    subtitle={$i18n.canisters.create_canister_subtitle}
+    testId="choose-create-as-new-canister"
+    on:click={selectCreate}
+  />
+  <CardItem
+    title={$i18n.canisters.link_canister_title}
+    subtitle={$i18n.canisters.link_canister_subtitle}
+    testId="choose-link-as-new-canister"
+    on:click={selectLink}
+  />
+</div>
+
+<style lang="scss">
+  .wizard-wrapper {
+    // Need to overwrite the default of wizrd-wrapper
+    justify-content: center !important;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/CardItem.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardItem.svelte
@@ -2,10 +2,10 @@
   export let testId: string | undefined = undefined;
 </script>
 
-<div class="card-item" role="button" on:click data-tid={testId}>
+<article class="card-item" role="button" on:click data-tid={testId}>
   <h4><slot name="title" /></h4>
   <span><slot name="subtitle" /></span>
-</div>
+</article>
 
 <style lang="scss">
   @use "../../themes/mixins/interaction";

--- a/frontend/svelte/src/lib/components/ui/CardItem.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardItem.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  export let title: string;
-  export let subtitle: string;
   export let testId: string | undefined = undefined;
 </script>
 
 <div class="card-item" role="button" on:click data-tid={testId}>
-  <h4>{title}</h4>
-  <span>{subtitle}</span>
+  <h4><slot name="title" /></h4>
+  <span><slot name="subtitle" /></span>
 </div>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/ui/CardItem.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardItem.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  export let title: string;
+  export let subtitle: string;
+  export let testId: string | undefined = undefined;
+</script>
+
+<div class="card-item" role="button" on:click data-tid={testId}>
+  <h4>{title}</h4>
+  <span>{subtitle}</span>
+</div>
+
+<style lang="scss">
+  @use "../../themes/mixins/interaction";
+  @use "../../themes/mixins/media";
+
+  .card-item {
+    padding: var(--padding-2x) var(--padding);
+    border-radius: var(--border-radius);
+
+    @include media.min-width(medium) {
+      padding: var(--padding-4x);
+    }
+
+    @include interaction.tappable;
+
+    &:hover {
+      background: var(--background-hover);
+    }
+
+    h4 {
+      line-height: 1;
+      margin-bottom: var(--padding);
+    }
+
+    span {
+      color: var(--gray-200);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
@@ -6,14 +6,14 @@
 
   export let placeholderLabelKey: string;
   export let name: string;
-  export let validPrincipal: Principal | undefined = undefined;
+  export let principal: Principal | undefined = undefined;
 
   let address: string = "";
-  $: validPrincipal = getPrincipalFromString(address);
+  $: principal = getPrincipalFromString(address);
   let showError: boolean = false;
 
   const showErrorIfAny = () => {
-    showError = address.length > 0 && validPrincipal === undefined;
+    showError = address.length > 0 && principal === undefined;
   };
   // Hide error on change
   $: address, (showError = false);

--- a/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import { i18n } from "../../stores/i18n";
+  import { getPrincipalFromString } from "../../utils/accounts.utils";
+  import InputWithError from "./InputWithError.svelte";
+
+  export let placeholderLabelKey: string;
+  export let name: string;
+  export let validPrincipal: Principal | undefined = undefined;
+
+  let address: string = "";
+  $: validPrincipal = getPrincipalFromString(address);
+  let showError: boolean = false;
+
+  const showErrorIfAny = () => {
+    showError = address.length > 0 && validPrincipal === undefined;
+  };
+  // Hide error on change
+  $: address, (showError = false);
+</script>
+
+<InputWithError
+  inputType="text"
+  {placeholderLabelKey}
+  {name}
+  bind:value={address}
+  theme="dark"
+  errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
+  on:blur={showErrorIfAny}
+/>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -264,6 +264,7 @@
     "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
     "link_canister_success": "The canister was linked successfully",
     "attach_canister": "Attach Canister",
+    "enter_canister_id": "Enter Canister ID:",
     "canister_id": "Canister ID"
   },
   "canister_detail": {

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -256,7 +256,15 @@
     "step3": "Send cycles to canisters",
     "principal_is": "Your principal id is",
     "create_or_link": "Create or Link Canister",
-    "empty": "No canisters yet."
+    "empty": "No canisters yet.",
+    "add_canister": "Add Canister",
+    "create_canister_title": "Create New Canister",
+    "create_canister_subtitle": "Create a new canister, to deploy your application",
+    "link_canister_title": "Link Canister To Account",
+    "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
+    "link_canister_success": "The canister was linked successfully",
+    "attach_canister": "Attach Canister",
+    "canister_id": "Canister ID"
   },
   "canister_detail": {
     "title": "Canister"

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -31,7 +31,9 @@
 
 <WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
   <svelte:fragment slot="title"
-    >{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment
+    ><span data-tid="create-link-canister-modal-title"
+      >{currentStep?.title ?? $i18n.accounts.add_account}</span
+    ></svelte:fragment
   >
   <svelte:fragment>
     {#if currentStep?.name === "SelectNewCanisterType"}

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import AttachCanister from "../../components/canisters/AttachCanister.svelte";
+  import SelectNewCanisterType from "../../components/canisters/SelectNewCanisterType.svelte";
+
+  import { i18n } from "../../stores/i18n";
+  import type { Step, Steps } from "../../stores/steps.state";
+  import WizardModal from "../WizardModal.svelte";
+
+  // TODO: Create Canister Flow https://dfinity.atlassian.net/browse/L2-227
+  const steps: Steps = [
+    {
+      name: "SelectNewCanisterType",
+      title: $i18n.canisters.add_canister,
+      showBackButton: false,
+    },
+    {
+      name: "AttachCanister",
+      title: $i18n.canisters.attach_canister,
+      showBackButton: false,
+    },
+  ];
+
+  let currentStep: Step | undefined;
+  let modal: WizardModal;
+
+  // TODO: Create Canister Flow https://dfinity.atlassian.net/browse/L2-227
+  const selectType = () => {
+    modal.next();
+  };
+</script>
+
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title"
+    >{currentStep?.title ?? $i18n.accounts.add_account}</svelte:fragment
+  >
+  <svelte:fragment>
+    {#if currentStep?.name === "SelectNewCanisterType"}
+      <SelectNewCanisterType on:nnsSelect={selectType} />
+    {/if}
+    {#if currentStep?.name === "AttachCanister"}
+      <AttachCanister on:nnsClose />
+    {/if}
+  </svelte:fragment>
+</WizardModal>

--- a/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/AddHotkeyModal.svelte
@@ -12,19 +12,19 @@
 
   export let neuronId: NeuronId;
 
-  let validPrincipal: Principal | undefined = undefined;
+  let principal: Principal | undefined = undefined;
   const dispatcher = createEventDispatcher();
 
   const add = async () => {
-    // Edge case: button is only enabled when validPrincipal is defined
-    if (validPrincipal === undefined) {
+    // Edge case: button is only enabled when principal is defined
+    if (principal === undefined) {
       toastsStore.error({
         labelKey: "error.principal_not_valid",
       });
       return;
     }
     startBusyNeuron({ initiator: "add-hotkey-neuron", neuronId });
-    await addHotkey({ neuronId, principal: validPrincipal });
+    await addHotkey({ neuronId, principal: principal });
     stopBusy("add-hotkey-neuron");
     dispatcher("nnsClose");
   };
@@ -36,7 +36,7 @@
     <div class="input-wrapper">
       <h5>{$i18n.neuron_detail.enter_hotkey}</h5>
       <PrincipalInput
-        bind:validPrincipal
+        bind:principal
         placeholderLabelKey="neuron_detail.add_hotkey_placeholder"
         name="hotkey-principal"
       />
@@ -46,7 +46,7 @@
       data-tid="add-hotkey-neuron-button"
       class="primary full-width"
       type="submit"
-      disabled={validPrincipal === undefined || $busy}
+      disabled={principal === undefined || $busy}
     >
       {$i18n.core.confirm}
     </button>

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -53,8 +53,7 @@ export const attachCanister = async (
     await listCanisters({ clearBeforeQuery: false });
     return { success: true };
   } catch (error) {
-    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
-    console.error(error);
+    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
     return { success: false };
   }
 };

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -1,7 +1,12 @@
-import { queryCanisters } from "../api/canisters.api";
+import type { Principal } from "@dfinity/principal";
+import {
+  attachCanister as attachCanisterApi,
+  queryCanisters,
+} from "../api/canisters.api";
 import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
+import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
 export const listCanisters = async ({
@@ -34,4 +39,22 @@ export const listCanisters = async ({
     },
     logMessage: "Syncing Canisters",
   });
+};
+
+export const attachCanister = async (
+  canisterId: Principal
+): Promise<{ success: boolean }> => {
+  try {
+    const identity = await getIdentity();
+    await attachCanisterApi({
+      identity,
+      canisterId,
+    });
+    await listCanisters({ clearBeforeQuery: false });
+    return { success: true };
+  } catch (error) {
+    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
+    console.error(error);
+    return { success: false };
+  }
 };

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -4,6 +4,7 @@ export type BusyStateInitiatorType =
   | "stake-neuron"
   | "update-delay"
   | "vote"
+  | "attach-canister"
   | "accounts"
   | "join-community-fund"
   | "split-neuron"

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -271,6 +271,14 @@ interface I18nCanisters {
   principal_is: string;
   create_or_link: string;
   empty: string;
+  add_canister: string;
+  create_canister_title: string;
+  create_canister_subtitle: string;
+  link_canister_title: string;
+  link_canister_subtitle: string;
+  link_canister_success: string;
+  attach_canister: string;
+  canister_id: string;
 }
 
 interface I18nCanister_detail {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -278,6 +278,7 @@ interface I18nCanisters {
   link_canister_subtitle: string;
   link_canister_success: string;
   attach_canister: string;
+  enter_canister_id: string;
   canister_id: string;
 }
 

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -89,8 +89,10 @@
 
     <svelte:fragment slot="footer">
       <Toolbar>
-        <button class="primary" on:click={openModal}
-          >{$i18n.canisters.create_or_link}</button
+        <button
+          data-tid="create-link-canister-button"
+          class="primary"
+          on:click={openModal}>{$i18n.canisters.create_or_link}</button
         >
       </Toolbar>
     </svelte:fragment>

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -15,6 +15,7 @@
   import CanisterCard from "../lib/components/canisters/CanisterCard.svelte";
   import type { CanisterId } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import { routeStore } from "../lib/stores/route.store";
+  import CreateOrLinkCanisterModal from "../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
 
   const loadCanisters = async () => {
     try {
@@ -48,8 +49,9 @@
   let noCanisters: boolean;
   $: noCanisters = !loading && $canistersStore.canisters?.length === 0;
 
-  // TODO: TBD https://dfinity.atlassian.net/browse/L2-227
-  const createOrLink = () => alert("Create or Link");
+  let modal: "CreateOrLinkCanister" | undefined = undefined;
+  const openModal = () => (modal = "CreateOrLinkCanister");
+  const closeModal = () => (modal = undefined);
 </script>
 
 {#if SHOW_CANISTERS_ROUTE}
@@ -87,11 +89,14 @@
 
     <svelte:fragment slot="footer">
       <Toolbar>
-        <button class="primary" on:click={createOrLink}
+        <button class="primary" on:click={openModal}
           >{$i18n.canisters.create_or_link}</button
         >
       </Toolbar>
     </svelte:fragment>
+    {#if modal === "CreateOrLinkCanister"}
+      <CreateOrLinkCanisterModal on:nnsClose={closeModal} />
+    {/if}
   </Layout>
 {/if}
 

--- a/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
@@ -1,6 +1,7 @@
 import { ICP, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import {
+  attachCanister,
   createCanister,
   queryCanisterDetails,
   queryCanisters,
@@ -17,7 +18,6 @@ describe("canisters-api", () => {
   const mockCMCCanister = mock<CMCCanister>();
   const mockICManagementCanister = mock<ICManagementCanister>();
   const mockLedgerCanister = mock<LedgerCanister>();
-  let spyGetCanisters;
 
   beforeEach(() => {
     jest
@@ -33,18 +33,41 @@ describe("canisters-api", () => {
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation(() => mockLedgerCanister);
-
-    spyGetCanisters = jest
-      .spyOn(mockNNSDappCanister, "getCanisters")
-      .mockResolvedValue([]);
   });
 
   describe("queryCanisters", () => {
     afterEach(() => jest.clearAllMocks());
+
     it("should call the canister to list the canisters 🤪", async () => {
       await queryCanisters({ identity: mockIdentity, certified: true });
 
-      expect(spyGetCanisters).toHaveReturnedTimes(1);
+      expect(mockNNSDappCanister.getCanisters).toHaveReturnedTimes(1);
+    });
+  });
+
+  describe("attachCanister", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should call the nns dapp canister to attach the canister id", async () => {
+      await attachCanister({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id,
+        name: "test name",
+      });
+
+      expect(mockNNSDappCanister.attachCanister).toBeCalled();
+    });
+
+    it("should call the nns dapp canister to attach the canister id with empty string as name when not present", async () => {
+      await attachCanister({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id,
+      });
+
+      expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
+        canisterId: mockCanisterDetails.id,
+        name: "",
+      });
     });
   });
 

--- a/frontend/svelte/src/tests/lib/components/accounts/AddAccountType.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/AddAccountType.spec.ts
@@ -51,12 +51,12 @@ describe("AddAccountType", () => {
   it("should select add account type subaccount", async () =>
     testSelectType({
       type: "subAccount",
-      selector: 'div[role="button"]:first-of-type',
+      selector: 'article[role="button"]:first-of-type',
     }));
 
   it("should select add account type hardwareWallet", async () =>
     testSelectType({
       type: "hardwareWallet",
-      selector: 'div[role="button"]:last-of-type',
+      selector: 'article[role="button"]:last-of-type',
     }));
 });

--- a/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
@@ -15,7 +15,9 @@ describe("CardItem", () => {
   it("should render a div with role button", () => {
     const { container } = render(CardItem, { props });
 
-    expect(container.querySelector("div[role='button']")).toBeInTheDocument();
+    expect(
+      container.querySelector("article[role='button']")
+    ).toBeInTheDocument();
   });
 
   it("should forward the click event", (done) => {
@@ -25,7 +27,7 @@ describe("CardItem", () => {
       done();
     });
 
-    const element = container.querySelector("div[role='button']");
+    const element = container.querySelector("article[role='button']");
     expect(element).not.toBeNull();
     element && fireEvent.click(element);
   });

--- a/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
+import CardItem from "../../../../lib/components/ui/CardItem.svelte";
+
+describe("CardItem", () => {
+  const props = {
+    title: "Test",
+    subtitle: "Subtitle text",
+  };
+
+  it("should render a div with role button", () => {
+    const { container } = render(CardItem, { props });
+
+    expect(container.querySelector("div[role='button']")).toBeInTheDocument();
+  });
+
+  it("should forward the click event", (done) => {
+    const { container, component } = render(CardItem, { props });
+
+    component.$on("click", () => {
+      done();
+    });
+
+    const element = container.querySelector("div[role='button']");
+    expect(element).not.toBeNull();
+    element && fireEvent.click(element);
+  });
+
+  it("should add a data test id", () => {
+    const testId = "test-id";
+    const { queryByTestId } = render(CardItem, { props: { ...props, testId } });
+
+    expect(queryByTestId(testId)).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/InputValueTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InputValueTest.svelte
@@ -7,8 +7,8 @@
 
   export let inputType: "text" | "icp" = "text";
   export let name: string;
-  export let value: string | undefined;
-  export let placeholderLabelKey: string | undefined;
+  export let value: string | undefined = undefined;
+  export let placeholderLabelKey: string = "test.placeholder";
 
   let amount: string | undefined = value;
   $: amount, (() => dispatch("testAmount", { amount }))();

--- a/frontend/svelte/src/tests/lib/components/ui/PrincipalInput.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/PrincipalInput.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor } from "@testing-library/svelte";
+import en from "../../../mocks/i18n.mock";
+import PrincipalInputTest from "./PrincipalInputTest.svelte";
+
+describe("PrincipalInput", () => {
+  const props = { name: "name", placeholderLabelKey: "test.placeholder" };
+
+  it("should render an input", () => {
+    const { getByTestId } = render(PrincipalInputTest, {
+      props,
+    });
+
+    expect(getByTestId("input-ui-element")).toBeInTheDocument();
+  });
+
+  it("should render an error message on blur", async () => {
+    const { getByText, getByTestId } = render(PrincipalInputTest, {
+      props,
+    });
+
+    const inputElement = getByTestId("input-ui-element");
+    expect(inputElement).not.toBeNull();
+
+    await fireEvent.input(inputElement, { target: { value: "not-valid" } });
+    await fireEvent.blur(inputElement);
+
+    await waitFor(() =>
+      expect(getByText(en.error.principal_not_valid)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/PrincipalInputTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/PrincipalInputTest.svelte
@@ -5,7 +5,7 @@
   export let placeholderLabelKey: string;
   export let name: string;
 
-  let validPrincipal: Principal | undefined = undefined;
+  let principal: Principal | undefined = undefined;
 </script>
 
-<PrincipalInput {name} {placeholderLabelKey} {validPrincipal} />
+<PrincipalInput {name} {placeholderLabelKey} {principal} />

--- a/frontend/svelte/src/tests/lib/components/ui/PrincipalInputTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/PrincipalInputTest.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import PrincipalInput from "../../../../lib/components/ui/PrincipalInput.svelte";
+
+  export let placeholderLabelKey: string;
+  export let name: string;
+
+  let validPrincipal: Principal | undefined = undefined;
+</script>
+
+<PrincipalInput {name} {placeholderLabelKey} {validPrincipal} />

--- a/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/accounts/AddAccountModal.spec.ts
@@ -42,7 +42,7 @@ describe("AddAccountModal", () => {
   it("should display two button cards", async () => {
     const { container } = await renderModal({ component: AddAccountModal });
 
-    const buttons = container.querySelectorAll('div[role="button"]');
+    const buttons = container.querySelectorAll('article[role="button"]');
     expect(buttons.length).toEqual(2);
   });
 

--- a/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor } from "@testing-library/svelte";
+import CreateOrLinkCanisterModal from "../../../../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
+import { attachCanister } from "../../../../lib/services/canisters.services";
+import en from "../../../mocks/i18n.mock";
+import { renderModal } from "../../../mocks/modal.mock";
+
+jest.mock("../../../../lib/services/canisters.services", () => {
+  return {
+    attachCanister: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+describe("CreateOrLinkCanisterModal", () => {
+  it("should display modal", () => {
+    const { container } = render(CreateOrLinkCanisterModal);
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should display two button cards", async () => {
+    const { container } = await renderModal({
+      component: CreateOrLinkCanisterModal,
+    });
+
+    const buttons = container.querySelectorAll('div[role="button"]');
+    expect(buttons.length).toEqual(2);
+  });
+
+  it("should attach an existing canister and close modal", async () => {
+    const { queryByTestId, container, component } = await renderModal({
+      component: CreateOrLinkCanisterModal,
+    });
+
+    const linkCanisterCard = queryByTestId("choose-link-as-new-canister");
+    expect(linkCanisterCard).toBeInTheDocument();
+
+    linkCanisterCard && (await fireEvent.click(linkCanisterCard));
+
+    // AttachCanister Screen
+    await waitFor(() =>
+      expect(queryByTestId("attach-canister-modal")).toBeInTheDocument()
+    );
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: "aaaaa-aa" },
+      }));
+
+    const buttonElement = queryByTestId("attach-canister-button");
+    expect(buttonElement).not.toBeNull();
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+
+    buttonElement && (await fireEvent.click(buttonElement));
+    expect(attachCanister).toBeCalled();
+
+    await waitFor(() => expect(onClose).toBeCalled());
+  });
+
+  it("should show an error and have disabled button if the principal is not valid", async () => {
+    const { queryByTestId, queryByText, container } = await renderModal({
+      component: CreateOrLinkCanisterModal,
+    });
+
+    const linkCanisterCard = queryByTestId("choose-link-as-new-canister");
+    expect(linkCanisterCard).toBeInTheDocument();
+
+    linkCanisterCard && (await fireEvent.click(linkCanisterCard));
+
+    // AttachCanister Screen
+    await waitFor(() =>
+      expect(queryByTestId("attach-canister-modal")).toBeInTheDocument()
+    );
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: "not-valid" },
+      }));
+    inputElement && (await fireEvent.blur(inputElement));
+
+    expect(queryByText(en.error.principal_not_valid)).toBeInTheDocument();
+
+    const buttonElement = queryByTestId("attach-canister-button");
+    expect(buttonElement).not.toBeNull();
+    expect(buttonElement?.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
@@ -26,7 +26,7 @@ describe("CreateOrLinkCanisterModal", () => {
       component: CreateOrLinkCanisterModal,
     });
 
-    const buttons = container.querySelectorAll('div[role="button"]');
+    const buttons = container.querySelectorAll('article[role="button"]');
     expect(buttons.length).toEqual(2);
   });
 

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -1,35 +1,77 @@
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
-import { listCanisters } from "../../../lib/services/canisters.services";
+import {
+  attachCanister,
+  listCanisters,
+} from "../../../lib/services/canisters.services";
 import { canistersStore } from "../../../lib/stores/canisters.store";
 import {
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
 } from "../../mocks/auth.store.mock";
-import { mockCanisters } from "../../mocks/canisters.mock";
+import { mockCanisterDetails, mockCanisters } from "../../mocks/canisters.mock";
 
 describe("canisters-services", () => {
   const spyQueryCanisters = jest
     .spyOn(api, "queryCanisters")
     .mockImplementation(() => Promise.resolve(mockCanisters));
 
-  it("should list canisters", async () => {
-    await listCanisters({});
+  const spyAttachCanister = jest
+    .spyOn(api, "attachCanister")
+    .mockImplementation(() => Promise.resolve(undefined));
 
-    expect(spyQueryCanisters).toHaveBeenCalled();
+  describe("listCanisters", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      canistersStore.setCanisters({ canisters: [], certified: true });
+    });
 
-    const store = get(canistersStore);
-    expect(store.canisters).toEqual(mockCanisters);
+    it("should list canisters", async () => {
+      await listCanisters({});
+
+      expect(spyQueryCanisters).toHaveBeenCalled();
+
+      const store = get(canistersStore);
+      expect(store.canisters).toEqual(mockCanisters);
+    });
+
+    it("should not list canisters if no identity", async () => {
+      setNoIdentity();
+
+      const call = async () => await listCanisters({});
+
+      await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+
+      resetIdentity();
+    });
   });
 
-  it("should not list canisters if no identity", async () => {
-    setNoIdentity();
+  describe("attachCanister", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      canistersStore.setCanisters({ canisters: [], certified: true });
+    });
 
-    const call = async () => await listCanisters({});
+    it("should call api to attach canister and list canisters again", async () => {
+      const response = await attachCanister(mockCanisterDetails.id);
+      expect(response.success).toBe(true);
+      expect(spyAttachCanister).toBeCalled();
+      expect(spyQueryCanisters).toBeCalled();
 
-    await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+      const store = get(canistersStore);
+      expect(store.canisters).toEqual(mockCanisters);
+    });
 
-    resetIdentity();
+    it("should not attach canister if no identity", async () => {
+      setNoIdentity();
+
+      const response = await attachCanister(mockCanisterDetails.id);
+      expect(response.success).toBe(false);
+      expect(spyAttachCanister).not.toBeCalled();
+      expect(spyQueryCanisters).not.toBeCalled();
+
+      resetIdentity();
+    });
   });
 });

--- a/frontend/svelte/src/tests/routes/Canisters.spec.ts
+++ b/frontend/svelte/src/tests/routes/Canisters.spec.ts
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor } from "@testing-library/svelte";
 import { listCanisters } from "../../lib/services/canisters.services";
 import { authStore } from "../../lib/stores/auth.store";
 import { canistersStore } from "../../lib/stores/canisters.store";
@@ -59,5 +60,20 @@ describe("Canisters", () => {
     const { queryAllByTestId } = render(Canisters);
 
     expect(queryAllByTestId("canister-card").length).toBe(2);
+  });
+
+  it("should open the CreateOrLinkCanisterModal on click to Create Or Link Canister", async () => {
+    const { queryByTestId } = render(Canisters);
+
+    const toolbarButton = queryByTestId("create-link-canister-button");
+    expect(toolbarButton).not.toBeNull();
+
+    toolbarButton !== null && (await fireEvent.click(toolbarButton));
+
+    await waitFor(() =>
+      expect(
+        queryByTestId("create-link-canister-modal-title")
+      ).toBeInTheDocument()
+    );
   });
 });


### PR DESCRIPTION
# Motivation

User can link an existing canister to the nns dapp user.

# Changes

* New Modal CreateOrLinkCanisterModal with two screens: SelectNewCanisterType and AttachCanister.
* New canister api: "attachCanister".
* New cansiter service: "attachCanister".
* Button in "Canisters" route opens CreateOrLinkCanisterModal.
* New UI Component: CardItem, created from cards in AddAccountType and reused there.
* New UI Component: PrincipalInput.

# Tests

* Test the Link Canister flow.
* Test the new canister api "attachCanister".
* Test the new canister service "attachCanister"
* Test that Canisters route opens CreateOrLinkCanisterModal.
* Test new UI Components.
