### PR TITLE
feat: disable auth idle manager

### DIFF
--- a/frontend/src/lib/constants/identity.constants.ts
+++ b/frontend/src/lib/constants/identity.constants.ts
@@ -1,3 +1,6 @@
 // Config replaces "process.env.IDENTITY_SERVICE_URL", prettier splits it in two lines.
 // prettier-ignore
-export const identityServiceURL: string = process.env.IDENTITY_SERVICE_URL as string;
+export const IDENTITY_SERVICE_URL: string = process.env.IDENTITY_SERVICE_URL as string;
+
+// The authentication expires after 30 minutes
+export const AUTH_SESSION_DURATION: bigint = BigInt(30 * 60 * 1_000_000_000);

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -1,11 +1,27 @@
 import type { Identity } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
 import { writable } from "svelte/store";
-import { identityServiceURL } from "../constants/identity.constants";
+import {
+  AUTH_SESSION_DURATION,
+  IDENTITY_SERVICE_URL,
+} from "../constants/identity.constants";
 
 export interface AuthStore {
   identity: Identity | undefined | null;
 }
+
+/**
+ * Create an AuthClient to manage authentication and identity.
+ * - Session duration is 30min (AUTH_SESSION_DURATION).
+ * - Disable idle manager that sign-out in case of inactivity after default 10min to avoid UX issues if multiple tabs are used as we observe the storage and sync the delegation on any changes
+ */
+const createAuthClient = (): Promise<AuthClient> =>
+  AuthClient.create({
+    idleOptions: {
+      disableIdle: true,
+      disableDefaultIdleCallback: true,
+    },
+  });
 
 /**
  * A store to handle authentication and the identity of the user.
@@ -34,7 +50,7 @@ const initAuthStore = () => {
     subscribe,
 
     sync: async () => {
-      const authClient: AuthClient = await AuthClient.create();
+      const authClient: AuthClient = await createAuthClient();
       const isAuthenticated: boolean = await authClient.isAuthenticated();
 
       set({
@@ -44,10 +60,10 @@ const initAuthStore = () => {
 
     signIn: () =>
       new Promise<void>((resolve, reject) => {
-        AuthClient.create().then((authClient: AuthClient) => {
+        createAuthClient().then((authClient: AuthClient) => {
           authClient.login({
-            identityProvider: identityServiceURL,
-            maxTimeToLive: BigInt(30 * 60 * 1_000_000_000), // 30 minutes
+            identityProvider: IDENTITY_SERVICE_URL,
+            maxTimeToLive: AUTH_SESSION_DURATION,
             onSuccess: () => {
               update((state: AuthStore) => ({
                 ...state,
@@ -62,7 +78,7 @@ const initAuthStore = () => {
       }),
 
     signOut: async () => {
-      const authClient: AuthClient = await AuthClient.create();
+      const authClient: AuthClient = await createAuthClient();
 
       await authClient.logout();
 


### PR DESCRIPTION
# Motivation

As NNS-dapp observes the local storage and sync the delegation status if anything changes it leads to some UX issues / quirks with the new idle manager of agent-js. Until we got time to implement it properly we decided to disable it.

Session duration of 30min, sync of the auth on storage change cronjob that verifies the delegation validity and warning about automatic logout are not affected by this PR - remains the same as they are since months. 

# Changes

- disable idle manager of auth client
- extract session duration to a constant
