### PR TITLE
L2-692: Detach canister remove extra notifications

### DIFF
--- a/frontend/svelte/src/lib/components/canister-detail/DetachCanisterButton.svelte
+++ b/frontend/svelte/src/lib/components/canister-detail/DetachCanisterButton.svelte
@@ -22,8 +22,7 @@
     stopBusy("detach-canister");
     close();
     if (success) {
-      toastsStore.show({
-        level: "success",
+      toastsStore.success({
         labelKey: "canister_detail.detach_success",
       });
       routeStore.replace({ path: AppPath.Canisters });

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -15,11 +15,12 @@ import type {
   CanisterSettings,
 } from "../canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "../canisters/nns-dapp/nns-dapp.types";
+import { AppPath } from "../constants/routes.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { Account } from "../types/account";
 import { InsufficientAmountError } from "../types/common.errors";
-import { getLastPathDetail } from "../utils/app-path.utils";
+import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { isController } from "../utils/canisters.utils";
 import {
   mapCanisterErrorToToastMessage,
@@ -265,6 +266,9 @@ export const detachCanister = async (
 export const routePathCanisterId = (
   path: string | undefined
 ): string | undefined => {
+  if (!isRoutePath({ path: AppPath.CanisterDetail, routePath: path })) {
+    return undefined;
+  }
   const canisterId: string | undefined = getLastPathDetail(path);
   return canisterId !== undefined && canisterId !== "" ? canisterId : undefined;
 };

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -144,7 +144,8 @@
     selectedCanister,
     canistersReady,
     (() => {
-      if (!canistersReady) {
+      // When detaching, this is also executed but there is no `routeCanisterId`.
+      if (!canistersReady || routeCanisterId === undefined) {
         return;
       }
 
@@ -174,11 +175,15 @@
 
       // handle unknown canister id from URL
       if (selectedCanister === undefined) {
-        toastsStore.error({
-          labelKey: replacePlaceholders($i18n.error.canister_not_found, {
-            $canister_id: routeCanisterId ?? "",
-          }),
-        });
+        // Show toast only it was not already present in the store
+        // for example, after detaching, the storeCanister is present, but not the selectedCanister
+        if (storeCanister === undefined) {
+          toastsStore.error({
+            labelKey: replacePlaceholders($i18n.error.canister_not_found, {
+              $canister_id: routeCanisterId ?? "",
+            }),
+          });
+        }
         goBack();
       }
     })();

--- a/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/canisters.services.spec.ts
@@ -307,6 +307,7 @@ describe("canisters-services", () => {
 
     it("should not get canister id from invalid path", () => {
       expect(routePathCanisterId("/#/canister/")).toBeUndefined();
+      expect(routePathCanisterId("/#/canisters")).toBeUndefined();
       expect(routePathCanisterId(undefined)).toBeUndefined();
     });
   });


### PR DESCRIPTION
# Motivation

User should not see error notifications after detaching a canister successfully.

# Changes

* "routePathCanisterId" checks whether the path is a Canister Detail path.
* Show error message of canister not found in CanisterDetails only if there was never a canister before.

# Tests

* Add test case in "routePathCanisterId".
