### PR TITLE
feat: do not reload canisters data on back

### DIFF
--- a/frontend/svelte/src/lib/utils/navigation.utils.ts
+++ b/frontend/svelte/src/lib/utils/navigation.utils.ts
@@ -10,13 +10,13 @@ export const reloadOnBack = <T>({
   currentData,
 }: {
   expectedPreviousPath: AppPath;
-  effectivePreviousPath: AppPath | string;
-  currentData: T[];
+  effectivePreviousPath: AppPath | string | undefined;
+  currentData: T[] | undefined;
 }): boolean => {
   const isReferrerDetail: boolean = isRoutePath({
     path: expectedPreviousPath,
     routePath: effectivePreviousPath,
   });
 
-  return isArrayEmpty(currentData) || !isReferrerDetail;
+  return isArrayEmpty(currentData ?? []) || !isReferrerDetail;
 };

--- a/frontend/svelte/src/lib/utils/navigation.utils.ts
+++ b/frontend/svelte/src/lib/utils/navigation.utils.ts
@@ -1,0 +1,22 @@
+import type { AppPath } from "../constants/routes.constants";
+import { isRoutePath } from "./app-path.utils";
+import { isArrayEmpty } from "./utils";
+
+// If the previous page is a particular detail page and if we have data in store, we don't reset and query the data in store after the route is mounted.
+// We do this to smoothness the back and forth navigation between the page and the detail page that have store that are not loaded at boot time.
+export const reloadOnBack = <T>({
+  expectedPreviousPath,
+  effectivePreviousPath,
+  currentData,
+}: {
+  expectedPreviousPath: AppPath;
+  effectivePreviousPath: AppPath | string;
+  currentData: T[];
+}): boolean => {
+  const isReferrerDetail: boolean = isRoutePath({
+    path: expectedPreviousPath,
+    routePath: effectivePreviousPath,
+  });
+
+  return isArrayEmpty(currentData) || !isReferrerDetail;
+};

--- a/frontend/svelte/src/lib/utils/navigation.utils.ts
+++ b/frontend/svelte/src/lib/utils/navigation.utils.ts
@@ -4,7 +4,7 @@ import { isArrayEmpty } from "./utils";
 
 // If the previous page is a particular detail page and if we have data in store, we don't reset and query the data in store after the route is mounted.
 // We do this to smoothness the back and forth navigation between the page and the detail page that have store that are not loaded at boot time.
-export const reloadOnBack = <T>({
+export const reloadRouteData = <T>({
   expectedPreviousPath,
   effectivePreviousPath,
   currentData,

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -15,9 +15,6 @@ import { i18n } from "../stores/i18n";
 import type { ProposalsFiltersStore } from "../stores/proposals.store";
 import { isDefined } from "./utils";
 
-export const emptyProposals = ({ length }: ProposalInfo[]): boolean =>
-  length <= 0;
-
 export const lastProposalId = (
   proposalInfos: ProposalInfo[]
 ): ProposalId | undefined => {

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -139,3 +139,5 @@ export const mapPromises = async <T, R>(
 
   return Promise.all(items.map(async (item) => await fun(item)));
 };
+
+export const isArrayEmpty = <T>({ length }: T[]): boolean => length <= 0;

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -140,4 +140,4 @@ export const mapPromises = async <T, R>(
   return Promise.all(items.map(async (item) => await fun(item)));
 };
 
-export const isArrayEmpty = <T>({ length }: T[]): boolean => length <= 0;
+export const isArrayEmpty = <T>({ length }: T[]): boolean => length === 0;

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -16,7 +16,7 @@
   import type { CanisterId } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import { routeStore } from "../lib/stores/route.store";
   import CreateOrLinkCanisterModal from "../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
-  import { reloadOnBack } from "../lib/utils/navigation.utils";
+  import { reloadRouteData } from "../lib/utils/navigation.utils";
 
   const loadCanisters = async () => {
     try {
@@ -36,7 +36,7 @@
       window.location.replace("/#/canisters");
     }
 
-    const reload: boolean = reloadOnBack({
+    const reload: boolean = reloadRouteData({
       expectedPreviousPath: AppPath.CanisterDetail,
       effectivePreviousPath: $routeStore.referrerPath,
       currentData: $canistersStore.canisters,

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -36,7 +36,7 @@
       window.location.replace("/#/canisters");
     }
 
-    const reload = reloadOnBack({
+    const reload: boolean = reloadOnBack({
       expectedPreviousPath: AppPath.CanisterDetail,
       effectivePreviousPath: $routeStore.referrerPath,
       currentData: $canistersStore.canisters,

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -16,6 +16,7 @@
   import type { CanisterId } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import { routeStore } from "../lib/stores/route.store";
   import CreateOrLinkCanisterModal from "../lib/modals/canisters/CreateOrLinkCanisterModal.svelte";
+  import { reloadOnBack } from "../lib/utils/navigation.utils";
 
   const loadCanisters = async () => {
     try {
@@ -33,6 +34,16 @@
   onMount(async () => {
     if (!SHOW_CANISTERS_ROUTE) {
       window.location.replace("/#/canisters");
+    }
+
+    const reload = reloadOnBack({
+      expectedPreviousPath: AppPath.CanisterDetail,
+      effectivePreviousPath: $routeStore.referrerPath,
+      currentData: $canistersStore.canisters,
+    });
+
+    if (!reload) {
+      return;
     }
 
     await loadCanisters();

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -4,7 +4,6 @@
   import ProposalsFilters from "../lib/components/proposals/ProposalsFilters.svelte";
   import { i18n } from "../lib/stores/i18n";
   import {
-    emptyProposals,
     hasMatchingProposals,
     lastProposalId,
   } from "../lib/utils/proposals.utils";
@@ -26,8 +25,8 @@
   } from "../lib/services/proposals.services";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { routeStore } from "../lib/stores/route.store";
-  import { isRoutePath } from "../lib/utils/app-path.utils";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
+  import { reloadOnBack } from "../lib/utils/navigation.utils";
 
   let loading: boolean = false;
   let hidden: boolean = false;
@@ -78,17 +77,13 @@
       window.location.replace(AppPath.Proposals);
     }
 
-    const isReferrerProposalDetail: boolean = isRoutePath({
-      path: AppPath.ProposalDetail,
-      routePath: $routeStore.referrerPath,
+    const reload = reloadOnBack({
+      expectedPreviousPath: AppPath.ProposalDetail,
+      effectivePreviousPath: $routeStore.referrerPath,
+      currentData: $proposalsStore.proposals,
     });
 
-    // If the previous page is the proposal detail page and if we have proposals in store, we don't reset and query the proposals after mount.
-    // We do this to smoothness the back and forth navigation between this page and the detail page.
-    if (
-      !emptyProposals($proposalsStore.proposals) &&
-      isReferrerProposalDetail
-    ) {
+    if (!reload) {
       initDebounceFindProposals();
       initialized = true;
       return;

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -77,7 +77,7 @@
       window.location.replace(AppPath.Proposals);
     }
 
-    const reload = reloadOnBack({
+    const reload: boolean = reloadOnBack({
       expectedPreviousPath: AppPath.ProposalDetail,
       effectivePreviousPath: $routeStore.referrerPath,
       currentData: $proposalsStore.proposals,

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -26,7 +26,7 @@
   import { toastsStore } from "../lib/stores/toasts.store";
   import { routeStore } from "../lib/stores/route.store";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
-  import { reloadOnBack } from "../lib/utils/navigation.utils";
+  import { reloadRouteData } from "../lib/utils/navigation.utils";
 
   let loading: boolean = false;
   let hidden: boolean = false;
@@ -77,7 +77,7 @@
       window.location.replace(AppPath.Proposals);
     }
 
-    const reload: boolean = reloadOnBack({
+    const reload: boolean = reloadRouteData({
       expectedPreviousPath: AppPath.ProposalDetail,
       effectivePreviousPath: $routeStore.referrerPath,
       currentData: $proposalsStore.proposals,

--- a/frontend/svelte/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/navigation.utils.spec.ts
@@ -1,0 +1,66 @@
+import { AppPath } from "../../../lib/constants/routes.constants";
+import { reloadRouteData } from "../../../lib/utils/navigation.utils";
+
+describe("navigation-utils", () => {
+  it("should not reload on back", () => {
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: `${AppPath.CanisterDetail}/va76m-bqaaa-aaaaa-aaayq-cai`,
+        currentData: ["test"],
+      })
+    ).toBeFalsy();
+  });
+
+  it("should reload if not expected route referrer", () => {
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: `${AppPath.NeuronDetail}/va76m-bqaaa-aaaaa-aaayq-cai`,
+        currentData: ["test"],
+      })
+    ).toBeTruthy();
+
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: AppPath.NeuronDetail,
+        currentData: ["test"],
+      })
+    ).toBeTruthy();
+
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: undefined,
+        currentData: ["test"],
+      })
+    ).toBeTruthy();
+
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: "/",
+        currentData: ["test"],
+      })
+    ).toBeTruthy();
+  });
+
+  it("should reload if data empty", () => {
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: `${AppPath.NeuronDetail}/va76m-bqaaa-aaaaa-aaayq-cai`,
+        currentData: [],
+      })
+    ).toBeTruthy();
+
+    expect(
+      reloadRouteData({
+        expectedPreviousPath: AppPath.CanisterDetail,
+        effectivePreviousPath: `${AppPath.NeuronDetail}/va76m-bqaaa-aaaaa-aaayq-cai`,
+        currentData: undefined,
+      })
+    ).toBeTruthy();
+  });
+});

--- a/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
@@ -8,7 +8,6 @@ import {
 import { DEFAULT_PROPOSALS_FILTERS } from "../../../lib/constants/proposals.constants";
 import {
   concatenateUniqueProposals,
-  emptyProposals,
   excludeProposals,
   hasMatchingProposals,
   hideProposal,
@@ -30,12 +29,6 @@ import {
 import { mockProposals } from "../../mocks/proposals.store.mock";
 
 describe("proposals-utils", () => {
-  it("should detect an empty list of proposals", () =>
-    expect(emptyProposals([])).toBeTruthy());
-
-  it("should detect an not empty list of proposals", () =>
-    expect(emptyProposals(mockProposals)).toBeFalsy());
-
   it("should find no last proposal id", () =>
     expect(lastProposalId([])).toBeUndefined());
 


### PR DESCRIPTION
# Motivation

To smoothness the ux, do not reload the canisters data on "back" from canister detail page.

This PR aligns the behavior to the "Voting" behavior.

# Changes

- test if data should be reloaded on back
- refactor existing test of "Voting" tab to be reused for "Canisters" tab
