### PR TITLE
L2-600: Add Controller Part 2

### DIFF
--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -4,7 +4,10 @@ import type { Principal } from "@dfinity/principal";
 import { CMCCanister } from "../canisters/cmc/cmc.canister";
 import { principalToSubAccount } from "../canisters/cmc/utils";
 import { ICManagementCanister } from "../canisters/ic-management/ic-management.canister";
-import type { CanisterDetails } from "../canisters/ic-management/ic-management.canister.types";
+import type {
+  CanisterDetails,
+  CanisterSettings,
+} from "../canisters/ic-management/ic-management.canister.types";
 import type { NNSDappCanister } from "../canisters/nns-dapp/nns-dapp.canister";
 import type {
   CanisterDetails as CanisterInfo,
@@ -84,6 +87,26 @@ export const attachCanister = async ({
   });
 
   logWithTimestamp("Attaching canister call complete.");
+};
+
+export const updateSettings = async ({
+  identity,
+  settings,
+  canisterId,
+}: {
+  identity: Identity;
+  settings: Partial<CanisterSettings>;
+  canisterId: Principal;
+}): Promise<void> => {
+  logWithTimestamp("Updating canister settings call...");
+  const { icMgt } = await canisters(identity);
+
+  await icMgt.updateSettings({
+    canisterId,
+    settings,
+  });
+
+  logWithTimestamp("Updating canister settings call complete.");
 };
 
 export const detachCanister = async ({

--- a/frontend/svelte/src/lib/canisters/ic-management/converters.ts
+++ b/frontend/svelte/src/lib/canisters/ic-management/converters.ts
@@ -29,7 +29,7 @@ export const toCanisterDetails = ({
   status: getCanisterStatus(status),
   memorySize: memory_size,
   cycles: cycles,
-  setting: {
+  settings: {
     controllers: settings.controllers.map((principal) => principal.toText()),
     freezingThreshold: settings.freezing_threshold,
     memoryAllocation: settings.memory_allocation,

--- a/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.ts
+++ b/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.ts
@@ -2,14 +2,18 @@ import {
   getManagementCanister,
   type ManagementCanisterRecord,
 } from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
 import { toCanisterDetails } from "./converters";
 import type {
   CanisterDetails,
+  CanisterSettings,
   ICMgtCanisterOptions,
 } from "./ic-management.canister.types";
 import { mapError } from "./ic-management.errors";
 import type { CanisterStatusResponse } from "./ic-management.types";
+
+const wrapWithArray = <T>(value: T | undefined): [T] | [] =>
+  value === undefined ? [] : [value];
 
 export class ICManagementCanister {
   private constructor(private readonly service: ManagementCanisterRecord) {
@@ -42,6 +46,36 @@ export class ICManagementCanister {
       return toCanisterDetails({
         response: rawResponse,
         canisterId,
+      });
+    } catch (e) {
+      throw mapError(e);
+    }
+  };
+
+  public updateSettings = async ({
+    canisterId,
+    settings: {
+      controllers,
+      freezingThreshold,
+      memoryAllocation,
+      computeAllocation,
+    },
+  }: {
+    canisterId: Principal;
+    settings: Partial<CanisterSettings>;
+  }): Promise<void> => {
+    try {
+      // Empty array does not change the value in the settings.
+      await this.service.update_settings({
+        canister_id: canisterId,
+        settings: {
+          controllers: wrapWithArray(
+            controllers?.map((c) => Principal.fromText(c))
+          ),
+          freezing_threshold: wrapWithArray(freezingThreshold),
+          memory_allocation: wrapWithArray(memoryAllocation),
+          compute_allocation: wrapWithArray(computeAllocation),
+        },
       });
     } catch (e) {
       throw mapError(e);

--- a/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.types.ts
+++ b/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.types.ts
@@ -27,6 +27,6 @@ export interface CanisterDetails {
   status: CanisterStatus;
   memorySize: bigint;
   cycles: bigint;
-  setting: CanisterSettings;
+  settings: CanisterSettings;
   moduleHash?: ArrayBuffer;
 }

--- a/frontend/svelte/src/lib/components/canister_details/AddCanisterControllerButton.svelte
+++ b/frontend/svelte/src/lib/components/canister_details/AddCanisterControllerButton.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-  import type { Principal } from "@dfinity/principal";
   import AddControllerModal from "../../modals/canisters/AddControllerModal.svelte";
   import { i18n } from "../../stores/i18n";
-
-  export let canisterId: Principal;
 
   let showModal: boolean = false;
   const openModal = () => (showModal = true);
@@ -17,5 +14,5 @@
 >
 
 {#if showModal}
-  <AddControllerModal {canisterId} on:nnsClose={close} />
+  <AddControllerModal on:nnsClose={close} />
 {/if}

--- a/frontend/svelte/src/lib/components/canister_details/ControllersCard.svelte
+++ b/frontend/svelte/src/lib/components/canister_details/ControllersCard.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
+  import { getContext } from "svelte";
+
   import type { CanisterDetails } from "../../canisters/ic-management/ic-management.canister.types";
   import { i18n } from "../../stores/i18n";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "../../types/canister-detail.context";
   import Card from "../ui/Card.svelte";
   import AddCanisterControllerButton from "./AddCanisterControllerButton.svelte";
 
-  export let canisterDetails: CanisterDetails;
+  const { store }: CanisterDetailsContext = getContext<CanisterDetailsContext>(
+    CANISTER_DETAILS_CONTEXT_KEY
+  );
+  let canisterDetails: CanisterDetails | undefined;
+  $: canisterDetails = $store.details;
+  let controllers: string[];
+  $: controllers = canisterDetails?.settings.controllers ?? [];
 
   const remove = (controller: string) => {
     // TODO: Remove Controller - https://dfinity.atlassian.net/browse/L2-601
@@ -15,7 +27,7 @@
 <Card testId="canister-controllers-card">
   <h4 slot="start">{$i18n.canister_detail.controllers}</h4>
   <ul>
-    {#each canisterDetails.setting.controllers as controller (controller)}
+    {#each controllers as controller (controller)}
       <li>
         <span>{controller}</span>
         <button
@@ -28,7 +40,7 @@
     {/each}
   </ul>
   <div class="actions">
-    <AddCanisterControllerButton canisterId={canisterDetails.id} />
+    <AddCanisterControllerButton />
   </div>
 </Card>
 

--- a/frontend/svelte/src/lib/components/canister_details/NewControllerReview.svelte
+++ b/frontend/svelte/src/lib/components/canister_details/NewControllerReview.svelte
@@ -1,14 +1,45 @@
 <script lang="ts">
-  import { busy } from "../../stores/busy.store";
+  import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import type { Principal } from "@dfinity/principal";
+  import { createEventDispatcher, getContext } from "svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "../../types/canister-detail.context";
+  import { toastsStore } from "../../stores/toasts.store";
+  import type { CanisterDetails } from "../../canisters/ic-management/ic-management.canister.types";
+  import { addController } from "../../services/canisters.services";
 
-  export let canisterId: Principal;
   export let controller: Principal;
 
-  const add = () => {
-    // TODO: Add controller
-    console.log("adding");
+  const { store, reloadDetails }: CanisterDetailsContext =
+    getContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY);
+
+  const dispatcher = createEventDispatcher();
+  const add = async () => {
+    const canisterDetails: CanisterDetails | undefined = $store.details;
+    if (canisterDetails === undefined) {
+      // Edge case
+      toastsStore.error({
+        labelKey: "error.unknown",
+      });
+      return;
+    }
+    const controllerString = controller.toText();
+    startBusy({ initiator: "add-controller-canister" });
+    const { success } = await addController({
+      controller: controllerString,
+      canisterDetails,
+    });
+    if (success) {
+      await reloadDetails(canisterDetails.id);
+    }
+    stopBusy("add-controller-canister");
+    // Leave it open in case the error can help fix the problem
+    if (success) {
+      dispatcher("nnsClose");
+    }
   };
 </script>
 
@@ -19,11 +50,16 @@
 >
   <div>
     <h5>{$i18n.canisters.canister_id}</h5>
-    <p>{canisterId.toText()}</p>
+    <p>{$store.details?.id.toText()}</p>
     <h5>{$i18n.canister_detail.new_controller}</h5>
     <p>{controller.toText()}</p>
   </div>
-  <button class="primary full-width" type="submit" disabled={$busy}>
+  <button
+    class="primary full-width"
+    type="submit"
+    disabled={$busy}
+    data-tid="confirm-new-canister-controller-button"
+  >
     {$i18n.accounts.confirm_and_send}
   </button>
 </form>

--- a/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/svelte/src/lib/components/ui/PrincipalInput.svelte
@@ -8,7 +8,7 @@
   export let name: string;
   export let principal: Principal | undefined = undefined;
 
-  let address: string = "";
+  let address: string = principal?.toText() ?? "";
   $: principal = getPrincipalFromString(address);
   let showError: boolean = false;
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -75,6 +75,7 @@
     "input_length": "Input must be longer than $length characters.",
     "not_canister_controller": "You are not the controller of this canister and cannot access its details.",
     "canister_details_not_found": "Sorry, there was an error loading the details of the canister. Please try again later.",
+    "controller_already_present": "Principal $principal is already a controller",
     "hardware_wallet_no_account": "No hardware wallet account provided."
   },
   "warning": {

--- a/frontend/svelte/src/lib/modals/canisters/AddControllerModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/AddControllerModal.svelte
@@ -6,8 +6,6 @@
   import type { Step, Steps } from "../../stores/steps.state";
   import WizardModal from "../WizardModal.svelte";
 
-  export let canisterId: Principal;
-
   const steps: Steps = [
     {
       name: "EnterController",
@@ -42,7 +40,7 @@
       </AddPrincipal>
     {/if}
     {#if currentStep?.name === "ConfirmController" && principal !== undefined}
-      <NewControllerReview {canisterId} controller={principal} />
+      <NewControllerReview controller={principal} on:nnsClose />
     {/if}
   </svelte:fragment>
 </WizardModal>

--- a/frontend/svelte/src/lib/stores/busy.store.ts
+++ b/frontend/svelte/src/lib/stores/busy.store.ts
@@ -8,6 +8,7 @@ export type BusyStateInitiatorType =
   | "detach-canister"
   | "create-canister"
   | "top-up-canister"
+  | "add-controller-canister"
   | "accounts"
   | "join-community-fund"
   | "split-neuron"

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -79,6 +79,7 @@ interface I18nError {
   input_length: string;
   not_canister_controller: string;
   canister_details_not_found: string;
+  controller_already_present: string;
   hardware_wallet_no_account: string;
 }
 

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -210,7 +210,7 @@
       {/if}
       {#if canisterDetails !== undefined}
         <CyclesCard cycles={canisterDetails.cycles} />
-        <ControllersCard {canisterDetails} />
+        <ControllersCard />
       {:else if errorKey !== undefined}
         <Card testId="canister-details-error-card">
           <p class="error-message">{translate({ labelKey: errorKey })}</p>

--- a/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
@@ -13,6 +13,7 @@ import {
   queryCanisterDetails,
   queryCanisters,
   topUpCanister,
+  updateSettings,
 } from "../../../lib/api/canisters.api";
 import {
   CREATE_CANISTER_MEMO,
@@ -27,7 +28,10 @@ import type { SubAccountArray } from "../../../lib/canisters/nns-dapp/nns-dapp.t
 import { CYCLES_MINTING_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
 import { mockSubAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
-import { mockCanisterDetails } from "../../mocks/canisters.mock";
+import {
+  mockCanisterDetails,
+  mockCanisterSettings,
+} from "../../mocks/canisters.mock";
 
 describe("canisters-api", () => {
   const mockNNSDappCanister = mock<NNSDappCanister>();
@@ -87,7 +91,38 @@ describe("canisters-api", () => {
     });
   });
 
-  describe("attachCanister", () => {
+  describe("updateSettings", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should call the ic management canister to update settings", async () => {
+      mockICManagementCanister.updateSettings.mockResolvedValue(undefined);
+      await updateSettings({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id,
+        settings: mockCanisterSettings,
+      });
+
+      expect(mockICManagementCanister.updateSettings).toBeCalled();
+    });
+
+    it("should call the ic management canister to update settings with partial settings", async () => {
+      const settings = {
+        controllers: [
+          "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
+        ],
+      };
+      mockICManagementCanister.updateSettings.mockResolvedValue(undefined);
+      await updateSettings({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id,
+        settings,
+      });
+
+      expect(mockICManagementCanister.updateSettings).toBeCalled();
+    });
+  });
+
+  describe("detachCanister", () => {
     afterEach(() => jest.clearAllMocks());
 
     it("should call the nns dapp canister to detach the canister id", async () => {

--- a/frontend/svelte/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -7,7 +7,11 @@ import { UserNotTheControllerError } from "../../../lib/canisters/ic-management/
 import type { CanisterStatusResponse } from "../../../lib/canisters/ic-management/ic-management.types";
 import { createAgent } from "../../../lib/utils/agent.utils";
 import { mockIdentity } from "../../mocks/auth.store.mock";
-import { mockCanisterDetails } from "../../mocks/canisters.mock";
+import {
+  mockCanisterDetails,
+  mockCanisterId,
+  mockCanisterSettings,
+} from "../../mocks/canisters.mock";
 
 describe("ICManagementCanister", () => {
   const createICManagement = async (service: ManagementCanisterRecord) => {
@@ -73,6 +77,69 @@ describe("ICManagementCanister", () => {
       const call = () =>
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
 
+      expect(call).rejects.toThrowError(Error);
+    });
+  });
+
+  describe("updateSettings", () => {
+    it("calls update_settings with new settings", async () => {
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      await icManagement.updateSettings({
+        canisterId: mockCanisterId,
+        settings: mockCanisterSettings,
+      });
+      expect(service.update_settings).toBeCalled();
+    });
+
+    it("works when passed partial settings", async () => {
+      const partialSettings = {
+        controllers: [
+          "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
+        ],
+      };
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      await icManagement.updateSettings({
+        canisterId: mockCanisterId,
+        settings: partialSettings,
+      });
+      expect(service.update_settings).toBeCalled();
+    });
+
+    it("throws UserNotTheControllerError", async () => {
+      const error = new Error("code: 403");
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: mockCanisterSettings,
+        });
+      expect(call).rejects.toThrowError(UserNotTheControllerError);
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: mockCanisterSettings,
+        });
       expect(call).rejects.toThrowError(Error);
     });
   });

--- a/frontend/svelte/src/tests/lib/components/canister_details/ControllersCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canister_details/ControllersCard.spec.ts
@@ -3,14 +3,13 @@
  */
 
 import { render } from "@testing-library/svelte";
-import ControllersCard from "../../../../lib/components/canister_details/ControllersCard.svelte";
-import { mockCanisterDetails } from "../../../mocks/canisters.mock";
 import en from "../../../mocks/i18n.mock";
+import ControllersCard from "./ControllersCardTest.svelte";
 
 describe("ControllersCard", () => {
   it("renders title", () => {
     const { queryByText } = render(ControllersCard, {
-      props: { canisterDetails: mockCanisterDetails },
+      props: { controllers: [] },
     });
 
     expect(queryByText(en.canister_detail.controllers)).toBeInTheDocument();
@@ -21,15 +20,8 @@ describe("ControllersCard", () => {
       "ryjl3-tyaaa-aaaaa-aaaba-cai",
       "rrkah-fqaaa-aaaaa-aaaaq-cai",
     ];
-    const canister = {
-      ...mockCanisterDetails,
-      setting: {
-        ...mockCanisterDetails.setting,
-        controllers,
-      },
-    };
     const { queryByText } = render(ControllersCard, {
-      props: { canisterDetails: canister },
+      props: { controllers },
     });
 
     expect(queryByText(controllers[0])).toBeInTheDocument();

--- a/frontend/svelte/src/tests/lib/components/canister_details/ControllersCardTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/canister_details/ControllersCardTest.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { onMount, setContext } from "svelte";
+  import ControllersCard from "../../../../lib/components/canister_details/ControllersCard.svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "../../../../lib/types/canister-detail.context";
+  import { mockCanisterDetailsStore } from "../../../mocks/canisters.mock";
+
+  export let controllers: string[];
+
+  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
+    store: mockCanisterDetailsStore,
+    reloadDetails: () => Promise.resolve(undefined),
+  });
+
+  onMount(() => {
+    mockCanisterDetailsStore.update((data) => ({
+      ...data,
+      details: {
+        ...data.details,
+        settings: {
+          ...data.details?.settings,
+          controllers,
+        },
+      },
+    }));
+  });
+</script>
+
+<ControllersCard on:nnsClose />

--- a/frontend/svelte/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -3,17 +3,27 @@
  */
 
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
-import AddControllerModal from "../../../../lib/modals/canisters/AddControllerModal.svelte";
-import { mockCanisterId } from "../../../mocks/canisters.mock";
+import { addController } from "../../../../lib/services/canisters.services";
 import { renderModal } from "../../../mocks/modal.mock";
+import AddControllerModal from "./AddControllerModalTest.svelte";
+
+jest.mock("../../../../lib/services/canisters.services", () => {
+  return {
+    addController: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
 
 describe("AddControllerModal", () => {
+  const reloadMock = jest.fn();
+
   const renderAddControllerModal = async (): Promise<RenderResult> => {
     return renderModal({
       component: AddControllerModal,
-      props: { canisterId: mockCanisterId },
+      props: { reloadDetails: reloadMock },
     });
   };
+
+  afterEach(() => jest.clearAllMocks());
 
   it("should display modal", async () => {
     const { container } = await renderAddControllerModal();
@@ -23,7 +33,8 @@ describe("AddControllerModal", () => {
 
   it("should call addController service and close modal", async () => {
     const principalString = "aaaaa-aa";
-    const { container, queryByTestId } = await renderAddControllerModal();
+    const { container, queryByTestId, component } =
+      await renderAddControllerModal();
 
     const inputElement = container.querySelector("input[type='text']");
     expect(inputElement).not.toBeNull();
@@ -42,6 +53,18 @@ describe("AddControllerModal", () => {
     await waitFor(() =>
       expect(queryByTestId("new-controller-review-screen")).toBeInTheDocument()
     );
-    // TODO: Add controller
+
+    const confirmButton = queryByTestId(
+      "confirm-new-canister-controller-button"
+    );
+    expect(confirmButton).not.toBeNull();
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+    confirmButton && (await fireEvent.click(confirmButton));
+
+    expect(addController).toBeCalled();
+
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/canisters/AddControllerModalTest.svelte
+++ b/frontend/svelte/src/tests/lib/modals/canisters/AddControllerModalTest.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import type { Principal } from "@dfinity/principal";
+  import AddControllerModal from "../../../../lib/modals/canisters/AddControllerModal.svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "../../../../lib/types/canister-detail.context";
+  import { mockCanisterDetailsStore } from "../../../mocks/canisters.mock";
+
+  export let reloadDetails: (canisterId: Principal) => Promise<void>;
+
+  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
+    store: mockCanisterDetailsStore,
+    reloadDetails,
+  });
+</script>
+
+<AddControllerModal on:nnsClose />

--- a/frontend/svelte/src/tests/mocks/canisters.mock.ts
+++ b/frontend/svelte/src/tests/mocks/canisters.mock.ts
@@ -22,12 +22,21 @@ export const mockCanisters: CanisterInfo[] = [
   mockCanister,
 ];
 
+export const mockCanisterSettings = {
+  freezing_threshold: BigInt(2),
+  controllers: [
+    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
+  ],
+  memory_allocation: BigInt(4),
+  compute_allocation: BigInt(10),
+};
+
 export const mockCanisterDetails: CanisterDetails = {
   id: mockCanisterId,
   status: CanisterStatus.Running,
   memorySize: BigInt(10),
   cycles: BigInt(30),
-  setting: {
+  settings: {
     controllers: [mockIdentity.getPrincipal().toText()],
     freezingThreshold: BigInt(30),
     memoryAllocation: BigInt(1000),


### PR DESCRIPTION
# Motivation

User can add controllers to canisters.

# Changes

* New IC Management Canister method "updateSettings".
* New Canister api function: "updateSettings".
* New Canister services: "updateSettings" and "addController".
* AddControllersCard uses new canister service to add a controller.
* ControllersCard and NewControllerReview use the canister details context to get the data instead of props.

# Tests

* Test for new IC Management method.
* Test for new canister api.
* Test for new canister services.
* Extend test case to add a new controller.
* Fix broken tests.
