### PR TITLE
L2-803: Bug, Merge maturity enabled w/out maturity

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -17,7 +17,8 @@
   const showModal = () => (isOpen = true);
   const closeModal = () => (isOpen = false);
 
-  const enoughMaturity = hasEnoughMaturityToMerge({
+  let enoughMaturity: boolean;
+  $: enoughMaturity = hasEnoughMaturityToMerge({
     neuron,
     fee: $mainTransactionFeeStore,
   });


### PR DESCRIPTION
# Motivation

User should not see merge maturity enabled without maturity.

# Changes

* Update enable or disable with neuron props changes.

# Tests

Not applicable.
