### PR TITLE
L2-653: Improve Canister Creation UX

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Toast.svelte
+++ b/frontend/svelte/src/lib/components/ui/Toast.svelte
@@ -4,7 +4,7 @@
    */
   import { toastsStore } from "../../stores/toasts.store";
   import { fade, fly } from "svelte/transition";
-  import { translate } from "../../utils/i18n.utils";
+  import { replacePlaceholders, translate } from "../../utils/i18n.utils";
   import { i18n } from "../../stores/i18n";
   import type { ToastLevel, ToastMsg } from "../../types/toast";
   import { onDestroy, onMount } from "svelte";
@@ -17,11 +17,13 @@
   let labelKey: string;
   let level: ToastLevel;
   let detail: string | undefined;
+  let substitutions: { [from: string]: string } | undefined;
 
-  $: ({ labelKey, level, detail } = msg);
-  $: text = `${translate({ labelKey })}${
-    detail !== undefined ? ` ${detail}` : ""
-  }`;
+  $: ({ labelKey, level, detail, substitutions } = msg);
+  $: text = replacePlaceholders(
+    `${translate({ labelKey })}${detail !== undefined ? ` ${detail}` : ""}`,
+    substitutions ?? {}
+  );
 
   let timeoutId: NodeJS.Timeout | undefined = undefined;
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -257,7 +257,7 @@
     "add_canister": "Add Canister",
     "create_canister_title": "Create New Canister",
     "create_canister_subtitle": "Create a new canister, to deploy your application",
-    "create_canister_success": "Canister created successfully",
+    "create_canister_success": "New canister with id $canisterId created successfully",
     "link_canister_title": "Link Canister To Account",
     "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
     "link_canister_success": "The canister was linked successfully",
@@ -330,7 +330,8 @@
     "no_transactions": "No transactions"
   },
   "busy_screen": {
-    "pending_approval_hw": "Please use your hardware wallet to approve."
+    "pending_approval_hw": "Please use your hardware wallet to approve.",
+    "take_long": "This might take a while."
   },
   "proposal_detail": {
     "title": "Proposal",

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -96,15 +96,20 @@
     }
     startBusy({
       initiator: "create-canister",
+      labelKey: "busy_screen.take_long",
     });
-    const { success } = await createCanister({
+    const canisterId = await createCanister({
       amount,
       fromSubAccount: account.subAccount,
     });
     stopBusy("create-canister");
-    if (success) {
-      toastsStore.success({
+    if (canisterId !== undefined) {
+      toastsStore.show({
+        level: "success",
         labelKey: "canisters.create_canister_success",
+        substitutions: {
+          $canisterId: canisterId.toText(),
+        },
       });
       dispatcher("nnsClose");
     }

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -60,12 +60,12 @@ export const createCanister = async ({
 }: {
   amount: number;
   fromSubAccount?: SubAccountArray;
-}): Promise<{ success: boolean }> => {
+}): Promise<Principal | undefined> => {
   try {
     const icpAmount = convertNumberToICP(amount);
     // TODO: Validate it's enough ICP https://dfinity.atlassian.net/browse/L2-615
     const identity = await getIdentity();
-    await createCanisterApi({
+    const canisterId = await createCanisterApi({
       identity,
       amount: icpAmount,
       fromSubAccount,
@@ -74,10 +74,10 @@ export const createCanister = async ({
     // We don't wait for `syncAccounts` to finish to give a better UX to the user.
     // `syncAccounts` might be slow since it loads all accounts and balances.
     syncAccounts();
-    return { success: true };
+    return canisterId;
   } catch (error) {
     // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
-    return { success: false };
+    return;
   }
 };
 

--- a/frontend/svelte/src/lib/stores/toasts.store.ts
+++ b/frontend/svelte/src/lib/stores/toasts.store.ts
@@ -24,16 +24,33 @@ const initToastsStore = () => {
       });
     },
 
-    success({ labelKey }: Pick<ToastMsg, "labelKey">) {
+    success({
+      labelKey,
+      substitutions,
+    }: Pick<ToastMsg, "labelKey" | "substitutions">) {
       this.show({
         labelKey,
+        substitutions,
         level: "success",
         duration: DEFAULT_TOAST_DURATION_MILLIS,
       });
     },
 
-    error({ labelKey, err }: { labelKey: string; err?: unknown }) {
-      this.show({ labelKey, level: "error", detail: errorToString(err) });
+    error({
+      labelKey,
+      err,
+      substitutions,
+    }: {
+      labelKey: string;
+      err?: unknown;
+      substitutions?: { [from: string]: string };
+    }) {
+      this.show({
+        labelKey,
+        level: "error",
+        detail: errorToString(err),
+        substitutions,
+      });
 
       if (err !== undefined) {
         console.error(err);

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -352,6 +352,7 @@ interface I18nWallet {
 
 interface I18nBusy_screen {
   pending_approval_hw: string;
+  take_long: string;
 }
 
 interface I18nProposal_detail {

--- a/frontend/svelte/src/lib/types/toast.ts
+++ b/frontend/svelte/src/lib/types/toast.ts
@@ -2,6 +2,7 @@ export type ToastLevel = "success" | "warn" | "error";
 
 export interface ToastMsg {
   labelKey: string;
+  substitutions?: { [from: string]: string };
   level: ToastLevel;
   detail?: string;
   duration?: number;

--- a/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Toast.spec.ts
@@ -41,4 +41,23 @@ describe("Toast", () => {
 
     expect(p?.textContent).toContain("more details");
   });
+
+  it("should render substitutions", async () => {
+    const canisterId = "aaaaa-aa";
+    const { container } = render(Toast, {
+      props: {
+        msg: {
+          labelKey: "canisters.create_canister_success",
+          level: "success",
+          substitutions: {
+            $canisterId: canisterId,
+          },
+        },
+      },
+    });
+
+    const p: HTMLParagraphElement | null = container.querySelector("p");
+
+    expect(p?.textContent).toContain(canisterId);
+  });
 });

--- a/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/CreateOrLinkCanisterModal.spec.ts
@@ -18,6 +18,7 @@ import {
   mockHardwareWalletAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
+import { mockCanister } from "../../../mocks/canisters.mock";
 import en from "../../../mocks/i18n.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 
@@ -25,13 +26,16 @@ jest.mock("../../../../lib/services/canisters.services", () => {
   return {
     attachCanister: jest.fn().mockResolvedValue({ success: true }),
     getIcpToCyclesExchangeRate: jest.fn().mockResolvedValue(BigInt(100_000)),
-    createCanister: jest.fn().mockResolvedValue({ success: true }),
+    createCanister: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockCanister.canister_id)),
   };
 });
 
 jest.mock("../../../../lib/stores/toasts.store", () => {
   return {
     toastsStore: {
+      show: jest.fn(),
       success: jest.fn(),
     },
   };
@@ -166,7 +170,7 @@ describe("CreateOrLinkCanisterModal", () => {
 
     await waitFor(() => expect(done).toBeCalled());
     expect(createCanister).toBeCalled();
-    expect(toastsStore.success).toBeCalled();
+    expect(toastsStore.show).toBeCalled();
   });
 
   // We added the hardware wallet in the accountsStore subscribe mock above.

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -167,8 +167,8 @@ describe("canisters-services", () => {
     afterEach(() => jest.clearAllMocks());
 
     it("should call api to create a canister", async () => {
-      const { success } = await createCanister({ amount: 3 });
-      expect(success).toBe(true);
+      const canisterId = await createCanister({ amount: 3 });
+      expect(canisterId).not.toBeUndefined();
       expect(spyCreateCanister).toBeCalled();
       expect(spyQueryCanisters).toBeCalled();
       expect(syncAccounts).toBeCalled();
@@ -177,8 +177,8 @@ describe("canisters-services", () => {
     it("should return success false if no identity", async () => {
       setNoIdentity();
 
-      const { success } = await createCanister({ amount: 3 });
-      expect(success).toBe(false);
+      const canisterId = await createCanister({ amount: 3 });
+      expect(canisterId).toBeUndefined();
       expect(spyCreateCanister).not.toBeCalled();
 
       resetIdentity();


### PR DESCRIPTION
# Motivation

Improve UX when creating a canister.

# Changes

* Toasts now accept an object for substitutions for the label key.
* Service "createCanister" returns new canister id when successful.
* Create canister success toast shows new canister id.
* Added a message in the busy screen when creating a canister.

# Tests

* Fix tests.
* New test case in Toast to check that it replaces placeholders.
