### PR TITLE
Use new ledger

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -249,7 +249,8 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
     done
   fi
   echo "Creating SNS"
-  ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml >sns_creation.idl
+  ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml |
+    tee /dev/stderr >sns_creation.idl
 
   echo "Populate canister_ids.json"
   if test -e canister_ids.json; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -241,10 +241,12 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_root.wasm' dfx.json) root
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_governance.wasm' dfx.json) governance
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_ledger.wasm' dfx.json) ledger
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_swap.wasm' dfx.json) swap
+    for canister in root governance ledger swap; do
+      ./target/ic/sns add-sns-wasm-for-tests \
+        --network "$DFX_NETWORK" \
+        --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \
+        --wasm-file "$(CANISTER="sns_$canister" jq -r '.canisters[env.CANISTER].wasm' dfx.json)" "$canister"
+    done
   fi
   echo "Creating SNS"
   ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml >sns_creation.idl

--- a/deploy.sh
+++ b/deploy.sh
@@ -259,11 +259,11 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
   else
     echo "{}" >canister_ids.json
   fi
-  idl2json <sns_creation.idl |
+  sed -n ':a;/^[(]/bb;d;ba;:b;p;n;bb' <sns_creation.idl |
+    idl2json |
     jq '.canisters[] | to_entries | map({ ("sns_"+.key): {(env.DFX_NETWORK): (.value[0])} }) | add' |
     jq -s '.[0] * .[1]' - canister_ids.json >canister_ids.json.new
   mv canister_ids.json.new canister_ids.json
-
 fi
 
 if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -241,9 +241,10 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file target/ic/sns-root-canister.wasm root
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file target/ic/sns-governance-canister.wasm governance
-    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file target/ic/ledger-canister_notify-method.wasm ledger
+    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_root.wasm' dfx.json) root
+    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_governance.wasm' dfx.json) governance
+    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_ledger.wasm' dfx.json) ledger
+    ./target/ic/sns add-sns-wasm-for-tests --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --wasm-file $(jq -r '.canisters.sns_swap.wasm' dfx.json) swap
   fi
   echo "Creating SNS"
   ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml >sns_creation.idl

--- a/dfx.json
+++ b/dfx.json
@@ -27,8 +27,8 @@
     },
     "sns_ledger": {
       "build": ["true"],
-      "candid": "target/ic/ledger.did",
-      "wasm": "target/ic/ledger-canister_notify-method.wasm",
+      "candid": "target/ic/ic-icrc1-ledger.did",
+      "wasm": "target/ic/ic-icrc1-ledger.wasm",
       "type": "custom"
     },
     "sns_swap": {

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -117,7 +117,7 @@ get_binary sns
 get_wasm registry-canister.wasm
 get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
-get_wasm ledger-canister_notify-method.wasm
+get_wasm ic-icrc1-ledger.wasm
 get_wasm root-canister.wasm
 get_wasm cycles-minting-canister.wasm
 get_wasm lifeline.wasm

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -117,6 +117,7 @@ get_binary sns
 get_wasm registry-canister.wasm
 get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
+get_wasm ledger-canister_notify-method.wasm
 get_wasm ic-icrc1-ledger.wasm
 get_wasm root-canister.wasm
 get_wasm cycles-minting-canister.wasm

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -46,6 +46,8 @@ RUN binary="governance-canister" && \
 
 FROM scratch AS scratch
 COPY --from=builder /ic/rs/nns/governance/canister/governance.did /governance.did
+COPY --from=builder /ic/rs/rosetta-api/ledger.did /ledger.private.did
+COPY --from=builder /ic/rs/rosetta-api/ledger_canister/ledger.did /ledger.did
 COPY --from=builder /ic/rs/rosetta-api/icrc1/ledger/icrc1.did /ic-icrc1-ledger.did
 COPY --from=builder /ic/rs/nns/gtc/canister/gtc.did /genesis_token.did
 COPY --from=builder /ic/rs/nns/cmc/cmc.did /cmc.did

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -31,18 +31,6 @@ ENV CARGO_TARGET_DIR=/ic/rs/target
 WORKDIR /ic/rs
 
 # Note: This is available as a download however we patch the source code to make testing easier.
-# Note: The naming convention of the wasm files needs to match this:
-#       https://github.com/dfinity/ic/blob/master/gitlab-ci/src/job_scripts/cargo_build_canisters.py#L82
-#       Otherwise the built binary will simply not be deployed by ic-nns-init.
-RUN binary=ledger-canister && \
-    features="notify-method" && \
-    cargo build --target wasm32-unknown-unknown --release -p "$binary" --features "$features"
-RUN binary=ledger-canister && \
-    features="notify-method" && \
-    ls "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/" && \
-    ic-cdk-optimizer -o "$CARGO_TARGET_DIR/${binary}_${features}.wasm" "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/${binary}.wasm"
-
-# Note: This is available as a download however we patch the source code to make testing easier.
 RUN binary="governance-canister" && \
     features="test" && \
     cargo build --target wasm32-unknown-unknown --release -p ic-nns-governance --features "$features"
@@ -58,8 +46,7 @@ RUN binary="governance-canister" && \
 
 FROM scratch AS scratch
 COPY --from=builder /ic/rs/nns/governance/canister/governance.did /governance.did
-COPY --from=builder /ic/rs/rosetta-api/ledger.did /ledger.private.did
-COPY --from=builder /ic/rs/rosetta-api/ledger_canister/ledger.did /ledger.did
+COPY --from=builder /ic/rs/rosetta-api/icrc1/ledger/icrc1.did /ic-icrc1-ledger.did
 COPY --from=builder /ic/rs/nns/gtc/canister/gtc.did /genesis_token.did
 COPY --from=builder /ic/rs/nns/cmc/cmc.did /cmc.did
 COPY --from=builder /ic/rs/nns/sns-wasm/canister/sns-wasm.did /sns_wasm.did


### PR DESCRIPTION
# Motivation
The SNS now uses a different ledger canister, and the swap canister can now be uploaded.

# Changes
* Download the new SNS wasm canister in addition to the existing ledger, which is still needed for the NNS.
* Get wasm paths from dfx.json when uploading wasm canisters
* Include the swap canister in the list that is uploaded

# Tests
- [x] Deploy an SNS to a testnet