### PR TITLE
L2-676: Simplify icp to tcycles conversion

### DIFF
--- a/frontend/svelte/src/lib/canisters/cmc/cmc.canister.ts
+++ b/frontend/svelte/src/lib/canisters/cmc/cmc.canister.ts
@@ -1,7 +1,6 @@
 import { Actor } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type { CMCCanisterOptions } from "./cmc.canister.types";
-import { CYCLES_PER_XDR } from "./cmc.constants";
 import { throwNotifyError } from "./cmc.errors";
 import { idlFactory } from "./cmc.idl";
 import type {
@@ -39,7 +38,7 @@ export class CMCCanister {
     const { data } = await this.service.get_icp_xdr_conversion_rate();
 
     // TODO: validate the certificate in the response - https://dfinity.atlassian.net/browse/FOLLOW-223
-    return (data.xdr_permyriad_per_icp * CYCLES_PER_XDR) / BigInt(10_000);
+    return data.xdr_permyriad_per_icp;
   };
 
   /**

--- a/frontend/svelte/src/lib/canisters/cmc/cmc.constants.ts
+++ b/frontend/svelte/src/lib/canisters/cmc/cmc.constants.ts
@@ -1,1 +1,0 @@
-export const CYCLES_PER_XDR = BigInt(1_000_000_000_000); // 1 trillion

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -12,7 +12,10 @@
   let tCyclesFormatted: number | undefined;
   $: tCyclesFormatted =
     icpToCyclesRatio !== undefined
-      ? convertIcpToTCycles({ icpNumber: amount, ratio: icpToCyclesRatio })
+      ? convertIcpToTCycles({
+          icpNumber: amount,
+          exchangeRate: icpToCyclesRatio,
+        })
       : undefined;
 
   const dispatcher = createEventDispatcher();

--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -7,14 +7,14 @@
 
   export let amount: number;
   export let account: Account;
-  export let icpToCyclesRatio: bigint | undefined = undefined;
+  export let icpToCyclesExchangeRate: bigint | undefined = undefined;
 
   let tCyclesFormatted: number | undefined;
   $: tCyclesFormatted =
-    icpToCyclesRatio !== undefined
+    icpToCyclesExchangeRate !== undefined
       ? convertIcpToTCycles({
           icpNumber: amount,
-          exchangeRate: icpToCyclesRatio,
+          exchangeRate: icpToCyclesExchangeRate,
         })
       : undefined;
 

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -22,7 +22,7 @@
       amount !== undefined && icpToCyclesRatio !== undefined
         ? convertIcpToTCycles({
             icpNumber: amount,
-            ratio: icpToCyclesRatio,
+            exchangeRate: icpToCyclesRatio,
           })
         : undefined);
 
@@ -31,7 +31,7 @@
       amountCycles !== undefined && icpToCyclesRatio !== undefined
         ? convertTCyclesToIcpNumber({
             tCycles: amountCycles,
-            ratio: icpToCyclesRatio,
+            exchangeRate: icpToCyclesRatio,
           })
         : undefined);
 

--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -9,7 +9,7 @@
   import Input from "../ui/Input.svelte";
 
   export let amount: number | undefined = undefined;
-  export let icpToCyclesRatio: bigint | undefined = undefined;
+  export let icpToCyclesExchangeRate: bigint | undefined = undefined;
 
   let isChanging: "icp" | "tCycles" | undefined = undefined;
   let amountCycles: number | undefined;
@@ -19,19 +19,19 @@
 
   const setCycles = () =>
     (amountCycles =
-      amount !== undefined && icpToCyclesRatio !== undefined
+      amount !== undefined && icpToCyclesExchangeRate !== undefined
         ? convertIcpToTCycles({
             icpNumber: amount,
-            exchangeRate: icpToCyclesRatio,
+            exchangeRate: icpToCyclesExchangeRate,
           })
         : undefined);
 
   const setAmount = () =>
     (amount =
-      amountCycles !== undefined && icpToCyclesRatio !== undefined
+      amountCycles !== undefined && icpToCyclesExchangeRate !== undefined
         ? convertTCyclesToIcpNumber({
             tCycles: amountCycles,
-            exchangeRate: icpToCyclesRatio,
+            exchangeRate: icpToCyclesExchangeRate,
           })
         : undefined);
 
@@ -67,7 +67,7 @@
         bind:value={amount}
         on:focus={() => (isChanging = "icp")}
         on:blur={() => (isChanging = undefined)}
-        disabled={icpToCyclesRatio === undefined}
+        disabled={icpToCyclesExchangeRate === undefined}
       />
       <Input
         placeholderLabelKey="canisters.t_cycles"
@@ -77,7 +77,7 @@
         bind:value={amountCycles}
         on:focus={() => (isChanging = "tCycles")}
         on:blur={() => (isChanging = undefined)}
-        disabled={icpToCyclesRatio === undefined}
+        disabled={icpToCyclesExchangeRate === undefined}
       />
     </div>
     <slot />

--- a/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -20,9 +20,9 @@
   } from "../../types/canister-detail.context";
   import CanisterIdInfo from "../../components/canisters/CanisterIdInfo.svelte";
 
-  let icpToCyclesRatio: bigint | undefined;
+  let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
-    icpToCyclesRatio = await getIcpToCyclesExchangeRate();
+    icpToCyclesExchangeRate = await getIcpToCyclesExchangeRate();
   });
 
   const steps: Steps = [
@@ -111,7 +111,7 @@
     {/if}
     {#if currentStep?.name === "SelectCycles" && account !== undefined}
       <SelectCyclesCanister
-        {icpToCyclesRatio}
+        {icpToCyclesExchangeRate}
         bind:amount
         on:nnsClose
         on:nnsSelectAmount={selectAmount}
@@ -131,7 +131,7 @@
     {#if currentStep?.name === "ConfirmCycles" && amount !== undefined && account !== undefined}
       <ConfirmCyclesCanister
         {account}
-        {icpToCyclesRatio}
+        {icpToCyclesExchangeRate}
         {amount}
         on:nnsClose
         on:nnsConfirm={addCycles}

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -17,9 +17,9 @@
   import type { CreateOrLinkType } from "../../types/canisters";
   import WizardModal from "../WizardModal.svelte";
 
-  let icpToCyclesRatio: bigint | undefined;
+  let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
-    icpToCyclesRatio = await getIcpToCyclesExchangeRate();
+    icpToCyclesExchangeRate = await getIcpToCyclesExchangeRate();
   });
 
   const steps: Steps = [
@@ -137,7 +137,7 @@
     {/if}
     {#if currentStep?.name === "SelectCycles"}
       <SelectCyclesCanister
-        {icpToCyclesRatio}
+        {icpToCyclesExchangeRate}
         bind:amount
         on:nnsClose
         on:nnsSelectAmount={selectAmount}
@@ -148,7 +148,7 @@
     {#if currentStep?.name === "ConfirmCycles" && amount !== undefined && account !== undefined}
       <ConfirmCyclesCanister
         {account}
-        {icpToCyclesRatio}
+        {icpToCyclesExchangeRate}
         {amount}
         on:nnsConfirm={create}
         on:nnsClose

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -17,7 +17,6 @@ import type {
   CanisterDetails as CanisterInfo,
   SubAccountArray,
 } from "../canisters/nns-dapp/nns-dapp.types";
-import { E8S_PER_ICP } from "../constants/icp.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
 import { getLastPathDetail } from "../utils/app-path.utils";
@@ -229,9 +228,7 @@ export const getIcpToCyclesExchangeRate = async (): Promise<
 > => {
   try {
     const identity = await getIdentity();
-    const trillionRatio = await getIcpToCyclesExchangeRateApi(identity);
-    // This transforms to ratio to E8s to T Cycles.
-    return trillionRatio / BigInt(E8S_PER_ICP);
+    return await getIcpToCyclesExchangeRateApi(identity);
   } catch (error) {
     // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
     return;

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -75,7 +75,7 @@ export const convertNumberToICP = (amount: number): ICP => {
 
 // `exchangeRate` is the number of 10,000ths of IMF SDR (currency code XDR) that corresponds to 1 ICP.
 // This value reflects the current market price of one ICP token.
-// https://sourcegraph.com/github.com/dfinity/ic@7cc18edf13bc7761bf58bf6e2eef558ba624adff/-/blob/rs/nns/cmc/cmc.did?L67
+// https://github.com/dfinity/ic/blob/8132ae34aeba2bf8b913647b85b9918e1cb8721c/rs/nns/cmc/cmc.did#L67
 const NUMBER_XDR_PER_ONE_ICP = 10_000;
 export const convertIcpToTCycles = ({
   icpNumber,

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -3,7 +3,6 @@ import {
   E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
   ICP_DISPLAYED_DECIMALS_DETAILED,
-  ONE_TRILLION,
   TRANSACTION_FEE_E8S,
 } from "../constants/icp.constants";
 import { InvalidAmountError } from "../types/neurons.errors";
@@ -74,21 +73,22 @@ export const convertNumberToICP = (amount: number): ICP => {
   return stake;
 };
 
+// `exchangeRate` comes from `xdr_permyriad_per_icp` from CMC
+// `exchangeRate` is 10,000ths SDRs per 1 ICP.
+// TODO: add link to comment.
+const SDR_PARTS_IN_RATIO = 10_000;
 export const convertIcpToTCycles = ({
   icpNumber,
-  ratio,
+  exchangeRate,
 }: {
   icpNumber: number;
-  ratio: bigint;
-}): number => {
-  const icp = convertNumberToICP(icpNumber);
-  return Number(icp.toE8s() * ratio) / ONE_TRILLION;
-};
+  exchangeRate: bigint;
+}): number => icpNumber * (Number(exchangeRate) / SDR_PARTS_IN_RATIO);
 
 export const convertTCyclesToIcpNumber = ({
   tCycles,
-  ratio,
+  exchangeRate,
 }: {
   tCycles: number;
-  ratio: bigint;
-}): number => (tCycles * Number(ONE_TRILLION)) / Number(ratio) / E8S_PER_ICP;
+  exchangeRate: bigint;
+}): number => tCycles / (Number(exchangeRate) / SDR_PARTS_IN_RATIO);

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -73,17 +73,17 @@ export const convertNumberToICP = (amount: number): ICP => {
   return stake;
 };
 
-// `exchangeRate` comes from `xdr_permyriad_per_icp` from CMC
-// `exchangeRate` is 10,000ths SDRs per 1 ICP.
-// TODO: add link to comment.
-const SDR_PARTS_IN_RATIO = 10_000;
+// `exchangeRate` is the number of 10,000ths of IMF SDR (currency code XDR) that corresponds to 1 ICP.
+// This value reflects the current market price of one ICP token.
+// https://sourcegraph.com/github.com/dfinity/ic@7cc18edf13bc7761bf58bf6e2eef558ba624adff/-/blob/rs/nns/cmc/cmc.did?L67
+const NUMBER_XDR_PER_ONE_ICP = 10_000;
 export const convertIcpToTCycles = ({
   icpNumber,
   exchangeRate,
 }: {
   icpNumber: number;
   exchangeRate: bigint;
-}): number => icpNumber * (Number(exchangeRate) / SDR_PARTS_IN_RATIO);
+}): number => icpNumber * (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);
 
 export const convertTCyclesToIcpNumber = ({
   tCycles,
@@ -91,4 +91,4 @@ export const convertTCyclesToIcpNumber = ({
 }: {
   tCycles: number;
   exchangeRate: bigint;
-}): number => tCycles / (Number(exchangeRate) / SDR_PARTS_IN_RATIO);
+}): number => tCycles / (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);

--- a/frontend/svelte/src/tests/lib/canisters/cmc.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/cmc.canister.spec.ts
@@ -31,10 +31,11 @@ describe("CyclesMintingCanister", () => {
 
   describe("CMCCanister.getIcpToCyclesConversionRate", () => {
     it("returns the conversion rate from ICP to cycles", async () => {
+      const exchangeRate = BigInt(10_000);
       const response: IcpXdrConversionRateResponse = {
         certificate: [],
         data: {
-          xdr_permyriad_per_icp: BigInt(10_000),
+          xdr_permyriad_per_icp: exchangeRate,
           timestamp_seconds: BigInt(10),
         },
         hash_tree: [],
@@ -46,7 +47,7 @@ describe("CyclesMintingCanister", () => {
 
       const res = await cmc.getIcpToCyclesConversionRate();
 
-      expect(res).toEqual(BigInt(1_000_000_000_000));
+      expect(res).toEqual(exchangeRate);
     });
   });
 

--- a/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -15,7 +15,7 @@ jest.mock("../../../../lib/services/canisters.services", () => {
 });
 
 describe("SelectCyclesCanister", () => {
-  const props = { icpToCyclesRatio: BigInt(10_000) };
+  const props = { icpToCyclesExchangeRate: BigInt(10_000) };
   it("renders button", () => {
     const { queryByText } = render(SelectCyclesCanister, { props });
 

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -1,7 +1,6 @@
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/canisters.api";
 import { UserNotTheControllerError } from "../../../lib/canisters/ic-management/ic-management.errors";
-import { E8S_PER_ICP } from "../../../lib/constants/icp.constants";
 import { syncAccounts } from "../../../lib/services/accounts.services";
 import {
   addController,
@@ -63,9 +62,10 @@ describe("canisters-services", () => {
     .spyOn(api, "queryCanisterDetails")
     .mockImplementation(() => Promise.resolve(mockCanisterDetails));
 
+  const exchangeRate = BigInt(10_000);
   const spyGetExchangeRate = jest
     .spyOn(api, "getIcpToCyclesExchangeRate")
-    .mockImplementation(() => Promise.resolve(BigInt(10_000 * E8S_PER_ICP)));
+    .mockImplementation(() => Promise.resolve(exchangeRate));
 
   describe("listCanisters", () => {
     afterEach(() => {
@@ -276,7 +276,7 @@ describe("canisters-services", () => {
 
     it("should call api to get conversion rate", async () => {
       const response = await getIcpToCyclesExchangeRate();
-      expect(response).toBe(BigInt(10_000));
+      expect(response).toBe(exchangeRate);
       expect(spyGetExchangeRate).toBeCalled();
     });
 

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -101,37 +101,46 @@ describe("icp-utils", () => {
 
   describe("convertIcpToTCycles", () => {
     it("converts ICP to TCycles", () => {
-      expect(convertIcpToTCycles({ icpNumber: 1, ratio: BigInt(10_000) })).toBe(
-        1
-      );
       expect(
-        convertIcpToTCycles({ icpNumber: 2.5, ratio: BigInt(10_000) })
+        convertIcpToTCycles({ icpNumber: 1, exchangeRate: BigInt(10_000) })
+      ).toBe(1);
+      expect(
+        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: BigInt(10_000) })
       ).toBe(2.5);
       expect(
-        convertIcpToTCycles({ icpNumber: 2.5, ratio: BigInt(20_000) })
+        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: BigInt(20_000) })
       ).toBe(5);
-      expect(convertIcpToTCycles({ icpNumber: 1, ratio: BigInt(15_000) })).toBe(
-        1.5
-      );
+      expect(
+        convertIcpToTCycles({ icpNumber: 1, exchangeRate: BigInt(15_000) })
+      ).toBe(1.5);
     });
   });
 
   describe("convertTCyclesToIcpNumber", () => {
     it("converts TCycles to number", () => {
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(10_000) })
+        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: BigInt(10_000) })
       ).toBe(1);
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(10_000) })
+        convertTCyclesToIcpNumber({
+          tCycles: 2.5,
+          exchangeRate: BigInt(10_000),
+        })
       ).toBe(2.5);
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 2.5, ratio: BigInt(20_000) })
+        convertTCyclesToIcpNumber({
+          tCycles: 2.5,
+          exchangeRate: BigInt(20_000),
+        })
       ).toBe(1.25);
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 1, ratio: BigInt(15_000) })
+        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: BigInt(15_000) })
       ).toBe(2 / 3);
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 4.32, ratio: BigInt(10_000) })
+        convertTCyclesToIcpNumber({
+          tCycles: 4.32,
+          exchangeRate: BigInt(10_000),
+        })
       ).toBe(4.32);
     });
   });


### PR DESCRIPTION
# Motivation

Simplify the code of the conversion of ICPs to TCycles and back.

# Changes

* Remove all calculations along the way.
* Utils gets the same exchange rate that CMC sends.
* Rename "ratio" to "exchangeRate".

# Tests

* Fix broken tests.
