### PR TITLE
L2-763: Mock data sns project detail

### DIFF
--- a/frontend/svelte/src/lib/components/sns-launchpad/SNSProjectCard.svelte
+++ b/frontend/svelte/src/lib/components/sns-launchpad/SNSProjectCard.svelte
@@ -9,6 +9,7 @@
   import { secondsToDuration } from "../../utils/date.utils";
   import Icp from "../ic/ICP.svelte";
   import Card from "../ui/Card.svelte";
+  import Logo from "../ui/Logo.svelte";
   import Spinner from "../ui/Spinner.svelte";
 
   export let project: SnsFullProject;
@@ -20,13 +21,14 @@
   let logo: string;
   let name: string;
   let description: string;
-  let deadline: bigint;
-  $: ({ logo, name, description, deadline } = summary);
+  let swapDeadline: bigint;
+  $: ({ logo, name, description, swapDeadline } = summary);
   let title: string;
   $: title = `${$i18n.sns_project.project} ${name}`;
 
   let durationTillDeadline: bigint;
-  $: durationTillDeadline = deadline - BigInt(Math.round(Date.now() / 1000));
+  $: durationTillDeadline =
+    swapDeadline - BigInt(Math.round(Date.now() / 1000));
 
   let myCommitment: ICP | undefined;
   $: myCommitment =
@@ -45,7 +47,7 @@
 
 <Card role="link" on:click={showProject}>
   <div class="title" slot="start">
-    <img src={logo} alt="project logo" />
+    <Logo src={logo} alt={$i18n.sns_launchpad.project_logo} />
     <h2>{title}</h2>
   </div>
 
@@ -79,13 +81,6 @@
       margin: 0;
       line-height: var(--line-height-standard);
     }
-  }
-
-  img {
-    width: var(--padding-3x);
-    height: var(--padding-3x);
-    border-radius: var(--border-radius);
-    border: 2px solid var(--background-contrast);
   }
 
   p {

--- a/frontend/svelte/src/lib/components/sns-project-detail/CommitmentProgressBar.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/CommitmentProgressBar.svelte
@@ -86,12 +86,12 @@
 
     &.up {
       // Borders do not support gradients
-      border-bottom: var(--padding-1_5x) solid var(--yellow-400);
+      border-bottom: var(--padding-1_5x) solid var(--warning-emphasis);
     }
 
     &.down {
       // Borders do not support gradients
-      border-top: var(--padding-1_5x) solid var(--header-background-fallback);
+      border-top: var(--padding-1_5x) solid var(--primary-gradient-fallback);
     }
   }
 

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
@@ -4,6 +4,7 @@
   import { i18n } from "../../stores/i18n";
   import Icp from "../ic/ICP.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
+  import Logo from "../ui/Logo.svelte";
 
   export let summary: SnsSummary;
 
@@ -12,7 +13,10 @@
 </script>
 
 <div data-tid="sns-project-detail-info">
-  <h1>{summary.name}</h1>
+  <div class="title">
+    <Logo src={summary.logo} alt={$i18n.sns_launchpad.project_logo} />
+    <h1>{summary.name}</h1>
+  </div>
   <p>
     {summary.description}
   </p>
@@ -52,6 +56,17 @@
 </div>
 
 <style lang="scss">
+  .title {
+    display: flex;
+    gap: var(--padding-1_5x);
+    align-items: center;
+    margin-bottom: var(--padding);
+
+    h1 {
+      margin: 0;
+      line-height: var(--line-height-standard);
+    }
+  }
   a {
     // TODO: change <a /> global styling?
     font-size: 1rem;

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
@@ -1,34 +1,34 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
+  import type { SnsSummary } from "../../services/sns.mock";
   import { i18n } from "../../stores/i18n";
   import Icp from "../ic/ICP.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
 
-  const mockIcp1 = ICP.fromString("5") as ICP;
-  const mockIcp2 = ICP.fromString("50") as ICP;
+  export let summary: SnsSummary;
+
+  const minCommitmentIcp = ICP.fromE8s(summary.minCommitment);
+  const maxCommitmentIcp = ICP.fromE8s(summary.maxCommitment);
 </script>
 
 <div data-tid="sns-project-detail-info">
-  <h1>Project Tetris</h1>
+  <h1>{summary.name}</h1>
   <p>
-    Tagline – Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    eiusmod tempor
+    {summary.description}
   </p>
-  <a href="https://6hsbt-vqaaa-aaaaf-aaafq-cai.ic0.app/"
-    >http://linkToValuePropositionExternal</a
-  >
+  <a href={summary.url} target="_blank">{summary.url}</a>
   <div class="details">
     <KeyValuePair>
       <svelte:fragment slot="key"
         >{$i18n.sns_project_detail.token_name}</svelte:fragment
       >
-      <span slot="value">Tetris Token</span>
+      <span slot="value">{summary.tokenName}</span>
     </KeyValuePair>
     <KeyValuePair>
       <svelte:fragment slot="key"
         >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
       >
-      <span slot="value">TET</span>
+      <span slot="value">{summary.symbol}</span>
     </KeyValuePair>
     <!-- TODO: Expandable Component -->
     <KeyValuePair info>
@@ -36,7 +36,7 @@
         >{$i18n.sns_project_detail.min_commitment}</svelte:fragment
       >
       <svelte:fragment slot="value">
-        <Icp icp={mockIcp1} singleLine />
+        <Icp icp={minCommitmentIcp} singleLine />
       </svelte:fragment>
     </KeyValuePair>
     <!-- TODO: Expandable Component -->
@@ -45,7 +45,7 @@
         >{$i18n.sns_project_detail.max_commitment}</svelte:fragment
       >
       <svelte:fragment slot="value"
-        ><Icp icp={mockIcp2} singleLine /></svelte:fragment
+        ><Icp icp={maxCommitmentIcp} singleLine /></svelte:fragment
       >
     </KeyValuePair>
   </div>

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -24,6 +24,17 @@
     swapState?.myCommitment !== undefined
       ? ICP.fromE8s(swapState?.myCommitment)
       : undefined;
+  let currentDateTillStartSeconds: number;
+  $: currentDateTillStartSeconds = Number(
+    BigInt(Math.round(Date.now() / 1000)) - project.summary.swapStart
+  );
+  let deadlineTillStartSeconds: number;
+  $: deadlineTillStartSeconds = Number(
+    project.summary.swapDeadline - project.summary.swapStart
+  );
+  let durationTillDeadline: bigint;
+  $: durationTillDeadline =
+    project.summary.swapDeadline - BigInt(Math.round(Date.now() / 1000));
 </script>
 
 {#if swapState === undefined}
@@ -54,13 +65,17 @@
         />
       </div>
       <div>
-        <ProgressBar value={85} max={100} color="blue">
+        <ProgressBar
+          value={currentDateTillStartSeconds}
+          max={deadlineTillStartSeconds}
+          color="blue"
+        >
           <p slot="top" class="push-apart">
             <span>
               {$i18n.sns_project_detail.deadline}
             </span>
             <span>
-              {secondsToDuration(BigInt(3600 * 24 * 14 + 3600 * 4))}
+              {secondsToDuration(durationTillDeadline)}
             </span>
           </p>
         </ProgressBar>

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -1,68 +1,90 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
+  import type { SnsSwapState } from "../../services/sns.mock";
   import { i18n } from "../../stores/i18n";
+  import type { SnsFullProject } from "../../stores/snsProjects.store";
   import { secondsToDuration } from "../../utils/date.utils";
   import Icp from "../ic/ICP.svelte";
   import Badge from "../ui/Badge.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import ProgressBar from "../ui/ProgressBar.svelte";
+  import Spinner from "../ui/Spinner.svelte";
   import CommitmentProgressBar from "./CommitmentProgressBar.svelte";
 
-  const mockIcp1 = ICP.fromString("1327") as ICP;
-  const mockIcp2 = ICP.fromString("20") as ICP;
+  export let project: SnsFullProject;
+
+  let swapState: SnsSwapState | undefined;
+  $: ({ swapState } = project);
+  let currentCommitment: bigint;
+  $: currentCommitment = swapState?.currentCommitment ?? BigInt(0);
+  let currentCommitmentIcp: ICP;
+  $: currentCommitmentIcp = ICP.fromE8s(currentCommitment);
+  let myCommitmentIcp: ICP | undefined;
+  $: myCommitmentIcp =
+    swapState?.myCommitment !== undefined
+      ? ICP.fromE8s(swapState?.myCommitment)
+      : undefined;
 </script>
 
-<div class="wrapper" data-tid="sns-project-detail-status">
-  <div class="title">
-    <h2>{$i18n.sns_project_detail.status}</h2>
-    <!-- TODO: Create another Badge for SNS? -->
-    <Badge>{$i18n.sns_project_detail.accepting}</Badge>
+{#if swapState === undefined}
+  <div class="wrapper">
+    <Spinner inline />
   </div>
-  <div class="content">
-    <KeyValuePair info testId="sns-project-current-commitment">
-      <svelte:fragment slot="key"
-        >{$i18n.sns_project_detail.current_commitment}</svelte:fragment
-      >
-      <svelte:fragment slot="value">
-        <Icp icp={mockIcp1} singleLine />
-      </svelte:fragment>
-    </KeyValuePair>
-    <div data-tid="sns-project-commitment-progress">
-      <CommitmentProgressBar
-        value={BigInt(1327)}
-        max={BigInt(3000)}
-        minimumIndicator={BigInt(1500)}
-      />
+{:else}
+  <div class="wrapper" data-tid="sns-project-detail-status">
+    <div class="title">
+      <h2>{$i18n.sns_project_detail.status}</h2>
+      <!-- TODO: Create another Badge for SNS? -->
+      <Badge>{$i18n.sns_project_detail.accepting}</Badge>
     </div>
-    <div>
-      <ProgressBar value={85} max={100} color="blue">
-        <p slot="top" class="push-apart">
-          <span>
-            {$i18n.sns_project_detail.deadline}
-          </span>
-          <span>
-            {secondsToDuration(BigInt(3600 * 24 * 14 + 3600 * 4))}
-          </span>
-        </p>
-      </ProgressBar>
-    </div>
-  </div>
-  <div class="actions">
-    <div>
-      <KeyValuePair>
+    <div class="content">
+      <KeyValuePair info testId="sns-project-current-commitment">
         <svelte:fragment slot="key"
-          >{$i18n.sns_project_detail.user_commitment}</svelte:fragment
+          >{$i18n.sns_project_detail.current_commitment}</svelte:fragment
         >
         <svelte:fragment slot="value">
-          <Icp icp={mockIcp2} singleLine />
+          <Icp icp={currentCommitmentIcp} singleLine />
         </svelte:fragment>
       </KeyValuePair>
+      <div data-tid="sns-project-commitment-progress">
+        <CommitmentProgressBar
+          value={currentCommitment}
+          max={project.summary.maxCommitment}
+          minimumIndicator={project.summary.minCommitment}
+        />
+      </div>
+      <div>
+        <ProgressBar value={85} max={100} color="blue">
+          <p slot="top" class="push-apart">
+            <span>
+              {$i18n.sns_project_detail.deadline}
+            </span>
+            <span>
+              {secondsToDuration(BigInt(3600 * 24 * 14 + 3600 * 4))}
+            </span>
+          </p>
+        </ProgressBar>
+      </div>
     </div>
-    <button class="primary small" data-tid="sns-project-participate-button"
-      >{$i18n.sns_project_detail.participate}</button
-    >
+    <div class="actions">
+      {#if myCommitmentIcp !== undefined}
+        <div>
+          <KeyValuePair>
+            <svelte:fragment slot="key"
+              >{$i18n.sns_project_detail.user_commitment}</svelte:fragment
+            >
+            <svelte:fragment slot="value">
+              <Icp icp={myCommitmentIcp} singleLine />
+            </svelte:fragment>
+          </KeyValuePair>
+        </div>
+      {/if}
+      <button class="primary small" data-tid="sns-project-participate-button"
+        >{$i18n.sns_project_detail.participate}</button
+      >
+    </div>
   </div>
-</div>
+{/if}
 
 <style lang="scss">
   @use "../../themes/mixins/media";
@@ -87,9 +109,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
-  }
-  .right {
-    text-align: right;
   }
 
   .push-apart {

--- a/frontend/svelte/src/lib/components/ui/Logo.svelte
+++ b/frontend/svelte/src/lib/components/ui/Logo.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let src: string;
+  export let alt: string;
+</script>
+
+<img {src} {alt} />
+
+<style lang="scss">
+  img {
+    width: var(--padding-3x);
+    height: var(--padding-3x);
+    border-radius: var(--border-radius);
+    border: 2px solid var(--background-contrast);
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
+++ b/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
@@ -46,13 +46,14 @@
 
       &.yellow {
         &::-moz-progress-bar {
-          background: var(--yellow-400);
+          background: var(--warning-emphasis);
         }
       }
 
       &.blue {
         &::-moz-progress-bar {
-          background: var(--header-background);
+          background: var(--primary-gradient-fallback);
+          background: var(--primary-gradient);
         }
       }
     }
@@ -82,13 +83,14 @@
 
     &.yellow {
       &::-webkit-progress-value {
-        background: var(--yellow-400);
+        background: var(--warning-emphasis);
       }
     }
 
     &.blue {
       &::-webkit-progress-value {
-        background: var(--header-background);
+        background: var(--primary-gradient-fallback);
+        background: var(--primary-gradient);
       }
     }
   }

--- a/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
+++ b/frontend/svelte/src/lib/components/ui/ProgressBar.svelte
@@ -26,7 +26,7 @@
   .wrapper {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-0_5x);
   }
 
   // Target only FF

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -504,6 +504,7 @@
     "projects": "Current Launches",
     "no_projects": "No current launches at the moment",
     "proposals": "Proposals",
+    "project_logo": "project logo",
     "no_proposals": "No current proposals at the moment"
   },
   "sns_project": {

--- a/frontend/svelte/src/lib/services/sns.mock.ts
+++ b/frontend/svelte/src/lib/services/sns.mock.ts
@@ -11,7 +11,8 @@ export interface SnsSummary {
   tokenName: string;
   description: string;
 
-  deadline: bigint; // seconds
+  swapDeadline: bigint; // seconds
+  swapStart: bigint; // seconds
   minCommitment: bigint; // e8s
   maxCommitment: bigint; // e8s
 }

--- a/frontend/svelte/src/lib/services/sns.services.ts
+++ b/frontend/svelte/src/lib/services/sns.services.ts
@@ -1,5 +1,5 @@
 import type { ProposalInfo } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
 import { mockProposalInfo } from "../../tests/mocks/proposal.mock";
 import {
   mockSnsSummaryList,
@@ -39,26 +39,19 @@ export const loadSnsFullProjects = async () => {
 /**
  * Loads summaries with swapStates
  */
-export const loadSnsFullProject = async (canisterId) => {
-  const summaries = await listSnsSummary();
-
+export const loadSnsFullProject = async (canisterId: string) => {
+  const [summaries, swapState] = await Promise.all([
+    listSnsSummary(),
+    loadSnsSwapState(Principal.fromText(canisterId)),
+  ]);
   snsSummariesStore.setSummaries({
     summaries,
     certified: true,
   });
-
-  await Promise.all(
-    summaries.map(
-      async ({ rootCanisterId }) =>
-        canisterId === rootCanisterId &&
-        loadSnsSwapState(rootCanisterId).then((swapState) =>
-          snsSwapStatesStore.setSwapState({
-            swapState,
-            certified: true,
-          })
-        )
-    )
-  );
+  snsSwapStatesStore.setSwapState({
+    swapState,
+    certified: true,
+  });
 };
 
 export const loadSnsSwapState = async (
@@ -127,7 +120,7 @@ export const listSnsProposals = async (): Promise<ProposalInfo[]> =>
   });
 
 export const routePathRootCanisterId = (path: string): string | undefined => {
-  if (!isRoutePath({ path: AppPath.NeuronDetail, routePath: path })) {
+  if (!isRoutePath({ path: AppPath.SNSProjectDetail, routePath: path })) {
     return undefined;
   }
   return getLastPathDetail(path);

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -531,6 +531,7 @@ interface I18nSns_launchpad {
   projects: string;
   no_projects: string;
   proposals: string;
+  project_logo: string;
   no_proposals: string;
 }
 

--- a/frontend/svelte/src/lib/utils/sns.utils.ts
+++ b/frontend/svelte/src/lib/utils/sns.utils.ts
@@ -7,6 +7,8 @@ export const getSnsProjectById = ({
   id?: string;
   projects?: SnsFullProject[];
 }): SnsFullProject | undefined =>
-  projects?.find(
-    ({ rootCanisterId }: SnsFullProject) => rootCanisterId.toText() === id
-  );
+  id === undefined
+    ? undefined
+    : projects?.find(
+        ({ rootCanisterId }: SnsFullProject) => rootCanisterId.toText() === id
+      );

--- a/frontend/svelte/src/lib/utils/sns.utils.ts
+++ b/frontend/svelte/src/lib/utils/sns.utils.ts
@@ -1,0 +1,12 @@
+import type { SnsFullProject } from "../stores/snsProjects.store";
+
+export const getSnsProjectById = ({
+  id,
+  projects,
+}: {
+  id?: string;
+  projects?: SnsFullProject[];
+}): SnsFullProject | undefined =>
+  projects?.find(
+    ({ rootCanisterId }: SnsFullProject) => rootCanisterId.toText() === id
+  );

--- a/frontend/svelte/src/tests/lib/components/sns-launchpad/SNSProject.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-launchpad/SNSProject.spec.ts
@@ -71,7 +71,7 @@ describe("SNSProjectCard", () => {
     });
 
     const durationTillDeadline =
-      mockSnsFullProject.summary.deadline -
+      mockSnsFullProject.summary.swapDeadline -
       BigInt(Math.round(Date.now() / 1000));
 
     expect(

--- a/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectInfoSection.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectInfoSection.spec.ts
@@ -4,15 +4,17 @@
 
 import { render } from "@testing-library/svelte";
 import ProjectInfoSection from "../../../../lib/components/sns-project-detail/ProjectInfoSection.svelte";
+import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 
 describe("ProjectInfoSection", () => {
+  const props = { summary: mockSnsFullProject.summary };
   it("should render title", async () => {
-    const { container } = render(ProjectInfoSection);
+    const { container } = render(ProjectInfoSection, { props });
     expect(container.querySelector("h1")).toBeInTheDocument();
   });
 
   it("should render project link", async () => {
-    const { container } = render(ProjectInfoSection);
+    const { container } = render(ProjectInfoSection, { props });
     expect(container.querySelector("a")).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/sns-project-detail/ProjectStatusSection.spec.ts
@@ -4,20 +4,22 @@
 
 import { render } from "@testing-library/svelte";
 import ProjectStatusSection from "../../../../lib/components/sns-project-detail/ProjectStatusSection.svelte";
+import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 
 describe("ProjectStatusSection", () => {
+  const props = { project: mockSnsFullProject };
   it("should render subtitle", async () => {
-    const { container } = render(ProjectStatusSection);
+    const { container } = render(ProjectStatusSection, { props });
     expect(container.querySelector("h2")).toBeInTheDocument();
   });
 
   it("should render project current commitment", async () => {
-    const { queryByTestId } = render(ProjectStatusSection);
+    const { queryByTestId } = render(ProjectStatusSection, { props });
     expect(queryByTestId("sns-project-current-commitment")).toBeInTheDocument();
   });
 
   it("should render project participate button", async () => {
-    const { queryByTestId } = render(ProjectStatusSection);
+    const { queryByTestId } = render(ProjectStatusSection, { props });
     expect(queryByTestId("sns-project-participate-button")).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -52,7 +52,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     deadline: BigInt(Math.round(Date.now() / 1000) + SECONDS_IN_DAY / 4),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
-    tokenName: "string",
+    tokenName: "Tetris",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACzSURBVHgB7ZrBCcIwAEUTcYSMI6KC2H2cw30UQRwoO1Ry6DkptMhL3zvk9C7vEPiExMPxPIbO2Jcj51wVU0pN3hy3eN/Pu+qdLtcmb3J3oUOMomAUBaModBkVN78oXukZWrjlwUWxNEZRMIqCURRcFBT+vijWeB/xTlEwioJRFIyi4KKYsyha3OKNj7oX74OLwigKRlEwioKLgsJq/yhal8KS3uR6pygYRcEoCkZRcCZR+AGaGlXJPd3qegAAAABJRU5ErkJggg==",
     name: "Tetris",
@@ -67,7 +67,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 30),
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(2000 * 100000000),
-    tokenName: "string",
+    tokenName: "Pacman",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAClSURBVHgB7dqxDYMwEEBRE2UET5I6icQUzMgc9EziHUAuqLElS+if/iuoruAXyCeL6fufjxTMuz5KKbeDOee0rXtq8Vs+TbM9cy3vWNX3fKWAjKIwisIoipBRU9iNYuTp3zM7eu6a9ZuiMIrCKAqjKNwoek711nuPkXPXrN8UhVEURlEYReFG4R3Fg4yiMIrCKAo3Cgr/o6AwisIoCqMojKIIuSadjJ5VyRrmqP4AAAAASUVORK5CYII=",
     name: "Pac-Man",
@@ -83,7 +83,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 10),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
-    tokenName: "string",
+    tokenName: "Mario",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACjSURBVHgB7dkxDkRAGEDh32ZPsuWWWy+JQ4gzimPolUpXIXMCM4nmjfcVqglegT+j+Xf9EZV5p8MyrZcL2/EX+7BFjs/8zVpbsi7nHpN0n6+okFEURlEYRVFlVPP4iaLkq37npFB6bZ8pCqMojKIwisKJomSP4s5zukcRvig4jKIwisKJgsK/HhRGURhFYRSFEwWFEwWFURRGURhFYRRFlWPSCah/Vck0pRWfAAAAAElFTkSuQmCC",
     name: "Super Mario",
@@ -98,7 +98,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 10),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
-    tokenName: "string",
+    tokenName: "Kong",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZkxCsJAFAUTETyAexcbEfZSHsJLBcTGu6wHsFK3SL0/EIvZzBSpHj87gYXHz3i+5M/QGfv6OB2mZvD5zqHcnC2lNHMppb+8ezd0iFIUlKKgFIUupcbNN4rpeB0i5Ndt1ZnRefNM7xQFpSgoRUEpCv02ijX3CZXoTmFJLnLGSj2nd4qCUhSUoqAUBXcUSxrF497O/j6ofz2iKEVBKQpKUbBRUHBHQUEpCkpRUIqCUhS6rElfBK1VyaWjTNYAAAAASUVORK5CYII=",
     name: "Donkey Kong",

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -49,7 +49,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(0),
 
-    deadline: BigInt(Math.round(Date.now() / 1000) + SECONDS_IN_DAY / 4),
+    swapDeadline: BigInt(Math.round(Date.now() / 1000) + SECONDS_IN_DAY / 4),
+    swapStart: BigInt(Math.round(Date.now() / 1000) - SECONDS_IN_DAY / 4),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
     tokenName: "Tetris",
@@ -64,7 +65,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(1),
 
-    deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 30),
+    swapDeadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 30),
+    swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 20),
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(2000 * 100000000),
     tokenName: "Pacman",
@@ -80,7 +82,10 @@ export const mockSnsSummaryList: SnsSummary[] = [
     rootCanisterId: principal(2),
 
     // what needs to be shown for upcomming projects
-    deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 10),
+    swapDeadline: BigInt(
+      SECONDS_TODAY + SECONDS_IN_DAY * 8 + SECONDS_IN_DAY / 2
+    ),
+    swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 5),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
     tokenName: "Mario",
@@ -95,7 +100,10 @@ export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(3),
 
-    deadline: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 10),
+    swapDeadline: BigInt(
+      SECONDS_TODAY + SECONDS_IN_DAY * 10 + SECONDS_IN_DAY / 3
+    ),
+    swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 3),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
     tokenName: "Kong",

--- a/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/SNSProjectDetail.spec.ts
@@ -2,14 +2,55 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
+import type { SnsSwapState } from "../../lib/services/sns.mock";
+import { loadSnsFullProject } from "../../lib/services/sns.services";
+import { routeStore } from "../../lib/stores/route.store";
+import {
+  snsSummariesStore,
+  snsSwapStatesStore,
+} from "../../lib/stores/snsProjects.store";
 import SNSProjectDetail from "../../routes/SNSProjectDetail.svelte";
+import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
+import { mockSnsFullProject } from "../mocks/sns-projects.mock";
+
+jest.mock("../../lib/services/sns.services", () => {
+  return {
+    loadSnsFullProject: jest.fn().mockResolvedValue(Promise.resolve()),
+    routePathRootCanisterId: jest
+      .fn()
+      .mockImplementation(() => mockSnsFullProject.rootCanisterId.toText()),
+  };
+});
 
 describe("SNSProjectDetail", () => {
+  jest
+    .spyOn(routeStore, "subscribe")
+    .mockImplementation(
+      mockRouteStoreSubscribe(
+        `/#/project/${mockSnsFullProject.rootCanisterId.toText()}`
+      )
+    );
+  beforeEach(() => {
+    snsSummariesStore.setSummaries({
+      summaries: [mockSnsFullProject.summary],
+      certified: true,
+    });
+    snsSwapStatesStore.setSwapState({
+      swapState: mockSnsFullProject.swapState as SnsSwapState,
+      certified: true,
+    });
+  });
   it("should render info section", () => {
     const { queryByTestId } = render(SNSProjectDetail);
 
     expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument();
+  });
+
+  it("should load project detail", () => {
+    render(SNSProjectDetail);
+
+    waitFor(() => expect(loadSnsFullProject).toBeCalled());
   });
 
   it("should render status section", () => {


### PR DESCRIPTION
# Motivation

User sees the actual project (but still mocked) details instead of hardcoded data.

# Changes

* Link from launchpad to project details.
* Load project details in SnsProjectDetail page.
* Read project from store in SnsProjectDetail.
* Add data props in ProjectStatusSection and ProjectInfoSection.

# Tests

* Fix tests with updated changes.
