### PR TITLE
Feat/l2 840 context store for project detail page

### DIFF
--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -2,7 +2,6 @@ import type { HttpAgent, Identity } from "@dfinity/agent";
 import type { DeployedSns, SnsWasmCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { InitSns, SnsWrapper } from "@dfinity/sns";
-import type { GetStateResponse } from "@dfinity/sns/dist/candid/sns_swap";
 import { mockSnsSummaryList } from "../../tests/mocks/sns-projects.mock";
 import { HOST } from "../constants/environment.constants";
 import {
@@ -350,7 +349,7 @@ export const querySnsSwapState = async ({
   // TODO: current deployed swap canister on testnet is empty
   // Error: "Message": "IC0304: Attempt to execute a message on canister mr56c-4qaaa-aaaaa-aacgq-cai which contains no Wasm module"
   // const { swap } = await swapState({});
-  let swap: GetStateResponse;
+  let swap: unknown;
   try {
     swap = await swapState({});
     console.log("swap", swap);

--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -347,6 +347,9 @@ export const querySnsSwapState = async ({
     certified,
   });
 
+  // TODO: current deployed swap canister on testnet is empty
+  // Error: "Message": "IC0304: Attempt to execute a message on canister mr56c-4qaaa-aaaaa-aacgq-cai which contains no Wasm module"
+  // const { swap } = await swapState({});
   let swap: GetStateResponse;
   try {
     swap = await swapState({});
@@ -354,10 +357,6 @@ export const querySnsSwapState = async ({
   } catch (err) {
     console.error("swap TBD");
   }
-
-  // TODO: current deployed swap canister on testnet is empty
-  // Error: "Message": "IC0304: Attempt to execute a message on canister mr56c-4qaaa-aaaaa-aacgq-cai which contains no Wasm module"
-  // const { swap } = await swapState({});
 
   logWithTimestamp(
     `Getting Sns ${rootCanisterId} swap state certified:${certified} done.`

--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -14,7 +14,7 @@ import { snsesCountStore } from "../stores/projects.store";
 import { ApiErrorKey } from "../types/api.errors";
 import type { SnsSummary, SnsSwapState } from "../types/sns";
 import { createAgent } from "../utils/agent.utils";
-import { logWithTimestamp } from "../utils/dev.utils";
+import { logWithTimestamp, shuffle } from "../utils/dev.utils";
 
 type RootCanisterId = string;
 
@@ -23,7 +23,7 @@ let snsUpdateWrappers: Promise<Map<RootCanisterId, SnsWrapper>> | undefined;
 
 // TODO(L2-751): remove and replace with effective data
 let mockSwapStates: SnsSwapState[] = [];
-const mockDummySwapStates: Partial<SnsSwapState>[] = [
+const mockDummySwapStates: Partial<SnsSwapState>[] = shuffle([
   {
     myCommitment: BigInt(25 * 100000000),
     currentCommitment: BigInt(100 * 100000000),
@@ -40,7 +40,7 @@ const mockDummySwapStates: Partial<SnsSwapState>[] = [
     myCommitment: undefined,
     currentCommitment: BigInt(1500 * 100000000),
   },
-];
+]);
 
 /**
  * List all deployed Snses - i.e list all Sns projects

--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -14,7 +14,7 @@ import { snsesCountStore } from "../stores/projects.store";
 import { ApiErrorKey } from "../types/api.errors";
 import type { SnsSummary, SnsSwapState } from "../types/sns";
 import { createAgent } from "../utils/agent.utils";
-import { logWithTimestamp, shuffle } from "../utils/dev.utils";
+import { logWithTimestamp } from "../utils/dev.utils";
 
 type RootCanisterId = string;
 
@@ -23,7 +23,7 @@ let snsUpdateWrappers: Promise<Map<RootCanisterId, SnsWrapper>> | undefined;
 
 // TODO(L2-751): remove and replace with effective data
 let mockSwapStates: SnsSwapState[] = [];
-const mockDummySwapStates: Partial<SnsSwapState>[] = shuffle([
+const mockDummySwapStates: Partial<SnsSwapState>[] = [
   {
     myCommitment: BigInt(25 * 100000000),
     currentCommitment: BigInt(100 * 100000000),
@@ -40,7 +40,7 @@ const mockDummySwapStates: Partial<SnsSwapState>[] = shuffle([
     myCommitment: undefined,
     currentCommitment: BigInt(1500 * 100000000),
   },
-]);
+];
 
 /**
  * List all deployed Snses - i.e list all Sns projects

--- a/frontend/svelte/src/lib/api/sns.api.ts
+++ b/frontend/svelte/src/lib/api/sns.api.ts
@@ -2,6 +2,7 @@ import type { HttpAgent, Identity } from "@dfinity/agent";
 import type { DeployedSns, SnsWasmCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { InitSns, SnsWrapper } from "@dfinity/sns";
+import type { GetStateResponse } from "@dfinity/sns/dist/candid/sns_swap";
 import { mockSnsSummaryList } from "../../tests/mocks/sns-projects.mock";
 import { HOST } from "../constants/environment.constants";
 import {
@@ -13,7 +14,7 @@ import { snsesCountStore } from "../stores/projects.store";
 import { ApiErrorKey } from "../types/api.errors";
 import type { SnsSummary, SnsSwapState } from "../types/sns";
 import { createAgent } from "../utils/agent.utils";
-import { logWithTimestamp } from "../utils/dev.utils";
+import { logWithTimestamp, shuffle } from "../utils/dev.utils";
 
 type RootCanisterId = string;
 
@@ -22,7 +23,7 @@ let snsUpdateWrappers: Promise<Map<RootCanisterId, SnsWrapper>> | undefined;
 
 // TODO(L2-751): remove and replace with effective data
 let mockSwapStates: SnsSwapState[] = [];
-const mockDummySwapStates: Partial<SnsSwapState>[] = [
+const mockDummySwapStates: Partial<SnsSwapState>[] = shuffle([
   {
     myCommitment: BigInt(25 * 100000000),
     currentCommitment: BigInt(100 * 100000000),
@@ -39,7 +40,7 @@ const mockDummySwapStates: Partial<SnsSwapState>[] = [
     myCommitment: undefined,
     currentCommitment: BigInt(1500 * 100000000),
   },
-];
+]);
 
 /**
  * List all deployed Snses - i.e list all Sns projects
@@ -275,10 +276,8 @@ export const querySnsSummary = async ({
         (await wrappers({ identity, certified })) ??
         new Map<RootCanisterId, SnsWrapper>()
       ).values(),
-    ].map(({ canisterIds: { rootCanisterId } }: SnsWrapper) => ({
-      ...mockSnsSummaryList[
-        Math.floor(0 + Math.random() * (mockSnsSummaryList.length - 1))
-      ],
+    ].map(({ canisterIds: { rootCanisterId } }: SnsWrapper, index) => ({
+      ...mockSnsSummaryList[index],
       rootCanisterId,
     }));
   }
@@ -348,6 +347,14 @@ export const querySnsSwapState = async ({
     certified,
   });
 
+  let swap: GetStateResponse;
+  try {
+    swap = await swapState({});
+    console.log("swap", swap);
+  } catch (err) {
+    console.error("swap TBD");
+  }
+
   // TODO: current deployed swap canister on testnet is empty
   // Error: "Message": "IC0304: Attempt to execute a message on canister mr56c-4qaaa-aaaaa-aacgq-cai which contains no Wasm module"
   // const { swap } = await swapState({});
@@ -364,11 +371,9 @@ export const querySnsSwapState = async ({
         new Map<RootCanisterId, SnsWrapper>()
       ).values(),
     ].map(
-      ({ canisterIds: { rootCanisterId } }) =>
+      ({ canisterIds: { rootCanisterId } }, index) =>
         ({
-          ...mockDummySwapStates[
-            Math.floor(0 + Math.random() * (mockDummySwapStates.length - 1))
-          ],
+          ...mockDummySwapStates[index],
           rootCanisterId,
         } as SnsSwapState)
     );

--- a/frontend/svelte/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/svelte/src/lib/components/launchpad/Projects.svelte
@@ -7,7 +7,6 @@
   import {
     snsFullProjectStore,
     type SnsFullProject,
-    snsSummariesStore,
     snsesCountStore,
   } from "../../stores/projects.store";
   import { onMount } from "svelte";

--- a/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -6,11 +6,22 @@
   import InfoContextKey from "../ui/InfoContextKey.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import Logo from "../ui/Logo.svelte";
+  import { getContext } from "svelte";
+  import {
+    PROJECT_DETAIL_CONTEXT_KEY,
+    type ProjectDetailContext,
+  } from "../../types/project-detail.context";
 
-  export let summary: SnsSummary;
+  const { store: projectDetailStore } = getContext<ProjectDetailContext>(
+    PROJECT_DETAIL_CONTEXT_KEY
+  );
 
-  const minCommitmentIcp = ICP.fromE8s(summary.minParticipationCommitment);
-  const maxCommitmentIcp = ICP.fromE8s(summary.maxParticipationCommitment);
+  let summary: SnsSummary;
+  $: summary = $projectDetailStore.summary as SnsSummary;
+  let minCommitmentIcp: ICP;
+  $: minCommitmentIcp = ICP.fromE8s(summary.minParticipationCommitment);
+  let maxCommitmentIcp: ICP;
+  $: maxCommitmentIcp = ICP.fromE8s(summary.maxParticipationCommitment);
 </script>
 
 <div data-tid="sns-project-detail-info">

--- a/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -17,6 +17,7 @@
   );
 
   let summary: SnsSummary;
+  // type safety validation is done in ProjectDetail component
   $: summary = $projectDetailStore.summary as SnsSummary;
   let minCommitmentIcp: ICP;
   $: minCommitmentIcp = ICP.fromE8s(summary.minParticipationCommitment);

--- a/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
   import ParticipateSwapModal from "../../modals/sns/ParticipateSwapModal.svelte";
-  import type { SnsSwapState } from "../../types/sns";
+  import type { SnsSummary, SnsSwapState } from "../../types/sns";
   import { i18n } from "../../stores/i18n";
-  import type { SnsFullProject } from "../../stores/projects.store";
   import { secondsToDuration } from "../../utils/date.utils";
   import { nowInSeconds } from "../../utils/neuron.utils";
   import { getProjectStatus, ProjectStatus } from "../../utils/sns.utils";
@@ -14,12 +13,22 @@
   import Spinner from "../ui/Spinner.svelte";
   import Tag from "../ui/Tag.svelte";
   import CommitmentProgressBar from "./CommitmentProgressBar.svelte";
+  import { getContext } from "svelte";
+  import {
+    PROJECT_DETAIL_CONTEXT_KEY,
+    type ProjectDetailContext,
+  } from "../../types/project-detail.context";
 
-  export let project: SnsFullProject;
+  const { store: projectDetailStore } = getContext<ProjectDetailContext>(
+    PROJECT_DETAIL_CONTEXT_KEY
+  );
+
+  let summary: SnsSummary;
+  $: summary = $projectDetailStore.summary as SnsSummary;
+  let swapState: SnsSwapState;
+  $: swapState = $projectDetailStore.swapState as SnsSwapState;
 
   const nowSeconds: number = nowInSeconds();
-  let swapState: SnsSwapState | undefined;
-  $: ({ swapState } = project);
   let currentCommitment: bigint;
   $: currentCommitment = swapState?.currentCommitment ?? BigInt(0);
   let currentCommitmentIcp: ICP;
@@ -31,20 +40,20 @@
       : undefined;
   let currentDateTillStartSeconds: number;
   $: currentDateTillStartSeconds = Number(
-    BigInt(nowSeconds) - project.summary.swapStart
+    BigInt(nowSeconds) - summary.swapStart
   );
   let deadlineTillStartSeconds: number;
   $: deadlineTillStartSeconds = Number(
-    project.summary.swapDeadline - project.summary.swapStart
+    summary.swapDeadline - summary.swapStart
   );
   let durationTillDeadline: bigint;
   $: durationTillDeadline =
-    project.summary.swapDeadline - BigInt(Math.round(Date.now() / 1000));
+    summary.swapDeadline - BigInt(Math.round(Date.now() / 1000));
 
   let showModal: boolean = false;
   const openModal = () => (showModal = true);
   const closeModal = () => (showModal = false);
-  $: durationTillDeadline = project.summary.swapDeadline - BigInt(nowSeconds);
+  $: durationTillDeadline = summary.swapDeadline - BigInt(nowSeconds);
   const statusTextMapper = {
     [ProjectStatus.Accepting]: $i18n.sns_project_detail.accepting,
     [ProjectStatus.Closed]: $i18n.sns_project_detail.closed,
@@ -52,7 +61,7 @@
   };
   let projectStatus: ProjectStatus;
   $: projectStatus = getProjectStatus({
-    summary: project.summary,
+    summary,
     nowInSeconds: nowSeconds,
   });
 </script>
@@ -80,8 +89,8 @@
       <div data-tid="sns-project-commitment-progress">
         <CommitmentProgressBar
           value={currentCommitment}
-          max={project.summary.maxCommitment}
-          minimumIndicator={project.summary.minCommitment}
+          max={summary.maxCommitment}
+          minimumIndicator={summary.minCommitment}
         />
       </div>
       {#if durationTillDeadline > 0}
@@ -127,7 +136,7 @@
 {/if}
 
 {#if showModal}
-  <ParticipateSwapModal {project} on:nnsClose={closeModal} />
+  <ParticipateSwapModal on:nnsClose={closeModal} />
 {/if}
 
 <style lang="scss">

--- a/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/svelte/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -24,6 +24,7 @@
   );
 
   let summary: SnsSummary;
+  // type safety validation is done in ProjectDetail component
   $: summary = $projectDetailStore.summary as SnsSummary;
   let swapState: SnsSwapState;
   $: swapState = $projectDetailStore.swapState as SnsSwapState;

--- a/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
+++ b/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
@@ -18,6 +18,7 @@
   );
 
   let summary: SnsSummary;
+  // type safety validation is done in ProjectDetail component
   $: summary = $projectDetailStore.summary as SnsSummary;
 
   const steps: Steps = [

--- a/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
+++ b/frontend/svelte/src/lib/modals/sns/ParticipateSwapModal.svelte
@@ -4,11 +4,21 @@
   import type { Step, Steps } from "../../stores/steps.state";
   import ParticipateScreen from "../../components/project-detail/ParticipateScreen.svelte";
   import ReviewParticipate from "../../components/project-detail/ReviewParticipate.svelte";
-  import type { SnsFullProject } from "../../stores/projects.store";
   import type { Account } from "../../types/account";
   import { ICP } from "@dfinity/nns";
+  import type { SnsSummary } from "../../types/sns";
+  import { getContext } from "svelte";
+  import {
+    PROJECT_DETAIL_CONTEXT_KEY,
+    type ProjectDetailContext,
+  } from "../../types/project-detail.context";
 
-  export let project: SnsFullProject;
+  const { store: projectDetailStore } = getContext<ProjectDetailContext>(
+    PROJECT_DETAIL_CONTEXT_KEY
+  );
+
+  let summary: SnsSummary;
+  $: summary = $projectDetailStore.summary as SnsSummary;
 
   const steps: Steps = [
     {
@@ -45,8 +55,8 @@
       bind:amount
       on:nnsNext={goNext}
       on:nnsClose
-      minAmount={ICP.fromE8s(project.summary.minParticipationCommitment)}
-      maxAmount={ICP.fromE8s(project.summary.maxParticipationCommitment)}
+      minAmount={ICP.fromE8s(summary.minParticipationCommitment)}
+      maxAmount={ICP.fromE8s(summary.maxParticipationCommitment)}
     />
   {/if}
   {#if currentStep.name === "ReviewTransaction" && selectedAccount !== undefined && amount !== undefined}

--- a/frontend/svelte/src/lib/services/sns.services.ts
+++ b/frontend/svelte/src/lib/services/sns.services.ts
@@ -16,7 +16,10 @@ import type { SnsSummary, SnsSwapState } from "../types/sns";
 import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
 import { loadSnsProposals } from "./proposals.services";
-import { queryAndUpdate } from "./utils.services";
+import {
+  queryAndUpdate,
+  type QueryAndUpdateOnResponse,
+} from "./utils.services";
 
 export const loadSnsSummaries = (): Promise<void> =>
   queryAndUpdate<SnsSummary[], unknown>({
@@ -46,7 +49,13 @@ export const loadSnsSummaries = (): Promise<void> =>
     logMessage: "Syncing Sns summaries",
   });
 
-export const loadSnsSummary = async (rootCanisterId: string) => {
+export const loadSnsSummary = async ({
+  rootCanisterId,
+  onLoad,
+}: {
+  rootCanisterId: string;
+  onLoad: QueryAndUpdateOnResponse<SnsSummary>;
+}) => {
   // TODO(L2-838): load only if not yet in store
 
   return queryAndUpdate<SnsSummary | undefined, unknown>({
@@ -56,12 +65,7 @@ export const loadSnsSummary = async (rootCanisterId: string) => {
         identity,
         certified,
       }),
-    onLoad: ({ response: summary, certified }) =>
-      // TODO(L2-840): detail page should not use that summaries store but only a dedicated state or context store
-      snsSummariesStore.setSummaries({
-        summaries: [...(summary ? [summary] : [])],
-        certified,
-      }),
+    onLoad,
     onError: ({ error: err, certified }) => {
       console.error(err);
 
@@ -113,7 +117,13 @@ export const loadSnsSwapStates = (): Promise<void> =>
     logMessage: "Syncing Sns swap state",
   });
 
-export const loadSnsSwapState = async (rootCanisterId: string) => {
+export const loadSnsSwapState = async ({
+  rootCanisterId,
+  onLoad,
+}: {
+  rootCanisterId: string;
+  onLoad: QueryAndUpdateOnResponse<SnsSwapState>;
+}) => {
   // TODO(L2-838): load only if not yet in store
 
   return queryAndUpdate<SnsSwapState, unknown>({
@@ -123,11 +133,7 @@ export const loadSnsSwapState = async (rootCanisterId: string) => {
         identity,
         certified,
       }),
-    onLoad: ({ response: swapState, certified }) =>
-      snsSwapStatesStore.setSwapState({
-        swapState,
-        certified: true,
-      }),
+    onLoad,
     onError: ({ error: err, certified }) => {
       console.error(err);
 

--- a/frontend/svelte/src/lib/types/project-detail.context.ts
+++ b/frontend/svelte/src/lib/types/project-detail.context.ts
@@ -1,0 +1,13 @@
+import type { Writable } from "svelte/store";
+import type { SnsSummary, SnsSwapState } from "./sns";
+
+export interface ProjectDetailStore {
+  summary: SnsSummary | undefined | null;
+  swapState: SnsSwapState | undefined | null;
+}
+
+export interface ProjectDetailContext {
+  store: Writable<ProjectDetailStore>;
+}
+
+export const PROJECT_DETAIL_CONTEXT_KEY = Symbol("project-detail");

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -94,9 +94,3 @@ export function triggerDebugReport(node: HTMLElement) {
     },
   };
 }
-
-export const shuffle = <T>(items: T[]): T[] =>
-  items
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -94,3 +94,9 @@ export function triggerDebugReport(node: HTMLElement) {
     },
   };
 }
+
+export const shuffle = <T>(items: T[]): T[] =>
+  items
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);

--- a/frontend/svelte/src/lib/utils/dev.utils.ts
+++ b/frontend/svelte/src/lib/utils/dev.utils.ts
@@ -95,6 +95,7 @@ export function triggerDebugReport(node: HTMLElement) {
   };
 }
 
+// TODO: to be deleted - use for mock data only
 export const shuffle = <T>(items: T[]): T[] =>
   items
     .map((value) => ({ value, sort: Math.random() }))

--- a/frontend/svelte/src/routes/ProjectDetail.svelte
+++ b/frontend/svelte/src/routes/ProjectDetail.svelte
@@ -50,15 +50,17 @@
   });
 
   const loadSummary = (rootCanisterId: string) => {
-    if ($snsSummariesStore.certified === true) {
-      // find certified from snsSummariesStore
-      const summaryMaybe = $snsSummariesStore.summaries?.find(
-        ({ rootCanisterId: rootCanister }) =>
-          rootCanister?.toText() === rootCanisterId
-      );
+    // try to get from snsSummariesStore
+    const summaryMaybe = $snsSummariesStore.summaries?.find(
+      ({ rootCanisterId: rootCanister }) =>
+        rootCanister?.toText() === rootCanisterId
+    );
 
-      if (summaryMaybe !== undefined) {
-        $projectDetailStore.summary = summaryMaybe;
+    if (summaryMaybe !== undefined) {
+      $projectDetailStore.summary = summaryMaybe;
+
+      // do not reload already certified data
+      if ($snsSummariesStore.certified === true) {
         return;
       }
     }
@@ -75,15 +77,18 @@
 
   const loadSwapState = (rootCanisterId: string) => {
     if (nonNullable($snsSwapStatesStore)) {
-      // find certified from snsSwapStatesStore
+      // try to get from snsSwapStatesStore
       const swapItemMaybe = $snsSwapStatesStore.find(
-        ({ swapState, certified }) =>
-          certified && swapState?.rootCanisterId?.toText() === rootCanisterId
+        (item) => item?.swapState?.rootCanisterId?.toText() === rootCanisterId
       );
 
       if (swapItemMaybe !== undefined) {
         $projectDetailStore.swapState = swapItemMaybe.swapState;
-        return;
+
+        if (swapItemMaybe.certified === true) {
+          // do not reload already certified data
+          return;
+        }
       }
     }
 

--- a/frontend/svelte/src/tests/lib/components/ContextWrapperTest.svelte
+++ b/frontend/svelte/src/tests/lib/components/ContextWrapperTest.svelte
@@ -8,4 +8,4 @@
   setContext(contextKey, contextValue);
 </script>
 
-<svelte:component this={Component} />
+<svelte:component this={Component} on:nnsClose />

--- a/frontend/svelte/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
+++ b/frontend/svelte/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
@@ -3,18 +3,38 @@
  */
 
 import { render } from "@testing-library/svelte";
+import { writable } from "svelte/store";
 import ProjectInfoSection from "../../../../lib/components/project-detail/ProjectInfoSection.svelte";
+import {
+  PROJECT_DETAIL_CONTEXT_KEY,
+  type ProjectDetailContext,
+  type ProjectDetailStore,
+} from "../../../../lib/types/project-detail.context";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
+import ContextWrapperTest from "../ContextWrapperTest.svelte";
 
 describe("ProjectInfoSection", () => {
-  const props = { summary: mockSnsFullProject.summary };
+  const renderProjectInfoSection = () =>
+    render(ContextWrapperTest, {
+      props: {
+        contextKey: PROJECT_DETAIL_CONTEXT_KEY,
+        contextValue: {
+          store: writable<ProjectDetailStore>({
+            summary: mockSnsFullProject.summary,
+            swapState: mockSnsFullProject.swapState,
+          }),
+        } as ProjectDetailContext,
+        Component: ProjectInfoSection,
+      },
+    });
+
   it("should render title", async () => {
-    const { container } = render(ProjectInfoSection, { props });
+    const { container } = renderProjectInfoSection();
     expect(container.querySelector("h1")).toBeInTheDocument();
   });
 
   it("should render project link", async () => {
-    const { container } = render(ProjectInfoSection, { props });
+    const { container } = renderProjectInfoSection();
     expect(container.querySelector("a")).toBeInTheDocument();
   });
 });

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -1,6 +1,7 @@
 import { Principal } from "@dfinity/principal";
 import type { SnsFullProject } from "../../lib/stores/projects.store";
 import type { SnsSummary, SnsSwapState } from "../../lib/types/sns";
+import { shuffle } from "../../lib/utils/dev.utils";
 
 const principal = (index: number): Principal =>
   [
@@ -45,7 +46,7 @@ export const mockSnsSwapState = (rootCanisterId: Principal): SnsSwapState =>
 const SECONDS_IN_DAY = 60 * 60 * 24;
 const SECONDS_TODAY = +new Date(new Date().toJSON().split("T")[0]) / 1000;
 
-export const mockSnsSummaryList: SnsSummary[] = [
+export const mockSnsSummaryList: SnsSummary[] = shuffle([
   {
     rootCanisterId: principal(0),
 
@@ -123,7 +124,12 @@ export const mockSnsSummaryList: SnsSummary[] = [
     description:
       "Tagline – Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor",
   },
-];
+])
+  // preserve indexes (important for unit tests)
+  .map((summary, index) => ({
+    ...summary,
+    rootCanisterId: principal(index),
+  }));
 
 export const mockSnsFullProject = {
   rootCanisterId: principal(0),

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -1,7 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import type { SnsFullProject } from "../../lib/stores/projects.store";
 import type { SnsSummary, SnsSwapState } from "../../lib/types/sns";
-import { shuffle } from "../../lib/utils/dev.utils";
 
 const principal = (index: number): Principal =>
   [
@@ -46,7 +45,7 @@ export const mockSnsSwapState = (rootCanisterId: Principal): SnsSwapState =>
 const SECONDS_IN_DAY = 60 * 60 * 24;
 const SECONDS_TODAY = +new Date(new Date().toJSON().split("T")[0]) / 1000;
 
-export const mockSnsSummaryList: SnsSummary[] = shuffle([
+export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(0),
 
@@ -124,7 +123,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
     description:
       "Tagline – Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor",
   },
-]);
+];
 
 export const mockSnsFullProject = {
   rootCanisterId: principal(0),

--- a/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/svelte/src/tests/mocks/sns-projects.mock.ts
@@ -1,6 +1,7 @@
 import { Principal } from "@dfinity/principal";
 import type { SnsFullProject } from "../../lib/stores/projects.store";
 import type { SnsSummary, SnsSwapState } from "../../lib/types/sns";
+import { shuffle } from "../../lib/utils/dev.utils";
 
 const principal = (index: number): Principal =>
   [
@@ -45,7 +46,7 @@ export const mockSnsSwapState = (rootCanisterId: Principal): SnsSwapState =>
 const SECONDS_IN_DAY = 60 * 60 * 24;
 const SECONDS_TODAY = +new Date(new Date().toJSON().split("T")[0]) / 1000;
 
-export const mockSnsSummaryList: SnsSummary[] = [
+export const mockSnsSummaryList: SnsSummary[] = shuffle([
   {
     rootCanisterId: principal(0),
 
@@ -123,7 +124,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     description:
       "Tagline – Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor",
   },
-];
+]);
 
 export const mockSnsFullProject = {
   rootCanisterId: principal(0),

--- a/frontend/svelte/src/tests/routes/ProjectDetail.spec.ts
+++ b/frontend/svelte/src/tests/routes/ProjectDetail.spec.ts
@@ -57,7 +57,7 @@ describe("ProjectDetail", () => {
     waitFor(() => expect(loadSnsSwapState).toBeCalled());
   });
 
-  describe("getting from summaries and swaps stores", () => {
+  describe("getting certified data from summaries and swaps stores", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
@@ -91,6 +91,43 @@ describe("ProjectDetail", () => {
       await tick();
 
       expect(loadSnsSwapState).toBeCalledTimes(0);
+    });
+  });
+
+  describe("getting uncertified data from summaries and swaps stores", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      snsSummariesStore.setSummaries({
+        summaries: [mockSnsFullProject.summary],
+        certified: false,
+      });
+      snsSwapStatesStore.setSwapState({
+        swapState: mockSnsFullProject.swapState as SnsSwapState,
+        certified: false,
+      });
+    });
+
+    afterEach(() => {
+      snsSummariesStore.reset();
+      snsSwapStatesStore.reset();
+      jest.clearAllMocks();
+    });
+
+    it("should not load summary if certified version available", async () => {
+      render(ProjectDetail);
+
+      await tick();
+
+      expect(loadSnsSummary).toBeCalledTimes(1);
+    });
+
+    it("should not load swap state if certified version available", async () => {
+      render(ProjectDetail);
+
+      await tick();
+
+      expect(loadSnsSwapState).toBeCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
# Motivation

The Sns project detail page should not load and use the all store of summaries but only use data related to the particular project.
[L2-840](https://dfinity.atlassian.net/browse/L2-840)

Click on loaded project then refresh

https://user-images.githubusercontent.com/98811342/179159676-b08f6a29-9e83-4d82-8767-1d622afb3f49.mov



# Changes

- switch from launchpad stores to context store on project-details page
- use summaries and swaps certified entries if available

# Tests

- ProjectDetail loading tests
