### PR TITLE
L2-685: Voting Power from proposal's ballot

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -54,7 +54,7 @@
 {#if visible}
   <Card>
     <h3 slot="start">{$i18n.proposal_detail__vote.headline}</h3>
-    <CastVoteCardNeuronSelect />
+    <CastVoteCardNeuronSelect {proposalInfo} />
     <VotingConfirmationToolbar {proposalInfo} on:nnsConfirm={vote} />
   </Card>
 {/if}

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -28,6 +28,7 @@
   $: total = selectedNeuronsVotingPower({
     neurons: $votingNeuronSelectStore.neurons,
     selectedIds: $votingNeuronSelectStore.selectedIds,
+    proposal: proposalInfo,
   });
   $: disabled = $votingNeuronSelectStore.selectedIds.length === 0 || $busy;
 

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
+  import type { ProposalInfo } from "@dfinity/nns";
   import { i18n } from "../../../stores/i18n";
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
-  import { selectedNeuronsVotingPower } from "../../../utils/proposals.utils";
+  import {
+    getVotingBallot,
+    selectedNeuronsVotingPower,
+  } from "../../../utils/proposals.utils";
   import { formatVotingPower } from "../../../utils/neuron.utils";
   import Checkbox from "../../ui/Checkbox.svelte";
+
+  export let proposalInfo: ProposalInfo;
 
   let total: bigint;
 
   $: total = selectedNeuronsVotingPower({
     neurons: $votingNeuronSelectStore.neurons,
     selectedIds: $votingNeuronSelectStore.selectedIds,
+    proposal: proposalInfo,
   });
 
   const toggleSelection = (neuronId: bigint) =>
@@ -23,6 +30,7 @@
 
 <ul>
   {#each $votingNeuronSelectStore.neurons as { neuronId, votingPower }}
+    {@const ballot = getVotingBallot({ neuronId, proposalInfo })}
     <li>
       <Checkbox
         inputId={`${neuronId}`}
@@ -34,7 +42,7 @@
       >
         <span class="neuron-id">{`${neuronId}`}</span>
         <span class="neuron-voting-power"
-          >{`${formatVotingPower(votingPower)}`}</span
+          >{`${formatVotingPower(ballot?.votingPower ?? votingPower)}`}</span
         >
       </Checkbox>
     </li>

--- a/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "../../../stores/i18n";
   import { votingNeuronSelectStore } from "../../../stores/proposals.store";
   import {
-    getVotingBallot,
+    getVotingPower,
     selectedNeuronsVotingPower,
   } from "../../../utils/proposals.utils";
   import { formatVotingPower } from "../../../utils/neuron.utils";
@@ -29,20 +29,21 @@
 </p>
 
 <ul>
-  {#each $votingNeuronSelectStore.neurons as { neuronId, votingPower }}
-    {@const ballot = getVotingBallot({ neuronId, proposalInfo })}
+  {#each $votingNeuronSelectStore.neurons as neuron}
     <li>
       <Checkbox
-        inputId={`${neuronId}`}
-        checked={$votingNeuronSelectStore.selectedIds.includes(neuronId)}
-        on:nnsChange={() => toggleSelection(neuronId)}
+        inputId={`${neuron.neuronId}`}
+        checked={$votingNeuronSelectStore.selectedIds.includes(neuron.neuronId)}
+        on:nnsChange={() => toggleSelection(neuron.neuronId)}
         theme="dark"
         text="block"
         selector="neuron-checkbox"
       >
-        <span class="neuron-id">{`${neuronId}`}</span>
+        <span class="neuron-id">{`${neuron.neuronId}`}</span>
         <span class="neuron-voting-power"
-          >{`${formatVotingPower(ballot?.votingPower ?? votingPower)}`}</span
+          >{`${formatVotingPower(
+            getVotingPower({ neuron, proposal: proposalInfo })
+          )}`}</span
         >
       </Checkbox>
     </li>

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -3,11 +3,14 @@ import {
   ICP,
   NeuronState,
   Topic,
+  Vote,
+  votedNeurons,
   type BallotInfo,
   type Followees,
   type Neuron,
   type NeuronId,
   type NeuronInfo,
+  type ProposalInfo,
 } from "@dfinity/nns";
 import type { SvelteComponent } from "svelte";
 import {
@@ -34,6 +37,7 @@ import {
 } from "./accounts.utils";
 import { enumValues } from "./enum.utils";
 import { formatNumber } from "./format.utils";
+import { getVotingBallot, getVotingPower } from "./proposals.utils";
 import { isDefined } from "./utils";
 
 export type StateInfo = {
@@ -551,3 +555,52 @@ export const hasEnoughMaturityToMerge = (neuron: NeuronInfo): boolean =>
 // fullNeuron is only for users with access.
 export const userAuthorizedNeuron = (neuron: NeuronInfo): boolean =>
   neuron.fullNeuron !== undefined;
+
+export type CompactNeuronInfo = {
+  id: NeuronId;
+  votingPower: bigint;
+  vote: Vote;
+};
+
+const getRecentBallot = ({
+  neuron,
+  proposalId,
+}: {
+  neuron: NeuronInfo;
+  proposalId?: bigint;
+}): BallotInfo | undefined =>
+  neuron.recentBallots.find(
+    ({ proposalId: currentId }) => currentId === proposalId
+  );
+
+// We try to get the from from the neurons ballots and also from the proposal ballots
+const getVote = ({
+  neuron,
+  proposal,
+}: {
+  neuron: NeuronInfo;
+  proposal: ProposalInfo;
+}): Vote | undefined =>
+  getRecentBallot({ neuron, proposalId: proposal.id })?.vote ??
+  getVotingBallot({ neuronId: neuron.neuronId, proposalInfo: proposal })?.vote;
+
+export const votedNeuronDetails = ({
+  neurons,
+  proposal,
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): CompactNeuronInfo[] =>
+  votedNeurons({
+    neurons: neurons,
+    proposal,
+  })
+    .map((neuron) => ({
+      id: neuron.neuronId,
+      votingPower: getVotingPower({ neuron, proposal }),
+      vote: getVote({ neuron, proposal }),
+    }))
+    // Exclude the cases where the vote was not found.
+    .filter(
+      (compactNeuronInfoMaybe) => compactNeuronInfoMaybe.vote !== undefined
+    ) as CompactNeuronInfo[];

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -573,7 +573,7 @@ const getRecentBallot = ({
     ({ proposalId: currentId }) => currentId === proposalId
   );
 
-// We try to get the from from the neurons ballots and also from the proposal ballots
+// We try to get the vote from the neurons ballots and also from the proposal ballots
 const getVote = ({
   neuron,
   proposal,

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -592,7 +592,7 @@ export const votedNeuronDetails = ({
   proposal: ProposalInfo;
 }): CompactNeuronInfo[] =>
   votedNeurons({
-    neurons: neurons,
+    neurons,
     proposal,
   })
     .map((neuron) => ({

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -1,4 +1,5 @@
 import type {
+  Ballot,
   NeuronId,
   NeuronInfo,
   Proposal,
@@ -144,13 +145,19 @@ export const hasMatchingProposals = ({
 export const selectedNeuronsVotingPower = ({
   neurons,
   selectedIds,
+  proposal,
 }: {
   neurons: NeuronInfo[];
   selectedIds: NeuronId[];
+  proposal: ProposalInfo;
 }): bigint =>
   neurons
     .filter(({ neuronId }) => selectedIds.includes(neuronId))
-    .reduce((sum, { votingPower }) => sum + votingPower, BigInt(0));
+    .map(({ neuronId, votingPower }) => {
+      const ballot = getVotingBallot({ neuronId, proposalInfo: proposal });
+      return ballot?.votingPower ?? votingPower;
+    })
+    .reduce((sum, votingPower) => sum + votingPower, BigInt(0));
 
 /**
  * Generate new selected neuron id list after new neurons response w/o spoiling the previously done user selection
@@ -286,3 +293,12 @@ export const mapProposalInfo = (
     status,
   };
 };
+
+export const getVotingBallot = ({
+  neuronId,
+  proposalInfo,
+}: {
+  neuronId: bigint;
+  proposalInfo: ProposalInfo;
+}): Ballot | undefined =>
+  proposalInfo.ballots.find((ballot) => ballot.neuronId === neuronId);

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -144,24 +144,24 @@ export const hasMatchingProposals = ({
 
 export const getVotingBallot = ({
   neuronId,
-  proposalInfo,
+  proposalInfo: { ballots },
 }: {
   neuronId: bigint;
   proposalInfo: ProposalInfo;
 }): Ballot | undefined =>
-  proposalInfo.ballots.find((ballot) => ballot.neuronId === neuronId);
+  ballots.find((ballot) => ballot.neuronId === neuronId);
 
 export const getVotingPower = ({
-  neuron,
+  neuron: { neuronId, votingPower },
   proposal,
 }: {
   neuron: NeuronInfo;
   proposal: ProposalInfo;
 }): bigint =>
   getVotingBallot({
-    neuronId: neuron.neuronId,
+    neuronId,
     proposalInfo: proposal,
-  })?.votingPower ?? neuron.votingPower;
+  })?.votingPower ?? votingPower;
 
 export const selectedNeuronsVotingPower = ({
   neurons,

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -142,6 +142,27 @@ export const hasMatchingProposals = ({
   );
 };
 
+export const getVotingBallot = ({
+  neuronId,
+  proposalInfo,
+}: {
+  neuronId: bigint;
+  proposalInfo: ProposalInfo;
+}): Ballot | undefined =>
+  proposalInfo.ballots.find((ballot) => ballot.neuronId === neuronId);
+
+export const getVotingPower = ({
+  neuron,
+  proposal,
+}: {
+  neuron: NeuronInfo;
+  proposal: ProposalInfo;
+}): bigint =>
+  getVotingBallot({
+    neuronId: neuron.neuronId,
+    proposalInfo: proposal,
+  })?.votingPower ?? neuron.votingPower;
+
 export const selectedNeuronsVotingPower = ({
   neurons,
   selectedIds,
@@ -153,10 +174,7 @@ export const selectedNeuronsVotingPower = ({
 }): bigint =>
   neurons
     .filter(({ neuronId }) => selectedIds.includes(neuronId))
-    .map(({ neuronId, votingPower }) => {
-      const ballot = getVotingBallot({ neuronId, proposalInfo: proposal });
-      return ballot?.votingPower ?? votingPower;
-    })
+    .map((neuron) => getVotingPower({ neuron, proposal }))
     .reduce((sum, votingPower) => sum + votingPower, BigInt(0));
 
 /**
@@ -293,12 +311,3 @@ export const mapProposalInfo = (
     status,
   };
 };
-
-export const getVotingBallot = ({
-  neuronId,
-  proposalInfo,
-}: {
-  neuronId: bigint;
-  proposalInfo: ProposalInfo;
-}): Ballot | undefined =>
-  proposalInfo.ballots.find((ballot) => ballot.neuronId === neuronId);

--- a/frontend/svelte/src/lib/utils/proposals.utils.ts
+++ b/frontend/svelte/src/lib/utils/proposals.utils.ts
@@ -151,6 +151,8 @@ export const getVotingBallot = ({
 }): Ballot | undefined =>
   ballots.find((ballot) => ballot.neuronId === neuronId);
 
+// We first check the voting power of the ballot from the proposal. Which is the voting power that was used to vote.
+// In the edge case that the proposal voting power is not present, then we show the neuron voting power.
 export const getVotingPower = ({
   neuron: { neuronId, votingPower },
   proposal,

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/VotesCard.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/VotesCard.spec.ts
@@ -71,11 +71,19 @@ describe("VotesCard", () => {
       ],
     };
     const votedNeurons = [mockNeuron, noVoted, yesVoted];
+    const proposal = {
+      ...mockProposalInfo,
+      ballots: votedNeurons.map(({ neuronId, votingPower }) => ({
+        neuronId,
+        votingPower,
+        vote: Vote.UNSPECIFIED,
+      })),
+    };
     it("should have title when proposal has been voted by some owned neuron", () => {
       neuronsStore.setNeurons({ neurons: votedNeurons, certified: true });
       const { getByText } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
       expect(getByText(en.proposal_detail.my_votes)).toBeInTheDocument();
@@ -85,7 +93,7 @@ describe("VotesCard", () => {
       neuronsStore.setNeurons({ neurons: [], certified: true });
       const { getByText } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
       expect(() => getByText(en.proposal_detail.my_votes)).toThrow();
@@ -95,7 +103,7 @@ describe("VotesCard", () => {
       neuronsStore.setNeurons({ neurons: votedNeurons, certified: true });
       const { container } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
       const neuronElements = container.querySelectorAll(
@@ -108,7 +116,7 @@ describe("VotesCard", () => {
       neuronsStore.setNeurons({ neurons: votedNeurons, certified: true });
       const { container } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
       const thumbUpElements = container.querySelectorAll(
@@ -126,7 +134,7 @@ describe("VotesCard", () => {
       neuronsStore.setNeurons({ neurons: votedNeurons, certified: true });
       const { getByTitle } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
 
@@ -153,7 +161,7 @@ describe("VotesCard", () => {
       neuronsStore.setNeurons({ neurons: votedNeurons, certified: true });
       const { container } = render(VotesCard, {
         props: {
-          proposalInfo: mockProposalInfo,
+          proposalInfo: proposal,
         },
       });
       const element = container.querySelector(`[data-tid="neuron-data"]`);

--- a/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/proposals.utils.spec.ts
@@ -10,6 +10,7 @@ import {
   concatenateUniqueProposals,
   excludeProposals,
   getVotingBallot,
+  getVotingPower,
   hasMatchingProposals,
   hideProposal,
   lastProposalId,
@@ -893,6 +894,44 @@ describe("proposals-utils", () => {
           proposalInfo: proposal,
         })
       ).toBeUndefined();
+    });
+  });
+
+  describe("getVotingPower", () => {
+    it("should return ballot voting power if present", () => {
+      const neuronId = BigInt(100);
+      const neuron = {
+        ...mockNeuron,
+        neuronId,
+      };
+      const ballot: Ballot = {
+        neuronId,
+        votingPower: BigInt(30),
+        vote: Vote.YES,
+      };
+      const proposal = {
+        ...mockProposalInfo,
+        ballots: [ballot],
+      };
+      expect(
+        getVotingPower({
+          neuron,
+          proposal,
+        })
+      ).toEqual(ballot.votingPower);
+    });
+
+    it("should return neuron voting power if no ballot", () => {
+      const proposal = {
+        ...mockProposalInfo,
+        ballots: [],
+      };
+      expect(
+        getVotingPower({
+          neuron: mockNeuron,
+          proposal,
+        })
+      ).toBe(mockNeuron.votingPower);
     });
   });
 });


### PR DESCRIPTION
# Motivation

User sees voting power of the proposal ballot instead of neuron voting power in the Proposal Detail.

# Changes

* Pass the proposal to the util "selectedNeuronsVotingPower".
* Add prop proposalInfo to VotingNeuronsSelect.
* New util "getVotingBallot".
* In VotesCard, use the voting power from the ballot instead of neuron's one.
* In VotingNeuronsSelect, use the voting power from the ballot instead of neuron's one.

# Tests

* Fix broken tests after changes.
* New test for getVotingBallot.
* Adapt tests to check the voting power of the ballots, not the neurons.
