### PR TITLE
Use the SNS version matching the canisters

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -216,7 +216,7 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
   dfx canister --network "$DFX_NETWORK" create sns_ledger --no-wallet || echo sns_ledger probably exists already.
   dfx canister --network "$DFX_NETWORK" create sns_root --no-wallet || echo sns_root probably exists already.
   dfx canister --network "$DFX_NETWORK" create sns_swap --no-wallet || echo sns_swap probably exists already.
-  sns deploy --network "$DFX_NETWORK" --token-name "Free Up My Time" --token-symbol FUT
+  PATH="$PWD/target/ic:$PATH" sns deploy --network "$DFX_NETWORK" --token-name "Free Up My Time" --token-symbol FUT
 fi
 
 if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -216,7 +216,7 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
   dfx canister --network "$DFX_NETWORK" create sns_ledger --no-wallet || echo sns_ledger probably exists already.
   dfx canister --network "$DFX_NETWORK" create sns_root --no-wallet || echo sns_root probably exists already.
   dfx canister --network "$DFX_NETWORK" create sns_swap --no-wallet || echo sns_swap probably exists already.
-  PATH="$PWD/target/ic:$PATH" sns deploy --network "$DFX_NETWORK" --token-name "Free Up My Time" --token-symbol FUT
+  ./target/ic/sns deploy --network "$DFX_NETWORK" --token-name "Free Up My Time" --token-symbol FUT
 fi
 
 if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then


### PR DESCRIPTION
# Motivation
When deploying, the sns version needs to match the canisters or else there can be hard-to-diagnose failures.

The matching `sns` binary is already downloaded, it just needs to be called explicitly in `deploy.sh`, rather than picking up whichever `sns` is in `PATH`.

# Changes
* Use the `sns` from the ic artifacts directory in `deploy.sh`

# Tests
* I have run `./deploy.sh --sns testnet` and it worked.  It still deploys "old" canisters from a week ago but that is orthogonal.