### PR TITLE
L2-902: Sns Neuron Id Display

### DIFF
--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -6,7 +6,7 @@
   import {
     getSnsDissolvingTimeInSeconds,
     getSnsLockedTimeInSeconds,
-    getSnsNeuronId,
+    getSnsNeuronIdAsHexString,
     getSnsNeuronStake,
     getSnsNeuronState,
     getSnsStateInfo,
@@ -22,7 +22,7 @@
   export let ariaLabel: string;
 
   let neuronId: string;
-  $: neuronId = getSnsNeuronId(neuron);
+  $: neuronId = getSnsNeuronIdAsHexString(neuron);
 
   let neuronICP: ICP;
   $: neuronICP = ICP.fromE8s(getSnsNeuronStake(neuron));

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -8,7 +8,7 @@
   import SnsNeuronCard from "../components/sns-neurons/SnsNeuronCard.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { snsProjectSelectedStore } from "../stores/projects.store";
-  import { getSnsNeuronId } from "../utils/sns-neuron.utils";
+  import { getSnsNeuronIdAsHexString } from "../utils/sns-neuron.utils";
   import type { Unsubscriber } from "svelte/store";
   import { onDestroy } from "svelte";
 
@@ -43,7 +43,7 @@
     <SkeletonCard />
     <SkeletonCard />
   {:else}
-    {#each $sortedSnsNeuronStore as neuron (getSnsNeuronId(neuron))}
+    {#each $sortedSnsNeuronStore as neuron (getSnsNeuronIdAsHexString(neuron))}
       <SnsNeuronCard
         role="link"
         {neuron}

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -3,6 +3,7 @@ import type { SnsNeuron } from "@dfinity/sns";
 import type { SnsNeuronState } from "../types/sns";
 import { nowInSeconds } from "./date.utils";
 import { stateTextMapper, type StateInfo } from "./neuron.utils";
+import { bytesToHexString } from "./utils";
 
 export const sortSnsNeuronsByCreatedTimestamp = (
   neurons: SnsNeuron[]
@@ -77,7 +78,6 @@ export const getSnsNeuronStake = ({
  *   id: { id: number[] },
  *   //...
  */
-// TODO: https://dfinity.atlassian.net/browse/L2-902
 export const getSnsNeuronId = (neuron: SnsNeuron): string =>
   // TODO: use upcoming fromDefinedNullable
-  neuron.id[0]?.id.join("") ?? "";
+  neuron.id[0]?.id !== undefined ? bytesToHexString(neuron.id[0]?.id) : "";

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -78,6 +78,6 @@ export const getSnsNeuronStake = ({
  *   id: { id: number[] },
  *   //...
  */
-export const getSnsNeuronId = (neuron: SnsNeuron): string =>
+export const getSnsNeuronIdAsHexString = (neuron: SnsNeuron): string =>
   // TODO: use upcoming fromDefinedNullable
-  neuron.id[0]?.id !== undefined ? bytesToHexString(neuron.id[0]?.id) : "";
+  bytesToHexString(neuron.id[0]?.id ?? []);

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -7,7 +7,7 @@ import SnsNeuronCard from "../../../../lib/components/sns-neurons/SnsNeuronCard.
 import { SECONDS_IN_YEAR } from "../../../../lib/constants/constants";
 import { nowInSeconds } from "../../../../lib/utils/date.utils";
 import { formatICP } from "../../../../lib/utils/icp.utils";
-import { getSnsNeuronId } from "../../../../lib/utils/sns-neuron.utils";
+import { getSnsNeuronIdAsHexString } from "../../../../lib/utils/sns-neuron.utils";
 import en from "../../../mocks/i18n.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
@@ -74,7 +74,9 @@ describe("SnsNeuronCard", () => {
       detailed: true,
     });
     expect(getByText(stakeText)).toBeInTheDocument();
-    expect(getByText(getSnsNeuronId(mockSnsNeuron))).toBeInTheDocument();
+    expect(
+      getByText(getSnsNeuronIdAsHexString(mockSnsNeuron))
+    ).toBeInTheDocument();
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -4,7 +4,7 @@ import { SECONDS_IN_YEAR } from "../../../lib/constants/constants";
 import {
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
-  getSnsNeuronId,
+  getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
   sortSnsNeuronsByCreatedTimestamp,
@@ -127,7 +127,7 @@ describe("sns-neuron utils", () => {
     });
   });
 
-  describe("getSnsNeuronId", () => {
+  describe("getSnsNeuronIdAsHexString", () => {
     it("returns id numbers concatenated", () => {
       const id = [
         154, 174, 251, 49, 236, 17, 214, 189, 195, 140, 58, 89, 61, 29, 138,
@@ -136,7 +136,7 @@ describe("sns-neuron utils", () => {
       const neuron: SnsNeuron = createMockSnsNeuron({
         id,
       });
-      expect(getSnsNeuronId(neuron)).toBe(
+      expect(getSnsNeuronIdAsHexString(neuron)).toBe(
         "9aaefb31ec11d6bdc38c3a593d1d8a714f308825603dd732b641c6610813ee24"
       );
     });

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -129,11 +129,16 @@ describe("sns-neuron utils", () => {
 
   describe("getSnsNeuronId", () => {
     it("returns id numbers concatenated", () => {
-      const id = [1, 2, 3, 4];
+      const id = [
+        154, 174, 251, 49, 236, 17, 214, 189, 195, 140, 58, 89, 61, 29, 138,
+        113, 79, 48, 136, 37, 96, 61, 215, 50, 182, 65, 198, 97, 8, 19, 238, 36,
+      ];
       const neuron: SnsNeuron = createMockSnsNeuron({
         id,
       });
-      expect(getSnsNeuronId(neuron)).toBe(id.join(""));
+      expect(getSnsNeuronId(neuron)).toBe(
+        "9aaefb31ec11d6bdc38c3a593d1d8a714f308825603dd732b641c6610813ee24"
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

Show the sns neuron id encoded in hex.

# Changes

* Implement the getSnsNeuronId like they do in the governance canister to display the neuron id.

# Tests

* Updated test for getSnsNeuronId
