### PR TITLE
L2-618: Message when user not canister controller

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -72,6 +72,8 @@
     "invalid_percentage": "Sorry, the percentage amount is not valid.",
     "principal_not_valid": "Please enter a valid principal.",
     "input_length": "Input must be longer than $length characters.",
+    "not_canister_controller": "You are not the controller of this canister and cannot access its details.",
+    "canister_details_not_found": "Sorry, there was an error loading the details of the canister. Please try again later.",
     "hardware_wallet_no_account": "No hardware wallet account provided."
   },
   "warning": {

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -153,18 +153,22 @@ export const routePathCanisterId = (
   return canisterId !== undefined && canisterId !== "" ? canisterId : undefined;
 };
 
+/**
+ * Makes a call to the IC Management "canister" to get the canister details
+ *
+ * @param canisterId: Principal
+ * @returns CanisterDetails
+ * @throws UserNotTheControllerError
+ * @throws Error
+ */
 export const getCanisterDetails = async (
   canisterId: Principal
-): Promise<CanisterDetails | undefined> => {
+): Promise<CanisterDetails> => {
   const identity = await getIdentity();
-  try {
-    return await queryCanisterDetailsApi({
-      canisterId,
-      identity,
-    });
-  } catch (error) {
-    // TODO: manage errors https://dfinity.atlassian.net/browse/L2-615
-  }
+  return queryCanisterDetailsApi({
+    canisterId,
+    identity,
+  });
 };
 
 export const getIcpToCyclesExchangeRate = async (): Promise<

--- a/frontend/svelte/src/lib/types/canister-detail.context.ts
+++ b/frontend/svelte/src/lib/types/canister-detail.context.ts
@@ -9,6 +9,7 @@ import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-
 export interface SelectCanisterDetailsStore {
   info: CanisterInfo | undefined;
   details: CanisterDetails | undefined;
+  controller: boolean | undefined;
 }
 
 export interface CanisterDetailsContext {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -76,6 +76,8 @@ interface I18nError {
   invalid_percentage: string;
   principal_not_valid: string;
   input_length: string;
+  not_canister_controller: string;
+  canister_details_not_found: string;
   hardware_wallet_no_account: string;
 }
 

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -104,11 +104,17 @@
         details: newDetails,
       }));
     } catch (error) {
+      const userNotController = error instanceof UserNotTheControllerError;
+      // Show an error if the error is not expected.
+      if (!userNotController) {
+        toastsStore.error({
+          labelKey: "error.canister_details_not_found",
+        });
+      }
       selectedCanisterStore.update((data) => ({
         ...data,
         details: undefined,
-        controller:
-          error instanceof UserNotTheControllerError ? false : undefined,
+        controller: userNotController ? false : undefined,
       }));
     } finally {
       loadingDetails = false;
@@ -224,7 +230,7 @@
         <button
           class="primary"
           on:click={() => (showAddCyclesModal = true)}
-          disabled={canisterDetails === undefined || $busy}
+          disabled={canisterInfo === undefined || $busy}
           >{$i18n.canister_detail.add_cycles}</button
         >
       </Toolbar>

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -79,10 +79,25 @@
 
   debugSelectedCanisterStore(selectedCanisterStore);
 
+  let loadingDetails: boolean = true;
+  let canisterInfo: CanisterInfo | undefined;
+  let canisterDetails: CanisterDetails | undefined = undefined;
+  $: canisterDetails = $selectedCanisterStore.details;
+  let errorKey: string | undefined = undefined;
+  $: errorKey =
+    $selectedCanisterStore.controller === false
+      ? "error.not_canister_controller"
+      : $selectedCanisterStore.controller === undefined && !loadingDetails
+      ? "error.canister_details_not_found"
+      : undefined;
+
+  let showAddCyclesModal: boolean = false;
+  const closeAddCyclesModal = async () => (showAddCyclesModal = false);
+
   const reloadDetails = async (canisterId: Principal) => {
     try {
       if (canisterId !== undefined) {
-        loading = true;
+        loadingDetails = true;
         const newDetails = await getCanisterDetails(canisterId);
         selectedCanisterStore.update((data) => ({
           ...data,
@@ -98,23 +113,8 @@
           error instanceof UserNotTheControllerError ? false : undefined,
       }));
     }
-    loading = false;
+    loadingDetails = false;
   };
-
-  let loading: boolean = false;
-  let canisterInfo: CanisterInfo | undefined;
-  let canisterDetails: CanisterDetails | undefined = undefined;
-  $: canisterDetails = $selectedCanisterStore.details;
-  let errorKey: string | undefined = undefined;
-  $: errorKey =
-    $selectedCanisterStore.controller === false
-      ? "error.not_canister_controller"
-      : $selectedCanisterStore.controller === undefined && !loading
-      ? "error.canister_details_not_found"
-      : undefined;
-
-  let showAddCyclesModal: boolean = false;
-  const closeAddCyclesModal = async () => (showAddCyclesModal = false);
 
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
     store: selectedCanisterStore,

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -96,15 +96,13 @@
 
   const reloadDetails = async (canisterId: Principal) => {
     try {
-      if (canisterId !== undefined) {
-        loadingDetails = true;
-        const newDetails = await getCanisterDetails(canisterId);
-        selectedCanisterStore.update((data) => ({
-          ...data,
-          controller: true,
-          details: newDetails,
-        }));
-      }
+      loadingDetails = true;
+      const newDetails = await getCanisterDetails(canisterId);
+      selectedCanisterStore.update((data) => ({
+        ...data,
+        controller: true,
+        details: newDetails,
+      }));
     } catch (error) {
       selectedCanisterStore.update((data) => ({
         ...data,
@@ -112,8 +110,9 @@
         controller:
           error instanceof UserNotTheControllerError ? false : undefined,
       }));
+    } finally {
+      loadingDetails = false;
     }
-    loadingDetails = false;
   };
 
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -1,5 +1,6 @@
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
+import { UserNotTheControllerError } from "../../../lib/canisters/ic-management/ic-management.errors";
 import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import { syncAccounts } from "../../../lib/services/accounts.services";
 import {
@@ -175,6 +176,17 @@ describe("canisters-services", () => {
 
       await expect(call).rejects.toThrow(Error(mockIdentityErrorMsg));
       resetIdentity();
+    });
+
+    it("should throw if getCanisterDetails api throws", async () => {
+      spyQueryCanisterDetails.mockRejectedValue(
+        new UserNotTheControllerError()
+      );
+
+      const call = () => getCanisterDetails(mockCanisterDetails.id);
+
+      await expect(call).rejects.toThrow(UserNotTheControllerError);
+      spyQueryCanisterDetails.mockRestore();
     });
   });
 

--- a/frontend/svelte/src/tests/mocks/canisters.mock.ts
+++ b/frontend/svelte/src/tests/mocks/canisters.mock.ts
@@ -46,4 +46,5 @@ export const mockCanistersStoreSubscribe = (
 export const mockCanisterDetailsStore = writable<SelectCanisterDetailsStore>({
   info: mockCanister,
   details: mockCanisterDetails,
+  controller: true,
 });


### PR DESCRIPTION
# Motivation

User gets a message when he or she can't view the canister details.

# Changes

* Add an errorDetailsKey to SelectCanisterDetailsStore.
* Use erroDetailsKey to display an error message in Canister Details route.
* getCanisterDetails throws the same as the canister api getCanisterDetails.

# Tests

* Test that service getCanisterDetails throws.
* Test that CanisterDetails route shows error message if user is not the controller.
