### PR TITLE
style: align no canisters left

### DIFF
--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -84,7 +84,7 @@
       {/each}
 
       {#if noCanisters}
-        <p class="no-canisters">{$i18n.canisters.empty}</p>
+        <p>{$i18n.canisters.empty}</p>
       {/if}
 
       {#if loading}
@@ -111,10 +111,5 @@
 <style lang="scss">
   .last-info {
     margin-bottom: var(--padding-3x);
-  }
-
-  .no-canisters {
-    text-align: center;
-    margin: var(--padding-2x) 0;
   }
 </style>


### PR DESCRIPTION
# Motivation

"No transactions" is displayed "left" aligned therefore I think we can also align "No canisters" that way too.

# Changes

- align text left

# Screenshot

<img width="1510" alt="Capture d’écran 2022-06-15 à 12 34 55" src="https://user-images.githubusercontent.com/16886711/173807627-70bb87a0-338a-4621-bb6b-61e100a84481.png">
<img width="1510" alt="Capture d’écran 2022-06-15 à 12 36 54" src="https://user-images.githubusercontent.com/16886711/173807736-ffaf4620-b829-48ea-bcf1-f76eb10584f3.png">
<img width="1510" alt="Capture d’écran 2022-06-15 à 12 35 02" src="https://user-images.githubusercontent.com/16886711/173807643-ef36f97a-deff-4236-a436-807871c91496.png">


