### PR TITLE
L2-716: Load transaction fee from Ledger Canister

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -22,6 +22,7 @@
   import { worker } from "./lib/services/worker.services";
   import { listNeurons } from "./lib/services/neurons.services";
   import CanisterDetail from "./routes/CanisterDetail.svelte";
+  import { loadMainTransactionFee } from "./lib/services/transaction-fees.services";
 
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
@@ -36,7 +37,11 @@
         return;
       }
 
-      await Promise.all([syncAccounts(), listNeurons()]);
+      await Promise.all([
+        syncAccounts(),
+        listNeurons(),
+        loadMainTransactionFee(),
+      ]);
     }
   );
 

--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -43,6 +43,19 @@ export const sendICP = async ({
   return response;
 };
 
+/**
+ * Returns transaction fee of the Ledger Canister in IC
+ *
+ * @returns {bigint}
+ */
+export const transactionFee = async ({ identity }: { identity: Identity }) => {
+  logWithTimestamp(`Getting transaction fee call...`);
+  const { canister } = await ledgerCanister({ identity });
+  const fee = await canister.transactionFee();
+  logWithTimestamp(`Getting transactoin fee complete.`);
+  return fee;
+};
+
 export const ledgerCanister = async ({
   identity,
 }: {

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -11,6 +11,7 @@
   import { ICP } from "@dfinity/nns";
   import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import { isValidInputAmount } from "../../utils/neuron.utils";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
@@ -22,7 +23,10 @@
     : undefined;
 
   let max: number = 0;
-  $: max = maxICP($store.selectedAccount?.balance);
+  $: max = maxICP({
+    icp: $store.selectedAccount?.balance,
+    fee: $mainTransactionFeeNumberStore,
+  });
 
   let validForm: boolean;
   $: validForm = isValidInputAmount({ amount, max });

--- a/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -11,7 +11,7 @@
   import { ICP } from "@dfinity/nns";
   import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import { isValidInputAmount } from "../../utils/neuron.utils";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
 
   const context: TransactionContext = getContext<TransactionContext>(
     NEW_TRANSACTION_CONTEXT_KEY
@@ -25,7 +25,7 @@
   let max: number = 0;
   $: max = maxICP({
     icp: $store.selectedAccount?.balance,
-    fee: $mainTransactionFeeNumberStore,
+    fee: $mainTransactionFeeStore,
   });
 
   let validForm: boolean;

--- a/frontend/svelte/src/lib/components/accounts/TransactionInfo.svelte
+++ b/frontend/svelte/src/lib/components/accounts/TransactionInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
   import { formattedTransactionFeeICP } from "../../utils/icp.utils";
 
   export let feeOnly: boolean = false;
@@ -24,7 +24,7 @@
 <h5>{$i18n.accounts.transaction_fee}</h5>
 
 <p class="fee">
-  {formattedTransactionFeeICP($mainTransactionFeeNumberStore)}
+  {formattedTransactionFeeICP($mainTransactionFeeStore)}
   {$i18n.core.icp}
 </p>
 

--- a/frontend/svelte/src/lib/components/accounts/TransactionInfo.svelte
+++ b/frontend/svelte/src/lib/components/accounts/TransactionInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
   import { formattedTransactionFeeICP } from "../../utils/icp.utils";
 
   export let feeOnly: boolean = false;
@@ -22,7 +23,10 @@
 
 <h5>{$i18n.accounts.transaction_fee}</h5>
 
-<p class="fee">{formattedTransactionFeeICP()} {$i18n.core.icp}</p>
+<p class="fee">
+  {formattedTransactionFeeICP($mainTransactionFeeNumberStore)}
+  {$i18n.core.icp}
+</p>
 
 <style lang="scss">
   h5 {

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -9,7 +9,7 @@
     hasEnoughMaturityToMerge,
     minMaturityMerge,
   } from "../../../utils/neuron.utils";
-  import { mainTransactionFeeNumberStore } from "../../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -24,7 +24,7 @@
     $i18n.neuron_detail.merge_maturity_disabled_tooltip,
     {
       $amount: formatICP({
-        value: BigInt(minMaturityMerge($mainTransactionFeeNumberStore)),
+        value: BigInt(minMaturityMerge($mainTransactionFeeStore)),
         detailed: true,
       }),
     }
@@ -33,7 +33,7 @@
   <button
     disabled={!hasEnoughMaturityToMerge({
       neuron,
-      fee: $mainTransactionFeeNumberStore,
+      fee: $mainTransactionFeeStore,
     })}
     class="primary small"
     on:click={showModal}>{$i18n.neuron_detail.merge_maturity}</button

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -5,8 +5,11 @@
   import Tooltip from "../../ui/Tooltip.svelte";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
   import { formatICP } from "../../../utils/icp.utils";
-  import { hasEnoughMaturityToMerge } from "../../../utils/neuron.utils";
-  import { MIN_MATURITY_MERGE } from "../../../constants/neurons.constants";
+  import {
+    hasEnoughMaturityToMerge,
+    minMaturityMerge,
+  } from "../../../utils/neuron.utils";
+  import { mainTransactionFeeNumberStore } from "../../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -20,12 +23,18 @@
   text={replacePlaceholders(
     $i18n.neuron_detail.merge_maturity_disabled_tooltip,
     {
-      $amount: formatICP({ value: BigInt(MIN_MATURITY_MERGE), detailed: true }),
+      $amount: formatICP({
+        value: BigInt(minMaturityMerge($mainTransactionFeeNumberStore)),
+        detailed: true,
+      }),
     }
   )}
 >
   <button
-    disabled={!hasEnoughMaturityToMerge(neuron)}
+    disabled={!hasEnoughMaturityToMerge({
+      neuron,
+      fee: $mainTransactionFeeNumberStore,
+    })}
     class="primary small"
     on:click={showModal}>{$i18n.neuron_detail.merge_maturity}</button
   >

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -9,7 +9,7 @@
   import { replacePlaceholders } from "../../../utils/i18n.utils";
   import { formatICP } from "../../../utils/icp.utils";
   import Tooltip from "../../ui/Tooltip.svelte";
-  import { mainTransactionFeeNumberStore } from "../../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -21,7 +21,7 @@
   let isSplittable: boolean;
   $: isSplittable = neuronCanBeSplit({
     neuron,
-    fee: $mainTransactionFeeNumberStore,
+    fee: $mainTransactionFeeStore,
   });
 </script>
 
@@ -29,7 +29,7 @@
   id="split-neuron-button"
   text={replacePlaceholders($i18n.neuron_detail.split_neuron_disabled_tooltip, {
     $amount: formatICP({
-      value: BigInt(minNeuronSplittable($mainTransactionFeeNumberStore)),
+      value: BigInt(minNeuronSplittable($mainTransactionFeeStore)),
       detailed: true,
     }),
   })}

--- a/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { MIN_NEURON_STAKE_SPLITTABLE } from "../../../constants/neurons.constants";
   import SplitNeuronModal from "../../../modals/neurons/SplitNeuronModal.svelte";
+  import {
+    minNeuronSplittable,
+    neuronCanBeSplit,
+  } from "../../../utils/neuron.utils";
   import { i18n } from "../../../stores/i18n";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
   import { formatICP } from "../../../utils/icp.utils";
-  import { neuronCanBeSplit } from "../../../utils/neuron.utils";
   import Tooltip from "../../ui/Tooltip.svelte";
+  import { mainTransactionFeeNumberStore } from "../../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -16,14 +19,17 @@
   const closeModal = () => (isOpen = false);
 
   let isSplittable: boolean;
-  $: isSplittable = neuronCanBeSplit(neuron);
+  $: isSplittable = neuronCanBeSplit({
+    neuron,
+    fee: $mainTransactionFeeNumberStore,
+  });
 </script>
 
 <Tooltip
   id="split-neuron-button"
   text={replacePlaceholders($i18n.neuron_detail.split_neuron_disabled_tooltip, {
     $amount: formatICP({
-      value: BigInt(MIN_NEURON_STAKE_SPLITTABLE),
+      value: BigInt(minNeuronSplittable($mainTransactionFeeNumberStore)),
       detailed: true,
     }),
   })}

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -9,6 +9,7 @@
   import AmountInput from "../ui/AmountInput.svelte";
   import CurrentBalance from "../accounts/CurrentBalance.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
 
   export let account: Account;
   let amount: number;
@@ -42,7 +43,10 @@
   };
 
   let max: number = 0;
-  $: max = maxICP(account.balance);
+  $: max = maxICP({
+    icp: account.balance,
+    fee: $mainTransactionFeeNumberStore,
+  });
 
   const stakeMaximum = () => (amount = max);
 </script>
@@ -61,7 +65,7 @@
   <div class="transaction-fee">
     <h5>{$i18n.neurons.transaction_fee}</h5>
     <small>
-      <span>{formattedTransactionFeeICP()}</span>
+      <span>{formattedTransactionFeeICP($mainTransactionFeeNumberStore)}</span>
       <span>ICP</span>
     </small>
   </div>

--- a/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/svelte/src/lib/components/neurons/StakeNeuron.svelte
@@ -9,7 +9,7 @@
   import AmountInput from "../ui/AmountInput.svelte";
   import CurrentBalance from "../accounts/CurrentBalance.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
 
   export let account: Account;
   let amount: number;
@@ -45,7 +45,7 @@
   let max: number = 0;
   $: max = maxICP({
     icp: account.balance,
-    fee: $mainTransactionFeeNumberStore,
+    fee: $mainTransactionFeeStore,
   });
 
   const stakeMaximum = () => (amount = max);
@@ -65,7 +65,7 @@
   <div class="transaction-fee">
     <h5>{$i18n.neurons.transaction_fee}</h5>
     <small>
-      <span>{formattedTransactionFeeICP($mainTransactionFeeNumberStore)}</span>
+      <span>{formattedTransactionFeeICP($mainTransactionFeeStore)}</span>
       <span>ICP</span>
     </small>
   </div>

--- a/frontend/svelte/src/lib/constants/icp.constants.ts
+++ b/frontend/svelte/src/lib/constants/icp.constants.ts
@@ -1,5 +1,5 @@
 export const E8S_PER_ICP = 100_000_000;
-export const TRANSACTION_FEE_E8S = 10_000;
+export const DEFAULT_TRANSACTION_FEE_E8S = 10_000;
 export const ONE_TRILLION = 1_000_000_000_000;
 
 export const ICP_DISPLAYED_DECIMALS = 2;

--- a/frontend/svelte/src/lib/constants/neurons.constants.ts
+++ b/frontend/svelte/src/lib/constants/neurons.constants.ts
@@ -1,10 +1,6 @@
-import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "./icp.constants";
-
-export const MIN_NEURON_STAKE_SPLITTABLE =
-  2 * E8S_PER_ICP + TRANSACTION_FEE_E8S;
+import { E8S_PER_ICP } from "./icp.constants";
 
 export const MAX_NEURONS_MERGED = 2;
-export const MIN_MATURITY_MERGE = TRANSACTION_FEE_E8S;
 export const MIN_NEURON_STAKE = E8S_PER_ICP;
 export const MAX_CONCURRENCY = 10;
 

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -286,8 +286,8 @@
     "review_create_canister": "Review Canister Creation",
     "t_cycles": "T Cycles",
     "minimum_cycles_text_1": "Minimum amount: 2T Cycles (inclusive of 1T Cycles fee if creating a new canister)",
-    "minimum_cycles_text_2": "Transaction fee of 0.0001 is charged to the source account.",
-    "transaction_fee": "The Transaction fee of 0.0001 is charged to the source account.",
+    "minimum_cycles_text_2": "Transaction fee of $amount is charged to the source account.",
+    "transaction_fee": "The Transaction fee of $amount is charged to the source account.",
     "review_cycles_purchase": "Review Cycles Purchase",
     "converted_to": "converted to"
   },

--- a/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -21,7 +21,7 @@
   import CanisterIdInfo from "../../components/canisters/CanisterIdInfo.svelte";
   import { replacePlaceholders } from "../../utils/i18n.utils";
   import { formattedTransactionFeeICP } from "../../utils/icp.utils";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
 
   let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
@@ -123,7 +123,7 @@
       >
         <p>
           {replacePlaceholders($i18n.canisters.transaction_fee, {
-            $amount: formattedTransactionFeeICP($mainTransactionFeeNumberStore),
+            $amount: formattedTransactionFeeICP($mainTransactionFeeStore),
           })}
         </p>
         <div>

--- a/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -19,6 +19,9 @@
     type CanisterDetailsContext,
   } from "../../types/canister-detail.context";
   import CanisterIdInfo from "../../components/canisters/CanisterIdInfo.svelte";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
+  import { formattedTransactionFeeICP } from "../../utils/icp.utils";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
 
   let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
@@ -118,7 +121,11 @@
         on:nnsClose
         on:nnsSelectAmount={selectAmount}
       >
-        <p>{$i18n.canisters.transaction_fee}</p>
+        <p>
+          {replacePlaceholders($i18n.canisters.transaction_fee, {
+            $amount: formattedTransactionFeeICP($mainTransactionFeeNumberStore),
+          })}
+        </p>
         <div>
           <div>
             <h5>{$i18n.accounts.source}</h5>

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -14,7 +14,7 @@
   import { i18n } from "../../stores/i18n";
   import type { Step, Steps } from "../../stores/steps.state";
   import { toastsStore } from "../../stores/toasts.store";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
   import type { Account } from "../../types/account";
   import type { CreateOrLinkType } from "../../types/canisters";
   import { replacePlaceholders } from "../../utils/i18n.utils";
@@ -150,7 +150,7 @@
         <p>{$i18n.canisters.minimum_cycles_text_1}</p>
         <p>
           {replacePlaceholders($i18n.canisters.minimum_cycles_text_2, {
-            $amount: formattedTransactionFeeICP($mainTransactionFeeNumberStore),
+            $amount: formattedTransactionFeeICP($mainTransactionFeeStore),
           })}
         </p>
       </SelectCyclesCanister>

--- a/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
+++ b/frontend/svelte/src/lib/modals/canisters/CreateOrLinkCanisterModal.svelte
@@ -14,8 +14,11 @@
   import { i18n } from "../../stores/i18n";
   import type { Step, Steps } from "../../stores/steps.state";
   import { toastsStore } from "../../stores/toasts.store";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
   import type { Account } from "../../types/account";
   import type { CreateOrLinkType } from "../../types/canisters";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
+  import { formattedTransactionFeeICP } from "../../utils/icp.utils";
   import WizardModal from "../WizardModal.svelte";
 
   let icpToCyclesExchangeRate: bigint | undefined;
@@ -145,7 +148,11 @@
         minimumCycles={NEW_CANISTER_MIN_T_CYCLES}
       >
         <p>{$i18n.canisters.minimum_cycles_text_1}</p>
-        <p>{$i18n.canisters.minimum_cycles_text_2}</p>
+        <p>
+          {replacePlaceholders($i18n.canisters.minimum_cycles_text_2, {
+            $amount: formattedTransactionFeeICP($mainTransactionFeeNumberStore),
+          })}
+        </p>
       </SelectCyclesCanister>
     {/if}
     {#if currentStep?.name === "ConfirmCycles" && amount !== undefined && account !== undefined}

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -4,16 +4,14 @@
   import { ICP, type NeuronInfo } from "@dfinity/nns";
   import { isValidInputAmount, neuronStake } from "../../utils/neuron.utils";
   import AmountInput from "../../components/ui/AmountInput.svelte";
-  import {
-    E8S_PER_ICP,
-    TRANSACTION_FEE_E8S,
-  } from "../../constants/icp.constants";
+  import { E8S_PER_ICP } from "../../constants/icp.constants";
   import { i18n } from "../../stores/i18n";
   import { formattedTransactionFeeICP } from "../../utils/icp.utils";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { createEventDispatcher } from "svelte";
   import { splitNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
+  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -29,7 +27,7 @@
   $: max =
     stakeE8s === BigInt(0)
       ? 0
-      : (Number(stakeE8s) - TRANSACTION_FEE_E8S) / E8S_PER_ICP;
+      : (Number(stakeE8s) - $mainTransactionFeeNumberStore) / E8S_PER_ICP;
 
   let validForm: boolean;
   $: validForm = isValidInputAmount({ amount, max });
@@ -71,7 +69,7 @@
     <div>
       <h5>{$i18n.neurons.transaction_fee}</h5>
 
-      <p>{formattedTransactionFeeICP()} ICP</p>
+      <p>{formattedTransactionFeeICP($mainTransactionFeeNumberStore)} ICP</p>
     </div>
 
     <button

--- a/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
+++ b/frontend/svelte/src/lib/modals/neurons/SplitNeuronModal.svelte
@@ -11,7 +11,7 @@
   import { createEventDispatcher } from "svelte";
   import { splitNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
-  import { mainTransactionFeeNumberStore } from "../../stores/transaction-fees.store";
+  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -27,7 +27,7 @@
   $: max =
     stakeE8s === BigInt(0)
       ? 0
-      : (Number(stakeE8s) - $mainTransactionFeeNumberStore) / E8S_PER_ICP;
+      : (Number(stakeE8s) - $mainTransactionFeeStore) / E8S_PER_ICP;
 
   let validForm: boolean;
   $: validForm = isValidInputAmount({ amount, max });
@@ -69,7 +69,7 @@
     <div>
       <h5>{$i18n.neurons.transaction_fee}</h5>
 
-      <p>{formattedTransactionFeeICP($mainTransactionFeeNumberStore)} ICP</p>
+      <p>{formattedTransactionFeeICP($mainTransactionFeeStore)} ICP</p>
     </div>
 
     <button

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -30,7 +30,7 @@ import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "../stores/busy.store";
 import { definedNeuronsStore, neuronsStore } from "../stores/neurons.store";
 import { toastsStore } from "../stores/toasts.store";
-import { mainTransactionFeeNumberStore } from "../stores/transaction-fees.store";
+import { mainTransactionFeeStore } from "../stores/transaction-fees.store";
 import type { Account } from "../types/account";
 import { InsufficientAmountError } from "../types/common.errors";
 import {
@@ -501,7 +501,7 @@ export const splitNeuron = async ({
       neuronId
     );
 
-    const transactionFee = get(mainTransactionFeeNumberStore);
+    const transactionFee = get(mainTransactionFeeStore);
     const transactionFeeAmount = transactionFee / E8S_PER_ICP;
     const stake = convertNumberToICP(amount + transactionFeeAmount);
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -23,13 +23,14 @@ import {
 } from "../api/governance.api";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "../constants/environment.constants";
-import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
+import { E8S_PER_ICP } from "../constants/icp.constants";
 import { MIN_VERSION_MERGE_MATURITY } from "../constants/neurons.constants";
 import type { LedgerIdentity } from "../identities/ledger.identity";
 import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "../stores/busy.store";
 import { definedNeuronsStore, neuronsStore } from "../stores/neurons.store";
 import { toastsStore } from "../stores/toasts.store";
+import { mainTransactionFeeNumberStore } from "../stores/transaction-fees.store";
 import type { Account } from "../types/account";
 import { InsufficientAmountError } from "../types/common.errors";
 import {
@@ -500,10 +501,11 @@ export const splitNeuron = async ({
       neuronId
     );
 
-    const transactionFeeAmount = TRANSACTION_FEE_E8S / E8S_PER_ICP;
+    const transactionFee = get(mainTransactionFeeNumberStore);
+    const transactionFeeAmount = transactionFee / E8S_PER_ICP;
     const stake = convertNumberToICP(amount + transactionFeeAmount);
 
-    if (!isEnoughToStakeNeuron({ stake, withTransactionFee: true })) {
+    if (!isEnoughToStakeNeuron({ stake, fee: transactionFee })) {
       throw new InsufficientAmountError();
     }
 

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -501,11 +501,11 @@ export const splitNeuron = async ({
       neuronId
     );
 
-    const transactionFee = get(mainTransactionFeeStore);
-    const transactionFeeAmount = transactionFee / E8S_PER_ICP;
+    const fee = get(mainTransactionFeeStore);
+    const transactionFeeAmount = fee / E8S_PER_ICP;
     const stake = convertNumberToICP(amount + transactionFeeAmount);
 
-    if (!isEnoughToStakeNeuron({ stake, fee: transactionFee })) {
+    if (!isEnoughToStakeNeuron({ stake, fee })) {
       throw new InsufficientAmountError();
     }
 

--- a/frontend/svelte/src/lib/services/transaction-fees.services.ts
+++ b/frontend/svelte/src/lib/services/transaction-fees.services.ts
@@ -1,0 +1,15 @@
+import { transactionFee } from "../api/ledger.api";
+import { transactionsFeeStore } from "../stores/transaction-fees.store";
+import { getIdentity } from "./auth.services";
+
+export const loadMainTransactionFee = async () => {
+  try {
+    const identity = await getIdentity();
+    const fee = await transactionFee({ identity });
+    transactionsFeeStore.setMain(fee);
+  } catch (error) {
+    // Swallow error and continue with the DEFAULT_TRANSACTION_FEE value
+    console.error("Error getting the transaction fee from the ledger");
+    console.error(error);
+  }
+};

--- a/frontend/svelte/src/lib/services/transaction-fees.services.ts
+++ b/frontend/svelte/src/lib/services/transaction-fees.services.ts
@@ -1,12 +1,12 @@
 import { transactionFee } from "../api/ledger.api";
-import { transactionsFeeStore } from "../stores/transaction-fees.store";
+import { transactionsFeesStore } from "../stores/transaction-fees.store";
 import { getIdentity } from "./auth.services";
 
 export const loadMainTransactionFee = async () => {
   try {
     const identity = await getIdentity();
     const fee = await transactionFee({ identity });
-    transactionsFeeStore.setMain(fee);
+    transactionsFeesStore.setMain(fee);
   } catch (error) {
     // Swallow error and continue with the DEFAULT_TRANSACTION_FEE value
     console.error("Error getting the transaction fee from the ledger");

--- a/frontend/svelte/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/svelte/src/lib/stores/transaction-fees.store.ts
@@ -16,7 +16,7 @@ const defaultTransactionFees = {
  * - setMain: replace the current fee in `main`.
  */
 const initTransactionFeesStore = () => {
-  const { subscribe, update, set } = writable<TransactionFeesStore>(
+  const { subscribe, update } = writable<TransactionFeesStore>(
     defaultTransactionFees
   );
 
@@ -28,11 +28,6 @@ const initTransactionFeesStore = () => {
         ...data,
         main: fee,
       }));
-    },
-
-    // Used in the tests
-    reset() {
-      set(defaultTransactionFees);
     },
   };
 };

--- a/frontend/svelte/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/svelte/src/lib/stores/transaction-fees.store.ts
@@ -1,0 +1,45 @@
+import { derived, writable } from "svelte/store";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "../constants/icp.constants";
+
+export type TransactionFeesStore = {
+  // Main Ledger of IC
+  main: bigint;
+};
+
+const defaultTransactionFees = {
+  main: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+};
+
+/**
+ * A store that contains the transaction fees of ledgers.
+ *
+ * - setMain: replace the current fee in `main`.
+ */
+const initTransactionFeesStore = () => {
+  const { subscribe, update, set } = writable<TransactionFeesStore>(
+    defaultTransactionFees
+  );
+
+  return {
+    subscribe,
+
+    setMain(fee: bigint) {
+      update((data) => ({
+        ...data,
+        main: fee,
+      }));
+    },
+
+    // Used in the tests
+    reset() {
+      set(defaultTransactionFees);
+    },
+  };
+};
+
+export const transactionsFeeStore = initTransactionFeesStore();
+
+export const mainTransactionFeeNumberStore = derived(
+  transactionsFeeStore,
+  ($store) => Number($store.main)
+);

--- a/frontend/svelte/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/svelte/src/lib/stores/transaction-fees.store.ts
@@ -37,9 +37,9 @@ const initTransactionFeesStore = () => {
   };
 };
 
-export const transactionsFeeStore = initTransactionFeesStore();
+export const transactionsFeesStore = initTransactionFeesStore();
 
-export const mainTransactionFeeNumberStore = derived(
-  transactionsFeeStore,
+export const mainTransactionFeeStore = derived(
+  transactionsFeesStore,
   ($store) => Number($store.main)
 );

--- a/frontend/svelte/src/lib/utils/icp.utils.ts
+++ b/frontend/svelte/src/lib/utils/icp.utils.ts
@@ -3,7 +3,6 @@ import {
   E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
   ICP_DISPLAYED_DECIMALS_DETAILED,
-  TRANSACTION_FEE_E8S,
 } from "../constants/icp.constants";
 import { InvalidAmountError } from "../types/neurons.errors";
 
@@ -51,13 +50,13 @@ export const sumICPs = (...icps: ICP[]): ICP =>
 
 // To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
 // e.g. not 0.00010000 but 0.0001
-export const formattedTransactionFeeICP = (): string =>
+export const formattedTransactionFeeICP = (fee: number): string =>
   formatICP({
-    value: ICP.fromE8s(BigInt(TRANSACTION_FEE_E8S)).toE8s(),
+    value: ICP.fromE8s(BigInt(fee)).toE8s(),
   });
 
-export const maxICP = (icp: ICP | undefined): number =>
-  Math.max((Number(icp?.toE8s() ?? 0) - TRANSACTION_FEE_E8S) / E8S_PER_ICP, 0);
+export const maxICP = ({ icp, fee }: { icp?: ICP; fee: number }): number =>
+  Math.max((Number(icp?.toE8s() ?? 0) - fee) / E8S_PER_ICP, 0);
 
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -602,14 +602,14 @@ export const votedNeuronDetails = ({
 export const minMaturityMerge = (fee: number): number => fee;
 
 export const hasEnoughMaturityToMerge = ({
-  neuron,
+  neuron: { fullNeuron },
   fee,
 }: {
   neuron: NeuronInfo;
   fee: number;
 }): boolean =>
-  neuron.fullNeuron !== undefined &&
-  neuron.fullNeuron.maturityE8sEquivalent > minMaturityMerge(fee);
+  fullNeuron !== undefined &&
+  fullNeuron.maturityE8sEquivalent > minMaturityMerge(fee);
 
 export const minNeuronSplittable = (fee: number): number =>
   2 * E8S_PER_ICP + fee;

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -18,12 +18,13 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_HALF_YEAR,
 } from "../constants/constants";
-import { E8S_PER_ICP, TRANSACTION_FEE_E8S } from "../constants/icp.constants";
+import {
+  DEFAULT_TRANSACTION_FEE_E8S,
+  E8S_PER_ICP,
+} from "../constants/icp.constants";
 import {
   MAX_NEURONS_MERGED,
-  MIN_MATURITY_MERGE,
   MIN_NEURON_STAKE,
-  MIN_NEURON_STAKE_SPLITTABLE,
 } from "../constants/neurons.constants";
 import IconHistoryToggleOff from "../icons/IconHistoryToggleOff.svelte";
 import IconLockClock from "../icons/IconLockClock.svelte";
@@ -94,12 +95,14 @@ export const votingPower = ({
       )
     : BigInt(0);
 
+// TODO: Do we need this? What does it mean to have a valid stake?
+// TODO: https://dfinity.atlassian.net/browse/L2-507
 export const hasValidStake = (neuron: NeuronInfo): boolean =>
   // Ignore if we can't validate the stake
   neuron.fullNeuron
     ? neuron.fullNeuron.cachedNeuronStake +
         neuron.fullNeuron.maturityE8sEquivalent >
-      BigInt(TRANSACTION_FEE_E8S)
+      BigInt(DEFAULT_TRANSACTION_FEE_E8S)
     : false;
 
 export const dissolveDelayMultiplier = (delayInSeconds: number): number =>
@@ -268,9 +271,6 @@ export const ballotsWithDefinedProposal = ({
     ({ proposalId }: BallotInfo) => proposalId !== undefined
   );
 
-export const neuronCanBeSplit = (neuron: NeuronInfo): boolean =>
-  neuronStake(neuron) >= BigInt(MIN_NEURON_STAKE_SPLITTABLE);
-
 export const isValidInputAmount = ({
   amount,
   max,
@@ -281,13 +281,11 @@ export const isValidInputAmount = ({
 
 export const isEnoughToStakeNeuron = ({
   stake,
-  withTransactionFee = false,
+  fee = 0,
 }: {
   stake: ICP;
-  withTransactionFee?: boolean;
-}): boolean =>
-  stake.toE8s() >=
-  MIN_NEURON_STAKE + (withTransactionFee ? TRANSACTION_FEE_E8S : 0);
+  fee?: number;
+}): boolean => stake.toE8s() >= MIN_NEURON_STAKE + fee;
 
 export const isEnoughMaturityToSpawn = ({
   neuron: { fullNeuron },
@@ -547,10 +545,6 @@ export const topicsToFollow = (neuron: NeuronInfo): Topic[] =>
     ? enumValues(Topic).filter((topic) => topic !== Topic.ManageNeuron)
     : enumValues(Topic);
 
-export const hasEnoughMaturityToMerge = (neuron: NeuronInfo): boolean =>
-  neuron.fullNeuron !== undefined &&
-  neuron.fullNeuron.maturityE8sEquivalent > MIN_MATURITY_MERGE;
-
 // NeuronInfo is public info.
 // fullNeuron is only for users with access.
 export const userAuthorizedNeuron = (neuron: NeuronInfo): boolean =>
@@ -604,3 +598,26 @@ export const votedNeuronDetails = ({
     .filter(
       (compactNeuronInfoMaybe) => compactNeuronInfoMaybe.vote !== undefined
     ) as CompactNeuronInfo[];
+
+export const minMaturityMerge = (fee: number): number => fee;
+
+export const hasEnoughMaturityToMerge = ({
+  neuron,
+  fee,
+}: {
+  neuron: NeuronInfo;
+  fee: number;
+}): boolean =>
+  neuron.fullNeuron !== undefined &&
+  neuron.fullNeuron.maturityE8sEquivalent > minMaturityMerge(fee);
+
+export const minNeuronSplittable = (fee: number): number =>
+  2 * E8S_PER_ICP + fee;
+
+export const neuronCanBeSplit = ({
+  neuron,
+  fee,
+}: {
+  neuron: NeuronInfo;
+  fee: number;
+}): boolean => neuronStake(neuron) >= BigInt(minNeuronSplittable(fee));

--- a/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/canisters.api.spec.ts
@@ -164,7 +164,14 @@ describe("canisters-api", () => {
   });
 
   describe("createCanister", () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+      // Avoid to print errors during test
+      jest.spyOn(console, "log").mockImplementation(() => undefined);
+    });
+
     it("should make a transfer, notify and attach the canister", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
@@ -247,7 +254,14 @@ describe("canisters-api", () => {
   });
 
   describe("topUpCanister", () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+      // Avoid to print errors during test
+      jest.spyOn(console, "log").mockImplementation(() => undefined);
+    });
+
     it("should make a transfer and notify", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
       mockCMCCanister.notifyTopUp.mockResolvedValue(BigInt(10));

--- a/frontend/svelte/src/tests/lib/api/ledger.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/ledger.api.spec.ts
@@ -1,73 +1,93 @@
 import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
-import { sendICP } from "../../../lib/api/ledger.api";
+import { sendICP, transactionFee } from "../../../lib/api/ledger.api";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 
 describe("ledger-api", () => {
-  let spyTransfer;
+  describe("sendICP", () => {
+    let spyTransfer;
 
-  const { identifier: accountIdentifier } = mockMainAccount;
-  const amount = ICP.fromE8s(BigInt(11_000));
+    const { identifier: accountIdentifier } = mockMainAccount;
+    const amount = ICP.fromE8s(BigInt(11_000));
 
-  beforeAll(() => {
+    beforeAll(() => {
+      const ledgerMock = mock<LedgerCanister>();
+      ledgerMock.transfer.mockResolvedValue(BigInt(0));
+
+      jest
+        .spyOn(LedgerCanister, "create")
+        .mockImplementation((): LedgerCanister => ledgerMock);
+
+      spyTransfer = jest.spyOn(ledgerMock, "transfer");
+    });
+
+    afterAll(() => jest.clearAllMocks());
+
+    it("should call ledger to send ICP", async () => {
+      await sendICP({
+        identity: mockIdentity,
+        to: accountIdentifier,
+        amount,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: AccountIdentifier.fromHex(accountIdentifier),
+        amount,
+      });
+    });
+
+    it("should call ledger to send ICP with subaccount Id", async () => {
+      const fromSubAccount = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 1,
+      ];
+      await sendICP({
+        identity: mockIdentity,
+        to: accountIdentifier,
+        amount,
+        fromSubAccount,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: AccountIdentifier.fromHex(accountIdentifier),
+        amount,
+        fromSubAccount,
+      });
+    });
+
+    it("should call ledger to send ICP with memo", async () => {
+      const memo = BigInt(444555);
+      await sendICP({
+        identity: mockIdentity,
+        to: accountIdentifier,
+        amount,
+        memo,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: AccountIdentifier.fromHex(accountIdentifier),
+        amount,
+        memo,
+      });
+    });
+  });
+
+  describe("transactionFee", () => {
+    const fee = BigInt(10_000);
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.transfer.mockResolvedValue(BigInt(0));
+    ledgerMock.transactionFee.mockResolvedValue(fee);
 
-    jest
-      .spyOn(LedgerCanister, "create")
-      .mockImplementation((): LedgerCanister => ledgerMock);
-
-    spyTransfer = jest.spyOn(ledgerMock, "transfer");
-  });
-
-  afterAll(() => jest.clearAllMocks());
-
-  it("should call ledger to send ICP", async () => {
-    await sendICP({
-      identity: mockIdentity,
-      to: accountIdentifier,
-      amount,
+    beforeEach(() => {
+      jest
+        .spyOn(LedgerCanister, "create")
+        .mockImplementation((): LedgerCanister => ledgerMock);
     });
 
-    expect(spyTransfer).toHaveBeenCalledWith({
-      to: AccountIdentifier.fromHex(accountIdentifier),
-      amount,
-    });
-  });
-
-  it("should call ledger to send ICP with subaccount Id", async () => {
-    const fromSubAccount = [
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 1,
-    ];
-    await sendICP({
-      identity: mockIdentity,
-      to: accountIdentifier,
-      amount,
-      fromSubAccount,
-    });
-
-    expect(spyTransfer).toHaveBeenCalledWith({
-      to: AccountIdentifier.fromHex(accountIdentifier),
-      amount,
-      fromSubAccount,
-    });
-  });
-
-  it("should call ledger to send ICP with memo", async () => {
-    const memo = BigInt(444555);
-    await sendICP({
-      identity: mockIdentity,
-      to: accountIdentifier,
-      amount,
-      memo,
-    });
-
-    expect(spyTransfer).toHaveBeenCalledWith({
-      to: AccountIdentifier.fromHex(accountIdentifier),
-      amount,
-      memo,
+    it("gets transaction fee from LedgerCanister", async () => {
+      const actualFee = await transactionFee({ identity: mockIdentity });
+      expect(actualFee).toEqual(fee);
+      expect(ledgerMock.transactionFee).toBeCalled();
     });
   });
 });

--- a/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -7,8 +7,8 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import NewTransactionAmount from "../../../../lib/components/accounts/NewTransactionAmount.svelte";
 import {
+  DEFAULT_TRANSACTION_FEE_E8S,
   E8S_PER_ICP,
-  TRANSACTION_FEE_E8S,
 } from "../../../../lib/constants/icp.constants";
 import { formatICP } from "../../../../lib/utils/icp.utils";
 import {
@@ -67,7 +67,8 @@ describe("NewTransactionAmount", () => {
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input?.getAttribute("max")).toEqual(
       `${
-        (Number(mockMainAccount.balance.toE8s()) - TRANSACTION_FEE_E8S) /
+        (Number(mockMainAccount.balance.toE8s()) -
+          DEFAULT_TRANSACTION_FEE_E8S) /
         E8S_PER_ICP
       }`
     );

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -6,8 +6,8 @@ import { tick } from "svelte/internal";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/governance.api";
 import {
+  DEFAULT_TRANSACTION_FEE_E8S,
   E8S_PER_ICP,
-  TRANSACTION_FEE_E8S,
 } from "../../../lib/constants/icp.constants";
 import { getAccountIdentityByPrincipal } from "../../../lib/services/accounts.services";
 import * as services from "../../../lib/services/neurons.services";
@@ -827,7 +827,7 @@ describe("neurons-services", () => {
     it("should add transaction fee to the amount", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       const amount = 2.2;
-      const transactionFee = TRANSACTION_FEE_E8S / E8S_PER_ICP;
+      const transactionFee = DEFAULT_TRANSACTION_FEE_E8S / E8S_PER_ICP;
       const amountWithFee = amount + transactionFee;
       await services.splitNeuron({
         neuronId: controlledNeuron.neuronId,

--- a/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -20,7 +20,9 @@ describe("transactionFee-services", () => {
     jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
-  afterEach(() => transactionsFeesStore.reset());
+  afterEach(() =>
+    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
+  );
 
   it("set transaction fee to the ledger canister value", async () => {
     await loadMainTransactionFee();

--- a/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -1,0 +1,44 @@
+import { get } from "svelte/store";
+import * as api from "../../../lib/api/ledger.api";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
+import { loadMainTransactionFee } from "../../../lib/services/transaction-fees.services";
+import {
+  mainTransactionFeeNumberStore,
+  transactionsFeeStore,
+} from "../../../lib/stores/transaction-fees.store";
+import { resetIdentity, setNoIdentity } from "../../mocks/auth.store.mock";
+
+describe("transactionFee-services", () => {
+  const fee = BigInt(30_000);
+
+  let spyTranactionFeeApi;
+  beforeEach(() => {
+    spyTranactionFeeApi = jest
+      .spyOn(api, "transactionFee")
+      .mockResolvedValue(fee);
+    // Avoid to print errors during test
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => transactionsFeeStore.reset());
+
+  it("set transaction fee to the ledger canister value", async () => {
+    await loadMainTransactionFee();
+
+    expect(spyTranactionFeeApi).toHaveBeenCalled();
+
+    const storeFee = get(mainTransactionFeeNumberStore);
+    expect(storeFee).toEqual(Number(fee));
+  });
+
+  it("should not set new fee if no identity", async () => {
+    setNoIdentity();
+
+    await loadMainTransactionFee();
+
+    const storeFee = get(mainTransactionFeeNumberStore);
+    expect(storeFee).toEqual(DEFAULT_TRANSACTION_FEE_E8S);
+
+    resetIdentity();
+  });
+});

--- a/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -3,8 +3,8 @@ import * as api from "../../../lib/api/ledger.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
 import { loadMainTransactionFee } from "../../../lib/services/transaction-fees.services";
 import {
-  mainTransactionFeeNumberStore,
-  transactionsFeeStore,
+  mainTransactionFeeStore,
+  transactionsFeesStore,
 } from "../../../lib/stores/transaction-fees.store";
 import { resetIdentity, setNoIdentity } from "../../mocks/auth.store.mock";
 
@@ -20,14 +20,14 @@ describe("transactionFee-services", () => {
     jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
-  afterEach(() => transactionsFeeStore.reset());
+  afterEach(() => transactionsFeesStore.reset());
 
   it("set transaction fee to the ledger canister value", async () => {
     await loadMainTransactionFee();
 
     expect(spyTranactionFeeApi).toHaveBeenCalled();
 
-    const storeFee = get(mainTransactionFeeNumberStore);
+    const storeFee = get(mainTransactionFeeStore);
     expect(storeFee).toEqual(Number(fee));
   });
 
@@ -36,7 +36,7 @@ describe("transactionFee-services", () => {
 
     await loadMainTransactionFee();
 
-    const storeFee = get(mainTransactionFeeNumberStore);
+    const storeFee = get(mainTransactionFeeStore);
     expect(storeFee).toEqual(DEFAULT_TRANSACTION_FEE_E8S);
 
     resetIdentity();

--- a/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -1,29 +1,29 @@
 import { get } from "svelte/store";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
 import {
-  mainTransactionFeeNumberStore,
-  transactionsFeeStore,
+  mainTransactionFeeStore,
+  transactionsFeesStore,
 } from "../../../lib/stores/transaction-fees.store";
 
-describe("transactionsFeeStore", () => {
-  beforeEach(() => transactionsFeeStore.reset());
+describe("transactionsFeesStore", () => {
+  beforeEach(() => transactionsFeesStore.reset());
   it("should set it to default transaction fee", () => {
-    const { main } = get(transactionsFeeStore);
+    const { main } = get(transactionsFeesStore);
     expect(main).toEqual(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
   });
 
   it("should set main value", () => {
     const newFee = 40_000;
-    transactionsFeeStore.setMain(BigInt(newFee));
-    const fee = get(mainTransactionFeeNumberStore);
+    transactionsFeesStore.setMain(BigInt(newFee));
+    const fee = get(mainTransactionFeeStore);
     expect(fee).toBe(newFee);
   });
 
   it("should reset to default", () => {
-    transactionsFeeStore.setMain(BigInt(40_000));
-    const fee1 = get(transactionsFeeStore);
-    transactionsFeeStore.reset();
-    const fee2 = get(transactionsFeeStore);
+    transactionsFeesStore.setMain(BigInt(40_000));
+    const fee1 = get(transactionsFeesStore);
+    transactionsFeesStore.reset();
+    const fee2 = get(transactionsFeesStore);
     expect(fee1.main).not.toEqual(fee2);
   });
 });

--- a/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -6,7 +6,9 @@ import {
 } from "../../../lib/stores/transaction-fees.store";
 
 describe("transactionsFeesStore", () => {
-  beforeEach(() => transactionsFeesStore.reset());
+  beforeEach(() =>
+    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
+  );
   it("should set it to default transaction fee", () => {
     const { main } = get(transactionsFeesStore);
     expect(main).toEqual(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
@@ -22,7 +24,7 @@ describe("transactionsFeesStore", () => {
   it("should reset to default", () => {
     transactionsFeesStore.setMain(BigInt(40_000));
     const fee1 = get(transactionsFeesStore);
-    transactionsFeesStore.reset();
+    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
     const fee2 = get(transactionsFeesStore);
     expect(fee1.main).not.toEqual(fee2);
   });

--- a/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/svelte/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -1,0 +1,29 @@
+import { get } from "svelte/store";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
+import {
+  mainTransactionFeeNumberStore,
+  transactionsFeeStore,
+} from "../../../lib/stores/transaction-fees.store";
+
+describe("transactionsFeeStore", () => {
+  beforeEach(() => transactionsFeeStore.reset());
+  it("should set it to default transaction fee", () => {
+    const { main } = get(transactionsFeeStore);
+    expect(main).toEqual(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
+  });
+
+  it("should set main value", () => {
+    const newFee = 40_000;
+    transactionsFeeStore.setMain(BigInt(newFee));
+    const fee = get(mainTransactionFeeNumberStore);
+    expect(fee).toBe(newFee);
+  });
+
+  it("should reset to default", () => {
+    transactionsFeeStore.setMain(BigInt(40_000));
+    const fee1 = get(transactionsFeeStore);
+    transactionsFeeStore.reset();
+    const fee2 = get(transactionsFeeStore);
+    expect(fee1.main).not.toEqual(fee2);
+  });
+});

--- a/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,4 +1,5 @@
 import { ICP } from "@dfinity/nns";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
 import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import {
   convertIcpToTCycles,
@@ -75,14 +76,36 @@ describe("icp-utils", () => {
   });
 
   it("should format a specific transaction fee", () =>
-    expect(formattedTransactionFeeICP()).toEqual("0.0001"));
+    expect(formattedTransactionFeeICP(DEFAULT_TRANSACTION_FEE_E8S)).toEqual(
+      "0.0001"
+    ));
 
   it("should max ICP value", () => {
-    expect(maxICP(undefined)).toEqual(0);
-    expect(maxICP(ICP.fromString("0") as ICP)).toEqual(0);
-    expect(maxICP(ICP.fromString("0.0001") as ICP)).toEqual(0);
-    expect(maxICP(ICP.fromString("0.00011") as ICP)).toEqual(0.00001);
-    expect(maxICP(ICP.fromString("1") as ICP)).toEqual(0.9999);
+    expect(maxICP({ fee: DEFAULT_TRANSACTION_FEE_E8S })).toEqual(0);
+    expect(
+      maxICP({
+        icp: ICP.fromString("0") as ICP,
+        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      })
+    ).toEqual(0);
+    expect(
+      maxICP({
+        icp: ICP.fromString("0.0001") as ICP,
+        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      })
+    ).toEqual(0);
+    expect(
+      maxICP({
+        icp: ICP.fromString("0.00011") as ICP,
+        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      })
+    ).toEqual(0.00001);
+    expect(
+      maxICP({
+        icp: ICP.fromString("1") as ICP,
+        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      })
+    ).toEqual(0.9999);
   });
 
   describe("convertNumberToICP", () => {

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -323,6 +323,8 @@ describe("utils", () => {
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+      // Avoid to print errors during test
+      jest.spyOn(console, "log").mockImplementation(() => undefined);
     });
 
     it("should recall the function until `shouldExit` is true", async () => {


### PR DESCRIPTION
# Motivation

Get the transaction fee from the Ledger Canister instead of using a hardcoded one.

# Changes

* New store for transaction fees.
* New transactionFee services to get the fee from the Ledger Canister
* New ledger api function to get the transaction fee.
* Transform some neurons constants into neuron utils.
* Read the transaction fee from the neuron utils instead of constant in components.

# Tests

* Test for the new store.
* Test for the new service.
* Test for the new ledger api function.
* Update broken tests after changes.
