### PR TITLE
refactor: *Nullable -> *Nullish

### DIFF
--- a/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/svelte/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -2,7 +2,7 @@ import { Actor } from "@dfinity/agent";
 import type { ProposalId } from "@dfinity/nns";
 import { AccountIdentifier } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
-import { nonNullable } from "../../utils/utils";
+import { nonNullish } from "../../utils/utils";
 import type { NNSDappCanisterOptions } from "./nns-dapp.canister.types";
 import { idlFactory as certifiedIdlFactory } from "./nns-dapp.certified.idl";
 import {
@@ -331,8 +331,7 @@ export class NNSDappCanister {
     }
 
     throw new UnknownProposalPayloadError(
-      errorText ??
-        (nonNullable(response) ? JSON.stringify(response) : undefined)
+      errorText ?? (nonNullish(response) ? JSON.stringify(response) : undefined)
     );
   }
 }

--- a/frontend/svelte/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/svelte/src/lib/components/launchpad/Projects.svelte
@@ -16,7 +16,7 @@
   import CardGrid from "../ui/CardGrid.svelte";
   import SkeletonProjectCard from "../ui/SkeletonProjectCard.svelte";
   import Spinner from "../ui/Spinner.svelte";
-  import { isNullable } from "../../utils/utils";
+  import { isNullish } from "../../utils/utils";
   import { routeStore } from "../../stores/route.store";
   import { AppPath } from "../../constants/routes.constants";
 
@@ -28,7 +28,7 @@
 
   let loading: boolean = false;
   $: loading =
-    isNullable($snsSummariesStore) || isNullable($snsSwapCommitmentsStore);
+    isNullish($snsSummariesStore) || isNullish($snsSwapCommitmentsStore);
 
   // TODO(L2-863): ask Mischa if use should be redirected or if a message should be displayed
   const goBack = () =>

--- a/frontend/svelte/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/svelte/src/lib/components/launchpad/Proposals.svelte
@@ -6,13 +6,13 @@
     openForVotesSnsProposalsStore,
     snsProposalsStore,
   } from "../../stores/projects.store";
-  import { isNullable } from "../../utils/utils";
+  import { isNullish } from "../../utils/utils";
   import CardGrid from "../ui/CardGrid.svelte";
   import SkeletonProposalCard from "../ui/SkeletonProposalCard.svelte";
   import ProposalCard from "./ProposalCard.svelte";
 
   let loading: boolean = false;
-  $: loading = isNullable($snsProposalsStore);
+  $: loading = isNullish($snsProposalsStore);
 
   const load = () => {
     if ($snsProposalsStore === undefined) {

--- a/frontend/svelte/src/lib/stores/projects.store.ts
+++ b/frontend/svelte/src/lib/stores/projects.store.ts
@@ -4,7 +4,7 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { derived, writable, type Readable } from "svelte/store";
 import type { SnsSummary, SnsSwapCommitment } from "../types/sns";
 import { isProposalOpenForVotes } from "../utils/proposals.utils";
-import { isNullable } from "../utils/utils";
+import { isNullish } from "../utils/utils";
 
 export type SnsSummariesStore =
   | {
@@ -69,7 +69,7 @@ const initSnsProposalsStore = () => {
 
 const initOpenForVotesSnsProposalsStore = () =>
   derived([snsProposalsStore], ([$snsProposalsStore]): ProposalInfo[] =>
-    isNullable($snsProposalsStore)
+    isNullish($snsProposalsStore)
       ? []
       : $snsProposalsStore.proposals.filter(isProposalOpenForVotes)
   );

--- a/frontend/svelte/src/lib/utils/anonymize.utils.ts
+++ b/frontend/svelte/src/lib/utils/anonymize.utils.ts
@@ -14,10 +14,10 @@ import type {
 import type { Account } from "../types/account";
 import { digestText } from "../utils/dev.utils";
 import { mapTransaction } from "../utils/transactions.utils";
-import { isNullable, mapPromises, nonNullable } from "./utils";
+import { isNullish, mapPromises, nonNullish } from "./utils";
 
 const anonymiseAvailability = (value: unknown): "yes" | "no" =>
-  nonNullable(value) ? "yes" : "no";
+  nonNullish(value) ? "yes" : "no";
 
 export const anonymize = async (value: unknown): Promise<string | undefined> =>
   value === undefined ? undefined : digestText(`${value}`);
@@ -207,7 +207,7 @@ export const anonymizeCanister = async (
 ): Promise<
   undefined | { [key in keyof Required<CanisterDetails>]: unknown }
 > => {
-  if (isNullable(canister)) {
+  if (isNullish(canister)) {
     return canister;
   }
 
@@ -230,7 +230,7 @@ export const anonymizeTransaction = async ({
 }): Promise<
   undefined | { [key in keyof Required<Transaction>]: unknown } | "no account"
 > => {
-  if (isNullable(transaction)) {
+  if (isNullish(transaction)) {
     return transaction;
   }
 

--- a/frontend/svelte/src/lib/utils/utils.ts
+++ b/frontend/svelte/src/lib/utils/utils.ts
@@ -132,14 +132,14 @@ export const bytesToHexString = (bytes: number[]): string =>
   );
 
 /** Is null or undefined */
-export const isNullable = <T>(
+export const isNullish = <T>(
   argument: T | undefined | null
 ): argument is undefined | null => argument === null || argument === undefined;
 
 /** Not null and not undefined */
-export const nonNullable = <T>(
+export const nonNullish = <T>(
   argument: T | undefined | null
-): argument is NonNullable<T> => !isNullable(argument);
+): argument is NonNullable<T> => !isNullish(argument);
 
 export const mapPromises = async <T, R>(
   items: Array<T> | undefined,

--- a/frontend/svelte/src/routes/ProjectDetail.svelte
+++ b/frontend/svelte/src/routes/ProjectDetail.svelte
@@ -27,7 +27,7 @@
     type ProjectDetailContext,
     type ProjectDetailStore,
   } from "../lib/types/project-detail.context";
-  import { isNullable, nonNullable } from "../lib/utils/utils";
+  import { isNullish, nonNullish } from "../lib/utils/utils";
   import { writable } from "svelte/store";
   import { concatSnsSummary } from "../lib/utils/sns.utils";
 
@@ -83,7 +83,7 @@
   };
 
   const loadSwapState = (rootCanisterId: string) => {
-    if (nonNullable($snsSwapCommitmentsStore)) {
+    if (nonNullish($snsSwapCommitmentsStore)) {
       // try to get from snsSwapStatesStore
       const swapItemMaybe = $snsSwapCommitmentsStore.find(
         (item) =>
@@ -139,9 +139,9 @@
   $: layoutTitleStore.set($projectDetailStore?.summary?.name ?? "");
 
   let loadingSummary: boolean;
-  $: loadingSummary = isNullable($projectDetailStore.summary);
+  $: loadingSummary = isNullish($projectDetailStore.summary);
   let loadingSwapState: boolean;
-  $: loadingSwapState = isNullable($projectDetailStore.swapCommitment);
+  $: loadingSwapState = isNullish($projectDetailStore.swapCommitment);
 
   // TODO(L2-838): if error redirect to launchpad and display error there
 </script>

--- a/frontend/svelte/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/svelte/src/tests/lib/utils/utils.spec.ts
@@ -4,8 +4,8 @@ import {
   debounce,
   isDefined,
   isHash,
-  isNullable,
-  nonNullable,
+  isNullish,
+  nonNullish,
   poll,
   PollingLimitExceededError,
   smallerVersion,
@@ -171,25 +171,25 @@ describe("utils", () => {
     });
   });
 
-  describe("isNullable", () => {
+  describe("isNullish", () => {
     it("should determine nullable", () => {
-      expect(isNullable(null)).toBeTruthy();
-      expect(isNullable(undefined)).toBeTruthy();
-      expect(isNullable(0)).toBeFalsy();
-      expect(isNullable(1)).toBeFalsy();
-      expect(isNullable("")).toBeFalsy();
-      expect(isNullable([])).toBeFalsy();
+      expect(isNullish(null)).toBeTruthy();
+      expect(isNullish(undefined)).toBeTruthy();
+      expect(isNullish(0)).toBeFalsy();
+      expect(isNullish(1)).toBeFalsy();
+      expect(isNullish("")).toBeFalsy();
+      expect(isNullish([])).toBeFalsy();
     });
   });
 
-  describe("nonNullable", () => {
+  describe("nonNullish", () => {
     it("should determine not nullable", () => {
-      expect(nonNullable(null)).toBeFalsy();
-      expect(nonNullable(undefined)).toBeFalsy();
-      expect(nonNullable(0)).toBeTruthy();
-      expect(nonNullable(1)).toBeTruthy();
-      expect(nonNullable("")).toBeTruthy();
-      expect(nonNullable([])).toBeTruthy();
+      expect(nonNullish(null)).toBeFalsy();
+      expect(nonNullish(undefined)).toBeFalsy();
+      expect(nonNullish(0)).toBeTruthy();
+      expect(nonNullish(1)).toBeTruthy();
+      expect(nonNullish("")).toBeTruthy();
+      expect(nonNullish([])).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
# Motivation

To remove confusion, rename `nullable` to `nullish`.
Goal:
- `null` | `undefined` → `nullish` 
- `[]` → `nullable`

# Changes

Renaming only