### PR TITLE
fix: 'await' has no effect on the type of this expression

### DIFF
--- a/frontend/svelte/src/lib/services/seed-neurons.services.ts
+++ b/frontend/svelte/src/lib/services/seed-neurons.services.ts
@@ -31,7 +31,7 @@ export const claimSeedNeurons = async () => {
   }
   try {
     const identity = await getLedgerIdentityProxy(hardwareWallet?.identifier);
-    const governance = await GenesisTokenCanister.create({
+    const governance = GenesisTokenCanister.create({
       agent: await createAgent({ identity, host: HOST }),
     });
 


### PR DESCRIPTION
# Motivation

Fix lint warning:

> Hint: 'await' has no effect on the type of this expression. 
>    const identity = await getLedgerIdentityProxy(hardwareWallet?.identifier);
>    const governance = await GenesisTokenCanister.create({
>      agent: await createAgent({ identity, host: HOST }),
>    });
