### PR TITLE
style: fix small modal height on mobile devices

### DIFF
--- a/frontend/svelte/src/lib/modals/Modal.svelte
+++ b/frontend/svelte/src/lib/modals/Modal.svelte
@@ -147,7 +147,9 @@
       width: var(--modal-big-width);
     }
 
-    height: min(calc(100% - var(--padding-6x)), var(--modal-max-height));
+    --modal-wrapper-height: min(calc(100% - var(--padding-6x)), var(--modal-max-height));
+
+    height: var(--modal-wrapper-height);
     max-width: calc(100vw - var(--padding-4x));
 
     --modal-toolbar-height: 35px;
@@ -230,5 +232,6 @@
 
   .small {
     height: fit-content;
+    max-height: var(--modal-wrapper-height);
   }
 </style>


### PR DESCRIPTION
# Motivation

Fix small modal height viewport overflow on mobile devices

# Changes

- use wrapper height as max-height for small modal

# Screenshot

Issue:

<img width="1321" alt="Capture d’écran 2022-06-01 à 10 58 00" src="https://user-images.githubusercontent.com/16886711/171367445-a2e84c53-cea8-433c-ad69-e698d2a4b354.png">


Fixed:

<img width="1321" alt="Capture d’écran 2022-06-01 à 10 57 45" src="https://user-images.githubusercontent.com/16886711/171367463-4d432979-6a27-4a9c-b5c1-41c90c383bf6.png">
