### PR TITLE
L2-727: Remove redirections to Flutter

### DIFF
--- a/frontend/svelte/env.config.mjs
+++ b/frontend/svelte/env.config.mjs
@@ -69,8 +69,6 @@ const LEDGER_CANISTER_URL = getRequiredEnvVar("LEDGER_CANISTER_URL");
 const OWN_CANISTER_URL = getRequiredEnvVar("OWN_CANISTER_URL");
 
 // Configuration
-// ... Redirects between the svelte and now deleted frontends
-const REDIRECT_TO_LEGACY = getRequiredEnvVar("REDIRECT_TO_LEGACY");
 // ... The testnet name
 const DEPLOY_ENV = getRequiredEnvVar("DEPLOY_ENV");
 // ... Whether to get the root key
@@ -80,7 +78,6 @@ export const envConfig = {
   ENVIRONMENT,
   DEPLOY_ENV,
   FETCH_ROOT_KEY,
-  REDIRECT_TO_LEGACY,
   MAINNET,
   HOST,
   OWN_CANISTER_ID,

--- a/frontend/svelte/jest-setup.ts
+++ b/frontend/svelte/jest-setup.ts
@@ -12,7 +12,6 @@ global.TextEncoder = TextEncoder;
 ).IntersectionObserver = IntersectionObserverPassive;
 
 // Environment Variables Setup
-process.env.REDIRECT_TO_LEGACY = "svelte";
 process.env.IDENTITY_SERVICE_URL = "http://localhost:8000/";
 process.env.OWN_CANISTER_ID = "qhbym-qaaaa-aaaaa-aaafq-cai";
 process.env.GOVERNANCE_CANISTER_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai";

--- a/frontend/svelte/rollup.config.js
+++ b/frontend/svelte/rollup.config.js
@@ -45,7 +45,6 @@ const replaceMap = [
   "ROLLUP_WATCH",
   "IDENTITY_SERVICE_URL",
   "DEPLOY_ENV",
-  "REDIRECT_TO_LEGACY",
   "FETCH_ROOT_KEY",
   "HOST",
   "OWN_CANISTER_ID",

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -14,7 +14,7 @@
   import Wallet from "./routes/Wallet.svelte";
   import ProposalDetail from "./routes/ProposalDetail.svelte";
   import { routeStore } from "./lib/stores/route.store";
-  import { AppPath, SHOW_ANY_TABS } from "./lib/constants/routes.constants";
+  import { AppPath } from "./lib/constants/routes.constants";
   import Toasts from "./lib/components/ui/Toasts.svelte";
   import { syncAccounts } from "./lib/services/accounts.services";
   import NeuronDetail from "./routes/NeuronDetail.svelte";
@@ -28,10 +28,6 @@
 
   const unsubscribeAuth: Unsubscriber = authStore.subscribe(
     async (auth: AuthStore) => {
-      if (!SHOW_ANY_TABS) {
-        return;
-      }
-
       await worker.syncAuthIdle(auth);
 
       // TODO: We do not need to load and sync the account data if we redirect to the Flutter app. Currently these data are not displayed with this application.

--- a/frontend/svelte/src/lib/constants/routes.constants.ts
+++ b/frontend/svelte/src/lib/constants/routes.constants.ts
@@ -11,34 +11,3 @@ export enum AppPath {
   SNSLaunchpad = "/#/sns-launchpad",
   SNSProjectDetail = "/#/sns-project",
 }
-
-// See the [README.md](../../../../../README.md) for when each tab should be shown in svelte.
-export const SHOW_ACCOUNTS_ROUTE = [
-  "svelte",
-  "both",
-  "prod",
-  "staging",
-].includes(process.env.REDIRECT_TO_LEGACY as string);
-export const SHOW_NEURONS_ROUTE = [
-  "svelte",
-  "both",
-  "prod",
-  "staging",
-].includes(process.env.REDIRECT_TO_LEGACY as string);
-export const SHOW_PROPOSALS_ROUTE = [
-  "svelte",
-  "both",
-  "prod",
-  "staging",
-].includes(process.env.REDIRECT_TO_LEGACY as string);
-export const SHOW_CANISTERS_ROUTE = [
-  "svelte",
-  "both",
-  "prod",
-  "staging",
-].includes(process.env.REDIRECT_TO_LEGACY as string);
-export const SHOW_ANY_TABS =
-  SHOW_ACCOUNTS_ROUTE ||
-  SHOW_ACCOUNTS_ROUTE ||
-  SHOW_PROPOSALS_ROUTE ||
-  SHOW_CANISTERS_ROUTE;

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Layout from "../lib/components/common/Layout.svelte";
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import type { Unsubscriber } from "svelte/types/runtime/store";
   import { accountsStore } from "../lib/stores/accounts.store";
   import type { AccountsStore } from "../lib/stores/accounts.store";
@@ -9,22 +9,12 @@
   import { i18n } from "../lib/stores/i18n";
   import Toolbar from "../lib/components/ui/Toolbar.svelte";
   import { routeStore } from "../lib/stores/route.store";
-  import {
-    AppPath,
-    SHOW_ACCOUNTS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import AddAcountModal from "../lib/modals/accounts/AddAccountModal.svelte";
   import { ICP } from "@dfinity/nns";
   import { sumICPs } from "../lib/utils/icp.utils";
   import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
-
-  // TODO: To be removed once this page has been implemented
-  onMount(() => {
-    if (!SHOW_ACCOUNTS_ROUTE) {
-      window.location.replace(AppPath.Accounts);
-    }
-  });
 
   let accounts: AccountsStore | undefined;
 
@@ -53,72 +43,69 @@
   }
 </script>
 
-{#if SHOW_ACCOUNTS_ROUTE}
-  <Layout>
-    <svelte:fragment slot="header">{$i18n.navigation.accounts}</svelte:fragment>
-    <section data-tid="accounts-body">
-      <div class="title">
-        <h1>{$i18n.accounts.title}</h1>
+<Layout>
+  <svelte:fragment slot="header">{$i18n.navigation.accounts}</svelte:fragment>
+  <section data-tid="accounts-body">
+    <div class="title">
+      <h1>{$i18n.accounts.title}</h1>
 
-        {#if accounts?.main}
-          <ICPComponent icp={totalBalance} />
-        {/if}
-      </div>
+      {#if accounts?.main}
+        <ICPComponent icp={totalBalance} />
+      {/if}
+    </div>
 
-      {#if accounts?.main?.identifier}
+    {#if accounts?.main?.identifier}
+      <AccountCard
+        role="link"
+        on:click={() => cardClick(accounts?.main?.identifier ?? "")}
+        showCopy
+        account={accounts?.main}>{$i18n.accounts.main}</AccountCard
+      >
+      {#each accounts.subAccounts || [] as subAccount}
         <AccountCard
           role="link"
-          on:click={() => cardClick(accounts?.main?.identifier ?? "")}
+          on:click={() => cardClick(subAccount.identifier)}
           showCopy
-          account={accounts?.main}>{$i18n.accounts.main}</AccountCard
+          account={subAccount}>{subAccount.name}</AccountCard
         >
-        {#each accounts.subAccounts || [] as subAccount}
-          <AccountCard
-            role="link"
-            on:click={() => cardClick(subAccount.identifier)}
-            showCopy
-            account={subAccount}>{subAccount.name}</AccountCard
-          >
-        {/each}
-        {#each accounts.hardwareWallets || [] as walletAccount}
-          <AccountCard
-            role="link"
-            on:click={() => cardClick(walletAccount.identifier)}
-            showCopy
-            account={walletAccount}>{walletAccount.name}</AccountCard
-          >
-        {/each}
-      {:else}
-        <SkeletonCard />
-      {/if}
-    </section>
+      {/each}
+      {#each accounts.hardwareWallets || [] as walletAccount}
+        <AccountCard
+          role="link"
+          on:click={() => cardClick(walletAccount.identifier)}
+          showCopy
+          account={walletAccount}>{walletAccount.name}</AccountCard
+        >
+      {/each}
+    {:else}
+      <SkeletonCard />
+    {/if}
+  </section>
 
-    <svelte:fragment slot="footer">
-      {#if accounts}
-        <Toolbar>
-          <button
-            class="primary full-width"
-            on:click={openNewTransaction}
-            data-tid="open-new-transaction"
-            >{$i18n.accounts.new_transaction}</button
-          >
-          <button
-            class="primary full-width"
-            on:click={openAddAccountModal}
-            data-tid="open-add-account-modal"
-            >{$i18n.accounts.add_account}</button
-          >
-        </Toolbar>
-      {/if}
-    </svelte:fragment>
-    {#if modal === "AddAccountModal"}
-      <AddAcountModal on:nnsClose={closeModal} />
+  <svelte:fragment slot="footer">
+    {#if accounts}
+      <Toolbar>
+        <button
+          class="primary full-width"
+          on:click={openNewTransaction}
+          data-tid="open-new-transaction"
+          >{$i18n.accounts.new_transaction}</button
+        >
+        <button
+          class="primary full-width"
+          on:click={openAddAccountModal}
+          data-tid="open-add-account-modal">{$i18n.accounts.add_account}</button
+        >
+      </Toolbar>
     {/if}
-    {#if modal === "NewTransaction"}
-      <NewTransactionModal on:nnsClose={closeModal} />
-    {/if}
-  </Layout>
-{/if}
+  </svelte:fragment>
+  {#if modal === "AddAccountModal"}
+    <AddAcountModal on:nnsClose={closeModal} />
+  {/if}
+  {#if modal === "NewTransaction"}
+    <NewTransactionModal on:nnsClose={closeModal} />
+  {/if}
+</Layout>
 
 <style lang="scss">
   @use "../lib/themes/mixins/media.scss";

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -3,10 +3,7 @@
   import type { Principal } from "@dfinity/principal";
   import type { CanisterDetails as CanisterInfo } from "../lib/canisters/nns-dapp/nns-dapp.types";
   import Layout from "../lib/components/common/Layout.svelte";
-  import {
-    AppPath,
-    SHOW_CANISTERS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import {
     getCanisterDetails,
     routePathCanisterId,
@@ -59,10 +56,6 @@
   $: $canistersStore, (canistersReady = canistersStoreReady());
 
   onMount(async () => {
-    if (!SHOW_CANISTERS_ROUTE) {
-      window.location.replace("/#/canisters");
-    }
-
     if (!canistersStoreReady()) {
       await listCanisters({ clearBeforeQuery: false });
     }
@@ -192,54 +185,50 @@
     $selectedCanisterStore);
 </script>
 
-{#if SHOW_CANISTERS_ROUTE}
-  <Layout on:nnsBack={goBack} layout="detail">
-    <svelte:fragment slot="header"
-      >{$i18n.canister_detail.title}</svelte:fragment
-    >
+<Layout on:nnsBack={goBack} layout="detail">
+  <svelte:fragment slot="header">{$i18n.canister_detail.title}</svelte:fragment>
 
-    <section>
-      {#if canisterInfo !== undefined}
-        <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
-        <CanisterCardSubTitle canister={canisterInfo} />
-        <div class="actions">
-          <DetachCanisterButton canisterId={canisterInfo.canister_id} />
-        </div>
-      {:else}
-        <div class="loader-title">
-          <SkeletonTitle />
-        </div>
-        <div class="loader-subtitle">
-          <SkeletonParagraph />
-        </div>
-      {/if}
-      {#if canisterDetails !== undefined}
-        <CyclesCard cycles={canisterDetails.cycles} />
-        <ControllersCard />
-      {:else if errorKey !== undefined}
-        <Card testId="canister-details-error-card">
-          <p class="error-message">{translate({ labelKey: errorKey })}</p>
-        </Card>
-      {:else}
-        <SkeletonCard />
-        <SkeletonCard />
-      {/if}
-    </section>
-    <svelte:fragment slot="footer">
-      <Toolbar>
-        <button
-          class="primary"
-          on:click={() => (showAddCyclesModal = true)}
-          disabled={canisterInfo === undefined || $busy}
-          >{$i18n.canister_detail.add_cycles}</button
-        >
-      </Toolbar>
-    </svelte:fragment>
-  </Layout>
+  <section>
+    {#if canisterInfo !== undefined}
+      <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
+      <CanisterCardSubTitle canister={canisterInfo} />
+      <div class="actions">
+        <DetachCanisterButton canisterId={canisterInfo.canister_id} />
+      </div>
+    {:else}
+      <div class="loader-title">
+        <SkeletonTitle />
+      </div>
+      <div class="loader-subtitle">
+        <SkeletonParagraph />
+      </div>
+    {/if}
+    {#if canisterDetails !== undefined}
+      <CyclesCard cycles={canisterDetails.cycles} />
+      <ControllersCard />
+    {:else if errorKey !== undefined}
+      <Card testId="canister-details-error-card">
+        <p class="error-message">{translate({ labelKey: errorKey })}</p>
+      </Card>
+    {:else}
+      <SkeletonCard />
+      <SkeletonCard />
+    {/if}
+  </section>
+  <svelte:fragment slot="footer">
+    <Toolbar>
+      <button
+        class="primary"
+        on:click={() => (showAddCyclesModal = true)}
+        disabled={canisterInfo === undefined || $busy}
+        >{$i18n.canister_detail.add_cycles}</button
+      >
+    </Toolbar>
+  </svelte:fragment>
+</Layout>
 
-  {#if showAddCyclesModal}
-    <AddCyclesModal on:nnsClose={closeAddCyclesModal} />
-  {/if}
+{#if showAddCyclesModal}
+  <AddCyclesModal on:nnsClose={closeAddCyclesModal} />
 {/if}
 
 <style lang="scss">

--- a/frontend/svelte/src/routes/Canisters.svelte
+++ b/frontend/svelte/src/routes/Canisters.svelte
@@ -7,10 +7,7 @@
   import { toastsStore } from "../lib/stores/toasts.store";
   import { listCanisters } from "../lib/services/canisters.services";
   import { canistersStore } from "../lib/stores/canisters.store";
-  import {
-    AppPath,
-    SHOW_CANISTERS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
   import CanisterCard from "../lib/components/canisters/CanisterCard.svelte";
   import type { CanisterId } from "../lib/canisters/nns-dapp/nns-dapp.types";
@@ -32,10 +29,6 @@
   };
 
   onMount(async () => {
-    if (!SHOW_CANISTERS_ROUTE) {
-      window.location.replace("/#/canisters");
-    }
-
     const reload: boolean = reloadRouteData({
       expectedPreviousPath: AppPath.CanisterDetail,
       effectivePreviousPath: $routeStore.referrerPath,
@@ -65,50 +58,47 @@
   const closeModal = () => (modal = undefined);
 </script>
 
-{#if SHOW_CANISTERS_ROUTE}
-  <Layout>
-    <svelte:fragment slot="header">{$i18n.navigation.canisters}</svelte:fragment
-    >
-    <section>
-      <p>{$i18n.canisters.text}</p>
-      <p class="last-info">
-        {$i18n.canisters.principal_is}
-        {$authStore.identity?.getPrincipal().toText()}
-      </p>
+<Layout>
+  <svelte:fragment slot="header">{$i18n.navigation.canisters}</svelte:fragment>
+  <section>
+    <p>{$i18n.canisters.text}</p>
+    <p class="last-info">
+      {$i18n.canisters.principal_is}
+      {$authStore.identity?.getPrincipal().toText()}
+    </p>
 
-      {#each $canistersStore.canisters ?? [] as canister}
-        <CanisterCard
-          role="link"
-          ariaLabel={$i18n.neurons.aria_label_neuron_card}
-          on:click={goToCanisterDetails(canister.canister_id)}
-          {canister}
-        />
-      {/each}
+    {#each $canistersStore.canisters ?? [] as canister}
+      <CanisterCard
+        role="link"
+        ariaLabel={$i18n.neurons.aria_label_neuron_card}
+        on:click={goToCanisterDetails(canister.canister_id)}
+        {canister}
+      />
+    {/each}
 
-      {#if noCanisters}
-        <p>{$i18n.canisters.empty}</p>
-      {/if}
-
-      {#if loading}
-        <SkeletonCard />
-        <SkeletonCard />
-      {/if}
-    </section>
-
-    <svelte:fragment slot="footer">
-      <Toolbar>
-        <button
-          data-tid="create-link-canister-button"
-          class="primary"
-          on:click={openModal}>{$i18n.canisters.create_or_link}</button
-        >
-      </Toolbar>
-    </svelte:fragment>
-    {#if modal === "CreateOrLinkCanister"}
-      <CreateOrLinkCanisterModal on:nnsClose={closeModal} />
+    {#if noCanisters}
+      <p>{$i18n.canisters.empty}</p>
     {/if}
-  </Layout>
-{/if}
+
+    {#if loading}
+      <SkeletonCard />
+      <SkeletonCard />
+    {/if}
+  </section>
+
+  <svelte:fragment slot="footer">
+    <Toolbar>
+      <button
+        data-tid="create-link-canister-button"
+        class="primary"
+        on:click={openModal}>{$i18n.canisters.create_or_link}</button
+      >
+    </Toolbar>
+  </svelte:fragment>
+  {#if modal === "CreateOrLinkCanister"}
+    <CreateOrLinkCanisterModal on:nnsClose={closeModal} />
+  {/if}
+</Layout>
 
 <style lang="scss">
   .last-info {

--- a/frontend/svelte/src/routes/NeuronDetail.svelte
+++ b/frontend/svelte/src/routes/NeuronDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { NeuronId } from "@dfinity/nns";
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import Layout from "../lib/components/common/Layout.svelte";
   import {
     routePathNeuronId,
@@ -12,10 +12,7 @@
   import NeuronMetaInfoCard from "../lib/components/neuron-detail/NeuronMetaInfoCard.svelte";
   import NeuronProposalsCard from "../lib/components/neuron-detail/NeuronProposalsCard.svelte";
   import NeuronVotingHistoryCard from "../lib/components/neuron-detail/NeuronVotingHistoryCard.svelte";
-  import {
-    AppPath,
-    SHOW_NEURONS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import { i18n } from "../lib/stores/i18n";
   import { routeStore } from "../lib/stores/route.store";
   import { neuronSelectStore, neuronsStore } from "../lib/stores/neurons.store";
@@ -23,16 +20,10 @@
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
   import { isRoutePath } from "../lib/utils/app-path.utils";
 
+  // Neurons are fetch on page load. No need to do it in the route.
+
   let neuronId: NeuronId | undefined;
   $: neuronSelectStore.select(neuronId);
-
-  // TODO: To be removed once this page has been implemented
-  onMount(() => {
-    if (!SHOW_NEURONS_ROUTE) {
-      window.location.replace(`/${window.location.hash}`);
-      return;
-    }
-  });
 
   const unsubscribe = routeStore.subscribe(async ({ path }) => {
     if (!isRoutePath({ path: AppPath.NeuronDetail, routePath: path })) {
@@ -74,25 +65,23 @@
   };
 </script>
 
-{#if SHOW_NEURONS_ROUTE}
-  <Layout on:nnsBack={goBack} layout="detail">
-    <svelte:fragment slot="header">{$i18n.neuron_detail.title}</svelte:fragment>
-    <section data-tid="neuron-detail">
-      {#if $neuronSelectStore}
-        <NeuronMetaInfoCard neuron={$neuronSelectStore} />
-        <NeuronMaturityCard neuron={$neuronSelectStore} />
-        <NeuronFollowingCard neuron={$neuronSelectStore} />
-        {#if IS_TESTNET}
-          <NeuronProposalsCard neuron={$neuronSelectStore} />
-        {/if}
-        <NeuronHotkeysCard neuron={$neuronSelectStore} />
-        <NeuronVotingHistoryCard neuron={$neuronSelectStore} />
-      {:else}
-        <SkeletonCard size="large" />
-        <SkeletonCard />
-        <SkeletonCard />
-        <SkeletonCard />
+<Layout on:nnsBack={goBack} layout="detail">
+  <svelte:fragment slot="header">{$i18n.neuron_detail.title}</svelte:fragment>
+  <section data-tid="neuron-detail">
+    {#if $neuronSelectStore}
+      <NeuronMetaInfoCard neuron={$neuronSelectStore} />
+      <NeuronMaturityCard neuron={$neuronSelectStore} />
+      <NeuronFollowingCard neuron={$neuronSelectStore} />
+      {#if IS_TESTNET}
+        <NeuronProposalsCard neuron={$neuronSelectStore} />
       {/if}
-    </section>
-  </Layout>
-{/if}
+      <NeuronHotkeysCard neuron={$neuronSelectStore} />
+      <NeuronVotingHistoryCard neuron={$neuronSelectStore} />
+    {:else}
+      <SkeletonCard size="large" />
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+    {/if}
+  </section>
+</Layout>

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Layout from "../lib/components/common/Layout.svelte";
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import type { Unsubscriber } from "svelte/types/runtime/store";
   import { authStore } from "../lib/stores/auth.store";
   import type { AuthStore } from "../lib/stores/auth.store";
@@ -11,24 +11,16 @@
   import type { NeuronId } from "@dfinity/nns";
   import { neuronsStore, sortedNeuronStore } from "../lib/stores/neurons.store";
   import { routeStore } from "../lib/stores/route.store";
-  import {
-    AppPath,
-    SHOW_NEURONS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import MergeNeuronsModal from "../lib/modals/neurons/MergeNeuronsModal.svelte";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
   import { MAX_NEURONS_MERGED } from "../lib/constants/neurons.constants";
   import Tooltip from "../lib/components/ui/Tooltip.svelte";
 
+  // Neurons are fetch on page load. No need to do it in the route.
+
   let isLoading: boolean = false;
   $: isLoading = $neuronsStore.neurons === undefined;
-
-  onMount(async () => {
-    // TODO: To be removed once this page has been implemented
-    if (!SHOW_NEURONS_ROUTE) {
-      window.location.replace("/#/neurons");
-    }
-  });
 
   let principalText: string = "";
 
@@ -54,70 +46,65 @@
   $: enoughNeuronsToMerge = $sortedNeuronStore.length >= MAX_NEURONS_MERGED;
 </script>
 
-{#if SHOW_NEURONS_ROUTE}
-  <Layout>
-    <svelte:fragment slot="header">{$i18n.navigation.neurons}</svelte:fragment>
-    <section data-tid="neurons-body">
-      <p>{$i18n.neurons.text}</p>
+<Layout>
+  <svelte:fragment slot="header">{$i18n.navigation.neurons}</svelte:fragment>
+  <section data-tid="neurons-body">
+    <p>{$i18n.neurons.text}</p>
 
-      <p>
-        {$i18n.neurons.principal_is}
-        {principalText}
-      </p>
+    <p>
+      {$i18n.neurons.principal_is}
+      {principalText}
+    </p>
 
-      {#if isLoading}
-        <SkeletonCard />
-        <SkeletonCard />
-      {:else}
-        {#each $sortedNeuronStore as neuron}
-          <NeuronCard
-            role="link"
-            ariaLabel={$i18n.neurons.aria_label_neuron_card}
-            on:click={goToNeuronDetails(neuron.neuronId)}
-            {neuron}
-          />
-        {/each}
-      {/if}
-    </section>
-    <svelte:fragment slot="footer">
-      <Toolbar>
+    {#if isLoading}
+      <SkeletonCard />
+      <SkeletonCard />
+    {:else}
+      {#each $sortedNeuronStore as neuron}
+        <NeuronCard
+          role="link"
+          ariaLabel={$i18n.neurons.aria_label_neuron_card}
+          on:click={goToNeuronDetails(neuron.neuronId)}
+          {neuron}
+        />
+      {/each}
+    {/if}
+  </section>
+  <svelte:fragment slot="footer">
+    <Toolbar>
+      <button
+        data-tid="stake-neuron-button"
+        class="primary"
+        on:click={() => openModal("stake-neuron")}
+        >{$i18n.neurons.stake_neurons}</button
+      >
+      {#if enoughNeuronsToMerge}
         <button
-          data-tid="stake-neuron-button"
-          class="primary full-width"
-          on:click={() => openModal("stake-neuron")}
-          >{$i18n.neurons.stake_neurons}</button
+          data-tid="merge-neurons-button"
+          class="primary"
+          on:click={() => openModal("merge-neurons")}
+          >{$i18n.neurons.merge_neurons}</button
         >
-        {#if enoughNeuronsToMerge}
+      {:else}
+        <Tooltip id="merge-neurons-info" text={$i18n.neurons.need_two_to_merge}>
           <button
+            disabled
             data-tid="merge-neurons-button"
             class="primary full-width"
             on:click={() => openModal("merge-neurons")}
             >{$i18n.neurons.merge_neurons}</button
           >
-        {:else}
-          <Tooltip
-            id="merge-neurons-info"
-            text={$i18n.neurons.need_two_to_merge}
-          >
-            <button
-              disabled
-              data-tid="merge-neurons-button"
-              class="primary full-width"
-              on:click={() => openModal("merge-neurons")}
-              >{$i18n.neurons.merge_neurons}</button
-            >
-          </Tooltip>
-        {/if}
-      </Toolbar>
-    </svelte:fragment>
-    {#if showModal === "stake-neuron"}
-      <CreateNeuronModal on:nnsClose={closeModal} />
-    {/if}
-    {#if showModal === "merge-neurons"}
-      <MergeNeuronsModal on:nnsClose={closeModal} />
-    {/if}
-  </Layout>
-{/if}
+        </Tooltip>
+      {/if}
+    </Toolbar>
+  </svelte:fragment>
+  {#if showModal === "stake-neuron"}
+    <CreateNeuronModal on:nnsClose={closeModal} />
+  {/if}
+  {#if showModal === "merge-neurons"}
+    <MergeNeuronsModal on:nnsClose={closeModal} />
+  {/if}
+</Layout>
 
 <style lang="scss">
   p:last-of-type {

--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -74,14 +74,14 @@
     <Toolbar>
       <button
         data-tid="stake-neuron-button"
-        class="primary"
+        class="primary full-width"
         on:click={() => openModal("stake-neuron")}
         >{$i18n.neurons.stake_neurons}</button
       >
       {#if enoughNeuronsToMerge}
         <button
           data-tid="merge-neurons-button"
-          class="primary"
+          class="primary full-width"
           on:click={() => openModal("merge-neurons")}
           >{$i18n.neurons.merge_neurons}</button
         >

--- a/frontend/svelte/src/routes/Proposals.svelte
+++ b/frontend/svelte/src/routes/Proposals.svelte
@@ -15,10 +15,7 @@
   import ProposalCard from "../lib/components/proposals/ProposalCard.svelte";
   import type { Unsubscriber } from "svelte/types/runtime/store";
   import { debounce } from "../lib/utils/utils";
-  import {
-    AppPath,
-    SHOW_PROPOSALS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import {
     listNextProposals,
     listProposals,
@@ -76,11 +73,6 @@
   };
 
   onMount(async () => {
-    // TODO: To be removed once this page has been implemented
-    if (!SHOW_PROPOSALS_ROUTE) {
-      window.location.replace(AppPath.Proposals);
-    }
-
     const reload: boolean = reloadRouteData({
       expectedPreviousPath: AppPath.ProposalDetail,
       effectivePreviousPath: $routeStore.referrerPath,
@@ -154,35 +146,33 @@
   $: neuronsLoaded = $neuronsStore.neurons !== undefined;
 </script>
 
-{#if SHOW_PROPOSALS_ROUTE}
-  <Layout>
-    <svelte:fragment slot="header">{$i18n.navigation.voting}</svelte:fragment>
-    <section data-tid="proposals-tab">
-      <p>{$i18n.voting.text}</p>
+<Layout>
+  <svelte:fragment slot="header">{$i18n.navigation.voting}</svelte:fragment>
+  <section data-tid="proposals-tab">
+    <p>{$i18n.voting.text}</p>
 
-      <ProposalsFilters />
+    <ProposalsFilters />
 
-      {#if neuronsLoaded}
-        <InfiniteScroll on:nnsIntersect={findNextProposals}>
-          {#each $proposalsStore.proposals as proposalInfo (proposalInfo.id)}
-            <ProposalCard {hidden} {proposalInfo} />
-          {/each}
-        </InfiniteScroll>
+    {#if neuronsLoaded}
+      <InfiniteScroll on:nnsIntersect={findNextProposals}>
+        {#each $proposalsStore.proposals as proposalInfo (proposalInfo.id)}
+          <ProposalCard {hidden} {proposalInfo} />
+        {/each}
+      </InfiniteScroll>
 
-        {#if nothingFound}
-          <p class="no-proposals">{$i18n.voting.nothing_found}</p>
-        {/if}
+      {#if nothingFound}
+        <p class="no-proposals">{$i18n.voting.nothing_found}</p>
       {/if}
+    {/if}
 
-      {#if loading || !neuronsLoaded}
-        <div class="spinner">
-          <SkeletonCard />
-          <SkeletonCard />
-        </div>
-      {/if}
-    </section>
-  </Layout>
-{/if}
+    {#if loading || !neuronsLoaded}
+      <div class="spinner">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    {/if}
+  </section>
+</Layout>
 
 <style lang="scss">
   .spinner {

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-  import { onMount, setContext } from "svelte";
+  import { setContext } from "svelte";
   import { i18n } from "../lib/stores/i18n";
   import Toolbar from "../lib/components/ui/Toolbar.svelte";
   import Layout from "../lib/components/common/Layout.svelte";
   import { routeStore } from "../lib/stores/route.store";
-  import {
-    AppPath,
-    SHOW_ACCOUNTS_ROUTE,
-  } from "../lib/constants/routes.constants";
+  import { AppPath } from "../lib/constants/routes.constants";
   import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import {
     getAccountTransactions,
@@ -31,12 +28,6 @@
   } from "../lib/types/selected-account.context";
   import { getAccountFromStore } from "../lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "../lib/stores/debug.store";
-
-  onMount(() => {
-    if (!SHOW_ACCOUNTS_ROUTE) {
-      window.location.replace(`/${window.location.hash}`);
-    }
-  });
 
   const goBack = () =>
     routeStore.navigate({
@@ -124,40 +115,38 @@
   // TODO(L2-581): Create WalletInfo component
 </script>
 
-{#if SHOW_ACCOUNTS_ROUTE}
-  <Layout on:nnsBack={goBack} layout="detail">
-    <svelte:fragment slot="header">{$i18n.wallet.title}</svelte:fragment>
+<Layout on:nnsBack={goBack} layout="detail">
+  <svelte:fragment slot="header">{$i18n.wallet.title}</svelte:fragment>
 
-    <section>
-      {#if $selectedAccountStore.account !== undefined}
-        <WalletSummary />
-        <div class="actions">
-          <WalletActions />
-        </div>
-        <TransactionList />
-      {:else}
-        <Spinner />
-      {/if}
-    </section>
+  <section>
+    {#if $selectedAccountStore.account !== undefined}
+      <WalletSummary />
+      <div class="actions">
+        <WalletActions />
+      </div>
+      <TransactionList />
+    {:else}
+      <Spinner />
+    {/if}
+  </section>
 
-    <svelte:fragment slot="footer">
-      <Toolbar>
-        <button
-          class="primary"
-          on:click={() => (showNewTransactionModal = true)}
-          disabled={$selectedAccountStore.account === undefined || $busy}
-          >{$i18n.accounts.new_transaction}</button
-        >
-      </Toolbar>
-    </svelte:fragment>
-  </Layout>
+  <svelte:fragment slot="footer">
+    <Toolbar>
+      <button
+        class="primary"
+        on:click={() => (showNewTransactionModal = true)}
+        disabled={$selectedAccountStore.account === undefined || $busy}
+        >{$i18n.accounts.new_transaction}</button
+      >
+    </Toolbar>
+  </svelte:fragment>
+</Layout>
 
-  {#if showNewTransactionModal}
-    <NewTransactionModal
-      on:nnsClose={() => (showNewTransactionModal = false)}
-      selectedAccount={$selectedAccountStore.account}
-    />
-  {/if}
+{#if showNewTransactionModal}
+  <NewTransactionModal
+    on:nnsClose={() => (showNewTransactionModal = false)}
+    selectedAccount={$selectedAccountStore.account}
+  />
 {/if}
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

Remove redirections from svelte to flutter.

# Changes

* Remove usage of `REDIRECT_TO_LEGACY` in svelte app.
* Remove all `SHOW_XXX` constants.
* Remove all checks with `SHOW_XXX` onMount to redirect to flutter.

# Tests

Not applicable.
