### PR TITLE
Fix: Do not fail spawning neurons

### DIFF
--- a/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/svelte/src/lib/components/neurons/NeuronCard.svelte
@@ -26,7 +26,7 @@
   export let disabled: boolean | undefined = undefined;
 
   // TODO: https://dfinity.atlassian.net/browse/L2-366
-  let stateInfo: StateInfo;
+  let stateInfo: StateInfo | undefined;
   $: stateInfo = getStateInfo(neuron.state);
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
@@ -74,17 +74,19 @@
     {/if}
   </div>
 
-  <div class="info">
-    <p
-      style={stateInfo.status === "warn"
-        ? `color: var(--warning-emphasis);`
-        : ""}
-      class="status"
-    >
-      {$i18n.neurons[`status_${stateInfo.textKey}`]}
-      <svelte:component this={stateInfo.Icon} />
-    </p>
-  </div>
+  {#if stateInfo !== undefined}
+    <div class="info">
+      <p
+        style={stateInfo.status === "warn"
+          ? `color: var(--warning-emphasis);`
+          : ""}
+        class="status"
+      >
+        {$i18n.neurons[`status_${stateInfo.textKey}`]}
+        <svelte:component this={stateInfo.Icon} />
+      </p>
+    </div>
+  {/if}
 
   {#if dissolvingTime !== undefined}
     <p class="duration">

--- a/frontend/svelte/src/lib/utils/neuron.utils.ts
+++ b/frontend/svelte/src/lib/utils/neuron.utils.ts
@@ -73,7 +73,7 @@ const stateTextMapper: StateMapper = {
   },
 };
 
-export const getStateInfo = (neuronState: NeuronState): StateInfo =>
+export const getStateInfo = (neuronState: NeuronState): StateInfo | undefined =>
   stateTextMapper[neuronState];
 
 export const votingPower = ({


### PR DESCRIPTION
# Motivation

Governance canister will be deployed first with the new spawning functionality. Until the new nns-dapp is release, the spawning neurons break the UI and show a blank page.

Fix the error and show only 0 ICP and that's it. At this point, we can't use the new state nor the new property. We just need to avoid the blank page.

# Changes

* stateInfo can be undefined for unknown states.
* Do not show state information if stateInfo is undefined.

# Tests

* Type changes only
