### PR TITLE
Fix: Round to 8 decimals when Selecting Cycles

### DIFF
--- a/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -21,19 +21,25 @@
   const setCycles = () =>
     (amountCycles =
       amount !== undefined && icpToCyclesExchangeRate !== undefined
-        ? convertIcpToTCycles({
-            icpNumber: amount,
-            exchangeRate: icpToCyclesExchangeRate,
-          })
+        ? // ICP Input misbehaves with more than eight decimals
+          Number(
+            convertIcpToTCycles({
+              icpNumber: amount,
+              exchangeRate: icpToCyclesExchangeRate,
+            }).toFixed(8)
+          )
         : undefined);
 
   const setAmount = () =>
     (amount =
       amountCycles !== undefined && icpToCyclesExchangeRate !== undefined
-        ? convertTCyclesToIcpNumber({
-            tCycles: amountCycles,
-            exchangeRate: icpToCyclesExchangeRate,
-          })
+        ? // ICP Input misbehaves with more than eight decimals
+          Number(
+            convertTCyclesToIcpNumber({
+              tCycles: amountCycles,
+              exchangeRate: icpToCyclesExchangeRate,
+            }).toFixed(8)
+          )
         : undefined);
 
   $: amount,


### PR DESCRIPTION
# Motivation

Round to eight decimal places while the user selects ICP or Cycles to avoid weird behavior with Input type="icp".

# Changes

* After converting ICP or Cycles to the other, round to only 8 decimals.

# Tests

UI Change.
