### PR TITLE
fix: proposal id can be undefined

### DIFF
--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte
@@ -9,7 +9,7 @@
   import Json from "../../common/Json.svelte";
   import NnsFunctionDetails from "./NnsFunctionDetails.svelte";
 
-  export let proposalId: ProposalId;
+  export let proposalId: ProposalId | undefined;
   export let proposal: Proposal | undefined;
 
   let actionKey: string | undefined;
@@ -35,7 +35,7 @@
       {/if}
     {/each}
 
-    {#if nnsFunctionId !== undefined}
+    {#if nnsFunctionId !== undefined && proposalId !== undefined}
       <NnsFunctionDetails {proposalId} {nnsFunctionId} />
     {/if}
   </dl>

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {ProposalId, ProposalStatus} from "@dfinity/nns";
+  import {type ProposalId, ProposalStatus} from "@dfinity/nns";
   import type { Proposal, ProposalInfo } from "@dfinity/nns";
   import Badge from "../../ui/Badge.svelte";
   import Card from "../../ui/Card.svelte";

--- a/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
+++ b/frontend/svelte/src/lib/components/proposal-detail/ProposalDetailCard/ProposalDetailCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProposalStatus } from "@dfinity/nns";
+  import {ProposalId, ProposalStatus} from "@dfinity/nns";
   import type { Proposal, ProposalInfo } from "@dfinity/nns";
   import Badge from "../../ui/Badge.svelte";
   import Card from "../../ui/Card.svelte";
@@ -13,6 +13,7 @@
   export let proposalInfo: ProposalInfo;
 
   let proposal: Proposal | undefined;
+  let id: ProposalId | undefined;
   let title: string | undefined;
   let status: ProposalStatus = ProposalStatus.PROPOSAL_STATUS_UNKNOWN;
   let color: ProposalColor;

--- a/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.spec.ts
@@ -40,6 +40,7 @@ describe("ProposalActions", () => {
     const { getByText } = render(ProposalActions, {
       props: {
         proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
       },
     });
 
@@ -51,6 +52,7 @@ describe("ProposalActions", () => {
     const { getByText } = render(ProposalActions, {
       props: {
         proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
       },
     });
 
@@ -65,6 +67,7 @@ describe("ProposalActions", () => {
     const nodeProviderActions = render(ProposalActions, {
       props: {
         proposal: proposalWithRewardNodeProviderAction,
+        proposalId: mockProposalInfo.id,
       },
     });
 
@@ -75,6 +78,7 @@ describe("ProposalActions", () => {
     const motionActions = render(ProposalActions, {
       props: {
         proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
       },
     });
 
@@ -94,6 +98,7 @@ describe("ProposalActions", () => {
       const { getByText } = render(ProposalActions, {
         props: {
           proposal: proposalWithNnsFunctionAction,
+          proposalId: mockProposalInfo.id,
         },
       });
 
@@ -113,6 +118,7 @@ describe("ProposalActions", () => {
       const { getByText } = render(ProposalActions, {
         props: {
           proposal: proposalWithNnsFunctionAction,
+          proposalId: mockProposalInfo.id,
         },
       });
 


### PR DESCRIPTION
# Motivation

Handle proposal id that can be undefined. Once properly typed, following lint error is thrown:

> Error: Type 'bigint | undefined' is not assignable to type 'bigint'.
>  Type 'undefined' is not assignable to type 'bigint'. (ts)
>
>  <ProposalActions proposalId={id} {proposal} />
> </CardInfo>

# Changes

- properly type variable
- handle undefined value
