### PR TITLE
style: fix tooltip not centered per default in Safari

### DIFF
--- a/frontend/svelte/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/svelte/src/lib/components/ui/Tooltip.svelte
@@ -80,7 +80,7 @@
 <style lang="scss">
   .tooltip-wrapper {
     position: relative;
-    display: var(--tooltip-display);
+    display: var(--tooltip-display, block);
     width: var(--tooltip-width);
   }
 


### PR DESCRIPTION
# Motivation

The tooltip is not centered per default on safari because it's parent is for some reason not an inherited block

# Changes

- set default css value for tooltip parent to block

# Screenshot

<img width="1450" alt="Capture d’écran 2022-07-20 à 20 26 08" src="https://user-images.githubusercontent.com/16886711/180055490-cee19472-cbd5-48fe-8e7c-ec373c220f09.png">
<img width="1450" alt="Capture d’écran 2022-07-20 à 20 26 21" src="https://user-images.githubusercontent.com/16886711/180055543-ecc2a3e1-6f04-44b8-925a-8df422071bd7.png">


