### PR TITLE
L2-815: Fix, ledger Error shows i18n key

### DIFF
--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -559,7 +559,7 @@
     "connect_many_apps": "Cannot connect to Ledger device. Please close all other wallet applications (e.g. Ledger Live) and try again.",
     "connect_not_supported": "Either you have other wallet applications open (e.g. Ledger Live), or your browser doesn't support WebHID, which is necessary to communicate with your Ledger hardware wallet. Supported browsers: Chrome (Desktop) v89+, Edge v89+, Opera v76+. Error: $err",
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right wallet?",
-    "user_cancel": "User denied the access to use the ledger device.",
+    "access_denied": "Access denied to use the ledger device.",
     "user_rejected_transaction": "The transaction was rejected on the ledger device.",
     "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to $minVersion.",
     "browser_not_supported": "Sorry, the browser does not support the WebHID API needed to connect the hardware wallet. Check support in https://caniuse.com/?search=WebHID",

--- a/frontend/svelte/src/lib/identities/ledger.identity.ts
+++ b/frontend/svelte/src/lib/identities/ledger.identity.ts
@@ -127,7 +127,7 @@ export class LedgerIdentity extends SignIdentity {
         ) {
           throw new LedgerErrorKey("error__ledger.browser_not_supported");
         }
-        throw new LedgerErrorKey("error__ledger.user_cancel");
+        throw new LedgerErrorKey("error__ledger.access_denied");
       }
 
       if ((err as LedgerHQTransportError)?.id === "NoDeviceFound") {

--- a/frontend/svelte/src/lib/services/neurons.services.ts
+++ b/frontend/svelte/src/lib/services/neurons.services.ts
@@ -219,10 +219,8 @@ export const stakeNeuron = async ({
 
     return newNeuronId;
   } catch (err) {
-    toastsStore.error({
-      labelKey: "error.stake_neuron",
-      err,
-    });
+    toastsStore.show(mapNeuronErrorToToastMessage(err));
+    return;
   }
 };
 

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -590,7 +590,7 @@ interface I18nError__ledger {
   connect_many_apps: string;
   connect_not_supported: string;
   unexpected_wallet: string;
-  user_cancel: string;
+  access_denied: string;
   user_rejected_transaction: string;
   version_not_supported: string;
   browser_not_supported: string;

--- a/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/ledger.services.spec.ts
@@ -94,7 +94,7 @@ describe("ledger-services", () => {
 
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
-          labelKey: "error__ledger.user_cancel",
+          labelKey: "error__ledger.access_denied",
         });
 
         spyToastError.mockRestore();

--- a/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/svelte/src/tests/lib/services/neurons.services.spec.ts
@@ -252,7 +252,7 @@ describe("neurons-services", () => {
       });
 
       expect(response).toBeUndefined();
-      expect(toastsStore.error).toBeCalled();
+      expect(toastsStore.show).toBeCalled();
     });
 
     it("should not stake neuron if no identity", async () => {
@@ -264,7 +264,7 @@ describe("neurons-services", () => {
       });
 
       expect(response).toBeUndefined();
-      expect(toastsStore.error).toBeCalled();
+      expect(toastsStore.show).toBeCalled();
 
       resetAccountIdentity();
     });


### PR DESCRIPTION
# Motivation

User error reported showed i18n key instead of the message.

# Changes

* Add error mapper to catch when staking a neuron.
* Make the error of HW connect more generic. It might happen that the device is not even connected.

# Tests

* Fix broken tests.
