### PR TITLE
fix: improve mobile button long text support

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalMeta.svelte
@@ -56,7 +56,6 @@
       padding: 0;
 
       font-size: var(--font-size-h5);
-      line-height: var(--line-height-standard);
       text-align: start;
       color: var(--gray-200);
       overflow-wrap: anywhere;

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
@@ -27,7 +27,6 @@
     :global(a) {
       font-size: var(--font-size-small);
       color: var(--blue-500-tint);
-      line-height: var(--line-height-standard);
       text-decoration: none;
     }
 

--- a/frontend/svelte/src/lib/themes/fonts.scss
+++ b/frontend/svelte/src/lib/themes/fonts.scss
@@ -90,5 +90,5 @@ small,
 a,
 button {
   font-size: var(--font-size-h4);
-  line-height: var(--line-height-title);
+  line-height: var(--line-height-standard);
 }


### PR DESCRIPTION
# Motivation

To have the same button height for the buttons with the long text the line-height was decreased.

# Changes

- Change A and Button default line-height to be default
- remove redundant styles

# Before

<img width="214" alt="image" src="https://user-images.githubusercontent.com/98811342/171641698-cf6b36bf-62d3-4aa0-a7b4-8455943dcb3b.png">

<img width="209" alt="image" src="https://user-images.githubusercontent.com/98811342/171641832-5f1058e6-ce71-4e99-b3a8-ac7fe27d2167.png">

<img width="427" alt="image" src="https://user-images.githubusercontent.com/98811342/171641887-16f35d0e-48cd-48e9-8a74-9a7774c9fcef.png">


# After

<img width="437" alt="image" src="https://user-images.githubusercontent.com/98811342/171640303-70445a2d-4246-41a3-bcc4-296323bc3d83.png">

<img width="888" alt="image" src="https://user-images.githubusercontent.com/98811342/171640403-95af003a-05ce-4d5d-ba31-9060170830ad.png">

<img width="526" alt="image" src="https://user-images.githubusercontent.com/98811342/171640882-2f526d9b-4bd7-4153-aff9-a67138ef7f48.png">
