### PR TITLE
chore: set missing return type

### DIFF
--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -51,7 +51,11 @@ export const sendICP = async ({
  *
  * @returns {bigint}
  */
-export const transactionFee = async ({ identity }: { identity: Identity }): Promise<bigint> => {
+export const transactionFee = async ({
+  identity,
+}: {
+  identity: Identity;
+}): Promise<bigint> => {
   logWithTimestamp(`Getting transaction fee call...`);
   const { canister } = await ledgerCanister({ identity });
   const fee = await canister.transactionFee();

--- a/frontend/svelte/src/lib/api/ledger.api.ts
+++ b/frontend/svelte/src/lib/api/ledger.api.ts
@@ -46,9 +46,12 @@ export const sendICP = async ({
 /**
  * Returns transaction fee of the Ledger Canister in IC
  *
+ * @param {Object} params
+ * @param {Identity} params.identity user identity
+ *
  * @returns {bigint}
  */
-export const transactionFee = async ({ identity }: { identity: Identity }) => {
+export const transactionFee = async ({ identity }: { identity: Identity }): Promise<bigint> => {
   logWithTimestamp(`Getting transaction fee call...`);
   const { canister } = await ledgerCanister({ identity });
   const fee = await canister.transactionFee();


### PR DESCRIPTION
# Motivation

Return type for `transactionFee` feature was not set.

> Hint: JSDoc types may be moved to TypeScript types. 
>  */
> export const transactionFee = async ({ identity }: { identity: Identity }) => {
>   logWithTimestamp(`Getting transaction fee call...`);

# Changes

- set return type
- add missing jsdoc
