### PR TITLE
refactor: get account from store path store

### DIFF
--- a/frontend/svelte/src/lib/services/accounts.services.ts
+++ b/frontend/svelte/src/lib/services/accounts.services.ts
@@ -20,7 +20,10 @@ import { accountsStore } from "../stores/accounts.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { Account } from "../types/account";
 import type { TransactionStore } from "../types/transaction.context";
-import { getAccountByPrincipal } from "../utils/accounts.utils";
+import {
+  getAccountByPrincipal,
+  getAccountFromStore,
+} from "../utils/accounts.utils";
 import { getLastPathDetail } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
 import { getIdentity } from "./auth.services";
@@ -139,33 +142,6 @@ export const routePathAccountIdentifier = (
     : undefined;
 };
 
-export const getAccountFromStore = (
-  identifier: string | undefined
-): Account | undefined => {
-  if (identifier === undefined) {
-    return undefined;
-  }
-
-  const { main, subAccounts, hardwareWallets }: AccountsStore =
-    get(accountsStore);
-
-  if (main?.identifier === identifier) {
-    return main;
-  }
-
-  const subAccount: Account | undefined = subAccounts?.find(
-    (account: Account) => account.identifier === identifier
-  );
-
-  if (subAccount !== undefined) {
-    return subAccount;
-  }
-
-  return hardwareWallets?.find(
-    (account: Account) => account.identifier === identifier
-  );
-};
-
 export const getAccountTransactions = async ({
   accountIdentifier,
   onLoad,
@@ -208,7 +184,10 @@ export const getAccountTransactions = async ({
 export const getAccountIdentity = async (
   identifier: string
 ): Promise<Identity | LedgerIdentity> => {
-  const account: Account | undefined = getAccountFromStore(identifier);
+  const account: Account | undefined = getAccountFromStore({
+    identifier,
+    accountsStore: get(accountsStore),
+  });
 
   if (account?.type === "hardwareWallet") {
     return getLedgerIdentityProxy(identifier);

--- a/frontend/svelte/src/lib/utils/accounts.utils.ts
+++ b/frontend/svelte/src/lib/utils/accounts.utils.ts
@@ -63,3 +63,31 @@ export const getPrincipalFromString = (
 export const isAccountHardwareWallet = (
   account: Account | undefined
 ): boolean => account?.type === "hardwareWallet";
+
+export const getAccountFromStore = ({
+  identifier,
+  accountsStore: { main, subAccounts, hardwareWallets },
+}: {
+  identifier: string | undefined;
+  accountsStore: AccountsStore;
+}): Account | undefined => {
+  if (identifier === undefined) {
+    return undefined;
+  }
+
+  if (main?.identifier === identifier) {
+    return main;
+  }
+
+  const subAccount: Account | undefined = subAccounts?.find(
+    (account: Account) => account.identifier === identifier
+  );
+
+  if (subAccount !== undefined) {
+    return subAccount;
+  }
+
+  return hardwareWallets?.find(
+    (account: Account) => account.identifier === identifier
+  );
+};

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -10,7 +10,6 @@
   } from "../lib/constants/routes.constants";
   import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import {
-    getAccountFromStore,
     getAccountTransactions,
     routePathAccountIdentifier,
   } from "../lib/services/accounts.services";
@@ -32,7 +31,10 @@
     type SelectedAccountContext,
     type SelectedAccountStore,
   } from "../lib/types/selected-account.context";
-  import { isAccountHardwareWallet } from "../lib/utils/accounts.utils";
+  import {
+    getAccountFromStore,
+    isAccountHardwareWallet,
+  } from "../lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "../lib/stores/debug.store";
 
   onMount(() => {
@@ -73,8 +75,10 @@
   $: routeAccountIdentifier = routePathAccountIdentifier($routeStore.path);
 
   let selectedAccount: Account | undefined;
-  $: $accountsStore,
-    (selectedAccount = getAccountFromStore(routeAccountIdentifier));
+  $: selectedAccount = getAccountFromStore({
+    identifier: routeAccountIdentifier,
+    accountsStore: $accountsStore,
+  });
 
   $: routeAccountIdentifier,
     selectedAccount,

--- a/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/accounts.services.spec.ts
@@ -5,7 +5,6 @@ import * as ledgerApi from "../../../lib/api/ledger.api";
 import { getLedgerIdentityProxy } from "../../../lib/proxy/ledger.services.proxy";
 import {
   addSubAccount,
-  getAccountFromStore,
   getAccountIdentity,
   getAccountIdentityByPrincipal,
   getAccountTransactions,
@@ -247,34 +246,6 @@ describe("accounts-services", () => {
     it("should not get account identifier from invalid path", () => {
       expect(routePathAccountIdentifier("/#/wallet/")).toBeUndefined();
       expect(routePathAccountIdentifier(undefined)).toBeUndefined();
-    });
-  });
-
-  describe("get-account", () => {
-    beforeAll(() =>
-      accountsStore.set({
-        main: mockMainAccount,
-        subAccounts: [mockSubAccount],
-      })
-    );
-
-    afterAll(() => accountsStore.reset());
-
-    it("should not return an account if no identifier is provided", () => {
-      expect(getAccountFromStore(undefined)).toBeUndefined();
-    });
-
-    it("should find no account if not matches", () => {
-      expect(getAccountFromStore("aaa")).toBeUndefined();
-    });
-
-    it("should return corresponding account", () => {
-      expect(getAccountFromStore(mockMainAccount.identifier)).toEqual(
-        mockMainAccount
-      );
-      expect(getAccountFromStore(mockSubAccount.identifier)).toEqual(
-        mockSubAccount
-      );
     });
   });
 

--- a/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/accounts.utils.spec.ts
@@ -2,6 +2,7 @@ import { Principal } from "@dfinity/principal";
 import {
   emptyAddress,
   getAccountByPrincipal,
+  getAccountFromStore,
   getPrincipalFromString,
   invalidAddress,
   isAccountHardwareWallet,
@@ -94,6 +95,40 @@ describe("accounts-utils", () => {
 
     it("returns false if no account", () => {
       expect(isAccountHardwareWallet(undefined)).toBeFalsy();
+    });
+  });
+
+  describe("getAccountFromStore", () => {
+    const accountsStore = {
+      main: mockMainAccount,
+      subAccounts: [mockSubAccount],
+    };
+
+    it("should not return an account if no identifier is provided", () => {
+      expect(
+        getAccountFromStore({ identifier: undefined, accountsStore })
+      ).toBeUndefined();
+    });
+
+    it("should find no account if not matches", () => {
+      expect(
+        getAccountFromStore({ identifier: "aaa", accountsStore })
+      ).toBeUndefined();
+    });
+
+    it("should return corresponding account", () => {
+      expect(
+        getAccountFromStore({
+          identifier: mockMainAccount.identifier,
+          accountsStore,
+        })
+      ).toEqual(mockMainAccount);
+      expect(
+        getAccountFromStore({
+          identifier: mockSubAccount.identifier,
+          accountsStore,
+        })
+      ).toEqual(mockSubAccount);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Follow-up of #957 - refactor `getAccountFromStore` to not access the store directly but gets it as parameter

# Changes

- `getAccountFromStore` function's declaration 
