### PR TITLE
L2-227: Create Canister part II

### DIFF
--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -6,7 +6,10 @@ import { principalToSubAccount } from "../canisters/cmc/utils";
 import { ICManagementCanister } from "../canisters/ic-management/ic-management.canister";
 import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
 import type { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
-import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
+import type {
+  CanisterDetails as CanisterInfo,
+  SubAccountArray,
+} from "../canisters/nns-dapp/nns-dapp.types";
 import { CYCLES_MINTING_CANISTER_ID } from "../constants/canister-ids.constants";
 import { HOST } from "../constants/environment.constants";
 import { createAgent } from "../utils/agent.utils";
@@ -14,6 +17,7 @@ import { logWithTimestamp } from "../utils/dev.utils";
 import { CREATE_CANISTER_MEMO, TOP_UP_CANISTER_MEMO } from "./constants.api";
 import { sendICP } from "./ledger.api";
 import { nnsDappCanister } from "./nns-dapp.api";
+import { toSubAccountId } from "./utils.api";
 
 export const queryCanisters = async ({
   identity,
@@ -86,10 +90,12 @@ export const createCanister = async ({
   identity,
   amount,
   name,
+  fromSubAccount,
 }: {
   identity: Identity;
   amount: ICP;
   name?: string;
+  fromSubAccount?: SubAccountArray;
 }): Promise<Principal> => {
   logWithTimestamp("Create canister call...");
 
@@ -102,6 +108,8 @@ export const createCanister = async ({
     principal: CYCLES_MINTING_CANISTER_ID,
     subAccount: SubAccount.fromBytes(toSubAccount) as SubAccount,
   });
+  const fromSubAccountId =
+    fromSubAccount !== undefined ? toSubAccountId(fromSubAccount) : undefined;
 
   // Transfer the funds
   const blockHeight = await sendICP({
@@ -109,6 +117,7 @@ export const createCanister = async ({
     identity,
     to: recipient.toHex(),
     amount,
+    fromSubAccountId,
   });
 
   // If this fails or the client loses connection

--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -9,6 +9,7 @@
   export let disableSelection: boolean = false;
   export let filterIdentifier: string | undefined = undefined;
   export let displayTitle: boolean = false;
+  export let hideHarwareWalletAccounts: boolean = false;
 
   const dispatch = createEventDispatcher();
   const chooseAccount = (selectedAccount: Account) => {
@@ -52,14 +53,16 @@
       >
     {/each}
 
-    {#each hardwareWalletAccounts as hardwareWalletAccount}
-      <AccountCard
-        role="button"
-        on:click={() => chooseAccount(hardwareWalletAccount)}
-        account={hardwareWalletAccount}
-        >{hardwareWalletAccount.name}</AccountCard
-      >
-    {/each}
+    {#if !hideHarwareWalletAccounts}
+      {#each hardwareWalletAccounts as hardwareWalletAccount}
+        <AccountCard
+          role="button"
+          on:click={() => chooseAccount(hardwareWalletAccount)}
+          account={hardwareWalletAccount}
+          >{hardwareWalletAccount.name}</AccountCard
+        >
+      {/each}
+    {/if}
   {:else}
     <SkeletonCard />
     <SkeletonCard />

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { syncAccounts } from "../../services/accounts.services";
-
   import { createCanister } from "../../services/canisters.services";
   import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -31,9 +31,6 @@
     });
     stopBusy("create-canister");
     if (success) {
-      // We don't wait for `syncAccounts` to finish to give a better UX to the user.
-      // `syncAccounts` might be slow since it loads all accounts and balances.
-      syncAccounts();
       toastsStore.success({
         labelKey: "canisters.create_canister_success",
       });

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -1,4 +1,94 @@
-<!-- TODO: https://dfinity.atlassian.net/browse/L2-227 -->
-<div class="wizard-wrapper" data-tid="confirm-create-canister-screen">
-  Confirm Cycles
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { syncAccounts } from "../../services/accounts.services";
+
+  import { createCanister } from "../../services/canisters.services";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { i18n } from "../../stores/i18n";
+  import { toastsStore } from "../../stores/toasts.store";
+  import type { Account } from "../../types/account";
+  import { formatNumber } from "../../utils/format.utils";
+  import { convertIcpToTCycles } from "../../utils/icp.utils";
+
+  export let amount: number;
+  export let account: Account;
+  export let icpToCyclesRatio: bigint | undefined = undefined;
+
+  let tCyclesFormatted: number | undefined;
+  $: tCyclesFormatted =
+    icpToCyclesRatio !== undefined
+      ? convertIcpToTCycles({ icpNumber: amount, ratio: icpToCyclesRatio })
+      : undefined;
+
+  const dispatcher = createEventDispatcher();
+  const create = async () => {
+    startBusy({
+      initiator: "create-canister",
+    });
+    const { success } = await createCanister({
+      amount,
+      fromSubAccount: account.subAccount,
+    });
+    stopBusy("create-canister");
+    if (success) {
+      // We don't wait for `syncAccounts` to finish to give a better UX to the user.
+      // `syncAccounts` might be slow since it loads all accounts and balances.
+      syncAccounts();
+      toastsStore.success({
+        labelKey: "canisters.create_canister_success",
+      });
+      dispatcher("nnsClose");
+    }
+  };
+</script>
+
+<div class="wizard-wrapper wrapper" data-tid="confirm-create-canister-screen">
+  <div class="content">
+    <div class="conversion">
+      <h3>{formatNumber(amount, { minFraction: 2, maxFraction: 2 })}</h3>
+      <p>{$i18n.core.icp}</p>
+      {#if tCyclesFormatted !== undefined}
+        <p>{$i18n.canisters.converted_to}</p>
+        <h3>
+          {formatNumber(tCyclesFormatted, { minFraction: 2, maxFraction: 2 })}
+        </h3>
+        <p>{$i18n.canisters.t_cycles}</p>
+      {/if}
+    </div>
+    <div>
+      <h5>{$i18n.accounts.source}</h5>
+      <p>{account.identifier}</p>
+    </div>
+  </div>
+  <button
+    class="primary full-width"
+    on:click={create}
+    data-tid="confirm-create-canister-button">{$i18n.core.confirm}</button
+  >
 </div>
+
+<style lang="scss">
+  .wizard-wrapper.wrapper {
+    justify-content: space-between;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+    gap: var(--padding-4x);
+  }
+
+  .conversion {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--padding);
+
+    p,
+    h3 {
+      margin: 0;
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -89,7 +89,6 @@
       />
     </div>
     <p>{$i18n.canisters.minimum_cycles_text}</p>
-    <p>{$i18n.canisters.app_subnets_beta}</p>
   </div>
   <button
     class="primary full-width"

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
-
   import { createEventDispatcher, onMount } from "svelte";
   import { E8S_PER_ICP } from "../../constants/icp.constants";
-  import { getIcpToCyclesExchangeRate } from "../../services/canisters.services";
   import { i18n } from "../../stores/i18n";
   import {
     convertIcpToTCycles,
@@ -12,13 +10,12 @@
   import Input from "../ui/Input.svelte";
 
   export let amount: number | undefined = undefined;
+  export let icpToCyclesRatio: bigint | undefined = undefined;
 
   let isChanging: "icp" | "tCycles" | undefined = undefined;
-  let icpToCyclesRatio: bigint | undefined;
   let amountCycles: number | undefined;
 
   onMount(async () => {
-    icpToCyclesRatio = await getIcpToCyclesExchangeRate();
     // Update cycles input if the component is mounted with some `amount`
     if (icpToCyclesRatio !== undefined && amount !== undefined) {
       amountCycles = convertIcpToTCycles({

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -271,7 +271,6 @@
     "review_create_canister": "Review Canister Creation",
     "t_cycles": "T Cycles",
     "minimum_cycles_text": "Minimum amount: 2T Cycles (inclusve of 1T Cycles fee if creating a new canister)",
-    "app_subnets_beta": "Application subnets are in beta and therefore Cycles might be lost",
     "review_cycles_purchase": "Review Cycles Purchase",
     "converted_to": "converted to"
   },

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -260,6 +260,7 @@
     "add_canister": "Add Canister",
     "create_canister_title": "Create New Canister",
     "create_canister_subtitle": "Create a new canister, to deploy your application",
+    "create_canister_success": "Canister created successfully",
     "link_canister_title": "Link Canister To Account",
     "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
     "link_canister_success": "The canister was linked successfully",

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -17,6 +17,7 @@ import { toastsStore } from "../stores/toasts.store";
 import { getPrincipalFromString } from "../utils/accounts.utils";
 import { getLastPathDetail } from "../utils/app-path.utils";
 import { convertNumberToICP } from "../utils/icp.utils";
+import { syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -69,6 +70,9 @@ export const createCanister = async ({
       fromSubAccount,
     });
     await listCanisters({ clearBeforeQuery: false });
+    // We don't wait for `syncAccounts` to finish to give a better UX to the user.
+    // `syncAccounts` might be slow since it loads all accounts and balances.
+    syncAccounts();
     return { success: true };
   } catch (error) {
     // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -1,17 +1,22 @@
 import type { Principal } from "@dfinity/principal";
 import {
   attachCanister as attachCanisterApi,
+  createCanister as createCanisterApi,
   getIcpToCyclesExchangeRate as getIcpToCyclesExchangeRateApi,
   queryCanisterDetails as queryCanisterDetailsApi,
   queryCanisters,
 } from "../api/canisters.api";
 import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
-import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
+import type {
+  CanisterDetails as CanisterInfo,
+  SubAccountArray,
+} from "../canisters/nns-dapp/nns-dapp.types";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
 import { getPrincipalFromString } from "../utils/accounts.utils";
 import { getLastPathDetail } from "../utils/app-path.utils";
+import { convertNumberToICP } from "../utils/icp.utils";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -45,6 +50,30 @@ export const listCanisters = async ({
     },
     logMessage: "Syncing Canisters",
   });
+};
+
+export const createCanister = async ({
+  amount,
+  fromSubAccount,
+}: {
+  amount: number;
+  fromSubAccount?: SubAccountArray;
+}): Promise<{ success: boolean }> => {
+  try {
+    const icpAmount = convertNumberToICP(amount);
+    // TODO: Validate it's enough ICP https://dfinity.atlassian.net/browse/L2-615
+    const identity = await getIdentity();
+    await createCanisterApi({
+      identity,
+      amount: icpAmount,
+      fromSubAccount,
+    });
+    await listCanisters({ clearBeforeQuery: false });
+    return { success: true };
+  } catch (error) {
+    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+    return { success: false };
+  }
 };
 
 export const attachCanister = async (

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -5,6 +5,7 @@ export type BusyStateInitiatorType =
   | "update-delay"
   | "vote"
   | "attach-canister"
+  | "create-canister"
   | "accounts"
   | "join-community-fund"
   | "split-neuron"

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -274,6 +274,7 @@ interface I18nCanisters {
   add_canister: string;
   create_canister_title: string;
   create_canister_subtitle: string;
+  create_canister_success: string;
   link_canister_title: string;
   link_canister_subtitle: string;
   link_canister_success: string;

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -285,7 +285,6 @@ interface I18nCanisters {
   review_create_canister: string;
   t_cycles: string;
   minimum_cycles_text: string;
-  app_subnets_beta: string;
   review_cycles_purchase: string;
   converted_to: string;
 }

--- a/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
@@ -1,4 +1,9 @@
-import { ICP, LedgerCanister } from "@dfinity/nns";
+import {
+  AccountIdentifier,
+  ICP,
+  LedgerCanister,
+  SubAccount,
+} from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import {
   attachCanister,
@@ -8,9 +13,15 @@ import {
   queryCanisters,
   topUpCanister,
 } from "../../../lib/api/canisters.api";
+import { CREATE_CANISTER_MEMO } from "../../../lib/api/constants.api";
+import { toSubAccountId } from "../../../lib/api/utils.api";
 import { CMCCanister } from "../../../lib/canisters/cmc/cmc.canister";
+import { principalToSubAccount } from "../../../lib/canisters/cmc/utils";
 import { ICManagementCanister } from "../../../lib/canisters/ic-management/ic-management.canister";
 import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
+import type { SubAccountArray } from "../../../lib/canisters/nns-dapp/nns-dapp.types";
+import { CYCLES_MINTING_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
+import { mockSubAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import { mockCanisterDetails } from "../../mocks/canisters.mock";
 
@@ -114,6 +125,43 @@ describe("canisters-api", () => {
         amount: ICP.fromString("3") as ICP,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
+      expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
+      expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
+        name: "",
+        canisterId: mockCanisterDetails.id,
+      });
+      expect(response).toEqual(mockCanisterDetails.id);
+    });
+
+    it("handles creating from subaccounts", async () => {
+      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+        mockCanisterDetails.id
+      );
+      const amount = ICP.fromString("3") as ICP;
+
+      const response = await createCanister({
+        identity: mockIdentity,
+        amount,
+        fromSubAccount: mockSubAccount.subAccount,
+      });
+      const principal = mockIdentity.getPrincipal();
+      const toSubAccount = principalToSubAccount(principal);
+      // To create a canister you need to send ICP to an account owned by the CMC, so that the CMC can burn those funds.
+      // To ensure everyone uses a unique address, the intended controller of the new canister is used to calculate the subaccount.
+      const recipient = AccountIdentifier.fromPrincipal({
+        principal: CYCLES_MINTING_CANISTER_ID,
+        subAccount: SubAccount.fromBytes(toSubAccount) as SubAccount,
+      });
+      const fromSubAccountId = toSubAccountId(
+        mockSubAccount.subAccount as SubAccountArray
+      );
+      expect(mockLedgerCanister.transfer).toBeCalledWith({
+        memo: CREATE_CANISTER_MEMO,
+        to: AccountIdentifier.fromHex(recipient.toHex()),
+        amount,
+        fromSubAccountId,
+      });
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         name: "",

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -7,6 +7,7 @@ import SelectAccount from "../../../../lib/components/accounts/SelectAccount.sve
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import {
   mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
@@ -31,6 +32,25 @@ describe("SelectAccount", () => {
     expect(
       getByText(mockMainAccount.identifier, { exact: false })
     ).toBeInTheDocument();
+
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("should not render hardware wallets when prop hideHarwareWalletAccounts is true", () => {
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(
+        mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
+      );
+
+    const { queryByText } = render(SelectAccount, {
+      props: { hideHarwareWalletAccounts: true },
+    });
+
+    expect(
+      queryByText(mockHardwareWalletAccount.name as string, { exact: false })
+    ).toBeNull();
 
     jest.clearAllMocks();
     jest.restoreAllMocks();

--- a/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -4,9 +4,7 @@
 
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import { tick } from "svelte";
 import SelectCyclesCanister from "../../../../lib/components/canisters/SelectCyclesCanister.svelte";
-import { getIcpToCyclesExchangeRate } from "../../../../lib/services/canisters.services";
 import { clickByTestId } from "../../../lib/testHelpers/clickByTestId";
 import en from "../../../mocks/i18n.mock";
 
@@ -17,24 +15,21 @@ jest.mock("../../../../lib/services/canisters.services", () => {
 });
 
 describe("SelectCyclesCanister", () => {
+  const props = { icpToCyclesRatio: BigInt(10_000) };
   it("renders message", () => {
-    const { queryByText } = render(SelectCyclesCanister);
+    const { queryByText } = render(SelectCyclesCanister, { props });
 
     expect(queryByText(en.canisters.minimum_cycles_text)).toBeInTheDocument();
   });
 
   it("renders two inputs", () => {
-    const { container } = render(SelectCyclesCanister);
+    const { container } = render(SelectCyclesCanister, { props });
 
     expect(container.querySelectorAll("input").length).toBe(2);
   });
 
   it("synchronizes icp input to tCycles input", async () => {
-    const { container } = render(SelectCyclesCanister);
-    // Wait for the onMount to load the conversion rate
-    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
-    // wait to update local variable with conversion rate
-    await tick();
+    const { container } = render(SelectCyclesCanister, { props });
 
     const icpInputElement = container.querySelector<HTMLInputElement>(
       'input[name="icp-amount"]'
@@ -61,11 +56,7 @@ describe("SelectCyclesCanister", () => {
   });
 
   it("synchronizes tCycles input to icp input", async () => {
-    const { container } = render(SelectCyclesCanister);
-    // Wait for the onMount to load the conversion rate
-    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
-    // wait to update local variable with conversion rate
-    await tick();
+    const { container } = render(SelectCyclesCanister, { props });
 
     const icpInputElement = container.querySelector<HTMLInputElement>(
       'input[name="icp-amount"]'
@@ -90,8 +81,10 @@ describe("SelectCyclesCanister", () => {
   });
 
   it("dispatches nnsSelectAmount event on click", async () => {
-    const { container, component, queryByTestId } =
-      render(SelectCyclesCanister);
+    const { container, component, queryByTestId } = render(
+      SelectCyclesCanister,
+      { props }
+    );
 
     const icpInputElement = container.querySelector<HTMLInputElement>(
       'input[name="icp-amount"]'

--- a/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
@@ -3,9 +3,22 @@
  */
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import CreateOrLinkCanisterModal from "../../../../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
-import { attachCanister } from "../../../../lib/services/canisters.services";
+import { syncAccounts } from "../../../../lib/services/accounts.services";
+import {
+  attachCanister,
+  createCanister,
+  getIcpToCyclesExchangeRate,
+} from "../../../../lib/services/canisters.services";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import { toastsStore } from "../../../../lib/stores/toasts.store";
 import { clickByTestId } from "../../../lib/testHelpers/clickByTestId";
+import {
+  mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 
@@ -13,10 +26,30 @@ jest.mock("../../../../lib/services/canisters.services", () => {
   return {
     attachCanister: jest.fn().mockResolvedValue({ success: true }),
     getIcpToCyclesExchangeRate: jest.fn().mockResolvedValue(BigInt(100_000)),
+    createCanister: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+jest.mock("../../../../lib/stores/toasts.store", () => {
+  return {
+    toastsStore: {
+      success: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../lib/services/accounts.services", () => {
+  return {
+    syncAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 
 describe("CreateOrLinkCanisterModal", () => {
+  jest
+    .spyOn(accountsStore, "subscribe")
+    .mockImplementation(
+      mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
+    );
   it("should display modal", () => {
     const { container } = render(CreateOrLinkCanisterModal);
 
@@ -89,12 +122,26 @@ describe("CreateOrLinkCanisterModal", () => {
     expect(buttonElement?.hasAttribute("disabled")).toBe(true);
   });
 
-  it("should create a canister from ICP", async () => {
-    const { queryByTestId, container } = await renderModal({
-      component: CreateOrLinkCanisterModal,
-    });
+  it("should create a canister from ICP and close modal", async () => {
+    const { queryByTestId, queryAllByTestId, container, component } =
+      await renderModal({
+        component: CreateOrLinkCanisterModal,
+      });
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
 
     await clickByTestId(queryByTestId, "choose-create-as-new-canister");
+
+    // Select Account Screen
+    await waitFor(() =>
+      expect(queryAllByTestId("account-card").length).toBeGreaterThan(0)
+    );
+    const accountCards = queryAllByTestId("account-card");
+    expect(accountCards.length).toBe(2);
+
+    fireEvent.click(accountCards[0]);
 
     // Select Amount Screen
     await waitFor(() =>
@@ -119,6 +166,36 @@ describe("CreateOrLinkCanisterModal", () => {
       ).toBeInTheDocument()
     );
 
-    // TODO: Finish flow - https://dfinity.atlassian.net/browse/L2-227
+    const done = jest.fn();
+    component.$on("nnsClose", done);
+
+    await clickByTestId(queryByTestId, "confirm-create-canister-button");
+
+    await waitFor(() => expect(done).toBeCalled());
+    expect(createCanister).toBeCalled();
+    expect(toastsStore.success).toBeCalled();
+    expect(syncAccounts).toBeCalled();
+  });
+
+  // We added the hardware wallet in the accountsStore subscribe mock above.
+  it("should not show hardware wallets in the accounts list", async () => {
+    const { queryByTestId, queryAllByTestId, queryByText } = await renderModal({
+      component: CreateOrLinkCanisterModal,
+    });
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
+
+    await clickByTestId(queryByTestId, "choose-create-as-new-canister");
+
+    // Select Account Screen
+    await waitFor(() =>
+      expect(queryAllByTestId("account-card").length).toBeGreaterThan(0)
+    );
+    const accountCards = queryAllByTestId("account-card");
+
+    expect(accountCards.length).toBe(2);
+    expect(queryByText(mockHardwareWalletAccount.name as string)).toBeNull();
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
@@ -5,7 +5,6 @@ import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import CreateOrLinkCanisterModal from "../../../../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
-import { syncAccounts } from "../../../../lib/services/accounts.services";
 import {
   attachCanister,
   createCanister,
@@ -35,12 +34,6 @@ jest.mock("../../../../lib/stores/toasts.store", () => {
     toastsStore: {
       success: jest.fn(),
     },
-  };
-});
-
-jest.mock("../../../../lib/services/accounts.services", () => {
-  return {
-    syncAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -174,7 +167,6 @@ describe("CreateOrLinkCanisterModal", () => {
     await waitFor(() => expect(done).toBeCalled());
     expect(createCanister).toBeCalled();
     expect(toastsStore.success).toBeCalled();
-    expect(syncAccounts).toBeCalled();
   });
 
   // We added the hardware wallet in the accountsStore subscribe mock above.

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -2,6 +2,7 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
+import { syncAccounts } from "../../../lib/services/accounts.services";
 import {
   attachCanister,
   createCanister,
@@ -17,6 +18,12 @@ import {
   setNoIdentity,
 } from "../../mocks/auth.store.mock";
 import { mockCanisterDetails, mockCanisters } from "../../mocks/canisters.mock";
+
+jest.mock("../../../lib/services/accounts.services", () => {
+  return {
+    syncAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
 
 describe("canisters-services", () => {
   const spyQueryCanisters = jest
@@ -159,6 +166,7 @@ describe("canisters-services", () => {
       expect(success).toBe(true);
       expect(spyCreateCanister).toBeCalled();
       expect(spyQueryCanisters).toBeCalled();
+      expect(syncAccounts).toBeCalled();
     });
 
     it("should return undefined if no identity", async () => {

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -4,6 +4,7 @@ import * as api from "../../../lib/api/canisters.api";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import {
   attachCanister,
+  createCanister,
   getCanisterDetails,
   getIcpToCyclesExchangeRate,
   listCanisters,
@@ -25,6 +26,10 @@ describe("canisters-services", () => {
   const spyAttachCanister = jest
     .spyOn(api, "attachCanister")
     .mockImplementation(() => Promise.resolve(undefined));
+
+  const spyCreateCanister = jest
+    .spyOn(api, "createCanister")
+    .mockImplementation(() => Promise.resolve(mockCanisterDetails.id));
 
   const spyQueryCanisterDetails = jest
     .spyOn(api, "queryCanisterDetails")
@@ -141,6 +146,27 @@ describe("canisters-services", () => {
       const response = await getIcpToCyclesExchangeRate();
       expect(response).toBeUndefined();
       expect(spyGetExchangeRate).not.toBeCalled();
+
+      resetIdentity();
+    });
+  });
+
+  describe("createCanister", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should call api to create a canister", async () => {
+      const { success } = await createCanister({ amount: 3 });
+      expect(success).toBe(true);
+      expect(spyCreateCanister).toBeCalled();
+      expect(spyQueryCanisters).toBeCalled();
+    });
+
+    it("should return undefined if no identity", async () => {
+      setNoIdentity();
+
+      const { success } = await createCanister({ amount: 3 });
+      expect(success).toBe(false);
+      expect(spyCreateCanister).not.toBeCalled();
 
       resetIdentity();
     });

--- a/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/svelte/src/tests/mocks/accounts.store.mock.ts
@@ -21,6 +21,10 @@ export const mockSubAccount: Account = {
   identifier:
     "aaaa5b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
   balance: ICP.fromString("1234567.8901") as ICP,
+  subAccount: [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 1,
+  ],
   name: "test subaccount",
   type: "subAccount",
 };

--- a/frontend/svelte/src/tests/routes/Canisters.spec.ts
+++ b/frontend/svelte/src/tests/routes/Canisters.spec.ts
@@ -18,6 +18,7 @@ import en from "../mocks/i18n.mock";
 jest.mock("../../lib/services/canisters.services", () => {
   return {
     listCanisters: jest.fn(),
+    getIcpToCyclesExchangeRate: jest.fn(),
   };
 });
 


### PR DESCRIPTION
# Motivation

User can create a canister from the main account or a subaccount.

# Changes

* Implemented the "ConfirmCyclesCanister" to create the canister on click.
* New canister service: "createCanister".
* Added the step to select an account when creating a canister.
* Added a prop to SelectAccount: "hideHarwareWalletAccounts"
* Added the parameter to create a canister from a subaccount in the canister api "createCanister"

# Tests

* Extend testing case in CreateOrLinkCanisterModal until canister creation.
* New test case in CreateOrLinkCanisterModal to check that hardware wallet accounts are not shown.
* New test for new canister service.
* New test case in SelectAccount for the new prop.
