### PR TITLE
L2-795: Swap Participation Flow 1 UI

### DIFF
--- a/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
+
   import { accountsStore } from "../../stores/accounts.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
@@ -8,7 +10,7 @@
   export let skipHardwareWallets: boolean = false;
 
   let selectableAccounts: Account[] | undefined;
-  accountsStore.subscribe((accounts) => {
+  const unsubscribe = accountsStore.subscribe((accounts) => {
     if (accounts.main !== undefined) {
       selectedAccount = accounts.main;
       selectableAccounts = [
@@ -18,6 +20,8 @@
       ];
     }
   });
+
+  onDestroy(unsubscribe);
 </script>
 
 <!-- TODO: Implement https://dfinity.atlassian.net/browse/L2-800 -->

--- a/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -12,7 +12,7 @@
   let selectableAccounts: Account[] | undefined;
   const unsubscribe = accountsStore.subscribe((accounts) => {
     if (accounts.main !== undefined) {
-      selectedAccount = accounts.main;
+      selectedAccount = selectedAccount ?? accounts.main;
       selectableAccounts = [
         accounts.main,
         ...(accounts.subAccounts ?? []),

--- a/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/svelte/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { accountsStore } from "../../stores/accounts.store";
+  import { i18n } from "../../stores/i18n";
+  import type { Account } from "../../types/account";
+  import Spinner from "../ui/Spinner.svelte";
+
+  export let selectedAccount: Account | undefined = undefined;
+  export let skipHardwareWallets: boolean = false;
+
+  let selectableAccounts: Account[] | undefined;
+  accountsStore.subscribe((accounts) => {
+    if (accounts.main !== undefined) {
+      selectedAccount = accounts.main;
+      selectableAccounts = [
+        accounts.main,
+        ...(accounts.subAccounts ?? []),
+        ...(skipHardwareWallets ? [] : accounts.hardwareWallets ?? []),
+      ];
+    }
+  });
+</script>
+
+<!-- TODO: Implement https://dfinity.atlassian.net/browse/L2-800 -->
+{#if selectableAccounts !== undefined}
+  <select
+    bind:value={selectedAccount}
+    name="account"
+    data-tid="select-account-dropdown"
+  >
+    {#each selectableAccounts as account}
+      <option value={account}>
+        {account.name ?? $i18n.accounts.main_account}</option
+      >
+    {/each}
+  </select>
+{:else}
+  <Spinner />
+{/if}

--- a/frontend/svelte/src/lib/components/project-detail/Participate.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/Participate.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import type { ICP } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
+  import { i18n } from "../../stores/i18n";
+  import {
+    mainTransactionFeeStoreAsIcp,
+    mainTransactionFeeStore,
+  } from "../../stores/transaction-fees.store";
+
+  import type { Account } from "../../types/account";
+  import { maxICP } from "../../utils/icp.utils";
+  import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
+  import IcpComponent from "../ic/ICP.svelte";
+  import Input from "../ui/Input.svelte";
+  import KeyValuePair from "../ui/KeyValuePair.svelte";
+
+  export let selectedAccount: Account | undefined = undefined;
+  export let amount: number | undefined = undefined;
+  // TODO: Handle min and max validations: https://dfinity.atlassian.net/browse/L2-798
+  export let minAmount: ICP;
+  export let maxAmount: ICP;
+
+  let max: number = 0;
+  $: max = maxICP({
+    icp: selectedAccount?.balance,
+    fee: $mainTransactionFeeStore,
+  });
+  const addMax = () => (amount = max);
+
+  let disableButton: boolean;
+  $: disableButton =
+    selectedAccount === undefined || amount === 0 || amount === undefined;
+
+  const dispatcher = createEventDispatcher();
+  const close = () => {
+    dispatcher("nnsClose");
+  };
+
+  const goNext = () => {
+    dispatcher("nnsNext");
+  };
+</script>
+
+<div class="wrapper" data-tid="sns-swap-participate-step-1">
+  <div>
+    {#if selectedAccount !== undefined}
+      <KeyValuePair>
+        <span slot="key">Source</span>
+        <IcpComponent slot="value" singleLine icp={selectedAccount?.balance} />
+      </KeyValuePair>
+    {/if}
+    <SelectAccountDropdown bind:selectedAccount skipHardwareWallets />
+  </div>
+  <div>
+    <KeyValuePair>
+      <span slot="key">Amount</span>
+      <!-- TODO: None of the current button classes matches style needed here -->
+      <button on:click|preventDefault={addMax} slot="value" class="text"
+        >{$i18n.core.max}</button
+      >
+    </KeyValuePair>
+    <!-- New Inputs do not show the placeholder above the input -->
+    <!-- Now adapt to the new design -->
+    <!-- Shall we create a new Input component? Or pass a prop? -->
+    <Input
+      inputType="icp"
+      name="amount"
+      placeholderLabelKey="sns_project_detail.enter_amount"
+      bind:value={amount}
+    />
+    <KeyValuePair>
+      <span slot="key">Min <IcpComponent singleLine icp={minAmount} /></span>
+      <span slot="value">max <IcpComponent singleLine icp={maxAmount} /></span>
+    </KeyValuePair>
+    <p class="right">
+      <span>{$i18n.accounts.transaction_fee}</span>
+      <IcpComponent singleLine icp={$mainTransactionFeeStoreAsIcp} />
+    </p>
+  </div>
+  <div class="actions">
+    <button
+      class="small secondary"
+      data-tid="sns-swap-participate-button-cancel"
+      on:click={close}>{$i18n.core.cancel}</button
+    >
+    <button
+      class="small primary"
+      data-tid="sns-swap-participate-button-next"
+      disabled={disableButton}
+      on:click={goNext}>{$i18n.sns_project_detail.participate}</button
+    >
+  </div>
+</div>
+
+<style lang="scss">
+  @use "../../themes/mixins/media";
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: var(--padding-2x);
+  }
+
+  .right {
+    text-align: right;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--padding-2x);
+
+    padding-top: var(--padding-4x);
+
+    & > button {
+      flex: 1;
+
+      @include media.min-width(medium) {
+        flex: none;
+      }
+    }
+  }
+</style>

--- a/frontend/svelte/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -6,13 +6,14 @@
     mainTransactionFeeStoreAsIcp,
     mainTransactionFeeStore,
   } from "../../stores/transaction-fees.store";
-
   import type { Account } from "../../types/account";
   import { maxICP } from "../../utils/icp.utils";
   import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../ic/ICP.svelte";
   import Input from "../ui/Input.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
+
+  // Tested in the ParticipateSwapModal
 
   export let selectedAccount: Account | undefined = undefined;
   export let amount: number | undefined = undefined;
@@ -59,9 +60,7 @@
         >{$i18n.core.max}</button
       >
     </KeyValuePair>
-    <!-- New Inputs do not show the placeholder above the input -->
-    <!-- Now adapt to the new design -->
-    <!-- Shall we create a new Input component? Or pass a prop? -->
+    <!-- TODO: ParticipateScreen -->
     <Input
       inputType="icp"
       name="amount"

--- a/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -9,8 +9,8 @@
 
   export let summary: SnsSummary;
 
-  const minCommitmentIcp = ICP.fromE8s(summary.minCommitment);
-  const maxCommitmentIcp = ICP.fromE8s(summary.maxCommitment);
+  const minCommitmentIcp = ICP.fromE8s(summary.minParticipationCommitment);
+  const maxCommitmentIcp = ICP.fromE8s(summary.maxParticipationCommitment);
 </script>
 
 <div data-tid="sns-project-detail-info">

--- a/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
+  import ParticipateSwapModal from "../../modals/sns/ParticipateSwapModal.svelte";
   import type { SnsSwapState } from "../../services/sns.mock";
   import { i18n } from "../../stores/i18n";
   import type { SnsFullProject } from "../../stores/projects.store";
@@ -36,6 +37,10 @@
   let durationTillDeadline: bigint;
   $: durationTillDeadline =
     project.summary.swapDeadline - BigInt(Math.round(Date.now() / 1000));
+
+  let showModal: boolean = false;
+  const openModal = () => (showModal = true);
+  const closeModal = () => (showModal = false);
 </script>
 
 {#if swapState === undefined}
@@ -96,11 +101,18 @@
           </KeyValuePair>
         </div>
       {/if}
-      <button class="primary small" data-tid="sns-project-participate-button"
+      <button
+        on:click={openModal}
+        class="primary small"
+        data-tid="sns-project-participate-button"
         >{$i18n.sns_project_detail.participate}</button
       >
     </div>
   </div>
+{/if}
+
+{#if showModal}
+  <ParticipateSwapModal {project} on:nnsClose={closeModal} />
 {/if}
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -1,0 +1,2 @@
+<!-- TODO: https://dfinity.atlassian.net/browse/L2-796 -->
+<div data-tid="sns-swap-participate-step-2">Review participate</div>

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -9,6 +9,7 @@
     "confirm_yes": "Yes, I'm sure",
     "confirm_no": "Cancel",
     "confirm": "Confirm",
+    "cancel": "Cancel",
     "yes": "Yes",
     "no": "No",
     "unspecified": "Unspecified",
@@ -119,6 +120,7 @@
   "accounts": {
     "title": "Accounts",
     "main": "Main",
+    "main_account": "Main Account",
     "new_transaction": "New Transaction",
     "add_account": "Add Account",
     "new_linked_title": "New Linked Account",
@@ -523,6 +525,7 @@
     "user_commitment": "Your Current Commitment",
     "status": "Status",
     "accepting": "Accepting Participation",
+    "enter_amount": "Enter Amount",
     "participate": "Participate"
   },
   "time": {

--- a/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
+++ b/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import WizardModal from "../WizardModal.svelte";
+  import type { Step, Steps } from "../../stores/steps.state";
+  import Participate from "../../components/project-detail/Participate.svelte";
+  import ReviewParticipate from "../../components/project-detail/ReviewParticipate.svelte";
+  import type { SnsFullProject } from "../../stores/projects.store";
+  import type { Account } from "../../types/account";
+  import { ICP } from "@dfinity/nns";
+
+  export let project: SnsFullProject;
+
+  const steps: Steps = [
+    {
+      name: "Participate",
+      showBackButton: false,
+      title: $i18n.sns_project_detail.participate,
+    },
+    {
+      name: "ReviewTransaction",
+      showBackButton: false,
+      title: $i18n.accounts.review_transaction,
+    },
+  ];
+
+  let currentStep: Step;
+  let modal: WizardModal;
+
+  let selectedAccount: Account | undefined;
+  let amount: number | undefined;
+
+  const goNext = () => {
+    modal.next();
+  };
+</script>
+
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+  <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
+  {#if currentStep.name === "Participate"}
+    <Participate
+      bind:selectedAccount
+      bind:amount
+      on:nnsNext={goNext}
+      on:nnsClose
+      minAmount={ICP.fromE8s(project.summary.minParticipationCommitment)}
+      maxAmount={ICP.fromE8s(project.summary.maxParticipationCommitment)}
+    />
+  {/if}
+  {#if currentStep.name === "ReviewTransaction"}
+    <ReviewParticipate />
+  {/if}
+</WizardModal>

--- a/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
+++ b/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "../../stores/i18n";
   import WizardModal from "../WizardModal.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
-  import Participate from "../../components/project-detail/Participate.svelte";
+  import ParticipateScreen from "../../components/project-detail/ParticipateScreen.svelte";
   import ReviewParticipate from "../../components/project-detail/ReviewParticipate.svelte";
   import type { SnsFullProject } from "../../stores/projects.store";
   import type { Account } from "../../types/account";
@@ -37,7 +37,7 @@
 <WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
   <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
   {#if currentStep.name === "Participate"}
-    <Participate
+    <ParticipateScreen
       bind:selectedAccount
       bind:amount
       on:nnsNext={goNext}

--- a/frontend/svelte/src/lib/services/sns.mock.ts
+++ b/frontend/svelte/src/lib/services/sns.mock.ts
@@ -15,6 +15,9 @@ export interface SnsSummary {
   swapStart: bigint; // seconds
   minCommitment: bigint; // e8s
   maxCommitment: bigint; // e8s
+
+  minParticipationCommitment: bigint; // e8s
+  maxParticipationCommitment: bigint; // e8s
 }
 
 export interface SnsSwapState {

--- a/frontend/svelte/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/svelte/src/lib/stores/transaction-fees.store.ts
@@ -1,3 +1,4 @@
+import { ICP } from "@dfinity/nns";
 import { derived, writable } from "svelte/store";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../constants/icp.constants";
 
@@ -37,4 +38,9 @@ export const transactionsFeesStore = initTransactionFeesStore();
 export const mainTransactionFeeStore = derived(
   transactionsFeesStore,
   ($store) => Number($store.main)
+);
+
+export const mainTransactionFeeStoreAsIcp = derived(
+  transactionsFeesStore,
+  ($store) => ICP.fromE8s($store.main)
 );

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -41,6 +41,7 @@ button {
   }
 
   &.primary,
+  &.secondary,
   &.danger,
   &.warning {
     border-radius: 50px;
@@ -80,6 +81,25 @@ button {
     &:focus {
       background: var(--primary-tint);
       @include effect.ripple-effect(--primary-tint);
+    }
+  }
+
+  &.secondary {
+    &[disabled],
+    &[disabled]:hover {
+      background: var(--disable);
+      color: var(--disable-contrast);
+      cursor: default;
+    }
+
+    background: var(--primary-contrast);
+    color: var(--primary);
+
+    @include effect.ripple-effect(--primary-contrast);
+
+    &:focus {
+      background: var(--primary-contrast);
+      @include effect.ripple-effect(--primary-contrast);
     }
   }
 

--- a/frontend/svelte/src/lib/themes/button.scss
+++ b/frontend/svelte/src/lib/themes/button.scss
@@ -92,6 +92,7 @@ button {
       cursor: default;
     }
 
+    // Same colors as primary but reversed
     background: var(--primary-contrast);
     color: var(--primary);
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -12,6 +12,7 @@ interface I18nCore {
   confirm_yes: string;
   confirm_no: string;
   confirm: string;
+  cancel: string;
   yes: string;
   no: string;
   unspecified: string;
@@ -128,6 +129,7 @@ interface I18nAuth {
 interface I18nAccounts {
   title: string;
   main: string;
+  main_account: string;
   new_transaction: string;
   add_account: string;
   new_linked_title: string;
@@ -552,6 +554,7 @@ interface I18nSns_project_detail {
   user_commitment: string;
   status: string;
   accepting: string;
+  enter_amount: string;
   participate: string;
 }
 

--- a/frontend/svelte/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -2,9 +2,10 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import ProjectStatusSection from "../../../../lib/components/project-detail/ProjectStatusSection.svelte";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
+import { clickByTestId } from "../../testHelpers/clickByTestId";
 
 describe("ProjectStatusSection", () => {
   const props = { project: mockSnsFullProject };
@@ -21,5 +22,13 @@ describe("ProjectStatusSection", () => {
   it("should render project participate button", async () => {
     const { queryByTestId } = render(ProjectStatusSection, { props });
     expect(queryByTestId("sns-project-participate-button")).toBeInTheDocument();
+  });
+
+  it("should open swap participation modal on participate click", async () => {
+    const { queryByTestId } = render(ProjectStatusSection, { props });
+    await clickByTestId(queryByTestId, "sns-project-participate-button");
+    await waitFor(() =>
+      expect(queryByTestId("sns-swap-participate-step-1")).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/svelte/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
+import ParticipateSwapModal from "../../../../lib/modals/sns/ParticipateSwapModal.svelte";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import { mockAccountsStoreSubscribe } from "../../../mocks/accounts.store.mock";
+import { renderModal } from "../../../mocks/modal.mock";
+import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
+import { clickByTestId } from "../../testHelpers/clickByTestId";
+
+describe("ParticipateSwapModal", () => {
+  const renderSwapModal = async (): Promise<RenderResult> => {
+    return renderModal({
+      component: ParticipateSwapModal,
+      props: { project: mockSnsFullProject },
+    });
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+  });
+
+  it("should display modal", async () => {
+    const { container } = await renderSwapModal();
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should display dropdown to select account and input to add amount", async () => {
+    const { queryByTestId, container } = await renderSwapModal();
+
+    expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
+    expect(container.querySelector("input[name='amount']")).toBeInTheDocument();
+  });
+
+  it("should trigger close on cancel", async () => {
+    const { queryByTestId, component } = await renderSwapModal();
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+
+    await clickByTestId(queryByTestId, "sns-swap-participate-button-cancel");
+    await waitFor(() => expect(onClose).toBeCalled());
+  });
+
+  it("should have disabled button by default", async () => {
+    const { queryByTestId } = await renderSwapModal();
+
+    const participateButton = queryByTestId("sns-swap-participate-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+  });
+
+  it("should enable button when input value changes", async () => {
+    const { queryByTestId, container } = await renderSwapModal();
+
+    const participateButton = queryByTestId("sns-swap-participate-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: "10" } });
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+  });
+
+  it("should move to the last step", async () => {
+    const { queryByTestId, container } = await renderSwapModal();
+
+    const participateButton = queryByTestId("sns-swap-participate-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: "10" } });
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+
+    participateButton && fireEvent.click(participateButton);
+    await waitFor(() =>
+      expect(queryByTestId("sns-swap-participate-step-2")).toBeFalsy()
+    );
+  });
+});

--- a/frontend/svelte/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/svelte/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -18,70 +18,95 @@ describe("ParticipateSwapModal", () => {
     });
   };
 
-  beforeEach(() => {
-    jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
+  describe("accountsStore is populated", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+    });
+
+    it("should display modal", async () => {
+      const { container } = await renderSwapModal();
+
+      expect(container.querySelector("div.modal")).not.toBeNull();
+    });
+
+    it("should display dropdown to select account and input to add amount", async () => {
+      const { queryByTestId, container } = await renderSwapModal();
+
+      expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
+      expect(
+        container.querySelector("input[name='amount']")
+      ).toBeInTheDocument();
+    });
+
+    it("should trigger close on cancel", async () => {
+      const { queryByTestId, component } = await renderSwapModal();
+
+      const onClose = jest.fn();
+      component.$on("nnsClose", onClose);
+
+      await clickByTestId(queryByTestId, "sns-swap-participate-button-cancel");
+      await waitFor(() => expect(onClose).toBeCalled());
+    });
+
+    it("should have disabled button by default", async () => {
+      const { queryByTestId } = await renderSwapModal();
+
+      const participateButton = queryByTestId(
+        "sns-swap-participate-button-next"
+      );
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+    });
+
+    it("should enable button when input value changes", async () => {
+      const { queryByTestId, container } = await renderSwapModal();
+
+      const participateButton = queryByTestId(
+        "sns-swap-participate-button-next"
+      );
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: "10" } });
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+    });
+
+    it("should move to the last step", async () => {
+      const { queryByTestId, container } = await renderSwapModal();
+
+      const participateButton = queryByTestId(
+        "sns-swap-participate-button-next"
+      );
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: "10" } });
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+
+      participateButton && fireEvent.click(participateButton);
+      await waitFor(() =>
+        expect(queryByTestId("sns-swap-participate-step-2")).toBeFalsy()
+      );
+    });
   });
 
-  it("should display modal", async () => {
-    const { container } = await renderSwapModal();
+  describe("accountsStore is empty", () => {
+    it("should have disabled button if no account is selected", async () => {
+      const { queryByTestId, container } = await renderSwapModal();
 
-    expect(container.querySelector("div.modal")).not.toBeNull();
-  });
+      const participateButton = queryByTestId(
+        "sns-swap-participate-button-next"
+      );
 
-  it("should display dropdown to select account and input to add amount", async () => {
-    const { queryByTestId, container } = await renderSwapModal();
+      const input = container.querySelector("input[name='amount']");
+      input && (await fireEvent.input(input, { target: { value: "10" } }));
 
-    expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
-    expect(container.querySelector("input[name='amount']")).toBeInTheDocument();
-  });
-
-  it("should trigger close on cancel", async () => {
-    const { queryByTestId, component } = await renderSwapModal();
-
-    const onClose = jest.fn();
-    component.$on("nnsClose", onClose);
-
-    await clickByTestId(queryByTestId, "sns-swap-participate-button-cancel");
-    await waitFor(() => expect(onClose).toBeCalled());
-  });
-
-  it("should have disabled button by default", async () => {
-    const { queryByTestId } = await renderSwapModal();
-
-    const participateButton = queryByTestId("sns-swap-participate-button-next");
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-  });
-
-  it("should enable button when input value changes", async () => {
-    const { queryByTestId, container } = await renderSwapModal();
-
-    const participateButton = queryByTestId("sns-swap-participate-button-next");
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-
-    const input = container.querySelector("input[name='amount']");
-    input && fireEvent.input(input, { target: { value: "10" } });
-    await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
-    );
-  });
-
-  it("should move to the last step", async () => {
-    const { queryByTestId, container } = await renderSwapModal();
-
-    const participateButton = queryByTestId("sns-swap-participate-button-next");
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-
-    const input = container.querySelector("input[name='amount']");
-    input && fireEvent.input(input, { target: { value: "10" } });
-    await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
-    );
-
-    participateButton && fireEvent.click(participateButton);
-    await waitFor(() =>
-      expect(queryByTestId("sns-swap-participate-step-2")).toBeFalsy()
-    );
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy();
+    });
   });
 });

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -53,6 +53,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapStart: BigInt(Math.round(Date.now() / 1000) - SECONDS_IN_DAY / 4),
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
+    minParticipationCommitment: BigInt(150000000),
+    maxParticipationCommitment: BigInt(5000000000),
     tokenName: "Tetris",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACzSURBVHgB7ZrBCcIwAEUTcYSMI6KC2H2cw30UQRwoO1Ry6DkptMhL3zvk9C7vEPiExMPxPIbO2Jcj51wVU0pN3hy3eN/Pu+qdLtcmb3J3oUOMomAUBaModBkVN78oXukZWrjlwUWxNEZRMIqCURRcFBT+vijWeB/xTlEwioJRFIyi4KKYsyha3OKNj7oX74OLwigKRlEwioKLgsJq/yhal8KS3uR6pygYRcEoCkZRcCZR+AGaGlXJPd3qegAAAABJRU5ErkJggg==",
@@ -69,6 +71,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 20),
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(2000 * 100000000),
+    minParticipationCommitment: BigInt(100000000),
+    maxParticipationCommitment: BigInt(3000000000),
     tokenName: "Pacman",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAClSURBVHgB7dqxDYMwEEBRE2UET5I6icQUzMgc9EziHUAuqLElS+if/iuoruAXyCeL6fufjxTMuz5KKbeDOee0rXtq8Vs+TbM9cy3vWNX3fKWAjKIwisIoipBRU9iNYuTp3zM7eu6a9ZuiMIrCKAqjKNwoek711nuPkXPXrN8UhVEURlEYReFG4R3Fg4yiMIrCKAo3Cgr/o6AwisIoCqMojKIIuSadjJ5VyRrmqP4AAAAASUVORK5CYII=",
@@ -88,6 +92,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 5),
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
+    minParticipationCommitment: BigInt(500000000),
+    maxParticipationCommitment: BigInt(10000000000),
     tokenName: "Mario",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACjSURBVHgB7dkxDkRAGEDh32ZPsuWWWy+JQ4gzimPolUpXIXMCM4nmjfcVqglegT+j+Xf9EZV5p8MyrZcL2/EX+7BFjs/8zVpbsi7nHpN0n6+okFEURlEYRVFlVPP4iaLkq37npFB6bZ8pCqMojKIwisKJomSP4s5zukcRvig4jKIwisKJgsK/HhRGURhFYRSFEwWFEwWFURRGURhFYRRFlWPSCah/Vck0pRWfAAAAAElFTkSuQmCC",
@@ -106,6 +112,8 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapStart: BigInt(SECONDS_TODAY - SECONDS_IN_DAY * 3),
     minCommitment: BigInt(500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
+    minParticipationCommitment: BigInt(150000000),
+    maxParticipationCommitment: BigInt(5000000000),
     tokenName: "Kong",
 
     logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZkxCsJAFAUTETyAexcbEfZSHsJLBcTGu6wHsFK3SL0/EIvZzBSpHj87gYXHz3i+5M/QGfv6OB2mZvD5zqHcnC2lNHMppb+8ezd0iFIUlKKgFIUupcbNN4rpeB0i5Ndt1ZnRefNM7xQFpSgoRUEpCv02ijX3CZXoTmFJLnLGSj2nd4qCUhSUoqAUBXcUSxrF497O/j6ofz2iKEVBKQpKUbBRUHBHQUEpCkpRUIqCUhS6rElfBK1VyaWjTNYAAAAASUVORK5CYII=",


### PR DESCRIPTION
# Motivation

User can select an account and enter an amount to participate in a swap.

# Changes

* New modal ParticipateSwapModal.
* New screens Participate and ReviewParticipate (setup only) used in the modal.
* New button class "secondary".
* Setup of new component "SelectAccountDropdown.
* Add minParticipationCommitment and maxParticipationCommitment to SNS Project mock data.

# Tests

* Tests for new Modal.
* Add test case in ProjectStatusSection that opens modal.
