### PR TITLE
Fix DELETE_CANISTER_IDS

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -224,7 +224,7 @@ if [[ "$DELETE_CANISTER_IDS" == "true" ]]; then
     : Back up the canister_ids.json
     cp canister_ids.json "canister_ids.json.$(date -Isecond -u | sed 's/+.*//g')"
     echo "Deleting the entries for $DFX_NETWORK in canister_ids.json ..."
-    DFX_NETWORK="$DFX_NETWORK" jq 'map(del(.[env.DFX_NETWORK]))' <canister_ids.json >canister_ids.json.new
+    DFX_NETWORK="$DFX_NETWORK" jq 'to_entries | map(del(.value[env.DFX_NETWORK])) | from_entries' <canister_ids.json >canister_ids.json.new
     mv canister_ids.json.new canister_ids.json
   fi
 fi


### PR DESCRIPTION
# Motivation
`./deploy.sh --delete-canister-ids` does not work correctly.  Given this input:
```
{
  "__Candid_UI": {
    "small06": "qaa6y-5yaaa-aaaaa-aaafa-cai",
    "small11": "qaa6y-5yaaa-aaaaa-aaafa-cai",
    "testnet": "su63m-yyaaa-aaaaa-aaala-cai"
  },
  "internet_identity": {
    "small06": "qjdve-lqaaa-aaaaa-aaaeq-cai",
    "small11": "qjdve-lqaaa-aaaaa-aaaeq-cai"
  },
  "nns-dapp": {
    "small06": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
    "small11": "qhbym-qaaaa-aaaaa-aaafq-cai",
    "testnet": "s55qq-oqaaa-aaaaa-aaakq-cai"
  },
  "sns_governance": {
    "small06": "q4eej-kyaaa-aaaaa-aaaha-cai"
  },
  "sns_ledger": {
    "small06": "q3fc5-haaaa-aaaaa-aaahq-cai"
  },
  "sns_root": {
    "small06": "qvhpv-4qaaa-aaaaa-aaagq-cai"
  },
  "sns_swap": {
    "small06": "sgymv-uiaaa-aaaaa-aaaia-cai"
  },
  "wasm_canister": {
    "small06": "qsgjb-riaaa-aaaaa-aaaga-cai"
  }
}
```
if we want to delete the testnet entries with current main we get:

```
max@sinkpad:~/dfn/nns-dapp/branches/fix-del (1:32)$ ./deploy.sh --delete testnet
Deleting the entries for testnet in canister_ids.json ...
Deleting the wallet for testnet in /home/max/.config/dfx/identity/default/wallets.json ...
max@sinkpad:~/dfn/nns-dapp/branches/fix-del (1:45)$ cat canister_ids.json 
[
  {
    "small06": "qaa6y-5yaaa-aaaaa-aaafa-cai",
    "small11": "qaa6y-5yaaa-aaaaa-aaafa-cai"
  },
  {
    "small06": "qjdve-lqaaa-aaaaa-aaaeq-cai",
    "small11": "qjdve-lqaaa-aaaaa-aaaeq-cai"
  },
  {
    "small06": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
    "small11": "qhbym-qaaaa-aaaaa-aaafq-cai"
  },
  {
    "small06": "q4eej-kyaaa-aaaaa-aaaha-cai"
  },
  {
    "small06": "q3fc5-haaaa-aaaaa-aaahq-cai"
  },
  {
    "small06": "qvhpv-4qaaa-aaaaa-aaagq-cai"
  },
  {
    "small06": "sgymv-uiaaa-aaaaa-aaaia-cai"
  },
  {
    "small06": "qsgjb-riaaa-aaaaa-aaaga-cai"
  }
]
```
so the canister names have been lost!

# Changes
* Fix the jq incantation for deleting canister IDs of one testnet.

# Tests
In the above example, we now get the correct output:
```
max@sinkpad:~/dfn/nns-dapp/branches/fix-del (2:02)$ ./deploy.sh --delete testnet
Deleting the entries for testnet in canister_ids.json ...
Deleting the wallet for testnet in /home/max/.config/dfx/identity/default/wallets.json ...
max@sinkpad:~/dfn/nns-dapp/branches/fix-del (2:10)$ cat canister_ids.json 
{
  "__Candid_UI": {
    "small06": "qaa6y-5yaaa-aaaaa-aaafa-cai",
    "small11": "qaa6y-5yaaa-aaaaa-aaafa-cai"
  },
  "internet_identity": {
    "small06": "qjdve-lqaaa-aaaaa-aaaeq-cai",
    "small11": "qjdve-lqaaa-aaaaa-aaaeq-cai"
  },
  "nns-dapp": {
    "small06": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
    "small11": "qhbym-qaaaa-aaaaa-aaafq-cai"
  },
  "sns_governance": {
    "small06": "q4eej-kyaaa-aaaaa-aaaha-cai"
  },
  "sns_ledger": {
    "small06": "q3fc5-haaaa-aaaaa-aaahq-cai"
  },
  "sns_root": {
    "small06": "qvhpv-4qaaa-aaaaa-aaagq-cai"
  },
  "sns_swap": {
    "small06": "sgymv-uiaaa-aaaaa-aaaia-cai"
  },
  "wasm_canister": {
    "small06": "qsgjb-riaaa-aaaaa-aaaga-cai"
  }
}
```