### PR TITLE
style: tooltip displayed with offset if menu open

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -12,17 +12,22 @@
   let tooltipStyle: string | undefined = undefined;
 
   const setPosition = debounce(() => {
-    // We get the main reference because at the moment the scrollbar is displayed in that element therefore it's the way to get to know the real width
-    const clientWidth = document.querySelector("main")?.clientWidth;
+    // We need the main reference because at the moment the scrollbar is displayed in that element therefore it's the way to get to know the real width - i.e. window width - scrollbar width
+    const main: HTMLElement | null = document.querySelector("main");
 
     if (
-      clientWidth === undefined ||
+      main === null ||
       tooltipComponent === undefined ||
       target === undefined
     ) {
       // Do nothing, we need the elements to be rendered in order to get their size and position to fix the tooltip
       return;
     }
+
+    const { innerWidth } = window;
+
+    const { clientWidth, offsetWidth } = main;
+    const scrollbarWidth: number = offsetWidth - clientWidth;
 
     const { left: targetLeft, width: targetWidth } =
       target.getBoundingClientRect();
@@ -31,7 +36,7 @@
     const { width: tooltipWidth } = tooltipComponent.getBoundingClientRect();
 
     const spaceLeft = targetCenter;
-    const spaceRight = clientWidth - targetCenter;
+    const spaceRight = innerWidth - scrollbarWidth - targetCenter;
 
     const overflowLeft = tooltipWidth / 2 - spaceLeft;
     const overflowRight = tooltipWidth / 2 - spaceRight;


### PR DESCRIPTION
# Motivation

Tooltip is displayed with an offset if menu is open.

# Changes

- instead of using `main` width, consider `window` width minus the `scrollbar` width

# Screenshots

Issue:

<img width="1499" alt="Capture d’écran 2022-06-29 à 14 07 55" src="https://user-images.githubusercontent.com/16886711/176436908-bf0a9e96-8bea-4460-bb72-04785027d71c.png">
<img width="1499" alt="Capture d’écran 2022-06-29 à 14 08 00" src="https://user-images.githubusercontent.com/16886711/176436922-b1f92c25-2db5-46d4-9d7f-9bfd9e00884e.png">


Solution:

<img width="1474" alt="Capture d’écran 2022-06-29 à 14 32 55" src="https://user-images.githubusercontent.com/16886711/176437167-167a649a-5395-4cfc-98af-78eafef5100e.png">
<img width="862" alt="Capture d’écran 2022-06-29 à 14 33 00" src="https://user-images.githubusercontent.com/16886711/176437177-ca64c8ae-281b-4a36-a8b3-4bb12318bcaa.png">
<img width="1023" alt="Capture d’écran 2022-06-29 à 14 33 04" src="https://user-images.githubusercontent.com/16886711/176437185-12a997b8-3464-4245-a5c7-1b714aeaaae0.png">
<img width="1023" alt="Capture d’écran 2022-06-29 à 14 33 12" src="https://user-images.githubusercontent.com/16886711/176437190-a9b34439-69b7-477d-82bb-4a6c3bc6c20f.png">
<img width="1467" alt="Capture d’écran 2022-06-29 à 14 33 17" src="https://user-images.githubusercontent.com/16886711/176437195-4123cb54-292a-4107-83b8-e28c051f4991.png">
