### PR TITLE
style: neuron footer tooltip button width

### DIFF
--- a/frontend/svelte/src/routes/Neurons.svelte
+++ b/frontend/svelte/src/routes/Neurons.svelte
@@ -123,4 +123,12 @@
   p:last-of-type {
     margin-bottom: var(--padding-3x);
   }
+
+  :global(footer .tooltip-wrapper) {
+    --tooltip-width: 50%;
+  }
+
+  :global(footer .tooltip-wrapper button) {
+    width: 100%;
+  }
 </style>


### PR DESCRIPTION
# Motivation

Apply width to neuron footer tooltip button as any footer button.

# Changes

- custom style in neuron page (I thought about making it global but it seems like an exception to use a tooltip in footer button)

# Screenshots

<img width="1460" alt="Capture d’écran 2022-06-22 à 07 47 07" src="https://user-images.githubusercontent.com/16886711/174952991-e382bad2-36bb-4683-8651-11c003bfbabe.png">
<img width="1460" alt="Capture d’écran 2022-06-22 à 07 47 15" src="https://user-images.githubusercontent.com/16886711/174952998-af60cfcb-7590-4be2-a4a5-d0214b57cb37.png">
<img width="1460" alt="Capture d’écran 2022-06-22 à 07 47 28" src="https://user-images.githubusercontent.com/16886711/174953009-ee108025-1731-433a-94ad-85338c0310a3.png">
<img width="1460" alt="Capture d’écran 2022-06-22 à 07 47 32" src="https://user-images.githubusercontent.com/16886711/174953012-d7ff6a5d-3a8c-4dbf-a2fa-bc3b1c84aae7.png">

