### PR TITLE
Update proposal definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arrayref"
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -197,17 +197,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.5.0"
+name = "block-buffer"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54757888b09a69be70b5ec303e382a74227392086ba808cb01eeca29233a2397"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "digest",
- "ff 0.10.1",
- "group 0.10.0",
+ "generic-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62250ece575fa9b22068b3a8d59586f01d426dd7785522efd97632959e71c986"
+dependencies = [
+ "digest 0.9.0",
+ "ff",
+ "group",
  "pairing",
  "rand_core 0.6.2",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -295,9 +305,12 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "byte-unit"
-version = "3.1.4"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
+checksum = "95ebf10dda65f19ff0f42ea15572a359ed60d7fc74fdc984d90310937be0014b"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "byteorder"
@@ -322,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9e536514a3c655568e23e36e68cbef20ee6595f641719ade03a849a13ed0ac"
+checksum = "a4f5cdd24185c6d6edba09bcfe06cf9c1e7fd579cbe5e4ae2dffba9c474a5a7f"
 dependencies = [
  "anyhow",
  "binread",
@@ -332,7 +345,7 @@ dependencies = [
  "candid_derive",
  "codespan-reporting",
  "hex",
- "ic-types 0.3.0",
+ "ic-types 0.4.1",
  "lalrpop",
  "lalrpop-util",
  "leb128",
@@ -409,7 +422,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -435,6 +448,54 @@ source = "git+https://github.com/enarx/ciborium?rev=e719537c99b564c3674a56defe53
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -472,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "constant_time_eq"
@@ -534,14 +595,24 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -593,9 +664,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.2",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -611,7 +695,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base64 0.13.0",
  "build-info",
@@ -625,6 +709,7 @@ dependencies = [
  "ic-certified-map 0.2.0",
  "ic-crypto-tree-hash",
  "ic-ic00-types",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
@@ -634,11 +719,11 @@ dependencies = [
  "lazy_static",
  "ledger-canister",
  "on_wire",
- "prost",
+ "prost 0.10.4",
  "rand 0.7.3",
  "serde",
  "serde_cbor",
- "sha2",
+ "sha2 0.9.9",
  "yansi",
 ]
 
@@ -685,9 +770,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
 ]
@@ -778,7 +863,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "dfn_core",
@@ -790,7 +875,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -799,7 +884,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -811,7 +896,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -823,7 +908,7 @@ dependencies = [
 [[package]]
 name = "dfn_json"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "on_wire",
  "serde",
@@ -833,7 +918,7 @@ dependencies = [
 [[package]]
 name = "dfn_macro"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -844,13 +929,12 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "dfn_core",
  "ic-base-types",
  "on_wire",
- "prost",
- "prost-types",
+ "prost 0.10.4",
 ]
 
 [[package]]
@@ -866,6 +950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -889,6 +983,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-consensus"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dd91246c940272326f665724138660a183577ffb77b384a5e10d67d2d5075a"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.2",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,7 +1007,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -910,16 +1019,16 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "c47abd0a791d2ac0c7aa1118715f85b83689e4522c4e3a244e159d4fc9848a8d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "ff 0.11.0",
+ "ff",
  "generic-array",
- "group 0.11.0",
+ "group",
  "rand_core 0.6.2",
  "sec1",
  "subtle",
@@ -945,9 +1054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -968,19 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core 0.6.2",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.2",
  "subtle",
@@ -994,7 +1102,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.13",
  "winapi",
 ]
 
@@ -1003,6 +1111,12 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "float-cmp"
@@ -1185,23 +1299,12 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "byteorder",
- "ff 0.10.1",
- "rand_core 0.6.2",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.0",
+ "ff",
  "rand_core 0.6.2",
  "subtle",
 ]
@@ -1214,9 +1317,9 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -1226,6 +1329,12 @@ checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1258,7 +1367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1267,7 +1376,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "generic-array",
  "hmac",
 ]
@@ -1286,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1297,16 +1406,16 @@ dependencies = [
  "ic-crypto-sha",
  "ic-protobuf",
  "phantom_newtype",
- "prost",
+ "prost 0.10.4",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
 ]
 
 [[package]]
 name = "ic-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "serde",
@@ -1316,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-protobuf",
  "serde",
@@ -1341,7 +1450,7 @@ source = "git+https://github.com/dfinity/cdk-rs?rev=7676e7f#7676e7f47e0d7505d97d
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -1351,18 +1460,18 @@ source = "git+https://github.com/dfinity/cdk-rs?rev=2112e912e156b271389a51777680
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "hex",
  "ic-types 0.8.0",
@@ -1372,46 +1481,47 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
- "ed25519-dalek",
+ "ed25519-consensus",
  "hex",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-protobuf",
  "ic-types 0.8.0",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "simple_asn1",
  "zeroize",
 ]
 
 [[package]]
-name = "ic-crypto-internal-bls12381-common"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+name = "ic-crypto-internal-bls12-381-type"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "bls12_381",
  "getrandom 0.2.2",
- "hex",
- "ic-crypto-internal-bls12381-serde-miracl",
- "ic-crypto-internal-types",
- "ic-crypto-sha",
+ "lazy_static",
  "miracl_core_bls12381",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "pairing",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sha2 0.9.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-internal-bls12381-serde-miracl"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
+ "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-types",
  "miracl_core_bls12381",
 ]
@@ -1419,23 +1529,23 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-fs-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "hex",
- "ic-crypto-internal-bls12381-common",
+ "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-bls12381-serde-miracl",
  "ic-crypto-internal-types",
  "ic-crypto-sha",
  "lazy_static",
  "miracl_core_bls12381",
- "rand_chacha 0.2.2",
+ "rand_chacha 0.3.1",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1443,20 +1553,31 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base64 0.11.0",
- "bls12_381",
  "hex",
- "ic-crypto-internal-bls12381-common",
+ "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-types",
  "ic-crypto-sha",
  "ic-protobuf",
  "ic-types 0.8.0",
- "pairing",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-seed"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "hex",
+ "ic-crypto-sha",
+ "ic-types 0.8.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "zeroize",
 ]
@@ -1464,24 +1585,23 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "openssl",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
- "bls12_381",
- "ff 0.10.1",
- "ic-crypto-internal-bls12381-common",
+ "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-bls12381-serde-miracl",
  "ic-crypto-internal-fs-ni-dkg",
+ "ic-crypto-internal-seed",
  "ic-crypto-internal-threshold-sig-bls12381-der",
  "ic-crypto-internal-types",
  "ic-crypto-sha",
@@ -1489,23 +1609,21 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "miracl_core_bls12381",
- "pairing",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "simple_asn1",
- "strum_macros",
+ "strum_macros 0.23.1",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "simple_asn1",
 ]
@@ -1513,12 +1631,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "fe-derive",
  "hex",
  "hex-literal",
  "ic-crypto-internal-hmac",
+ "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-sha",
  "ic-types 0.8.0",
@@ -1526,9 +1645,10 @@ dependencies = [
  "lazy_static",
  "p256",
  "paste",
- "rand 0.8.3",
- "rand_chacha 0.3.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "subtle",
  "zeroize",
@@ -1537,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -1546,8 +1666,8 @@ dependencies = [
  "phantom_newtype",
  "serde",
  "serde_cbor",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "thiserror",
  "zeroize",
 ]
@@ -1555,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -1574,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "serde",
  "zeroize",
@@ -1583,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1591,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "chrono",
  "dfn_core",
@@ -1607,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha",
@@ -1619,10 +1739,10 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base64 0.11.0",
- "ed25519-dalek",
+ "ed25519-consensus",
  "ic-base-types",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -1634,17 +1754,17 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
 ]
 
 [[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "float-cmp",
@@ -1656,20 +1776,83 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-icrc1"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "candid",
+ "ciborium",
+ "hex",
+ "ic-base-types",
+ "ic-crypto-sha",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-icrc1-client"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "async-trait",
+ "candid",
+ "ic-base-types",
+ "ic-icrc1",
+ "ic-ledger-core",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "ic-ledger-canister-core"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "async-trait",
+ "candid",
+ "ic-base-types",
+ "ic-constants",
+ "ic-ic00-types",
+ "ic-ledger-core",
+ "ic-utils",
+ "serde",
+]
+
+[[package]]
+name = "ic-ledger-core"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "async-trait",
+ "candid",
+ "hex",
+ "ic-base-types",
+ "ic-constants",
+ "ic-crypto-sha",
+ "ic-ic00-types",
+ "ic-utils",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
 name = "ic-metrics-encoder"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
+ "anyhow",
  "async-trait",
  "build-info",
  "build-info-build",
@@ -1682,18 +1865,19 @@ dependencies = [
  "ic-crypto-sha",
  "ic-ic00-types",
  "ledger-canister",
+ "num",
  "serde",
 ]
 
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ed25519-dalek",
  "ic-base-types",
@@ -1706,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1723,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "comparable",
@@ -1738,16 +1922,15 @@ dependencies = [
  "ic-types 0.8.0",
  "lazy_static",
  "on_wire",
- "prost",
- "prost-types",
+ "prost 0.10.4",
  "serde",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "ic-base-types",
  "lazy_static",
@@ -1756,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "async-trait",
  "build-info",
@@ -1778,27 +1961,28 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-protobuf",
+ "ic-sns-swap",
  "ledger-canister",
  "on_wire",
- "prost",
+ "prost 0.10.4",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "registry-canister",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
 ]
 
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
  "maplit",
- "prost",
+ "prost 0.10.4",
  "serde",
  "serde_json",
  "slog",
@@ -1807,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -1819,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -1830,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "ic-ic00-types",
@@ -1841,52 +2025,144 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "ic-protobuf",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
 ]
 
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "bytes",
  "candid",
  "ic-protobuf",
- "prost",
- "prost-types",
+ "prost 0.10.4",
  "serde",
 ]
 
 [[package]]
-name = "ic-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78ec6f58886cdc252d6f912dc794211bd6bbc39ddc9dcda434b2dc16c335b3"
+name = "ic-sns-governance"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
- "base32",
+ "async-trait",
+ "build-info",
+ "build-info-build",
+ "bytes",
+ "candid",
+ "clap",
+ "comparable",
+ "csv",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
+ "hex",
+ "ic-base-types",
+ "ic-crypto-sha",
+ "ic-ic00-types",
+ "ic-icrc1",
+ "ic-icrc1-client",
+ "ic-ledger-core",
+ "ic-metrics-encoder",
+ "ic-nervous-system-common",
+ "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-root",
+ "ic-protobuf",
+ "lazy_static",
+ "ledger-canister",
+ "maplit",
+ "num",
+ "on_wire",
+ "prost 0.10.4",
+ "prost-build 0.10.4",
+ "rand 0.8.5",
+ "registry-canister",
+ "serde",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
+]
+
+[[package]]
+name = "ic-sns-swap"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "async-trait",
+ "build-info",
+ "build-info-build",
+ "bytes",
+ "candid",
+ "comparable",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
+ "hex",
+ "ic-base-types",
+ "ic-crypto-sha",
+ "ic-ic00-types",
+ "ic-icrc1",
+ "ic-ledger-core",
+ "ic-metrics-encoder",
+ "ic-nervous-system-common",
+ "ic-nervous-system-common-test-keys",
+ "ic-nervous-system-root",
+ "ic-protobuf",
+ "ic-sns-governance",
+ "lazy_static",
+ "on_wire",
+ "prost 0.10.4",
+ "prost-build 0.9.0",
+ "registry-canister",
+ "serde",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
+]
+
+[[package]]
+name = "ic-sys"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
+dependencies = [
+ "hex",
+ "ic-crypto-sha",
+ "lazy_static",
+ "libc",
+ "nix",
+ "phantom_newtype",
+ "wsl",
+]
+
+[[package]]
+name = "ic-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e9cac29df1f2906137c327ed24dfc398460eda054abaa6107273c11afe6384"
+dependencies = [
  "crc32fast",
+ "data-encoding",
  "hex",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
 [[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "base32",
  "base64 0.11.0",
  "bincode",
- "byte-unit",
  "candid",
  "chrono",
  "derive_more 0.99.8-alpha.0",
@@ -1907,14 +2183,14 @@ dependencies = [
  "num-traits",
  "once_cell",
  "phantom_newtype",
- "prost",
+ "prost 0.10.4",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "serde_with",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "thiserror",
  "url",
 ]
@@ -1922,16 +2198,17 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "bitflags",
  "cvt",
  "features",
  "hex",
+ "ic-sys",
  "libc",
  "nix",
- "prost",
- "rand 0.8.3",
+ "prost 0.10.4",
+ "rand 0.8.5",
  "scoped_threadpool",
  "serde",
  "thiserror",
@@ -1956,19 +2233,31 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "intmap"
-version = "0.7.0"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50930385956f6c4a0b99f3dd654adcc40788456c36e17c5b20e1d1ceb523ec6"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "intmap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b357564d111300f8a33b79e06795235529a627a1f7078d2b1db7f7dcdf032874"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnet"
@@ -1999,13 +2288,12 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "2c8a5a96d92d849c4499d99461da81c9cdc1467418a8ed2aaeb407e8d85940ed"
 dependencies = [
  "cfg-if 1.0.0",
  "elliptic-curve",
- "sec1",
 ]
 
 [[package]]
@@ -2021,7 +2309,7 @@ dependencies = [
  "ena",
  "itertools",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.5.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -2058,8 +2346,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 [[package]]
 name = "ledger-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
+ "async-trait",
  "byteorder",
  "candid",
  "ciborium",
@@ -2070,12 +2359,14 @@ dependencies = [
  "dfn_http",
  "dfn_http_metrics",
  "dfn_protobuf",
- "digest",
+ "digest 0.9.0",
  "hex",
  "ic-base-types",
  "ic-constants",
  "ic-crypto-sha",
  "ic-ic00-types",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nns-constants",
  "ic-utils",
@@ -2083,8 +2374,8 @@ dependencies = [
  "lazy_static",
  "on_wire",
  "phantom_newtype",
- "prost",
- "prost-derive",
+ "prost 0.10.4",
+ "prost-derive 0.10.1",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -2105,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libm"
@@ -2123,14 +2414,14 @@ checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest",
+ "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -2141,7 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest",
+ "digest 0.9.0",
  "subtle",
 ]
 
@@ -2257,6 +2548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5c13471499e00775be202c9007d365fdab9b1c65624c95b238b2f3037a2c1c"
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2590,7 @@ dependencies = [
  "ic-certified-map 0.1.0",
  "ic-crypto-sha",
  "ic-ic00-types",
+ "ic-ledger-core",
  "ic-nervous-system-common",
  "ic-nervous-system-root",
  "ic-nns-common",
@@ -2310,7 +2608,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "tar",
 ]
 
@@ -2339,6 +2637,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,9 +2673,18 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.3",
+ "rand 0.8.5",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2383,6 +2704,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2419,6 +2752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 
 [[package]]
 name = "once_cell"
@@ -2481,6 +2823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,21 +2839,20 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "elliptic-curve",
- "sec1",
 ]
 
 [[package]]
 name = "pairing"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
- "group 0.10.0",
+ "group",
 ]
 
 [[package]]
@@ -2526,14 +2873,24 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset 0.4.2",
  "indexmap",
 ]
 
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "candid",
  "serde",
@@ -2648,11 +3005,21 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -2662,7 +3029,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.2",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.2",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+dependencies = [
+ "bytes",
+ "cfg-if 1.0.0",
+ "cmake",
+ "heck 0.4.0",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.2",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2680,12 +3102,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
 ]
 
 [[package]]
@@ -2713,19 +3145,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.2",
- "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2740,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
@@ -2776,15 +3207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core 0.6.2",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,9 +3214,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2812,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2832,14 +3254,14 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "registry-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5b2647754d0c2200b645d08a6ddce32251438ed5#5b2647754d0c2200b645d08a6ddce32251438ed5"
+source = "git+https://github.com/dfinity/ic?rev=5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c#5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -2869,10 +3291,19 @@ dependencies = [
  "ipnet",
  "leb128",
  "on_wire",
- "prost",
+ "prost 0.10.4",
  "serde",
  "serde_cbor",
  "url",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2934,10 +3365,11 @@ checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "subtle",
@@ -3032,11 +3464,22 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3047,14 +3490,14 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "simple_asn1"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "chrono",
  "num-bigint",
  "num-traits",
  "thiserror",
+ "time 0.3.11",
 ]
 
 [[package]]
@@ -3116,9 +3559,27 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+
+[[package]]
+name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck 0.3.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3126,7 +3587,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.2",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3140,14 +3601,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
-name = "syn"
-version = "1.0.86"
+name = "subtle-ng"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
+name = "syn"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3180,6 +3647,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.13",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3679,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3228,6 +3715,24 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-keccak"
@@ -3270,9 +3775,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"
@@ -3282,6 +3787,12 @@ checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
@@ -3330,6 +3841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,6 +3869,17 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"
@@ -3383,6 +3911,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "wyz"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
-candid = "0.7.14"
+candid = "0.7.15"
 futures = "0.3.21"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
@@ -20,25 +20,26 @@ lzma-rs = "0.2.0"
 tar = "0.4.37"
 hex = "0.4.3"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-dfn_json = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-dfn_macro = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+dfn_json = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+dfn_macro = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
 ic-certified-map = { git = "https://github.com/dfinity/cdk-rs", rev = "7676e7f"}
-ic-crypto-sha = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-ledger-canister = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
-registry-canister = { git = "https://github.com/dfinity/ic", rev = "5b2647754d0c2200b645d08a6ddce32251438ed5" }
+ic-crypto-sha = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+ledger-canister = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
+registry-canister = { git = "https://github.com/dfinity/ic", rev = "5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c" }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -10,11 +10,12 @@ use candid::CandidType;
 use dfn_candid::Candid;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha::Sha256;
+use ic_ledger_core::timestamp::TimeStamp;
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID};
 use itertools::Itertools;
 use ledger_canister::Operation::{self, Burn, Mint, Transfer};
-use ledger_canister::{AccountIdentifier, BlockHeight, Memo, Subaccount, TimeStamp, Tokens};
+use ledger_canister::{AccountIdentifier, BlockHeight, Memo, Subaccount, Tokens};
 use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
 use std::cmp::min;
@@ -852,9 +853,11 @@ impl AccountsStore {
             hardware_wallet_accounts_count: self.hardware_wallet_accounts_count,
             transactions_count: self.transactions.len() as u64,
             block_height_synced_up_to: self.block_height_synced_up_to,
-            earliest_transaction_timestamp_nanos: earliest_transaction.map_or(0, |t| t.timestamp.timestamp_nanos),
+            earliest_transaction_timestamp_nanos: earliest_transaction
+                .map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch()),
             earliest_transaction_block_height: earliest_transaction.map_or(0, |t| t.block_height),
-            latest_transaction_timestamp_nanos: latest_transaction.map_or(0, |t| t.timestamp.timestamp_nanos),
+            latest_transaction_timestamp_nanos: latest_transaction
+                .map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch()),
             latest_transaction_block_height: latest_transaction.map_or(0, |t| t.block_height),
             seconds_since_last_ledger_sync: duration_since_last_sync.as_secs(),
             neurons_created_count: self.neuron_accounts.len() as u64,

--- a/rs/src/accounts_store/tests.rs
+++ b/rs/src/accounts_store/tests.rs
@@ -380,7 +380,12 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(transfer, neuron_memo, block_height, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            transfer,
+            neuron_memo,
+            block_height,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -413,7 +418,12 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup1, Memo(0), block_height + 2, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            topup1,
+            Memo(0),
+            block_height + 2,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -427,7 +437,12 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup2, Memo(0), block_height + 3, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            topup2,
+            Memo(0),
+            block_height + 3,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -451,7 +466,12 @@ fn append_transaction_detects_neuron_transactions_from_external_accounts() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(transfer, neuron_memo, block_height, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            transfer,
+            neuron_memo,
+            block_height,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -466,7 +486,12 @@ fn append_transaction_detects_neuron_transactions_from_external_accounts() {
     };
     let previous_transaction_count = store.transactions.len();
     store
-        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            topup,
+            Memo(0),
+            block_height + 1,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
 
     // No new transaction should have been added, but the neuron should be queued for refreshing
@@ -527,7 +552,12 @@ fn topup_neuron_owned_by_other_principal_refreshes_balance_using_neurons_princip
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp::from_nanos_since_unix_epoch(100))
+        .append_transaction(
+            topup,
+            Memo(0),
+            block_height + 1,
+            TimeStamp::from_nanos_since_unix_epoch(100),
+        )
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),

--- a/rs/src/accounts_store/tests.rs
+++ b/rs/src/accounts_store/tests.rs
@@ -110,7 +110,7 @@ fn add_account_adds_principal_and_sets_transaction_types() {
             transfer,
             Memo(0),
             store.get_block_height_synced_up_to().unwrap_or(0) + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
 
@@ -125,7 +125,7 @@ fn add_account_adds_principal_and_sets_transaction_types() {
             stake_neuron,
             Memo(1678183231181200159),
             store.get_block_height_synced_up_to().unwrap_or(0) + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
 
@@ -140,7 +140,7 @@ fn add_account_adds_principal_and_sets_transaction_types() {
             topup_neuron,
             Memo(0),
             store.get_block_height_synced_up_to().unwrap_or(0) + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
 
@@ -333,7 +333,7 @@ fn hardware_wallet_transactions_tracked_correctly() {
             transfer,
             Memo(0),
             store.get_block_height_synced_up_to().unwrap_or(0) + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
 
@@ -346,7 +346,7 @@ fn hardware_wallet_transactions_tracked_correctly() {
             transfer,
             Memo(0),
             store.get_block_height_synced_up_to().unwrap_or(0) + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
 
@@ -380,7 +380,7 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(transfer, neuron_memo, block_height, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(transfer, neuron_memo, block_height, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -398,7 +398,7 @@ fn append_transaction_detects_neuron_transactions() {
             notification,
             Memo(block_height),
             block_height + 1,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
     assert!(matches!(
@@ -413,7 +413,7 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup1, Memo(0), block_height + 2, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(topup1, Memo(0), block_height + 2, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -427,7 +427,7 @@ fn append_transaction_detects_neuron_transactions() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup2, Memo(0), block_height + 3, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(topup2, Memo(0), block_height + 3, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -451,7 +451,7 @@ fn append_transaction_detects_neuron_transactions_from_external_accounts() {
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(transfer, neuron_memo, block_height, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(transfer, neuron_memo, block_height, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -466,7 +466,7 @@ fn append_transaction_detects_neuron_transactions_from_external_accounts() {
     };
     let previous_transaction_count = store.transactions.len();
     store
-        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
 
     // No new transaction should have been added, but the neuron should be queued for refreshing
@@ -512,7 +512,7 @@ fn topup_neuron_owned_by_other_principal_refreshes_balance_using_neurons_princip
             stake_neuron_transfer,
             neuron_memo,
             block_height,
-            TimeStamp { timestamp_nanos: 100 },
+            TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
     assert!(matches!(
@@ -527,7 +527,7 @@ fn topup_neuron_owned_by_other_principal_refreshes_balance_using_neurons_princip
         fee: Tokens::from_e8s(10000),
     };
     store
-        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp { timestamp_nanos: 100 })
+        .append_transaction(topup, Memo(0), block_height + 1, TimeStamp::from_nanos_since_unix_epoch(100))
         .unwrap();
     assert!(matches!(
         store.transactions.back().unwrap().transaction_type.unwrap(),
@@ -821,7 +821,7 @@ fn prune_transactions() {
         },
     );
 
-    let timestamp = TimeStamp { timestamp_nanos: 100 };
+    let timestamp = TimeStamp::from_nanos_since_unix_epoch(100);
     for _ in 0..10 {
         let transfer1 = Burn {
             amount: Tokens::from_e8s(100_000),
@@ -1015,7 +1015,7 @@ fn setup_test_store() -> AccountsStore {
     let mut store = AccountsStore::default();
     store.add_account(principal1);
     store.add_account(principal2);
-    let timestamp = TimeStamp { timestamp_nanos: 100 };
+    let timestamp = TimeStamp::from_nanos_since_unix_epoch(100);
     {
         let transfer = Mint {
             amount: Tokens::from_e8s(1_000_000_000),

--- a/rs/src/ledger_sync.rs
+++ b/rs/src/ledger_sync.rs
@@ -1,6 +1,7 @@
 use crate::canisters::ledger;
 use crate::state::STATE;
 use dfn_core::CanisterId;
+use ic_ledger_core::block::BlockType;
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use lazy_static::lazy_static;
 use ledger_canister::protobuf::ArchiveIndexEntry;
@@ -81,7 +82,7 @@ async fn get_blocks(from: BlockHeight, tip_of_chain: BlockHeight) -> Result<Vec<
     let results: Vec<_> = blocks
         .into_iter()
         .enumerate()
-        .map(|(index, block)| (range.start() + (index as u64), block.decode().unwrap()))
+        .map(|(index, block)| (range.start() + (index as u64), Block::decode(block).unwrap()))
         .collect();
 
     Ok(results)

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -1,13 +1,14 @@
 use crate::proposals::def::{
     AddFirewallRulesPayload, AddNnsCanisterProposal, AddNnsCanisterProposalTrimmed, AddNodeOperatorPayload,
     AddNodesToSubnetPayload, AddOrRemoveDataCentersProposalPayload, BlessReplicaVersionPayload,
-    ChangeNnsCanisterProposal, ChangeNnsCanisterProposalTrimmed, CreateSubnetPayload, RecoverSubnetPayload,
-    RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload, RemoveNodeOperatorsPayloadHumanReadable,
-    RemoveNodesFromSubnetPayload, RemoveNodesPayload, RerouteCanisterRangePayload, SetAuthorizedSubnetworkListArgs,
-    SetFirewallConfigPayload, StopOrStartNnsCanisterProposal, UpdateFirewallRulesPayload,
-    UpdateIcpXdrConversionRatePayload, UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload,
-    UpdateSubnetPayload, UpdateSubnetReplicaVersionPayload, UpdateUnassignedNodesConfigPayload,
-    UpgradeRootProposalPayload, UpgradeRootProposalPayloadTrimmed,
+    ChangeNnsCanisterProposal, ChangeNnsCanisterProposalTrimmed, CompleteCanisterMigrationPayload, CreateSubnetPayload,
+    PrepareCanisterMigrationPayload, RecoverSubnetPayload, RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload,
+    RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload, RemoveNodesPayload,
+    RerouteCanisterRangesPayload, SetAuthorizedSubnetworkListArgs, SetFirewallConfigPayload,
+    StopOrStartNnsCanisterProposal, UpdateFirewallRulesPayload, UpdateIcpXdrConversionRatePayload,
+    UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload, UpdateSubnetPayload,
+    UpdateSubnetReplicaVersionPayload, UpdateUnassignedNodesConfigPayload, UpgradeRootProposalPayload,
+    UpgradeRootProposalPayloadTrimmed,
 };
 use candid::CandidType;
 use ic_base_types::CanisterId;
@@ -116,10 +117,12 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
         21 => identity::<AddOrRemoveDataCentersProposalPayload>(payload_bytes),
         22 => identity::<UpdateUnassignedNodesConfigPayload>(payload_bytes),
         23 => transform::<RemoveNodeOperatorsPayload, RemoveNodeOperatorsPayloadHumanReadable>(payload_bytes),
-        24 => identity::<RerouteCanisterRangePayload>(payload_bytes),
+        24 => identity::<RerouteCanisterRangesPayload>(payload_bytes),
         25 => identity::<AddFirewallRulesPayload>(payload_bytes),
         26 => identity::<RemoveFirewallRulesPayload>(payload_bytes),
         27 => identity::<UpdateFirewallRulesPayload>(payload_bytes),
+        28 => identity::<PrepareCanisterMigrationPayload>(payload_bytes),
+        29 => identity::<CompleteCanisterMigrationPayload>(payload_bytes),
         _ => Err("Unrecognised NNS function".to_string()),
     }
 }
@@ -345,9 +348,9 @@ mod def {
     }
 
     // NNS function 24 - RerouteCanisterRange
-    // https://github.com/dfinity/ic/blob/5b2647754d0c2200b645d08a6ddce32251438ed5/rs/registry/canister/src/mutations/reroute_canister_range.rs#L46
-    pub type RerouteCanisterRangePayload =
-        registry_canister::mutations::reroute_canister_range::RerouteCanisterRangePayload;
+    // https://github.com/dfinity/ic/blob/5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c/rs/registry/canister/src/mutations/reroute_canister_ranges.rs#L66
+    pub type RerouteCanisterRangesPayload =
+        registry_canister::mutations::reroute_canister_ranges::RerouteCanisterRangesPayload;
 
     // NNS function 25 - AddFirewallRules
     // https://github.com/dfinity/ic/blob/5b2647754d0c2200b645d08a6ddce32251438ed5/rs/registry/canister/src/mutations/firewall.rs#L218
@@ -360,6 +363,16 @@ mod def {
     // NNS function 27 - UpdateFirewallRules
     // https://github.com/dfinity/ic/blob/5b2647754d0c2200b645d08a6ddce32251438ed5/rs/registry/canister/src/mutations/firewall.rs#L246
     pub type UpdateFirewallRulesPayload = registry_canister::mutations::firewall::UpdateFirewallRulesPayload;
+
+    // NNS function 28 - PrepareCanisterMigration
+    // https://github.com/dfinity/ic/blob/5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c/rs/registry/canister/src/mutations/prepare_canister_migration.rs#L67
+    pub type PrepareCanisterMigrationPayload =
+        registry_canister::mutations::prepare_canister_migration::PrepareCanisterMigrationPayload;
+
+    // NNS function 29 - CompleteCanisterMigration
+    // https://github.com/dfinity/ic/blob/5a1b0fe380dda87e7a3fcc62d48d646a91d2f12c/rs/registry/canister/src/mutations/complete_canister_migration.rs#L34
+    pub type CompleteCanisterMigrationPayload =
+        registry_canister::mutations::complete_canister_migration::CompleteCanisterMigrationPayload;
 
     // Use a serde field attribute to custom serialize the Nat candid type.
     fn serialize_optional_nat<S>(nat: &Option<candid::Nat>, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
# Motivation

Currently the NNS Dapp is not able to deserialize proposal payloads.
To fix this we need to update the proposal definitions to the latest versions, that is what this PR does.

# Changes

- Update dependencies on packages contained in the IC repo (https://github.com/dfinity/ic/).
- Add 2 new proposal types (`PrepareCanisterMigration` and `CompleteCanisterMigration`).
- Update the payload definition for `RerouteCanisterRangesPayload` proposals.
- Fix type mismatches due to the ledger canister having recently split its protobuf types into a separate module.

# Tests

This has been tested by myself, @lmuntaner and @mstrasinskis on the testnet (https://si2b5-pyaaa-aaaaa-aaaja-cai.nnsdapp.dfinity.network/)
