### PR TITLE
L2-738: Improve FF error message with HW

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -518,6 +518,7 @@
     "user_cancel": "User denied the access to use the ledger device.",
     "user_rejected_transaction": "The transaction was rejected on the ledger device.",
     "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to $minVersion.",
+    "browser_not_supported": "Sorry, the browser does not support the WebHID API needed to connect the hardware wallet. Check support in https://caniuse.com/?search=WebHID",
     "incorrect_identifier": "Wallet account identifier doesn't match. Are you sure you connected the right wallet? Expected identifier: $identifier. Wallet identifier: $ledgerIdentifier."
   },
   "error__attach_wallet": {

--- a/frontend/svelte/src/lib/identities/ledger.identity.ts
+++ b/frontend/svelte/src/lib/identities/ledger.identity.ts
@@ -122,6 +122,11 @@ export class LedgerIdentity extends SignIdentity {
       if (
         (err as LedgerHQTransportError)?.name === "TransportOpenUserCancelled"
       ) {
+        if (
+          (err as LedgerHQTransportError)?.message.includes("not supported")
+        ) {
+          throw new LedgerErrorKey("error__ledger.browser_not_supported");
+        }
         throw new LedgerErrorKey("error__ledger.user_cancel");
       }
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -546,6 +546,7 @@ interface I18nError__ledger {
   user_cancel: string;
   user_rejected_transaction: string;
   version_not_supported: string;
+  browser_not_supported: string;
   incorrect_identifier: string;
 }
 


### PR DESCRIPTION
# Motivation

Users that try to connect a hardware wallet with Firefox should know why it's failing.

# Changes

* Check the error thrown when trying to connect to the ledger device and change the message key for the error.

# Tests

Not applicable.
