### PR TITLE
Fix: Navigation issue on Neuron Detail

### DIFF
--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -25,6 +25,7 @@ import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "../constants/environment.constants";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import { MIN_VERSION_MERGE_MATURITY } from "../constants/neurons.constants";
+import { AppPath } from "../constants/routes.constants";
 import type { LedgerIdentity } from "../identities/ledger.identity";
 import { getLedgerIdentityProxy } from "../proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "../stores/busy.store";
@@ -39,7 +40,7 @@ import {
   NotFoundError,
 } from "../types/neurons.errors";
 import { isAccountHardwareWallet } from "../utils/accounts.utils";
-import { getLastPathDetailId } from "../utils/app-path.utils";
+import { getLastPathDetailId, isRoutePath } from "../utils/app-path.utils";
 import { mapNeuronErrorToToastMessage } from "../utils/error.utils";
 import { translate } from "../utils/i18n.utils";
 import { convertNumberToICP } from "../utils/icp.utils";
@@ -847,5 +848,9 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
   }
 };
 
-export const routePathNeuronId = (path: string): NeuronId | undefined =>
-  getLastPathDetailId(path);
+export const routePathNeuronId = (path: string): NeuronId | undefined => {
+  if (!isRoutePath({ path: AppPath.NeuronDetail, routePath: path })) {
+    return undefined;
+  }
+  return getLastPathDetailId(path);
+};

--- a/frontend/svelte/src/routes/NeuronDetail.svelte
+++ b/frontend/svelte/src/routes/NeuronDetail.svelte
@@ -21,6 +21,7 @@
   import { neuronSelectStore, neuronsStore } from "../lib/stores/neurons.store";
   import { IS_TESTNET } from "../lib/constants/environment.constants";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
+  import { isRoutePath } from "../lib/utils/app-path.utils";
 
   let neuronId: NeuronId | undefined;
   $: neuronSelectStore.select(neuronId);
@@ -34,6 +35,9 @@
   });
 
   const unsubscribe = routeStore.subscribe(async ({ path }) => {
+    if (!isRoutePath({ path: AppPath.NeuronDetail, routePath: path })) {
+      return;
+    }
     const neuronIdMaybe = routePathNeuronId(path);
     if (neuronIdMaybe === undefined) {
       unsubscribe();

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -1163,6 +1163,8 @@ describe("neurons-services", () => {
       expect(routePathNeuronId("/#/neuron/")).toBeUndefined();
       expect(routePathNeuronId("/#/neuron/1.5")).toBeUndefined();
       expect(routePathNeuronId("/#/neuron/123n")).toBeUndefined();
+      expect(routePathNeuronId("/#/neurons/")).toBeUndefined();
+      expect(routePathNeuronId("/#/accounts/")).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
# Motivation

Fix issue when user tries to navigate out of the neurons detail page with the menu.

# Changes

* Skip checks in the NeuronDetail page when route changes but it's not a neuron detail page.
* Add extra check when getting the neuron id from the path in "routePathNeuronId".

# Tests

* Add test cases in routePathNeuronId.
