### PR TITLE
Delete the network for all IDs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -253,7 +253,7 @@ if [[ "$DELETE_WALLET" == "true" ]]; then
         : Back up wallet
         cp "${WALLET_FILE}" "${WALLET_FILE}.$(date -Isecond -u | sed 's/+.*//g')"
         echo "Deleting the wallet for $DFX_NETWORK in $WALLET_FILE ..."
-        DFX_NETWORK="$DFX_NETWORK" DFX_ID="$DFX_ID" jq 'del(.identities[env.DFX_ID][env.DFX_NETWORK])' "${WALLET_FILE}" >"${WALLET_FILE}.new"
+        DFX_NETWORK="$DFX_NETWORK" DFX_ID="$DFX_ID" jq 'del(.identities[env.DFX_ID][env.DFX_NETWORK])' "${WALLET_FILE}" | jq -s first >"${WALLET_FILE}.new"
         mv "${WALLET_FILE}.new" "${WALLET_FILE}"
       fi
     done

--- a/deploy.sh
+++ b/deploy.sh
@@ -244,14 +244,17 @@ if [[ "$DELETE_CANISTER_IDS" == "true" ]]; then
 fi
 
 if [[ "$DELETE_WALLET" == "true" ]]; then
-  WALLET_FILE="${HOME}/.config/dfx/identity/$(dfx identity whoami)/wallets.json"
-  if test -e "$WALLET_FILE"; then
-    : Back up wallet
-    cp "${WALLET_FILE}" "${WALLET_FILE}.$(date -Isecond -u | sed 's/+.*//g')"
-    echo "Deleting the wallet for $DFX_NETWORK in $WALLET_FILE ..."
-    DFX_NETWORK="$DFX_NETWORK" jq 'del(.identities.default[env.DFX_NETWORK])' "${WALLET_FILE}" >"${WALLET_FILE}.new"
-    mv "${WALLET_FILE}.new" "${WALLET_FILE}"
-  fi
+  dfx identity list |
+    while read DFX_ID; do
+      WALLET_FILE="${HOME}/.config/dfx/identity/$DFX_ID/wallets.json"
+      if test -e "$WALLET_FILE"; then
+        : Back up wallet
+        cp "${WALLET_FILE}" "${WALLET_FILE}.$(date -Isecond -u | sed 's/+.*//g')"
+        echo "Deleting the wallet for $DFX_NETWORK in $WALLET_FILE ..."
+        DFX_NETWORK="$DFX_NETWORK" DFX_ID="$DFX_ID" jq 'del(.identities[env.DFX_ID][env.DFX_NETWORK])' "${WALLET_FILE}" >"${WALLET_FILE}.new"
+        mv "${WALLET_FILE}.new" "${WALLET_FILE}"
+      fi
+    done
 fi
 
 if [[ "$START_DFX" == "true" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -244,8 +244,10 @@ if [[ "$DELETE_CANISTER_IDS" == "true" ]]; then
 fi
 
 if [[ "$DELETE_WALLET" == "true" ]]; then
-  dfx identity list |
-    while read DFX_ID; do
+  # Note: "list" puts a '*' printed next to the current ID, but it is on stderr
+  #       so we discard it on dev/null leaving just the user's identities, one per line.
+  dfx identity list 2>/dev/null |
+    while read -r DFX_ID; do
       WALLET_FILE="${HOME}/.config/dfx/identity/$DFX_ID/wallets.json"
       if test -e "$WALLET_FILE"; then
         : Back up wallet


### PR DESCRIPTION
# Motivation
After redeploying a testnet, all wallet canisters are gone.  This is correct and expected, however if there are wallets in the user's config, they will fail to work with a confusing message.  There is  already a command that cleans local user state, for use after deploying a testnet, however it only deleted the wallet for one identity.  Now that we use several identities, that is no longer enough.

# Changes
* `--delete` now deletes the wallets for a network from all identities.

# Tests
I have run this and examined the wallet files.