### PR TITLE
L2-771: Adapt Layout to SNS

### DIFF
--- a/frontend/svelte/src/lib/components/common/Layout.svelte
+++ b/frontend/svelte/src/lib/components/common/Layout.svelte
@@ -7,7 +7,7 @@
   import Back from "../header/Back.svelte";
   import SplitPane from "../ui/SplitPane.svelte";
 
-  export let layout: "main" | "detail" = "main";
+  export let layout: "old-main" | "old-detail" | "detail" | "main" = "old-main";
 
   let showFooter: boolean;
   $: showFooter = $$slots.footer;
@@ -21,7 +21,7 @@
 <SplitPane bind:sticky>
   <Header slot="header">
     <svelte:fragment slot="start">
-      {#if layout === "detail"}
+      {#if layout === "detail" || layout === "old-detail"}
         <Back on:nnsBack />
       {:else}
         <MenuButton bind:open />
@@ -33,7 +33,7 @@
 
   <Menu slot="menu" bind:open {sticky} />
 
-  <main>
+  <main class={layout}>
     <slot />
   </main>
 
@@ -49,5 +49,12 @@
     height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
+
+    &.old-detail,
+    &.old-main {
+      --section-max-width: 800px;
+      --section-padding: var(--padding-2x) var(--padding-2x)
+        var(--footer-height);
+    }
   }
 </style>

--- a/frontend/svelte/src/lib/components/header/Logout.svelte
+++ b/frontend/svelte/src/lib/components/header/Logout.svelte
@@ -16,7 +16,7 @@
     margin: 0;
 
     :global(svg) {
-      width: var(--padding-2_5x);
+      width: var(--padding-2x);
     }
   }
 

--- a/frontend/svelte/src/lib/components/ui/TwoColumns.svelte
+++ b/frontend/svelte/src/lib/components/ui/TwoColumns.svelte
@@ -18,6 +18,7 @@
     flex-direction: column;
     gap: var(--row-gap);
     min-height: 100%;
+    width: 100%;
 
     & .right {
       flex: 1;
@@ -36,7 +37,7 @@
 
       .right {
         grid-column-start: 7;
-        grid-column-end: 12;
+        grid-column-end: 13;
       }
     }
   }

--- a/frontend/svelte/src/lib/themes/theme.scss
+++ b/frontend/svelte/src/lib/themes/theme.scss
@@ -67,7 +67,7 @@ main {
 }
 
 section {
-  padding: var(--padding-2x) var(--padding-2x) var(--footer-height);
+  padding: var(--section-padding);
   max-width: var(--section-max-width);
   margin: 0 auto;
 }

--- a/frontend/svelte/src/lib/themes/variables.scss
+++ b/frontend/svelte/src/lib/themes/variables.scss
@@ -15,14 +15,18 @@
   --padding-6x: calc(6 * var(--padding));
   --padding-8x: calc(8 * var(--padding));
 
-  --column-gap: var(--padding-2x);
+  --column-gap: var(--padding-4x);
   --row-gap: var(--padding-3x);
 
   --border-radius: 10px;
 
   --z-index: 1;
 
-  --section-max-width: 800px;
+  --section-max-width: 1300px;
+  --section-padding: var(--padding-4x) var(--padding-2x);
+  @include media.min-width(medium) {
+    --section-padding: var(--padding-4x);
+  }
   --footer-height: 20vh;
 
   --animation-time-normal: 0.2s;

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -543,6 +543,8 @@ interface I18nSns_project_detail {
   min_commitment_goal: string;
   deadline: string;
   user_commitment: string;
+  status: string;
+  accepting: string;
   participate: string;
 }
 

--- a/frontend/svelte/src/routes/CanisterDetail.svelte
+++ b/frontend/svelte/src/routes/CanisterDetail.svelte
@@ -185,7 +185,7 @@
     $selectedCanisterStore);
 </script>
 
-<Layout on:nnsBack={goBack} layout="detail">
+<Layout on:nnsBack={goBack} layout="old-detail">
   <svelte:fragment slot="header">{$i18n.canister_detail.title}</svelte:fragment>
 
   <section>

--- a/frontend/svelte/src/routes/NeuronDetail.svelte
+++ b/frontend/svelte/src/routes/NeuronDetail.svelte
@@ -70,7 +70,7 @@
   };
 </script>
 
-<Layout on:nnsBack={goBack} layout="detail">
+<Layout on:nnsBack={goBack} layout="old-detail">
   <svelte:fragment slot="header">{$i18n.neuron_detail.title}</svelte:fragment>
   <section data-tid="neuron-detail">
     {#if neuron}

--- a/frontend/svelte/src/routes/ProposalDetail.svelte
+++ b/frontend/svelte/src/routes/ProposalDetail.svelte
@@ -92,7 +92,7 @@
   });
 </script>
 
-<Layout on:nnsBack={goBack} layout="detail">
+<Layout on:nnsBack={goBack} layout="old-detail">
   <svelte:fragment slot="header">{$i18n.proposal_detail.title}</svelte:fragment>
 
   <section>

--- a/frontend/svelte/src/routes/SNSLaunchpad.svelte
+++ b/frontend/svelte/src/routes/SNSLaunchpad.svelte
@@ -15,8 +15,10 @@
   });
 </script>
 
-<Layout>
+<Layout layout="main">
   <svelte:fragment slot="header">{$i18n.sns_launchpad.header}</svelte:fragment>
-  <SNSProjects />
-  <SNSProposals />
+  <section>
+    <SNSProjects />
+    <SNSProposals />
+  </section>
 </Layout>

--- a/frontend/svelte/src/routes/SNSProjectDetail.svelte
+++ b/frontend/svelte/src/routes/SNSProjectDetail.svelte
@@ -35,13 +35,8 @@
   section {
     box-sizing: border-box;
     min-height: 100%;
-    padding: var(--padding-2x) var(--padding);
 
     display: flex;
     align-items: stretch;
-
-    @include media.min-width(medium) {
-      padding: var(--padding-2x) var(--padding-2_5x);
-    }
   }
 </style>

--- a/frontend/svelte/src/routes/Wallet.svelte
+++ b/frontend/svelte/src/routes/Wallet.svelte
@@ -115,7 +115,7 @@
   // TODO(L2-581): Create WalletInfo component
 </script>
 
-<Layout on:nnsBack={goBack} layout="detail">
+<Layout on:nnsBack={goBack} layout="old-detail">
   <svelte:fragment slot="header">{$i18n.wallet.title}</svelte:fragment>
 
   <section>


### PR DESCRIPTION
# Motivation

Adapt page layout to new design for SNS.

# Changes

* Rename current "layout" props to "old-detail" and "old-main". Use "detail" and "main" for new layout.
* Change default "section" padding and max-width.
* Change column-gap to 32px
* Use section in SNSLaunchPad page.

# Tests

* Not applicable. Only CSS changes.
