### PR TITLE
feat: woff2 mime type support

### DIFF
--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -165,6 +165,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
             "jpg" => Some("image/jpeg"),
             "ico" => Some("image/x-icon"),
             "ttf" => Some("font/ttf"),
+            "woff2" => Some("font/woff2"),
             _ => None,
         })
         .flatten()


### PR DESCRIPTION
# Motivation

Add font `woff2` to the list of supported mime type.

# Note

Found the mime type `font/woff2` mentioned in various discussion on SO and also in this link: https://www.iana.org/assignments/media-types/media-types.xhtml#font

# Changes

- add response mime type `font/woff2` to the asset canister
