### PR TITLE
feat: translate nns-dapp errors and display max length in account error msg

### DIFF
--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -79,7 +79,7 @@ export class NNSDappCanister {
       certified
     ).get_account();
     if (AccountNotFound === null) {
-      throw new AccountNotFoundError("Account not found");
+      throw new AccountNotFoundError("error__account.not_found");
     }
 
     if (Ok) {
@@ -87,7 +87,7 @@ export class NNSDappCanister {
     }
 
     // We should never reach here. Some of the previous properties should be present.
-    throw new Error("Error getting account details");
+    throw new Error("error__account.no_details");
   }
 
   /**
@@ -108,18 +108,19 @@ export class NNSDappCanister {
     );
 
     if (AccountNotFound === null) {
-      throw new AccountNotFoundError("Error creating subAccount");
+      throw new AccountNotFoundError("error__account.create_subaccount");
     }
 
     if (NameTooLong === null) {
-      // Which is the character?
-      throw new NameTooLongError(`Error, name "${subAccountName}" is too long`);
+      throw new NameTooLongError("error__account.subaccount_too_long", {
+        $subAccountName: subAccountName,
+      });
     }
 
     if (SubAccountLimitExceeded === null) {
       // Which is the limit of subaccounts?
       throw new SubAccountLimitExceededError(
-        `Error, subAccount limit exceeded`
+        "error__account.create_subaccount_limit_exceeded"
       );
     }
 
@@ -128,7 +129,7 @@ export class NNSDappCanister {
     }
 
     // We should never reach here. Some of the previous properties should be present.
-    throw new Error("Error creating subaccount");
+    throw new Error("error__account.create_subaccount");
   }
 
   public async registerHardwareWallet(
@@ -138,11 +139,18 @@ export class NNSDappCanister {
       await this.certifiedService.register_hardware_wallet(request);
 
     if ("AccountNotFound" in response && response.AccountNotFound === null) {
-      throw new AccountNotFoundError("Error registering hardware wallet");
+      throw new AccountNotFoundError(
+        "error__attach_wallet.register_hardware_wallet"
+      );
     }
 
     if ("NameTooLong" in response && response.NameTooLong === null) {
-      throw new NameTooLongError(`Error, name "${request.name}" is too long`);
+      throw new NameTooLongError(
+        "error__attach_wallet.create_hardware_wallet_too_long",
+        {
+          $accountName: request.name,
+        }
+      );
     }
 
     if (
@@ -172,7 +180,10 @@ export class NNSDappCanister {
 
     if ("AccountNotFound" in response && response.AccountNotFound === null) {
       throw new AccountNotFoundError(
-        `Error renaming subAccount, account (${request.account_identifier}) not found`
+        "error__account.rename_account_not_found",
+        {
+          $account_identifier: request.account_identifier,
+        }
       );
     }
 
@@ -180,15 +191,15 @@ export class NNSDappCanister {
       "SubAccountNotFound" in response &&
       response.SubAccountNotFound === null
     ) {
-      throw new AccountNotFoundError(
-        `Error renaming subAccount, subAccount (${request.account_identifier}) not found`
-      );
+      throw new AccountNotFoundError("error__account.subaccount_not_found", {
+        $account_identifier: request.account_identifier,
+      });
     }
 
     if ("NameTooLong" in response && response.NameTooLong === null) {
-      throw new NameTooLongError(
-        `Error, name "${request.new_name}" is too long`
-      );
+      throw new NameTooLongError("error__account.subaccount_too_long", {
+        $subAccountName: request.new_name,
+      });
     }
   };
 

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -1,6 +1,15 @@
-export class AccountNotFoundError extends Error {
-  constructor(message: string) {
+import type {I18nSubstitutions} from '../../utils/i18n.utils';
+
+export abstract class AccountTranslateError extends Error {
+  // Optional substitutions values that can be used to fill the error message
+  substitutions?: I18nSubstitutions;
+}
+
+export class AccountNotFoundError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
     super(message);
+
+    this.substitutions = substitutions;
   }
 }
 
@@ -10,9 +19,11 @@ export class SubAccountLimitExceededError extends Error {
   }
 }
 
-export class NameTooLongError extends Error {
-  constructor(message: string) {
+export class NameTooLongError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
     super(message);
+
+    this.substitutions = substitutions;
   }
 }
 

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -1,4 +1,4 @@
-import type {I18nSubstitutions} from '../../utils/i18n.utils';
+import type { I18nSubstitutions } from "../../utils/i18n.utils";
 
 export abstract class AccountTranslateError extends Error {
   // Optional substitutions values that can be used to fill the error message

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -4,7 +4,7 @@
    */
   import { toastsStore } from "../../stores/toasts.store";
   import { fade, fly } from "svelte/transition";
-  import { translate } from "../../utils/i18n.utils";
+  import {type I18nSubstitutions, replacePlaceholders, translate} from "../../utils/i18n.utils";
   import { i18n } from "../../stores/i18n";
   import type { ToastLevel, ToastMsg } from "../../types/toast";
   import { onDestroy, onMount } from "svelte";
@@ -17,9 +17,10 @@
   let labelKey: string;
   let level: ToastLevel;
   let detail: string | undefined;
+  let substitutions: I18nSubstitutions | undefined;
 
-  $: ({ labelKey, level, detail } = msg);
-  $: text = `${translate({ labelKey })}${
+  $: ({ labelKey, level, detail, substitutions } = msg);
+  $: text = `${replacePlaceholders(translate({ labelKey }), substitutions ?? {})}${
     detail !== undefined ? ` ${detail}` : ""
   }`;
 

--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -4,7 +4,11 @@
    */
   import { toastsStore } from "../../stores/toasts.store";
   import { fade, fly } from "svelte/transition";
-  import {type I18nSubstitutions, replacePlaceholders, translate} from "../../utils/i18n.utils";
+  import {
+    type I18nSubstitutions,
+    replacePlaceholders,
+    translate,
+  } from "../../utils/i18n.utils";
   import { i18n } from "../../stores/i18n";
   import type { ToastLevel, ToastMsg } from "../../types/toast";
   import { onDestroy, onMount } from "svelte";
@@ -20,9 +24,10 @@
   let substitutions: I18nSubstitutions | undefined;
 
   $: ({ labelKey, level, detail, substitutions } = msg);
-  $: text = `${replacePlaceholders(translate({ labelKey }), substitutions ?? {})}${
-    detail !== undefined ? ` ${detail}` : ""
-  }`;
+  $: text = `${replacePlaceholders(
+    translate({ labelKey }),
+    substitutions ?? {}
+  )}${detail !== undefined ? ` ${detail}` : ""}`;
 
   let timeoutId: NodeJS.Timeout | undefined = undefined;
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -27,12 +27,9 @@
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",
     "missing_identity": "The operation cannot be executed without any identity.",
-    "create_subaccount": "Sorry, there was an unexpected error when creating your linked account, please try again.",
     "rename_subaccount": "An error occurred while renaming your linked account.",
     "rename_subaccount_no_account": "No linked account provided.",
     "rename_subaccount_type": "The account provided is not a linked account. Only linked account can be renamed.",
-    "create_subaccount_too_long": "The name of the linked account is too long. Please, choose a shorter name.",
-    "create_subaccount_limit_exceeded": "Sorry, you reached the limit of linked accounts in this account.",
     "get_neurons": "There was an unexpected issue while searching for the neurons.",
     "get_known_neurons": "There was an unexpected issue while searching for the known neurons.",
     "register_vote": "Sorry, there was an error while registering the vote. Please try again.",
@@ -447,6 +444,17 @@
     "no_name": "No account name provided.",
     "no_identity": "No identity connected to your hardware wallet.",
     "already_registered": "The hardware wallet is already registered with another account.",
-    "limit_exceeded": "The limit of hardware wallet that can be attached has been reached."
+    "limit_exceeded": "The limit of hardware wallet that can be attached has been reached.",
+    "register_hardware_wallet": "Error registering hardware wallet",
+    "create_hardware_wallet_too_long": "The name $accountName is too long (max. 24 characters). Please, choose a shorter name."
+  },
+  "error__account": {
+    "not_found": "Account not found",
+    "no_details": "Error getting account details",
+    "subaccount_too_long": "The name $subAccountName of the linked account is too long (max. 24 characters). Please, choose a shorter name.",
+    "create_subaccount_limit_exceeded": "Sorry, you reached the limit of linked accounts in this account.",
+    "create_subaccount": "Sorry, there was an unexpected error when creating your linked account, please try again.",
+    "subaccount_not_found": "Error renaming subAccount, subAccount ($account_identifier) not found",
+    "rename_account_not_found": "Error renaming subAccount, account ($account_identifier) not found"
   }
 }

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -8,10 +8,6 @@ import {
 } from "../api/accounts.api";
 import { sendICP } from "../api/ledger.api";
 import { toSubAccountId } from "../api/utils.api";
-import {
-  NameTooLongError,
-  SubAccountLimitExceededError,
-} from "../canisters/nns-dapp/nns-dapp.errors";
 import type {
   AccountIdentifierString,
   Transaction,
@@ -47,10 +43,12 @@ export const syncAccounts = (): Promise<void> => {
       // Explicitly handle only UPDATE errors
       accountsStore.reset();
 
-      toastsStore.error({
-        labelKey: "error.accounts_not_found",
-        err,
-      });
+      toastsStore.error(
+        toToastError({
+          err,
+          fallbackErrorLabelKey: "error.accounts_not_found",
+        })
+      );
     },
     logMessage: "Syncing Accounts",
   });
@@ -68,17 +66,12 @@ export const addSubAccount = async ({
 
     await syncAccounts();
   } catch (err: unknown) {
-    const labelKey =
-      err instanceof NameTooLongError
-        ? "accounts.create_subaccount_too_long"
-        : err instanceof SubAccountLimitExceededError
-        ? "accounts.create_subaccount_limit_exceeded"
-        : "accounts.create_subaccount";
-
-    toastsStore.error({
-      labelKey,
-      err,
-    });
+    toastsStore.error(
+      toToastError({
+        err,
+        fallbackErrorLabelKey: "error__account.create_subaccount",
+      })
+    );
   }
 };
 

--- a/frontend/svelte/src/lib/stores/toasts.store.ts
+++ b/frontend/svelte/src/lib/stores/toasts.store.ts
@@ -2,6 +2,7 @@ import { writable } from "svelte/store";
 import { DEFAULT_TOAST_DURATION_MILLIS } from "../constants/constants";
 import type { ToastMsg } from "../types/toast";
 import { errorToString } from "../utils/error.utils";
+import type { I18nSubstitutions } from "../utils/i18n.utils";
 
 /**
  * Toast messages.
@@ -32,8 +33,21 @@ const initToastsStore = () => {
       });
     },
 
-    error({ labelKey, err }: { labelKey: string; err?: unknown }) {
-      this.show({ labelKey, level: "error", detail: errorToString(err) });
+    error({
+      labelKey,
+      err,
+      substitutions,
+    }: {
+      labelKey: string;
+      err?: unknown;
+      substitutions?: I18nSubstitutions;
+    }) {
+      this.show({
+        labelKey,
+        level: "error",
+        detail: errorToString(err),
+        substitutions,
+      });
 
       if (err !== undefined) {
         console.error(err);

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -31,12 +31,9 @@ interface I18nError {
   list_proposals: string;
   list_canisters: string;
   missing_identity: string;
-  create_subaccount: string;
   rename_subaccount: string;
   rename_subaccount_no_account: string;
   rename_subaccount_type: string;
-  create_subaccount_too_long: string;
-  create_subaccount_limit_exceeded: string;
   get_neurons: string;
   get_known_neurons: string;
   register_vote: string;
@@ -476,6 +473,18 @@ interface I18nError__attach_wallet {
   no_identity: string;
   already_registered: string;
   limit_exceeded: string;
+  register_hardware_wallet: string;
+  create_hardware_wallet_too_long: string;
+}
+
+interface I18nError__account {
+  not_found: string;
+  no_details: string;
+  subaccount_too_long: string;
+  create_subaccount_limit_exceeded: string;
+  create_subaccount: string;
+  subaccount_not_found: string;
+  rename_account_not_found: string;
 }
 
 interface I18n {
@@ -506,4 +515,5 @@ interface I18n {
   time: I18nTime;
   error__ledger: I18nError__ledger;
   error__attach_wallet: I18nError__attach_wallet;
+  error__account: I18nError__account;
 }

--- a/frontend/svelte/src/lib/types/toast.ts
+++ b/frontend/svelte/src/lib/types/toast.ts
@@ -1,3 +1,5 @@
+import type { I18nSubstitutions } from "../utils/i18n.utils";
+
 export type ToastLevel = "success" | "warn" | "error";
 
 export interface ToastMsg {
@@ -6,4 +8,5 @@ export interface ToastMsg {
   detail?: string;
   duration?: number;
   id?: symbol;
+  substitutions?: I18nSubstitutions;
 }

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -16,7 +16,7 @@ import {
   NotFoundError,
 } from "../types/neurons.errors";
 import type { ToastMsg } from "../types/toast";
-import { translate } from "./i18n.utils";
+import { translate, type I18nSubstitutions } from "./i18n.utils";
 
 export const errorToString = (err?: unknown): string | undefined =>
   typeof err === "string"
@@ -82,7 +82,7 @@ export const toToastError = ({
 }: {
   err: unknown | undefined;
   fallbackErrorLabelKey: string;
-}): { labelKey: string; err?: unknown } => {
+}): { labelKey: string; err?: unknown; substitutions?: I18nSubstitutions } => {
   let errorKey: boolean = false;
   const message: string | undefined = (err as Error)?.message;
 
@@ -91,10 +91,16 @@ export const toToastError = ({
     errorKey = label !== message;
   }
 
+  type ErrorSubstitutions = { substitutions?: I18nSubstitutions };
+
   return {
     labelKey: errorKey
       ? (err as { message: string }).message
       : fallbackErrorLabelKey,
     ...(!errorKey && { err }),
+    ...((err as ErrorSubstitutions | undefined)?.substitutions !==
+      undefined && {
+      substitutions: (err as ErrorSubstitutions).substitutions,
+    }),
   };
 };

--- a/frontend/svelte/src/lib/utils/i18n.utils.ts
+++ b/frontend/svelte/src/lib/utils/i18n.utils.ts
@@ -45,13 +45,15 @@ export const translate = ({
 const escapeRegExp = (regExpText: string): string =>
   regExpText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 
+export type I18nSubstitutions = { [from: string]: string };
+
 /**
  * @example
  * ("Why $1?", {$1: "World", Why: "Hello", "?": "!"}) => "Hello World!"
  */
 export const replacePlaceholders = (
   text: string,
-  substitutions: { [from: string]: string }
+  substitutions: I18nSubstitutions
 ): string => {
   let result = text;
   for (const [key, value] of Object.entries(substitutions)) {

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -190,7 +190,9 @@ describe("NNSDapp", () => {
         {
           AccountNotFound: null,
         },
-        new AccountNotFoundError("error__attach_wallet.register_hardware_wallet")
+        new AccountNotFoundError(
+          "error__attach_wallet.register_hardware_wallet"
+        )
       ));
 
     it("should throw register hardware wallet error name too long", async () =>
@@ -198,7 +200,10 @@ describe("NNSDapp", () => {
         {
           NameTooLong: null,
         },
-        new NameTooLongError("error__attach_wallet.create_hardware_wallet_too_long", {$accountName: "test"})
+        new NameTooLongError(
+          "error__attach_wallet.create_hardware_wallet_too_long",
+          { $accountName: "test" }
+        )
       ));
 
     it("should throw register hardware wallet error already registered", async () =>

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -190,7 +190,7 @@ describe("NNSDapp", () => {
         {
           AccountNotFound: null,
         },
-        new AccountNotFoundError("Error registering hardware wallet")
+        new AccountNotFoundError("error__attach_wallet.register_hardware_wallet")
       ));
 
     it("should throw register hardware wallet error name too long", async () =>
@@ -198,7 +198,7 @@ describe("NNSDapp", () => {
         {
           NameTooLong: null,
         },
-        new NameTooLongError(`Error, name "test" is too long`)
+        new NameTooLongError("error__attach_wallet.create_hardware_wallet_too_long", {$accountName: "test"})
       ));
 
     it("should throw register hardware wallet error already registered", async () =>

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -41,4 +41,20 @@ describe("Toast", () => {
 
     expect(p?.textContent).toContain("more details");
   });
+
+  it("should replace place holder in text", async () => {
+    const { container } = render(Toast, {
+      props: {msg: {
+          labelKey: 'error__account.subaccount_not_found',
+          level: "error",
+          substitutions: {
+            $account_identifier: 'testtesttest'
+          }
+        }},
+    });
+
+    const p: HTMLParagraphElement | null = container.querySelector("p");
+
+    expect(p?.textContent).toContain("testtesttest");
+  });
 });

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -44,13 +44,15 @@ describe("Toast", () => {
 
   it("should replace place holder in text", async () => {
     const { container } = render(Toast, {
-      props: {msg: {
-          labelKey: 'error__account.subaccount_not_found',
+      props: {
+        msg: {
+          labelKey: "error__account.subaccount_not_found",
           level: "error",
           substitutions: {
-            $account_identifier: 'testtesttest'
-          }
-        }},
+            $account_identifier: "testtesttest",
+          },
+        },
+      },
     });
 
     const p: HTMLParagraphElement | null = container.querySelector("p");

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -93,7 +93,7 @@ describe("accounts-services", () => {
 
       expect(spyToastError).toBeCalled();
       expect(spyToastError).toBeCalledWith({
-        labelKey: "accounts.create_subaccount",
+        labelKey: "error__account.create_subaccount",
         err: new Error(en.error.missing_identity),
       });
 


### PR DESCRIPTION
# Motivation

- translate nns-dapp canister errors
- display max length (24 characters) in error message related to account's name

# Changes

- transform error msgs from plain text to i18n keys
- use placeholders `substitutions` object from throw error to display
- add and replace placeholders `substitutions` in toast msg (option)
- edit error msg with "max 24 chars" length
