### PR TITLE
feat: canister "Copy" action and other card display improvements

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/AccountCard.svelte
@@ -2,7 +2,7 @@
   import type { Account } from "../../types/account";
   import Card from "../ui/Card.svelte";
   import ICP from "../ic/ICP.svelte";
-  import Identifier from "../ic/Identifier.svelte";
+  import Identifier from "../ui/Identifier.svelte";
   import type { ICP as ICPType } from "@dfinity/nns";
   import AccountBadge from "./AccountBadge.svelte";
 
@@ -26,17 +26,10 @@
 </Card>
 
 <style lang="scss">
-  @use "../../themes/mixins/text.scss";
   @use "../../themes/mixins/card.scss";
 
   .title {
     @include card.stacked-title;
-  }
-
-  h3 {
-    line-height: var(--line-height-standard);
-    margin: 0 var(--padding) 0 0;
-
-    @include text.truncate;
+    @include card.title;
   }
 </style>

--- a/frontend/svelte/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/svelte/src/lib/components/accounts/TransactionCard.svelte
@@ -2,7 +2,7 @@
   import type { Account } from "../../types/account";
   import Card from "../ui/Card.svelte";
   import ICP from "../ic/ICP.svelte";
-  import Identifier from "../ic/Identifier.svelte";
+  import Identifier from "../ui/Identifier.svelte";
   import type { ICP as ICPType } from "@dfinity/nns";
   import type {
     AccountIdentifierString,
@@ -77,18 +77,11 @@
 </Card>
 
 <style lang="scss">
-  @use "../../themes/mixins/text.scss";
   @use "../../themes/mixins/card.scss";
 
   .title {
     @include card.stacked-title;
-  }
-
-  h3 {
-    line-height: var(--line-height-standard);
-    margin: 0 var(--padding) 0 0;
-
-    @include text.truncate;
+    @include card.title;
   }
 
   p {

--- a/frontend/svelte/src/lib/components/canister_details/CyclesCard.svelte
+++ b/frontend/svelte/src/lib/components/canister_details/CyclesCard.svelte
@@ -4,7 +4,6 @@
   import Card from "../ui/Card.svelte";
 
   export let cycles: bigint;
-  // TODO: UI - https://dfinity.atlassian.net/browse/L2-599
 </script>
 
 <Card testId="canister-cycles-card">

--- a/frontend/svelte/src/lib/components/canister_details/CyclesCard.svelte
+++ b/frontend/svelte/src/lib/components/canister_details/CyclesCard.svelte
@@ -8,8 +8,7 @@
 </script>
 
 <Card testId="canister-cycles-card">
-  <h4 slot="start">{$i18n.canister_detail.cycles}</h4>
-  <p>
+  <p aria-label={$i18n.canister_detail.cycles}>
     <span class="cycles">{formatCyclesToTCycles(cycles)}</span>
     <span>{$i18n.canister_detail.t_cycles}</span>
   </p>
@@ -19,12 +18,12 @@
   p {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: baseline;
     gap: var(--padding);
   }
 
   .cycles {
     font-weight: 700;
-    font-size: var(--font-size-h4);
+    font-size: var(--font-size-h3);
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
@@ -1,50 +1,27 @@
 <script lang="ts">
   import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
   import Card from "../ui/Card.svelte";
-  import Identifier from "../ui/Identifier.svelte";
-  import Copy from "../ui/Copy.svelte";
+  import CanisterCardTitle from "./CanisterCardTitle.svelte";
+  import CanisterCardSubTitle from "./CanisterCardSubTitle.svelte";
 
   export let canister: CanisterDetails;
   export let role: undefined | "link" | "button" | "checkbox" = undefined;
   export let ariaLabel: string | undefined = undefined;
-
-  let canisterId: string;
-  $: canisterId = canister.canister_id.toText();
-  let validName: boolean;
-  $: validName = canister.name.length > 0;
 </script>
 
 <Card {role} {ariaLabel} on:click testId="canister-card">
   <div slot="start" class="title-block">
-    <div class="title">
-      <h3>{validName ? canister.name : canisterId}</h3>
-
-      {#if !validName}
-        <Copy value={canisterId} />
-      {/if}
-    </div>
+    <CanisterCardTitle {canister} />
   </div>
 
-  {#if validName}
-    <Identifier identifier={canisterId} showCopy />
-  {/if}
+    <CanisterCardSubTitle {canister} />
 </Card>
 
 <style lang="scss">
   @use "../../themes/mixins/card.scss";
 
-  .title {
+  .title-block {
     @include card.stacked-title;
     @include card.title;
-  }
-
-  .title {
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
-
-    :global(button) {
-      margin-left: var(--padding-0_5x);
-    }
   }
 </style>

--- a/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
   import Card from "../ui/Card.svelte";
+  import Identifier from "../ui/Identifier.svelte";
+  import Copy from "../ui/Copy.svelte";
 
   export let canister: CanisterDetails;
   export let role: undefined | "link" | "button" | "checkbox" = undefined;
@@ -13,8 +15,36 @@
 </script>
 
 <Card {role} {ariaLabel} on:click testId="canister-card">
-  <h3 slot="start">{validName ? canister.name : canisterId}</h3>
+  <div slot="start" class="title-block">
+    <div class="title">
+      <h3>{validName ? canister.name : canisterId}</h3>
+
+      {#if !validName}
+        <Copy value={canisterId} />
+      {/if}
+    </div>
+  </div>
+
   {#if validName}
-    <p>{canisterId}</p>
+    <Identifier identifier={canisterId} showCopy />
   {/if}
 </Card>
+
+<style lang="scss">
+  @use "../../themes/mixins/card.scss";
+
+  .title {
+    @include card.stacked-title;
+    @include card.title;
+  }
+
+  .title {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+
+    :global(button) {
+      margin-left: var(--padding-0_5x);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCard.svelte
@@ -14,7 +14,7 @@
     <CanisterCardTitle {canister} />
   </div>
 
-    <CanisterCardSubTitle {canister} />
+  <CanisterCardSubTitle {canister} />
 </Card>
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/canisters/CanisterCardSubTitle.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCardSubTitle.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
   import Identifier from "../ui/Identifier.svelte";
-  import {mapCanisterDetails} from '../../utils/canisters.utils';
+  import { mapCanisterDetails } from "../../utils/canisters.utils";
 
   export let canister: CanisterDetails;
 
   let canisterId: string;
   let validName: boolean;
-  $: ({canisterId, validName} = mapCanisterDetails(canister));
+  $: ({ canisterId, validName } = mapCanisterDetails(canister));
 </script>
 
 {#if validName}

--- a/frontend/svelte/src/lib/components/canisters/CanisterCardSubTitle.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCardSubTitle.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
+  import Identifier from "../ui/Identifier.svelte";
+  import {mapCanisterDetails} from '../../utils/canisters.utils';
+
+  export let canister: CanisterDetails;
+
+  let canisterId: string;
+  let validName: boolean;
+  $: ({canisterId, validName} = mapCanisterDetails(canister));
+</script>
+
+{#if validName}
+  <Identifier identifier={canisterId} showCopy />
+{/if}

--- a/frontend/svelte/src/lib/components/canisters/CanisterCardTitle.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCardTitle.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
   import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
   import Copy from "../ui/Copy.svelte";
-  import {mapCanisterDetails} from '../../utils/canisters.utils';
+  import { mapCanisterDetails } from "../../utils/canisters.utils";
 
   export let canister: CanisterDetails;
-  export let titleTag: 'h1' | 'h3' = 'h3'
+  export let titleTag: "h1" | "h3" = "h3";
 
   let canisterId: string;
   let validName: boolean;
-  $: ({canisterId, validName} = mapCanisterDetails(canister));
+  $: ({ canisterId, validName } = mapCanisterDetails(canister));
 </script>
 
 <div class="title">
-  <svelte:element this={titleTag}>{validName ? canister.name : canisterId}</svelte:element>
+  <svelte:element this={titleTag}
+    >{validName ? canister.name : canisterId}</svelte:element
+  >
 
   {#if !validName}
     <Copy value={canisterId} />

--- a/frontend/svelte/src/lib/components/canisters/CanisterCardTitle.svelte
+++ b/frontend/svelte/src/lib/components/canisters/CanisterCardTitle.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { CanisterDetails } from "../../canisters/nns-dapp/nns-dapp.types";
+  import Copy from "../ui/Copy.svelte";
+  import {mapCanisterDetails} from '../../utils/canisters.utils';
+
+  export let canister: CanisterDetails;
+  export let titleTag: 'h1' | 'h3' = 'h3'
+
+  let canisterId: string;
+  let validName: boolean;
+  $: ({canisterId, validName} = mapCanisterDetails(canister));
+</script>
+
+<div class="title">
+  <svelte:element this={titleTag}>{validName ? canister.name : canisterId}</svelte:element>
+
+  {#if !validName}
+    <Copy value={canisterId} />
+  {/if}
+</div>
+
+<style lang="scss">
+  .title {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+
+    :global(button) {
+      margin-left: var(--padding-0_5x);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/Copy.svelte
+++ b/frontend/svelte/src/lib/components/ui/Copy.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import IconCopy from "../../icons/IconCopy.svelte";
+  import { i18n } from "../../stores/i18n";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
+
+  export let value: string;
+
+  const copyToClipboard = async () =>
+    await navigator.clipboard.writeText(value);
+</script>
+
+<button
+  on:click|stopPropagation={copyToClipboard}
+  aria-label={replacePlaceholders($i18n.core.copy, {
+    $value: value,
+  })}
+  class="icon-only"
+>
+  <IconCopy />
+</button>
+
+<style lang="scss">
+  button {
+    height: 30px;
+    width: 30px;
+    padding: var(--padding-0_5x) var(--padding-0_5x) 0;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/Identifier.svelte
+++ b/frontend/svelte/src/lib/components/ui/Identifier.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import IconCopy from "../../icons/IconCopy.svelte";
-  import { i18n } from "../../stores/i18n";
+  import Copy from "./Copy.svelte";
 
   export let identifier: string;
   export let label: string | undefined = undefined;
@@ -9,9 +8,6 @@
 
   let labelText: string;
   $: labelText = label === undefined ? "" : `${label} `;
-
-  const copyToClipboard = async () =>
-    await navigator.clipboard.writeText(identifier);
 </script>
 
 <p>
@@ -19,13 +15,7 @@
     >{labelText}{identifier}</span
   >
   {#if showCopy}
-    <button
-      on:click|stopPropagation={copyToClipboard}
-      aria-label={labelText + $i18n.accounts.copy_identifier}
-      class="icon-only"
-    >
-      <IconCopy />
-    </button>
+    <Copy value={identifier} />
   {/if}
 </p>
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -17,7 +17,8 @@
     "principal": "Principal",
     "toggle": "toggle",
     "save_log_file": "Save the app state to the file",
-    "principal_id": "Principal ID"
+    "principal_id": "Principal ID",
+    "copy": "Copy \"$value\" to clipboard"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -97,7 +98,6 @@
   "accounts": {
     "title": "Accounts",
     "main": "Main",
-    "copy_identifier": "Copy identifier to clipboard",
     "new_transaction": "New Transaction",
     "add_account": "Add Account",
     "new_linked_title": "New Linked Account",

--- a/frontend/svelte/src/lib/themes/mixins/_card.scss
+++ b/frontend/svelte/src/lib/themes/mixins/_card.scss
@@ -1,3 +1,5 @@
+@use "./text.scss";
+
 @mixin stacked-title {
   display: grid;
   flex-direction: column;
@@ -23,4 +25,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+@mixin title {
+  line-height: var(--line-height-standard);
+  margin: 0 var(--padding) 0 0;
+
+  @include text.truncate;
 }

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -21,6 +21,7 @@ interface I18nCore {
   toggle: string;
   save_log_file: string;
   principal_id: string;
+  copy: string;
 }
 
 interface I18nError {
@@ -106,7 +107,6 @@ interface I18nAuth {
 interface I18nAccounts {
   title: string;
   main: string;
-  copy_identifier: string;
   new_transaction: string;
   add_account: string;
   new_linked_title: string;

--- a/frontend/svelte/src/lib/utils/canisters.utils.ts
+++ b/frontend/svelte/src/lib/utils/canisters.utils.ts
@@ -17,3 +17,22 @@ export const formatCyclesToTCycles = (cycles: bigint): string =>
     minFraction: 3,
     maxFraction: 3,
   });
+
+/**
+ * If no name is provided for the canister the information fallbacks to its ID.
+ */
+export const mapCanisterDetails = ({
+  canister_id,
+  name,
+}: CanisterDetails): {
+  name: string;
+  validName: boolean;
+  canisterId: string;
+} => {
+  const canisterId: string = canister_id.toText();
+  return {
+    name: name ?? canisterId,
+    validName: name.length > 0,
+    canisterId,
+  };
+};

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -35,6 +35,8 @@
   import { toastsStore } from "../lib/stores/toasts.store";
   import { busy } from "../lib/stores/busy.store";
   import { getCanisterFromStore } from "../lib/utils/canisters.utils";
+  import CanisterCardTitle from "../lib/components/canisters/CanisterCardTitle.svelte";
+  import CanisterCardSubTitle from "../lib/components/canisters/CanisterCardSubTitle.svelte";
 
   // TODO: checking if ready is similar to what's done in <ProposalDetail /> for the neurons.
   // Therefore we can probably refactor this to generic function.
@@ -150,9 +152,6 @@
 
   let showAddCyclesModal: boolean = false;
   const closeAddCyclesModal = async () => (showAddCyclesModal = false);
-
-  let canisterIdString: string = "";
-  $: canisterIdString = canisterInfo?.canister_id.toText() ?? "";
 </script>
 
 {#if SHOW_CANISTERS_ROUTE}
@@ -163,12 +162,9 @@
 
     <section>
       {#if canisterInfo !== undefined}
-        <h1>{canisterIdString}</h1>
-        <p>
-          {replacePlaceholders($i18n.canister_detail.id, {
-            $canisterId: canisterIdString,
-          })}
-        </p>
+        <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
+        <CanisterCardSubTitle canister={canisterInfo} />
+
         <div class="actions">
           <DetachCanisterButton canisterId={canisterInfo.canister_id} />
         </div>

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -204,10 +204,6 @@
 <style lang="scss">
   @use "../lib/themes/mixins/media";
 
-  p:last-of-type {
-    margin-bottom: var(--padding-3x);
-  }
-
   .actions {
     margin-bottom: var(--padding-3x);
     display: flex;

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -16,7 +16,7 @@
   } from "../lib/services/accounts.services";
   import { accountsStore } from "../lib/stores/accounts.store";
   import Spinner from "../lib/components/ui/Spinner.svelte";
-  import Identifier from "../lib/components/ic/Identifier.svelte";
+  import Identifier from "../lib/components/ui/Identifier.svelte";
   import ICP from "../lib/components/ic/ICP.svelte";
   import type { AccountIdentifier } from "@dfinity/nns/dist/types/types/common";
   import { toastsStore } from "../lib/stores/toasts.store";

--- a/frontend/svelte/src/tests/lib/components/canister_details/CyclesCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canister_details/CyclesCard.spec.ts
@@ -8,12 +8,16 @@ import { formatCyclesToTCycles } from "../../../../lib/utils/canisters.utils";
 import en from "../../../mocks/i18n.mock";
 
 describe("CyclesCard", () => {
-  it("renders title", () => {
-    const { queryByText } = render(CyclesCard, {
+  it("renders title as aria label", () => {
+    const { container } = render(CyclesCard, {
       props: { cycles: BigInt(10) },
     });
 
-    expect(queryByText(en.canister_detail.cycles)).toBeInTheDocument();
+    expect(
+      (container.querySelector("p") as HTMLParagraphElement).getAttribute(
+        "aria-label"
+      )
+    ).toEqual(en.canister_detail.cycles);
   });
 
   it("renders cycles", () => {

--- a/frontend/svelte/src/tests/lib/components/canisters/CanisterCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/CanisterCard.spec.ts
@@ -47,27 +47,6 @@ describe("CanisterCard", () => {
     expect(articleElement?.getAttribute("aria-label")).toBe(ariaLabel);
   });
 
-  it("renders the canister name if present", async () => {
-    const canisterName = "Da best Canister";
-    const { getByText } = render(CanisterCard, {
-      props: {
-        canister: { ...mockCanister, name: canisterName },
-      },
-    });
-    expect(getByText(canisterName)).toBeInTheDocument();
-  });
-
-  it("renders the canister id in text if name is empty string", async () => {
-    const { queryAllByText } = render(CanisterCard, {
-      props: {
-        canister: { ...mockCanister, name: "" },
-      },
-    });
-    expect(
-      queryAllByText(mockCanister.canister_id.toText()).length
-    ).toBeGreaterThan(0);
-  });
-
   it("renders the canister id", async () => {
     const { queryAllByText } = render(CanisterCard, {
       props: {
@@ -77,5 +56,33 @@ describe("CanisterCard", () => {
     expect(
       queryAllByText(mockCanister.canister_id.toText()).length
     ).toBeGreaterThan(0);
+  });
+
+  it("renders copy if no name present", async () => {
+    const { queryByRole } = render(CanisterCard, {
+      props: {
+        canister: { ...mockCanister },
+      },
+    });
+
+    const button = queryByRole("button");
+
+    expect(button?.getAttribute("aria-label")).toEqual(
+      `Copy "${mockCanister.canister_id.toText()}" to clipboard`
+    );
+  });
+
+  it("renders copy if name present", async () => {
+    const { queryByRole } = render(CanisterCard, {
+      props: {
+        canister: { ...mockCanister, name: "test" },
+      },
+    });
+
+    const button = queryByRole("button");
+
+    expect(button?.getAttribute("aria-label")).toEqual(
+      `Copy "${mockCanister.canister_id.toText()}" to clipboard`
+    );
   });
 });

--- a/frontend/svelte/src/tests/lib/components/canisters/CanisterCardSubTitle.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/CanisterCardSubTitle.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import CanisterCardSubTitle from "../../../../lib/components/canisters/CanisterCardSubTitle.svelte";
+import { mockCanister } from "../../../mocks/canisters.mock";
+
+describe("CanisterCardSubTitle", () => {
+  it("renders the canister id", async () => {
+    const { queryAllByText, container } = render(CanisterCardSubTitle, {
+      props: {
+        canister: { ...mockCanister, name: "test" },
+      },
+    });
+    expect(
+      queryAllByText(mockCanister.canister_id.toText()).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("do not render the canister id if name not present", async () => {
+    const { queryAllByText } = render(CanisterCardSubTitle, {
+      props: {
+        canister: mockCanister,
+      },
+    });
+    expect(queryAllByText(mockCanister.canister_id.toText()).length).toEqual(0);
+  });
+
+  it("renders copy if name present", async () => {
+    const { queryByRole } = render(CanisterCardSubTitle, {
+      props: {
+        canister: { ...mockCanister, name: "test" },
+      },
+    });
+
+    const button = queryByRole("button");
+
+    expect(button?.getAttribute("aria-label")).toEqual(
+      `Copy "${mockCanister.canister_id.toText()}" to clipboard`
+    );
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/canisters/CanisterCardTitle.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/CanisterCardTitle.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import CanisterCardTitle from "../../../../lib/components/canisters/CanisterCardTitle.svelte";
+import { mockCanister } from "../../../mocks/canisters.mock";
+
+describe("CanisterCardTitle", () => {
+  it("renders the canister name if present", async () => {
+    const canisterName = "Da best Canister";
+    const { getByText } = render(CanisterCardTitle, {
+      props: {
+        canister: { ...mockCanister, name: canisterName },
+      },
+    });
+    expect(getByText(canisterName)).toBeInTheDocument();
+  });
+
+  it("renders the canister id in text if name is empty string", async () => {
+    const { queryAllByText } = render(CanisterCardTitle, {
+      props: {
+        canister: { ...mockCanister, name: "" },
+      },
+    });
+    expect(
+      queryAllByText(mockCanister.canister_id.toText()).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the canister id", async () => {
+    const { queryAllByText } = render(CanisterCardTitle, {
+      props: {
+        canister: mockCanister,
+      },
+    });
+    expect(
+      queryAllByText(mockCanister.canister_id.toText()).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders title as h3 per default", async () => {
+    const { container } = render(CanisterCardTitle, {
+      props: {
+        canister: mockCanister,
+      },
+    });
+    expect(container.querySelector("h3")).not.toBeNull();
+  });
+
+  it("renders title as h1", async () => {
+    const { container } = render(CanisterCardTitle, {
+      props: {
+        canister: mockCanister,
+        titleTag: "h1",
+      },
+    });
+    expect(container.querySelector("h1")).not.toBeNull();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/Copy.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Copy.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import Copy from "../../../../lib/components/ui/Copy.svelte";
+
+describe("Copy", () => {
+  const value: string = "test-copy";
+  const props: { value: string } = { value };
+
+  it("should render an accessible button", () => {
+    const { queryByRole } = render(Copy, {
+      props,
+    });
+
+    const button = queryByRole("button");
+
+    expect(button?.getAttribute("aria-label")).toEqual(
+      `Copy "${value}" to clipboard`
+    );
+  });
+
+  it("should copy value to clipboard", () => {
+    const { getByRole } = render(Copy, {
+      props,
+    });
+
+    Object.assign(window.navigator, {
+      clipboard: {
+        writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+      },
+    });
+
+    const button = getByRole("button");
+    fireEvent.click(button);
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(value);
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { fireEvent, render } from "@testing-library/svelte";
-import Identifier from "../../../../lib/components/ic/Identifier.svelte";
+import Identifier from "../../../../lib/components/ui/Identifier.svelte";
 
 describe("Identifier", () => {
   const identifier: string = "test-identifier";

--- a/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
@@ -28,7 +28,7 @@ describe("Identifier", () => {
     const button = queryByRole("button");
 
     expect(button?.getAttribute("aria-label")).toEqual(
-      "Copy identifier to clipboard"
+      `Copy "${identifier}" to clipboard`
     );
   });
 

--- a/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import Identifier from "../../../../lib/components/ui/Identifier.svelte";
 
 describe("Identifier", () => {

--- a/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Identifier.spec.ts
@@ -20,7 +20,7 @@ describe("Identifier", () => {
     expect(button).toBeNull();
   });
 
-  it("should render an accessible button", () => {
+  it("should render a copy button", () => {
     const { queryByRole } = render(Identifier, {
       props: { identifier, showCopy: true },
     });
@@ -29,25 +29,6 @@ describe("Identifier", () => {
 
     expect(button?.getAttribute("aria-label")).toEqual(
       `Copy "${identifier}" to clipboard`
-    );
-  });
-
-  it("should copy identifier to clipboard", () => {
-    const { getByRole } = render(Identifier, {
-      props: { identifier, showCopy: true },
-    });
-
-    Object.assign(window.navigator, {
-      clipboard: {
-        writeText: jest.fn().mockImplementation(() => Promise.resolve()),
-      },
-    });
-
-    const button = getByRole("button");
-    fireEvent.click(button);
-
-    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      identifier
     );
   });
 });

--- a/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
@@ -52,7 +52,9 @@ describe("CanisterDetail", () => {
     const title = container.querySelector("h1");
 
     await waitFor(() => expect(title).not.toBeNull());
-    expect((title as HTMLElement).textContent).toEqual(mockCanister.canister_id.toText());
+    expect((title as HTMLElement).textContent).toEqual(
+      mockCanister.canister_id.toText()
+    );
   });
 
   it("should fetch canisters from nns-dapp if store is not loaded yet", async () => {

--- a/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/CanisterDetail.spec.ts
@@ -45,6 +45,16 @@ describe("CanisterDetail", () => {
     expect(getByText(en.canister_detail.title)).toBeInTheDocument();
   });
 
+  it("should render title once loaded", async () => {
+    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
+    const { container } = render(CanisterDetail);
+
+    const title = container.querySelector("h1");
+
+    await waitFor(() => expect(title).not.toBeNull());
+    expect((title as HTMLElement).textContent).toEqual(mockCanister.canister_id.toText());
+  });
+
   it("should fetch canisters from nns-dapp if store is not loaded yet", async () => {
     render(CanisterDetail);
     await waitFor(() => expect(listCanisters).toBeCalled());


### PR DESCRIPTION
# Motivation

It can be handy to make the "Copy" feature available for canisters. It also aligns the UX of the screen with other screens.

It was discussed with Mischa who suggested small improvements at the same time.

- in list: add "copy" action next to title (first line) or next to canister id (second line) if a name is displayed
- in detail: likewise + remove duplicate canister id if no name as in card + remove "Cycles" title in cycles card

# Changes

- create `CanisterCardTitle` and `CanisterCardSubtitle` (I wish I could have used one cmp but did not find a way)
- use above components in `CanisterCard` and `CanisterDetail`
- refactor `Identifier` from folder `icp` to `ui`
- extract `Copy` action from `Identifier` to create a standalone cmp
- remove title in `CycleCard`

# Screenshots

On it, need to fix mobile alignment...
