### PR TITLE
Fix: Back buttons working in add cycles flow

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccount.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccount.svelte
@@ -36,7 +36,11 @@
       (hardwareWalletAccounts?.length > 0 && !hideHardwareWalletAccounts));
 </script>
 
-<div class="wizard-list" class:disabled={disableSelection}>
+<div
+  class="wizard-list"
+  class:disabled={disableSelection}
+  data-tid="select-account-screen"
+>
   {#if mainAccount}
     {#if showTitle}
       <h4>{$i18n.accounts.my_accounts}</h4>

--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -45,7 +45,10 @@
     <slot />
   </div>
   <FooterModal>
-    <button class="secondary small" on:click={() => dispatcher("nnsBack")}
+    <button
+      class="secondary small"
+      on:click={() => dispatcher("nnsBack")}
+      data-tid="confirm-cycles-canister-button-back"
       >{$i18n.canisters.edit_cycles}</button
     >
     <button

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -105,6 +105,7 @@
     <button
       type="button"
       class="secondary small"
+      data-tid="select-cycles-button-back"
       on:click={() => dispatcher("nnsBack")}
       >{$i18n.canisters.edit_source}</button
     >

--- a/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -119,6 +119,7 @@
         {icpToCyclesExchangeRate}
         bind:amount
         on:nnsClose
+        on:nnsBack={() => modal.back()}
         on:nnsSelectAmount={selectAmount}
       >
         <p>
@@ -143,6 +144,7 @@
         {icpToCyclesExchangeRate}
         {amount}
         on:nnsClose
+        on:nnsBack={() => modal.back()}
         on:nnsConfirm={addCycles}
       >
         <div>

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -50,6 +50,70 @@ describe("AddCyclesModal", () => {
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
+  it("should be able to go back", async () => {
+    const { queryByTestId, queryAllByTestId, container, component } =
+      await renderModal({
+        component: AddCyclesModalTest,
+        props,
+      });
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
+
+    // Select Account Screen
+    const accountCards = queryAllByTestId("account-card");
+    expect(accountCards.length).toBe(2);
+
+    fireEvent.click(accountCards[0]);
+
+    // Select Amount Screen
+    await waitFor(() =>
+      expect(queryByTestId("select-cycles-screen")).toBeInTheDocument()
+    );
+
+    await clickByTestId(queryByTestId, "select-cycles-button-back");
+
+    // Back to: Select Account Screen
+    await waitFor(() =>
+      expect(queryByTestId("select-account-screen")).toBeInTheDocument()
+    );
+
+    const accountCards2 = queryAllByTestId("account-card");
+
+    fireEvent.click(accountCards2[0]);
+
+    // Select Amount Screen
+    await waitFor(() =>
+      expect(queryByTestId("select-cycles-screen")).toBeInTheDocument()
+    );
+
+    const icpInputElement = container.querySelector('input[name="icp-amount"]');
+    expect(icpInputElement).not.toBeNull();
+
+    icpInputElement &&
+      (await fireEvent.input(icpInputElement, {
+        target: { value: 2 },
+      }));
+    icpInputElement && (await fireEvent.blur(icpInputElement));
+
+    await clickByTestId(queryByTestId, "select-cycles-button");
+
+    // Confirm Create Canister Screen
+    await waitFor(() =>
+      expect(
+        queryByTestId("confirm-cycles-canister-screen")
+      ).toBeInTheDocument()
+    );
+
+    await clickByTestId(queryByTestId, "confirm-cycles-canister-button-back");
+
+    // Select Amount Screen
+    await waitFor(() =>
+      expect(queryByTestId("select-cycles-screen")).toBeInTheDocument()
+    );
+  });
+
   it("should top up a canister from ICP and close modal", async () => {
     const { queryByTestId, queryAllByTestId, container, component } =
       await renderModal({

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -51,11 +51,10 @@ describe("AddCyclesModal", () => {
   });
 
   it("should be able to go back", async () => {
-    const { queryByTestId, queryAllByTestId, container, component } =
-      await renderModal({
-        component: AddCyclesModalTest,
-        props,
-      });
+    const { queryByTestId, queryAllByTestId, container } = await renderModal({
+      component: AddCyclesModalTest,
+      props,
+    });
     // Wait for the onMount to load the conversion rate
     await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
     // wait to update local variable with conversion rate


### PR DESCRIPTION
# Motivation

User is able to use secondary buttons to go back in the Add Cycles flow.

# Changes

* Listen for the "nnsBack" event in the AddCyclesModal.

# Tests

* Add test for the specific fix added here.
