### PR TITLE
Add small12

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -85,6 +85,18 @@
       "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
       "type": "persistent"
     },
+    "small12": {
+      "config": {
+        "BUILD": "dev",
+        "FETCH_ROOT_KEY": true,
+        "REDIRECT_TO_LEGACY": "both",
+        "ENABLE_NEW_SPAWN_FEATURE": true,
+        "HOST": "https://small12.dfinity.network",
+        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.small12.dfinity.network"
+      },
+      "providers": ["http://[2a00:fb01:400:42:5000:54ff:fef3:eb8]:8080"],
+      "type": "persistent"
+    },
     "small11": {
       "config": {
         "BUILD": "dev",


### PR DESCRIPTION
# Motivation
It is sometimes useful to have yet another small temporary testnet.  3 should really be enough though.

# Changes
* Add `small12` to the list of testnets in `dfx.json`.

# Tests
See https://qhbym-qaaaa-aaaaa-aaafq-cai.small12.dfinity.network