### PR TITLE
feat: simplify canister introduction text

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -249,10 +249,7 @@
   },
   "canisters": {
     "title": "Canisters",
-    "text": "Canisters are computational units (a form of smart contracts). They are powered by “cycles”, which they must be pre-charged with. You create cycles by converting ICP tokens.",
-    "step1": "Create new canisters",
-    "step2": "Link canisters to your account",
-    "step3": "Send cycles to canisters",
+    "text": "Developers can create and manage their canisters (a form of smart contracts) and cycles consumption here.",
     "principal_is": "Your principal id is",
     "create_or_link": "Create or Link Canister",
     "empty": "No canisters yet.",

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -264,9 +264,6 @@ interface I18nVoting {
 interface I18nCanisters {
   title: string;
   text: string;
-  step1: string;
-  step2: string;
-  step3: string;
   principal_is: string;
   create_or_link: string;
   empty: string;

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -58,11 +58,6 @@
   <Layout>
     <section>
       <p>{$i18n.canisters.text}</p>
-      <ul>
-        <li>{$i18n.canisters.step1}</li>
-        <li>{$i18n.canisters.step2}</li>
-        <li>{$i18n.canisters.step3}</li>
-      </ul>
       <p class="last-info">
         {$i18n.canisters.principal_is}
         {$authStore.identity?.getPrincipal().toText()}

--- a/frontend/svelte/src/tests/routes/Canisters.spec.ts
+++ b/frontend/svelte/src/tests/routes/Canisters.spec.ts
@@ -39,9 +39,6 @@ describe("Canisters", () => {
     const { getByText } = render(Canisters);
 
     expect(getByText(en.canisters.text)).toBeInTheDocument();
-    expect(getByText(en.canisters.step1)).toBeInTheDocument();
-    expect(getByText(en.canisters.step2)).toBeInTheDocument();
-    expect(getByText(en.canisters.step3)).toBeInTheDocument();
   });
 
   it("should subscribe to store", () =>


### PR DESCRIPTION
# Motivation

Discussed with Mischa, as for other screens, try to spare some not useful texts to spare spaces for what's useful - i.e. more spaces for the list of canisters.

# Changes

- update canister introduction text

# Screenshot

<img width="1098" alt="Capture d’écran 2022-06-01 à 11 03 25" src="https://user-images.githubusercontent.com/16886711/171369417-fd859516-1d0c-4717-82a4-7fd7a8e29780.png">

