### PR TITLE
Move the canisters tab to svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ This environment varibale controls whether the svelte or flutter implementation 
 | `REDIRECT_` | Login     | Accounts tab | Neurons tab | Proposals tab | Canisters tab |
 | `TO_LEGACY` | page      |              |             |               |               |
 |-------------|-----------|--------------|-------------|---------------|---------------|
-| prod        | svelte    | flutter      | flutter     | flutter       | flutter       |
-| staging     | svelte    | flutter      | flutter     | svelte        | flutter       |
+| prod        | svelte    | svelte       | svelte      | svelte        | svelte        |
+| staging     | svelte    | svelte       | svelte      | svelte        | svelte        |
 | svelte      | svelte    | svelte       | svelte      | svelte        | svelte        |
 | flutter     | svelte    | flutter      | flutter     | flutter       | flutter       |
 | both        | svelte    | both         | both        | both          | both          |

--- a/deploy.sh
+++ b/deploy.sh
@@ -220,8 +220,7 @@ if [[ "$POPULATE" == "true" ]]; then
   # Create users and neurons
   # Note: Cannot be used with flutter.
   REDIRECT_TO_LEGACY="$(jq -re .REDIRECT_TO_LEGACY frontend/ts/src/config.json)"
-  [[ "$REDIRECT_TO_LEGACY" == "prod" ]] ||
-    [[ "$REDIRECT_TO_LEGACY" == "flutter" ]] || {
+  [[ "$REDIRECT_TO_LEGACY" == "flutter" ]] || {
     echo Creating users and neurons...
     pushd e2e-tests
     npm ci

--- a/e2e-tests/specs/redirect-to-legacy.e2e.ts
+++ b/e2e-tests/specs/redirect-to-legacy.e2e.ts
@@ -11,26 +11,26 @@ import { skipUnlessBrowserIs } from "../common/test";
 const REDIRECTS = {
   [RedirectToLegacy.prod]: {
     [RouteHash.Accounts]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Neurons]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Proposals]: {
       [FrontendPath.Flutter]: FrontendPath.Svelte,
       [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Canisters]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
   },
   [RedirectToLegacy.staging]: {
     [RouteHash.Accounts]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Neurons]: {
       [FrontendPath.Flutter]: FrontendPath.Svelte,
@@ -41,8 +41,8 @@ const REDIRECTS = {
       [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
     [RouteHash.Canisters]: {
-      [FrontendPath.Flutter]: FrontendPath.Flutter,
-      [FrontendPath.Svelte]: FrontendPath.Flutter,
+      [FrontendPath.Flutter]: FrontendPath.Svelte,
+      [FrontendPath.Svelte]: FrontendPath.Svelte,
     },
   },
   [RedirectToLegacy.flutter]: {

--- a/frontend/dart/lib/data/env.dart
+++ b/frontend/dart/lib/data/env.dart
@@ -2,4 +2,4 @@ const REDIRECT_TO_LEGACY = String.fromEnvironment('REDIRECT_TO_LEGACY');
 bool showAccountsRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }
 bool showNeuronsRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }
 bool showProposalsRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }
-bool showCanistersRoute() { return ["flutter", "both", "prod", "staging"].contains(REDIRECT_TO_LEGACY); }
+bool showCanistersRoute() { return ["flutter", "both"].contains(REDIRECT_TO_LEGACY); }

--- a/frontend/dart/web/index.html
+++ b/frontend/dart/web/index.html
@@ -108,7 +108,7 @@
       }
     </style>
     <script src="logout.js" type="application/javascript"></script>
-    <script> document.location.hash.startsWith("#/canisters") || document.location.pathname.startsWith("/v2/") || document.location.pathname = "/v2/";
+    <script> document.location.pathname.startsWith("/v2/") || document.location.pathname = "/v2/";
     </script>
   </head>
   <body>

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -29,9 +29,12 @@ export const SHOW_PROPOSALS_ROUTE = [
   "prod",
   "staging",
 ].includes(process.env.REDIRECT_TO_LEGACY as string);
-export const SHOW_CANISTERS_ROUTE = ["svelte", "both"].includes(
-  process.env.REDIRECT_TO_LEGACY as string
-);
+export const SHOW_CANISTERS_ROUTE = [
+  "svelte",
+  "both",
+  "prod",
+  "staging",
+].includes(process.env.REDIRECT_TO_LEGACY as string);
 export const SHOW_ANY_TABS =
   SHOW_ACCOUNTS_ROUTE ||
   SHOW_ACCOUNTS_ROUTE ||


### PR DESCRIPTION
# Motivation
We would like to release the svelte version of the canisters tab.

# Changes
* Update REDIRECT_TO_LEGACY so that prod and staging use the svelte version of the canisters tab.
* Update documentation.
* Enable testnet population for "prod" builds; this requires svelte.

# Tests
- See CI.
- Also, I will test this with the redirect e2e test against a deployment to the nns-dapp testnet.....  Testing...done. OK