### PR TITLE
fix: glitchy ui on signout

### DIFF
--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -22,7 +22,8 @@ export const logout = async ({
   window.localStorage.clear();
 
   // We reload the page to make sure all the states are cleared
-  window.location.reload();
+  // Trigger this reload after a brief timeout to allow the rendering of the sign-in page first otherwise the ui might be displayed as glitchy (login screen rendered over current view)
+  setTimeout(() => window.location.reload(), 50)
 };
 
 /**

--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -23,7 +23,7 @@ export const logout = async ({
 
   // We reload the page to make sure all the states are cleared
   // Trigger this reload after a brief timeout to allow the rendering of the sign-in page first otherwise the ui might be displayed as glitchy (login screen rendered over current view)
-  setTimeout(() => window.location.reload(), 50)
+  setTimeout(() => window.location.reload(), 50);
 };
 
 /**

--- a/frontend/svelte/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/auth.services.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { AuthClient } from "@dfinity/auth-client";
+import { waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 import {
   displayAndCleanLogoutMsg,
@@ -50,7 +51,7 @@ describe("auth-services", () => {
 
     await logout({});
 
-    expect(spy).toHaveBeenCalled();
+    await waitFor(() => expect(spy).toHaveBeenCalled());
   });
 
   it("should add msg to url", async () => {


### PR DESCRIPTION
# Motivation

UI has become glitchy on signout.

# Notes

- There might be cleaner way to solve this, like detecting through events the next re-rendering of the auth page and triggering the reload only when it happens but, meanwhile, this small `timeout` seems to be the pragmatic solution.

- tried `await tick()` but it did not work out

# Changes

- reload window after 50ms on signout instead of instant

# Screenshots

Glitch:

![glitch](https://user-images.githubusercontent.com/16886711/174959205-b74155ac-5f36-47e6-9f5a-622e414eabf3.gif)
<img width="1305" alt="Capture d’écran 2022-06-22 à 08 28 59" src="https://user-images.githubusercontent.com/16886711/174959224-34fd9b20-ed77-4bd4-a794-eb3e81b522ce.png">

Ok:

![ok](https://user-images.githubusercontent.com/16886711/174959238-f7472981-5a15-4435-841c-8cf6376bf2fb.gif)
