### PR TITLE
L2-227: Create canister flow Part I

### DIFF
--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -32,6 +32,19 @@ export const queryCanisters = async ({
   return response;
 };
 
+export const getIcpToCyclesExchangeRate = async (
+  identity: Identity
+): Promise<bigint> => {
+  logWithTimestamp("Getting ICP to Cycles ratio call...");
+  const { cmc } = await canisters(identity);
+
+  const response = await cmc.getIcpToCyclesConversionRate();
+
+  logWithTimestamp("Getting ICP to Cycles ratio complete.");
+
+  return response;
+};
+
 export const queryCanisterDetails = async ({
   identity,
   canisterId,

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -9,11 +9,8 @@
   import { toastsStore } from "../../stores/toasts.store";
   import NewTransactionInfo from "./NewTransactionInfo.svelte";
   import { ICP } from "@dfinity/nns";
-  import { maxICP } from "../../utils/icp.utils";
-  import {
-    convertNumberToICP,
-    isValidInputAmount,
-  } from "../../utils/neuron.utils";
+  import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
+  import { isValidInputAmount } from "../../utils/neuron.utils";
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -1,0 +1,1 @@
+<div class="wizard-wrapper">Confirm Cycles</div>

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -1,1 +1,4 @@
-<div class="wizard-wrapper">Confirm Cycles</div>
+<!-- TODO: https://dfinity.atlassian.net/browse/L2-227 -->
+<div class="wizard-wrapper" data-tid="confirm-create-canister-screen">
+  Confirm Cycles
+</div>

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { ICP } from "@dfinity/nns";
+
+  import { createEventDispatcher, onMount } from "svelte";
+  import { E8S_PER_ICP } from "../../constants/icp.constants";
   import { getIcpToCyclesExchangeRate } from "../../services/canisters.services";
   import { i18n } from "../../stores/i18n";
-  import { convertIcpToTCycles } from "../../utils/icp.utils";
+  import {
+    convertIcpToTCycles,
+    convertTCyclesToE8s,
+  } from "../../utils/icp.utils";
   import Input from "../ui/Input.svelte";
 
   let icpToCyclesRatio: bigint | undefined;
@@ -13,42 +19,62 @@
   let amountIcp: number;
   const updateCycles = () => {
     if (icpToCyclesRatio !== undefined) {
-      console.log(amountIcp);
-      amountCycles = Number(convertIcpToTCycles(amountIcp, icpToCyclesRatio));
+      amountCycles = convertIcpToTCycles({
+        icpNumber: amountIcp,
+        ratio: icpToCyclesRatio,
+      });
     }
   };
   let amountCycles: number;
   const updateIcp = () => {
-    console.log("update the other input");
+    if (icpToCyclesRatio !== undefined) {
+      amountIcp =
+        Number(
+          convertTCyclesToE8s({
+            tCycles: amountCycles,
+            ratio: icpToCyclesRatio,
+          })
+        ) / E8S_PER_ICP;
+    }
   };
 
-  $: {
-    console.log(icpToCyclesRatio);
-  }
+  const dispatcher = createEventDispatcher();
+  const selectAccount = () => {
+    dispatcher("nnsSelectAmount", {
+      amount: ICP.fromString(String(amountIcp)),
+    });
+  };
 </script>
 
-<div class="wizard-wrapper wrapper">
-  <div>
-    <Input
-      placeholderLabelKey="core.icp"
-      inputType="icp"
-      name="icp-amount"
-      theme="dark"
-      bind:value={amountIcp}
-      on:blur={updateCycles}
-      disabled={icpToCyclesRatio === undefined}
-    />
-    <Input
-      placeholderLabelKey="canisters.t_cycles"
-      inputType="number"
-      name="t-cycles-amount"
-      theme="dark"
-      bind:value={amountCycles}
-      on:blur={updateIcp}
-      disabled={icpToCyclesRatio === undefined}
-    />
+<div class="wizard-wrapper wrapper" data-tid="select-cycles-screen">
+  <div class="content">
+    <div class="inputs">
+      <Input
+        placeholderLabelKey="core.icp"
+        inputType="icp"
+        name="icp-amount"
+        theme="dark"
+        bind:value={amountIcp}
+        on:blur={updateCycles}
+        disabled={icpToCyclesRatio === undefined}
+      />
+      <Input
+        placeholderLabelKey="canisters.t_cycles"
+        inputType="number"
+        name="t-cycles-amount"
+        theme="dark"
+        bind:value={amountCycles}
+        on:blur={updateIcp}
+        disabled={icpToCyclesRatio === undefined}
+      />
+    </div>
+    <p>{$i18n.canisters.minimum_cycles_text}</p>
+    <p>{$i18n.canisters.app_subnets_beta}</p>
   </div>
-  <button class="primary full-width"
+  <button
+    class="primary full-width"
+    on:click={selectAccount}
+    data-tid="select-cycles-button"
     >{$i18n.canisters.review_cycles_purchase}</button
   >
 </div>
@@ -56,5 +82,17 @@
 <style lang="scss">
   .wizard-wrapper.wrapper {
     justify-content: space-between;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+  }
+
+  .inputs {
+    display: flex;
+    gap: var(--padding-2x);
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -11,24 +11,37 @@
   } from "../../utils/icp.utils";
   import Input from "../ui/Input.svelte";
 
+  export let amount: number | undefined = undefined;
+
   let icpToCyclesRatio: bigint | undefined;
   onMount(async () => {
     icpToCyclesRatio = await getIcpToCyclesExchangeRate();
+    // Update cycles input if the component is mounted with some `amount`
+    if (icpToCyclesRatio !== undefined && amount !== undefined) {
+      amountCycles = convertIcpToTCycles({
+        icpNumber: amount,
+        ratio: icpToCyclesRatio,
+      });
+    }
   });
 
-  let amountIcp: number;
   const updateCycles = () => {
+    // Reset cycles
+    if (amount === undefined) {
+      amountCycles = undefined;
+      return;
+    }
     if (icpToCyclesRatio !== undefined) {
       amountCycles = convertIcpToTCycles({
-        icpNumber: amountIcp,
+        icpNumber: amount,
         ratio: icpToCyclesRatio,
       });
     }
   };
-  let amountCycles: number;
+  let amountCycles: number | undefined;
   const updateIcp = () => {
-    if (icpToCyclesRatio !== undefined) {
-      amountIcp =
+    if (icpToCyclesRatio !== undefined && amountCycles !== undefined) {
+      amount =
         Number(
           convertTCyclesToE8s({
             tCycles: amountCycles,
@@ -41,9 +54,10 @@
   const dispatcher = createEventDispatcher();
   const selectAccount = () => {
     dispatcher("nnsSelectAmount", {
-      amount: ICP.fromString(String(amountIcp)),
+      amount: ICP.fromString(String(amount)),
     });
   };
+  // TODO: Add validations - https://dfinity.atlassian.net/browse/L2-644
 </script>
 
 <div class="wizard-wrapper wrapper" data-tid="select-cycles-screen">
@@ -54,7 +68,7 @@
         inputType="icp"
         name="icp-amount"
         theme="dark"
-        bind:value={amountIcp}
+        bind:value={amount}
         on:blur={updateCycles}
         disabled={icpToCyclesRatio === undefined}
       />

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getIcpToCyclesExchangeRate } from "../../services/canisters.services";
+  import { i18n } from "../../stores/i18n";
+  import { convertIcpToTCycles } from "../../utils/icp.utils";
+  import Input from "../ui/Input.svelte";
+
+  let icpToCyclesRatio: bigint | undefined;
+  onMount(async () => {
+    icpToCyclesRatio = await getIcpToCyclesExchangeRate();
+  });
+
+  let amountIcp: number;
+  const updateCycles = () => {
+    if (icpToCyclesRatio !== undefined) {
+      console.log(amountIcp);
+      amountCycles = Number(convertIcpToTCycles(amountIcp, icpToCyclesRatio));
+    }
+  };
+  let amountCycles: number;
+  const updateIcp = () => {
+    console.log("update the other input");
+  };
+
+  $: {
+    console.log(icpToCyclesRatio);
+  }
+</script>
+
+<div class="wizard-wrapper wrapper">
+  <div>
+    <Input
+      placeholderLabelKey="core.icp"
+      inputType="icp"
+      name="icp-amount"
+      theme="dark"
+      bind:value={amountIcp}
+      on:blur={updateCycles}
+      disabled={icpToCyclesRatio === undefined}
+    />
+    <Input
+      placeholderLabelKey="canisters.t_cycles"
+      inputType="number"
+      name="t-cycles-amount"
+      theme="dark"
+      bind:value={amountCycles}
+      on:blur={updateIcp}
+      disabled={icpToCyclesRatio === undefined}
+    />
+  </div>
+  <button class="primary full-width"
+    >{$i18n.canisters.review_cycles_purchase}</button
+  >
+</div>
+
+<style lang="scss">
+  .wizard-wrapper.wrapper {
+    justify-content: space-between;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectNewCanisterType.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { i18n } from "../../stores/i18n";
+  import type { CreateOrLinkType } from "../../types/canisters";
   import CardItem from "../ui/CardItem.svelte";
 
   const dispatcher = createEventDispatcher();
-  const dispatchSelect = (type: "newCanisterCreate" | "newCanisterAttach") => {
+  const dispatchSelect = (type: CreateOrLinkType) => {
     dispatcher("nnsSelect", { type });
   };
   const selectCreate = () => {

--- a/frontend/svelte/src/lib/components/ui/Input.svelte
+++ b/frontend/svelte/src/lib/components/ui/Input.svelte
@@ -133,6 +133,7 @@
     {max}
     {autocomplete}
     on:blur
+    on:focus
     on:input={handleInput}
     on:keydown={handleKeyDown}
   />

--- a/frontend/svelte/src/lib/constants/icp.constants.ts
+++ b/frontend/svelte/src/lib/constants/icp.constants.ts
@@ -1,5 +1,6 @@
 export const E8S_PER_ICP = 100_000_000;
 export const TRANSACTION_FEE_E8S = 10_000;
+export const ONE_TRILLION = BigInt(1000000) * BigInt(1000000);
 
 /*
  * The format should be:

--- a/frontend/svelte/src/lib/constants/icp.constants.ts
+++ b/frontend/svelte/src/lib/constants/icp.constants.ts
@@ -1,6 +1,6 @@
 export const E8S_PER_ICP = 100_000_000;
 export const TRANSACTION_FEE_E8S = 10_000;
-export const ONE_TRILLION = BigInt(1000000) * BigInt(1000000);
+export const ONE_TRILLION = 1_000_000_000_000;
 
 /*
  * The format should be:

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -265,7 +265,14 @@
     "link_canister_success": "The canister was linked successfully",
     "attach_canister": "Attach Canister",
     "enter_canister_id": "Enter Canister ID:",
-    "canister_id": "Canister ID"
+    "canister_id": "Canister ID",
+    "enter_amount": "Enter Amount",
+    "review_create_canister": "Review Canister Creation",
+    "t_cycles": "T Cycles",
+    "minimum_cycles_text": "Minimum amount: 2T Cycles (inclusve of 1T Cycles fee if creating a new canister)",
+    "app_subnets_beta": "Application subneets are in beta and therefore Cycles might be lost",
+    "review_cycles_purchase": "Review Cycles Purchase",
+    "converted_to": "converted to"
   },
   "canister_detail": {
     "title": "Canister",

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -270,7 +270,7 @@
     "review_create_canister": "Review Canister Creation",
     "t_cycles": "T Cycles",
     "minimum_cycles_text": "Minimum amount: 2T Cycles (inclusve of 1T Cycles fee if creating a new canister)",
-    "app_subnets_beta": "Application subneets are in beta and therefore Cycles might be lost",
+    "app_subnets_beta": "Application subnets are in beta and therefore Cycles might be lost",
     "review_cycles_purchase": "Review Cycles Purchase",
     "converted_to": "converted to"
   },

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -1,30 +1,56 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import AttachCanister from "../../components/canisters/AttachCanister.svelte";
+  import ConfirmCyclesCanister from "../../components/canisters/ConfirmCyclesCanister.svelte";
+  import SelectCyclesCanister from "../../components/canisters/SelectCyclesCanister.svelte";
   import SelectNewCanisterType from "../../components/canisters/SelectNewCanisterType.svelte";
-
   import { i18n } from "../../stores/i18n";
   import type { Step, Steps } from "../../stores/steps.state";
+  import type { CreateOrLinkType } from "../../types/canisters";
   import WizardModal from "../WizardModal.svelte";
 
-  // TODO: Create Canister Flow https://dfinity.atlassian.net/browse/L2-227
   const steps: Steps = [
     {
       name: "SelectNewCanisterType",
       title: $i18n.canisters.add_canister,
       showBackButton: false,
     },
+  ];
+  const attachCanisterSteps = [
     {
       name: "AttachCanister",
       title: $i18n.canisters.attach_canister,
-      showBackButton: false,
+      showBackButton: true,
+    },
+  ];
+  const createCanisterSteps = [
+    {
+      name: "SelectCycles",
+      title: $i18n.canisters.enter_amount,
+      showBackButton: true,
+    },
+    {
+      name: "ConfirmCycles",
+      title: $i18n.canisters.review_create_canister,
+      showBackButton: true,
     },
   ];
 
   let currentStep: Step | undefined;
   let modal: WizardModal;
 
-  // TODO: Create Canister Flow https://dfinity.atlassian.net/browse/L2-227
-  const selectType = () => {
+  const selectType = async ({
+    detail,
+  }: CustomEvent<{ type: CreateOrLinkType }>) => {
+    // We preserve the first step in the array because we want the current first step to *not* be re-rendered. It would cause a flickering of the content of the modal.
+    steps.splice(1, steps.length);
+    steps.push(
+      ...(detail.type === "newCanisterAttach"
+        ? attachCanisterSteps
+        : createCanisterSteps)
+    );
+    // Wait steps to be applied - components to be updated - before being able to navigate to next step
+    await tick();
     modal.next();
   };
 </script>
@@ -41,6 +67,12 @@
     {/if}
     {#if currentStep?.name === "AttachCanister"}
       <AttachCanister on:nnsClose />
+    {/if}
+    {#if currentStep?.name === "SelectCycles"}
+      <SelectCyclesCanister on:nnsClose />
+    {/if}
+    {#if currentStep?.name === "ConfirmCycles"}
+      <ConfirmCyclesCanister on:nnsClose />
     {/if}
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { ICP } from "@dfinity/nns";
   import { tick } from "svelte";
   import AttachCanister from "../../components/canisters/AttachCanister.svelte";
   import ConfirmCyclesCanister from "../../components/canisters/ConfirmCyclesCanister.svelte";

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -39,7 +39,7 @@
 
   let currentStep: Step | undefined;
   let modal: WizardModal;
-  let amount: ICP | undefined;
+  let amount: number | undefined;
 
   const selectType = async ({
     detail,
@@ -56,8 +56,7 @@
     modal.next();
   };
 
-  const selectAmount = ({ detail }: CustomEvent<{ amount: ICP }>) => {
-    amount = detail.amount;
+  const selectAmount = () => {
     modal.next();
   };
 
@@ -78,7 +77,11 @@
       <AttachCanister on:nnsClose />
     {/if}
     {#if currentStep?.name === "SelectCycles"}
-      <SelectCyclesCanister on:nnsClose on:nnsSelectAmount={selectAmount} />
+      <SelectCyclesCanister
+        bind:amount
+        on:nnsClose
+        on:nnsSelectAmount={selectAmount}
+      />
     {/if}
     {#if currentStep?.name === "ConfirmCycles"}
       <ConfirmCyclesCanister on:nnsClose />

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { ICP } from "@dfinity/nns";
   import { tick } from "svelte";
   import AttachCanister from "../../components/canisters/AttachCanister.svelte";
   import ConfirmCyclesCanister from "../../components/canisters/ConfirmCyclesCanister.svelte";
@@ -38,6 +39,7 @@
 
   let currentStep: Step | undefined;
   let modal: WizardModal;
+  let amount: ICP | undefined;
 
   const selectType = async ({
     detail,
@@ -53,6 +55,13 @@
     await tick();
     modal.next();
   };
+
+  const selectAmount = ({ detail }: CustomEvent<{ amount: ICP }>) => {
+    amount = detail.amount;
+    modal.next();
+  };
+
+  // TODO: Finish flow - https://dfinity.atlassian.net/browse/L2-227
 </script>
 
 <WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
@@ -69,7 +78,7 @@
       <AttachCanister on:nnsClose />
     {/if}
     {#if currentStep?.name === "SelectCycles"}
-      <SelectCyclesCanister on:nnsClose />
+      <SelectCyclesCanister on:nnsClose on:nnsSelectAmount={selectAmount} />
     {/if}
     {#if currentStep?.name === "ConfirmCycles"}
       <ConfirmCyclesCanister on:nnsClose />

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -2,13 +2,11 @@ import type { Principal } from "@dfinity/principal";
 import {
   attachCanister as attachCanisterApi,
   getIcpToCyclesExchangeRate as getIcpToCyclesExchangeRateApi,
-  queryCanisterDetails,
+  queryCanisterDetails as queryCanisterDetailsApi,
   queryCanisters,
 } from "../api/canisters.api";
-import type {
-  CanisterDetails,
-  CanisterDetails as CanisterInfo,
-} from "../canisters/nns-dapp/nns-dapp.types";
+import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
+import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
@@ -78,7 +76,7 @@ export const getCanisterDetails = async (
 ): Promise<CanisterDetails | undefined> => {
   const identity = await getIdentity();
   try {
-    return await queryCanisterDetails({
+    return await queryCanisterDetailsApi({
       canisterId,
       identity,
     });

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -1,11 +1,15 @@
 import type { Principal } from "@dfinity/principal";
 import {
   attachCanister as attachCanisterApi,
+  getIcpToCyclesExchangeRate as getIcpToCyclesExchangeRateApi,
   queryCanisterDetails,
   queryCanisters,
 } from "../api/canisters.api";
-import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
-import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
+import type {
+  CanisterDetails,
+  CanisterDetails as CanisterInfo,
+} from "../canisters/nns-dapp/nns-dapp.types";
+import { E8S_PER_ICP } from "../constants/icp.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
 import { getPrincipalFromString } from "../utils/accounts.utils";
@@ -80,5 +84,19 @@ export const getCanisterDetails = async (
     });
   } catch (error) {
     // TODO: manage errors https://dfinity.atlassian.net/browse/L2-615
+  }
+};
+
+export const getIcpToCyclesExchangeRate = async (): Promise<
+  bigint | undefined
+> => {
+  try {
+    const identity = await getIdentity();
+    const trillionRatio = await getIcpToCyclesExchangeRateApi(identity);
+    // This transforms to ratio to E8s to T Cycles.
+    return trillionRatio / BigInt(E8S_PER_ICP);
+  } catch (error) {
+    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+    return;
   }
 };

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -48,9 +48,9 @@ import { isAccountHardwareWallet } from "../utils/accounts.utils";
 import { getLastPathDetailId } from "../utils/app-path.utils";
 import { mapNeuronErrorToToastMessage } from "../utils/error.utils";
 import { translate } from "../utils/i18n.utils";
+import { convertNumberToICP } from "../utils/icp.utils";
 import {
   canBeMerged,
-  convertNumberToICP,
   followeesByTopic,
   isEnoughToStakeNeuron,
   isHotKeyControllable,

--- a/frontend/svelte/src/lib/types/canisters.ts
+++ b/frontend/svelte/src/lib/types/canisters.ts
@@ -1,0 +1,1 @@
+export type CreateOrLinkType = "newCanisterCreate" | "newCanisterAttach";

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -280,6 +280,13 @@ interface I18nCanisters {
   attach_canister: string;
   enter_canister_id: string;
   canister_id: string;
+  enter_amount: string;
+  review_create_canister: string;
+  t_cycles: string;
+  minimum_cycles_text: string;
+  app_subnets_beta: string;
+  review_cycles_purchase: string;
+  converted_to: string;
 }
 
 interface I18nCanister_detail {

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -26,8 +26,9 @@ export const maxICP = (icp: ICP | undefined): number =>
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);
 
+const ICP_DECIMAL_ACCURACY = 8;
 export const convertNumberToICP = (amount: number): ICP => {
-  const stake = ICP.fromString(amount.toFixed(8));
+  const stake = ICP.fromString(amount.toFixed(ICP_DECIMAL_ACCURACY));
 
   if (!(stake instanceof ICP) || stake === undefined) {
     throw new InvalidAmountError();

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -36,10 +36,23 @@ export const convertNumberToICP = (amount: number): ICP => {
   return stake;
 };
 
-export const convertIcpToTCycles = (
-  icpNumber: number,
-  ratio: bigint
-): bigint => {
+export const convertIcpToTCycles = ({
+  icpNumber,
+  ratio,
+}: {
+  icpNumber: number;
+  ratio: bigint;
+}): number => {
   const icp = convertNumberToICP(icpNumber);
-  return (icp.toE8s() * ratio) / ONE_TRILLION;
+  return Number(icp.toE8s() * ratio) / ONE_TRILLION;
+};
+
+export const convertTCyclesToE8s = ({
+  tCycles,
+  ratio,
+}: {
+  tCycles: number;
+  ratio: bigint;
+}): bigint => {
+  return BigInt(tCycles * ONE_TRILLION) / ratio;
 };

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -1,5 +1,10 @@
 import { ICP } from "@dfinity/nns";
-import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
+import {
+  E8S_PER_ICP,
+  ONE_TRILLION,
+  TRANSACTION_FEE_E8S,
+} from "../constants/icp.constants";
+import { InvalidAmountError } from "../types/errors";
 
 export const formatICP = (value: bigint): string =>
   new Intl.NumberFormat("fr-FR", {
@@ -20,3 +25,21 @@ export const maxICP = (icp: ICP | undefined): number =>
 
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);
+
+export const convertNumberToICP = (amount: number): ICP => {
+  const stake = ICP.fromString(amount.toFixed(8));
+
+  if (!(stake instanceof ICP) || stake === undefined) {
+    throw new InvalidAmountError();
+  }
+
+  return stake;
+};
+
+export const convertIcpToTCycles = (
+  icpNumber: number,
+  ratio: bigint
+): bigint => {
+  const icp = convertNumberToICP(icpNumber);
+  return (icp.toE8s() * ratio) / ONE_TRILLION;
+};

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -4,7 +4,7 @@ import {
   ONE_TRILLION,
   TRANSACTION_FEE_E8S,
 } from "../constants/icp.constants";
-import { InvalidAmountError } from "../types/errors";
+import { InvalidAmountError } from "../types/neurons.errors";
 
 export const formatICP = (value: bigint): string =>
   new Intl.NumberFormat("fr-FR", {
@@ -54,6 +54,4 @@ export const convertTCyclesToE8s = ({
 }: {
   tCycles: number;
   ratio: bigint;
-}): bigint => {
-  return BigInt(tCycles * ONE_TRILLION) / ratio;
-};
+}): bigint => BigInt(tCycles * ONE_TRILLION) / ratio;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -28,7 +28,6 @@ import IconLockOpen from "../icons/IconLockOpen.svelte";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Step } from "../stores/steps.state";
 import type { Account } from "../types/account";
-import { InvalidAmountError } from "../types/neurons.errors";
 import {
   getAccountByPrincipal,
   isAccountHardwareWallet,
@@ -275,16 +274,6 @@ export const isValidInputAmount = ({
   amount?: number;
   max: number;
 }): boolean => amount !== undefined && amount > 0 && amount <= max;
-
-export const convertNumberToICP = (amount: number): ICP => {
-  const stake = ICP.fromString(amount.toFixed(8));
-
-  if (!(stake instanceof ICP) || stake === undefined) {
-    throw new InvalidAmountError();
-  }
-
-  return stake;
-};
 
 export const isEnoughToStakeNeuron = ({
   stake,

--- a/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "jest-mock-extended";
 import {
   attachCanister,
   createCanister,
+  getIcpToCyclesExchangeRate,
   queryCanisterDetails,
   queryCanisters,
   topUpCanister,
@@ -85,6 +86,18 @@ describe("canisters-api", () => {
         mockCanisterDetails.id
       );
       expect(response).toEqual(mockCanisterDetails);
+    });
+  });
+
+  describe("getIcpToCyclesExchangeRate", () => {
+    it("should call CMC to get conversion rate", async () => {
+      mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(
+        BigInt(10_000)
+      );
+
+      const response = await getIcpToCyclesExchangeRate(mockIdentity);
+      expect(mockCMCCanister.getIcpToCyclesConversionRate).toBeCalled();
+      expect(response).toEqual(BigInt(10_000));
     });
   });
 

--- a/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import SelectCyclesCanister from "../../../../lib/components/canisters/SelectCyclesCanister.svelte";
+import { getIcpToCyclesExchangeRate } from "../../../../lib/services/canisters.services";
+import { clickByTestId } from "../../../lib/testHelpers/clickByTestId";
+import en from "../../../mocks/i18n.mock";
+
+jest.mock("../../../../lib/services/canisters.services", () => {
+  return {
+    getIcpToCyclesExchangeRate: jest.fn().mockResolvedValue(BigInt(10_000)),
+  };
+});
+
+describe("SelectCyclesCanister", () => {
+  it("renders message", () => {
+    const { queryByText } = render(SelectCyclesCanister);
+
+    expect(queryByText(en.canisters.minimum_cycles_text)).toBeInTheDocument();
+  });
+
+  it("renders two inputs", () => {
+    const { container } = render(SelectCyclesCanister);
+
+    expect(container.querySelectorAll("input").length).toBe(2);
+  });
+
+  it("synchronizes icp input to tCycles input", async () => {
+    const { container } = render(SelectCyclesCanister);
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
+
+    const icpInputElement = container.querySelector<HTMLInputElement>(
+      'input[name="icp-amount"]'
+    );
+    expect(icpInputElement).not.toBeNull();
+    const tCyclesInputElement = container.querySelector<HTMLInputElement>(
+      'input[name="t-cycles-amount"]'
+    );
+    expect(tCyclesInputElement).not.toBeNull();
+
+    const value = 2;
+    icpInputElement &&
+      (await fireEvent.input(icpInputElement, {
+        target: { value },
+      }));
+    icpInputElement && (await fireEvent.blur(icpInputElement));
+
+    tCyclesInputElement &&
+      expect(tCyclesInputElement.value).toBe(String(value));
+  });
+
+  it("synchronizes tCycles input to icp input", async () => {
+    const { container } = render(SelectCyclesCanister);
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
+
+    const icpInputElement = container.querySelector<HTMLInputElement>(
+      'input[name="icp-amount"]'
+    );
+    expect(icpInputElement).not.toBeNull();
+    const tCyclesInputElement = container.querySelector<HTMLInputElement>(
+      'input[name="t-cycles-amount"]'
+    );
+    expect(tCyclesInputElement).not.toBeNull();
+
+    const value = 2;
+    tCyclesInputElement &&
+      (await fireEvent.input(tCyclesInputElement, {
+        target: { value },
+      }));
+    tCyclesInputElement && (await fireEvent.blur(tCyclesInputElement));
+
+    icpInputElement && expect(icpInputElement.value).toBe(String(value));
+  });
+
+  it("dispatches nnsSelectAmount event on click", async () => {
+    const { container, component, queryByTestId } =
+      render(SelectCyclesCanister);
+
+    const icpInputElement = container.querySelector<HTMLInputElement>(
+      'input[name="icp-amount"]'
+    );
+    expect(icpInputElement).not.toBeNull();
+
+    icpInputElement &&
+      (await fireEvent.input(icpInputElement, {
+        target: { value: 2 },
+      }));
+    icpInputElement && (await fireEvent.blur(icpInputElement));
+
+    const fn = jest.fn();
+    component.$on("nnsSelectAmount", fn);
+    await clickByTestId(queryByTestId, "select-cycles-button");
+
+    await waitFor(() => expect(fn).toBeCalled());
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -46,14 +46,18 @@ describe("SelectCyclesCanister", () => {
     expect(tCyclesInputElement).not.toBeNull();
 
     const value = 2;
+    // Inputs are synchronized when they are focused
+    icpInputElement && fireEvent.focus(icpInputElement);
     icpInputElement &&
       (await fireEvent.input(icpInputElement, {
         target: { value },
       }));
-    icpInputElement && (await fireEvent.blur(icpInputElement));
 
-    tCyclesInputElement &&
-      expect(tCyclesInputElement.value).toBe(String(value));
+    await waitFor(
+      () =>
+        tCyclesInputElement &&
+        expect(tCyclesInputElement.value).toBe(String(value))
+    );
   });
 
   it("synchronizes tCycles input to icp input", async () => {
@@ -73,13 +77,16 @@ describe("SelectCyclesCanister", () => {
     expect(tCyclesInputElement).not.toBeNull();
 
     const value = 2;
+    // Inputs are synchronized when they are focused
+    tCyclesInputElement && fireEvent.focus(tCyclesInputElement);
     tCyclesInputElement &&
       (await fireEvent.input(tCyclesInputElement, {
         target: { value },
       }));
-    tCyclesInputElement && (await fireEvent.blur(tCyclesInputElement));
 
-    icpInputElement && expect(icpInputElement.value).toBe(String(value));
+    await waitFor(
+      () => icpInputElement && expect(icpInputElement.value).toBe(String(value))
+    );
   });
 
   it("dispatches nnsSelectAmount event on click", async () => {
@@ -95,7 +102,6 @@ describe("SelectCyclesCanister", () => {
       (await fireEvent.input(icpInputElement, {
         target: { value: 2 },
       }));
-    icpInputElement && (await fireEvent.blur(icpInputElement));
 
     const fn = jest.fn();
     component.$on("nnsSelectAmount", fn);

--- a/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -9,7 +9,11 @@ describe("SetDissolveDelay", () => {
   // Tested in CreateNeuronModal.spec.ts
   it("is not tested in isolation", () => {
     render(SetDissolveDelay, {
-      props: { neuron: mockNeuron, cancelButtonText: "Cancel" },
+      props: {
+        neuron: mockNeuron,
+        cancelButtonText: "Cancel",
+        confirmButtonText: "Set Dissolve",
+      },
     });
     expect(true).toBeTruthy();
   });

--- a/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/CardItem.spec.ts
@@ -4,7 +4,7 @@
 
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
-import CardItem from "../../../../lib/components/ui/CardItem.svelte";
+import CardItem from "./CardItemTest.svelte";
 
 describe("CardItem", () => {
   const props = {

--- a/frontend/svelte/src/tests/lib/components/ui/CardItemTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/CardItemTest.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import CardItem from "../../../../lib/components/ui/CardItem.svelte";
+
+  export let title: string;
+  export let subtitle: string;
+  export let testId: string | undefined = undefined;
+</script>
+
+<CardItem on:click {testId}>
+  <svelte:fragment slot="title">{title}</svelte:fragment>
+  <svelte:fragment slot="subtitle">{subtitle}</svelte:fragment>
+</CardItem>

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -122,6 +122,7 @@ describe("canisters-services", () => {
       const call = () => getCanisterDetails(mockCanisterDetails.id);
 
       await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+      resetIdentity();
     });
   });
 

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -1,9 +1,11 @@
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
+import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import {
   attachCanister,
   getCanisterDetails,
+  getIcpToCyclesExchangeRate,
   listCanisters,
   routePathCanisterId,
 } from "../../../lib/services/canisters.services";
@@ -27,6 +29,10 @@ describe("canisters-services", () => {
   const spyQueryCanisterDetails = jest
     .spyOn(api, "queryCanisterDetails")
     .mockImplementation(() => Promise.resolve(mockCanisterDetails));
+
+  const spyGetExchangeRate = jest
+    .spyOn(api, "getIcpToCyclesExchangeRate")
+    .mockImplementation(() => Promise.resolve(BigInt(10_000 * E8S_PER_ICP)));
 
   describe("listCanisters", () => {
     afterEach(() => {
@@ -116,6 +122,24 @@ describe("canisters-services", () => {
       const call = () => getCanisterDetails(mockCanisterDetails.id);
 
       await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
+    });
+  });
+
+  describe("getIcpToCyclesExchangeRate", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should call api to get conversion rate", async () => {
+      const response = await getIcpToCyclesExchangeRate();
+      expect(response).toBe(BigInt(10_000));
+      expect(spyGetExchangeRate).toBeCalled();
+    });
+
+    it("should return undefined if no identity", async () => {
+      setNoIdentity();
+
+      const response = await getIcpToCyclesExchangeRate();
+      expect(response).toBeUndefined();
+      expect(spyGetExchangeRate).not.toBeCalled();
 
       resetIdentity();
     });

--- a/frontend/svelte/src/tests/lib/testHelpers/clickByTestId.ts
+++ b/frontend/svelte/src/tests/lib/testHelpers/clickByTestId.ts
@@ -1,0 +1,11 @@
+import { fireEvent } from "@testing-library/dom";
+
+export const clickByTestId = async (
+  queryByTestId: (matcher: string) => HTMLElement | null,
+  testId: string
+) => {
+  const element = queryByTestId(testId);
+  expect(element).toBeInTheDocument();
+
+  element && (await fireEvent.click(element));
+};

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,5 +1,7 @@
 import { ICP } from "@dfinity/nns";
+import { InvalidAmountError } from "../../../lib/types/errors";
 import {
+  convertNumberToICP,
   formatICP,
   formattedTransactionFeeICP,
   maxICP,
@@ -47,5 +49,19 @@ describe("icp-utils", () => {
     expect(maxICP(ICP.fromString("0.0001") as ICP)).toEqual(0);
     expect(maxICP(ICP.fromString("0.00011") as ICP)).toEqual(0.00001);
     expect(maxICP(ICP.fromString("1") as ICP)).toEqual(0.9999);
+  });
+
+  describe("convertNumberToICP", () => {
+    it("returns ICP from number", () => {
+      expect(convertNumberToICP(10)?.toE8s()).toBe(BigInt(1_000_000_000));
+      expect(convertNumberToICP(10.1234)?.toE8s()).toBe(BigInt(1_012_340_000));
+      expect(convertNumberToICP(0.004)?.toE8s()).toBe(BigInt(400_000));
+      expect(convertNumberToICP(0.00000001)?.toE8s()).toBe(BigInt(1));
+    });
+
+    it("raises error on negative numbers", () => {
+      const call = () => convertNumberToICP(-10);
+      expect(call).toThrow(InvalidAmountError);
+    });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,7 +1,10 @@
 import { ICP } from "@dfinity/nns";
+import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import { InvalidAmountError } from "../../../lib/types/errors";
 import {
+  convertIcpToTCycles,
   convertNumberToICP,
+  convertTCyclesToE8s,
   formatICP,
   formattedTransactionFeeICP,
   maxICP,
@@ -62,6 +65,40 @@ describe("icp-utils", () => {
     it("raises error on negative numbers", () => {
       const call = () => convertNumberToICP(-10);
       expect(call).toThrow(InvalidAmountError);
+    });
+  });
+
+  describe("convertIcpToTCycles", () => {
+    it("converts ICP to TCycles", () => {
+      expect(convertIcpToTCycles({ icpNumber: 1, ratio: BigInt(10_000) })).toBe(
+        1
+      );
+      expect(
+        convertIcpToTCycles({ icpNumber: 2.5, ratio: BigInt(10_000) })
+      ).toBe(2.5);
+      expect(
+        convertIcpToTCycles({ icpNumber: 2.5, ratio: BigInt(20_000) })
+      ).toBe(5);
+      expect(convertIcpToTCycles({ icpNumber: 1, ratio: BigInt(15_000) })).toBe(
+        1.5
+      );
+    });
+  });
+
+  describe("convertTCyclesToE8s", () => {
+    it("converts TCycles to E8s", () => {
+      expect(convertTCyclesToE8s({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
+        BigInt(E8S_PER_ICP)
+      );
+      expect(convertTCyclesToE8s({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
+        BigInt(E8S_PER_ICP * 2.5)
+      );
+      expect(convertTCyclesToE8s({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
+        BigInt(125_000_000)
+      );
+      expect(convertTCyclesToE8s({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
+        BigInt(66666666)
+      );
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,6 +1,6 @@
 import { ICP } from "@dfinity/nns";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
-import { InvalidAmountError } from "../../../lib/types/errors";
+import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import {
   convertIcpToTCycles,
   convertNumberToICP,

--- a/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/neuron.utils.spec.ts
@@ -13,7 +13,6 @@ import {
   MIN_NEURON_STAKE,
 } from "../../../lib/constants/neurons.constants";
 import type { Step } from "../../../lib/stores/steps.state";
-import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import { enumValues } from "../../../lib/utils/enum.utils";
 import {
   ageMultiplier,
@@ -21,7 +20,6 @@ import {
   ballotsWithDefinedProposal,
   canBeMerged,
   checkInvalidState,
-  convertNumberToICP,
   dissolveDelayMultiplier,
   followeesByTopic,
   followeesNeurons,
@@ -644,20 +642,6 @@ describe("neuron-utils", () => {
 
     it("return false if amount is higher than max", () => {
       expect(isValidInputAmount({ amount: 40, max: 10 })).toBe(false);
-    });
-  });
-
-  describe("convertNumberToICP", () => {
-    it("returns ICP from number", () => {
-      expect(convertNumberToICP(10)?.toE8s()).toBe(BigInt(1_000_000_000));
-      expect(convertNumberToICP(10.1234)?.toE8s()).toBe(BigInt(1_012_340_000));
-      expect(convertNumberToICP(0.004)?.toE8s()).toBe(BigInt(400_000));
-      expect(convertNumberToICP(0.00000001)?.toE8s()).toBe(BigInt(1));
-    });
-
-    it("raises error on negative numbers", () => {
-      const call = () => convertNumberToICP(-10);
-      expect(call).toThrow(InvalidAmountError);
     });
   });
 


### PR DESCRIPTION
# Motivation

User can enter ICP or TCycles amount and move to confirm create canister screen.

# Changes

* Add different steps in CreateOrLinkCanisterModal depending on initial selection.
* New screen: SelectCyclesCanister.
* Move neuron util "convertNumberToICP" to icp utils.
* New icp utils: "convertIcpToTCycles" and "convertTCyclesToE8s".
* New canister api function "getIcpToCyclesExchangeRate".
* New canister service "getIcpToCyclesExchangeRate".

# Tests

* Test new steps in CreateOrLinkCanisterModal
* Test that SelectCyclesCanister synchronizes inputs.
* Move "convertNumberToICP" test to icp utils.
* New tests for new icp utils.
