### PR TITLE
style: align canister review cycles on small screen

### DIFF
--- a/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/svelte/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -51,6 +51,8 @@
 </div>
 
 <style lang="scss">
+  @use "../../themes/mixins/media.scss";
+
   .wizard-wrapper.wrapper {
     justify-content: space-between;
   }
@@ -64,15 +66,19 @@
   }
 
   .conversion {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: var(--padding);
     margin-bottom: var(--padding-3x);
 
     p,
     h3 {
       margin: 0;
+      display: inline-block;
+    }
+
+    @include media.min-width(small) {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: var(--padding);
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

Prevent cycles conversion text to overflow on small screen.

# Screenshots

<img width="1510" alt="Capture d’écran 2022-06-21 à 14 23 19" src="https://user-images.githubusercontent.com/16886711/174798454-79265d42-58e3-47ac-98ba-4e392efcd607.png">
<img width="1510" alt="Capture d’écran 2022-06-21 à 14 23 47" src="https://user-images.githubusercontent.com/16886711/174798463-be77cc0c-95a9-4006-81e8-083e4ec510fd.png">
<img width="1510" alt="Capture d’écran 2022-06-21 à 14 23 55" src="https://user-images.githubusercontent.com/16886711/174798471-d9ad7049-4426-4ebf-a1e0-d50b0a3b8220.png">
<img width="1510" alt="Capture d’écran 2022-06-21 à 14 23 58" src="https://user-images.githubusercontent.com/16886711/174798473-f6f66775-f082-4a4d-a0a9-e77a0130d0ef.png">
<img width="1510" alt="Capture d’écran 2022-06-21 à 14 24 00" src="https://user-images.githubusercontent.com/16886711/174798475-7b571383-ed38-4c16-9731-611a486b8182.png">
<img width="1510" alt="Capture d’écran 2022-06-21 à 14 24 03" src="https://user-images.githubusercontent.com/16886711/174798478-82f06e92-8c0e-43b1-ba00-486d9c0d0c4b.png">

