### PR TITLE
L2-836 and L2-891: Add title swap and account

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -196,6 +196,29 @@ const wrapper = async ({
 // TODO(L2-751): remove mock data
 let mockSnsSummaries: QuerySnsSummary[] = [];
 
+export const querySwapCanisterAccount = async ({
+  rootCanisterId,
+  identity,
+  controller,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  controller: Principal;
+}): Promise<AccountIdentifier> => {
+  const snsWrapper: SnsWrapper = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+  const principalSubaccont = SubAccount.fromPrincipal(controller);
+  const accountIdentifier = AccountIdentifier.fromPrincipal({
+    principal: snsWrapper.canisterIds.swapCanisterId,
+    subAccount: principalSubaccont,
+  });
+
+  return accountIdentifier;
+};
+
 // TODO: ultimately querySnsSummaries and querySummary will not return SnsSummary types but rather a summary related types provided by Candid sns governance
 export const querySnsSummaries = async ({
   identity,
@@ -448,10 +471,10 @@ export const participateInSnsSwap = async ({
     rootCanisterId: rootCanisterId.toText(),
     certified: true,
   });
-  const principalSubaccont = SubAccount.fromPrincipal(controller);
-  const accountIdentifier = AccountIdentifier.fromPrincipal({
-    principal: snsWrapper.canisterIds.swapCanisterId,
-    subAccount: principalSubaccont,
+  const accountIdentifier = await querySwapCanisterAccount({
+    rootCanisterId,
+    identity,
+    controller,
   });
 
   // Send amount to the ledger

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -1,11 +1,5 @@
 import type { HttpAgent, Identity } from "@dfinity/agent";
-import {
-  AccountIdentifier,
-  ICP,
-  SnsWasmCanister,
-  SubAccount,
-  type DeployedSns,
-} from "@dfinity/nns";
+import type { DeployedSns, ICP, SnsWasmCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { InitSnsWrapper, SnsWrapper } from "@dfinity/sns";
 import { mockSnsSummaryList } from "../../tests/mocks/sns-projects.mock";
@@ -26,6 +20,7 @@ import type {
 } from "../types/sns.query";
 import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
+import { getSwapCanisterAccount } from "../utils/sns.utils";
 import { ledgerCanister } from "./ledger.api";
 
 let snsQueryWrappers: Promise<Map<QueryRootCanisterId, SnsWrapper>> | undefined;
@@ -195,22 +190,6 @@ const wrapper = async ({
 
 // TODO(L2-751): remove mock data
 let mockSnsSummaries: QuerySnsSummary[] = [];
-
-export const querySwapCanisterAccount = ({
-  controller,
-  swapCanisterId,
-}: {
-  controller: Principal;
-  swapCanisterId: Principal;
-}): AccountIdentifier => {
-  const principalSubaccont = SubAccount.fromPrincipal(controller);
-  const accountIdentifier = AccountIdentifier.fromPrincipal({
-    principal: swapCanisterId,
-    subAccount: principalSubaccont,
-  });
-
-  return accountIdentifier;
-};
 
 // TODO: ultimately querySnsSummaries and querySummary will not return SnsSummary types but rather a summary related types provided by Candid sns governance
 export const querySnsSummaries = async ({
@@ -471,7 +450,7 @@ export const participateInSnsSwap = async ({
     rootCanisterId: rootCanisterId.toText(),
     certified: true,
   });
-  const accountIdentifier = querySwapCanisterAccount({
+  const accountIdentifier = getSwapCanisterAccount({
     swapCanisterId,
     controller,
   });

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -37,9 +37,10 @@
 
   let destinationAddress: AccountIdentifier | undefined;
   $: (async () => {
-    if ($store.summary?.swapCanisterId !== undefined) {
-      destinationAddress = await getSwapAccount($store.summary?.swapCanisterId);
-    }
+    destinationAddress =
+      $store.summary?.swapCanisterId !== undefined
+        ? await getSwapAccount($store.summary?.swapCanisterId)
+        : undefined;
   })();
 
   let accepted: boolean = false;

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import type { ICP } from "@dfinity/nns";
+  import type { AccountIdentifier } from "@dfinity/nns";
   import { createEventDispatcher, getContext } from "svelte";
   import IconSouth from "../../icons/IconSouth.svelte";
   import IconWarning from "../../icons/IconWarning.svelte";
   import FooterModal from "../../modals/FooterModal.svelte";
-  import { participateInSwap } from "../../services/sns.services";
+  import {
+    getSwapAccount,
+    participateInSwap,
+  } from "../../services/sns.services";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import { toastsStore } from "../../stores/toasts.store";
@@ -30,6 +34,13 @@
 
   let icpAmount: ICP;
   $: icpAmount = convertNumberToICP(amount);
+
+  let destinationAddress: AccountIdentifier | undefined;
+  $: (async () => {
+    if ($store.summary?.rootCanisterId !== undefined) {
+      destinationAddress = await getSwapAccount($store.summary?.rootCanisterId);
+    }
+  })();
 
   let accepted: boolean = false;
   const toggelAccept = () => (accepted = !accepted);
@@ -65,7 +76,7 @@
 <div data-tid="sns-swap-participate-step-2">
   <div class="info">
     <KeyValuePair>
-      <span slot="key">Source</span>
+      <span slot="key">{$i18n.accounts.source}</span>
       <Icp slot="value" singleLine icp={account.balance} />
     </KeyValuePair>
     <div>
@@ -89,8 +100,10 @@
     </div>
     <div>
       <h5>{$i18n.accounts.destination}</h5>
-      <!-- TODO: What is this? Question pending to be answered -->
-      <p>Entrepot 1239871294879871249123</p>
+      <p>{$store.summary?.name}</p>
+      {#if destinationAddress !== undefined}
+        <p>{destinationAddress.toHex()}</p>
+      {/if}
     </div>
     <div>
       <h5>{$i18n.sns_project_detail.description}</h5>

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -37,8 +37,8 @@
 
   let destinationAddress: AccountIdentifier | undefined;
   $: (async () => {
-    if ($store.summary?.rootCanisterId !== undefined) {
-      destinationAddress = await getSwapAccount($store.summary?.rootCanisterId);
+    if ($store.summary?.swapCanisterId !== undefined) {
+      destinationAddress = await getSwapAccount($store.summary?.swapCanisterId);
     }
   })();
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -564,8 +564,8 @@
     "status_unspecified": "Unspecified",
     "transaction_fee": "(transaction fee)",
     "description": "Description",
-    "participate_swap_description": "Participate in Token Swap",
-    "participate_swap_warning": "Your participation cannot be withdrawn by you. If the token swap is not successful, your commitment will be automatically transferred back to your main ICP account.",
+    "participate_swap_description": "Participate in Decentralized Sale",
+    "participate_swap_warning": "Your participation cannot be withdrawn by you. If the sale is not successful, your commitment will be automatically transferred back to your main ICP account.",
     "understand_agree": "I understand and agree.",
     "edit_transaction": "Edit Transaction",
     "execute": "Execute",
@@ -638,7 +638,7 @@
     "undefined_project": "The requested project is invalid or throws an error.",
     "list_summaries": "There was an unexpected error while loading the summaries of all deployed projects.",
     "load_summary": "There was an unexpected error while loading the project.",
-    "list_swap_commitments": "There was an unexpected error while loading the commitments of the swaps of all deployed projects.",
-    "load_swap_commitment": "There was an unexpected error while loading the commitment of the swap of the project."
+    "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
+    "load_swap_commitment": "There was an unexpected error while loading the commitment of of the project."
   }
 }

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -247,14 +247,13 @@ export const routePathRootCanisterId = (path: string): string | undefined => {
 };
 
 export const getSwapAccount = async (
-  rootCanisterId: Principal
+  swapCanisterId: Principal
 ): Promise<AccountIdentifier | undefined> => {
   try {
     const identity = await getIdentity();
-    return await querySwapCanisterAccount({
-      rootCanisterId,
+    return querySwapCanisterAccount({
       controller: identity.getPrincipal(),
-      identity,
+      swapCanisterId,
     });
   } catch (error) {
     return undefined;

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -13,7 +13,6 @@ import {
   querySnsSwapCommitments,
   querySnsSwapState,
   querySnsSwapStates,
-  querySwapCanisterAccount,
 } from "../api/sns.api";
 import { AppPath } from "../constants/routes.constants";
 import {
@@ -27,7 +26,7 @@ import type { SnsSwapCommitment } from "../types/sns";
 import type { QuerySnsSummary, QuerySnsSwapState } from "../types/sns.query";
 import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
-import { concatSnsSummaries } from "../utils/sns.utils";
+import { concatSnsSummaries, getSwapCanisterAccount } from "../utils/sns.utils";
 import { getAccountIdentity } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
@@ -248,16 +247,12 @@ export const routePathRootCanisterId = (path: string): string | undefined => {
 
 export const getSwapAccount = async (
   swapCanisterId: Principal
-): Promise<AccountIdentifier | undefined> => {
-  try {
-    const identity = await getIdentity();
-    return querySwapCanisterAccount({
-      controller: identity.getPrincipal(),
-      swapCanisterId,
-    });
-  } catch (error) {
-    return undefined;
-  }
+): Promise<AccountIdentifier> => {
+  const identity = await getIdentity();
+  return getSwapCanisterAccount({
+    controller: identity.getPrincipal(),
+    swapCanisterId,
+  });
 };
 
 export const participateInSwap = async ({

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -1,4 +1,9 @@
-import { ICP, Topic, type ProposalInfo } from "@dfinity/nns";
+import {
+  ICP,
+  Topic,
+  type AccountIdentifier,
+  type ProposalInfo,
+} from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import {
   participateInSnsSwap,
@@ -8,6 +13,7 @@ import {
   querySnsSwapCommitments,
   querySnsSwapState,
   querySnsSwapStates,
+  querySwapCanisterAccount,
 } from "../api/sns.api";
 import { AppPath } from "../constants/routes.constants";
 import {
@@ -23,6 +29,7 @@ import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
 import { concatSnsSummaries } from "../utils/sns.utils";
 import { getAccountIdentity } from "./accounts.services";
+import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
 import {
   queryAndUpdate,
@@ -237,6 +244,21 @@ export const routePathRootCanisterId = (path: string): string | undefined => {
     return undefined;
   }
   return getLastPathDetail(path);
+};
+
+export const getSwapAccount = async (
+  rootCanisterId: Principal
+): Promise<AccountIdentifier | undefined> => {
+  try {
+    const identity = await getIdentity();
+    return await querySwapCanisterAccount({
+      rootCanisterId,
+      controller: identity.getPrincipal(),
+      identity,
+    });
+  } catch (error) {
+    return undefined;
+  }
 };
 
 export const participateInSwap = async ({

--- a/frontend/src/lib/types/sns.query.ts
+++ b/frontend/src/lib/types/sns.query.ts
@@ -1,12 +1,14 @@
+import type { Principal } from "@dfinity/principal";
 import type { SnsSwap } from "@dfinity/sns";
 import type { SnsSummary } from "./sns";
 
 export type QueryRootCanisterId = string;
 
 // TODO: this type is temporary, ultimately it should be updated with the proper candid type that will be used to query the summary from the backend
-export type QuerySnsSummary = Omit<SnsSummary, "swap">;
+export type QuerySnsSummary = Omit<SnsSummary, "swap" | "swapCanisterId">;
 
 export type QuerySnsSwapState = {
   rootCanisterId: QueryRootCanisterId;
+  swapCanisterId: Principal;
   swap: [] | [SnsSwap];
 };

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -12,6 +12,8 @@ export interface SnsSummarySwap {
 
 export interface SnsSummary {
   rootCanisterId: Principal;
+  // Used to calculate the account for the participation.
+  swapCanisterId: Principal;
 
   // TODO: to be replaced with real types for real data
 

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,3 +1,4 @@
+import { AccountIdentifier, SubAccount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwap, SnsSwapInit, SnsSwapState } from "@dfinity/sns";
 import type { SnsSummary } from "../types/sns";
@@ -109,4 +110,20 @@ export const concatSnsSummary = ([summary, swap]: [
       state,
     },
   };
+};
+
+export const getSwapCanisterAccount = ({
+  controller,
+  swapCanisterId,
+}: {
+  controller: Principal;
+  swapCanisterId: Principal;
+}): AccountIdentifier => {
+  const principalSubaccont = SubAccount.fromPrincipal(controller);
+  const accountIdentifier = AccountIdentifier.fromPrincipal({
+    principal: swapCanisterId,
+    subAccount: principalSubaccont,
+  });
+
+  return accountIdentifier;
 };

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -171,9 +171,8 @@ describe("sns-api", () => {
 
   it("should return swap canister account", async () => {
     const expectedAccount = await querySwapCanisterAccount({
-      rootCanisterId: rootCanisterIdMock,
+      swapCanisterId: rootCanisterIdMock,
       controller: mockIdentity.getPrincipal(),
-      identity: mockIdentity,
     });
     expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
   });

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -3,7 +3,12 @@
  */
 
 import type { HttpAgent } from "@dfinity/agent";
-import { ICP, LedgerCanister, type SnsWasmCanisterOptions } from "@dfinity/nns";
+import {
+  AccountIdentifier,
+  ICP,
+  LedgerCanister,
+  type SnsWasmCanisterOptions,
+} from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import mock from "jest-mock-extended/lib/Mock";
 import { get } from "svelte/store";
@@ -13,6 +18,7 @@ import {
   querySnsSwapCommitment,
   querySnsSwapState,
   querySnsSwapStates,
+  querySwapCanisterAccount,
 } from "../../../lib/api/sns.api";
 import {
   importInitSnsWrapper,
@@ -161,5 +167,14 @@ describe("sns-api", () => {
 
     expect(ledgerCanisterMock.transfer).toBeCalled();
     expect(notifyParticipationSpy).toBeCalled();
+  });
+
+  it("should return swap canister account", async () => {
+    const expectedAccount = await querySwapCanisterAccount({
+      rootCanisterId: rootCanisterIdMock,
+      controller: mockIdentity.getPrincipal(),
+      identity: mockIdentity,
+    });
+    expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
   });
 });

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -3,12 +3,7 @@
  */
 
 import type { HttpAgent } from "@dfinity/agent";
-import {
-  AccountIdentifier,
-  ICP,
-  LedgerCanister,
-  type SnsWasmCanisterOptions,
-} from "@dfinity/nns";
+import { ICP, LedgerCanister, type SnsWasmCanisterOptions } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import mock from "jest-mock-extended/lib/Mock";
 import { get } from "svelte/store";
@@ -18,7 +13,6 @@ import {
   querySnsSwapCommitment,
   querySnsSwapState,
   querySnsSwapStates,
-  querySwapCanisterAccount,
 } from "../../../lib/api/sns.api";
 import {
   importInitSnsWrapper,
@@ -167,13 +161,5 @@ describe("sns-api", () => {
 
     expect(ledgerCanisterMock.transfer).toBeCalled();
     expect(notifyParticipationSpy).toBeCalled();
-  });
-
-  it("should return swap canister account", async () => {
-    const expectedAccount = await querySwapCanisterAccount({
-      swapCanisterId: rootCanisterIdMock,
-      controller: mockIdentity.getPrincipal(),
-    });
-    expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
   });
 });

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { AccountIdentifier } from "@dfinity/nns";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 import ParticipateSwapModal from "../../../../lib/modals/sns/ParticipateSwapModal.svelte";
@@ -12,7 +13,10 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "../../../../lib/types/project-detail.context";
-import { mockAccountsStoreSubscribe } from "../../../mocks/accounts.store.mock";
+import {
+  mockAccountsStoreSubscribe,
+  mockMainAccount,
+} from "../../../mocks/accounts.store.mock";
 import { renderModalContextWrapper } from "../../../mocks/modal.mock";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 import { clickByTestId } from "../../testHelpers/clickByTestId";
@@ -20,6 +24,11 @@ import { clickByTestId } from "../../testHelpers/clickByTestId";
 jest.mock("../../../../lib/services/sns.services", () => {
   return {
     participateInSwap: jest.fn().mockResolvedValue({ success: true }),
+    getSwapAccount: jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(AccountIdentifier.fromHex(mockMainAccount.identifier))
+      ),
   };
 });
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -3,12 +3,7 @@ import { Principal } from "@dfinity/principal";
 import * as api from "../../../lib/api/sns.api";
 import * as services from "../../../lib/services/sns.services";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
-import {
-  mockIdentity,
-  mockPrincipal,
-  resetIdentity,
-  setNoIdentity,
-} from "../../mocks/auth.store.mock";
+import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockSnsSwapCommitment } from "../../mocks/sns-projects.mock";
 
 const { participateInSwap, getSwapAccount } = services;
@@ -81,23 +76,10 @@ describe("sns-services", () => {
   });
 
   describe("getSwapAccount", () => {
-    const spyQuery = jest
-      .spyOn(api, "querySwapCanisterAccount")
-      .mockImplementation(() =>
-        AccountIdentifier.fromHex(mockMainAccount.identifier)
-      );
     afterEach(() => jest.clearAllMocks());
     it("should return the swap canister account identifier", async () => {
       const account = await getSwapAccount(mockPrincipal);
       expect(account).toBeInstanceOf(AccountIdentifier);
-      expect(spyQuery).toBeCalled();
-    });
-    it("should return undefined if no identity", async () => {
-      setNoIdentity();
-      const account = await getSwapAccount(mockPrincipal);
-      expect(account).toBeUndefined();
-      expect(spyQuery).not.toBeCalled();
-      resetIdentity();
     });
   });
 });

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -84,7 +84,7 @@ describe("sns-services", () => {
     const spyQuery = jest
       .spyOn(api, "querySwapCanisterAccount")
       .mockImplementation(() =>
-        Promise.resolve(AccountIdentifier.fromHex(mockMainAccount.identifier))
+        AccountIdentifier.fromHex(mockMainAccount.identifier)
       );
     afterEach(() => jest.clearAllMocks());
     it("should return the swap canister account identifier", async () => {

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,8 +1,11 @@
+import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
   concatSnsSummaries,
   concatSnsSummary,
+  getSwapCanisterAccount,
 } from "../../../lib/utils/sns.utils";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   mockSnsSummaryList,
   mockSummary,
@@ -10,6 +13,7 @@ import {
   mockSwapInit,
   mockSwapState,
 } from "../../mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 
 describe("sns-utils", () => {
   describe("concat sns summaries", () => {
@@ -233,6 +237,16 @@ describe("sns-utils", () => {
         swap: mockSwap,
         swapCanisterId,
       });
+    });
+  });
+
+  describe("getSwapCanisterAccount", () => {
+    it("should return swap canister account", async () => {
+      const expectedAccount = await getSwapCanisterAccount({
+        swapCanisterId: rootCanisterIdMock,
+        controller: mockIdentity.getPrincipal(),
+      });
+      expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,3 +1,4 @@
+import { Principal } from "@dfinity/principal";
 import {
   concatSnsSummaries,
   concatSnsSummary,
@@ -30,6 +31,7 @@ describe("sns-utils", () => {
         [
           {
             rootCanisterId: "1234",
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [],
@@ -49,6 +51,7 @@ describe("sns-utils", () => {
         [
           {
             rootCanisterId: "1234",
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -68,6 +71,7 @@ describe("sns-utils", () => {
         [
           {
             rootCanisterId: "1234",
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -87,6 +91,7 @@ describe("sns-utils", () => {
         [
           {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -108,6 +113,7 @@ describe("sns-utils", () => {
         [
           {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -127,6 +133,7 @@ describe("sns-utils", () => {
           },
           {
             rootCanisterId: mockSnsSummaryList[1].rootCanisterId.toText(),
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -174,6 +181,7 @@ describe("sns-utils", () => {
           mockSummary,
           {
             rootCanisterId: "1234",
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [],
@@ -192,6 +200,7 @@ describe("sns-utils", () => {
           mockSummary,
           {
             rootCanisterId: "1234",
+            swapCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 init: [mockSwapInit],
@@ -204,10 +213,12 @@ describe("sns-utils", () => {
       expect(call).toThrow();
     });
     it("should concat summary and swap", () => {
+      const swapCanisterId = Principal.fromText("aaaaa-aa");
       const summary = concatSnsSummary([
         mockSummary,
         {
           rootCanisterId: "1234",
+          swapCanisterId,
           swap: [
             {
               init: [mockSwapInit],
@@ -220,6 +231,7 @@ describe("sns-utils", () => {
       expect(summary).toEqual({
         ...mockSummary,
         swap: mockSwap,
+        swapCanisterId,
       });
     });
   });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -101,6 +101,7 @@ export const mockSwap: SnsSummarySwap = {
 export const mockSnsSummaryList: SnsSummary[] = shuffle([
   {
     rootCanisterId: principal(0),
+    swapCanisterId: principal(3),
 
     minCommitment: BigInt(1500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
@@ -118,6 +119,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
   },
   {
     rootCanisterId: principal(1),
+    swapCanisterId: principal(2),
 
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(2000 * 100000000),
@@ -135,6 +137,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
   },
   {
     rootCanisterId: principal(2),
+    swapCanisterId: principal(1),
 
     minCommitment: BigInt(1000 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),
@@ -152,6 +155,7 @@ export const mockSnsSummaryList: SnsSummary[] = shuffle([
   },
   {
     rootCanisterId: principal(3),
+    swapCanisterId: principal(0),
 
     minCommitment: BigInt(500 * 100000000),
     maxCommitment: BigInt(3000 * 100000000),


### PR DESCRIPTION
# Motivation

User can see the account where ICP is transferred when participating in a swap.

User participates in a Decentralized Sale, not in a swap.

# Changes

* Change Swap reference to Decentralized Sale in user facing communication.
* New sns api function querySwapCanisterAccount.
* Use new sns api function when participating.
* New sns service to get the account which uses new sns api querySwapCanisterAccount.
* Use new sns service in the ReviewParticipate component.

# Tests

* Fix broken test.
* New test for new sns api function.
* New test for new sns service function
