### PR TITLE
L2-888: Fetch user commitment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -800,9 +800,9 @@
       "peer": true
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.2-nightly-2022-07-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-26.tgz",
-      "integrity": "sha512-puiODj/TOYqwc26nCrxqTO8TqKQ5VRdv4Wm3hN3qmhUAtBc5UsaaiByP/wzvnvou9vVYmd5jl9NonzVtWg126g=="
+      "version": "0.0.2-nightly-2022-07-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-27.tgz",
+      "integrity": "sha512-u/EL5OtZd4STYIGM1YdJUsjncgLVpAxf73bw2MXlAd/gefaBVLZDUAIWEILToc6TpnWaJOEOSq826Y8CB7Vi1w=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -9349,9 +9349,9 @@
       "peer": true
     },
     "@dfinity/sns": {
-      "version": "0.0.2-nightly-2022-07-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-26.tgz",
-      "integrity": "sha512-puiODj/TOYqwc26nCrxqTO8TqKQ5VRdv4Wm3hN3qmhUAtBc5UsaaiByP/wzvnvou9vVYmd5jl9NonzVtWg126g=="
+      "version": "0.0.2-nightly-2022-07-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-27.tgz",
+      "integrity": "sha512-u/EL5OtZd4STYIGM1YdJUsjncgLVpAxf73bw2MXlAd/gefaBVLZDUAIWEILToc6TpnWaJOEOSq826Y8CB7Vi1w=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -403,17 +403,18 @@ export const querySnsSwapCommitment = async ({
     `Getting Sns ${rootCanisterId} swap commitment certified:${certified} call...`
   );
 
-  const snsWrapper: SnsWrapper = await wrapper({
+  const { getUserCommitment, swapState }: SnsWrapper = await wrapper({
     rootCanisterId,
     identity,
     certified,
   });
 
-  const [userCommitment, swapState] = await Promise.all([
-    snsWrapper.getUserCommitment({
+  // TODO: Read the current total commitment from SnsSummary instead of SnsSwapCommitment
+  const [userCommitment, state] = await Promise.all([
+    getUserCommitment({
       principal_id: [identity.getPrincipal()],
     }),
-    snsWrapper.swapState({}),
+    swapState({}),
   ]);
 
   logWithTimestamp(
@@ -422,8 +423,7 @@ export const querySnsSwapCommitment = async ({
   return {
     rootCanisterId: Principal.fromText(rootCanisterId),
     myCommitment: userCommitment,
-    currentCommitment:
-      swapState?.derived?.[0]?.buyer_total_icp_e8s ?? BigInt(0),
+    currentCommitment: state?.derived?.[0]?.buyer_total_icp_e8s ?? BigInt(0),
   };
 };
 

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -25,34 +25,13 @@ import type {
   QuerySnsSwapState,
 } from "../types/sns.query";
 import { createAgent } from "../utils/agent.utils";
-import { logWithTimestamp, shuffle } from "../utils/dev.utils";
+import { logWithTimestamp } from "../utils/dev.utils";
 import { ledgerCanister } from "./ledger.api";
 
 let snsQueryWrappers: Promise<Map<QueryRootCanisterId, SnsWrapper>> | undefined;
 let snsUpdateWrappers:
   | Promise<Map<QueryRootCanisterId, SnsWrapper>>
   | undefined;
-
-// TODO(L2-751): remove and replace with effective data
-let mockSwapCommitments: SnsSwapCommitment[] = [];
-const mockDummySwapCommitments: Partial<SnsSwapCommitment>[] = shuffle([
-  {
-    myCommitment: BigInt(25 * 100000000),
-    currentCommitment: BigInt(100 * 100000000),
-  },
-  {
-    myCommitment: BigInt(5 * 100000000),
-    currentCommitment: BigInt(775 * 100000000),
-  },
-  {
-    myCommitment: undefined,
-    currentCommitment: BigInt(1000 * 100000000),
-  },
-  {
-    myCommitment: undefined,
-    currentCommitment: BigInt(1500 * 100000000),
-  },
-]);
 
 /**
  * List all deployed Snses - i.e list all Sns projects
@@ -424,32 +403,27 @@ export const querySnsSwapCommitment = async ({
     `Getting Sns ${rootCanisterId} swap commitment certified:${certified} call...`
   );
 
-  // TODO: use sns wrapper and query ledger (?)
+  const snsWrapper: SnsWrapper = await wrapper({
+    rootCanisterId,
+    identity,
+    certified,
+  });
+
+  const [userCommitment, swapState] = await Promise.all([
+    snsWrapper.getUserCommitment({
+      principal_id: [identity.getPrincipal()],
+    }),
+    snsWrapper.swapState({}),
+  ]);
 
   logWithTimestamp(
     `Getting Sns ${rootCanisterId} swap commitment certified:${certified} done.`
   );
-
-  // TODO(L2-751): remove mock data
-  if (mockSwapCommitments.length === 0) {
-    mockSwapCommitments = [
-      ...(
-        (await wrappers({ identity, certified })) ??
-        new Map<QueryRootCanisterId, SnsWrapper>()
-      ).values(),
-    ].map(
-      ({ canisterIds: { rootCanisterId } }, index) =>
-        ({
-          ...mockDummySwapCommitments[index],
-          rootCanisterId,
-        } as SnsSwapCommitment)
-    );
-  }
-
-  // TODO(L2-829, L2-751): remove and replace with effective data - i.e. summary comes from sns gov canister through sns wrapper
-  return mockSwapCommitments.find(
-    (mock) => rootCanisterId === mock.rootCanisterId.toText()
-  ) as SnsSwapCommitment;
+  return {
+    rootCanisterId: Principal.fromText(rootCanisterId),
+    myCommitment: userCommitment,
+    currentCommitment: swapState?.derived[0]?.buyer_total_icp_e8s ?? BigInt(0),
+  };
 };
 
 export const participateInSnsSwap = async ({

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -422,7 +422,8 @@ export const querySnsSwapCommitment = async ({
   return {
     rootCanisterId: Principal.fromText(rootCanisterId),
     myCommitment: userCommitment,
-    currentCommitment: swapState?.derived[0]?.buyer_total_icp_e8s ?? BigInt(0),
+    currentCommitment:
+      swapState?.derived?.[0]?.buyer_total_icp_e8s ?? BigInt(0),
   };
 };
 

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -27,7 +27,7 @@
   $: myCommitment =
     swapCommitment?.myCommitment === undefined
       ? undefined
-      : ICP.fromE8s(swapCommitment.myCommitment);
+      : ICP.fromE8s(swapCommitment.myCommitment.amount_icp_e8s);
 </script>
 
 {#if durationTillDeadline !== undefined || myCommitment !== undefined}

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -29,9 +29,9 @@
   let max_icp_e8s: bigint;
   $: ({ min_icp_e8s, max_icp_e8s } = init);
 
-  // TODO: display current commitment (info soon available in a new candid field)
   let currentCommitment: bigint;
-  $: currentCommitment = min_icp_e8s;
+  $: currentCommitment =
+    $projectDetailStore.swapCommitment?.currentCommitment ?? BigInt(0);
 
   let currentCommitmentIcp: ICP;
   $: currentCommitmentIcp = ICP.fromE8s(currentCommitment);

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -25,7 +25,7 @@
   let myCommitmentIcp: ICP | undefined;
   $: myCommitmentIcp =
     swapCommitment?.myCommitment !== undefined
-      ? ICP.fromE8s(swapCommitment.myCommitment)
+      ? ICP.fromE8s(swapCommitment.myCommitment.amount_icp_e8s)
       : undefined;
 
   let showModal: boolean = false;

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -262,7 +262,13 @@ export const participateInSwap = async ({
     await loadSnsSwapCommitment({
       strategy: "update",
       rootCanisterId: rootCanisterId.toText(),
-      onLoad: ({ response: swapCommitment }) => onSuccess?.(swapCommitment),
+      onLoad: ({ response: swapCommitment, certified }) => {
+        snsSwapCommitmentsStore.setSwapCommitment({
+          swapCommitment,
+          certified,
+        });
+        onSuccess?.(swapCommitment);
+      },
       onError: () => {
         // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-798
       },

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -1,5 +1,9 @@
 import type { Principal } from "@dfinity/principal";
-import type { SnsSwapInit, SnsSwapState } from "@dfinity/sns";
+import type {
+  SnsSwapBuyerState,
+  SnsSwapInit,
+  SnsSwapState,
+} from "@dfinity/sns";
 
 export interface SnsSummarySwap {
   init: SnsSwapInit;
@@ -24,6 +28,6 @@ export interface SnsSummary {
 
 export interface SnsSwapCommitment {
   rootCanisterId: Principal;
-  myCommitment: bigint | undefined; // e8s
+  myCommitment: SnsSwapBuyerState | undefined; // e8s
   currentCommitment: bigint; // e8s
 }

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -10,6 +10,7 @@ import { get } from "svelte/store";
 import {
   participateInSnsSwap,
   querySnsSummaries,
+  querySnsSwapCommitment,
   querySnsSwapState,
   querySnsSwapStates,
 } from "../../../lib/api/sns.api";
@@ -19,7 +20,11 @@ import {
 } from "../../../lib/proxy/api.import.proxy";
 import { snsesCountStore } from "../../../lib/stores/projects.store";
 import { mockIdentity } from "../../mocks/auth.store.mock";
-import { mockSwapInit, mockSwapState } from "../../mocks/sns-projects.mock";
+import {
+  createBuyersState,
+  mockSwapInit,
+  mockSwapState,
+} from "../../mocks/sns-projects.mock";
 import {
   deployedSnsMock,
   governanceCanisterIdMock,
@@ -43,9 +48,17 @@ describe("sns-api", () => {
         state: [mockSwapState],
       },
     ],
+    derived: [
+      {
+        sns_tokens_per_icp: 1,
+        buyer_total_icp_e8s: BigInt(1_000_000_000),
+      },
+    ],
   };
 
   const notifyParticipationSpy = jest.fn().mockResolvedValue(undefined);
+  const mockUserCommitment = createBuyersState(BigInt(100_000_000));
+  const getUserCommitmentSpy = jest.fn().mockResolvedValue(mockUserCommitment);
   const ledgerCanisterMock = mock<LedgerCanister>();
 
   beforeEach(() => {
@@ -71,6 +84,7 @@ describe("sns-api", () => {
         metadata: () => Promise.resolve("metadata"),
         swapState: () => Promise.resolve(mockQuerySwap),
         notifyParticipation: notifyParticipationSpy,
+        getUserCommitment: getUserCommitmentSpy,
       })
     );
   });
@@ -121,6 +135,20 @@ describe("sns-api", () => {
 
     expect(states.length).toEqual(1);
     expect(states[0]?.swap).toEqual(mockQuerySwap.swap);
+  });
+
+  it("should return swap commitment", async () => {
+    const commitment = await querySnsSwapCommitment({
+      rootCanisterId: rootCanisterIdMock.toText(),
+      identity: mockIdentity,
+      certified: false,
+    });
+    expect(getUserCommitmentSpy).toBeCalled();
+    expect(commitment).toEqual({
+      rootCanisterId: rootCanisterIdMock,
+      myCommitment: mockUserCommitment,
+      currentCommitment: mockQuerySwap.derived[0].buyer_total_icp_e8s,
+    });
   });
 
   it("should participate in a swap by transferring and notifying", async () => {

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -78,7 +78,8 @@ describe("ProjectCardSwapInfo", () => {
     });
 
     const icpValue = formatICP({
-      value: mockSnsFullProject.swapCommitment?.myCommitment as bigint,
+      value: mockSnsFullProject.swapCommitment?.myCommitment
+        ?.amount_icp_e8s as bigint,
     });
 
     expect(getByText(icpValue, { exact: false })).toBeInTheDocument();

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -162,7 +162,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
   .map((summary, index) => ({
     ...summary,
     rootCanisterId: principal(index),
-  })) as SnsSummary[];
+  })) as unknown as SnsSummary[];
 
 export const mockSummary = mockSnsSummaryList[0];
 

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -29,7 +29,7 @@ const principal = (index: number): Principal =>
     ),
   ][index];
 
-const createBuyersState = (amount) => ({
+export const createBuyersState = (amount) => ({
   icp_disbursing: false,
   amount_sns_e8s: BigInt(0),
   amount_icp_e8s: amount,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -29,18 +29,24 @@ const principal = (index: number): Principal =>
     ),
   ][index];
 
+const createBuyersState = (amount) => ({
+  icp_disbursing: false,
+  amount_sns_e8s: BigInt(0),
+  amount_icp_e8s: amount,
+  sns_disbursing: false,
+});
 export const mockSnsSwapCommitment = (
   rootCanisterId: Principal
 ): SnsSwapCommitment =>
   ({
     [principal(0).toText()]: {
       rootCanisterId: principal(0),
-      myCommitment: BigInt(25 * 100000000),
+      myCommitment: createBuyersState(BigInt(25 * 100000000)),
       currentCommitment: BigInt(100 * 100000000),
     },
     [principal(1).toText()]: {
       rootCanisterId: principal(1),
-      myCommitment: BigInt(5 * 100000000),
+      myCommitment: createBuyersState(BigInt(5 * 100000000)),
       currentCommitment: BigInt(775 * 100000000),
     },
     [principal(2).toText()]: {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -2,7 +2,11 @@ import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsSwapState } from "@dfinity/sns";
 import type { Subscriber } from "svelte/store";
 import type { SnsFullProject } from "../../lib/stores/projects.store";
-import type { SnsSummary, SnsSwapCommitment } from "../../lib/types/sns";
+import type {
+  SnsSummary,
+  SnsSummarySwap,
+  SnsSwapCommitment,
+} from "../../lib/types/sns";
 import { shuffle } from "../../lib/utils/dev.utils";
 
 export const mockProjectSubscribe =
@@ -89,7 +93,7 @@ export const mockSwapState = {
   buyers: [],
 } as SnsSwapState;
 
-export const mockSwap = {
+export const mockSwap: SnsSummarySwap = {
   init: mockSwapInit,
   state: mockSwapState,
 };
@@ -168,7 +172,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
   .map((summary, index) => ({
     ...summary,
     rootCanisterId: principal(index),
-  })) as unknown as SnsSummary[];
+  })) as SnsSummary[];
 
 export const mockSummary = mockSnsSummaryList[0];
 


### PR DESCRIPTION
# Motivation

User can see whether he or she is participating in a decentralized sale.

# Changes

* Change myCommitment prop type to SnsSwapBuyerState in SnsSwapCommitment
* Use new sns method getUserCommitment in the querySnsSwapCommitment sns api instead of mocked data.
* Upgrade sns-js

# Tests

* Add test for querySnsSwapCommitment sns api function.
* Fix broken test after type change.
