### PR TITLE
Fix payload cannot be larger than error

### DIFF
--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -15,6 +15,7 @@ import {
   HardwareWalletAttachError,
   NameTooLongError,
   ProposalPayloadNotFoundError,
+  ProposalPayloadTooLargeError,
   SubAccountLimitExceededError,
   UnknownProposalPayloadError,
 } from "./nns-dapp.errors";
@@ -323,6 +324,10 @@ export class NNSDappCanister {
     const errorText = "Err" in response ? response.Err : undefined;
     if (errorText?.includes("Proposal not found") === true) {
       throw new ProposalPayloadNotFoundError();
+    }
+
+    if (errorText?.includes("cannot be larger than") === true) {
+      throw new ProposalPayloadTooLargeError();
     }
 
     throw new UnknownProposalPayloadError(

--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -73,3 +73,4 @@ export class UnknownProposalPayloadError extends Error {
 }
 
 export class ProposalPayloadNotFoundError extends Error {}
+export class ProposalPayloadTooLargeError extends Error {}

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/NnsFunctionDetails.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/NnsFunctionDetails.svelte
@@ -16,7 +16,7 @@
     $i18n.proposal_detail.unknown_nns_function;
 
   let payload: object | undefined | null;
-  $: payload = $proposalPayloadsStore.get(proposalId);
+  $: $proposalPayloadsStore, (payload = $proposalPayloadsStore.get(proposalId));
   $: if (proposalId !== undefined && !$proposalPayloadsStore.has(proposalId)) {
     loadProposalPayload({
       proposalId,

--- a/frontend/svelte/src/lib/services/proposals.services.ts
+++ b/frontend/svelte/src/lib/services/proposals.services.ts
@@ -7,7 +7,10 @@ import {
   queryProposals,
   registerVote,
 } from "../api/proposals.api";
-import { ProposalPayloadNotFoundError } from "../canisters/nns-dapp/nns-dapp.errors";
+import {
+  ProposalPayloadNotFoundError,
+  ProposalPayloadTooLargeError,
+} from "../canisters/nns-dapp/nns-dapp.errors";
 import {
   startBusy,
   stopBusy,
@@ -263,6 +266,14 @@ export const loadProposalPayload = async ({
   } catch (err) {
     console.error(err);
 
+    if (err instanceof ProposalPayloadTooLargeError) {
+      proposalPayloadsStore.setPayload({
+        proposalId,
+        payload: { error: "Payload too large" },
+      });
+
+      return;
+    }
     if (err instanceof ProposalPayloadNotFoundError) {
       toastsStore.error({
         labelKey: "error.proposal_payload_not_found",

--- a/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/svelte/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -12,6 +12,7 @@ import {
   HardwareWalletAttachError,
   NameTooLongError,
   ProposalPayloadNotFoundError,
+  ProposalPayloadTooLargeError,
   SubAccountLimitExceededError,
   UnknownProposalPayloadError,
 } from "../../../lib/canisters/nns-dapp/nns-dapp.errors";
@@ -390,6 +391,21 @@ describe("NNSDapp", () => {
       });
 
     expect(call).rejects.toThrowError(ProposalPayloadNotFoundError);
+  });
+
+  it("should throw ProposalPayloadTooLargeError", async () => {
+    const service = mock<NNSDappService>();
+    service.get_proposal_payload.mockResolvedValue({
+      Err: "An error occurred while loading proposal payload. IC0504: Canister xxxx violated contract: ic0.msg_reply_data_append: application payload size (2553969) cannot be larger than 2097152",
+    });
+    const nnsDapp = await createNnsDapp(service);
+
+    const call = () =>
+      nnsDapp.getProposalPayload({
+        proposalId: BigInt(0),
+      });
+
+    expect(call).rejects.toThrowError(ProposalPayloadTooLargeError);
   });
 
   it("should throw UnknownProposalPayloadError", async () => {

--- a/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/proposals.services.spec.ts
@@ -2,7 +2,10 @@ import type { NeuronId, ProposalInfo } from "@dfinity/nns";
 import { GovernanceError, Vote } from "@dfinity/nns";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/proposals.api";
-import { ProposalPayloadNotFoundError } from "../../../lib/canisters/nns-dapp/nns-dapp.errors";
+import {
+  ProposalPayloadNotFoundError,
+  ProposalPayloadTooLargeError,
+} from "../../../lib/canisters/nns-dapp/nns-dapp.errors";
 import { DEFAULT_PROPOSALS_FILTERS } from "../../../lib/constants/proposals.constants";
 import * as neuronsServices from "../../../lib/services/neurons.services";
 import {
@@ -521,6 +524,20 @@ describe("proposals-services", () => {
       await loadProposalPayload({ proposalId: BigInt(0) });
 
       expect(get(proposalPayloadsStore).get(BigInt(0))).toBeNull();
+    });
+
+    it("should update proposalPayloadsStore with null if the payload was not found", async () => {
+      proposalPayloadsStore.reset();
+
+      jest.spyOn(api, "queryProposalPayload").mockImplementation(() => {
+        throw new ProposalPayloadTooLargeError();
+      });
+
+      await loadProposalPayload({ proposalId: BigInt(0) });
+
+      expect(get(proposalPayloadsStore).get(BigInt(0))).toEqual({
+        error: "Payload too large",
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

Handling the case when the wasm is too large to be loaded (`An error occurred while loading proposal payload. IC0504: Canister xyz violated contract: ic0.msg_reply_data_append: application payload size (2553969) cannot be larger than 2097152`)

Skip the error toast and display the custom message in the payload block:
![image](https://user-images.githubusercontent.com/98811342/175559986-14f9092e-d8a0-48a7-b60f-789b6ddf12f2.png)

# Changes

- new error type `ProposalPayloadTooLargeError`

# Tests

- nns-dapp.canister.spec.ts
- proposals.services.spec.ts