### PR TITLE
Deploy wasm canister only

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -350,7 +350,7 @@ if [[ "$POPULATE" == "true" ]]; then
   }
 fi
 
-if [[ "$DEPLOY_SNS_WASM_CANISTER" == "true" ]]; then
+if [[ "$DEPLOY_SNS" == "true" ]]; then
   echo "Checking cycle balance"
   while dfx wallet --network "$DFX_NETWORK" balance | awk '{exit $1 >= 51.00}'; do
     WALLET_CANISTER="$(dfx identity --network "$DFX_NETWORK" get-wallet)"

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,6 +66,9 @@ help_text() {
 	--ii
 	  Create the internet_identity canister.
 
+	--sns-wasm
+	  Create or update an SNS wasm canister.
+
 	--sns
 	  Create an SNS canister set.
 
@@ -97,6 +100,7 @@ START_DFX="false"
 DEPLOY_NNS_BACKEND="false"
 DEPLOY_II="false"
 DEPLOY_SNS="false"
+DEPLOY_SNS_WASM_CANISTER=""
 DEPLOY_NNS_DAPP="false"
 POPULATE="false"
 OPEN_NNS_DAPP="false"
@@ -131,9 +135,14 @@ while (($# > 0)); do
     GUESS="false"
     DEPLOY_II="true"
     ;;
+  --sns-wasm)
+    GUESS="false"
+    DEPLOY_SNS_WASM_CANISTER="true"
+    ;;
   --sns)
     GUESS="false"
     DEPLOY_SNS="true"
+    DEPLOY_SNS_WASM_CANISTER="${DEPLOY_SNS_WASM_CANISTER:-ifnotinstalled}"
     ;;
   --nns-backend)
     GUESS="false"
@@ -274,14 +283,17 @@ fi
 # Note: There may be multiple SNS canister sets; at present this can be done in a somewhat clunky way by
 # adding numbers to SNS canister names, however in fiture versions of dfx, it will be possible to have
 # several dfx.json, so we can have one dfx.json per SNS and one for the nns-dapp project, without weird names.
-if [[ "$DEPLOY_SNS" == "true" ]]; then
+if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
   # If the wasm canister has not been installed already, install it.
   echo Checking whether sns wasm is installed
   SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister 2>/dev/null || echo NOPE)"
-  if [[ "${SNS_WASM_CANISTER_ID:-}" != "NOPE" ]]; then
+  [[ "${SNS_WASM_CANISTER_ID:-}" == "NOPE" ]] || {
     echo "SNS wasm/management canister already installed at: $SNS_WASM_CANISTER_ID"
+  }
+  if [[ "${SNS_WASM_CANISTER_ID:-}" != "NOPE" ]] && [[ "$DEPLOY_SNS_WASM_CANISTER" == "ifnotinstalled" ]]; then
+    echo "Using existing WASM canister..."
   else
-    echo "Creating SNS wasm canister..."
+    echo "Deploying SNS wasm canister..."
     NNS_URL="$(./e2e-tests/scripts/nns-dashboard --dfx-network "$DFX_NETWORK")"
     SNS_SUBNETS="$(ic-admin --nns-url "$NNS_URL" get-subnet-list | jq -r '. | map("principal \"" + . + "\"") | join("; ")')"
     dfx deploy --network "$DFX_NETWORK" wasm_canister --argument '( record { sns_subnet_ids = vec { '"$SNS_SUBNETS"' } } )' --no-wallet
@@ -295,37 +307,6 @@ if [[ "$DEPLOY_SNS" == "true" ]]; then
         --wasm-file "$(CANISTER="sns_$canister" jq -r '.canisters[env.CANISTER].wasm' dfx.json)" "$canister"
     done
   fi
-  echo "Checking cycle balance"
-  while dfx wallet --network "$DFX_NETWORK" balance | awk '{exit $1 >= 51.00}'; do
-    WALLET_CANISTER="$(dfx identity --network "$DFX_NETWORK" get-wallet)"
-    echo "Please add 51T cycles to this canister: $WALLET_CANISTER"
-    read -rp "Press enter when done ..."
-    echo
-  done
-
-  echo "Creating SNS"
-  ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml >sns_creation.idl
-
-  echo "Populate canister_ids.json"
-  if test -e canister_ids.json; then
-    EXISTING_CANISTER_IDS="canister_ids.$(date -Iseconds)"
-    cp canister_ids.json "$EXISTING_CANISTER_IDS"
-  else
-    echo "{}" >canister_ids.json
-  fi
-  sed -n ':a;/^[(]/bb;d;ba;:b;p;n;bb' <sns_creation.idl |
-    idl2json |
-    jq '.canisters[] | to_entries | map({ ("sns_"+.key): {(env.DFX_NETWORK): (.value[0])} }) | add' |
-    jq -s '.[1] * .[0]' - canister_ids.json >canister_ids.json.new
-  mv canister_ids.json.new canister_ids.json
-
-  # Note: This must come afetr the canister_ids has been updated.
-  echo "SNS state after creation"
-  dfx canister --network "$DFX_NETWORK" call sns_swap get_state '( record {} )'
-  echo "Tell the swap canister to get tokens"
-  dfx canister --network "$DFX_NETWORK" call sns_swap refresh_sns_tokens '( record {} )'
-  echo "SNS swap state should now have tokens"
-  dfx canister --network "$DFX_NETWORK" call sns_swap get_state '( record {} )'
 fi
 
 if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
@@ -361,6 +342,40 @@ if [[ "$POPULATE" == "true" ]]; then
       SCREENSHOT=1 xargs -I {} npm run test -- --spec "./specs/{}"
     popd
   }
+fi
+
+if [[ "$DEPLOY_SNS_WASM_CANISTER" == "true" ]]; then
+  echo "Checking cycle balance"
+  while dfx wallet --network "$DFX_NETWORK" balance | awk '{exit $1 >= 51.00}'; do
+    WALLET_CANISTER="$(dfx identity --network "$DFX_NETWORK" get-wallet)"
+    echo "Please add 51T cycles to this canister: $WALLET_CANISTER"
+    read -rp "Press enter when done ..."
+    echo
+  done
+
+  echo "Creating SNS"
+  ./target/ic/sns deploy --network "$DFX_NETWORK" --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" --init-config-file sns_init.yml >sns_creation.idl
+
+  echo "Populate canister_ids.json"
+  if test -e canister_ids.json; then
+    EXISTING_CANISTER_IDS="canister_ids.$(date -Iseconds)"
+    cp canister_ids.json "$EXISTING_CANISTER_IDS"
+  else
+    echo "{}" >canister_ids.json
+  fi
+  sed -n ':a;/^[(]/bb;d;ba;:b;p;n;bb' <sns_creation.idl |
+    idl2json |
+    jq '.canisters[] | to_entries | map({ ("sns_"+.key): {(env.DFX_NETWORK): (.value[0])} }) | add' |
+    jq -s '.[1] * .[0]' - canister_ids.json >canister_ids.json.new
+  mv canister_ids.json.new canister_ids.json
+
+  # Note: This must come afetr the canister_ids has been updated.
+  echo "SNS state after creation"
+  dfx canister --network "$DFX_NETWORK" call sns_swap get_state '( record {} )'
+  echo "Tell the swap canister to get tokens"
+  dfx canister --network "$DFX_NETWORK" call sns_swap refresh_sns_tokens '( record {} )'
+  echo "SNS swap state should now have tokens"
+  dfx canister --network "$DFX_NETWORK" call sns_swap get_state '( record {} )'
 fi
 
 if [[ "$OPEN_NNS_DAPP" == "true" ]]; then

--- a/dfx.json
+++ b/dfx.json
@@ -31,31 +31,41 @@
       "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-06-17/internet_identity_dev.wasm\" -o internet_identity.wasm"
     },
     "wasm_canister": {
-      "build": ["true"],
+      "build": [
+        "true"
+      ],
       "candid": "target/ic/sns_wasm.did",
       "wasm": "target/ic/sns-wasm-canister.wasm",
       "type": "custom"
     },
     "sns_governance": {
-      "build": ["true"],
+      "build": [
+        "true"
+      ],
       "candid": "target/ic/sns_governance.did",
       "wasm": "target/ic/sns-governance-canister.wasm",
       "type": "custom"
     },
     "sns_ledger": {
-      "build": ["true"],
+      "build": [
+        "true"
+      ],
       "candid": "target/ic/ic-icrc1-ledger.did",
       "wasm": "target/ic/ic-icrc1-ledger.wasm",
       "type": "custom"
     },
     "sns_swap": {
-      "build": ["true"],
+      "build": [
+        "true"
+      ],
       "candid": "target/ic/sns_swap.did",
       "wasm": "target/ic/sns-swap-canister.wasm",
       "type": "custom"
     },
     "sns_root": {
-      "build": ["true"],
+      "build": [
+        "true"
+      ],
       "candid": "target/ic/sns_root.did",
       "wasm": "target/ic/sns-root-canister.wasm",
       "type": "custom"
@@ -74,7 +84,9 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/"
       },
-      "providers": ["https://ic0.app/"],
+      "providers": [
+        "https://ic0.app/"
+      ],
       "type": "persistent"
     },
     "staging": {
@@ -84,11 +96,11 @@
         "REDIRECT_TO_LEGACY": "prod",
         "ENABLE_NEW_SPAWN_FEATURE": true,
         "ENABLE_SNS_NEURONS": false,
-        "HOST": "https://nnsdapp.dfinity.network",
-        "OWN_URL": "https://OWN_CANISTER_ID.nnsdapp.dfinity.network",
-        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network"
+        "HOST": "https://nnsdapp.dfinity.network"
       },
-      "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"
+      ],
       "type": "persistent"
     },
     "testnet": {
@@ -98,11 +110,11 @@
         "REDIRECT_TO_LEGACY": "prod",
         "ENABLE_NEW_SPAWN_FEATURE": true,
         "ENABLE_SNS_NEURONS": true,
-        "HOST": "https://nnsdapp.dfinity.network",
-        "OWN_URL": "https://OWN_CANISTER_ID.nnsdapp.dfinity.network",
-        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network"
+        "HOST": "https://nnsdapp.dfinity.network"
       },
-      "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"
+      ],
       "type": "persistent"
     },
     "small12": {
@@ -112,10 +124,11 @@
         "REDIRECT_TO_LEGACY": "both",
         "ENABLE_NEW_SPAWN_FEATURE": true,
         "ENABLE_SNS_NEURONS": true,
-        "HOST": "https://small12.dfinity.network",
-        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.small12.dfinity.network"
+        "HOST": "https://small12.dfinity.network"
       },
-      "providers": ["http://[2a00:fb01:400:42:5000:54ff:fef3:eb8]:8080"],
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:54ff:fef3:eb8]:8080"
+      ],
       "type": "persistent"
     },
     "small11": {
@@ -125,10 +138,11 @@
         "REDIRECT_TO_LEGACY": "both",
         "ENABLE_NEW_SPAWN_FEATURE": true,
         "ENABLE_SNS_NEURONS": true,
-        "HOST": "https://small11.dfinity.network",
-        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.small11.dfinity.network"
+        "HOST": "https://small11.dfinity.network"
       },
-      "providers": ["http://[2a00:fb01:400:42:5000:eeff:feae:ab37]:8080"],
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:eeff:feae:ab37]:8080"
+      ],
       "type": "persistent"
     },
     "small06": {
@@ -138,10 +152,11 @@
         "REDIRECT_TO_LEGACY": "both",
         "ENABLE_NEW_SPAWN_FEATURE": true,
         "ENABLE_SNS_NEURONS": true,
-        "HOST": "https://small06.dfinity.network",
-        "IDENTITY_SERVICE_URL": "https://qjdve-lqaaa-aaaaa-aaaeq-cai.small06.dfinity.network"
+        "HOST": "https://small06.dfinity.network"
       },
-      "providers": ["http://[2a00:fb01:400:42:5000:caff:fed1:b2e7]:8080"],
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:caff:fed1:b2e7]:8080"
+      ],
       "type": "persistent"
     },
     "local": {
@@ -171,7 +186,7 @@
       "config": {
         "RUSTC_VERSION": "1.58.1",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
-        "IC_COMMIT": "5b66c3f6994a43777b1161ef7f587698e1265773"
+        "IC_COMMIT": "268db05d70b3cc20475ba3ac046c0db9bd66c688"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
For demos, and also for providing stable sns-wasm canister IDs, it is desirable to deploy the sns-wasm canister by itself without creating an SNS.

# Changes
* Separate wasm canister deployment out into a separate step, with a separate flag.
  * Note: If an SNS is requested and there is no wasm canister, one will be deployed even without the new explicit `--sns-wasm`, so existing scripts will not break on account of the new flag.

# Tests
* Used to deploy small12 - with a small hiccup with the II canister IDs.  Added a fix (deleting unnecessary configuration) to this PR.
* Deployed to small06 repeatedly until I observed no usability or functionality issues.