### PR TITLE
L2 830 sns summary data loading state

### DIFF
--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -146,12 +146,12 @@ const wrappers = async ({
   switch (certified) {
     case false:
       if (!snsQueryWrappers) {
-        snsQueryWrappers = await initWrappers({ identity, certified: false });
+        snsQueryWrappers = initWrappers({ identity, certified: false });
       }
       return snsQueryWrappers;
     default:
       if (!snsUpdateWrappers) {
-        snsUpdateWrappers = await initWrappers({ identity, certified: true });
+        snsUpdateWrappers = initWrappers({ identity, certified: true });
       }
       return snsUpdateWrappers;
   }

--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -9,14 +9,16 @@ import {
   importSnsWasmCanister,
   type SnsWasmCanisterCreate,
 } from "../proxy/api.import.proxy";
+import { snsesCountStore } from "../stores/projects.store";
 import { ApiErrorKey } from "../types/api.errors";
 import type { SnsSummary } from "../types/sns";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
 
 type RootCanisterId = string;
-let snsQueryWrappers: Map<RootCanisterId, SnsWrapper> | undefined;
-let snsUpdateWrappers: Map<RootCanisterId, SnsWrapper> | undefined;
+
+let snsQueryWrappers: Promise<Map<RootCanisterId, SnsWrapper>> | undefined;
+let snsUpdateWrappers: Promise<Map<RootCanisterId, SnsWrapper>> | undefined;
 
 /**
  * List all deployed Snses - i.e list all Sns projects
@@ -100,6 +102,8 @@ const loadSnsWrappers = async ({
   });
 
   const rootCanisterIds: Principal[] = await listSnses({ agent, certified });
+
+  snsesCountStore.set(rootCanisterIds.length);
 
   const results: PromiseSettledResult<SnsWrapper>[] = await Promise.allSettled(
     rootCanisterIds.map((rootCanisterId: Principal) =>

--- a/frontend/svelte/src/lib/components/common/RouteModule.svelte
+++ b/frontend/svelte/src/lib/components/common/RouteModule.svelte
@@ -92,7 +92,7 @@
     position: absolute;
     @include display.inset;
 
-    color: rgba(var(--background-contrast-rgb), 0.2);
+    color: rgba(var(--background-contrast-rgb), var(--very-light-opacity));
   }
 
   .authLayout {

--- a/frontend/svelte/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/svelte/src/lib/components/launchpad/Projects.svelte
@@ -8,15 +8,20 @@
     snsFullProjectStore,
     type SnsFullProject,
     snsSummariesStore,
+    snsesCountStore,
   } from "../../stores/projects.store";
   import { onMount } from "svelte";
   import ProjectCard from "./ProjectCard.svelte";
   import CardGrid from "../ui/CardGrid.svelte";
   import SkeletonProjectCard from "../ui/SkeletonProjectCard.svelte";
+  import Spinner from "../ui/Spinner.svelte";
 
   let loading: boolean = false;
   let projects: SnsFullProject[] | undefined;
   $: projects = $snsFullProjectStore;
+
+  let projectCount: number | undefined;
+  $: projectCount = $snsesCountStore;
 
   const load = async () => {
     // show loading state only when store is empty
@@ -35,10 +40,15 @@
 </script>
 
 {#if loading}
-  <CardGrid>
-    <SkeletonProjectCard />
-    <SkeletonProjectCard />
-  </CardGrid>
+  {#if projectCount === undefined}
+    <Spinner />
+  {:else}
+    <CardGrid>
+      {#each Array(projectCount) as _}
+        <SkeletonProjectCard />
+      {/each}
+    </CardGrid>
+  {/if}
 {:else if projects !== undefined}
   <CardGrid>
     {#each projects as project (project.rootCanisterId.toText())}

--- a/frontend/svelte/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/svelte/src/lib/components/launchpad/Projects.svelte
@@ -41,7 +41,9 @@
 
 {#if loading}
   {#if projectCount === undefined}
-    <Spinner />
+    <div>
+      <Spinner inline />
+    </div>
   {:else}
     <CardGrid>
       {#each Array(projectCount) as _}
@@ -59,3 +61,10 @@
     <p>{$i18n.sns_launchpad.no_projects}</p>
   {/if}
 {/if}
+
+<style lang="scss">
+  // match page spinner
+  div {
+    color: rgba(var(--background-contrast-rgb), var(--very-light-opacity));
+  }
+</style>

--- a/frontend/svelte/src/lib/services/sns.services.ts
+++ b/frontend/svelte/src/lib/services/sns.services.ts
@@ -1,6 +1,5 @@
 import type { ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { get } from "svelte/store";
 import { mockProposalInfo } from "../../tests/mocks/proposal.mock";
 import { querySnsSummaries, querySnsSummary } from "../api/sns.api";
 import { AppPath } from "../constants/routes.constants";
@@ -45,25 +44,11 @@ const mockDummySwapStates: Partial<SnsSwapState>[] = [
   },
 ];
 
-const ignoreSnsSummaryResult = (certified: boolean): boolean => {
-  const $snsSummariesStore = get(snsSummariesStore);
-
-  /**
-   Since we have chosen not to refetch the data when navigating through the pages,
-   the result of the `query` should be ignored if the `update` is already loaded.
-   */
-  return certified === false && $snsSummariesStore.certified === true;
-};
-
 export const loadSnsSummaries = (): Promise<void> =>
   queryAndUpdate<SnsSummary[], unknown>({
     request: ({ certified, identity }) =>
       querySnsSummaries({ certified, identity }),
     onLoad: ({ response: summaries, certified }) => {
-      if (ignoreSnsSummaryResult(certified)) {
-        return;
-      }
-
       snsSummariesStore.setSummaries({
         summaries,
         certified,
@@ -114,17 +99,12 @@ export const loadSnsSummary = async (canisterId: string) => {
         identity,
         certified,
       }),
-    onLoad: ({ response: summary, certified }) => {
-      if (ignoreSnsSummaryResult(certified)) {
-        return;
-      }
-
+    onLoad: ({ response: summary, certified }) =>
       // TODO(L2-840): detail page should not use that summaries store but only a dedicated state or context store
       snsSummariesStore.setSummaries({
         summaries: [...(summary ? [summary] : [])],
         certified,
-      });
-    },
+      }),
     onError: ({ error: err, certified }) => {
       console.error(err);
 

--- a/frontend/svelte/src/lib/stores/projects.store.ts
+++ b/frontend/svelte/src/lib/stores/projects.store.ts
@@ -81,6 +81,9 @@ const initSnsSwapStatesStore = () => {
   };
 };
 
+// used to improve loading state display only
+export const snsesCountStore = writable<number | undefined>(undefined);
+
 export const snsSummariesStore = initSnsSummariesStore();
 export const snsSwapStatesStore = initSnsSwapStatesStore();
 

--- a/frontend/svelte/src/lib/themes/themes/dark.scss
+++ b/frontend/svelte/src/lib/themes/themes/dark.scss
@@ -45,6 +45,7 @@
   --menu-background-contrast: var(--card-background-contrast);
 
   --light-opacity: 0.6;
+  --very-light-opacity: 0.4;
 
   // Overlays - based on dark card background rgb color
   --backdrop: rgba(39, 41, 41, 0.8);

--- a/frontend/svelte/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/svelte/src/tests/lib/api/sns.api.spec.ts
@@ -1,9 +1,15 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
+import { get } from "svelte/store";
 import { querySnsSummaries } from "../../../lib/api/sns.api";
 import {
   importInitSns,
   importSnsWasmCanister,
 } from "../../../lib/proxy/api.import.proxy";
+import { snsesCountStore } from "../../../lib/stores/projects.store";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   deployedSnsMock,
@@ -49,5 +55,16 @@ describe("sns-api", () => {
     // TODO: currently summaries use mock data and get the value randomly therefore we cannot test it more precisely
     expect(summaries).not.toBeNull();
     expect(summaries.length).toEqual(1);
+  });
+
+  it("should update snsesCountStore", async () => {
+    await querySnsSummaries({
+      identity: mockIdentity,
+      certified: true,
+    });
+
+    const $snsesCountStore = get(snsesCountStore);
+
+    expect($snsesCountStore).toEqual(deployedSnsMock.length);
   });
 });

--- a/frontend/svelte/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -2,10 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import Projects from "../../../../lib/components/launchpad/Projects.svelte";
 import { loadSnsSummaries } from "../../../../lib/services/sns.services";
 import {
+  snsesCountStore,
   snsSummariesStore,
   snsSwapStatesStore,
 } from "../../../../lib/stores/projects.store";
@@ -59,8 +60,18 @@ describe("Projects", () => {
     expect(queryByText(en.sns_launchpad.no_projects)).toBeInTheDocument();
   });
 
-  it("should render skeletons on loading", () => {
-    const { queryAllByTestId } = render(Projects);
-    expect(queryAllByTestId("skeleton-card").length).toBeGreaterThanOrEqual(1);
+  it("should render spinner on loading", () => {
+    const { queryByTestId } = render(Projects);
+    expect(queryByTestId("spinner")).toBeInTheDocument();
+  });
+
+  it("should render skeletons after snsesCountStore update", async () => {
+    const { getAllByTestId } = render(Projects);
+
+    snsesCountStore.set(3);
+
+    await waitFor(() =>
+      expect(getAllByTestId("skeleton-card").length).toBeGreaterThanOrEqual(3)
+    );
   });
 });


### PR DESCRIPTION
# Motivation

Added more granular loading state display to improve user experience during the sns data loading (could take some time because of big request quantity)

# Changes

- initially display a spinner, then the correct amount of project skeleton cards
- fix multiple loading of snsWrappers

# Tests
- wrappers call should update snsesCountStore

# Screenshots

https://user-images.githubusercontent.com/98811342/178949103-e6a685f4-fecb-4e02-a0fd-f00d756121bb.mp4



