### PR TITLE
Filter sns proposals by open status

### DIFF
--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -3,7 +3,7 @@
   import { listSnsProposals } from "../../services/sns.services";
   import { i18n } from "../../stores/i18n";
   import {
-    openForVotesSnsProposalsStore,
+    openSnsProposalsStore,
     snsProposalsStore,
   } from "../../stores/projects.store";
   import { isNullish } from "../../utils/utils";
@@ -28,11 +28,11 @@
     <SkeletonProposalCard />
     <SkeletonProposalCard />
   </CardGrid>
-{:else if $openForVotesSnsProposalsStore.length === 0}
+{:else if $openSnsProposalsStore.length === 0}
   <p class="no-proposals">{$i18n.voting.nothing_found}</p>
 {:else}
   <CardGrid>
-    {#each $openForVotesSnsProposalsStore as proposalInfo (proposalInfo.id)}
+    {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}
       <ProposalCard {proposalInfo} />
     {/each}
   </CardGrid>

--- a/frontend/src/lib/stores/projects.store.ts
+++ b/frontend/src/lib/stores/projects.store.ts
@@ -71,7 +71,9 @@ const initOpenSnsProposalsStore = () =>
   derived([snsProposalsStore], ([$snsProposalsStore]): ProposalInfo[] =>
     isNullish($snsProposalsStore)
       ? []
-      : $snsProposalsStore.proposals.filter(({status}) => status === ProposalStatus.PROPOSAL_STATUS_OPEN)
+      : $snsProposalsStore.proposals.filter(
+          ({ status }) => status === ProposalStatus.PROPOSAL_STATUS_OPEN
+        )
   );
 
 const initSnsSummariesStore = () => {
@@ -149,8 +151,7 @@ const initSnsProjectSelectedStore = () => {
 export const snsesCountStore = writable<number | undefined>(undefined);
 
 export const snsProposalsStore = initSnsProposalsStore();
-export const openSnsProposalsStore =
-  initOpenSnsProposalsStore();
+export const openSnsProposalsStore = initOpenSnsProposalsStore();
 
 export const snsSummariesStore = initSnsSummariesStore();
 export const snsSwapCommitmentsStore = initSnsSwapCommitmentsStore();

--- a/frontend/src/lib/stores/projects.store.ts
+++ b/frontend/src/lib/stores/projects.store.ts
@@ -1,10 +1,9 @@
-import type { ProposalInfo } from "@dfinity/nns";
+import { ProposalStatus, type ProposalInfo } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { derived, writable, type Readable } from "svelte/store";
 import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 import type { SnsSummary, SnsSwapCommitment } from "../types/sns";
-import { isProposalOpenForVotes } from "../utils/proposals.utils";
 import { isNullish } from "../utils/utils";
 
 export type SnsSummariesStore =
@@ -68,11 +67,11 @@ const initSnsProposalsStore = () => {
   };
 };
 
-const initOpenForVotesSnsProposalsStore = () =>
+const initOpenSnsProposalsStore = () =>
   derived([snsProposalsStore], ([$snsProposalsStore]): ProposalInfo[] =>
     isNullish($snsProposalsStore)
       ? []
-      : $snsProposalsStore.proposals.filter(isProposalOpenForVotes)
+      : $snsProposalsStore.proposals.filter(({status}) => status === ProposalStatus.PROPOSAL_STATUS_OPEN)
   );
 
 const initSnsSummariesStore = () => {
@@ -150,8 +149,8 @@ const initSnsProjectSelectedStore = () => {
 export const snsesCountStore = writable<number | undefined>(undefined);
 
 export const snsProposalsStore = initSnsProposalsStore();
-export const openForVotesSnsProposalsStore =
-  initOpenForVotesSnsProposalsStore();
+export const openSnsProposalsStore =
+  initOpenSnsProposalsStore();
 
 export const snsSummariesStore = initSnsSummariesStore();
 export const snsSwapCommitmentsStore = initSnsSwapCommitmentsStore();

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { type ProposalInfo, ProposalStatus } from "@dfinity/nns";
+import { ProposalStatus, type ProposalInfo } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import Proposals from "../../../../lib/components/launchpad/Proposals.svelte";
 import { listSnsProposals } from "../../../../lib/services/sns.services";
@@ -56,7 +56,9 @@ describe("Proposals", () => {
   });
 
   it("should display proposal cards", async () => {
-    mockProposals([{ ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN }]);
+    mockProposals([
+      { ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN },
+    ]);
 
     const { getAllByTestId } = render(Proposals);
 
@@ -66,7 +68,9 @@ describe("Proposals", () => {
   });
 
   it("should hide skeletons", async () => {
-    mockProposals([{ ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN }]);
+    mockProposals([
+      { ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN },
+    ]);
 
     const { container, getAllByTestId } = render(Proposals);
 

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import type { ProposalInfo } from "@dfinity/nns";
+import { type ProposalInfo, ProposalStatus } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import Proposals from "../../../../lib/components/launchpad/Proposals.svelte";
 import { listSnsProposals } from "../../../../lib/services/sns.services";
@@ -55,8 +55,8 @@ describe("Proposals", () => {
     );
   });
 
-  it("should proposal cards", async () => {
-    mockProposals([{ ...mockProposalInfo }]);
+  it("should display proposal cards", async () => {
+    mockProposals([{ ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN }]);
 
     const { getAllByTestId } = render(Proposals);
 
@@ -66,7 +66,7 @@ describe("Proposals", () => {
   });
 
   it("should hide skeletons", async () => {
-    mockProposals([{ ...mockProposalInfo }]);
+    mockProposals([{ ...mockProposalInfo, status: ProposalStatus.PROPOSAL_STATUS_OPEN }]);
 
     const { container, getAllByTestId } = render(Proposals);
 

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -1,3 +1,4 @@
+import { ProposalStatus } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
@@ -124,11 +125,19 @@ describe("projects.store", () => {
           ...mockProposalInfo,
           id: BigInt(111),
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_REJECTED,
         },
         {
           ...mockProposalInfo,
           id: BigInt(222),
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds - 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_OPEN,
+        },
+        {
+          ...mockProposalInfo,
+          id: BigInt(222),
+          deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_ACCEPTED,
         },
       ];
 
@@ -140,7 +149,7 @@ describe("projects.store", () => {
       const $openSnsProposalsStore = get(openSnsProposalsStore);
 
       expect($openSnsProposalsStore.length).toBe(1);
-      expect($openSnsProposalsStore[0]).toEqual(proposals[0]);
+      expect($openSnsProposalsStore[0]).toEqual(proposals[1]);
     });
   });
 

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -5,7 +5,7 @@ import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
 import {
   committedProjectsStore,
   isNnsProjectStore,
-  openForVotesSnsProposalsStore,
+  openSnsProposalsStore,
   openProjectsStore,
   snsProjectSelectedStore,
   snsProposalsStore,
@@ -137,10 +137,10 @@ describe("projects.store", () => {
         certified: false,
       });
 
-      const $openForVotesSnsProposalsStore = get(openForVotesSnsProposalsStore);
+      const $openSnsProposalsStore = get(openSnsProposalsStore);
 
-      expect($openForVotesSnsProposalsStore.length).toBe(1);
-      expect($openForVotesSnsProposalsStore[0]).toEqual(proposals[0]);
+      expect($openSnsProposalsStore.length).toBe(1);
+      expect($openSnsProposalsStore[0]).toEqual(proposals[0]);
     });
   });
 

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -6,8 +6,8 @@ import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
 import {
   committedProjectsStore,
   isNnsProjectStore,
-  openSnsProposalsStore,
   openProjectsStore,
+  openSnsProposalsStore,
   snsProjectSelectedStore,
   snsProposalsStore,
   snsSummariesStore,


### PR DESCRIPTION
# Motivation

Display only `state=open` SNS proposals on the launchpad page

# Changes

- update store logic
- rename store

# Tests

- updated according to the new logic
