### PR TITLE
Chore: Handle Multiple Request to CMC

### DIFF
--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -145,7 +145,7 @@ const pollNotifyCreateCanister = async ({
           controller,
           block_index: blockHeight,
         }),
-      shouldRecall: (error: Error) => error instanceof ProcessingError,
+      shouldExit: (error: Error) => !(error instanceof ProcessingError),
     });
   } catch (error) {
     if (error instanceof PollingLimitExceededError) {
@@ -240,7 +240,7 @@ const pollNotifyTopUpCanister = async ({
           canister_id: canisterId,
           block_index: blockHeight,
         }),
-      shouldRecall: (error: Error) => error instanceof ProcessingError,
+      shouldExit: (error: Error) => !(error instanceof ProcessingError),
     });
   } catch (error) {
     if (error instanceof PollingLimitExceededError) {

--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -200,7 +200,7 @@ export const createCanister = async ({
   // If this fails or the client loses connection, nns dapp backend polls the transactions
   // and will also notify to CMC the transaction if it's pending.
   // If the backend is faster to notify, we might get a ProcessingError.
-  // We poll CMC until we stop getting ProcessingError or we request more than MAX_POLLING_TIMES
+  // We poll CMC until we stop getting ProcessingError or we request more than DEFAUL_MAX_POLLING_ATTEMPTS
   const canisterId = await pollNotifyCreateCanister({
     cmc,
     controller: principal,

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -1,4 +1,5 @@
 import type { Principal } from "@dfinity/principal";
+import { errorToString } from "./error.utils";
 
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export const debounce = (func: Function, timeout?: number) => {
@@ -228,6 +229,8 @@ export const poll = async <T>({
     if (shouldExit(error)) {
       throw error;
     }
+    // Log swallowed errors
+    console.log(`Error polling: ${errorToString(error)}`);
   }
   await waitForMilliseconds(500);
   return poll({

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -202,19 +202,19 @@ const MAX_POLLING_TIMES = 10;
  *
  * @param {Object} params
  * @param {fn} params.fn Function to call
- * @param {shouldRecall} params.shouldRecall Function to check whether error raised deserves a recall or not.
+ * @param {shouldExit} params.shouldExit Function to check whether function shuold stop polling.
  * @param {maxTimes} params.maxTimes Param to override the default number of times to poll.
  *
  * @returns
  */
 export const poll = async <T>({
   fn,
-  shouldRecall,
+  shouldExit,
   maxTimes = MAX_POLLING_TIMES,
   counter = 1,
 }: {
   fn: () => Promise<T>;
-  shouldRecall: (err: Error) => boolean;
+  shouldExit: (err: Error) => boolean;
   maxTimes?: number;
   counter?: number;
 }): Promise<T> => {
@@ -224,14 +224,14 @@ export const poll = async <T>({
   try {
     return await fn();
   } catch (error) {
-    if (!shouldRecall(error)) {
+    if (shouldExit(error)) {
       throw error;
     }
   }
   await waitForMilliseconds(500);
   return poll({
     fn,
-    shouldRecall,
+    shouldExit,
     maxTimes,
     counter: counter + 1,
   });

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -196,7 +196,7 @@ const waitForMilliseconds = (milliseconds: number): Promise<void> =>
   });
 
 export class PollingLimitExceededError extends Error {}
-const MAX_POLLING_TIMES = 10;
+const DEFAUL_MAX_POLLING_ATTEMPTS = 10;
 /**
  * Function that polls a specific function, checking error with passed argument to recall or not.
  *
@@ -211,7 +211,7 @@ const MAX_POLLING_TIMES = 10;
 export const poll = async <T>({
   fn,
   shouldExit,
-  maxAttempts = MAX_POLLING_TIMES,
+  maxAttempts = DEFAUL_MAX_POLLING_ATTEMPTS,
   counter = 0,
 }: {
   fn: () => Promise<T>;

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -202,23 +202,24 @@ const MAX_POLLING_TIMES = 10;
  *
  * @param {Object} params
  * @param {fn} params.fn Function to call
- * @param {shouldExit} params.shouldExit Function to check whether function shuold stop polling.
- * @param {maxTimes} params.maxTimes Param to override the default number of times to poll.
+ * @param {shouldExit} params.shouldExit Function to check whether function should stop polling when it throws an error
+ * @param {maxAttempts} params.maxAttempts Param to override the default number of times to poll.
+ * @param {counter} params.counter Param to check how many times it has polled.
  *
  * @returns
  */
 export const poll = async <T>({
   fn,
   shouldExit,
-  maxTimes = MAX_POLLING_TIMES,
-  counter = 1,
+  maxAttempts = MAX_POLLING_TIMES,
+  counter = 0,
 }: {
   fn: () => Promise<T>;
   shouldExit: (err: Error) => boolean;
-  maxTimes?: number;
+  maxAttempts?: number;
   counter?: number;
 }): Promise<T> => {
-  if (counter >= maxTimes) {
+  if (counter >= maxAttempts) {
     throw new PollingLimitExceededError();
   }
   try {
@@ -232,7 +233,7 @@ export const poll = async <T>({
   return poll({
     fn,
     shouldExit,
-    maxTimes,
+    maxAttempts,
     counter: counter + 1,
   });
 };

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   isHash,
   isNullable,
   nonNullable,
+  poll,
   smallerVersion,
   stringifyJson,
   uniqueObjects,
@@ -314,6 +315,47 @@ describe("utils", () => {
           currentVersion: "13.4.5",
         })
       ).toBe(false);
+    });
+  });
+
+  describe("poll", () => {
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+    });
+
+    it("should recall the function until `shouldRecall` is false", async () => {
+      const maxCalls = 3;
+      let calls = 0;
+      await poll({
+        fn: async () => {
+          calls += 1;
+          if (calls < maxCalls) {
+            throw new Error();
+          }
+          return calls;
+        },
+        shouldRecall: () => calls < maxCalls,
+      });
+      expect(calls).toBe(maxCalls);
+    });
+
+    it("should return the value of `fn` when it doesn't throw", async () => {
+      const result = 10;
+      const expected = await poll({
+        fn: async () => result,
+        shouldRecall: () => false,
+      });
+      expect(expected).toBe(result);
+    });
+
+    it("should throw ", async () => {
+      const result = 10;
+      const expected = await poll({
+        fn: async () => result,
+        shouldRecall: () => false,
+      });
+      expect(expected).toBe(result);
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -324,7 +324,7 @@ describe("utils", () => {
       jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
     });
 
-    it("should recall the function until `shouldRecall` is false", async () => {
+    it("should recall the function until `shouldExit` is true", async () => {
       const maxCalls = 3;
       let calls = 0;
       await poll({
@@ -335,7 +335,7 @@ describe("utils", () => {
           }
           return calls;
         },
-        shouldRecall: () => calls < maxCalls,
+        shouldExit: () => calls >= maxCalls,
       });
       expect(calls).toBe(maxCalls);
     });
@@ -344,16 +344,16 @@ describe("utils", () => {
       const result = 10;
       const expected = await poll({
         fn: async () => result,
-        shouldRecall: () => false,
+        shouldExit: () => false,
       });
       expect(expected).toBe(result);
     });
 
-    it("should throw ", async () => {
+    it("should throw when `shuoldExit` returns trye", async () => {
       const result = 10;
       const expected = await poll({
         fn: async () => result,
-        shouldRecall: () => false,
+        shouldExit: () => true,
       });
       expect(expected).toBe(result);
     });


### PR DESCRIPTION
# Motivation

CMC notify calls might fail because the nns dapp canister also makes the calls. Ignore the error if it fails because of that.

# Changes

* Poll notifyCreateCanister or notifyTopUpCanister from CMCanister in canister api createCanister and topUpCanister.
* Add new util "poll" to poll any function.

# Tests

* Add test cases in Canister api functions.
* New test for util "poll".
