### PR TITLE
build: bump nns-js and agent-js

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -8,9 +8,9 @@
       "name": "svelte-app",
       "version": "1.0.0",
       "dependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/auth-client": "^0.11.1",
-        "@dfinity/nns": "nightly",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/auth-client": "^0.11.3",
+        "@dfinity/nns": "^0.4.3",
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
         "@ledgerhq/hw-transport-webhid": "^6.27.1",
         "@zondax/ledger-icp": "^0.6.0"
@@ -661,9 +661,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
-      "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.3.tgz",
+      "integrity": "sha512-pqiogLey6S83SG5BS93hBCtXfGRW6tkxa8Y0c9HwxOP/wRoVEuKHdTcOn7rL/HN4mDTwxkdqK4EC1Kv24S1q4Q==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -672,41 +672,41 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1"
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3"
       }
     },
     "node_modules/@dfinity/auth-client": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.11.1.tgz",
-      "integrity": "sha512-Fb5jv8W6EF3jAr2d8lowunqAaqk5WHIckEFskaflVqWuiH0hDwbFFjeWn554jhkyM6pVq30ikXxbaUWI9sSXgw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.11.3.tgz",
+      "integrity": "sha512-+wwjoucE8ZIjcA1IG+OQ8OxFoAajYfnELbSMZE1p3FGlbC0X3gpab0bbXqh8VKou8Ng1eRU+sAwItruCLiIBHg==",
       "peerDependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/authentication": "^0.11.1",
-        "@dfinity/identity": "^0.11.1",
-        "@dfinity/principal": "^0.11.1"
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/authentication": "^0.11.3",
+        "@dfinity/identity": "^0.11.3",
+        "@dfinity/principal": "^0.11.3"
       }
     },
     "node_modules/@dfinity/authentication": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.11.1.tgz",
-      "integrity": "sha512-I1t7Ac4iJbTK7KSO+WIA3/rzkCSGDlDcPWKVrTrve39MY1i/yX+2lI0DjOJJtgtvYBLVm1hcY2MHYX7m36DcJw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.11.3.tgz",
+      "integrity": "sha512-11VaXRMlz9iS0sWzP7eeEShl5r6rqb57XzlorwdcqmSchWEdw3+Gm0INqFWrQ382FSEDmZ7qDbMfJ/S9P6fddA==",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/identity": "^0.11.1",
-        "@dfinity/principal": "^0.11.1"
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/identity": "^0.11.3",
+        "@dfinity/principal": "^0.11.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.1.tgz",
-      "integrity": "sha512-EYZZg+x7OgZxa56D9SWMeTlaMb09HJ7wIfL42+l/e0lgrx+sTXYxKe8bM9FrUW9AWo9/gKkOGV/IxJL/Acncng=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+      "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA=="
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.11.1.tgz",
-      "integrity": "sha512-at8BMq2cQSEvfBWh0NM81b0cwkHLiJJNEqd6wMkDEHFDVayZzOgJrpBgU9JY52q4JCp5Ow6xcR2DVfhgVZrD/g==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.11.3.tgz",
+      "integrity": "sha512-AXgrG6a7PxJmiZOC12ooKvPeOfh4+v3dR7D6jynLlN4qMy0ry+BMZhWkyjWrlRR3p8oMznzfjoMuKN5pOrBKDg==",
       "peer": true,
       "dependencies": {
         "@types/webappsec-credential-management": "^0.6.2",
@@ -716,18 +716,18 @@
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/principal": "^0.11.1"
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/principal": "^0.11.3"
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.2-nightly-2022-06-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-01.tgz",
-      "integrity": "sha512-VZmU1inq5zADHkqwWKBKrA7kDOh3rAvjvbxZaxxaNAp6g7C9BsyMhjCUc3rJ30MAl2fN1b1upwW+PgH/Byw6rA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3.tgz",
+      "integrity": "sha512-z3eR11sa2RACb5Och3D9OMwZkp3qU8HSqZs6ikL2l6N+nchPJYv9TPg5txb+BNd3XI0h3fqSGThxG7DnLS54Ew==",
       "dependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.1.tgz",
-      "integrity": "sha512-TlYkwq0fLwmY24X/vrw8mXNRYTkelkM0R5wGjhgK7au24zn7lcXYW3HG+se8YYWFICYY4prI1cS8/6N9z14qjg=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+      "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -2525,7 +2525,7 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "peer": true
     },
     "node_modules/browser-process-hrtime": {
@@ -3063,7 +3063,7 @@
     "node_modules/delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -4270,7 +4270,7 @@
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
@@ -6225,7 +6225,7 @@
     "node_modules/json-text-sequence": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
       "dependencies": {
         "delimit-stream": "0.1.0"
       }
@@ -6509,7 +6509,7 @@
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "peer": true
     },
     "node_modules/minimatch": {
@@ -9274,9 +9274,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
-      "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.3.tgz",
+      "integrity": "sha512-pqiogLey6S83SG5BS93hBCtXfGRW6tkxa8Y0c9HwxOP/wRoVEuKHdTcOn7rL/HN4mDTwxkdqK4EC1Kv24S1q4Q==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -9286,27 +9286,27 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.11.1.tgz",
-      "integrity": "sha512-Fb5jv8W6EF3jAr2d8lowunqAaqk5WHIckEFskaflVqWuiH0hDwbFFjeWn554jhkyM6pVq30ikXxbaUWI9sSXgw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.11.3.tgz",
+      "integrity": "sha512-+wwjoucE8ZIjcA1IG+OQ8OxFoAajYfnELbSMZE1p3FGlbC0X3gpab0bbXqh8VKou8Ng1eRU+sAwItruCLiIBHg==",
       "requires": {}
     },
     "@dfinity/authentication": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.11.1.tgz",
-      "integrity": "sha512-I1t7Ac4iJbTK7KSO+WIA3/rzkCSGDlDcPWKVrTrve39MY1i/yX+2lI0DjOJJtgtvYBLVm1hcY2MHYX7m36DcJw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.11.3.tgz",
+      "integrity": "sha512-11VaXRMlz9iS0sWzP7eeEShl5r6rqb57XzlorwdcqmSchWEdw3+Gm0INqFWrQ382FSEDmZ7qDbMfJ/S9P6fddA==",
       "peer": true,
       "requires": {}
     },
     "@dfinity/candid": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.1.tgz",
-      "integrity": "sha512-EYZZg+x7OgZxa56D9SWMeTlaMb09HJ7wIfL42+l/e0lgrx+sTXYxKe8bM9FrUW9AWo9/gKkOGV/IxJL/Acncng=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+      "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA=="
     },
     "@dfinity/identity": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.11.1.tgz",
-      "integrity": "sha512-at8BMq2cQSEvfBWh0NM81b0cwkHLiJJNEqd6wMkDEHFDVayZzOgJrpBgU9JY52q4JCp5Ow6xcR2DVfhgVZrD/g==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.11.3.tgz",
+      "integrity": "sha512-AXgrG6a7PxJmiZOC12ooKvPeOfh4+v3dR7D6jynLlN4qMy0ry+BMZhWkyjWrlRR3p8oMznzfjoMuKN5pOrBKDg==",
       "peer": true,
       "requires": {
         "@types/webappsec-credential-management": "^0.6.2",
@@ -9317,13 +9317,13 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.2-nightly-2022-06-01",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-01.tgz",
-      "integrity": "sha512-VZmU1inq5zADHkqwWKBKrA7kDOh3rAvjvbxZaxxaNAp6g7C9BsyMhjCUc3rJ30MAl2fN1b1upwW+PgH/Byw6rA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3.tgz",
+      "integrity": "sha512-z3eR11sa2RACb5Och3D9OMwZkp3qU8HSqZs6ikL2l6N+nchPJYv9TPg5txb+BNd3XI0h3fqSGThxG7DnLS54Ew==",
       "requires": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",
@@ -9350,9 +9350,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.1.tgz",
-      "integrity": "sha512-TlYkwq0fLwmY24X/vrw8mXNRYTkelkM0R5wGjhgK7au24zn7lcXYW3HG+se8YYWFICYY4prI1cS8/6N9z14qjg=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+      "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",
@@ -10720,7 +10720,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "peer": true
     },
     "browser-process-hrtime": {
@@ -11123,7 +11123,7 @@
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
     },
     "detect-indent": {
       "version": "6.1.0",
@@ -12036,7 +12036,7 @@
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "peer": true,
       "requires": {
         "hash.js": "^1.0.3",
@@ -13499,7 +13499,7 @@
     "json-text-sequence": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -13716,7 +13716,7 @@
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "peer": true
     },
     "minimatch": {

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -61,9 +61,9 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.11.1",
-    "@dfinity/auth-client": "^0.11.1",
-    "@dfinity/nns": "nightly",
+    "@dfinity/agent": "^0.11.3",
+    "@dfinity/auth-client": "^0.11.3",
+    "@dfinity/nns": "^0.4.3",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
     "@ledgerhq/hw-transport-webhid": "^6.27.1",
     "@zondax/ledger-icp": "^0.6.0"


### PR DESCRIPTION
# Motivation

Bump nns-js to `v0.4.3` and agent-js `v0.11.3` to provide a polyfill for `setBigUint64` in `agent-js` for users on iOS < v15.


# Changes

- bump nns-js and agent-js
