### PR TITLE
fix: glitchy signout

### DIFF
--- a/frontend/svelte/src/lib/services/auth.services.ts
+++ b/frontend/svelte/src/lib/services/auth.services.ts
@@ -22,8 +22,7 @@ export const logout = async ({
   window.localStorage.clear();
 
   // We reload the page to make sure all the states are cleared
-  // Trigger this reload after a brief timeout to allow the rendering of the sign-in page first otherwise the ui might be displayed as glitchy (login screen rendered over current view)
-  setTimeout(() => window.location.reload(), 50);
+  window.location.reload();
 };
 
 /**

--- a/frontend/svelte/src/routes/Auth.svelte
+++ b/frontend/svelte/src/routes/Auth.svelte
@@ -51,37 +51,48 @@
 </script>
 
 {#if !signedIn}
-  <img
-    src="/assets/nns_background.jpeg"
-    loading="lazy"
-    role="presentation"
-    alt=""
-    aria-hidden="true"
-    class="background"
-  />
+  <div class="container">
+    <img
+      src="/assets/nns_background.jpeg"
+      role="presentation"
+      alt=""
+      aria-hidden="true"
+      class="background"
+    />
 
-  <Banner />
+    <Banner />
 
-  <main data-tid="auth-page">
-    <h1>{$i18n.auth.nns}</h1>
-    <h2>{$i18n.auth.ic}</h2>
-    <p>{$i18n.auth.icp_governance}</p>
-    <button on:click={signIn} data-tid="login-button">{$i18n.auth.login}</button
-    >
-  </main>
+    <main data-tid="auth-page">
+      <h1>{$i18n.auth.nns}</h1>
+      <h2>{$i18n.auth.ic}</h2>
+      <p>{$i18n.auth.icp_governance}</p>
+      <button on:click={signIn} data-tid="login-button"
+        >{$i18n.auth.login}</button
+      >
+    </main>
 
-  <img
-    src="/assets/100_on_chain-small-centered-white_text.svg"
-    role="presentation"
-    alt={$i18n.auth.on_chain}
-    class="bottom-banner"
-    loading="lazy"
-  />
+    <img
+      src="/assets/100_on_chain-small-centered-white_text.svg"
+      role="presentation"
+      alt={$i18n.auth.on_chain}
+      class="bottom-banner"
+      loading="lazy"
+    />
+  </div>
 {/if}
 
 <style lang="scss">
   @use "../lib/themes/mixins/img";
   @use "../lib/themes/mixins/media";
+
+  .container {
+    position: fixed;
+    inset: 0;
+
+    display: block;
+
+    background: black;
+  }
 
   main {
     height: 100%;


### PR DESCRIPTION
# Motivation

Follow-up of #1020. Adding a fixed background and removing the lazy loading of the images (that is loaded anyway) seems to make the signout less glitchy for the eyes.

Still has to be tested on mobile devices.

# Changes

- remove `loading=lazy` for the image as it is always loaded
- add a scree background behind login screen
- remove timeout for reload
