### PR TITLE
style: redo a different background for card block on the proposal detail page

### DIFF
--- a/frontend/svelte/src/lib/components/ui/CardBlock.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardBlock.svelte
@@ -38,8 +38,8 @@
   article {
     text-decoration: none;
 
-    background: var(--background);
-    color: var(--background-contrast);
+    background: var(--gray-50-background);
+    color: var(--gray50-background-contrast);
 
     padding: var(--padding-1_5x);
     margin: var(--padding-1_5x) 0;


### PR DESCRIPTION
# Motivation

Card blocks on proposal detail page used to be presented with a different background. This redo this ui colors.

# Note

it used to be `--gray100` and now will be `-gray50` because I deprecated 100.

# Changes

- set background and contrast to `-gray50` for card block.

# Screenshots

<img width="1249" alt="Capture d’écran 2022-06-01 à 16 11 31" src="https://user-images.githubusercontent.com/16886711/171425650-3e232f3f-7af1-4ae1-88f3-70c797bdde33.png">
<img width="1249" alt="Capture d’écran 2022-06-01 à 16 11 49" src="https://user-images.githubusercontent.com/16886711/171425664-bcc77a46-54d4-4e15-9f4c-bbfe6a8f2698.png">
