### PR TITLE
style: adjust button line-height to support 2 lines of text in big bu…

### DIFF
--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -51,7 +51,7 @@ button {
     min-height: var(--button-min-height);
 
     font-size: var(--font-size-small);
-    line-height: 1.25;
+    line-height: var(--line-height-standard);
 
     @include media.min-width(medium) {
       font-size: var(--font-size-h3);

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -51,6 +51,7 @@ button {
     min-height: var(--button-min-height);
 
     font-size: var(--font-size-small);
+    line-height: 1.25;
 
     @include media.min-width(medium) {
       font-size: var(--font-size-h3);
@@ -59,6 +60,7 @@ button {
     &.small {
       min-height: inherit;
       font-size: inherit;
+      line-height: var(--line-height-title);
       padding: var(--padding-0_5x) var(--padding);
     }
   }


### PR DESCRIPTION
# Motivation

[Different Button Height on Safari iPhone 13 ](https://dfinity.atlassian.net/browse/L2-709)

# Changes

- line-height is adjusted to support 2 lines within normal height.

# Tests

## before
<img width="333" alt="image" src="https://user-images.githubusercontent.com/98811342/173804291-76389799-1f3f-47bd-9e02-954c5767fc5d.png">

## after
<img width="325" alt="image" src="https://user-images.githubusercontent.com/98811342/173804402-3a5df69a-5f1c-441c-ae66-36ef8a6c1c58.png">

### small buttons should look the same
<img width="408" alt="image" src="https://user-images.githubusercontent.com/98811342/173804458-b908f2a1-d0d4-4797-bd0b-2c5a63c39690.png">

