### PR TITLE
feat: display account icp detailed value in a tooltip

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { accountName as getAccountName } from "../../utils/transactions.utils";
   import { i18n } from "../../stores/i18n";
-  import ICP from "../ic/ICP.svelte";
+  import ICPComponent from "../ic/ICP.svelte";
   import Identifier from "../ui/Identifier.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
   import { getContext } from "svelte";
@@ -12,6 +12,7 @@
   import { formatICP } from "../../utils/icp.utils";
   import Tooltip from "../ui/Tooltip.svelte";
   import { replacePlaceholders } from "../../utils/i18n.utils";
+  import {ICP} from '@dfinity/nns';
 
   const { store } = getContext<SelectedAccountContext>(
     SELECTED_ACCOUNT_CONTEXT_KEY
@@ -23,9 +24,12 @@
     mainName: $i18n.accounts.main,
   });
 
+  let accountBalance: ICP;
+  $: accountBalance = $store.account?.balance ?? ICP.fromString("0") as ICP;
+
   let detailedICP: string;
   $: detailedICP = formatICP({
-    value: ($store.account?.balance ?? ICP.fromString("0")).toE8s(),
+    value: accountBalance.toE8s(),
     detailed: true,
   });
 </script>
@@ -41,19 +45,19 @@
       }
     )}
   >
-    <ICP icp={$store.account.balance} />
+    <ICPComponent icp={accountBalance} />
   </Tooltip>
 </div>
 <div class="address">
   <Identifier
-    identifier={$store.account.identifier}
+    identifier={$store.account?.identifier ?? ""}
     label={$i18n.wallet.address}
     showCopy
     size="medium"
   />
   {#if isAccountHardwareWallet($store.account)}
     <Identifier
-      identifier={$store.account.principal?.toString() ?? ""}
+      identifier={$store.account?.principal?.toString() ?? ""}
       label={$i18n.wallet.principal}
       showCopy
     />

--- a/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
@@ -9,6 +9,9 @@
     SELECTED_ACCOUNT_CONTEXT_KEY,
     type SelectedAccountContext,
   } from "../../types/selected-account.context";
+  import { formatICP } from "../../utils/icp.utils";
+  import Tooltip from "../ui/Tooltip.svelte";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
 
   const { store } = getContext<SelectedAccountContext>(
     SELECTED_ACCOUNT_CONTEXT_KEY
@@ -19,11 +22,27 @@
     account: $store.account,
     mainName: $i18n.accounts.main,
   });
+
+  let detailedICP: string;
+  $: detailedICP = formatICP({
+    value: ($store.account?.balance ?? ICP.fromString("0")).toE8s(),
+    detailed: true,
+  });
 </script>
 
 <div class="title">
   <h1>{accountName}</h1>
-  <ICP icp={$store.account.balance} />
+  <Tooltip
+    id="wallet-detailed-icp"
+    text={replacePlaceholders(
+      $i18n.accounts.current_balance_detail,
+      {
+        $amount: detailedICP,
+      }
+    )}
+  >
+    <ICP icp={$store.account.balance} />
+  </Tooltip>
 </div>
 <div class="address">
   <Identifier

--- a/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { accountName as getAccountName } from "../../utils/transactions.utils";
+  import { i18n } from "../../stores/i18n";
+  import ICP from "../ic/ICP.svelte";
+  import Identifier from "../ui/Identifier.svelte";
+  import { isAccountHardwareWallet } from "../../utils/accounts.utils";
+  import { getContext } from "svelte";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    type SelectedAccountContext,
+  } from "../../types/selected-account.context";
+
+  const { store } = getContext<SelectedAccountContext>(
+    SELECTED_ACCOUNT_CONTEXT_KEY
+  );
+
+  let accountName: string;
+  $: accountName = getAccountName({
+    account: $store.account,
+    mainName: $i18n.accounts.main,
+  });
+</script>
+
+<div class="title">
+  <h1>{accountName}</h1>
+  <ICP icp={$store.account.balance} />
+</div>
+<div class="address">
+  <Identifier
+    identifier={$store.account.identifier}
+    label={$i18n.wallet.address}
+    showCopy
+    size="medium"
+  />
+  {#if isAccountHardwareWallet($store.account)}
+    <Identifier
+      identifier={$store.account.principal?.toString() ?? ""}
+      label={$i18n.wallet.principal}
+      showCopy
+    />
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "../../themes/mixins/media.scss";
+
+  .title {
+    display: block;
+    width: 100%;
+
+    margin: var(--padding-2x) 0;
+
+    --icp-font-size: var(--font-size-h1);
+
+    // Minimum height of ICP value + ICP label (ICP component)
+    min-height: calc(
+      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
+    );
+
+    @include media.min-width(medium) {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+  }
+
+  .address {
+    margin-bottom: var(--padding-4x);
+    :global(p:first-of-type) {
+      color: var(--gray-50);
+      margin-bottom: var(--padding);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -69,6 +69,7 @@
 <style lang="scss">
   .tooltip-wrapper {
     position: relative;
+    display: inline-block;
   }
 
   .tooltip {

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -154,7 +154,8 @@
     "hardware_wallet_add_hotkey_title": "Confirm Addition of Hotkey",
     "hardware_wallet_add_hotkey_text_neuron": "This action will add your NNS dapp principal as a hotkey to neuron $neuronId.",
     "hardware_wallet_add_hotkey_text_principal": "Your NNS dapp principal is: $principalId",
-    "hardware_wallet_add_hotkey_text_confirm": "Are you sure you want to continue?"
+    "hardware_wallet_add_hotkey_text_confirm": "Are you sure you want to continue?",
+    "current_balance_detail": "Current balance: $amount ICP"
   },
   "neurons": {
     "title": "Neurons",

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -164,6 +164,7 @@ interface I18nAccounts {
   hardware_wallet_add_hotkey_text_neuron: string;
   hardware_wallet_add_hotkey_text_principal: string;
   hardware_wallet_add_hotkey_text_confirm: string;
+  current_balance_detail: string;
 }
 
 interface I18nNeurons {

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -15,15 +15,13 @@
   } from "../lib/services/accounts.services";
   import { accountsStore } from "../lib/stores/accounts.store";
   import Spinner from "../lib/components/ui/Spinner.svelte";
-  import Identifier from "../lib/components/ui/Identifier.svelte";
-  import ICP from "../lib/components/ic/ICP.svelte";
   import type { AccountIdentifier } from "@dfinity/nns/dist/types/types/common";
   import { toastsStore } from "../lib/stores/toasts.store";
   import { replacePlaceholders } from "../lib/utils/i18n.utils";
   import type { Account } from "../lib/types/account";
   import { writable } from "svelte/store";
   import WalletActions from "../lib/components/accounts/WalletActions.svelte";
-  import { accountName as getAccountName } from "../lib/utils/transactions.utils";
+  import WalletSummary from "../lib/components/accounts/WalletSummary.svelte";
   import { busy } from "../lib/stores/busy.store";
   import TransactionList from "../lib/components/accounts/TransactionList.svelte";
   import {
@@ -33,7 +31,6 @@
   } from "../lib/types/selected-account.context";
   import {
     getAccountFromStore,
-    isAccountHardwareWallet,
   } from "../lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "../lib/stores/debug.store";
 
@@ -116,12 +113,6 @@
       }
     })();
 
-  let accountName: string;
-  $: accountName = getAccountName({
-    account: selectedAccount,
-    mainName: $i18n.accounts.main,
-  });
-
   let showNewTransactionModal = false;
 
   // TODO(L2-581): Create WalletInfo component
@@ -133,26 +124,7 @@
 
     <section>
       {#if $selectedAccountStore.account !== undefined}
-        <div class="title">
-          <h1>{accountName}</h1>
-          <ICP icp={$selectedAccountStore.account.balance} />
-        </div>
-        <div class="address">
-          <Identifier
-            identifier={$selectedAccountStore.account.identifier}
-            label={$i18n.wallet.address}
-            showCopy
-            size="medium"
-          />
-          {#if isAccountHardwareWallet($selectedAccountStore.account)}
-            <Identifier
-              identifier={$selectedAccountStore.account.principal?.toString() ??
-                ""}
-              label={$i18n.wallet.principal}
-              showCopy
-            />
-          {/if}
-        </div>
+        <WalletSummary />
         <div class="actions">
           <WalletActions />
         </div>
@@ -183,35 +155,6 @@
 {/if}
 
 <style lang="scss">
-  @use "../lib/themes/mixins/media.scss";
-
-  .title {
-    display: block;
-    width: 100%;
-
-    margin: var(--padding-2x) 0;
-
-    --icp-font-size: var(--font-size-h1);
-
-    // Minimum height of ICP value + ICP label (ICP component)
-    min-height: calc(
-      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
-    );
-
-    @include media.min-width(medium) {
-      display: inline-flex;
-      justify-content: space-between;
-      align-items: baseline;
-    }
-  }
-
-  .address {
-    margin-bottom: var(--padding-4x);
-    :global(p:first-of-type) {
-      color: var(--gray-50);
-      margin-bottom: var(--padding);
-    }
-  }
   .actions {
     margin-bottom: var(--padding-3x);
     display: flex;

--- a/frontend/svelte/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import { writable } from "svelte/store";
+import WalletSummary from "../../../../lib/components/accounts/WalletSummary.svelte";
+import {
+  SELECTED_ACCOUNT_CONTEXT_KEY,
+  type SelectedAccountContext,
+  type SelectedAccountStore,
+} from "../../../../lib/types/selected-account.context";
+import { formatICP } from "../../../../lib/utils/icp.utils";
+import { mockMainAccount } from "../../../mocks/accounts.store.mock";
+import en from "../../../mocks/i18n.mock";
+import ContextWrapperTest from "../ContextWrapperTest.svelte";
+
+describe("WalletSummary", () => {
+  const renderWalletSummary = () =>
+    render(ContextWrapperTest, {
+      props: {
+        contextKey: SELECTED_ACCOUNT_CONTEXT_KEY,
+        contextValue: {
+          store: writable<SelectedAccountStore>({
+            account: mockMainAccount,
+            transactions: undefined,
+          }),
+        } as SelectedAccountContext,
+        Component: WalletSummary,
+      },
+    });
+
+  it("should render title", () => {
+    const { getByText } = renderWalletSummary();
+
+    expect(getByText(en.accounts.main)).toBeInTheDocument();
+  });
+
+  it("should render an account identifier", () => {
+    const { getByText } = renderWalletSummary();
+
+    expect(
+      getByText(mockMainAccount.identifier, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render a balance in ICP", () => {
+    const { getByText, queryByTestId } = renderWalletSummary();
+
+    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
+
+    expect(icp?.innerHTML).toEqual(
+      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+    );
+    expect(getByText(`ICP`)).toBeTruthy();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -10,6 +10,7 @@ import {
   type SelectedAccountContext,
   type SelectedAccountStore,
 } from "../../../../lib/types/selected-account.context";
+import { replacePlaceholders } from "../../../../lib/utils/i18n.utils";
 import { formatICP } from "../../../../lib/utils/icp.utils";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
@@ -53,5 +54,28 @@ describe("WalletSummary", () => {
       `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
     );
     expect(getByText(`ICP`)).toBeTruthy();
+  });
+
+  it("should contain a tooltip", () => {
+    const { container } = renderWalletSummary();
+
+    expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
+  });
+
+  it("should render a detailed balance in ICP in a tooltip", () => {
+    const { container } = renderWalletSummary();
+
+    const icp: HTMLDivElement | null = container.querySelector(
+      "#wallet-detailed-icp"
+    );
+
+    expect(icp?.textContent).toEqual(
+      replacePlaceholders(en.accounts.current_balance_detail, {
+        $amount: `${formatICP({
+          value: mockMainAccount.balance.toE8s(),
+          detailed: true,
+        })}`,
+      })
+    );
   });
 });

--- a/frontend/svelte/src/tests/routes/Wallet.spec.ts
+++ b/frontend/svelte/src/tests/routes/Wallet.spec.ts
@@ -50,7 +50,7 @@ describe("Wallet", () => {
   };
 
   describe("loading", () => {
-    it("should render title", async () => {
+    it("should render title", () => {
       const { getAllByText } = render(Wallet);
 
       expect(getAllByText(en.wallet.title).length).toBeGreaterThan(0);


### PR DESCRIPTION
# Motivation

On "Wallet" page only, display account ICP value in a detailed way and in a tooltip.

# Changes

- refactor wallet summary to dedicated `<WalletSummary />` component
- use `<Tooltip />` to display detailed ICP value
- style tootlip to `inline-block` to align tooltip correctly on column display

# Screenshots

<img width="1510" alt="Capture d’écran 2022-06-13 à 08 35 05" src="https://user-images.githubusercontent.com/16886711/173294008-d7699753-8456-4d14-81d8-6178aa982db5.png">
<img width="1510" alt="Capture d’écran 2022-06-13 à 08 35 16" src="https://user-images.githubusercontent.com/16886711/173294021-7886b104-ba59-404e-8b9b-41c712a786dd.png">
<img width="1510" alt="Capture d’écran 2022-06-13 à 08 35 30" src="https://user-images.githubusercontent.com/16886711/173294039-916a3683-7cf9-43aa-8f5e-83640044133c.png">

