### PR TITLE
L2-735: Use Collapsible component in ProjectInfoSection

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/svelte/src/lib/components/neurons/FollowTopicSection.svelte
@@ -59,19 +59,17 @@
 
 <article data-tid={`follow-topic-${topic}-section`}>
   <Collapsible {id} iconSize="medium">
-    <svelte:fragment slot="header">
-      <div class="wrapper">
-        <div>
-          <h3>{title}</h3>
-          <p class="subtitle">{subtitle}</p>
-        </div>
-        <div class="toolbar">
-          <h3 class="badge" data-tid={`topic-${topic}-followees-badge`}>
-            {followees.length}
-          </h3>
-        </div>
+    <div class="wrapper" slot="header">
+      <div>
+        <h3>{title}</h3>
+        <p class="subtitle">{subtitle}</p>
       </div>
-    </svelte:fragment>
+      <div class="toolbar">
+        <h3 class="badge" data-tid={`topic-${topic}-followees-badge`}>
+          {followees.length}
+        </h3>
+      </div>
+    </div>
     <div class="content" data-tid="follow-topic-section-current">
       <h5>{$i18n.follow_neurons.current_followees}</h5>
       <ul>

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
@@ -3,6 +3,7 @@
   import type { SnsSummary } from "../../services/sns.mock";
   import { i18n } from "../../stores/i18n";
   import Icp from "../ic/ICP.svelte";
+  import Collapsible from "../ui/Collapsible.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import Logo from "../ui/Logo.svelte";
 
@@ -34,24 +35,36 @@
       >
       <span slot="value">{summary.symbol}</span>
     </KeyValuePair>
-    <!-- TODO: Expandable Component -->
-    <KeyValuePair info>
-      <svelte:fragment slot="key"
-        >{$i18n.sns_project_detail.min_commitment}</svelte:fragment
-      >
-      <svelte:fragment slot="value">
-        <Icp icp={minCommitmentIcp} singleLine />
-      </svelte:fragment>
-    </KeyValuePair>
-    <!-- TODO: Expandable Component -->
-    <KeyValuePair info>
-      <svelte:fragment slot="key"
-        >{$i18n.sns_project_detail.max_commitment}</svelte:fragment
-      >
-      <svelte:fragment slot="value"
-        ><Icp icp={maxCommitmentIcp} singleLine /></svelte:fragment
-      >
-    </KeyValuePair>
+    <div>
+      <Collapsible iconSize="none">
+        <KeyValuePair info slot="header">
+          <svelte:fragment slot="key"
+            >{$i18n.sns_project_detail.min_commitment}</svelte:fragment
+          >
+          <svelte:fragment slot="value">
+            <Icp icp={minCommitmentIcp} singleLine />
+          </svelte:fragment>
+        </KeyValuePair>
+        <p class="small">
+          This is the text that is hidden and should appear on click
+        </p>
+      </Collapsible>
+    </div>
+    <div>
+      <Collapsible iconSize="none">
+        <KeyValuePair info slot="header">
+          <svelte:fragment slot="key"
+            >{$i18n.sns_project_detail.max_commitment}</svelte:fragment
+          >
+          <svelte:fragment slot="value"
+            ><Icp icp={maxCommitmentIcp} singleLine /></svelte:fragment
+          >
+        </KeyValuePair>
+        <p class="small">
+          This should be an explanation of what does maximum commitment means
+        </p>
+      </Collapsible>
+    </div>
   </div>
 </div>
 
@@ -78,5 +91,9 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding);
+  }
+
+  .small {
+    font-size: var(--font-size-small);
   }
 </style>

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectInfoSection.svelte
@@ -3,7 +3,7 @@
   import type { SnsSummary } from "../../services/sns.mock";
   import { i18n } from "../../stores/i18n";
   import Icp from "../ic/ICP.svelte";
-  import Collapsible from "../ui/Collapsible.svelte";
+  import InfoContextKey from "../ui/InfoContextKey.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import Logo from "../ui/Logo.svelte";
 
@@ -35,36 +35,28 @@
       >
       <span slot="value">{summary.symbol}</span>
     </KeyValuePair>
-    <div>
-      <Collapsible iconSize="none">
-        <KeyValuePair info slot="header">
-          <svelte:fragment slot="key"
-            >{$i18n.sns_project_detail.min_commitment}</svelte:fragment
-          >
-          <svelte:fragment slot="value">
-            <Icp icp={minCommitmentIcp} singleLine />
-          </svelte:fragment>
-        </KeyValuePair>
+    <KeyValuePair>
+      <InfoContextKey slot="key"
+        ><svelte:fragment slot="header"
+          >{$i18n.sns_project_detail.min_commitment}</svelte:fragment
+        >
         <p class="small">
           This is the text that is hidden and should appear on click
         </p>
-      </Collapsible>
-    </div>
-    <div>
-      <Collapsible iconSize="none">
-        <KeyValuePair info slot="header">
-          <svelte:fragment slot="key"
-            >{$i18n.sns_project_detail.max_commitment}</svelte:fragment
-          >
-          <svelte:fragment slot="value"
-            ><Icp icp={maxCommitmentIcp} singleLine /></svelte:fragment
-          >
-        </KeyValuePair>
+      </InfoContextKey>
+      <Icp slot="value" icp={minCommitmentIcp} singleLine />
+    </KeyValuePair>
+    <KeyValuePair>
+      <InfoContextKey slot="key"
+        ><svelte:fragment slot="header"
+          >{$i18n.sns_project_detail.max_commitment}</svelte:fragment
+        >
         <p class="small">
           This should be an explanation of what does maximum commitment means
         </p>
-      </Collapsible>
-    </div>
+      </InfoContextKey>
+      <Icp slot="value" icp={maxCommitmentIcp} singleLine />
+    </KeyValuePair>
   </div>
 </div>
 

--- a/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/sns-project-detail/ProjectStatusSection.svelte
@@ -6,6 +6,7 @@
   import { secondsToDuration } from "../../utils/date.utils";
   import Icp from "../ic/ICP.svelte";
   import Badge from "../ui/Badge.svelte";
+  import InfoContextKey from "../ui/InfoContextKey.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import ProgressBar from "../ui/ProgressBar.svelte";
   import Spinner from "../ui/Spinner.svelte";
@@ -49,13 +50,14 @@
       <Badge>{$i18n.sns_project_detail.accepting}</Badge>
     </div>
     <div class="content">
-      <KeyValuePair info testId="sns-project-current-commitment">
-        <svelte:fragment slot="key"
-          >{$i18n.sns_project_detail.current_commitment}</svelte:fragment
-        >
-        <svelte:fragment slot="value">
-          <Icp icp={currentCommitmentIcp} singleLine />
-        </svelte:fragment>
+      <KeyValuePair testId="sns-project-current-commitment">
+        <InfoContextKey slot="key">
+          <svelte:fragment slot="header"
+            >{$i18n.sns_project_detail.current_commitment}</svelte:fragment
+          >
+          <p>Some details about what the current commitment means.</p>
+        </InfoContextKey>
+        <Icp slot="value" icp={currentCommitmentIcp} singleLine />
       </KeyValuePair>
       <div data-tid="sns-project-commitment-progress">
         <CommitmentProgressBar

--- a/frontend/svelte/src/lib/components/ui/CardBlock.svelte
+++ b/frontend/svelte/src/lib/components/ui/CardBlock.svelte
@@ -45,7 +45,9 @@
   }
 
   h3 {
-    margin: 0;
+    // increase click area
+    margin: calc(-1 * var(--padding));
+    padding: var(--padding);
   }
 
   .content {

--- a/frontend/svelte/src/lib/components/ui/Collapsible.svelte
+++ b/frontend/svelte/src/lib/components/ui/Collapsible.svelte
@@ -8,7 +8,7 @@
   export let initiallyExpanded: boolean = false;
   export let maxContentHeight: number | undefined = undefined;
 
-  export let iconSize: "small" | "medium" = "small";
+  export let iconSize: "small" | "medium" | "none" = "small";
 
   // Minimum height when some part of the text-content is visible (empirical value)
   const CONTENT_MIN_HEIGHT = 40;
@@ -65,19 +65,21 @@
   <div class="header-content">
     <slot name="header" />
   </div>
-  <button
-    class="collapsible-expand-icon"
-    class:size-medium={iconSize === "medium"}
-    class:expanded
-    data-tid="collapsible-expand-button"
-    aria-expanded={expanded}
-    aria-controls={id}
-    title={replacePlaceholders($i18n.proposal_detail.summary_toggle_view, {
-      $toggleView: toggleView,
-    })}
-  >
-    <IconExpandMore />
-  </button>
+  {#if iconSize !== "none"}
+    <button
+      class="collapsible-expand-icon"
+      class:size-medium={iconSize === "medium"}
+      class:expanded
+      data-tid="collapsible-expand-button"
+      aria-expanded={expanded}
+      aria-controls={id}
+      title={replacePlaceholders($i18n.proposal_detail.summary_toggle_view, {
+        $toggleView: toggleView,
+      })}
+    >
+      <IconExpandMore />
+    </button>
+  {/if}
 </div>
 <div
   data-tid="collapsible-content"
@@ -103,10 +105,6 @@
   .header {
     @include interaction.tappable;
     user-select: none;
-
-    // increase click area
-    margin: calc(-1 * var(--padding));
-    padding: var(--padding);
 
     position: relative;
 

--- a/frontend/svelte/src/lib/components/ui/InfoContextKey.svelte
+++ b/frontend/svelte/src/lib/components/ui/InfoContextKey.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import IconInfoOutline from "../../icons/IconInfoOutline.svelte";
+  import Collapsible from "./Collapsible.svelte";
+</script>
+
+<Collapsible iconSize="none">
+  <span class="wrapper" slot="header">
+    <slot name="header" />
+    <span class="icon">
+      <IconInfoOutline />
+    </span>
+  </span>
+  <slot />
+</Collapsible>
+
+<style lang="scss">
+  .wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+  }
+
+  .icon {
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
+++ b/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
@@ -11,7 +11,9 @@
       <slot name="key" />
     </span>
     {#if info}
-      <IconInfoOutline />
+      <span class="icon">
+        <IconInfoOutline />
+      </span>
     {/if}
   </dt>
   <dd>
@@ -34,6 +36,13 @@
     display: flex;
     align-items: center;
     gap: var(--padding);
+  }
+
+  .icon {
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   dd {

--- a/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
+++ b/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
@@ -26,6 +26,8 @@
     gap: var(--padding-2x);
 
     margin: 0;
+
+    width: 100%;
   }
 
   dt {

--- a/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
+++ b/frontend/svelte/src/lib/components/ui/KeyValuePair.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import IconInfoOutline from "../../icons/IconInfoOutline.svelte";
-
-  export let info: boolean = false;
   export let testId: string | undefined = undefined;
 </script>
 
@@ -10,11 +7,6 @@
     <span>
       <slot name="key" />
     </span>
-    {#if info}
-      <span class="icon">
-        <IconInfoOutline />
-      </span>
-    {/if}
   </dt>
   <dd>
     <slot name="value" />
@@ -25,6 +17,7 @@
   dl {
     display: flex;
     justify-content: space-between;
+    align-items: baseline;
     gap: var(--padding-2x);
 
     margin: 0;
@@ -36,13 +29,6 @@
     display: flex;
     align-items: center;
     gap: var(--padding);
-  }
-
-  .icon {
-    color: var(--primary);
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   dd {

--- a/frontend/svelte/src/tests/lib/components/ui/Collapsible.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/Collapsible.spec.ts
@@ -15,10 +15,21 @@ const props = (props) => ({
 });
 
 describe("Collapsible", () => {
-  it("should render header and content", () => {
-    const { getByText } = render(CollapsibleTest);
+  it("should render header, content and button", () => {
+    const { getByText, queryByTestId } = render(CollapsibleTest);
     expect(getByText("Jack")).toBeInTheDocument();
     expect(getByText("Sparrow")).toBeInTheDocument();
+    expect(queryByTestId("collapsible-expand-button")).toBeInTheDocument();
+  });
+
+  it("should not render button", () => {
+    const { getByText, queryByTestId } = render(
+      CollapsibleTest,
+      props({ iconSize: "none" })
+    );
+    expect(getByText("Jack")).toBeInTheDocument();
+    expect(getByText("Sparrow")).toBeInTheDocument();
+    expect(queryByTestId("collapsible-expand-button")).not.toBeInTheDocument();
   });
 
   it("should render ids", () => {

--- a/frontend/svelte/src/tests/lib/components/ui/InfoContextKey.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/InfoContextKey.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import InfoContextKeyTest from "./InfoContextKeyTest.svelte";
+
+describe("InfoContextKey", () => {
+  const header = "header-content";
+  const content = "test-content";
+  it("should render header, info icon", () => {
+    const { queryByText, queryByTestId } = render(InfoContextKeyTest, {
+      props: { content, header },
+    });
+
+    expect(queryByText(header)).toBeInTheDocument();
+    expect(queryByTestId("icon-info")).toBeInTheDocument();
+  });
+
+  it("should be initially collapsed", () => {
+    const { queryByText } = render(InfoContextKeyTest, {
+      props: { content, header },
+    });
+    expect(queryByText(content)).not.toBeVisible();
+  });
+
+  it("should show extra content on click", async () => {
+    const { container, getByTestId, queryByText } = render(InfoContextKeyTest, {
+      props: { content },
+    });
+    expect(queryByText(content)).not.toBeVisible();
+
+    await fireEvent.click(getByTestId("collapsible-header"));
+    waitFor(() =>
+      expect(
+        container.querySelector('[aria-expanded="true"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(queryByText(content)).toBeVisible();
+  });
+});

--- a/frontend/svelte/src/tests/lib/components/ui/InfoContextKeyTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/InfoContextKeyTest.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import InfoContextKey from "../../../../lib/components/ui/InfoContextKey.svelte";
+
+  export let header: string;
+  export let content: string;
+</script>
+
+<InfoContextKey>
+  <span slot="header">{header}</span>
+  <p>{content}</p>
+</InfoContextKey>

--- a/frontend/svelte/src/tests/lib/components/ui/KeyValuePair.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/ui/KeyValuePair.spec.ts
@@ -16,12 +16,4 @@ describe("KeyValuePair", () => {
     expect(queryByText(key)).toBeInTheDocument();
     expect(queryByText(value)).toBeInTheDocument();
   });
-
-  it("should render info icon", () => {
-    const { queryByTestId } = render(KeyValuePairTest, {
-      props: { key, value, info: true },
-    });
-
-    expect(queryByTestId("icon-info")).toBeInTheDocument();
-  });
 });

--- a/frontend/svelte/src/tests/lib/components/ui/KeyValuePairTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ui/KeyValuePairTest.svelte
@@ -3,10 +3,9 @@
 
   export let key: string;
   export let value: string;
-  export let info: boolean = false;
 </script>
 
-<KeyValuePair {info}>
+<KeyValuePair>
   <p slot="key">{key}</p>
   <p slot="value">{value}</p>
 </KeyValuePair>


### PR DESCRIPTION
# Motivation

User can see the information on max and min commitment items when clicking on them.

# Changes

* Changes in Collapsible component: add "none" to the iconSize prop values. Which hides the button.
* Move the extra clickable space to the CardBlock.
* Use the Collapsible in the ProjectInfoSection.
* Remove info icon from KeyValuePair.
* New InfoContextKey component that adds info icon and makes content collapsible.

# Tests

* Add proper test case to Collapsible component.
* Text for new component InfoContextKey.
* Remove test case for KeyValuePair.