### PR TITLE
L2-679: Improve merge maturity error with HW

### DIFF
--- a/frontend/svelte/src/lib/constants/neurons.constants.ts
+++ b/frontend/svelte/src/lib/constants/neurons.constants.ts
@@ -7,3 +7,5 @@ export const MAX_NEURONS_MERGED = 2;
 export const MIN_MATURITY_MERGE = TRANSACTION_FEE_E8S;
 export const MIN_NEURON_STAKE = E8S_PER_ICP;
 export const MAX_CONCURRENCY = 10;
+
+export const MIN_VERSION_MERGE_MATURITY = "2.0.6";

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -475,6 +475,7 @@
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right wallet?",
     "user_cancel": "User denied the access to use the ledger device.",
     "user_rejected_transaction": "The transaction was rejected on the ledger device.",
+    "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to $minVersion.",
     "incorrect_identifier": "Wallet account identifier doesn't match. Are you sure you connected the right wallet? Expected identifier: $identifier. Wallet identifier: $ledgerIdentifier."
   },
   "error__attach_wallet": {

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -185,8 +185,8 @@ export const assertLedgerVersion = async ({
     return;
   }
 
-  const response = await identity.getVersion();
-  const currentVersion = `${response.major}.${response.minor}.${response.patch}`;
+  const { major, minor, patch } = await identity.getVersion();
+  const currentVersion = `${major}.${minor}.${patch}`;
   if (smallerVersion({ currentVersion, minVersion })) {
     const labels = get(i18n);
     throw new LedgerErrorMessage(

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -11,6 +11,7 @@ import { LedgerErrorKey, LedgerErrorMessage } from "../types/ledger.errors";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { toToastError } from "../utils/error.utils";
 import { replacePlaceholders } from "../utils/i18n.utils";
+import { isSmallerVersion } from "../utils/utils";
 import { syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 
@@ -169,5 +170,30 @@ export const listNeuronsHardwareWallet = async (): Promise<{
       fallbackErrorLabelKey,
     });
     return { neurons: [], err: fallbackErrorLabelKey };
+  }
+};
+
+export const assertLedgerVersion = async ({
+  identity,
+  minVersion,
+}: {
+  identity: Identity | LedgerIdentity;
+  minVersion: string;
+}): Promise<void> => {
+  // Ignore when identity not LedgerIdentity
+  if (!(identity instanceof LedgerIdentity)) {
+    return;
+  }
+
+  const response = await identity.getVersion();
+  const currentVersion = `${response.major}.${response.minor}.${response.patch}`;
+  if (isSmallerVersion({ currentVersion, minVersion })) {
+    const labels = get(i18n);
+    throw new LedgerErrorMessage(
+      replacePlaceholders(labels.error__ledger.version_not_supported, {
+        $minVersion: minVersion,
+        $currentVersion: currentVersion,
+      })
+    );
   }
 };

--- a/frontend/svelte/src/lib/services/ledger.services.ts
+++ b/frontend/svelte/src/lib/services/ledger.services.ts
@@ -11,7 +11,7 @@ import { LedgerErrorKey, LedgerErrorMessage } from "../types/ledger.errors";
 import { hashCode, logWithTimestamp } from "../utils/dev.utils";
 import { toToastError } from "../utils/error.utils";
 import { replacePlaceholders } from "../utils/i18n.utils";
-import { isSmallerVersion } from "../utils/utils";
+import { smallerVersion } from "../utils/utils";
 import { syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 
@@ -187,7 +187,7 @@ export const assertLedgerVersion = async ({
 
   const response = await identity.getVersion();
   const currentVersion = `${response.major}.${response.minor}.${response.patch}`;
-  if (isSmallerVersion({ currentVersion, minVersion })) {
+  if (smallerVersion({ currentVersion, minVersion })) {
     const labels = get(i18n);
     throw new LedgerErrorMessage(
       replacePlaceholders(labels.error__ledger.version_not_supported, {

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -31,7 +31,10 @@ import { getNeuronBalance } from "../api/ledger.api";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "../constants/environment.constants";
 import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
-import { MAX_CONCURRENCY } from "../constants/neurons.constants";
+import {
+  MAX_CONCURRENCY,
+  MIN_VERSION_MERGE_MATURITY,
+} from "../constants/neurons.constants";
 import type { LedgerIdentity } from "../identities/ledger.identity";
 import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "../stores/busy.store";
@@ -687,7 +690,10 @@ export const mergeMaturity = async ({
       neuronId
     );
 
-    await assertLedgerVersion({ identity, minVersion: "2.0.6" });
+    await assertLedgerVersion({
+      identity,
+      minVersion: MIN_VERSION_MERGE_MATURITY,
+    });
 
     await mergeMaturityApi({ neuronId, percentageToMerge, identity });
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -64,6 +64,7 @@ import {
   syncAccounts,
 } from "./accounts.services";
 import { getIdentity } from "./auth.services";
+import { assertLedgerVersion } from "./ledger.services";
 import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 
 const getIdentityAndNeuronHelper = async (
@@ -685,6 +686,8 @@ export const mergeMaturity = async ({
     const identity: Identity = await getIdentityOfControllerByNeuronId(
       neuronId
     );
+
+    await assertLedgerVersion({ identity, minVersion: "2.0.6" });
 
     await mergeMaturityApi({ neuronId, percentageToMerge, identity });
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -502,6 +502,7 @@ interface I18nError__ledger {
   unexpected_wallet: string;
   user_cancel: string;
   user_rejected_transaction: string;
+  version_not_supported: string;
   incorrect_identifier: string;
 }
 

--- a/frontend/svelte/src/lib/utils/error.utils.ts
+++ b/frontend/svelte/src/lib/utils/error.utils.ts
@@ -15,6 +15,7 @@ import {
 } from "../canisters/cmc/cmc.errors";
 import { UserNotTheControllerError } from "../canisters/ic-management/ic-management.errors";
 import { InsufficientAmountError } from "../types/common.errors";
+import { LedgerErrorMessage } from "../types/ledger.errors";
 import {
   CannotBeMerged,
   InvalidAmountError,
@@ -42,6 +43,14 @@ const factoryMappingErrorToToastMessage =
       err: error,
       fallbackErrorLabelKey: testFallbackKey,
     });
+    if (error instanceof LedgerErrorMessage) {
+      return {
+        level: "error",
+        // Label key not needed, the transation is already in the message of the error
+        labelKey: "",
+        detail: error.message,
+      };
+    }
     // Return if error found is not fallback
     if (toastError.labelKey !== testFallbackKey) {
       return {

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -167,7 +167,7 @@ const addZeros = (nums: number[], amountZeros: number): number[] => {
  * @param currentVersion Ex: "2.0.0"
  * @returns boolean
  */
-export const isSmallerVersion = ({
+export const smallerVersion = ({
   minVersion,
   currentVersion,
 }: {

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -154,13 +154,10 @@ export const mapPromises = async <T, R>(
 export const isArrayEmpty = <T>({ length }: T[]): boolean => length === 0;
 
 const AMOUNT_VERSION_PARTS = 3;
-const addZeros = (nums: number[], amountZeros: number): number[] => {
-  const newNumbers = [...nums];
-  while (newNumbers.length < amountZeros) {
-    newNumbers.push(0);
-  }
-  return newNumbers;
-};
+const addZeros = (nums: number[], amountZeros: number): number[] =>
+  amountZeros > nums.length
+    ? [...nums, ...[...Array(amountZeros - nums.length).keys()].map(() => 0)]
+    : nums;
 /**
  * Returns true if the current version is smaller than the minVersion, false if equal or bigger.
  *

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -152,3 +152,52 @@ export const mapPromises = async <T, R>(
 };
 
 export const isArrayEmpty = <T>({ length }: T[]): boolean => length === 0;
+
+const addZeros = (nums: number[], amountZeros: number): number[] => {
+  const newNumbers = [...nums];
+  while (newNumbers.length < amountZeros) {
+    newNumbers.push(0);
+  }
+  return newNumbers;
+};
+/**
+ * Returns true if the current version is smaller than the minVersion, false if equal or bigger.
+ *
+ * @param minVersion Ex: "1.0.0"
+ * @param currentVersion Ex: "2.0.0"
+ * @returns boolean
+ */
+export const isSmallerVersion = ({
+  minVersion,
+  currentVersion,
+}: {
+  minVersion: string;
+  currentVersion: string;
+}): boolean => {
+  const [minMajor, minMinor, minPatch] = addZeros(
+    minVersion.split(".").map(Number),
+    3
+  );
+  const [currentMajor, currentMinor, currentPatch] = addZeros(
+    currentVersion.split(".").map(Number),
+    3
+  );
+  // Check major version
+  if (currentMajor < minMajor) {
+    return true;
+  }
+  if (currentMajor > minMajor) {
+    return false;
+  }
+  // Major versions match
+  // Check minor version
+  if (currentMinor < minMinor) {
+    return true;
+  }
+  if (currentMinor > minMinor) {
+    return false;
+  }
+  // Minor version match
+  // Check patch version
+  return currentPatch < minPatch;
+};

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -153,6 +153,7 @@ export const mapPromises = async <T, R>(
 
 export const isArrayEmpty = <T>({ length }: T[]): boolean => length === 0;
 
+const AMOUNT_VERSION_PARTS = 3;
 const addZeros = (nums: number[], amountZeros: number): number[] => {
   const newNumbers = [...nums];
   while (newNumbers.length < amountZeros) {
@@ -174,30 +175,20 @@ export const smallerVersion = ({
   minVersion: string;
   currentVersion: string;
 }): boolean => {
-  const [minMajor, minMinor, minPatch] = addZeros(
+  const minVersionStandarized = addZeros(
     minVersion.split(".").map(Number),
-    3
-  );
-  const [currentMajor, currentMinor, currentPatch] = addZeros(
+    AMOUNT_VERSION_PARTS
+  ).join(".");
+  const currentVersionStandarized = addZeros(
     currentVersion.split(".").map(Number),
-    3
+    AMOUNT_VERSION_PARTS
+  ).join(".");
+  // Versions need to have the same number of parts to be comparable
+  // Source: https://stackoverflow.com/a/65687141
+  return (
+    currentVersionStandarized.localeCompare(minVersionStandarized, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }) < 0
   );
-  // Check major version
-  if (currentMajor < minMajor) {
-    return true;
-  }
-  if (currentMajor > minMajor) {
-    return false;
-  }
-  // Major versions match
-  // Check minor version
-  if (currentMinor < minMinor) {
-    return true;
-  }
-  if (currentMinor > minMinor) {
-    return false;
-  }
-  // Minor version match
-  // Check patch version
-  return currentPatch < minPatch;
 };

--- a/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
@@ -1,5 +1,6 @@
 import type { HttpAgent } from "@dfinity/agent";
 import { principalToAccountIdentifier } from "@dfinity/nns";
+import { LedgerError, type ResponseVersion } from "@zondax/ledger-icp";
 import { mock } from "jest-mock-extended";
 import * as api from "../../../lib/api/governance.api";
 import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
@@ -8,6 +9,7 @@ import { LedgerIdentity } from "../../../lib/identities/ledger.identity";
 import * as accountsServices from "../../../lib/services/accounts.services";
 import * as authServices from "../../../lib/services/auth.services";
 import {
+  assertLedgerVersion,
   connectToHardwareWallet,
   getLedgerIdentity,
   listNeuronsHardwareWallet,
@@ -16,12 +18,16 @@ import {
 } from "../../../lib/services/ledger.services";
 import { authStore } from "../../../lib/stores/auth.store";
 import { toastsStore } from "../../../lib/stores/toasts.store";
-import { LedgerErrorKey } from "../../../lib/types/ledger.errors";
+import {
+  LedgerErrorKey,
+  LedgerErrorMessage,
+} from "../../../lib/types/ledger.errors";
 import * as agent from "../../../lib/utils/agent.utils";
 import { replacePlaceholders } from "../../../lib/utils/i18n.utils";
 import {
   mockAuthStoreSubscribe,
   mockGetIdentity,
+  mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
@@ -317,6 +323,88 @@ describe("ledger-services", () => {
 
         spyToastError.mockRestore();
       });
+    });
+  });
+
+  describe("assertLedgerVersion", () => {
+    it("should throw if ledger version is smaller than min version", async () => {
+      const minVersion = "2.0.6";
+      const versionResponse: ResponseVersion = {
+        returnCode: LedgerError.NoErrors,
+        testMode: true,
+        major: 1,
+        minor: 0,
+        patch: 10,
+        deviceLocked: false,
+        targetId: "test",
+      };
+      const identity = await MockLedgerIdentity.create({
+        version: versionResponse,
+      });
+
+      const call = () =>
+        assertLedgerVersion({
+          identity,
+          minVersion,
+        });
+      expect(call).rejects.toThrow(LedgerErrorMessage);
+    });
+
+    it("should not throw if ledger version is larger than min version", async () => {
+      const minVersion = "2.0.6";
+      const versionResponse: ResponseVersion = {
+        returnCode: LedgerError.NoErrors,
+        testMode: true,
+        major: 3,
+        minor: 0,
+        patch: 10,
+        deviceLocked: false,
+        targetId: "test",
+      };
+      const identity = await MockLedgerIdentity.create({
+        version: versionResponse,
+      });
+
+      const call = () =>
+        assertLedgerVersion({
+          identity,
+          minVersion,
+        });
+      expect(call).not.toThrow(LedgerErrorMessage);
+    });
+
+    it("should not throw if ledger version is the same as min version", async () => {
+      const minVersion = "2.0.6";
+      const versionResponse: ResponseVersion = {
+        returnCode: LedgerError.NoErrors,
+        testMode: true,
+        major: 2,
+        minor: 0,
+        patch: 6,
+        deviceLocked: false,
+        targetId: "test",
+      };
+      const identity = await MockLedgerIdentity.create({
+        version: versionResponse,
+      });
+
+      const call = () =>
+        assertLedgerVersion({
+          identity,
+          minVersion,
+        });
+      expect(call).not.toThrow(LedgerErrorMessage);
+    });
+
+    it("should not throw if identity is not LedgerIdentity", async () => {
+      const minVersion = "2.0.6";
+
+      const call = () =>
+        assertLedgerVersion({
+          identity: mockIdentity,
+          minVersion,
+        });
+      expect(call).not.toThrow(LedgerErrorMessage);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -5,6 +5,7 @@ import {
   isDefined,
   isHash,
   isNullable,
+  isSmallerVersion,
   nonNullable,
   stringifyJson,
   uniqueObjects,
@@ -214,6 +215,105 @@ describe("utils", () => {
       expect(isHash(bytes(""))).toBe(false);
       expect(isHash(bytes(NaN))).toBe(false);
       expect(isHash(bytes(Infinity))).toBe(false);
+    });
+  });
+
+  describe("isSmallerVersion", () => {
+    it("returns true if current version is smaller than min version", () => {
+      expect(
+        isSmallerVersion({
+          minVersion: "1.0",
+          currentVersion: "0.0.9",
+        })
+      ).toBe(true);
+      expect(
+        isSmallerVersion({
+          minVersion: "2.0.0",
+          currentVersion: "1.9.9",
+        })
+      ).toBe(true);
+      expect(
+        isSmallerVersion({
+          minVersion: "2.1.5",
+          currentVersion: "2.1.4",
+        })
+      ).toBe(true);
+      expect(
+        isSmallerVersion({
+          minVersion: "2.1.5",
+          currentVersion: "1.8.9",
+        })
+      ).toBe(true);
+      expect(
+        isSmallerVersion({
+          minVersion: "2",
+          currentVersion: "1",
+        })
+      ).toBe(true);
+    });
+    it("returns false if current version is bigger than min version", () => {
+      expect(
+        isSmallerVersion({
+          minVersion: "0.0.9",
+          currentVersion: "1.0",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "1.9.9",
+          currentVersion: "2.0.0",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "2.1.4",
+          currentVersion: "2.1.5",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "1.8.9",
+          currentVersion: "2.1.5",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "1",
+          currentVersion: "2",
+        })
+      ).toBe(false);
+    });
+    it("returns false if current version is same as min version", () => {
+      expect(
+        isSmallerVersion({
+          minVersion: "1",
+          currentVersion: "1.0",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "2",
+          currentVersion: "2.0.0",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "2.1.4",
+          currentVersion: "2.1.4",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "1.0.0",
+          currentVersion: "1",
+        })
+      ).toBe(false);
+      expect(
+        isSmallerVersion({
+          minVersion: "13.4.5",
+          currentVersion: "13.4.5",
+        })
+      ).toBe(false);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -5,8 +5,8 @@ import {
   isDefined,
   isHash,
   isNullable,
-  isSmallerVersion,
   nonNullable,
+  smallerVersion,
   stringifyJson,
   uniqueObjects,
 } from "../../../lib/utils/utils";
@@ -218,34 +218,34 @@ describe("utils", () => {
     });
   });
 
-  describe("isSmallerVersion", () => {
+  describe("smallerVersion", () => {
     it("returns true if current version is smaller than min version", () => {
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1.0",
           currentVersion: "0.0.9",
         })
       ).toBe(true);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2.0.0",
           currentVersion: "1.9.9",
         })
       ).toBe(true);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2.1.5",
           currentVersion: "2.1.4",
         })
       ).toBe(true);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2.1.5",
           currentVersion: "1.8.9",
         })
       ).toBe(true);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2",
           currentVersion: "1",
         })
@@ -253,31 +253,31 @@ describe("utils", () => {
     });
     it("returns false if current version is bigger than min version", () => {
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "0.0.9",
           currentVersion: "1.0",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1.9.9",
           currentVersion: "2.0.0",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2.1.4",
           currentVersion: "2.1.5",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1.8.9",
           currentVersion: "2.1.5",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1",
           currentVersion: "2",
         })
@@ -285,31 +285,31 @@ describe("utils", () => {
     });
     it("returns false if current version is same as min version", () => {
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1",
           currentVersion: "1.0",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2",
           currentVersion: "2.0.0",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "2.1.4",
           currentVersion: "2.1.4",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "1.0.0",
           currentVersion: "1",
         })
       ).toBe(false);
       expect(
-        isSmallerVersion({
+        smallerVersion({
           minVersion: "13.4.5",
           currentVersion: "13.4.5",
         })

--- a/frontend/svelte/src/tests/mocks/ledger.identity.mock.ts
+++ b/frontend/svelte/src/tests/mocks/ledger.identity.mock.ts
@@ -1,3 +1,4 @@
+import type { ResponseVersion } from "@zondax/ledger-icp";
 import { LEDGER_DEFAULT_DERIVE_PATH } from "../../lib/constants/ledger.constants";
 import { LedgerIdentity } from "../../lib/identities/ledger.identity";
 import { Secp256k1PublicKey } from "../../lib/keys/secp256k1";
@@ -20,18 +21,27 @@ export const testSecp256k1Vectors: Array<[string, string]> = [
 export const mockLedgerIdentifier =
   "4f3d4b40cdb852732601fccf8bd24dffe44957a647cb867913e982d98cf85676";
 
+type MockIdentityOptions = {
+  version?: ResponseVersion;
+};
 // eslint-disable-next-line
 // @ts-ignore: test file
 export class MockLedgerIdentity extends LedgerIdentity {
-  constructor() {
+  constructor({ version }: MockIdentityOptions = {}) {
     // @ts-ignore - we do not use the service for mocking purpose
     super(
       LEDGER_DEFAULT_DERIVE_PATH,
       Secp256k1PublicKey.fromRaw(fromHexString(rawPublicKeyHex))
     );
+
+    if (version !== undefined) {
+      this.getVersion = () => Promise.resolve(version);
+    }
   }
 
-  public static async create(): Promise<LedgerIdentity> {
-    return new MockLedgerIdentity();
+  public static async create(
+    options: MockIdentityOptions = {}
+  ): Promise<LedgerIdentity> {
+    return new MockLedgerIdentity(options);
   }
 }


### PR DESCRIPTION
# Motivation

User sees proper error when merging maturity of a HW neuron with old version.

# Changes

* Add ledger service "assertLedgerVersion" that throws if Ledger version is less than minVersion.
* Use ledger service in "mergeMaturity" service.
* New util "smallerVersion" that returns boolean comparing two versions.
* Manage LedgerErrorMessage type errors separately in error mapping.

# Tests

* Test for new util.
* Test for new ledger service.
