### PR TITLE
Fix: Revert Tooltip and add Padding

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/svelte/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -88,6 +88,7 @@
 <style lang="scss">
   .wrapper {
     position: relative;
+    padding-bottom: var(--padding-2x);
 
     display: flex;
     flex-direction: column;

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -69,7 +69,6 @@
 <style lang="scss">
   .tooltip-wrapper {
     position: relative;
-    display: inline-block;
   }
 
   .tooltip {


### PR DESCRIPTION
# Motivation

User sees NeuronCard of the same size when merging neurons.

# Changes

* Revert `display: inline-block;` in the Tooltip.
* Add padding bottom to merge neurons first screen to keep consistency.

# Tests

No test, UI fixes.
