### PR TITLE
fix: hide dev banner

### DIFF
--- a/frontend/svelte/src/lib/components/header/Banner.svelte
+++ b/frontend/svelte/src/lib/components/header/Banner.svelte
@@ -24,11 +24,16 @@
 
   $: visible,
     (() => {
+      if (!banner) {
+        // If no banner has to be displayed, setting or removing the header offset can be skipped
+        return;
+      }
+
       const {
         documentElement: { style },
       } = document;
 
-      if (banner && visible) {
+      if (visible) {
         style.setProperty("--header-offset", "50px");
         return;
       }

--- a/frontend/svelte/src/lib/components/header/Banner.svelte
+++ b/frontend/svelte/src/lib/components/header/Banner.svelte
@@ -28,7 +28,7 @@
         documentElement: { style },
       } = document;
 
-      if (visible) {
+      if (banner && visible) {
         style.setProperty("--header-offset", "50px");
         return;
       }

--- a/frontend/svelte/src/lib/components/header/Banner.svelte
+++ b/frontend/svelte/src/lib/components/header/Banner.svelte
@@ -16,26 +16,26 @@
   const localEnv: boolean = ROLLUP_WATCH;
   const banner: boolean = testnet && !localEnv;
 
-  const rootStyle: string = `
-    <style>
-      :root {
-        --header-offset: 50px;
-      }
-    </style>
-  `;
-
   const close = () => {
     visible = false;
 
     localStorage.setItem(localstorageKey, "false");
   };
-</script>
 
-<svelte:head>
-  {#if banner && visible}
-    {@html rootStyle}
-  {/if}
-</svelte:head>
+  $: visible,
+    (() => {
+      const {
+        documentElement: { style },
+      } = document;
+
+      if (visible) {
+        style.setProperty("--header-offset", "50px");
+        return;
+      }
+
+      style.removeProperty("--header-offset");
+    })();
+</script>
 
 {#if banner && visible}
   <div>


### PR DESCRIPTION
# Motivation

Following our change in the layout, if the dev banner gets hidden, the spacing isn't removed because Svelte does not remove the style in head.

# Changes

- instead of `svelte:head` use style property on the document

# Original issue that is solved with this PR

![remove](https://user-images.githubusercontent.com/16886711/176371975-68941a81-30c7-4651-b3aa-f19450cda4d7.gif)

