### PR TITLE
L2 835 total balance tooltip

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
+
   /** Used in aria-describedby */
   import { debounce, isNullable } from "../../utils/utils";
 
@@ -15,7 +17,12 @@
     // We need the main reference because at the moment the scrollbar is displayed in that element therefore it's the way to get to know the real width - i.e. window width - scrollbar width
     const main: HTMLElement | null = document.querySelector("main");
 
-    if (main === null || tooltipComponent === undefined || isNullable(target)) {
+    if (
+      destroyed ||
+      main === null ||
+      tooltipComponent === undefined ||
+      target === undefined
+    ) {
       // Do nothing, we need the elements to be rendered in order to get their size and position to fix the tooltip
       return;
     }
@@ -48,6 +55,9 @@
   });
 
   $: innerWidth, tooltipComponent, target, setPosition();
+
+  let destroyed: boolean = false;
+  onDestroy(() => (destroyed = true));
 </script>
 
 <svelte:window bind:innerWidth />

--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /** Used in aria-describedby */
-  import { debounce } from "../../utils/utils";
+  import { debounce, isNullable } from "../../utils/utils";
 
   export let id: string;
   export let text = "";
@@ -15,11 +15,7 @@
     // We need the main reference because at the moment the scrollbar is displayed in that element therefore it's the way to get to know the real width - i.e. window width - scrollbar width
     const main: HTMLElement | null = document.querySelector("main");
 
-    if (
-      main === null ||
-      tooltipComponent === undefined ||
-      target === undefined
-    ) {
+    if (main === null || tooltipComponent === undefined || isNullable(target)) {
       // Do nothing, we need the elements to be rendered in order to get their size and position to fix the tooltip
       return;
     }

--- a/frontend/svelte/src/lib/i18n/en.json
+++ b/frontend/svelte/src/lib/i18n/en.json
@@ -165,6 +165,7 @@
     "hardware_wallet_add_hotkey_text_neuron": "This action will add your NNS dapp principal as a hotkey to neuron $neuronId.",
     "hardware_wallet_add_hotkey_text_principal": "Your NNS dapp principal is: $principalId",
     "hardware_wallet_add_hotkey_text_confirm": "Are you sure you want to continue?",
+    "current_balance_total": "Total balance: $amount ICP",
     "current_balance_detail": "Current balance: $amount ICP"
   },
   "neurons": {

--- a/frontend/svelte/src/lib/types/i18n.d.ts
+++ b/frontend/svelte/src/lib/types/i18n.d.ts
@@ -174,6 +174,7 @@ interface I18nAccounts {
   hardware_wallet_add_hotkey_text_neuron: string;
   hardware_wallet_add_hotkey_text_principal: string;
   hardware_wallet_add_hotkey_text_confirm: string;
+  current_balance_total: string;
   current_balance_detail: string;
 }
 

--- a/frontend/svelte/src/routes/Accounts.svelte
+++ b/frontend/svelte/src/routes/Accounts.svelte
@@ -11,11 +11,13 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import AddAcountModal from "../lib/modals/accounts/AddAccountModal.svelte";
   import { ICP } from "@dfinity/nns";
-  import { sumICPs } from "../lib/utils/icp.utils";
+  import { formatICP, sumICPs } from "../lib/utils/icp.utils";
   import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
   import Footer from "../lib/components/common/Footer.svelte";
   import MainContentWrapper from "../lib/components/ui/MainContentWrapper.svelte";
+  import Tooltip from "../lib/components/ui/Tooltip.svelte";
+  import { replacePlaceholders } from "../lib/utils/i18n.utils";
 
   let accounts: AccountsStore | undefined;
 
@@ -34,6 +36,7 @@
   const closeModal = () => (modal = undefined);
 
   let totalBalance: ICP;
+  let totalICP: string;
   const zeroICPs = ICP.fromE8s(BigInt(0));
   $: {
     totalBalance = sumICPs(
@@ -41,6 +44,10 @@
       ...(accounts?.subAccounts || []).map(({ balance }) => balance),
       ...(accounts?.hardwareWallets || []).map(({ balance }) => balance)
     );
+    totalICP = formatICP({
+      value: totalBalance.toE8s(),
+      detailed: true,
+    });
   }
 </script>
 
@@ -50,7 +57,14 @@
       <h1>{$i18n.accounts.title}</h1>
 
       {#if accounts?.main}
-        <ICPComponent icp={totalBalance} />
+        <Tooltip
+          id="wallet-total-icp"
+          text={replacePlaceholders($i18n.accounts.current_balance_total, {
+            $amount: totalICP,
+          })}
+        >
+          <ICPComponent icp={totalBalance} />
+        </Tooltip>
       {/if}
     </div>
 
@@ -127,7 +141,7 @@
     @include media.min-width(medium) {
       display: inline-flex;
       justify-content: space-between;
-      align-items: center;
+      align-items: baseline;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

Display a tooltip with the total amount of ICP (to match the account detail page feature)
[L2-835](https://dfinity.atlassian.net/browse/L2-835)

<img width="1190" alt="Screenshot 2022-07-12 at 07 54 39" src="https://user-images.githubusercontent.com/98811342/178431982-8ccd586b-6a04-44b6-a486-9d86e3bc70be.png">

# Changes

- new tooltip on Account page

# Tests

- should render a total balance in a tooltip
