### PR TITLE
L2-734: SNS Project Detail Status UI

### DIFF
--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
@@ -58,7 +58,11 @@
   }
 
   .details {
-    margin-top: var(--padding);
+    margin-top: var(--padding-2x);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
   }
 
   .contrast {

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -1,3 +1,117 @@
-<div>
-  <h2>Status</h2>
+<script lang="ts">
+  import { ICP } from "@dfinity/nns";
+  import { i18n } from "../../stores/i18n";
+  import { secondsToDuration } from "../../utils/date.utils";
+  import Icp from "../ic/ICP.svelte";
+  import Badge from "../ui/Badge.svelte";
+  import KeyValuePair from "../ui/KeyValuePair.svelte";
+  import ProgressBar from "../ui/ProgressBar.svelte";
+
+  const mockIcp1 = ICP.fromString("1327") as ICP;
+  const mockIcp2 = ICP.fromString("20") as ICP;
+</script>
+
+<div class="wrapper">
+  <div class="title">
+    <h2>{$i18n.sns_project_detail.status}</h2>
+    <!-- TODO: Create another Badge for SNS? -->
+    <Badge>{$i18n.sns_project_detail.accepting}</Badge>
+  </div>
+  <div class="content">
+    <KeyValuePair info testId="sns-project-current-commitment">
+      <svelte:fragment slot="key"
+        >{$i18n.sns_project_detail.current_commitment}</svelte:fragment
+      >
+      <svelte:fragment slot="value">
+        <Icp icp={mockIcp1} singleLine />
+      </svelte:fragment>
+    </KeyValuePair>
+    <div data-tid="sns-project-commitment-progress">
+      <ProgressBar value={1327} max={3000}>
+        <p slot="top" class="right">
+          {$i18n.sns_project_detail.max_commitment}
+        </p>
+        <p slot="bottom">
+          {$i18n.sns_project_detail.min_commitment_goal}
+        </p>
+      </ProgressBar>
+    </div>
+    <div>
+      <ProgressBar value={85} max={100}>
+        <p slot="top" class="stretch">
+          <span>
+            {$i18n.sns_project_detail.deadline}
+          </span>
+          <span>
+            {secondsToDuration(BigInt(3600 * 24 * 14 + 3600 * 4))}
+          </span>
+        </p>
+      </ProgressBar>
+    </div>
+  </div>
+  <div class="actions">
+    <div>
+      <KeyValuePair>
+        <svelte:fragment slot="key"
+          >{$i18n.sns_project_detail.user_commitment}</svelte:fragment
+        >
+        <svelte:fragment slot="value">
+          <Icp icp={mockIcp2} singleLine />
+        </svelte:fragment>
+      </KeyValuePair>
+    </div>
+    <button class="primary small" data-tid="sns-project-participate-button"
+      >{$i18n.sns_project_detail.participate}</button
+    >
+  </div>
 </div>
+
+<style lang="scss">
+  @use "../../themes/mixins/media";
+  p {
+    margin: 0;
+  }
+
+  .wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+
+  .title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-2x);
+  }
+  .right {
+    text-align: right;
+  }
+
+  .stretch {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-end;
+    gap: var(--padding-2x);
+
+    flex: 1;
+
+    @include media.min-width(medium) {
+      align-items: flex-start;
+
+      flex: initial;
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -38,7 +38,7 @@
     </div>
     <div>
       <ProgressBar value={85} max={100}>
-        <p slot="top" class="stretch">
+        <p slot="top" class="push-apart">
           <span>
             {$i18n.sns_project_detail.deadline}
           </span>
@@ -94,7 +94,7 @@
     text-align: right;
   }
 
-  .stretch {
+  .push-apart {
     display: flex;
     justify-content: space-between;
   }

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -11,7 +11,7 @@
   const mockIcp2 = ICP.fromString("20") as ICP;
 </script>
 
-<div class="wrapper">
+<div class="wrapper" data-tid="sns-project-detail-status">
   <div class="title">
     <h2>{$i18n.sns_project_detail.status}</h2>
     <!-- TODO: Create another Badge for SNS? -->

--- a/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
+++ b/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
@@ -2,11 +2,14 @@
   import IconInfoOutline from "../../icons/IconInfoOutline.svelte";
 
   export let info: boolean = false;
+  export let testId: string | undefined = undefined;
 </script>
 
-<dl>
+<dl data-tid={testId}>
   <dt>
-    <slot name="key" />
+    <span>
+      <slot name="key" />
+    </span>
     {#if info}
       <IconInfoOutline />
     {/if}
@@ -20,6 +23,9 @@
   dl {
     display: flex;
     justify-content: space-between;
+    gap: var(--padding-2x);
+
+    margin: 0;
   }
 
   dt {

--- a/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
+++ b/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  // Html default is 1 anyway
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress?retiredLocale=ca#attr-max
+  export let max: number = 1;
+  export let value: number;
+</script>
+
+<!-- TODO: https://dfinity.atlassian.net/browse/L2-759 -->
+<div>
+  <slot name="top" />
+  <progress {max} {value} />
+  <slot name="bottom" />
+</div>
+
+<style lang="scss">
+  progress {
+    width: 100%;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/TwoColumns.svelte
+++ b/frontend/svelte/src/lib/components/ui/TwoColumns.svelte
@@ -2,21 +2,26 @@
   export let testId: string | undefined = undefined;
 </script>
 
-<section data-tid={testId}>
+<div class="wrapper" data-tid={testId}>
   <div class="left">
     <slot name="left" />
   </div>
   <div class="right">
     <slot name="right" />
   </div>
-</section>
+</div>
 
 <style lang="scss">
   @use "../../themes/mixins/media";
-  section {
+  .wrapper {
     display: flex;
     flex-direction: column;
     gap: var(--row-gap);
+    min-height: 100%;
+
+    & .right {
+      flex: 1;
+    }
 
     @include media.min-width(large) {
       display: grid;

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -503,7 +503,14 @@
     "token_name": "Token Name",
     "token_symbol": "Token Symbol",
     "min_commitment": "Minimum Commitment",
-    "max_commitment": "Maximum Commitment"
+    "max_commitment": "Maximum Commitment",
+    "current_commitment": "Current Overall Commitment",
+    "min_commitment_goal": "Minimum Commitment Goal",
+    "deadline": "Deadline",
+    "user_commitment": "Your Current Commitment",
+    "status": "Status",
+    "accepting": "Accepting Participation",
+    "participate": "Participate"
   },
   "time": {
     "year": "year",

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -532,6 +532,11 @@ interface I18nSns_project_detail {
   token_symbol: string;
   min_commitment: string;
   max_commitment: string;
+  current_commitment: string;
+  min_commitment_goal: string;
+  deadline: string;
+  user_commitment: string;
+  participate: string;
 }
 
 interface I18nTime {

--- a/frontend/svelte/src/routes/SNSProjectDetail.svelte
+++ b/frontend/svelte/src/routes/SNSProjectDetail.svelte
@@ -22,8 +22,26 @@
 
 <Layout on:nnsBack={goBack} layout="detail">
   <svelte:fragment slot="header">Project Tetris</svelte:fragment>
-  <TwoColumns>
-    <ProjectInfoSection slot="left" />
-    <ProjectStatusSection slot="right" />
-  </TwoColumns>
+  <section>
+    <TwoColumns>
+      <ProjectInfoSection slot="left" />
+      <ProjectStatusSection slot="right" />
+    </TwoColumns>
+  </section>
 </Layout>
+
+<style lang="scss">
+  @use "../lib/themes/mixins/media";
+  section {
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: var(--padding-2x) var(--padding);
+
+    display: flex;
+    align-items: stretch;
+
+    @include media.min-width(medium) {
+      padding: var(--padding-2x) var(--padding-2_5x);
+    }
+  }
+</style>

--- a/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectStatusSection.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import ProjectStatusSection from "../../../../lib/components/sns-project-detail/ProjectStatusSection.svelte";
+
+describe("ProjectStatusSection", () => {
+  it("should render subtitle", async () => {
+    const { container } = render(ProjectStatusSection);
+    expect(container.querySelector("h2")).toBeInTheDocument();
+  });
+
+  it("should render project current commitment", async () => {
+    const { queryByTestId } = render(ProjectStatusSection);
+    expect(queryByTestId("sns-project-current-commitment")).toBeInTheDocument();
+  });
+
+  it("should render project participate button", async () => {
+    const { queryByTestId } = render(ProjectStatusSection);
+    expect(queryByTestId("sns-project-participate-button")).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/ProgressBar.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/ProgressBar.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import ProgressBarTest from "./ProgressBarTest.svelte";
+
+describe("ProgressBar", () => {
+  it("should render a progress element with value", () => {
+    const value = 85;
+    const { container } = render(ProgressBarTest, {
+      props: { value, max: 100 },
+    });
+
+    const progressElement = container.querySelector("progress");
+    expect(progressElement).not.toBeNull();
+    progressElement && expect(progressElement.value).toBe(value);
+  });
+
+  it("should render a progress element with max value", () => {
+    const value = 85;
+    const max = 100;
+    const { container } = render(ProgressBarTest, {
+      props: { value, max },
+    });
+
+    const progressElement = container.querySelector("progress");
+    expect(progressElement).not.toBeNull();
+    progressElement && expect(progressElement.max).toBe(max);
+  });
+
+  it("should render top and bottom slots", () => {
+    const value = 85;
+    const max = 100;
+    const { container } = render(ProgressBarTest, {
+      props: { value, max, top: "test top", bottom: "test bottom" },
+    });
+
+    const progressElement = container.querySelector("progress");
+    expect(progressElement).not.toBeNull();
+    progressElement && expect(progressElement.max).toBe(max);
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/ProgressBarTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/ProgressBarTest.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import ProgressBar from "../../../../lib/components/ui/ProgressBar.svelte";
+
+  export let value: number | undefined = undefined;
+  export let max: number | undefined = undefined;
+  export let top: string | undefined = undefined;
+  export let bottom: string | undefined = undefined;
+</script>
+
+<ProgressBar {value} {max}>
+  <p slot="top">
+    {top}
+  </p>
+  <p slot="bottom">
+    {bottom}
+  </p>
+</ProgressBar>

--- a/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
@@ -11,4 +11,10 @@ describe("SNSProjectDetail", () => {
 
     expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument();
   });
+
+  it("should render status section", () => {
+    const { queryByTestId } = render(SNSProjectDetail);
+
+    expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Motivation

User can see the project commitment status in the project detail page.

# Changes

* Implement the ProjectStatusSection UI.
* The second part of TwoColumns takes over all the remaining space.
* Expand the SNSProjectDetail to have the height of at least the whole screen.
* New UI Component: ProgressBar. NOT IMPLEMENTED YET, just setup.

# Tests

* Setup test for ProgressBar.
* Setup test for ProjectStatusSection.
* Add test case in SNSProjectDetail.
