### PR TITLE
fix/feat: canister icp <-> cycles

### DIFF
--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
   import { createEventDispatcher, onMount } from "svelte";
-  import { E8S_PER_ICP } from "../../constants/icp.constants";
   import { i18n } from "../../stores/i18n";
   import {
     convertIcpToTCycles,
-    convertTCyclesToE8s,
+    convertTCyclesToIcp,
   } from "../../utils/icp.utils";
   import Input from "../ui/Input.svelte";
 
@@ -15,45 +14,38 @@
   let isChanging: "icp" | "tCycles" | undefined = undefined;
   let amountCycles: number | undefined;
 
-  onMount(async () => {
-    // Update cycles input if the component is mounted with some `amount`
-    if (icpToCyclesRatio !== undefined && amount !== undefined) {
-      amountCycles = convertIcpToTCycles({
-        icpNumber: amount,
-        ratio: icpToCyclesRatio,
-      });
-    }
-  });
+  // Update cycles input if the component is mounted with some `amount`
+  onMount(() => setCycles());
 
-  $: {
-    if (icpToCyclesRatio !== undefined) {
-      if (isChanging === "icp") {
-        // Update cycles input
-        if (amount === undefined) {
-          amountCycles = undefined;
-        } else {
-          amountCycles = convertIcpToTCycles({
+  const setCycles = () =>
+    (amountCycles =
+      amount !== undefined && icpToCyclesRatio !== undefined
+        ? convertIcpToTCycles({
             icpNumber: amount,
             ratio: icpToCyclesRatio,
-          });
-        }
+          })
+        : undefined);
+
+  const setAmount = () =>
+    (amount =
+      amountCycles !== undefined && icpToCyclesRatio !== undefined
+        ? convertTCyclesToIcp({
+            tCycles: amountCycles,
+            ratio: icpToCyclesRatio,
+          })
+        : undefined);
+
+  $: amount,
+    amountCycles,
+    (() => {
+      switch (isChanging) {
+        case "icp":
+          setCycles();
+          break;
+        case "tCycles":
+          setAmount();
       }
-      if (isChanging === "tCycles") {
-        // Update icp input
-        if (amountCycles === undefined) {
-          amount = undefined;
-        } else {
-          amount =
-            Number(
-              convertTCyclesToE8s({
-                tCycles: amountCycles,
-                ratio: icpToCyclesRatio,
-              })
-            ) / E8S_PER_ICP;
-        }
-      }
-    }
-  }
+    })();
 
   const dispatcher = createEventDispatcher();
   const selectAccount = () => {
@@ -79,7 +71,7 @@
       />
       <Input
         placeholderLabelKey="canisters.t_cycles"
-        inputType="number"
+        inputType="icp"
         name="t-cycles-amount"
         theme="dark"
         bind:value={amountCycles}

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -4,7 +4,7 @@
   import { i18n } from "../../stores/i18n";
   import {
     convertIcpToTCycles,
-    convertTCyclesToIcp,
+    convertTCyclesToIcpNumber,
   } from "../../utils/icp.utils";
   import Input from "../ui/Input.svelte";
 
@@ -29,7 +29,7 @@
   const setAmount = () =>
     (amount =
       amountCycles !== undefined && icpToCyclesRatio !== undefined
-        ? convertTCyclesToIcp({
+        ? convertTCyclesToIcpNumber({
             tCycles: amountCycles,
             ratio: icpToCyclesRatio,
           })

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -62,10 +62,10 @@ export const convertIcpToTCycles = ({
   return Number(icp.toE8s() * ratio) / ONE_TRILLION;
 };
 
-export const convertTCyclesToE8s = ({
+export const convertTCyclesToIcp = ({
   tCycles,
   ratio,
 }: {
   tCycles: number;
   ratio: bigint;
-}): bigint => BigInt(tCycles * ONE_TRILLION) / ratio;
+}): number => (tCycles * Number(ONE_TRILLION)) / Number(ratio) / E8S_PER_ICP;

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -62,7 +62,7 @@ export const convertIcpToTCycles = ({
   return Number(icp.toE8s() * ratio) / ONE_TRILLION;
 };
 
-export const convertTCyclesToIcp = ({
+export const convertTCyclesToIcpNumber = ({
   tCycles,
   ratio,
 }: {

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -86,18 +86,18 @@ describe("icp-utils", () => {
 
   describe("convertTCyclesToIcpNumber", () => {
     it("converts TCycles to number", () => {
-      expect(convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
-        1
-      );
-      expect(convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
-        2.5
-      );
-      expect(convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
-        1.25
-      );
-      expect(convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
-        2 / 3
-      );
+      expect(
+        convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(10_000) })
+      ).toBe(1);
+      expect(
+        convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(10_000) })
+      ).toBe(2.5);
+      expect(
+        convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(20_000) })
+      ).toBe(1.25);
+      expect(
+        convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(15_000) })
+      ).toBe(2 / 3);
       expect(
         convertTCyclesToIcpNumber({ tCycles: 4.32, ratio: BigInt(10_000) })
       ).toBe(4.32);

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,10 +1,9 @@
 import { ICP } from "@dfinity/nns";
-import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import {
   convertIcpToTCycles,
   convertNumberToICP,
-  convertTCyclesToE8s,
+  convertTCyclesToIcp,
   formatICP,
   formattedTransactionFeeICP,
   maxICP,
@@ -85,20 +84,23 @@ describe("icp-utils", () => {
     });
   });
 
-  describe("convertTCyclesToE8s", () => {
-    it("converts TCycles to E8s", () => {
-      expect(convertTCyclesToE8s({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
-        BigInt(E8S_PER_ICP)
+  describe("convertTCyclesToIcp", () => {
+    it("converts TCycles to ICP", () => {
+      expect(convertTCyclesToIcp({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
+        1
       );
-      expect(convertTCyclesToE8s({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
-        BigInt(E8S_PER_ICP * 2.5)
+      expect(convertTCyclesToIcp({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
+        2.5
       );
-      expect(convertTCyclesToE8s({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
-        BigInt(125_000_000)
+      expect(convertTCyclesToIcp({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
+        1.25
       );
-      expect(convertTCyclesToE8s({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
-        BigInt(66666666)
+      expect(convertTCyclesToIcp({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
+        2 / 3
       );
+      expect(
+        convertTCyclesToIcp({ tCycles: 4.32, ratio: BigInt(10_000) })
+      ).toBe(4.32);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -3,7 +3,7 @@ import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import {
   convertIcpToTCycles,
   convertNumberToICP,
-  convertTCyclesToIcp,
+  convertTCyclesToIcpNumber,
   formatICP,
   formattedTransactionFeeICP,
   maxICP,
@@ -84,22 +84,22 @@ describe("icp-utils", () => {
     });
   });
 
-  describe("convertTCyclesToIcp", () => {
-    it("converts TCycles to ICP", () => {
-      expect(convertTCyclesToIcp({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
+  describe("convertTCyclesToIcpNumber", () => {
+    it("converts TCycles to number", () => {
+      expect(convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(10_000) })).toBe(
         1
       );
-      expect(convertTCyclesToIcp({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
+      expect(convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(10_000) })).toBe(
         2.5
       );
-      expect(convertTCyclesToIcp({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
+      expect(convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(20_000) })).toBe(
         1.25
       );
-      expect(convertTCyclesToIcp({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
+      expect(convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(15_000) })).toBe(
         2 / 3
       );
       expect(
-        convertTCyclesToIcp({ tCycles: 4.32, ratio: BigInt(10_000) })
+        convertTCyclesToIcpNumber({ tCycles: 4.32, ratio: BigInt(10_000) })
       ).toBe(4.32);
     });
   });


### PR DESCRIPTION
# Motivation

- feat: use type "icp" for cycles input (1.234 instead of 1,234)
- fix: `Uncaught (in promise) RangeError: The number 4320000000000.0005 cannot be converted to a BigInt because it is not an integer`
- refactor: remove double code and extract local functions

# Changes

- set type `icp` for cycles `Input`
- extract local functions `setAmount` and `setCycles`
- spare double code of `onMount`
- rename function `convertTCyclesToE8s` to `convertTCyclesToIcp`, change method signature to `Number` and fix conversion with number casting

# Screenshots

Error and input type number:

<img width="1321" alt="Capture d’écran 2022-06-01 à 08 42 56" src="https://user-images.githubusercontent.com/16886711/171348751-4212c725-2963-478a-910b-fcdad9256522.png">

