### PR TITLE
build: redo nns-js nightly dependency

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/agent": "^0.11.3",
         "@dfinity/auth-client": "^0.11.3",
-        "@dfinity/nns": "^0.4.2-nightly-2022-06-03",
+        "@dfinity/nns": "nightly",
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
         "@ledgerhq/hw-transport-webhid": "^6.27.1",
         "@zondax/ledger-icp": "^0.6.0"
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.2-nightly-2022-06-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-03.tgz",
-      "integrity": "sha512-P9D369KZJ7N3iInvCLsOJSBnoDC7mffq6vwrGVrmpqN6cGh9igyKxzfK1Uvey+4w5OPBYOgAEDREPlFj6ZlK9A==",
+      "version": "0.4.3-nightly-2022-06-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-04.tgz",
+      "integrity": "sha512-NhZzhGRSaZx4e0RRlnIOx5/us6Bf5Kz1bhVal6OEGZhJXktZPukmUEXO2ACg04BSA1dSuJUsHuxR22rceS4mcQ==",
       "dependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",
@@ -9317,13 +9317,13 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.2-nightly-2022-06-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-03.tgz",
-      "integrity": "sha512-P9D369KZJ7N3iInvCLsOJSBnoDC7mffq6vwrGVrmpqN6cGh9igyKxzfK1Uvey+4w5OPBYOgAEDREPlFj6ZlK9A==",
+      "version": "0.4.3-nightly-2022-06-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-04.tgz",
+      "integrity": "sha512-NhZzhGRSaZx4e0RRlnIOx5/us6Bf5Kz1bhVal6OEGZhJXktZPukmUEXO2ACg04BSA1dSuJUsHuxR22rceS4mcQ==",
       "requires": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",

--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dfinity/agent": "^0.11.3",
         "@dfinity/auth-client": "^0.11.3",
-        "@dfinity/nns": "^0.4.3",
+        "@dfinity/nns": "^0.4.2-nightly-2022-06-03",
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
         "@ledgerhq/hw-transport-webhid": "^6.27.1",
         "@zondax/ledger-icp": "^0.6.0"
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3.tgz",
-      "integrity": "sha512-z3eR11sa2RACb5Och3D9OMwZkp3qU8HSqZs6ikL2l6N+nchPJYv9TPg5txb+BNd3XI0h3fqSGThxG7DnLS54Ew==",
+      "version": "0.4.2-nightly-2022-06-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-03.tgz",
+      "integrity": "sha512-P9D369KZJ7N3iInvCLsOJSBnoDC7mffq6vwrGVrmpqN6cGh9igyKxzfK1Uvey+4w5OPBYOgAEDREPlFj6ZlK9A==",
       "dependencies": {
-        "@dfinity/agent": "^0.11.3",
-        "@dfinity/candid": "^0.11.3",
-        "@dfinity/principal": "^0.11.3",
+        "@dfinity/agent": "^0.11.1",
+        "@dfinity/candid": "^0.11.1",
+        "@dfinity/principal": "^0.11.1",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",
@@ -9317,13 +9317,13 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3.tgz",
-      "integrity": "sha512-z3eR11sa2RACb5Och3D9OMwZkp3qU8HSqZs6ikL2l6N+nchPJYv9TPg5txb+BNd3XI0h3fqSGThxG7DnLS54Ew==",
+      "version": "0.4.2-nightly-2022-06-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.2-nightly-2022-06-03.tgz",
+      "integrity": "sha512-P9D369KZJ7N3iInvCLsOJSBnoDC7mffq6vwrGVrmpqN6cGh9igyKxzfK1Uvey+4w5OPBYOgAEDREPlFj6ZlK9A==",
       "requires": {
-        "@dfinity/agent": "^0.11.3",
-        "@dfinity/candid": "^0.11.3",
-        "@dfinity/principal": "^0.11.3",
+        "@dfinity/agent": "^0.11.1",
+        "@dfinity/candid": "^0.11.1",
+        "@dfinity/principal": "^0.11.1",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",

--- a/frontend/svelte/package.json
+++ b/frontend/svelte/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@dfinity/agent": "^0.11.3",
     "@dfinity/auth-client": "^0.11.3",
-    "@dfinity/nns": "^0.4.3",
+    "@dfinity/nns": "nightly",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.1",
     "@ledgerhq/hw-transport-webhid": "^6.27.1",
     "@zondax/ledger-icp": "^0.6.0"


### PR DESCRIPTION
# Motivation

This PR aims to redo the nns-js nightly dependency that was temporary replaced with an actually release in #953.

# Changes

- redo nns-js dependency to nightly of Friday Jun. 3
