### PR TITLE
L2 769 dynamic loading for sns pages

### DIFF
--- a/frontend/svelte/src/lib/components/sns-launchpad/SNSLaunchpadContent.svelte
+++ b/frontend/svelte/src/lib/components/sns-launchpad/SNSLaunchpadContent.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import SNSProjects from "./SNSProjects.svelte";
+  import SNSProposals from "./SNSProposals.svelte";
+</script>
+
+<SNSProjects />
+<SNSProposals />

--- a/frontend/svelte/src/lib/components/sns-project-detail/SNSProjectDetailContent.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/SNSProjectDetailContent.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import ProjectInfoSection from "./ProjectInfoSection.svelte";
+  import ProjectStatusSection from "./ProjectStatusSection.svelte";
+  import TwoColumns from "../ui/TwoColumns.svelte";
+</script>
+
+<section>
+  <TwoColumns>
+    <ProjectInfoSection slot="left" />
+    <ProjectStatusSection slot="right" />
+  </TwoColumns>
+</section>
+
+<style lang="scss">
+  @use "../../../lib/themes/mixins/media";
+
+  section {
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: var(--padding-2x) var(--padding);
+
+    display: flex;
+    align-items: stretch;
+
+    @include media.min-width(medium) {
+      padding: var(--padding-2x) var(--padding-2_5x);
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -543,6 +543,8 @@ interface I18nSns_project_detail {
   min_commitment_goal: string;
   deadline: string;
   user_commitment: string;
+  status: string;
+  accepting: string;
   participate: string;
 }
 

--- a/frontend/svelte/src/routes/SNSLaunchpad.svelte
+++ b/frontend/svelte/src/routes/SNSLaunchpad.svelte
@@ -8,6 +8,7 @@
   import { routeStore } from "../lib/stores/route.store";
 
   let pageContent: typeof SvelteComponent | undefined;
+
   const importPageContent = async () => {
     pageContent = await (
       await import("../lib/components/sns-launchpad/SNSLaunchpadContent.svelte")

--- a/frontend/svelte/src/routes/SNSLaunchpad.svelte
+++ b/frontend/svelte/src/routes/SNSLaunchpad.svelte
@@ -1,22 +1,35 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, SvelteComponent } from "svelte";
   import Layout from "../lib/components/common/Layout.svelte";
-  import SNSProjects from "../lib/components/sns-launchpad/SNSProjects.svelte";
-  import SNSProposals from "../lib/components/sns-launchpad/SNSProposals.svelte";
+  import Spinner from "../lib/components/ui/Spinner.svelte";
   import { IS_TESTNET } from "../lib/constants/environment.constants";
   import { AppPath } from "../lib/constants/routes.constants";
   import { i18n } from "../lib/stores/i18n";
   import { routeStore } from "../lib/stores/route.store";
 
+  let pageContent: typeof SvelteComponent | undefined;
+  const importPageContent = async () => {
+    pageContent = await (
+      await import("../lib/components/sns-launchpad/SNSLaunchpadContent.svelte")
+    ).default;
+  };
+
   onMount(() => {
     if (!IS_TESTNET) {
       routeStore.replace({ path: AppPath.Accounts });
+      return;
     }
+
+    importPageContent();
   });
 </script>
 
 <Layout>
   <svelte:fragment slot="header">{$i18n.sns_launchpad.header}</svelte:fragment>
-  <SNSProjects />
-  <SNSProposals />
+
+  {#if pageContent === undefined}
+    <Spinner />
+  {:else}
+    <svelte:component this={pageContent} />
+  {/if}
 </Layout>

--- a/frontend/svelte/src/routes/SNSProjectDetail.svelte
+++ b/frontend/svelte/src/routes/SNSProjectDetail.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, SvelteComponent } from "svelte";
   import Layout from "../lib/components/common/Layout.svelte";
-  import ProjectInfoSection from "../lib/components/sns-project-detail/ProjectInfoSection.svelte";
-  import ProjectStatusSection from "../lib/components/sns-project-detail/ProjectStatusSection.svelte";
-  import TwoColumns from "../lib/components/ui/TwoColumns.svelte";
+  import Spinner from "../lib/components/ui/Spinner.svelte";
   import { IS_TESTNET } from "../lib/constants/environment.constants";
   import { AppPath } from "../lib/constants/routes.constants";
   import { routeStore } from "../lib/stores/route.store";
 
+  let pageContent: typeof SvelteComponent | undefined;
+
+  const importPageContent = async () => {
+    pageContent = await (
+      await import(
+        "../lib/components/sns-project-detail/SNSProjectDetailContent.svelte"
+      )
+    ).default;
+  };
+
   onMount(() => {
     if (!IS_TESTNET) {
       routeStore.replace({ path: AppPath.Accounts });
+      return;
     }
+
+    importPageContent();
   });
 
   const goBack = () =>
@@ -22,26 +33,10 @@
 
 <Layout on:nnsBack={goBack} layout="detail">
   <svelte:fragment slot="header">Project Tetris</svelte:fragment>
-  <section>
-    <TwoColumns>
-      <ProjectInfoSection slot="left" />
-      <ProjectStatusSection slot="right" />
-    </TwoColumns>
-  </section>
+
+  {#if pageContent === undefined}
+    <Spinner />
+  {:else}
+    <svelte:component this={pageContent} />
+  {/if}
 </Layout>
-
-<style lang="scss">
-  @use "../lib/themes/mixins/media";
-  section {
-    box-sizing: border-box;
-    min-height: 100%;
-    padding: var(--padding-2x) var(--padding);
-
-    display: flex;
-    align-items: stretch;
-
-    @include media.min-width(medium) {
-      padding: var(--padding-2x) var(--padding-2_5x);
-    }
-  }
-</style>

--- a/frontend/svelte/src/tests/lib/components/sns-launchpad/SNSLaunchpadContent.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-launchpad/SNSLaunchpadContent.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import SNSLaunchpadContent from "../../../../lib/components/sns-launchpad/SNSLaunchpadContent.svelte";
+import en from "../../../mocks/i18n.mock";
+
+jest.mock("../../../../lib/services/sns.services", () => {
+  return {
+    loadSnsFullProjects: jest.fn().mockResolvedValue(Promise.resolve()),
+  };
+});
+
+describe("SNSLaunchpadContent", () => {
+  it("should render a spinner", () => {
+    const { queryByText } = render(SNSLaunchpadContent);
+
+    expect(queryByText(en.sns_launchpad.projects)).toBeInTheDocument();
+    expect(queryByText(en.sns_launchpad.proposals)).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/sns-project-detail/SNSProjectDetailContent.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-project-detail/SNSProjectDetailContent.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import SNSProjectDetailContent from "../../../../lib/components/sns-project-detail/SNSProjectDetailContent.svelte";
+
+describe("SNSProjectDetailContent", () => {
+  it("should render info section", () => {
+    const { queryByTestId } = render(SNSProjectDetailContent);
+
+    expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument();
+  });
+
+  it("should render status section", () => {
+    const { queryByTestId } = render(SNSProjectDetailContent);
+
+    expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+  });
+});

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -22,6 +22,10 @@ describe("utils", () => {
     jest.spyOn(global, "setTimeout");
   });
 
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it("should debounce function with timeout", () => {
     const testDebounce = debounce(callback, 100);
 

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -95,7 +95,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(3),
 
-    deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 10),
+    deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 1000),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
     tokenName: "string",

--- a/frontend/svelte/src/tests/routes/SNSLaunchpad.spec.ts
+++ b/frontend/svelte/src/tests/routes/SNSLaunchpad.spec.ts
@@ -7,7 +7,7 @@ import SNSLaunchpad from "../../routes/SNSLaunchpad.svelte";
 import en from "../mocks/i18n.mock";
 
 describe("SNSLaunchpad", () => {
-  it("should render header", () => {
+  it("should render a header", () => {
     const { queryByText } = render(SNSLaunchpad);
 
     expect(queryByText(en.sns_launchpad.header)).toBeInTheDocument();

--- a/frontend/svelte/src/tests/routes/SNSLaunchpad.spec.ts
+++ b/frontend/svelte/src/tests/routes/SNSLaunchpad.spec.ts
@@ -13,10 +13,9 @@ describe("SNSLaunchpad", () => {
     expect(queryByText(en.sns_launchpad.header)).toBeInTheDocument();
   });
 
-  it("should render sub blocks", () => {
-    const { queryByText } = render(SNSLaunchpad);
+  it("should render a spinner", () => {
+    const { getByTestId } = render(SNSLaunchpad);
 
-    expect(queryByText(en.sns_launchpad.projects)).toBeInTheDocument();
-    expect(queryByText(en.sns_launchpad.proposals)).toBeInTheDocument();
+    expect(getByTestId("spinner")).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
@@ -6,15 +6,15 @@ import { render } from "@testing-library/svelte";
 import SNSProjectDetail from "../../routes/SNSProjectDetail.svelte";
 
 describe("SNSProjectDetail", () => {
-  it("should render info section", () => {
-    const { queryByTestId } = render(SNSProjectDetail);
+  it("should render a header", () => {
+    const { queryByText } = render(SNSProjectDetail);
 
-    expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument();
+    expect(queryByText("Project Tetris")).toBeInTheDocument();
   });
 
-  it("should render status section", () => {
-    const { queryByTestId } = render(SNSProjectDetail);
+  it("should render a spinner", () => {
+    const { getByTestId } = render(SNSProjectDetail);
 
-    expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+    expect(getByTestId("spinner")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

Use dynamic loading for the sns pages to decrease the main bundle size.
[L2-769](https://dfinity.atlassian.net/browse/L2-769)

https://user-images.githubusercontent.com/98811342/176130596-c1f75946-44f8-4cb3-8d01-4b51bd63cdf6.mov

# Changes

- routes/sns pages works as proxy with the initial layout
- SNSLaunchpadContent.svelte (launchpad imported content)
- SNSProjectDetailContent.svelte (project imported content)

# Tests

- SNSLaunchpadContent
- ### SNSProjectDetailContent
