### PR TITLE
feat: lazy load sns at boot time

### DIFF
--- a/frontend/src/lib/proxy/sns.services.proxy.ts
+++ b/frontend/src/lib/proxy/sns.services.proxy.ts
@@ -1,0 +1,11 @@
+const importSnsServices = () => import("../services/sns.services");
+
+export const loadSnsSummariesProxy = async (): Promise<void> => {
+  const { loadSnsSummaries } = await importSnsServices();
+  return loadSnsSummaries();
+};
+
+export const loadSnsSwapCommitmentsProxy = async (): Promise<void> => {
+  const { loadSnsSwapCommitments } = await importSnsServices();
+  return loadSnsSwapCommitments();
+};

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,7 +1,10 @@
 import { ENABLE_SNS_NEURONS } from "../constants/environment.constants";
+import {
+  loadSnsSummariesProxy,
+  loadSnsSwapCommitmentsProxy,
+} from "../proxy/sns.services.proxy";
 import { syncAccounts } from "./accounts.services";
 import { listNeurons } from "./neurons.services";
-import { loadSnsSummaries, loadSnsSwapCommitments } from "./sns.services";
 import { loadMainTransactionFee } from "./transaction-fees.services";
 
 export const initApp = (): Promise<
@@ -15,7 +18,7 @@ export const initApp = (): Promise<
 
   // Sns in an initiative currently under development and not proposed on mainnet yet
   const initSns: Promise<void>[] = ENABLE_SNS_NEURONS
-    ? [loadSnsSummaries(), loadSnsSwapCommitments()]
+    ? [loadSnsSummariesProxy(), loadSnsSwapCommitmentsProxy()]
     : [];
 
   /**


### PR DESCRIPTION
# Motivation

When user access the login screen, the JavaScript code related to Sns should not be loaded until he/she sign-in.

# Changes

- lazy load sns services initialization

# Boot time Screenshots

Before PR:

<img width="1510" alt="Capture d’écran 2022-08-01 à 10 52 52" src="https://user-images.githubusercontent.com/16886711/182111699-e9730b21-b651-47e4-b3fb-622ccf847868.png">

After PR:

<img width="1510" alt="Capture d’écran 2022-08-01 à 10 52 27" src="https://user-images.githubusercontent.com/16886711/182111674-e83737af-fc96-433e-a32e-d3ab2b9d0a8c.png">

