### PR TITLE
L2-718: Do not check neuron balance always

### DIFF
--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -1,34 +1,10 @@
 import type { HttpAgent, Identity } from "@dfinity/agent";
 import type { BlockHeight } from "@dfinity/nns";
-import {
-  AccountIdentifier,
-  ICP,
-  LedgerCanister,
-  type Neuron,
-} from "@dfinity/nns";
+import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
 import { LEDGER_CANISTER_ID } from "../constants/canister-ids.constants";
 import { HOST } from "../constants/environment.constants";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
-
-export const getNeuronBalance = async ({
-  neuron,
-  identity,
-  certified,
-}: {
-  neuron: Neuron;
-  identity: Identity;
-  certified: boolean;
-}): Promise<ICP> => {
-  logWithTimestamp(`Getting Neuron Balance certified:${certified} call...`);
-  const { canister } = await ledgerCanister({ identity });
-  const response = await canister.accountBalance({
-    accountIdentifier: AccountIdentifier.fromHex(neuron.accountIdentifier),
-    certified,
-  });
-  logWithTimestamp(`Getting Neuron Balance certified:${certified} complete.`);
-  return response;
-};
 
 /**
  * Transfer ICP between accounts.

--- a/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -25,7 +25,6 @@
     // The fetched neuron doesn't belong to a user so it should not be added to the neuronsStore
     await loadNeuron({
       neuronId,
-      skipCheck: true,
       setNeuron: ({ neuron: neuronInfo }) => (neuron = neuronInfo),
       handleError: () => {
         neuron = undefined;

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -1,11 +1,5 @@
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
-import {
-  Topic,
-  type ICP,
-  type Neuron,
-  type NeuronId,
-  type NeuronInfo,
-} from "@dfinity/nns";
+import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { makeDummyProposals as makeDummyProposalsApi } from "../api/dev.api";
@@ -27,14 +21,10 @@ import {
   startDissolving as startDissolvingApi,
   stopDissolving as stopDissolvingApi,
 } from "../api/governance.api";
-import { getNeuronBalance } from "../api/ledger.api";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "../constants/environment.constants";
 import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
-import {
-  MAX_CONCURRENCY,
-  MIN_VERSION_MERGE_MATURITY,
-} from "../constants/neurons.constants";
+import { MIN_VERSION_MERGE_MATURITY } from "../constants/neurons.constants";
 import type { LedgerIdentity } from "../identities/ledger.identity";
 import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "../stores/busy.store";
@@ -60,7 +50,6 @@ import {
   isIdentityController,
   userAuthorizedNeuron,
 } from "../utils/neuron.utils";
-import { createChunks, isDefined } from "../utils/utils";
 import {
   getAccountIdentity,
   getAccountIdentityByPrincipal,
@@ -243,10 +232,8 @@ export const stakeNeuron = async ({
  * @param {callback} params.callback an optional callback that can be called when the data are successfully loaded (certified or not). Useful for example to close synchronously a busy spinner once all data have been fetched.
  */
 export const listNeurons = async ({
-  skipCheck = false,
   callback,
 }: {
-  skipCheck?: boolean;
   callback?: (certified: boolean) => void;
 } = {}): Promise<void> => {
   return queryAndUpdate<NeuronInfo[], unknown>({
@@ -255,20 +242,6 @@ export const listNeurons = async ({
       neuronsStore.setNeurons({ neurons, certified });
 
       callback?.(certified);
-
-      if (!certified || skipCheck) {
-        return;
-      }
-      try {
-        // Query the ledger for each neuron
-        // refresh those whose stake does not match their ledger balance.
-        const refetch = await shouldRefetchNeurons(neurons);
-        if (refetch) {
-          listNeurons({ skipCheck: true });
-        }
-      } catch (error) {
-        console.error(error);
-      }
     },
     onError: ({ error, certified }) => {
       if (certified !== true) {
@@ -284,115 +257,6 @@ export const listNeurons = async ({
       });
     },
   });
-};
-
-const balanceMatchesStake = ({
-  balance,
-  fullNeuron,
-}: {
-  balance: ICP;
-  fullNeuron: Neuron;
-}): boolean => balance.toE8s() === fullNeuron.cachedNeuronStake;
-
-const balanceIsMoreThanOne = ({ balance }: { balance: ICP }): boolean =>
-  balance.toE8s() > E8S_PER_ICP;
-
-const findNeuronsStakeNotBalance = async ({
-  neurons,
-  identity,
-}: {
-  neurons: Neuron[];
-  identity: Identity;
-}): Promise<NeuronId[]> => {
-  // TODO switch to getting multiple balances in a single request once it is supported by the ledger.
-  // Until the above is supported we must limit the max concurrency otherwise our requests may be throttled.
-
-  const neuronChunks: Neuron[][] = createChunks(neurons, MAX_CONCURRENCY);
-
-  let neuronIdsToRefresh: NeuronId[] = [];
-
-  for (const neuronChunk of neuronChunks) {
-    const notMatchingNeuronIds: NeuronId[] = (
-      await getNeuronsBalance({ neurons: neuronChunk, identity })
-    )
-      .filter((params) => !balanceMatchesStake(params))
-      // We can only refresh a neuron if its balance is at least 1 ICP
-      .filter(balanceIsMoreThanOne)
-      .map(({ fullNeuron }) => fullNeuron.id)
-      .filter(isDefined);
-
-    neuronIdsToRefresh = [...neuronIdsToRefresh, ...notMatchingNeuronIds];
-  }
-
-  return neuronIdsToRefresh;
-};
-
-const getNeuronsBalance = async ({
-  neurons,
-  identity,
-}: {
-  neurons: Neuron[];
-  identity: Identity;
-}): Promise<
-  {
-    balance: ICP;
-    fullNeuron: Neuron;
-  }[]
-> =>
-  Promise.all(
-    neurons.map(
-      async (fullNeuron): Promise<{ balance: ICP; fullNeuron: Neuron }> => ({
-        // NOTE: We fetch the balance in an uncertified way as it's more efficient,
-        // and a malicious actor wouldn't gain anything by spoofing this value.
-        // This data is used only to now which neurons need to be refreshed.
-        // This data is not shown to the user, nor stored in any store.
-        balance: await getNeuronBalance({
-          neuron: fullNeuron,
-          identity,
-          certified: false,
-        }),
-        fullNeuron,
-      })
-    )
-  );
-
-const claimNeurons =
-  (identity: Identity) =>
-  (neuronIds: NeuronId[]): Promise<Array<NeuronId | undefined>> =>
-    Promise.all(
-      neuronIds.map((neuronId) => claimOrRefreshNeuron({ identity, neuronId }))
-    );
-
-const shouldRefetchNeurons = async (
-  neurons: NeuronInfo[]
-): Promise<boolean> => {
-  const identity = await getIdentity();
-
-  const fullNeurons: Neuron[] = neurons
-    .map(({ fullNeuron }) => fullNeuron)
-    .filter(isDefined);
-
-  if (fullNeurons.length === 0) {
-    return false;
-  }
-
-  const neuronIdsToRefresh: NeuronId[] = await findNeuronsStakeNotBalance({
-    neurons: fullNeurons,
-    identity,
-  });
-
-  if (neuronIdsToRefresh.length === 0) {
-    return false;
-  }
-
-  // We found neurons that need to be refreshed.
-  const neuronIdsChunks: NeuronId[][] = createChunks(
-    neuronIdsToRefresh,
-    MAX_CONCURRENCY
-  );
-  await Promise.all(neuronIdsChunks.map(claimNeurons(identity)));
-
-  return true;
 };
 
 // We always want to call this with the user identity
@@ -491,7 +355,7 @@ export const mergeNeurons = async ({
     await mergeNeuronsApi({ sourceNeuronId, targetNeuronId, identity });
     success = true;
 
-    await listNeurons({ skipCheck: true });
+    await listNeurons();
 
     return targetNeuronId;
   } catch (err) {
@@ -668,7 +532,7 @@ export const disburse = async ({
 
     await disburseApi({ neuronId, toAccountId, identity });
 
-    await Promise.all([syncAccounts(), listNeurons({ skipCheck: true })]);
+    await Promise.all([syncAccounts(), listNeurons()]);
 
     return { success: true };
   } catch (err) {
@@ -883,9 +747,6 @@ export const removeFollowee = async ({
 export const loadNeuron = ({
   neuronId,
   forceFetch = false,
-  // Check also the Neuron's stake when loading only one.
-  // Same we do when loading the list of neurons.
-  skipCheck = false,
   setNeuron,
   handleError,
   strategy,
@@ -926,26 +787,7 @@ export const loadNeuron = ({
         catchError(new NotFoundError(`Neuron with id ${neuronId} not found`));
         return;
       }
-      if (!certified || skipCheck) {
-        setNeuron({ neuron, certified });
-        return;
-      }
-      // If the check is required, we don't want to call `setNeuron` until it has finished.
-      // For example: to avoid closing the "IncreaseStakeNeuronModal" before we finish this check.
-      const refetch = await shouldRefetchNeurons([neuron]);
-      if (refetch) {
-        await loadNeuron({
-          neuronId,
-          forceFetch,
-          setNeuron,
-          handleError,
-          // Avoid an infinite loop skipping check
-          skipCheck: true,
-          strategy: "query",
-        });
-      } else {
-        setNeuron({ neuron, certified });
-      }
+      setNeuron({ neuron, certified });
     },
     onError: ({ error, certified }) => {
       console.error(error);
@@ -961,19 +803,23 @@ export const loadNeuron = ({
 // Not resolve until the neuron has been loaded
 export const reloadNeuron = (neuronId: NeuronId) =>
   new Promise<void>((resolve) => {
-    loadNeuron({
-      neuronId,
-      forceFetch: true,
-      strategy: "update",
-      skipCheck: false,
-      setNeuron: ({ neuron, certified }) => {
-        neuronsStore.pushNeurons({ neurons: [neuron], certified });
-        resolve();
-      },
-      handleError: () => {
-        resolve();
-      },
-    });
+    getIdentity()
+      // To update the neuron stake with the subaccount balance
+      .then((identity) => claimOrRefreshNeuron({ identity, neuronId }))
+      .then(() => {
+        loadNeuron({
+          neuronId,
+          forceFetch: true,
+          strategy: "update",
+          setNeuron: ({ neuron, certified }) => {
+            neuronsStore.pushNeurons({ neurons: [neuron], certified });
+            resolve();
+          },
+          handleError: () => {
+            resolve();
+          },
+        });
+      });
   });
 
 export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {

--- a/frontend/svelte/src/tests/App.spec.ts
+++ b/frontend/svelte/src/tests/App.spec.ts
@@ -70,8 +70,6 @@ describe("App", () => {
     // query + update calls
     const numberOfCalls = 2;
 
-    const numberOfCheckNeuronsBalance = 1;
-
     await waitFor(() =>
       expect(mockNNSDappCanister.addAccount).toHaveBeenCalledTimes(
         numberOfCalls
@@ -86,7 +84,7 @@ describe("App", () => {
 
     await waitFor(() =>
       expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(
-        numberOfCalls + numberOfCheckNeuronsBalance
+        numberOfCalls
       )
     );
   });

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -5,7 +5,6 @@ import { mock } from "jest-mock-extended";
 import { tick } from "svelte/internal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/governance.api";
-import * as ledgerApi from "../../../lib/api/ledger.api";
 import {
   E8S_PER_ICP,
   TRANSACTION_FEE_E8S,
@@ -186,10 +185,6 @@ describe("neurons-services", () => {
   const spyClaimOrRefresh = jest
     .spyOn(api, "claimOrRefreshNeuron")
     .mockImplementation(() => Promise.resolve(undefined));
-
-  const spyGetNeuronBalance = jest
-    .spyOn(ledgerApi, "getNeuronBalance")
-    .mockImplementation(() => Promise.resolve(ICP.fromString("1") as ICP));
 
   afterEach(() => {
     spyGetNeuron.mockClear();


### PR DESCRIPTION
# Motivation

Do not check neuron balance every time we load a neuron.

# Changes

* Remove logic to check the neuron balance and claim the neuron if it doesn't match the stake.
* Call claimOrRefresh only on "reloadNeuron".

# Tests

* Remove test cases.
* Add test case for reloadNeuron.
