### PR TITLE
build: bump sns-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -800,9 +800,9 @@
       "peer": true
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.2-nightly-2022-07-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-27.tgz",
-      "integrity": "sha512-u/EL5OtZd4STYIGM1YdJUsjncgLVpAxf73bw2MXlAd/gefaBVLZDUAIWEILToc6TpnWaJOEOSq826Y8CB7Vi1w=="
+      "version": "0.0.2-nightly-2022-07-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-28.tgz",
+      "integrity": "sha512-fjd80NhM1ydP1jvBuDh6K5Qz9W2On9kVkupHjUrrKZSfrxX9j4LeDHnWQYRWqFyNMK8kQ0oKJGU8Dp+zGPZlWA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -9349,9 +9349,9 @@
       "peer": true
     },
     "@dfinity/sns": {
-      "version": "0.0.2-nightly-2022-07-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-27.tgz",
-      "integrity": "sha512-u/EL5OtZd4STYIGM1YdJUsjncgLVpAxf73bw2MXlAd/gefaBVLZDUAIWEILToc6TpnWaJOEOSq826Y8CB7Vi1w=="
+      "version": "0.0.2-nightly-2022-07-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.2-nightly-2022-07-28.tgz",
+      "integrity": "sha512-fjd80NhM1ydP1jvBuDh6K5Qz9W2On9kVkupHjUrrKZSfrxX9j4LeDHnWQYRWqFyNMK8kQ0oKJGU8Dp+zGPZlWA=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",


### PR DESCRIPTION
# Motivation

Bump sns-js which contains the renaming of the canister with prefix `Sns`. Because we use the wrapper this needs no changes in nns-dapp.

# Changes

- bump sns-js nightly
