### PR TITLE
chore: Bump IC to the latest version

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -296,7 +296,7 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     echo "Deploying SNS wasm canister..."
     NNS_URL="$(./e2e-tests/scripts/nns-dashboard --dfx-network "$DFX_NETWORK")"
     SNS_SUBNETS="$(ic-admin --nns-url "$NNS_URL" get-subnet-list | jq -r '. | map("principal \"" + . + "\"") | join("; ")')"
-    dfx deploy --network "$DFX_NETWORK" wasm_canister --argument '( record { sns_subnet_ids = vec { '"$SNS_SUBNETS"' } } )' --no-wallet
+    dfx deploy --network "$DFX_NETWORK" wasm_canister --argument '( record { sns_subnet_ids = vec { '"$SNS_SUBNETS"' }; access_controls_enabled = false; } )' --no-wallet
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"

--- a/dfx.json
+++ b/dfx.json
@@ -191,7 +191,7 @@
       "config": {
         "RUSTC_VERSION": "1.58.1",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
-        "IC_COMMIT": "268db05d70b3cc20475ba3ac046c0db9bd66c688"
+        "IC_COMMIT": "54a57a1f6f1ed99e66d6cde3100a0565e826385f"
       },
       "packtool": ""
     }

--- a/dfx.json
+++ b/dfx.json
@@ -36,7 +36,12 @@
       ],
       "candid": "target/ic/sns_wasm.did",
       "wasm": "target/ic/sns-wasm-canister.wasm",
-      "type": "custom"
+      "type": "custom",
+      "remote": {
+        "id": {
+          "small11": "qjdve-lqaaa-aaaaa-aaaeq-cai"
+        }
+      }
     },
     "sns_governance": {
       "build": [


### PR DESCRIPTION
# Motivation
The SNS has a new flag to prevent uploading wasms to the wasms canister.  We need to set it to false for testing.

# Changes
* Bump IC
* Set the `sns-wasm` canister `access_controls_enabled` to `false`.

# Tests
I have deployed small12 with this change.