### PR TITLE
build: bump nns-js (update google-protobuf) and sns-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -750,13 +750,13 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.6.0-nightly-2022-07-21",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.6.0-nightly-2022-07-21.tgz",
-      "integrity": "sha512-2aXT9dBIfb3OSFNUIf79jJPcbNNSsDVW9W44yOLKturANWs1mNR3DSdl/yAm343nHYNqIbR7qkQYK/vZrTY6jg==",
+      "version": "0.7.0-nightly-2022-08-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-nightly-2022-08-03.tgz",
+      "integrity": "sha512-MS+BjE2tArFhuhvs/FBg6iYDQLLPOqORs8s1RJ5FFoqk927UZcEPYz1eog57qxBWpkO+D0tzbCDjIDTngKX2Og==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.19.4",
+        "google-protobuf": "^3.21.0",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
@@ -802,9 +802,9 @@
       "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw=="
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.3-nightly-2022-08-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-nightly-2022-08-02.tgz",
-      "integrity": "sha512-8AMlAQZA29LS2QYxmE6mIbjw25ixqWY36tvqlgUl2SzSKb1NRuEqCY4bVAp/qNDhmgtXKQSaCEDy724qrcrAOg=="
+      "version": "0.0.3-nightly-2022-08-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-nightly-2022-08-03.tgz",
+      "integrity": "sha512-rdUsdSo92YRsjXFV2nuE5mv31hFOXZc0BgZVytWpSIMVzdxoEMqDFeta7/se2ebW76bzo3RtIhS+0ovRkDw1oA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -9459,13 +9459,13 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.6.0-nightly-2022-07-21",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.6.0-nightly-2022-07-21.tgz",
-      "integrity": "sha512-2aXT9dBIfb3OSFNUIf79jJPcbNNSsDVW9W44yOLKturANWs1mNR3DSdl/yAm343nHYNqIbR7qkQYK/vZrTY6jg==",
+      "version": "0.7.0-nightly-2022-08-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-nightly-2022-08-03.tgz",
+      "integrity": "sha512-MS+BjE2tArFhuhvs/FBg6iYDQLLPOqORs8s1RJ5FFoqk927UZcEPYz1eog57qxBWpkO+D0tzbCDjIDTngKX2Og==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.19.4",
+        "google-protobuf": "^3.21.0",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       },
@@ -9494,9 +9494,9 @@
       "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw=="
     },
     "@dfinity/sns": {
-      "version": "0.0.3-nightly-2022-08-02",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-nightly-2022-08-02.tgz",
-      "integrity": "sha512-8AMlAQZA29LS2QYxmE6mIbjw25ixqWY36tvqlgUl2SzSKb1NRuEqCY4bVAp/qNDhmgtXKQSaCEDy724qrcrAOg=="
+      "version": "0.0.3-nightly-2022-08-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-nightly-2022-08-03.tgz",
+      "integrity": "sha512-rdUsdSo92YRsjXFV2nuE5mv31hFOXZc0BgZVytWpSIMVzdxoEMqDFeta7/se2ebW76bzo3RtIhS+0ovRkDw1oA=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",


### PR DESCRIPTION
# Motivation

We couldn't bump nns-js nightly yesterday because the google-protobuf was breaking the tests. As it was patched yesterday, this bump finally introduces nns-js that has peer dependencies on agent-js.

sns-js bumped at the same time but no changes there.
