### PR TITLE
L2-721: i18n Canister api errors

### DIFF
--- a/frontend/svelte/src/lib/api/canisters.api.ts
+++ b/frontend/svelte/src/lib/api/canisters.api.ts
@@ -2,7 +2,7 @@ import type { Identity } from "@dfinity/agent";
 import { AccountIdentifier, ICP, SubAccount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { CMCCanister } from "../canisters/cmc/cmc.canister";
-import { CMCError, ProcessingError } from "../canisters/cmc/cmc.errors";
+import { ProcessingError } from "../canisters/cmc/cmc.errors";
 import type { Cycles } from "../canisters/cmc/cmc.types";
 import { principalToSubAccount } from "../canisters/cmc/utils";
 import { ICManagementCanister } from "../canisters/ic-management/ic-management.canister";
@@ -22,6 +22,7 @@ import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { poll, PollingLimitExceededError } from "../utils/utils";
 import { CREATE_CANISTER_MEMO, TOP_UP_CANISTER_MEMO } from "./constants.api";
+import { ApiErrorKey } from "./errors.api";
 import { sendICP } from "./ledger.api";
 import { nnsDappCanister } from "./nns-dapp.api";
 
@@ -153,10 +154,7 @@ const pollNotifyCreateCanister = async ({
     });
   } catch (error) {
     if (pollingLimit(error)) {
-      // TODO: i18n errors https://dfinity.atlassian.net/browse/L2-721
-      throw new CMCError(
-        "Error creating canister. Canister might be created, refresh the page. Try again if not."
-      );
+      throw new ApiErrorKey("error.limit_exceeded_creating_canister");
     }
     throw error;
   }
@@ -247,10 +245,7 @@ const pollNotifyTopUpCanister = async ({
     });
   } catch (error) {
     if (pollingLimit(error)) {
-      // TODO: i18n errors https://dfinity.atlassian.net/browse/L2-721
-      throw new CMCError(
-        "Error topping up canister. ICP might have been transferred, refresh the page. Try again if not."
-      );
+      throw new ApiErrorKey("error.limit_exceeded_topping_up_canister.");
     }
     throw error;
   }

--- a/frontend/svelte/src/lib/api/errors.api.ts
+++ b/frontend/svelte/src/lib/api/errors.api.ts
@@ -1,0 +1,5 @@
+export class ApiErrorKey extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -86,6 +86,8 @@
     "canister_top_up_unknown": "Sorry, there was an error adding cycles to the canister.",
     "canister_update_settings": "Sorry, there was an error updating the canister settings.",
     "not_canister_controller_to_update": "The current user is not the controller of the canister. Only controllers can change the settings.",
+    "limit_exceeded_topping_up_canister": "Error topping up canister. ICP might have been transferred, refresh the page. Try again if not.",
+    "limit_exceeded_creating_canister": "Error creating canister. Canister might be created, refresh the page. Try again if not.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -90,6 +90,8 @@ interface I18nError {
   canister_top_up_unknown: string;
   canister_update_settings: string;
   not_canister_controller_to_update: string;
+  limit_exceeded_topping_up_canister: string;
+  limit_exceeded_creating_canister: string;
   canister_invalid_transaction: string;
 }
 


### PR DESCRIPTION
# Motivation

Errors from polling service in canisters api are translatable.

# Changes

* New Error type `ApiErrorKey` thrown when polling is exceeded.

# Tests

No extra tests
