### PR TITLE
L2-334: Setup Canister Detail Page

### DIFF
--- a/frontend/svelte/src/lib/components/canisters/ControllersCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ControllersCard.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { i18n } from "../../stores/i18n";
+  import Card from "../ui/Card.svelte";
+
+  // TODO: UI - https://dfinity.atlassian.net/browse/L2-599
+  // TODO: Add Controller - https://dfinity.atlassian.net/browse/L2-600
+  // TODO: Remove Controller - https://dfinity.atlassian.net/browse/L2-601
+</script>
+
+<Card testId="canister-controllers-card">
+  <h4 slot="start">{$i18n.canister_detail.controllers}</h4>
+</Card>

--- a/frontend/svelte/src/lib/components/canisters/CyclesCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CyclesCard.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import Card from "../ui/Card.svelte";
+
+  // TODO: Add Cycles - https://dfinity.atlassian.net/browse/L2-598
+  // TODO: UI - https://dfinity.atlassian.net/browse/L2-599
+</script>
+
+<Card testId="canister-cycles-card">
+  <h4 slot="start">{$i18n.canister_detail.cycles}</h4>
+</Card>

--- a/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonParagraph.svelte
@@ -23,7 +23,7 @@
     );
     background: var(--skeleton-text-background);
 
-    line-height: 0.8;
+    line-height: var(--skeleton-text-line-height, 0.8);
 
     user-select: none;
     pointer-events: none;

--- a/frontend/svelte/src/lib/components/ui/SkeletonTitle.svelte
+++ b/frontend/svelte/src/lib/components/ui/SkeletonTitle.svelte
@@ -1,0 +1,13 @@
+<script>
+  import SkeletonParagraph from "./SkeletonParagraph.svelte";
+</script>
+
+<span>
+  <SkeletonParagraph />
+</span>
+
+<style lang="scss">
+  span {
+    --skeleton-text-line-height: 2;
+  }
+</style>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -268,7 +268,10 @@
     "canister_id": "Canister ID"
   },
   "canister_detail": {
-    "title": "Canister"
+    "title": "Canister",
+    "id": "Id: $canisterId",
+    "cycles": "Cycles",
+    "controllers": "Controllers"
   },
   "topics": {
     "Unspecified": "Unspecified",

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -1,11 +1,15 @@
 import type { Principal } from "@dfinity/principal";
 import {
   attachCanister as attachCanisterApi,
+  queryCanisterDetails,
   queryCanisters,
 } from "../api/canisters.api";
-import type { CanisterDetails } from "../canisters/nns-dapp/nns-dapp.types";
+import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
+import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
+import { getPrincipalFromString } from "../utils/accounts.utils";
+import { getLastPathDetail } from "../utils/app-path.utils";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -18,7 +22,7 @@ export const listCanisters = async ({
     canistersStore.setCanisters({ canisters: undefined, certified: true });
   }
 
-  return queryAndUpdate<CanisterDetails[], unknown>({
+  return queryAndUpdate<CanisterInfo[], unknown>({
     request: (options) => queryCanisters(options),
     onLoad: ({ response: canisters, certified }) =>
       canistersStore.setCanisters({ canisters, certified }),
@@ -55,5 +59,26 @@ export const attachCanister = async (
   } catch (error) {
     // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
     return { success: false };
+  }
+};
+
+export const routePathCanisterId = (path: string): Principal | undefined => {
+  const maybeIdString = getLastPathDetail(path);
+  return maybeIdString !== undefined
+    ? getPrincipalFromString(maybeIdString)
+    : undefined;
+};
+
+export const getCanisterDetails = async (
+  canisterId: Principal
+): Promise<CanisterDetails | undefined> => {
+  const identity = await getIdentity();
+  try {
+    return await queryCanisterDetails({
+      canisterId,
+      identity,
+    });
+  } catch (error) {
+    // TODO: manage errors https://dfinity.atlassian.net/browse/L2-615
   }
 };

--- a/frontend/svelte/src/lib/stores/debug.store.ts
+++ b/frontend/svelte/src/lib/stores/debug.store.ts
@@ -1,5 +1,6 @@
 import { derived, type Readable, type Writable } from "svelte/store";
 import type { AddAccountStore } from "../types/add-account.context";
+import type { SelectCanisterDetailsStore } from "../types/canister-detail.context";
 import type { HardwareWalletNeuronsStore } from "../types/hardware-wallet-neurons.context";
 import type { SelectedAccountStore } from "../types/selected-account.context";
 import type { TransactionStore } from "../types/transaction.context";
@@ -37,6 +38,10 @@ let selectedAccountStore: Readable<SelectedAccountStore>;
 export const debugSelectedAccountStore = (
   store: Writable<SelectedAccountStore>
 ) => (selectedAccountStore = createDerivedStore(store));
+let selectedCanisterStore: Readable<SelectCanisterDetailsStore>;
+export const debugSelectedCanisterStore = (
+  store: Writable<SelectCanisterDetailsStore>
+) => (selectedCanisterStore = createDerivedStore(store));
 
 /**
  * Collects state of all available stores (also from context)
@@ -60,6 +65,7 @@ export const initDebugStore = () =>
       hardwareWalletNeuronsStore,
       transactionStore,
       selectedAccountStore,
+      selectedCanisterStore,
     ],
     ([
       $routeStore,
@@ -77,6 +83,7 @@ export const initDebugStore = () =>
       $hardwareWalletNeuronsStore,
       $transactionStore,
       $selectedAccountStore,
+      $selectedCanisterStore,
     ]) => ({
       route: $routeStore,
       accounts: $accountsStore,
@@ -93,5 +100,6 @@ export const initDebugStore = () =>
       hardwareWalletNeurons: $hardwareWalletNeuronsStore,
       transaction: $transactionStore,
       selectedAccount: $selectedAccountStore,
+      selectedCanister: $selectedCanisterStore,
     })
   );

--- a/frontend/svelte/src/lib/types/canister-detail.context.ts
+++ b/frontend/svelte/src/lib/types/canister-detail.context.ts
@@ -1,0 +1,17 @@
+import type { Writable } from "svelte/store";
+import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
+import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
+
+/**
+ * A store that contains canister info and detail.
+ */
+export interface SelectCanisterDetailsStore {
+  info: CanisterInfo | undefined;
+  details: CanisterDetails | undefined;
+}
+
+export interface CanisterDetailsContext {
+  store: Writable<SelectCanisterDetailsStore>;
+}
+
+export const CANISTER_DETAILS_CONTEXT_KEY = Symbol("canister-details");

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -284,6 +284,9 @@ interface I18nCanisters {
 
 interface I18nCanister_detail {
   title: string;
+  id: string;
+  cycles: string;
+  controllers: string;
 }
 
 interface I18nTopics {

--- a/frontend/svelte/src/lib/utils/canisters.utils.ts
+++ b/frontend/svelte/src/lib/utils/canisters.utils.ts
@@ -1,0 +1,13 @@
+import type { Principal } from "@dfinity/principal";
+import type { CanistersStore } from "../stores/canisters.store";
+
+export const getCanisterInfoById = ({
+  canisterId,
+  canistersStore,
+}: {
+  canisterId: Principal;
+  canistersStore: CanistersStore;
+}) =>
+  canistersStore.canisters?.find(
+    ({ canister_id }) => canister_id.toText() === canisterId.toText()
+  );

--- a/frontend/svelte/src/lib/utils/canisters.utils.ts
+++ b/frontend/svelte/src/lib/utils/canisters.utils.ts
@@ -1,4 +1,5 @@
 import type { Principal } from "@dfinity/principal";
+import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
 import type { CanistersStore } from "../stores/canisters.store";
 
 export const getCanisterInfoById = ({
@@ -7,7 +8,7 @@ export const getCanisterInfoById = ({
 }: {
   canisterId: Principal;
   canistersStore: CanistersStore;
-}) =>
+}): CanisterInfo | undefined =>
   canistersStore.canisters?.find(
     ({ canister_id }) => canister_id.toText() === canisterId.toText()
   );

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -36,6 +36,7 @@
     if (!SHOW_CANISTERS_ROUTE) {
       window.location.replace("/#/canisters");
     }
+    // TODO L2-628
     await listCanisters({ clearBeforeQuery: false });
   });
 

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -1,26 +1,105 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onDestroy, onMount, setContext } from "svelte";
+  import type { Principal } from "@dfinity/principal";
+  import type { CanisterDetails as CanisterInfo } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import HeadlessLayout from "../lib/components/common/HeadlessLayout.svelte";
   import {
     AppPath,
     SHOW_CANISTERS_ROUTE,
   } from "../lib/constants/routes.constants";
+  import {
+    listCanisters,
+    getCanisterDetails,
+    routePathCanisterId,
+  } from "../lib/services/canisters.services";
   import { i18n } from "../lib/stores/i18n";
   import { routeStore } from "../lib/stores/route.store";
+  import { isRoutePath } from "../lib/utils/app-path.utils";
+  import { canistersStore } from "../lib/stores/canisters.store";
+  import { replacePlaceholders } from "../lib/utils/i18n.utils";
+  import SkeletonParagraph from "../lib/components/ui/SkeletonParagraph.svelte";
+  import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
+  import CyclesCard from "../lib/components/canisters/CyclesCard.svelte";
+  import ControllersCard from "../lib/components/canisters/ControllersCard.svelte";
+  import { getCanisterInfoById } from "../lib/utils/canisters.utils";
+  import SkeletonTitle from "../lib/components/ui/SkeletonTitle.svelte";
+  import { writable } from "svelte/store";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+    type SelectCanisterDetailsStore,
+  } from "../lib/types/canister-detail.context";
+  import { debugSelectedCanisterStore } from "../lib/stores/debug.store";
+  import type { CanisterDetails } from "../lib/canisters/ic-management/ic-management.canister.types";
 
   onMount(async () => {
     if (!SHOW_CANISTERS_ROUTE) {
       window.location.replace("/#/canisters");
     }
+    await listCanisters({ clearBeforeQuery: false });
   });
+
+  let canisterId: Principal | undefined = undefined;
+  let canisterInfo: CanisterInfo | undefined;
+  let canisterDetails: CanisterDetails | undefined = undefined;
+
+  const canisterDetailStore = writable<SelectCanisterDetailsStore>({
+    info: undefined,
+    details: undefined,
+  });
+  // Update data in the store if source data changes
+  $: {
+    // If we navigate to a page where `canisterId` is undefined
+    // the `routeStore.subscribe` will redirect to Canisters Page
+    if (canisterId !== undefined) {
+      canisterInfo = getCanisterInfoById({
+        canisterId,
+        canistersStore: $canistersStore,
+      });
+      canisterDetailStore.update(() => ({
+        info: canisterInfo,
+        details: canisterDetails,
+      }));
+    }
+  }
+  debugSelectedCanisterStore(canisterDetailStore);
+
+  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
+    store: canisterDetailStore,
+  });
+
+  const unsubscribeRouteStore = routeStore.subscribe(
+    async ({ path: routePath }) => {
+      if (!isRoutePath({ path: AppPath.CanisterDetail, routePath })) {
+        return;
+      }
+      const newCanisterId = routePathCanisterId(routePath);
+
+      if (newCanisterId === undefined) {
+        // Navigate to the canisters list in no canisterId found
+        routeStore.replace({ path: AppPath.Canisters });
+        return;
+      }
+
+      // Refetch if path changes
+      if (newCanisterId.toText() !== canisterId?.toText()) {
+        // This automatically changes `canisterInfo`
+        canisterId = newCanisterId;
+        // Reset details while are being fetched
+        canisterDetails = undefined;
+        canisterDetails = await getCanisterDetails(newCanisterId);
+      }
+    }
+  );
+  onDestroy(unsubscribeRouteStore);
 
   const goBack = () => {
     routeStore.navigate({
       path: AppPath.Canisters,
     });
   };
-  // TODO: setup details page: https://dfinity.atlassian.net/browse/L2-334
-  // TODO: canister details card UI: https://dfinity.atlassian.net/browse/L2-599
+  let canisterIdString: string | undefined;
+  $: canisterIdString = canisterInfo?.canister_id.toText();
 </script>
 
 {#if SHOW_CANISTERS_ROUTE}
@@ -28,6 +107,57 @@
     <svelte:fragment slot="header"
       >{$i18n.canister_detail.title}</svelte:fragment
     >
-    <section />
+    <!-- TS is not smart enought to understand that if canisterStore is defined, canisterIdString is also defined -->
+    <section>
+      {#if canisterInfo !== undefined && canisterIdString !== undefined}
+        <h1>{canisterIdString}</h1>
+        <p>
+          {replacePlaceholders($i18n.canister_detail.id, {
+            $canisterId: canisterIdString,
+          })}
+        </p>
+      {:else}
+        <div class="loader-title">
+          <SkeletonTitle />
+        </div>
+        <div class="loader-subtitle">
+          <SkeletonParagraph />
+        </div>
+      {/if}
+      {#if canisterDetails !== undefined}
+        <CyclesCard />
+        <ControllersCard />
+      {:else}
+        <SkeletonCard />
+        <SkeletonCard />
+      {/if}
+    </section>
   </HeadlessLayout>
 {/if}
+
+<style lang="scss">
+  @use "../lib/themes/mixins/media";
+
+  p:last-of-type {
+    margin-bottom: var(--padding-3x);
+  }
+
+  .loader-title {
+    width: 100%;
+    margin-top: var(--padding);
+    margin-bottom: var(--padding-2x);
+
+    @include media.min-width(medium) {
+      width: 50%;
+    }
+  }
+
+  .loader-subtitle {
+    width: 100%;
+    margin-bottom: var(--padding-3x);
+
+    @include media.min-width(medium) {
+      width: 35%;
+    }
+  }
+</style>

--- a/frontend/svelte/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
@@ -9,7 +9,11 @@ describe("ConfirmDissolveDelay", () => {
   // Tested in CreateNeuronModal.spec.ts
   it("is not tested in isolation", () => {
     render(ConfirmDisolveDelay, {
-      props: { neuron: mockNeuron, delayInSeconds: 10_000 },
+      props: {
+        neuron: mockNeuron,
+        delayInSeconds: 10_000,
+        confirmButtonText: "confirm",
+      },
     });
     expect(true).toBeTruthy();
   });

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -77,6 +77,8 @@ describe("canisters-services", () => {
       expect(response.success).toBe(false);
       expect(spyAttachCanister).not.toBeCalled();
       expect(spyQueryCanisters).not.toBeCalled();
+
+      resetIdentity();
     });
   });
 
@@ -101,7 +103,7 @@ describe("canisters-services", () => {
   });
 
   describe("getCanisterDetails", () => {
-    it("should fetch canister deetails and load them in the store", async () => {
+    it("should fetch canister details", async () => {
       const canister = await getCanisterDetails(mockCanisterDetails.id);
 
       expect(spyQueryCanisterDetails).toBeCalled();

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -1,8 +1,11 @@
+import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
 import {
   attachCanister,
+  getCanisterDetails,
   listCanisters,
+  routePathCanisterId,
 } from "../../../lib/services/canisters.services";
 import { canistersStore } from "../../../lib/stores/canisters.store";
 import {
@@ -20,6 +23,10 @@ describe("canisters-services", () => {
   const spyAttachCanister = jest
     .spyOn(api, "attachCanister")
     .mockImplementation(() => Promise.resolve(undefined));
+
+  const spyQueryCanisterDetails = jest
+    .spyOn(api, "queryCanisterDetails")
+    .mockImplementation(() => Promise.resolve(mockCanisterDetails));
 
   describe("listCanisters", () => {
     afterEach(() => {
@@ -70,6 +77,43 @@ describe("canisters-services", () => {
       expect(response.success).toBe(false);
       expect(spyAttachCanister).not.toBeCalled();
       expect(spyQueryCanisters).not.toBeCalled();
+    });
+  });
+
+  describe("routePathCanisterId", () => {
+    it("should return principal if valid in the url", () => {
+      const path = "/#/canister/tqtu6-byaaa-aaaaa-aaana-cai";
+
+      expect(routePathCanisterId(path)).toBeInstanceOf(Principal);
+    });
+
+    it("should return undefined if not valid in the url", () => {
+      const path = "/#/canister/not-valid-principal";
+
+      expect(routePathCanisterId(path)).toBeUndefined();
+    });
+
+    it("should return undefined if no last detail in the path", () => {
+      const path = "/#/canister";
+
+      expect(routePathCanisterId(path)).toBeUndefined();
+    });
+  });
+
+  describe("getCanisterDetails", () => {
+    it("should fetch canister deetails and load them in the store", async () => {
+      const canister = await getCanisterDetails(mockCanisterDetails.id);
+
+      expect(spyQueryCanisterDetails).toBeCalled();
+      expect(canister).toEqual(mockCanisterDetails);
+    });
+
+    it("should not fetch canister details if no identity", async () => {
+      setNoIdentity();
+
+      const call = () => getCanisterDetails(mockCanisterDetails.id);
+
+      await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
 
       resetIdentity();
     });

--- a/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/canisters.store.spec.ts
@@ -3,18 +3,26 @@ import { canistersStore } from "../../../lib/stores/canisters.store";
 import { mockCanisters } from "../../mocks/canisters.mock";
 
 describe("canisters-store", () => {
-  it("should set canisters", () => {
-    canistersStore.setCanisters({ canisters: mockCanisters, certified: true });
+  describe("canistersStore", () => {
+    it("should set canisters", () => {
+      canistersStore.setCanisters({
+        canisters: mockCanisters,
+        certified: true,
+      });
 
-    const store = get(canistersStore);
-    expect(store.canisters).toEqual(mockCanisters);
-  });
+      const store = get(canistersStore);
+      expect(store.canisters).toEqual(mockCanisters);
+    });
 
-  it("should reset canisters", () => {
-    canistersStore.setCanisters({ canisters: mockCanisters, certified: true });
-    canistersStore.setCanisters({ canisters: undefined, certified: true });
+    it("should reset canisters", () => {
+      canistersStore.setCanisters({
+        canisters: mockCanisters,
+        certified: true,
+      });
+      canistersStore.setCanisters({ canisters: undefined, certified: true });
 
-    const store = get(canistersStore);
-    expect(store.canisters).toBeUndefined();
+      const store = get(canistersStore);
+      expect(store.canisters).toBeUndefined();
+    });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/canisters.utils.spec.ts
@@ -1,0 +1,42 @@
+import { Principal } from "@dfinity/principal";
+import { getCanisterInfoById } from "../../../lib/utils/canisters.utils";
+import { mockCanisters } from "../../mocks/canisters.mock";
+
+describe("canister-utils", () => {
+  describe("getCanisterInfoById", () => {
+    it("should return the canister info if present", () => {
+      const store = {
+        canisters: mockCanisters,
+        certified: true,
+      };
+      const canister = getCanisterInfoById({
+        canisterId: mockCanisters[0].canister_id,
+        canistersStore: store,
+      });
+      expect(canister).toBe(mockCanisters[0]);
+    });
+
+    it("should return undefined if not present", () => {
+      const store = {
+        canisters: mockCanisters,
+        certified: true,
+      };
+      const canister = getCanisterInfoById({
+        canisterId: Principal.fromText("aaaaa-aa"),
+        canistersStore: store,
+      });
+      expect(canister).toBeUndefined();
+    });
+    it("should return undefiend if no canisters in the store", () => {
+      const store = {
+        canisters: undefined,
+        certified: true,
+      };
+      const canister = getCanisterInfoById({
+        canisterId: mockCanisters[0].canister_id,
+        canistersStore: store,
+      });
+      expect(canister).toBeUndefined();
+    });
+  });
+});

--- a/frontend/svelte/src/tests/mocks/canisters.mock.ts
+++ b/frontend/svelte/src/tests/mocks/canisters.mock.ts
@@ -8,9 +8,10 @@ import type { CanisterDetails as CanisterInfo } from "../../lib/canisters/nns-da
 import type { CanistersStore } from "../../lib/stores/canisters.store";
 import { mockIdentity } from "./auth.store.mock";
 
+const mockCanisterId = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
 export const mockCanister = {
   name: "",
-  canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+  canister_id: mockCanisterId,
 };
 export const mockCanisters: CanisterInfo[] = [
   {
@@ -21,7 +22,7 @@ export const mockCanisters: CanisterInfo[] = [
 ];
 
 export const mockCanisterDetails: CanisterDetails = {
-  id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+  id: mockCanisterId,
   status: CanisterStatus.Running,
   memorySize: BigInt(10),
   cycles: BigInt(30),

--- a/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
@@ -2,14 +2,79 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
+import {
+  getCanisterDetails,
+  listCanisters,
+} from "../../lib/services/canisters.services";
+import { canistersStore } from "../../lib/stores/canisters.store";
+import { routeStore } from "../../lib/stores/route.store";
 import CanisterDetail from "../../routes/CanisterDetail.svelte";
+import { mockCanister, mockCanisterDetails } from "../mocks/canisters.mock";
 import en from "../mocks/i18n.mock";
+import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
+
+jest.mock("../../lib/services/canisters.services", () => {
+  return {
+    listCanisters: jest.fn(),
+    routePathCanisterId: () => mockCanister.canister_id,
+    getCanisterDetails: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockCanisterDetails)),
+  };
+});
 
 describe("CanisterDetail", () => {
+  jest
+    .spyOn(routeStore, "subscribe")
+    .mockImplementation(
+      mockRouteStoreSubscribe(
+        `/#/canister/${mockCanister.canister_id.toText()}`
+      )
+    );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    canistersStore.setCanisters({ canisters: undefined, certified: true });
+  });
+
   it("should render title", () => {
     const { getByText } = render(CanisterDetail);
 
     expect(getByText(en.canister_detail.title)).toBeInTheDocument();
+  });
+
+  it("should fetch canisters from nns-dapp", async () => {
+    render(CanisterDetail);
+    await waitFor(() => expect(listCanisters).toBeCalled());
+  });
+
+  it("should get canister details", async () => {
+    render(CanisterDetail);
+    await waitFor(() => expect(getCanisterDetails).toBeCalled());
+  });
+
+  it("should render canister id", async () => {
+    // Need to be the same that routePathCanisterId returns.
+    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
+    const { queryAllByText } = render(CanisterDetail);
+
+    await waitFor(() =>
+      expect(
+        queryAllByText(mockCanister.canister_id.toText()).length
+      ).toBeGreaterThan(0)
+    );
+  });
+
+  it("should render cards", async () => {
+    // Need to be the same that routePathCanisterId returns.
+    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
+    const { queryByTestId } = render(CanisterDetail);
+
+    await waitFor(() =>
+      expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
+    );
+    // Waiting for the one above is enough
+    expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

User can see the canister title in the canister detail page.

# Changes

* New canister service "loadCanisterDetails" that fetches canister details and adds them to the store.
* New store "canisterDetailsStore" which stores the data of a canister. It's a different type than from nns dapp.
* New canister service "routePathCanisterId" to read the canister id from the url.
* Setup of "ControllersCard" and "CyclesCard" to help parallel development.
* CanisterDetails route component triggers fetching canisters and details and read them from the stores.

# Tests

* New test for new two canister services.
* Extend CanisterDetails route tests.
