### PR TITLE
Install idl2json

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -203,12 +203,15 @@ install_sns_darwin() {
 
 install_idl2json() {
   (
+    set -euo pipefail # These are not inherited in a subsell.
     build_dir="$(mktemp -d)"
     cd "$build_dir"
     git clone https://github.com/dfinity/idl2json.git
     cd idl2json
     cargo build --release
     mv target/release/idl2json "$USER_BIN"
+    cd /tmp
+    rm -fr "${build_dir:-this-is-not-the-dir-you-are-looking-for}" # This is defensive code; build_dir SHOULD be defined.
   )
 }
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -60,6 +60,9 @@ if test -z "${USER_PROFILE:-}"; then
   }
 fi
 
+USER_BIN="$HOME/.local/bin"
+mkdir -p "$USER_BIN"
+
 NEW_TERMINAL_NEEDED=false
 append_to_profile() {
   printf '\n%s\n' "$1" >>"$USER_PROFILE"
@@ -175,14 +178,10 @@ install_cmake_linux() {
 # Note: There is an open ticket to factor out all definitions of IC_ADMIN.
 IC_COMMIT=7fcae4939dc6fac179ce3dd25ded6e6b650e2293
 install_ic_admin_linux() {
-  local USER_BIN="$HOME/.local/bin"
-  mkdir -p "$USER_BIN"
   curl "https://download.dfinity.systems/ic/${IC_COMMIT}/release/ic-admin.gz" | gunzip >"$USER_BIN/ic-admin"
   chmod +x "$USER_BIN/ic-admin"
 }
 install_ic_admin_darwin() {
-  local USER_BIN="$HOME/.local/bin"
-  mkdir -p "$USER_BIN"
   curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/ic-admin.gz" | gunzip >"$USER_BIN/ic-admin"
   chmod +x "$USER_BIN/ic-admin"
   # shellcheck disable=SC2016
@@ -191,19 +190,26 @@ install_ic_admin_darwin() {
 }
 
 install_sns_linux() {
-  local USER_BIN="$HOME/.local/bin"
-  mkdir -p "$USER_BIN"
   curl "https://download.dfinity.systems/ic/${IC_COMMIT}/release/sns.gz" | gunzip >"$USER_BIN/sns"
   chmod +x "$USER_BIN/sns"
 }
 install_sns_darwin() {
-  local USER_BIN="$HOME/.local/bin"
-  mkdir -p "$USER_BIN"
   curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/sns.gz" | gunzip >"$USER_BIN/sns"
   chmod +x "$USER_BIN/sns"
   # shellcheck disable=SC2016
   command -v sns ||
     append_to_profile "export PATH=\"\$PATH:${USER_BIN}\""
+}
+
+install_idl2json() {
+  (
+    build_dir="$(mktemp -d)"
+    cd "$build_dir"
+    git clone https://github.com/dfinity/idl2json.git
+    cd idl2json
+    cargo build --release
+    mv target/release/idl2json "$USER_BIN"
+  )
 }
 
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
@@ -228,6 +234,7 @@ command -v cmake || "install_cmake_$OS"
 command -V ic-cdk-optimizer || install_ic_cdk_optimizer
 command -V ic-admin || "install_ic_admin_$OS"
 command -v sns || "install_sns_$OS"
+command -v idl2json || install_idl2json
 
 echo "OK, all set to go!"
 [[ "$NEW_TERMINAL_NEEDED" == "false" ]] || echo "Please open a fresh terminal for these changes to take effect."


### PR DESCRIPTION
# Motivation
When sns canisters are created via the sns-wasms canister, not dfx, they are no longer added to the `canister_ids.json`.  It is possible to use `idl2json` and `jq` to use the `sns` cli response to populate `canister_ids.json`, and so create  
a better developer experience.  This requires `idl2json` to be available.

# Changes
* Add code to install idl2json to the setup script

# Tests
* Installation works on:
  - [x] Linux
  - [x] Mac M1
  - [x] Mac Intel