### PR TITLE
L2-615: Manage Canister Errors

### DIFF
--- a/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.ts
+++ b/frontend/svelte/src/lib/canisters/ic-management/ic-management.canister.ts
@@ -52,6 +52,14 @@ export class ICManagementCanister {
     }
   };
 
+  /**
+   * Updateds canister settings
+   *
+   * @param {Principal} canisterId
+   * @param {CanisterSettings} settings
+   * @returns Promise<void>
+   * @throws UserNotTheController, Error
+   */
   public updateSettings = async ({
     canisterId,
     settings: {

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -5,6 +5,11 @@ import type { NNSDappCanisterOptions } from "./nns-dapp.canister.types";
 import { idlFactory as certifiedIdlFactory } from "./nns-dapp.certified.idl";
 import {
   AccountNotFoundError,
+  CanisterAlreadyAttachedError,
+  CanisterLimitExceededError,
+  CanisterNameAlreadyTakenError,
+  CanisterNameTooLongError,
+  CanisterNotFoundError,
   HardwareWalletAttachError,
   NameTooLongError,
   SubAccountLimitExceededError,
@@ -233,7 +238,34 @@ export class NNSDappCanister {
     if ("Ok" in response) {
       return;
     }
-    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
+    if (
+      "CanisterAlreadyAttached" in response &&
+      response.CanisterAlreadyAttached === null
+    ) {
+      throw new CanisterAlreadyAttachedError(
+        "error__canister.already_attached",
+        {
+          $canisterId: canisterId.toText(),
+        }
+      );
+    }
+    if ("NameAlreadyTaken" in response && response.NameAlreadyTaken === null) {
+      throw new CanisterNameAlreadyTakenError("error__canister.name_taken", {
+        $name: name,
+      });
+    }
+    if ("NameTooLong" in response && response.NameTooLong === null) {
+      throw new CanisterNameTooLongError("error__canister.name_too_long", {
+        $name: name,
+      });
+    }
+    if (
+      "CanisterLimitExceeded" in response &&
+      response.CanisterLimitExceeded === null
+    ) {
+      throw new CanisterLimitExceededError("error__canister.limit_exceeded");
+    }
+    // Edge case
     throw new Error(`Error attaching canister ${JSON.stringify(response)}`);
   };
 
@@ -244,7 +276,12 @@ export class NNSDappCanister {
     if ("Ok" in response) {
       return;
     }
-    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
+    if ("CanisterNotFound" in response && response.CanisterNotFound === null) {
+      throw new CanisterNotFoundError("error__canister.detach_not_found", {
+        $canisterId: canisterId.toText(),
+      });
+    }
+    // Edge case
     throw new Error(`Error detaching canister ${JSON.stringify(response)}`);
   };
 

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -32,3 +32,36 @@ export class HardwareWalletAttachError extends Error {
     super(message);
   }
 }
+
+export class CanisterAlreadyAttachedError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
+    super(message);
+
+    this.substitutions = substitutions;
+  }
+}
+export class CanisterNameAlreadyTakenError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
+    super(message);
+
+    this.substitutions = substitutions;
+  }
+}
+
+export class CanisterNameTooLongError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
+    super(message);
+
+    this.substitutions = substitutions;
+  }
+}
+
+export class CanisterLimitExceededError extends AccountTranslateError {}
+
+export class CanisterNotFoundError extends AccountTranslateError {
+  constructor(message: string, substitutions?: I18nSubstitutions) {
+    super(message);
+
+    this.substitutions = substitutions;
+  }
+}

--- a/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/AttachCanister.svelte
@@ -20,13 +20,17 @@
     }
     startBusy({ initiator: "attach-canister" });
     const { success } = await attachCanister(principal);
+    stopBusy("attach-canister");
     if (success) {
       toastsStore.success({
         labelKey: "canisters.link_canister_success",
+        substitutions: {
+          $canisterId: principal.toText(),
+        },
       });
+      // Leave modal open if not successful in case the error can be fixed.
+      dispatcher("nnsClose");
     }
-    stopBusy("attach-canister");
-    dispatcher("nnsClose");
   };
 </script>
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -80,7 +80,13 @@
     "controller_not_present": "Principal is already not a controller.",
     "pub_key_not_hex_string": "$key is not a hex string.",
     "pub_key_hex_string_invalid_length": "The key must be >= 130 characters and <= 150 characters.",
-    "hardware_wallet_no_account": "No hardware wallet account provided."
+    "hardware_wallet_no_account": "No hardware wallet account provided.",
+    "canister_refund": "Sorry, the operation was not successful and the amoun has been refunded.",
+    "canister_creation_unknown": "Sorry, there was an error creating the canister.",
+    "canister_top_up_unknown": "Sorry, there was an error adding cycles to the canister.",
+    "canister_update_settings": "Sorry, there was an error updating the canister settings.",
+    "not_canister_controller_to_update": "The current user is not the controller of the canister. Only controllers can change the settings.",
+    "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired."
@@ -266,7 +272,7 @@
     "create_canister_success": "New canister with id $canisterId created successfully",
     "link_canister_title": "Link Canister To Account",
     "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
-    "link_canister_success": "The canister was linked successfully",
+    "link_canister_success": "The canister ($canisterId) was linked successfully",
     "attach_canister": "Attach Canister",
     "enter_canister_id": "Enter Canister ID:",
     "canister_id": "Canister ID",
@@ -489,5 +495,15 @@
     "create_subaccount": "Sorry, there was an unexpected error when creating your linked account, please try again.",
     "subaccount_not_found": "Error renaming subAccount, subAccount ($account_identifier) not found",
     "rename_account_not_found": "Error renaming subAccount, account ($account_identifier) not found"
+  },
+  "error__canister": {
+    "already_attached": "Canister ($canisterId) is already attached",
+    "name_taken": "The name $name is already in use. Names must be unique.",
+    "name_too_long": "The name $name is too long (max. 24 characters). Please, choose a shorter name.",
+    "limit_exceeded": "The limit of canisters that can be attached has been exceeded.",
+    "detach_not_found": "Error detaching, canister ($canisterId) not found.",
+    "unknown_attach": "Error attaching canister.",
+    "unknown_detach": "Error detaching canister.",
+    "get_exchange_rate": "Error getting the exchange rate of ICP to Cycles."
   }
 }

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -21,7 +21,10 @@ import type { Account } from "../types/account";
 import { InsufficientAmountError } from "../types/common.errors";
 import { getLastPathDetail } from "../utils/app-path.utils";
 import { isController } from "../utils/canisters.utils";
-import { mapCanisterErrorToToastMessage } from "../utils/error.utils";
+import {
+  mapCanisterErrorToToastMessage,
+  toToastError,
+} from "../utils/error.utils";
 import { convertNumberToICP } from "../utils/icp.utils";
 import { syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
@@ -97,8 +100,9 @@ export const createCanister = async ({
     syncAccounts();
     return canisterId;
   } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
-    toastsStore.show(mapCanisterErrorToToastMessage(error));
+    toastsStore.show(
+      mapCanisterErrorToToastMessage(error, "error.canister_creation_unknown")
+    );
     return;
   }
 };
@@ -128,8 +132,9 @@ export const topUpCanister = async ({
     syncAccounts();
     return { success: true };
   } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
-    toastsStore.show(mapCanisterErrorToToastMessage(error));
+    toastsStore.show(
+      mapCanisterErrorToToastMessage(error, "error.canister_top_up_unknown")
+    );
     return { success: false };
   }
 };
@@ -204,7 +209,9 @@ export const updateSettings = async ({
     });
     return { success: true };
   } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+    toastsStore.show(
+      mapCanisterErrorToToastMessage(error, "error.canister_update_settings")
+    );
     return { success: false };
   }
 };
@@ -220,8 +227,13 @@ export const attachCanister = async (
     });
     await listCanisters({ clearBeforeQuery: false });
     return { success: true };
-  } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+  } catch (err) {
+    toastsStore.error(
+      toToastError({
+        err,
+        fallbackErrorLabelKey: "error__canister.unknown_attach",
+      })
+    );
     return { success: false };
   }
 };
@@ -239,8 +251,13 @@ export const detachCanister = async (
     success = true;
     await listCanisters({ clearBeforeQuery: false });
     return { success };
-  } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+  } catch (err) {
+    toastsStore.error(
+      toToastError({
+        err,
+        fallbackErrorLabelKey: "error__canister.unknown_detach",
+      })
+    );
     return { success };
   }
 };
@@ -276,8 +293,11 @@ export const getIcpToCyclesExchangeRate = async (): Promise<
   try {
     const identity = await getIdentity();
     return await getIcpToCyclesExchangeRateApi(identity);
-  } catch (error) {
-    // TODO: Manage proper errors https://dfinity.atlassian.net/browse/L2-615
+  } catch (err) {
+    toastsStore.error({
+      labelKey: "error__canister.get_exchange_rate",
+      err,
+    });
     return;
   }
 };

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -85,6 +85,12 @@ interface I18nError {
   pub_key_not_hex_string: string;
   pub_key_hex_string_invalid_length: string;
   hardware_wallet_no_account: string;
+  canister_refund: string;
+  canister_creation_unknown: string;
+  canister_top_up_unknown: string;
+  canister_update_settings: string;
+  not_canister_controller_to_update: string;
+  canister_invalid_transaction: string;
 }
 
 interface I18nWarning {
@@ -520,6 +526,17 @@ interface I18nError__account {
   rename_account_not_found: string;
 }
 
+interface I18nError__canister {
+  already_attached: string;
+  name_taken: string;
+  name_too_long: string;
+  limit_exceeded: string;
+  detach_not_found: string;
+  unknown_attach: string;
+  unknown_detach: string;
+  get_exchange_rate: string;
+}
+
 interface I18n {
   lang: Languages;
   core: I18nCore;
@@ -549,4 +566,5 @@ interface I18n {
   error__ledger: I18nError__ledger;
   error__attach_wallet: I18nError__attach_wallet;
   error__account: I18nError__account;
+  error__canister: I18nError__canister;
 }

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -4,6 +4,11 @@ import { mock } from "jest-mock-extended";
 import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import {
   AccountNotFoundError,
+  CanisterAlreadyAttachedError,
+  CanisterLimitExceededError,
+  CanisterNameAlreadyTakenError,
+  CanisterNameTooLongError,
+  CanisterNotFoundError,
   HardwareWalletAttachError,
   NameTooLongError,
   SubAccountLimitExceededError,
@@ -252,7 +257,70 @@ describe("NNSDapp", () => {
 
       expect(service.attach_canister).toBeCalled();
     });
-    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
+
+    it("should throw CanisterAlreadyAttachedError", async () => {
+      const service = mock<NNSDappService>();
+      service.attach_canister.mockResolvedValue({
+        CanisterAlreadyAttached: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.attachCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterAlreadyAttachedError);
+    });
+
+    it("should throw CanisterNameAlreadyTakenError", async () => {
+      const service = mock<NNSDappService>();
+      service.attach_canister.mockResolvedValue({
+        NameAlreadyTaken: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.attachCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
+    });
+
+    it("should throw CanisterNameTooLongError", async () => {
+      const service = mock<NNSDappService>();
+      service.attach_canister.mockResolvedValue({
+        NameTooLong: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.attachCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterNameTooLongError);
+    });
+
+    it("should throw CanisterLimitExceededError", async () => {
+      const service = mock<NNSDappService>();
+      service.attach_canister.mockResolvedValue({
+        CanisterLimitExceeded: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.attachCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterLimitExceededError);
+    });
   });
 
   describe("NNSDapp.detachCanister", () => {
@@ -265,6 +333,17 @@ describe("NNSDapp", () => {
 
       expect(service.detach_canister).toBeCalled();
     });
-    // TODO: Throw proper errors https://dfinity.atlassian.net/browse/L2-615
+
+    it("should throw CanisterNotFoundError", async () => {
+      const service = mock<NNSDappService>();
+      service.detach_canister.mockResolvedValue({
+        CanisterNotFound: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () => nnsDapp.detachCanister(mockCanister.canister_id);
+
+      expect(call).rejects.toThrowError(CanisterNotFoundError);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

User has appropriate feedback when something goes wrong in the Canisters tab.

# Changes

* nns-dapp canister throws different error classes depending on response when attaching or detaching canisters.
* canister services check errors in the catch and show errors accordingly.

# Tests

* Test that nns-dapp canister throws errors according to response.
