### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
-*   @dfinity/gix
+# For questions, reach out to: <gix@dfinity.org>


### PR DESCRIPTION
The codeowners file was being a bit spammy. This clarifies the
maintainership of the repo and will help us stay on top of our GH
notifications.
