### PR TITLE
style: redo overflow-x on headless layout

### DIFF
--- a/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
+++ b/frontend/svelte/src/lib/components/common/HeadlessLayout.svelte
@@ -73,7 +73,9 @@
     position: absolute;
 
     inset: calc(var(--headless-layout-header-height)) 0 0;
-    overflow: auto;
+
+    overflow-y: auto;
+    overflow-x: hidden;
 
     background-color: var(--gray-50-background);
   }


### PR DESCRIPTION
# Motivation

"Neuron" detail page overflows again on mobile devices. Therefore we should redo the `overflow-x` on the headless layout even though we have improved the positioned of the tooltip that leads to this styling issue.