### PR TITLE
feat: display title "My accounts" on select accounts component if user has hardware wallets too

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -9,7 +9,7 @@
   export let disableSelection: boolean = false;
   export let filterIdentifier: string | undefined = undefined;
   export let displayTitle: boolean = false;
-  export let hideHarwareWalletAccounts: boolean = false;
+  export let hideHardwareWalletAccounts: boolean = false;
 
   const dispatch = createEventDispatcher();
   const chooseAccount = (selectedAccount: Account) => {
@@ -32,7 +32,8 @@
   let showTitle: boolean = false;
   $: showTitle =
     displayTitle &&
-    (subAccounts?.length > 0 || hardwareWalletAccounts?.length > 0);
+    (subAccounts?.length > 0 ||
+      (hardwareWalletAccounts?.length > 0 && !hideHardwareWalletAccounts));
 </script>
 
 <div class="wizard-list" class:disabled={disableSelection}>
@@ -58,7 +59,7 @@
       >
     {/each}
 
-    {#if !hideHarwareWalletAccounts}
+    {#if !hideHardwareWalletAccounts}
       {#each hardwareWalletAccounts as hardwareWalletAccount}
         <AccountCard
           role="button"

--- a/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccount.svelte
@@ -27,11 +27,14 @@
   $: hardwareWalletAccounts = ($accountsStore?.hardwareWallets ?? []).filter(
     ({ identifier }: Account) => identifier !== filterIdentifier
   );
+
+  let showTitle: boolean = false;
+  $: showTitle = displayTitle && (subAccounts?.length > 0 || hardwareWalletAccounts?.length > 0)
 </script>
 
 <div class="wizard-list" class:disabled={disableSelection}>
   {#if mainAccount}
-    {#if displayTitle && subAccounts?.length > 0}
+    {#if showTitle}
       <h4>{$i18n.accounts.my_accounts}</h4>
     {/if}
 

--- a/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
+++ b/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
@@ -73,7 +73,10 @@
     position: absolute;
 
     inset: calc(var(--headless-layout-header-height)) 0 0;
-    overflow: auto;
+
+    /** TODO(L2-610): workaround for release - clean solution in development (PR #908) */
+    overflow-y: auto;
+    overflow-x: hidden;
 
     background-color: var(--gray-50-background);
   }

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -93,7 +93,7 @@
     {/if}
     {#if currentStep?.name === "SelectAccount"}
       <SelectAccount
-        hideHarwareWalletAccounts
+        hideHardwareWalletAccounts
         on:nnsSelectAccount={onSelectAccount}
       />
     {/if}

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -42,7 +42,7 @@ describe("SelectAccount", () => {
     expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
   });
 
-  it("should render a title", async () => {
+  it("should render a title with subaccount", async () => {
     accountsStore.set({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
@@ -57,6 +57,26 @@ describe("SelectAccount", () => {
 
     await waitFor(() =>
       expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
+    );
+
+    accountsStore.reset();
+  });
+
+  it("should render a title with hardware wallet", async () => {
+    accountsStore.set({
+      main: mockMainAccount,
+      subAccounts: undefined,
+      hardwareWallets: [mockSubAccount],
+    });
+
+    const { queryByText } = render(SelectAccount, {
+      props: {
+        displayTitle: true,
+      },
+    });
+
+    await waitFor(() =>
+        expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
     );
 
     accountsStore.reset();

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -112,11 +112,11 @@ describe("SelectAccount", () => {
     const { queryByText } = render(SelectAccount, {
       props: {
         displayTitle: true,
-        hideHardwareWalletAccounts: true
+        hideHardwareWalletAccounts: true,
       },
     });
 
-    expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument()
+    expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
 
     accountsStore.reset();
   });

--- a/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -37,7 +37,7 @@ describe("SelectAccount", () => {
     jest.restoreAllMocks();
   });
 
-  it("should not render hardware wallets when prop hideHarwareWalletAccounts is true", () => {
+  it("should not render hardware wallets when prop hideHardwareWalletAccounts is true", () => {
     jest
       .spyOn(accountsStore, "subscribe")
       .mockImplementation(
@@ -45,7 +45,7 @@ describe("SelectAccount", () => {
       );
 
     const { queryByText } = render(SelectAccount, {
-      props: { hideHarwareWalletAccounts: true },
+      props: { hideHardwareWalletAccounts: true },
     });
 
     expect(
@@ -98,6 +98,25 @@ describe("SelectAccount", () => {
     await waitFor(() =>
       expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
     );
+
+    accountsStore.reset();
+  });
+
+  it("should not render a title with hardware wallet if these kind of accounts should be hidden", async () => {
+    accountsStore.set({
+      main: mockMainAccount,
+      subAccounts: undefined,
+      hardwareWallets: [mockSubAccount],
+    });
+
+    const { queryByText } = render(SelectAccount, {
+      props: {
+        displayTitle: true,
+        hideHardwareWalletAccounts: true
+      },
+    });
+
+    expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument()
 
     accountsStore.reset();
   });


### PR DESCRIPTION
# Motivation

On select accounts component, the title "My accounts" can be displayed if user has sub-accounts. It can also be displayed if user has hardware wallets.

# Changes

- if `displayTitle` prop is set and user has no subaccounts but has hardware wallet, display title as well
