### PR TITLE
Fix: Error message when toggling community fund

### DIFF
--- a/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.svelte
+++ b/frontend/svelte/src/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.svelte
@@ -20,12 +20,13 @@
 
   const joinFund = async () => {
     startBusy({ initiator: "toggle-community-fund" });
+    const successMessageKey = isCommunityFund
+      ? "neuron_detail.leave_community_fund_success"
+      : "neuron_detail.join_community_fund_success";
     const id = await toggleCommunityFund(neuron);
     if (id !== undefined) {
       toastsStore.success({
-        labelKey: isCommunityFund
-          ? "neuron_detail.leave_community_fund_success"
-          : "neuron_detail.join_community_fund_success",
+        labelKey: successMessageKey,
       });
     }
     closeModal();


### PR DESCRIPTION
# Motivation

Fix notification message when toggling community fund.

# Changes

* Set the message before making the call.

# Tests

* Only messaging changes.
