### PR TITLE
L2-715: Ledger use candid

### DIFF
--- a/frontend/svelte/package-lock.json
+++ b/frontend/svelte/package-lock.json
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.4.3-nightly-2022-06-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-08.tgz",
-      "integrity": "sha512-j5WeHrD+ou+LI3ACVlctPSY1oANpehzsB3fJDhLGNV8YAgP8bTqBX3zwJTlXIJLheaeOcaZkpBcLBvnLIS6l+Q==",
+      "version": "0.4.3-nightly-2022-06-17",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-17.tgz",
+      "integrity": "sha512-J094qE58UgsitXD2bLEoqrTbnFLDJ1llM9UNIOy38NvXfp8XKBPRxOZQr8HhUeBFCmUOd3oKlNIAirMC6MS3rg==",
       "dependencies": {
         "@dfinity/agent": "^0.11.3",
         "@dfinity/candid": "^0.11.3",
@@ -9283,9 +9283,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.4.3-nightly-2022-06-08",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-08.tgz",
-      "integrity": "sha512-j5WeHrD+ou+LI3ACVlctPSY1oANpehzsB3fJDhLGNV8YAgP8bTqBX3zwJTlXIJLheaeOcaZkpBcLBvnLIS6l+Q==",
+      "version": "0.4.3-nightly-2022-06-17",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.4.3-nightly-2022-06-17.tgz",
+      "integrity": "sha512-J094qE58UgsitXD2bLEoqrTbnFLDJ1llM9UNIOy38NvXfp8XKBPRxOZQr8HhUeBFCmUOd3oKlNIAirMC6MS3rg==",
       "requires": {
         "@dfinity/agent": "^0.11.3",
         "@dfinity/candid": "^0.11.3",

--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -3,6 +3,7 @@ import type { BlockHeight } from "@dfinity/nns";
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
 import { LEDGER_CANISTER_ID } from "../constants/canister-ids.constants";
 import { HOST } from "../constants/environment.constants";
+import { isLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
 
@@ -58,6 +59,7 @@ const ledgerCanister = async ({
   const canister = LedgerCanister.create({
     agent,
     canisterId: LEDGER_CANISTER_ID,
+    hardwareWallet: await isLedgerIdentityProxy(identity),
   });
 
   logWithTimestamp(`LC complete.`);

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -101,8 +101,6 @@ export const createCanister = async ({
     syncAccounts();
     return canisterId;
   } catch (error) {
-    console.log("in da error");
-    console.log(error);
     toastsStore.show(
       mapCanisterErrorToToastMessage(error, "error.canister_creation_unknown")
     );

--- a/frontend/svelte/src/lib/services/canisters.services.ts
+++ b/frontend/svelte/src/lib/services/canisters.services.ts
@@ -27,7 +27,7 @@ import {
   toToastError,
 } from "../utils/error.utils";
 import { convertNumberToICP } from "../utils/icp.utils";
-import { syncAccounts } from "./accounts.services";
+import { getAccountIdentity, syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -89,7 +89,7 @@ export const createCanister = async ({
     const icpAmount = convertNumberToICP(amount);
     assertEnoughBalance({ amount: icpAmount, account });
 
-    const identity = await getIdentity();
+    const identity = await getAccountIdentity(account.identifier);
     const canisterId = await createCanisterApi({
       identity,
       amount: icpAmount,
@@ -101,6 +101,8 @@ export const createCanister = async ({
     syncAccounts();
     return canisterId;
   } catch (error) {
+    console.log("in da error");
+    console.log(error);
     toastsStore.show(
       mapCanisterErrorToToastMessage(error, "error.canister_creation_unknown")
     );
@@ -121,7 +123,7 @@ export const topUpCanister = async ({
     const icpAmount = convertNumberToICP(amount);
     assertEnoughBalance({ amount: icpAmount, account });
 
-    const identity = await getIdentity();
+    const identity = await getAccountIdentity(account.identifier);
     await topUpCanisterApi({
       identity,
       canisterId,

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -171,8 +171,8 @@ const getStakeNeuronPropsByAccount = ({
  *
  * @param {Object} params
  * @param {amount} params.amount the new neuron value. a number that will be converted to ICP.
- * @param {amount} params.amount the source account for the neuron - i.e. the account that will be linked with the neuron and that provides the ICP.
- * @param {amount} [params.amount=true] load the neuron and update the neurons store once created - i.e. certified=true query to load neuron and push to store.
+ * @param {account} params.account the source account for the neuron - i.e. the account that will be linked with the neuron and that provides the ICP.
+ * @param {loadNeuron} [params.loadNeuron=true] load the neuron and update the neurons store once created.
  */
 export const stakeNeuron = async ({
   amount,


### PR DESCRIPTION
# Motivation

nns-js uses ledger candid interface by default. When interacting with hardware wallet, we want to keep using protobuf.

# Changes

* Upgrade nns-js
* Pass "hardwareWallet" param when creating the LedgerCanister.
* Get identity based on the account when creating and topping up canisters.

# Tests

No new tests.
