### PR TITLE
Fix: Improve split and spawn neuron

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -194,7 +194,6 @@
     "confirm_update_delay": "Confirm and Update Delay",
     "confirm_set_delay": "Confirm and Set Delay",
     "merge_neurons_article_title": "IC NNS Neurons Can Now Be Merged",
-    "split_neuron_success": "Neuron successfully split.",
     "cannot_merge_neuron_community": "Neurons that joined the Community Fund can't be merged.",
     "cannot_merge_neuron_hotkey": "You cannot merge neurons controlled by hotkey",
     "cannot_merge_hardware_wallet": "Merging of neurons controlled via hardware wallet is not yet supported.",

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -46,7 +46,11 @@
       return;
     }
     startBusy({ initiator: "split-neuron" });
-    const id = await splitNeuron({ neuronId: neuron.neuronId, amount });
+
+    const id = await splitNeuron({
+      neuronId: neuron.neuronId,
+      amount,
+    });
     if (id !== undefined) {
       toastsStore.success({
         labelKey: "neurons.split_neuron_success",

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -53,7 +53,7 @@
     });
     if (id !== undefined) {
       toastsStore.success({
-        labelKey: "neurons.split_neuron_success",
+        labelKey: "neuron_detail.split_neuron_success",
       });
     }
     dispatcher("nnsClose");

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -30,7 +30,7 @@ import {
 import { getNeuronBalance } from "../api/ledger.api";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "../constants/environment.constants";
-import { E8S_PER_ICP } from "../constants/icp.constants";
+import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
 import { MAX_CONCURRENCY } from "../constants/neurons.constants";
 import type { LedgerIdentity } from "../identities/ledger.identity";
 import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
@@ -622,18 +622,16 @@ export const splitNeuron = async ({
       neuronId
     );
 
-    const stake = convertNumberToICP(amount);
+    const transactionFeeAmount = TRANSACTION_FEE_E8S / E8S_PER_ICP;
+    const stake = convertNumberToICP(amount + transactionFeeAmount);
 
     if (!isEnoughToStakeNeuron({ stake, withTransactionFee: true })) {
       throw new InsufficientAmountError();
     }
 
     await splitNeuronApi({ neuronId, identity, amount: stake });
-    toastsStore.success({
-      labelKey: "neuron_detail.split_neuron_success",
-    });
 
-    await getAndLoadNeuron(neuronId);
+    await listNeurons();
 
     return neuronId;
   } catch (err) {
@@ -704,7 +702,7 @@ export const spawnNeuron = async ({
 
     await spawnNeuronApi({ neuronId, percentageToSpawn, identity });
 
-    await getAndLoadNeuron(neuronId);
+    await listNeurons();
 
     return { success: true };
   } catch (err) {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -204,7 +204,6 @@ interface I18nNeurons {
   confirm_update_delay: string;
   confirm_set_delay: string;
   merge_neurons_article_title: string;
-  split_neuron_success: string;
   cannot_merge_neuron_community: string;
   cannot_merge_neuron_hotkey: string;
   cannot_merge_hardware_wallet: string;

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -6,7 +6,10 @@ import { tick } from "svelte/internal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/governance.api";
 import * as ledgerApi from "../../../lib/api/ledger.api";
-import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
+import {
+  E8S_PER_ICP,
+  TRANSACTION_FEE_E8S,
+} from "../../../lib/constants/icp.constants";
 import * as services from "../../../lib/services/neurons.services";
 import * as busyStore from "../../../lib/stores/busy.store";
 import {
@@ -884,6 +887,23 @@ describe("neurons-services", () => {
       });
 
       expect(spySplitNeuron).toHaveBeenCalled();
+    });
+
+    it("should add transaction fee to the amount", async () => {
+      neuronsStore.pushNeurons({ neurons, certified: true });
+      const amount = 2.2;
+      const transactionFee = TRANSACTION_FEE_E8S / E8S_PER_ICP;
+      const amountWithFee = amount + transactionFee;
+      await services.splitNeuron({
+        neuronId: controlledNeuron.neuronId,
+        amount,
+      });
+
+      expect(spySplitNeuron).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        neuronId: controlledNeuron.neuronId,
+        amount: ICP.fromE8s(BigInt(Math.round(amountWithFee * E8S_PER_ICP))),
+      });
     });
 
     it("should not update neuron if no identity", async () => {


### PR DESCRIPTION
# Motivation

User can see the splitted or spawned neurons immediately after the action.

The amount to split a neuron will be the amount of the new neuron. This is more user friendly.

# Changes

* Add transaction fee to the amount on `splitNeuron` service.
* Neuron services "splitNeuron" and "spawnNeuron" do not load only one neuron, but call "listNeurons".

# Tests

* Test to check that the transaction fee is added to the amount when splitting a neuron.
