### PR TITLE
fix: tooltip breaking list of cards width

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/svelte/src/lib/components/accounts/WalletSummary.svelte
@@ -71,6 +71,7 @@
     margin: var(--padding-2x) 0;
 
     --icp-font-size: var(--font-size-h1);
+    --tooltip-display: inline-block;
 
     // Minimum height of ICP value + ICP label (ICP component)
     min-height: calc(

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -69,7 +69,7 @@
 <style lang="scss">
   .tooltip-wrapper {
     position: relative;
-    display: inline-block;
+    display: var(--tooltip-display);
   }
 
   .tooltip {


### PR DESCRIPTION
# Motivation

Tooltip `display` property breaks list of cards ("Merge neurons") width if displayed

# Changes

- make `display` property optional

# Screenshots

<img width="642" alt="screenshot_2022-06-15_at_12 06 05" src="https://user-images.githubusercontent.com/16886711/173805805-d1229b8b-82c7-4b63-8a8a-eca3bc866a46.png">

<img width="1510" alt="Capture d’écran 2022-06-15 à 12 24 28" src="https://user-images.githubusercontent.com/16886711/173805858-d370499d-2306-488a-a0d1-cdd24deeea80.png">
<img width="1510" alt="Capture d’écran 2022-06-15 à 12 24 31" src="https://user-images.githubusercontent.com/16886711/173805873-f3a8b32d-6ef8-4462-8720-03dc3bf7f437.png">
<img width="1510" alt="Capture d’écran 2022-06-15 à 12 24 41" src="https://user-images.githubusercontent.com/16886711/173805875-16e856ef-82f2-41dc-85a8-43a0df886772.png">


