### PR TITLE
Make cycles fast

### DIFF
--- a/e2e-tests/scripts/nns-canister.patch
+++ b/e2e-tests/scripts/nns-canister.patch
@@ -33,17 +33,15 @@ diff --git a/rs/nns/cmc/src/main.rs b/rs/nns/cmc/src/main.rs
 index 2c02d80dc..5a6072dc7 100644
 --- a/rs/nns/cmc/src/main.rs
 +++ b/rs/nns/cmc/src/main.rs
-@@ -106,8 +106,8 @@ impl State {
-             minting_account_id: None,
-             authorized_subnets: BTreeMap::new(),
-             default_subnets: vec![],
--            icp_xdr_conversion_rate: None,
--            average_icp_xdr_conversion_rate: None,
-+            icp_xdr_conversion_rate: Some(IcpXdrConversionRate{ timestamp_seconds: 1652443527, xdr_permyriad_per_icp: 60154 }),
-+            average_icp_xdr_conversion_rate: Some(IcpXdrConversionRate{ timestamp_seconds: 1652443527, xdr_permyriad_per_icp: 60154 }),
-             recent_icp_xdr_rates: Some(vec![
-                 IcpXdrConversionRate::default();
-                 NUM_DAYS_FOR_ICP_XDR_AVERAGE
+@@ -95,7 +95,7 @@ struct State {
+ impl State {
+     fn default() -> Self {
+         let resolution = Duration::from_secs(60);
+-        let max_age = Duration::from_secs(60 * 60);
++        let max_age = Duration::from_secs(60 * 2);
+ 
+         Self {
+             ledger_canister_id: CanisterId::ic_00(),
 @@ -320,6 +320,7 @@ fn get_icp_xdr_conversion_rate_() {
  
  #[export_name = "canister_update set_icp_xdr_conversion_rate"]


### PR DESCRIPTION
# Motivation
Cycle minting rate limiting is now applied in the CMC canister.  Creating an SMS is expensive enough that we run into the rate limit quite quickly (although it seems to me that we hit the limit much too quickly - need to check).  If we hit the rate limiter, no more cycles can be minted for an hour, which significantly slows down test deployments, especially if there are bugs and the deployment needs to be repeated.

# Changes
* Reduce the rate limit time from 1 hour to 2 minutes.  Long enough that we can see that the limit exists but not so long that testnet deployment times are impacted seriously.
* Deleted a CMC patch that we don't need any more.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
