### PR TITLE
feat: open csp for data: images

### DIFF
--- a/frontend/svelte/scripts/build.index.mjs
+++ b/frontend/svelte/scripts/build.index.mjs
@@ -51,7 +51,7 @@ const updateCSP = (content) => {
         http-equiv="Content-Security-Policy"
         content="default-src 'none';
         connect-src 'self' ${cspConnectSrc()};
-        img-src 'self' https://nns.raw.ic0.app/;
+        img-src 'self' data: https://nns.raw.ic0.app/;
         child-src 'self';
         manifest-src 'self';
         script-src 'unsafe-eval' 'strict-dynamic' 'nonce-main-31858fd0-b02b-4e0b-bf0b-c49e9b515a25' 'nonce-main-bc619616-7c54-4009-abff-493dd9b42bac';


### PR DESCRIPTION
# Motivation

Sns mockup images are provided as data:base64 images, therefore we should open the csp rules to such types of images. 

# Changes

- open csp for `data:` images
