### PR TITLE
L2-665: Improve getting neuron identity

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -59,7 +59,7 @@
     "unexpected_number_neurons_merge": "Sorry, the number of neurons to merge should be only 2. Please try selecting again.",
     "cannot_merge": "Those two neurons cannot be merged.",
     "split_neuron": "Sorry, there was an unexpected error splitting the neuron. Please try again later.",
-    "not_authorized": "Sorry, you are not authorized to perform this action.",
+    "not_authorized_neuron_action": "Sorry, non of your principals is the controller of the neuron.",
     "invalid_sender": "Sorry, you can't send funds from this account.",
     "insufficient_funds": "Sorry, there are not enough funds in this account",
     "transfer_error": "Sorry, there was an error with the transaction. Please try again later.",

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -226,14 +226,14 @@ export const getAccountIdentity = async (
 
 export const getAccountIdentityByPrincipal = async (
   principalString: string
-): Promise<Identity | LedgerIdentity> => {
+): Promise<Identity | LedgerIdentity | null> => {
   const accounts = get(accountsStore);
   const account = getAccountByPrincipal({
     principal: principalString,
     accounts,
   });
   if (account === undefined) {
-    throw new Error(`Account with principal ${principalString} not found!`);
+    return null;
   }
   return getAccountIdentity(account.identifier);
 };

--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -226,14 +226,14 @@ export const getAccountIdentity = async (
 
 export const getAccountIdentityByPrincipal = async (
   principalString: string
-): Promise<Identity | LedgerIdentity | null> => {
+): Promise<Identity | LedgerIdentity | undefined> => {
   const accounts = get(accountsStore);
   const account = getAccountByPrincipal({
     principal: principalString,
     accounts,
   });
   if (account === undefined) {
-    return null;
+    return;
   }
   return getAccountIdentity(account.identifier);
 };

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -132,7 +132,7 @@ export const getIdentityOfControllerByNeuronId = async (
   const neuronIdentity = await getAccountIdentityByPrincipal(
     neuron.fullNeuron.controller
   );
-  if (neuronIdentity === null) {
+  if (neuronIdentity === undefined) {
     throw new NotAuthorizedNeuronError();
   }
   // `getAccountIdentityByPrincipal` returns the current user identity (because of `getIdentity`) if the account is not a hardware wallet.

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -63,7 +63,7 @@ interface I18nError {
   unexpected_number_neurons_merge: string;
   cannot_merge: string;
   split_neuron: string;
-  not_authorized: string;
+  not_authorized_neuron_action: string;
   invalid_sender: string;
   insufficient_funds: string;
   transfer_error: string;

--- a/frontend/svelte/src/lib/types/neurons.errors.ts
+++ b/frontend/svelte/src/lib/types/neurons.errors.ts
@@ -1,6 +1,6 @@
 export class NotFoundError extends Error {}
 
-export class NotAuthorizedError extends Error {}
+export class NotAuthorizedNeuronError extends Error {}
 
 export class InvalidAmountError extends Error {}
 

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -12,7 +12,7 @@ import {
   CannotBeMerged,
   InsufficientAmountError,
   InvalidAmountError,
-  NotAuthorizedError,
+  NotAuthorizedNeuronError,
   NotFoundError,
 } from "../types/neurons.errors";
 import type { ToastMsg } from "../types/toast";
@@ -46,7 +46,7 @@ export const mapNeuronErrorToToastMessage = (error: Error): ToastMsg => {
   /* eslint-disable-next-line @typescript-eslint/ban-types */
   const collection: Array<[Function, string]> = [
     [NotFoundError, "error.neuron_not_found"],
-    [NotAuthorizedError, "error.not_authorized"],
+    [NotAuthorizedNeuronError, "error.not_authorized_neuron_action"],
     [InvalidAmountError, "error.amount_not_valid"],
     [InsufficientAmountError, "error.amount_not_enough"],
     [CouldNotClaimNeuronError, "error.neuron_not_found"],

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -412,7 +412,7 @@ describe("accounts-services", () => {
       const expectedIdentity = await getAccountIdentityByPrincipal(
         "gje2w-p7x7x-yuy72-bllam-x2itq-znokr-jnvf6-5dzn4-45jiy-5wvbo-uqe"
       );
-      expect(expectedIdentity).toBe(null);
+      expect(expectedIdentity).toBeUndefined();
       accountsStore.reset();
     });
   });

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -403,5 +403,17 @@ describe("accounts-services", () => {
       expect(getLedgerIdentityProxy).toBeCalled();
       accountsStore.reset();
     });
+
+    it("returns null if no main account nor hardware wallet account", async () => {
+      accountsStore.set({
+        main: mockMainAccount,
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+      const expectedIdentity = await getAccountIdentityByPrincipal(
+        "gje2w-p7x7x-yuy72-bllam-x2itq-znokr-jnvf6-5dzn4-45jiy-5wvbo-uqe"
+      );
+      expect(expectedIdentity).toBe(null);
+      accountsStore.reset();
+    });
   });
 });


### PR DESCRIPTION
# Motivation

User can perform neuron actions before accounts are loaded.

# Changes

* Check first if principal in authStore is the controller of a neuron in getIdentityOfControllerByNeuronId
* Rename NotAuthorizedError to NotAuthorizedNeuronError to customize the error message to neurons.
* getAccountIdentityByPrincipal does not throw an error when no account, instead returns null.

# Tests

* Add tests for getIdentityOfControllerByNeuronId.
* Add test case for getAccountIdentityByPrincipal
