### PR TITLE
feat: ICP decimals detailed for neurons

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -74,7 +74,7 @@
                 {
                   $stake: formatICP({
                     value: neuron.fullNeuron.cachedNeuronStake,
-                    detailed: true
+                    detailed: true,
                   }),
                   $delayMultiplier: dissolveDelayMultiplier(
                     Number(neuron.dissolveDelaySeconds)

--- a/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -74,6 +74,7 @@
                 {
                   $stake: formatICP({
                     value: neuron.fullNeuron.cachedNeuronStake,
+                    detailed: true
                   }),
                   $delayMultiplier: dissolveDelayMultiplier(
                     Number(neuron.dissolveDelaySeconds)

--- a/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -33,6 +33,7 @@
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
+        detailed: true
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -32,8 +32,7 @@
     <h5>{$i18n.neuron_detail.current_stake}</h5>
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: formatICP({ value: neuronICP }),
-        detailed: true,
+        $amount: formatICP({ value: neuronICP, detailed: true }),
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -33,7 +33,7 @@
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
-        detailed: true
+        detailed: true,
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -21,7 +21,7 @@
     $i18n.neuron_detail.merge_maturity_disabled_tooltip,
     {
       $amount: formatICP({ value: BigInt(MIN_MATURITY_MERGE) }),
-      detailed: true
+      detailed: true,
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -20,8 +20,7 @@
   text={replacePlaceholders(
     $i18n.neuron_detail.merge_maturity_disabled_tooltip,
     {
-      $amount: formatICP({ value: BigInt(MIN_MATURITY_MERGE) }),
-      detailed: true,
+      $amount: formatICP({ value: BigInt(MIN_MATURITY_MERGE), detailed: true }),
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -21,6 +21,7 @@
     $i18n.neuron_detail.merge_maturity_disabled_tooltip,
     {
       $amount: formatICP({ value: BigInt(MIN_MATURITY_MERGE) }),
+      detailed: true
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -38,7 +38,7 @@
     $i18n.neuron_detail.spawn_maturity_disabled_tooltip,
     {
       $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE) }),
-      detailed: true
+      detailed: true,
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -37,8 +37,7 @@
   text={replacePlaceholders(
     $i18n.neuron_detail.spawn_maturity_disabled_tooltip,
     {
-      $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE) }),
-      detailed: true,
+      $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE), detailed: true }),
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -38,6 +38,7 @@
     $i18n.neuron_detail.spawn_maturity_disabled_tooltip,
     {
       $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE) }),
+      detailed: true
     }
   )}
 >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -23,7 +23,7 @@
   id="split-neuron-button"
   text={replacePlaceholders($i18n.neuron_detail.split_neuron_disabled_tooltip, {
     $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE_SPLITTABLE) }),
-    detailed: true
+    detailed: true,
   })}
 >
   <button on:click={openModal} class="primary small" disabled={!isSplittable}

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -23,6 +23,7 @@
   id="split-neuron-button"
   text={replacePlaceholders($i18n.neuron_detail.split_neuron_disabled_tooltip, {
     $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE_SPLITTABLE) }),
+    detailed: true
   })}
 >
   <button on:click={openModal} class="primary small" disabled={!isSplittable}

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -22,8 +22,10 @@
 <Tooltip
   id="split-neuron-button"
   text={replacePlaceholders($i18n.neuron_detail.split_neuron_disabled_tooltip, {
-    $amount: formatICP({ value: BigInt(MIN_NEURON_STAKE_SPLITTABLE) }),
-    detailed: true,
+    $amount: formatICP({
+      value: BigInt(MIN_NEURON_STAKE_SPLITTABLE),
+      detailed: true,
+    }),
   })}
 >
   <button on:click={openModal} class="primary small" disabled={!isSplittable}

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -52,7 +52,7 @@
     <p>
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
-        detailed: true
+        detailed: true,
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -51,8 +51,7 @@
     <h5>{$i18n.neurons.neuron_balance}</h5>
     <p>
       {replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: formatICP({ value: neuronICP }),
-        detailed: true,
+        $amount: formatICP({ value: neuronICP, detailed: true }),
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -52,6 +52,7 @@
     <p>
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
+        detailed: true
       })}
     </p>
   </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -67,6 +67,7 @@
         <p>
           {replacePlaceholders($i18n.neurons.icp_stake, {
             $amount: formatICP({ value: neuronStake(neuron) }),
+            detailed: true
           })}
         </p>
       </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -66,8 +66,7 @@
         <h5>{$i18n.neurons.neuron_balance}</h5>
         <p>
           {replacePlaceholders($i18n.neurons.icp_stake, {
-            $amount: formatICP({ value: neuronStake(neuron) }),
-            detailed: true,
+            $amount: formatICP({ value: neuronStake(neuron), detailed: true }),
           })}
         </p>
       </div>

--- a/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -67,7 +67,7 @@
         <p>
           {replacePlaceholders($i18n.neurons.icp_stake, {
             $amount: formatICP({ value: neuronStake(neuron) }),
-            detailed: true
+            detailed: true,
           })}
         </p>
       </div>

--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -57,9 +57,10 @@
       <ICPComponent
         label={$i18n.neurons.voting_power}
         icp={ICP.fromE8s(neuron.votingPower)}
+        detailed
       />
     {:else if neuronICP}
-      <ICPComponent icp={neuronICP} />
+      <ICPComponent icp={neuronICP} detailed />
     {/if}
   </div>
 

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -54,8 +54,7 @@
     <h5>{$i18n.neurons.neuron_balance}</h5>
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: formatICP({ value: neuronICP }),
-        detailed: true,
+        $amount: formatICP({ value: neuronICP, detailed: true }),
       })}
     </p>
 

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -55,6 +55,7 @@
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
+        detailed: true
       })}
     </p>
 

--- a/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -55,7 +55,7 @@
     <p data-tid="neuron-stake">
       {replacePlaceholders($i18n.neurons.icp_stake, {
         $amount: formatICP({ value: neuronICP }),
-        detailed: true
+        detailed: true,
       })}
     </p>
 

--- a/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
@@ -77,6 +77,7 @@ describe("NeuronCard", () => {
       value:
         (mockNeuron.fullNeuron as Neuron).cachedNeuronStake -
         (mockNeuron.fullNeuron as Neuron).neuronFees,
+      detailed: true
     });
     expect(getByText(stakeText)).toBeInTheDocument();
     expect(getByText(mockNeuron.neuronId.toString())).toBeInTheDocument();
@@ -169,7 +170,7 @@ describe("NeuronCard", () => {
         proposerNeuron: true,
       },
     });
-    const votingValue = formatICP({ value: mockNeuron.votingPower });
+    const votingValue = formatICP({ value: mockNeuron.votingPower, detailed: true });
     expect(getByText(votingValue)).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/neurons/NeuronCard.spec.ts
@@ -77,7 +77,7 @@ describe("NeuronCard", () => {
       value:
         (mockNeuron.fullNeuron as Neuron).cachedNeuronStake -
         (mockNeuron.fullNeuron as Neuron).neuronFees,
-      detailed: true
+      detailed: true,
     });
     expect(getByText(stakeText)).toBeInTheDocument();
     expect(getByText(mockNeuron.neuronId.toString())).toBeInTheDocument();
@@ -170,7 +170,10 @@ describe("NeuronCard", () => {
         proposerNeuron: true,
       },
     });
-    const votingValue = formatICP({ value: mockNeuron.votingPower, detailed: true });
+    const votingValue = formatICP({
+      value: mockNeuron.votingPower,
+      detailed: true,
+    });
     expect(getByText(votingValue)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

Community wish more precision in the display of the neurons ICP. Therefore this PR extends the display of the ICP in the neurons tabs to the `detailed` display. See previous PR #947 and #949 for details.

# Changes

- in neurons route and component use `formatICP` and `<ICP/>` cmp with option `detailed`

# Screenshots

<img width="1236" alt="Capture d’écran 2022-06-03 à 14 26 54" src="https://user-images.githubusercontent.com/16886711/171855324-c9a83d87-66f2-40ea-b63d-86dc89c351ab.png">
<img width="1236" alt="Capture d’écran 2022-06-03 à 14 26 59" src="https://user-images.githubusercontent.com/16886711/171855336-c8e74f9f-0cbd-47e8-9188-d388eba3e713.png">
<img width="1236" alt="Capture d’écran 2022-06-03 à 14 27 03" src="https://user-images.githubusercontent.com/16886711/171855345-62a2414b-6c38-479d-8b3e-03d0502cb34a.png">

