### PR TITLE
Fix: Opacity of busy screen

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/svelte/src/lib/components/accounts/NewTransactionReview.svelte
@@ -21,7 +21,12 @@
   const dispatcher = createEventDispatcher();
 
   const executeTransaction = async () => {
-    startBusy({ initiator: "accounts" });
+    startBusy({
+      initiator: "accounts",
+      ...(isAccountHardwareWallet($store.selectedAccount) && {
+        labelKey: "busy_screen.pending_approval_hw",
+      }),
+    });
 
     const { success } = await transferICP($store);
 

--- a/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
+++ b/frontend/svelte/src/lib/components/ui/BusyScreen.svelte
@@ -27,7 +27,7 @@
     position: fixed;
     inset: 0;
 
-    background-color: rgba(var(--background-rgb), 0.75);
+    background-color: rgba(var(--background-rgb), 0.3);
   }
 
   .content {


### PR DESCRIPTION
# Motivation

Users using hardware wallet want to be able to confirm what's on the device and what's on the screen.

# Changes

* Reduce opacity of the BusyScreen.
* Add hardware wallet message on busy screen for new transactions.

# Tests

Not applicable.