### PR TITLE
feat: reload sns data after participate swap & use global data for detail page

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -269,7 +269,7 @@ export const querySnsSummary = async ({
     ].map(({ canisterIds: { rootCanisterId } }: SnsWrapper, index) => ({
       ...mockSnsSummaryList[index],
       rootCanisterId,
-      certified
+      certified,
     }));
   }
 
@@ -351,7 +351,7 @@ export const querySnsSwapState = async ({
     swapCanisterId,
     swap,
     derived,
-    certified
+    certified,
   };
 };
 

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -270,6 +270,7 @@ export const querySnsSummary = async ({
     ].map(({ canisterIds: { rootCanisterId } }: SnsWrapper, index) => ({
       ...mockSnsSummaryList[index],
       rootCanisterId,
+      certified
     }));
   }
 
@@ -352,6 +353,7 @@ export const querySnsSwapState = async ({
     swapCanisterId,
     swap,
     derived,
+    certified
   };
 };
 

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -274,6 +274,7 @@ export const querySnsSummary = async ({
   }
 
   // TODO(L2-829, L2-751): remove and replace with effective data - i.e. summary comes from sns gov canister through sns wrapper
+  console.log("Sns metadata", summary);
   return mockSnsSummaries.find(
     ({ rootCanisterId: canisterId }: QuerySnsSummary) =>
       canisterId?.toText() === rootCanisterId

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -52,7 +52,6 @@ const listSnses = async ({
 
   const SnsWasmCanister: SnsWasmCanisterCreate = await importSnsWasmCanister();
 
-  console.log({ WASM_CANISTER_ID, path: "src/lib/api/sns.api.ts" });
   const { listSnses }: SnsWasmCanister = SnsWasmCanister.create({
     canisterId: Principal.fromText(WASM_CANISTER_ID),
     agent,
@@ -275,7 +274,6 @@ export const querySnsSummary = async ({
   }
 
   // TODO(L2-829, L2-751): remove and replace with effective data - i.e. summary comes from sns gov canister through sns wrapper
-  console.log("Sns metadata", summary);
   return mockSnsSummaries.find(
     ({ rootCanisterId: canisterId }: QuerySnsSummary) =>
       canisterId?.toText() === rootCanisterId

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -10,6 +10,7 @@
     type ProjectDetailContext,
   } from "../../types/project-detail.context";
   import Spinner from "../../../lib/components/ui/Spinner.svelte";
+  import { isNullish } from "../../utils/utils";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
@@ -19,7 +20,7 @@
   $: summary = $projectDetailStore.summary;
 </script>
 
-{#if summary === undefined || summary === null}
+{#if isNullish(summary)}
   <!-- TODO: replace with a skeleton -->
   <Spinner inline />
 {:else}

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -9,42 +9,51 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "../../types/project-detail.context";
+  import { isNullish } from "../../utils/utils";
+  import Spinner from "../../../lib/components/ui/Spinner.svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
-  let summary: SnsSummary;
-  // type safety validation is done in ProjectDetail component
-  $: summary = $projectDetailStore.summary as SnsSummary;
+  let summary: SnsSummary | undefined | null;
+  $: summary = $projectDetailStore.summary;
+
+  let loadingSummary: boolean;
+  $: loadingSummary = isNullish($projectDetailStore.summary);
 </script>
 
-<div data-tid="sns-project-detail-info">
-  <div class="title">
-    <Logo src={summary.logo} alt={$i18n.sns_launchpad.project_logo} />
-    <h1>{summary.name}</h1>
-  </div>
-  <p class="value">
-    {summary.description}
-  </p>
-  <a href={summary.url} target="_blank">{summary.url}</a>
-  <div class="details">
-    <KeyValuePair>
-      <svelte:fragment slot="key"
-        >{$i18n.sns_project_detail.token_name}</svelte:fragment
-      >
-      <span class="value" slot="value">{summary.tokenName}</span>
-    </KeyValuePair>
-    <KeyValuePair>
-      <svelte:fragment slot="key"
-        >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
-      >
-      <span class="value" slot="value">{summary.symbol}</span>
-    </KeyValuePair>
+{#if loadingSummary}
+  <!-- TODO: replace with a skeleton -->
+  <Spinner inline />
+{:else}
+  <div data-tid="sns-project-detail-info">
+    <div class="title">
+      <Logo src={summary.logo} alt={$i18n.sns_launchpad.project_logo} />
+      <h1>{summary.name}</h1>
+    </div>
+    <p class="value">
+      {summary.description}
+    </p>
+    <a href={summary.url} target="_blank">{summary.url}</a>
+    <div class="details">
+      <KeyValuePair>
+        <svelte:fragment slot="key"
+          >{$i18n.sns_project_detail.token_name}</svelte:fragment
+        >
+        <span class="value" slot="value">{summary.tokenName}</span>
+      </KeyValuePair>
+      <KeyValuePair>
+        <svelte:fragment slot="key"
+          >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
+        >
+        <span class="value" slot="value">{summary.symbol}</span>
+      </KeyValuePair>
 
-    <ProjectSwapDetails />
+      <ProjectSwapDetails />
+    </div>
   </div>
-</div>
+{/if}
 
 <style lang="scss">
   .title {

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -9,7 +9,6 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "../../types/project-detail.context";
-  import { isNullish } from "../../utils/utils";
   import Spinner from "../../../lib/components/ui/Spinner.svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
@@ -18,12 +17,9 @@
 
   let summary: SnsSummary | undefined | null;
   $: summary = $projectDetailStore.summary;
-
-  let loadingSummary: boolean;
-  $: loadingSummary = isNullish($projectDetailStore.summary);
 </script>
 
-{#if loadingSummary}
+{#if summary === undefined || summary === null}
   <!-- TODO: replace with a skeleton -->
   <Spinner inline />
 {:else}

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -28,7 +28,7 @@
   export let account: Account;
   export let amount: number;
 
-  const { store }: ProjectDetailContext = getContext<ProjectDetailContext>(
+  const { store, reload }: ProjectDetailContext = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
@@ -57,7 +57,7 @@
         account,
         amount: icpAmount,
         rootCanisterId: $store.summary.rootCanisterId,
-        onSuccess: (swapCommitment) => ($store.swapCommitment = swapCommitment),
+        onSuccess: reload,
       });
       if (success) {
         toastsStore.success({

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -58,7 +58,7 @@
         rootCanisterId: $store.summary.rootCanisterId,
       });
       if (success) {
-        reload();
+        await reload();
 
         toastsStore.success({
           labelKey: "sns_project_detail.participate_success",

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -56,9 +56,10 @@
         account,
         amount: icpAmount,
         rootCanisterId: $store.summary.rootCanisterId,
-        onSuccess: reload,
       });
       if (success) {
+        reload();
+
         toastsStore.success({
           labelKey: "sns_project_detail.participate_success",
         });

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -28,9 +28,8 @@
   export let account: Account;
   export let amount: number;
 
-  const { store, reload }: ProjectDetailContext = getContext<ProjectDetailContext>(
-    PROJECT_DETAIL_CONTEXT_KEY
-  );
+  const { store, reload }: ProjectDetailContext =
+    getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
 
   let icpAmount: ICP;
   $: icpAmount = convertNumberToICP(amount);

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -232,12 +232,10 @@ export const participateInSwap = async ({
   amount,
   rootCanisterId,
   account,
-  onSuccess,
 }: {
   amount: ICP;
   rootCanisterId: Principal;
   account: Account;
-  onSuccess?: () => void;
 }): Promise<{ success: boolean }> => {
   try {
     const accountIdentity = await getAccountIdentity(account.identifier);
@@ -249,8 +247,6 @@ export const participateInSwap = async ({
       controller: accountIdentity.getPrincipal(),
       fromSubAccount: "subAccount" in account ? account.subAccount : undefined,
     });
-
-    onSuccess?.();
 
     return { success: true };
   } catch (error) {

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -249,10 +249,11 @@ export const participateInSwap = async ({
   amount: ICP;
   rootCanisterId: Principal;
   account: Account;
-  onSuccess?: (swapState: SnsSwapCommitment) => void;
+  onSuccess?: () => void;
 }): Promise<{ success: boolean }> => {
   try {
     const accountIdentity = await getAccountIdentity(account.identifier);
+
     await participateInSnsSwap({
       identity: accountIdentity,
       rootCanisterId,
@@ -260,20 +261,9 @@ export const participateInSwap = async ({
       controller: accountIdentity.getPrincipal(),
       fromSubAccount: "subAccount" in account ? account.subAccount : undefined,
     });
-    await loadSnsSwapCommitment({
-      strategy: "update",
-      rootCanisterId: rootCanisterId.toText(),
-      onLoad: ({ response: swapCommitment, certified }) => {
-        snsSwapCommitmentsStore.setSwapCommitment({
-          swapCommitment,
-          certified,
-        });
-        onSuccess?.(swapCommitment);
-      },
-      onError: () => {
-        // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-798
-      },
-    });
+
+    onSuccess?.();
+
     return { success: true };
   } catch (error) {
     // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-798

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -30,11 +30,7 @@ import { getSwapCanisterAccount } from "../utils/sns.utils";
 import { getAccountIdentity } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
-import {
-  queryAndUpdate,
-  type QueryAndUpdateOnResponse,
-  type QueryAndUpdateStrategy,
-} from "./utils.services";
+import { queryAndUpdate } from "./utils.services";
 
 export const loadSnsSummaries = (): Promise<void> => {
   snsQueryStore.setLoadingState();
@@ -45,8 +41,7 @@ export const loadSnsSummaries = (): Promise<void> => {
         querySnsSummaries({ certified, identity }),
         querySnsSwapStates({ certified, identity }),
       ]),
-    onLoad: ({ response, certified }) =>
-      snsQueryStore.setResponse({ response, certified }),
+    onLoad: ({ response }) => snsQueryStore.setData(response),
     onError: ({ error: err, certified }) => {
       console.error(err);
 
@@ -71,13 +66,9 @@ export const loadSnsSummaries = (): Promise<void> => {
 /** Combined request: querySnsSummary + querySnsSwapState */
 export const loadSnsSummary = async ({
   rootCanisterId,
-  onLoad,
   onError,
 }: {
   rootCanisterId: string;
-  onLoad: QueryAndUpdateOnResponse<
-    [QuerySnsSummary | undefined, QuerySnsSwapState | undefined]
-  >;
   onError: () => void;
 }) =>
   queryAndUpdate<
@@ -93,7 +84,8 @@ export const loadSnsSummary = async ({
         }),
         querySnsSwapState({ rootCanisterId, identity, certified }),
       ]),
-    onLoad,
+    onLoad: ({ response: data }) =>
+      snsQueryStore.updateData({ data, rootCanisterId }),
     onError: ({ error: err, certified }) => {
       console.error(err);
 
@@ -150,24 +142,20 @@ export const loadSnsSwapCommitments = (): Promise<void> => {
 
 export const loadSnsSwapCommitment = async ({
   rootCanisterId,
-  onLoad,
   onError,
-  strategy = "query_and_update",
 }: {
   rootCanisterId: string;
-  onLoad: QueryAndUpdateOnResponse<SnsSwapCommitment>;
   onError: () => void;
-  strategy?: QueryAndUpdateStrategy;
 }) =>
   queryAndUpdate<SnsSwapCommitment, unknown>({
-    strategy,
     request: ({ certified, identity }) =>
       querySnsSwapCommitment({
         rootCanisterId,
         identity,
         certified,
       }),
-    onLoad,
+    onLoad: ({ response: swapCommitment, certified }) =>
+      snsSwapCommitmentsStore.setSwapCommitment({ swapCommitment, certified }),
     onError: ({ error: err, certified }) => {
       console.error(err);
 

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -96,6 +96,13 @@ const initSnsQueryStore = () => {
       });
     },
 
+    /**
+     * Note about undefined data (edge case):
+     *
+     * The data parameter can contain undefined values if the backend does not find the related info for the root canister id.
+     * This should not happen since we update the store if the user interact with a project that was actually already successfully fetched.
+     * However, if this would ever happen and to prevent issues, we clean up the store for the related root canister id.
+     */
     updateData({
       data: [updatedSummary, updatedSwap],
       rootCanisterId,

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -60,14 +60,23 @@ export const openSnsProposalsStore = initOpenSnsProposalsStore();
 
 export type SnsQueryStore =
   | {
-      response: [QuerySnsSummary[], QuerySnsSwapState[]];
-      certified: boolean;
+      summaries: QuerySnsSummary[];
+      swaps: QuerySnsSwapState[];
     }
   | undefined
   | null;
 
+/**
+ * A store that contains the results of the queries (query and update) calls NNS-dapp performs to fetch Sns data from the backend.
+ * Various derived stores will subscribe to this store to prepare, format and map the data in a way that can be use by the components.
+ *
+ * - reset: mark the store to not have been populated yet
+ * - setLoadingState: explicitly set the store to not containing any data. useful to display various loading interaction while data are loaded
+ * - setData: the function that initializes the store when the app starts
+ * - updateData: a function to update the data of a particular root canister id - e.g. used to reload a particular sns project after user has participated to a sale
+ */
 const initSnsQueryStore = () => {
-  const { subscribe, set } = writable<SnsQueryStore>(undefined);
+  const { subscribe, set, update } = writable<SnsQueryStore>(undefined);
 
   return {
     subscribe,
@@ -80,11 +89,42 @@ const initSnsQueryStore = () => {
       set(null);
     },
 
-    setResponse(data: {
-      response: [QuerySnsSummary[], QuerySnsSwapState[]];
-      certified: boolean;
+    setData([summaries, swaps]: [QuerySnsSummary[], QuerySnsSwapState[]]) {
+      set({
+        summaries,
+        swaps,
+      });
+    },
+
+    updateData({
+      data: [updatedSummary, updatedSwap],
+      rootCanisterId,
+    }: {
+      data: [QuerySnsSummary | undefined, QuerySnsSwapState | undefined];
+      rootCanisterId: string;
     }) {
-      set(data);
+      update((store: SnsQueryStore) => ({
+        summaries:
+          updatedSummary === undefined
+            ? (store?.summaries ?? []).filter(
+                ({ rootCanisterId: canisterId }) =>
+                  canisterId.toText() !== rootCanisterId
+              )
+            : (store?.summaries ?? []).map((summary) =>
+                summary.rootCanisterId.toText() === rootCanisterId
+                  ? summary
+                  : updatedSummary
+              ),
+        swaps:
+          updatedSwap === undefined
+            ? (store?.swaps ?? []).filter(
+                ({ rootCanisterId: canisterId }) =>
+                  canisterId !== rootCanisterId
+              )
+            : (store?.swaps ?? []).map((swap) =>
+                swap.rootCanisterId === rootCanisterId ? swap : updatedSwap
+              ),
+      }));
     },
   };
 };
@@ -98,7 +138,10 @@ export const snsQueryStore = initSnsQueryStore();
  * The response of the Snses about summary and swap derived to data that can be used by NNS-dapp - i.e. it filters undefined and optional swap data, sort data for consistency
  */
 export const snsSummariesStore = derived(snsQueryStore, (data: SnsQueryStore) =>
-  mapAndSortSnsQueryToSummaries(data?.response ?? [[], []])
+  mapAndSortSnsQueryToSummaries({
+    summaries: data?.summaries ?? [],
+    swaps: data?.swaps ?? [],
+  })
 );
 
 // ************** Sns commitment **************

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -119,8 +119,8 @@ const initSnsQueryStore = () => {
               )
             : (store?.summaries ?? []).map((summary) =>
                 summary.rootCanisterId.toText() === rootCanisterId
-                  ? summary
-                  : updatedSummary
+                  ? updatedSummary
+                  : summary
               ),
         swaps:
           updatedSwap === undefined
@@ -129,7 +129,7 @@ const initSnsQueryStore = () => {
                   canisterId !== rootCanisterId
               )
             : (store?.swaps ?? []).map((swap) =>
-                swap.rootCanisterId === rootCanisterId ? swap : updatedSwap
+                swap.rootCanisterId === rootCanisterId ? updatedSwap : swap
               ),
       }));
     },

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -8,7 +8,7 @@ export interface ProjectDetailStore {
 
 export interface ProjectDetailContext {
   store: Writable<ProjectDetailStore>;
-  reload: () => void;
+  reload: () => Promise<void>;
 }
 
 export const PROJECT_DETAIL_CONTEXT_KEY = Symbol("project-detail");

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -8,6 +8,7 @@ export interface ProjectDetailStore {
 
 export interface ProjectDetailContext {
   store: Writable<ProjectDetailStore>;
+  reload: () => void;
 }
 
 export const PROJECT_DETAIL_CONTEXT_KEY = Symbol("project-detail");

--- a/frontend/src/lib/types/sns.query.ts
+++ b/frontend/src/lib/types/sns.query.ts
@@ -4,15 +4,18 @@ import type { SnsSummary } from "./sns";
 
 export type QueryRootCanisterId = string;
 
+export type QueryCertified = { certified: boolean };
+
 // TODO: this type is temporary, ultimately it should be updated with the proper candid type that will be used to query the summary from the backend
 export type QuerySnsSummary = Omit<
   SnsSummary,
   "swap" | "derived" | "swapCanisterId"
->;
+> &
+  QueryCertified;
 
 export type QuerySnsSwapState = {
   rootCanisterId: QueryRootCanisterId;
   swapCanisterId: Principal;
   swap: [] | [SnsSwap];
   derived: [] | [SnsSwapDerivedState];
-};
+} & QueryCertified;

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -8,7 +8,6 @@ import type {
 } from "@dfinity/sns";
 import type { SnsSummary } from "../types/sns";
 import type { QuerySnsSummary, QuerySnsSwapState } from "../types/sns.query";
-import { assertNonNullish } from "./asserts.utils";
 import { fromNullable } from "./did.utils";
 
 type OptionalSwapSummary = QuerySnsSummary & {
@@ -55,10 +54,13 @@ const sortSnsSummaries = (summaries: SnsSummary[]): SnsSummary[] =>
  * If either of those are missing, that would indicate a bigger issue with the swap canister and can be safely ignored from the nns-dapp.
  *
  */
-export const mapAndSortSnsQueryToSummaries = ([summaries, swaps]: [
-  QuerySnsSummary[],
-  QuerySnsSwapState[]
-]): SnsSummary[] => {
+export const mapAndSortSnsQueryToSummaries = ({
+  summaries,
+  swaps,
+}: {
+  summaries: QuerySnsSummary[];
+  swaps: QuerySnsSwapState[];
+}): SnsSummary[] => {
   const allSummaries: OptionalSwapSummary[] = summaries.map(
     ({ rootCanisterId, ...rest }: OptionalSwapSummary) => {
       const swapState = swaps.find(
@@ -98,45 +100,6 @@ export const mapAndSortSnsQueryToSummaries = ([summaries, swaps]: [
   );
 };
 
-export const concatSnsSummary = ([summary, swap]: [
-  QuerySnsSummary | undefined,
-  QuerySnsSwapState | undefined
-]): SnsSummary => {
-  assertNonNullish(summary);
-  assertNonNullish(swap);
-
-  /**
-   * See above `mapAndSortSnsQueryToSummaries` doc to get to know why swap and derived are mandatory.
-   */
-  const possibleSwap: SnsSwap | undefined = fromNullable(swap?.swap);
-  assertNonNullish(possibleSwap);
-
-  const possibleDerived: SnsSwapDerivedState | undefined = fromNullable(
-    swap?.derived
-  );
-  assertNonNullish(possibleDerived);
-
-  const { init: possibleInit, state: possibleState } = possibleSwap;
-
-  const init: SnsSwapInit | undefined = fromNullable(possibleInit);
-  const state: SnsSwapState | undefined = fromNullable(possibleState);
-
-  assertNonNullish(init);
-  assertNonNullish(state);
-
-  const { swapCanisterId } = swap;
-
-  return {
-    ...summary,
-    swapCanisterId,
-    swap: {
-      init,
-      state,
-    },
-    derived: possibleDerived,
-  };
-};
-
 export const getSwapCanisterAccount = ({
   controller,
   swapCanisterId,
@@ -144,10 +107,10 @@ export const getSwapCanisterAccount = ({
   controller: Principal;
   swapCanisterId: Principal;
 }): AccountIdentifier => {
-  const principalSubaccont = SubAccount.fromPrincipal(controller);
+  const principalSubaccount = SubAccount.fromPrincipal(controller);
   const accountIdentifier = AccountIdentifier.fromPrincipal({
     principal: swapCanisterId,
-    subAccount: principalSubaccont,
+    subAccount: principalSubaccount,
   });
 
   return accountIdentifier;

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -17,19 +17,15 @@
     routePathRootCanisterId,
   } from "../lib/services/sns.services";
   import { isRoutePath } from "../lib/utils/app-path.utils";
-  import {
-    snsQueryStore,
-    snsSwapCommitmentsStore,
-  } from "../lib/stores/sns.store";
+  import { snsSwapCommitmentsStore } from "../lib/stores/sns.store";
   import Spinner from "../lib/components/ui/Spinner.svelte";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
     type ProjectDetailStore,
   } from "../lib/types/project-detail.context";
-  import { isNullish, nonNullish } from "../lib/utils/utils";
+  import { isNullish } from "../lib/utils/utils";
   import { writable } from "svelte/store";
-  import { concatSnsSummary } from "../lib/utils/sns.utils";
   import { snsSummariesStore } from "../lib/stores/sns.store";
 
   onMount(() => {
@@ -41,8 +37,6 @@
   const loadSummary = (rootCanisterId: string) =>
     loadSnsSummary({
       rootCanisterId,
-      onLoad: ({ response }) =>
-        ($projectDetailStore.summary = concatSnsSummary(response)),
       onError: () => {
         // hide unproven data
         $projectDetailStore.summary = null;
@@ -53,8 +47,6 @@
   const loadSwapState = (rootCanisterId: string) =>
     loadSnsSwapCommitment({
       rootCanisterId,
-      onLoad: ({ response: swapCommitment }) =>
-        ($projectDetailStore.swapCommitment = swapCommitment),
       onError: () => {
         // hide unproven data
         $projectDetailStore.swapCommitment = null;

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -157,12 +157,7 @@
     {:else}
       <TwoColumns>
         <div slot="left">
-          {#if loadingSummary}
-            <!-- TODO: replace with a skeleton -->
-            <Spinner inline />
-          {:else}
-            <ProjectInfoSection />
-          {/if}
+          <ProjectInfoSection />
         </div>
         <div slot="right">
           <ProjectStatusSection />

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -99,7 +99,7 @@
         ? $snsSwapCommitmentsStore?.find(
             (item) =>
               item?.swapCommitment?.rootCanisterId?.toText() === rootCanisterId
-          )
+          )?.swapCommitment
         : null;
   };
 

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -54,7 +54,7 @@
       },
     });
 
-  const reload = () => {
+  const reload = async () => {
     const { path } = $routeStore;
 
     const rootCanisterId = routePathRootCanisterId(path);
@@ -64,8 +64,10 @@
       return;
     }
 
-    loadSummary(rootCanisterId);
-    loadSwapState(rootCanisterId);
+    await Promise.all([
+      loadSummary(rootCanisterId),
+      loadSwapState(rootCanisterId),
+    ]);
   };
 
   const projectDetailStore = writable<ProjectDetailStore>({

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -42,7 +42,7 @@ describe("Projects", () => {
       SnsSwapLifecycle.Open,
     ];
 
-    snsQueryStore.setResponse(
+    snsQueryStore.setData(
       snsResponsesForLifecycle({
         lifecycles,
       })
@@ -60,10 +60,7 @@ describe("Projects", () => {
   it("should render a message when no projects available", () => {
     const principal = mockSnsSummaryList[0].rootCanisterId;
 
-    snsQueryStore.setResponse({
-      response: [[], []],
-      certified: false,
-    });
+    snsQueryStore.setData([[], []]);
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,

--- a/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
@@ -10,17 +10,18 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "../../../../lib/types/project-detail.context";
+import type { SnsSummary } from "../../../../lib/types/sns";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 import ContextWrapperTest from "../ContextWrapperTest.svelte";
 
 describe("ProjectInfoSection", () => {
-  const renderProjectInfoSection = () =>
+  const renderProjectInfoSection = (summary: SnsSummary | undefined) =>
     render(ContextWrapperTest, {
       props: {
         contextKey: PROJECT_DETAIL_CONTEXT_KEY,
         contextValue: {
           store: writable<ProjectDetailStore>({
-            summary: mockSnsFullProject.summary,
+            summary,
             swapCommitment: mockSnsFullProject.swapCommitment,
           }),
         } as ProjectDetailContext,
@@ -29,12 +30,17 @@ describe("ProjectInfoSection", () => {
     });
 
   it("should render title", async () => {
-    const { container } = renderProjectInfoSection();
+    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
     expect(container.querySelector("h1")).toBeInTheDocument();
   });
 
   it("should render project link", async () => {
-    const { container } = renderProjectInfoSection();
+    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
     expect(container.querySelector("a")).toBeInTheDocument();
+  });
+
+  it("should not render content if the summary is not yet defined", async () => {
+    const { container } = renderProjectInfoSection(undefined);
+    expect(container.querySelector("h1")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -33,6 +33,8 @@ jest.mock("../../../../lib/services/sns.services", () => {
 });
 
 describe("ParticipateSwapModal", () => {
+  const reload = jest.fn();
+
   const renderSwapModal = () =>
     renderModalContextWrapper({
       Component: ParticipateSwapModal,
@@ -42,6 +44,7 @@ describe("ParticipateSwapModal", () => {
           summary: mockSnsFullProject.summary,
           swapCommitment: mockSnsFullProject.swapCommitment,
         }),
+        reload,
       } as ProjectDetailContext,
     });
 
@@ -154,6 +157,7 @@ describe("ParticipateSwapModal", () => {
       fireEvent.click(confirmButton);
 
       await waitFor(() => expect(participateInSwap).toBeCalled());
+      await waitFor(() => expect(reload).toHaveBeenCalled());
     });
 
     it("should move to the last step and go back", async () => {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -1,10 +1,8 @@
 import { AccountIdentifier, ICP } from "@dfinity/nns";
-import { Principal } from "@dfinity/principal";
 import * as api from "../../../lib/api/sns.api";
 import * as services from "../../../lib/services/sns.services";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
-import { mockSnsSwapCommitment } from "../../mocks/sns-projects.mock";
 
 const { participateInSwap, getSwapAccount } = services;
 
@@ -24,12 +22,8 @@ jest.mock("../../../lib/services/accounts.services", () => {
 
 describe("sns-services", () => {
   describe("participateInSwap", () => {
-    const spyQuery = jest
-      .spyOn(api, "querySnsSwapCommitment")
-      .mockImplementation(() =>
-        Promise.resolve(mockSnsSwapCommitment(Principal.fromText("aaaaa-aa")))
-      );
     afterEach(() => jest.clearAllMocks());
+
     it("should call api.participateInSnsSwap and return success true", async () => {
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
@@ -41,7 +35,23 @@ describe("sns-services", () => {
       });
       expect(success).toBe(true);
       expect(spyParticipate).toBeCalled();
-      expect(spyQuery).toBeCalled();
+    });
+
+    it("should execute optional callback on successful participation to swap", async () => {
+      jest
+        .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() => Promise.resolve(undefined));
+
+      const onSuccess = jest.fn();
+
+      await participateInSwap({
+        amount: ICP.fromString("3") as ICP,
+        rootCanisterId: mockPrincipal,
+        account: mockMainAccount,
+        onSuccess,
+      });
+
+      expect(onSuccess).toHaveBeenCalled();
     });
 
     it("should return success false if api call fails", async () => {
@@ -55,7 +65,6 @@ describe("sns-services", () => {
       });
       expect(success).toBe(false);
       expect(spyParticipate).toBeCalled();
-      expect(spyQuery).not.toBeCalled();
     });
 
     it("should return success false if no identity", async () => {
@@ -70,7 +79,6 @@ describe("sns-services", () => {
       });
       expect(success).toBe(false);
       expect(spyParticipate).not.toBeCalled();
-      expect(spyQuery).not.toBeCalled();
       resetAccountIdentity();
     });
   });

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -37,23 +37,6 @@ describe("sns-services", () => {
       expect(spyParticipate).toBeCalled();
     });
 
-    it("should execute optional callback on successful participation to swap", async () => {
-      jest
-        .spyOn(api, "participateInSnsSwap")
-        .mockImplementation(() => Promise.resolve(undefined));
-
-      const onSuccess = jest.fn();
-
-      await participateInSwap({
-        amount: ICP.fromString("3") as ICP,
-        rootCanisterId: mockPrincipal,
-        account: mockMainAccount,
-        onSuccess,
-      });
-
-      expect(onSuccess).toHaveBeenCalled();
-    });
-
     it("should return success false if api call fails", async () => {
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -36,13 +36,13 @@ describe("projects.store", () => {
     });
 
     it("should filter projects that are active", () => {
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
       const open = get(activePadProjectsStore);
       expect(open?.length).toEqual(1);
 
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({
           lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
         })
@@ -50,7 +50,7 @@ describe("projects.store", () => {
       const open2 = get(activePadProjectsStore);
       expect(open2?.length).toEqual(2);
 
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Unspecified] })
       );
       const noOpen = get(activePadProjectsStore);
@@ -58,14 +58,14 @@ describe("projects.store", () => {
     });
 
     it("should filter projects that are committed only", () => {
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Committed] })
       );
 
       const committed = get(committedProjectsStore);
       expect(committed?.length).toEqual(1);
 
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
       const noCommitted = get(committedProjectsStore);

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -1,4 +1,6 @@
 import { ProposalStatus } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 import {
   openSnsProposalsStore,
@@ -12,6 +14,7 @@ import {
   mockSnsSummaryList,
   mockSnsSwapCommitment,
 } from "../../mocks/sns-projects.mock";
+import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
 describe("sns.store", () => {
   describe("snsSwapStatesStore", () => {
@@ -31,69 +34,132 @@ describe("sns.store", () => {
     });
   });
 
-  describe("filter projects store", () => {
-    beforeAll(() => {
-      snsQueryStore.reset();
-    });
-
-    afterAll(() => {
-      snsQueryStore.reset();
-    });
-
-    const principal = mockSnsSummaryList[0].rootCanisterId;
-
-    snsSwapCommitmentsStore.setSwapCommitment({
-      swapCommitment: mockSnsSwapCommitment(principal),
-      certified: true,
-    });
-
-    describe("sns proposals", () => {
-      it("should store proposals", () => {
-        const proposals = [{ ...mockProposalInfo }];
-        snsProposalsStore.setProposals({
-          proposals,
-          certified: false,
-        });
-
-        const $snsProposalsStore = get(snsProposalsStore);
-
-        expect($snsProposalsStore?.proposals).toEqual(proposals);
-        expect($snsProposalsStore?.certified).toBeFalsy();
+  describe("sns proposals", () => {
+    it("should store proposals", () => {
+      const proposals = [{ ...mockProposalInfo }];
+      snsProposalsStore.setProposals({
+        proposals,
+        certified: false,
       });
 
-      it("should filter open proposals", () => {
-        const nowSeconds = new Date().getTime() / 1000;
-        const proposals = [
-          {
-            ...mockProposalInfo,
-            id: BigInt(111),
-            deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
-            status: ProposalStatus.PROPOSAL_STATUS_REJECTED,
-          },
-          {
-            ...mockProposalInfo,
-            id: BigInt(222),
-            deadlineTimestampSeconds: BigInt(Math.round(nowSeconds - 10000)),
-            status: ProposalStatus.PROPOSAL_STATUS_OPEN,
-          },
-          {
-            ...mockProposalInfo,
-            id: BigInt(222),
-            deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
-            status: ProposalStatus.PROPOSAL_STATUS_ACCEPTED,
-          },
-        ];
+      const $snsProposalsStore = get(snsProposalsStore);
 
-        snsProposalsStore.setProposals({
-          proposals,
-          certified: false,
-        });
+      expect($snsProposalsStore?.proposals).toEqual(proposals);
+      expect($snsProposalsStore?.certified).toBeFalsy();
+    });
 
-        const $openSnsProposalsStore = get(openSnsProposalsStore);
+    it("should filter open proposals", () => {
+      const nowSeconds = new Date().getTime() / 1000;
+      const proposals = [
+        {
+          ...mockProposalInfo,
+          id: BigInt(111),
+          deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_REJECTED,
+        },
+        {
+          ...mockProposalInfo,
+          id: BigInt(222),
+          deadlineTimestampSeconds: BigInt(Math.round(nowSeconds - 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_OPEN,
+        },
+        {
+          ...mockProposalInfo,
+          id: BigInt(222),
+          deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
+          status: ProposalStatus.PROPOSAL_STATUS_ACCEPTED,
+        },
+      ];
 
-        expect($openSnsProposalsStore.length).toBe(1);
-        expect($openSnsProposalsStore[0]).toEqual(proposals[1]);
+      snsProposalsStore.setProposals({
+        proposals,
+        certified: false,
       });
+
+      const $openSnsProposalsStore = get(openSnsProposalsStore);
+
+      expect($openSnsProposalsStore.length).toBe(1);
+      expect($openSnsProposalsStore[0]).toEqual(proposals[1]);
+    });
+  });
+
+  describe("query store", () => {
+    beforeAll(() => snsQueryStore.reset());
+
+    afterEach(() => snsQueryStore.reset());
+
+    it("should set the data", () => {
+      const data = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+        certified: true,
+      });
+
+      snsQueryStore.setData(data);
+
+      const store = get(snsQueryStore);
+      expect(store?.summaries).toEqual(data[0]);
+      expect(store?.swaps).toEqual(data[1]);
+    });
+
+    it("should reset the store", () => {
+      const data = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+        certified: true,
+      });
+
+      snsQueryStore.setData(data);
+      snsQueryStore.reset();
+
+      const store = get(snsQueryStore);
+      expect(store).toBeUndefined();
+    });
+
+    it("should set the store as loading state", () => {
+      const data = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+        certified: true,
+      });
+
+      snsQueryStore.setData(data);
+      snsQueryStore.setLoadingState();
+
+      const store = get(snsQueryStore);
+      expect(store).toBeNull();
+    });
+
+    it("should update the data", () => {
+      const data = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Pending],
+        certified: true,
+      });
+
+      snsQueryStore.setData(data);
+
+      const [summaries, swaps] = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+        certified: true,
+      });
+
+      const rootCanisterId = summaries[0].rootCanisterId as Principal;
+
+      snsQueryStore.updateData({
+        data: [summaries[0], swaps[0]],
+        rootCanisterId: rootCanisterId.toText(),
+      });
+
+      const updatedStore = get(snsQueryStore);
+      expect(
+        updatedStore?.summaries.find(
+          (summary) =>
+            summary.rootCanisterId.toText() === rootCanisterId.toText()
+        )
+      ).toEqual(summaries[0]);
+
+      expect(
+        updatedStore?.swaps.find(
+          (swap) => swap.rootCanisterId === rootCanisterId.toText()
+        )
+      ).toEqual(swaps[0]);
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -162,4 +162,33 @@ describe("sns.store", () => {
       ).toEqual(swaps[0]);
     });
   });
+
+  it("should filter the data", () => {
+    const data = snsResponsesForLifecycle({
+      lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Pending],
+      certified: true,
+    });
+
+    snsQueryStore.setData(data);
+
+    const rootCanisterId = data[0][0].rootCanisterId as Principal;
+
+    snsQueryStore.updateData({
+      data: [undefined, undefined],
+      rootCanisterId: rootCanisterId.toText(),
+    });
+
+    const updatedStore = get(snsQueryStore);
+    expect(
+      updatedStore?.summaries.find(
+        (summary) => summary.rootCanisterId.toText() === rootCanisterId.toText()
+      )
+    ).toBeUndefined();
+
+    expect(
+      updatedStore?.swaps.find(
+        (swap) => swap.rootCanisterId === rootCanisterId.toText()
+      )
+    ).toBeUndefined();
+  });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,7 +1,6 @@
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
-  concatSnsSummary,
   getSwapCanisterAccount,
   mapAndSortSnsQueryToSummaries,
 } from "../../../lib/utils/sns.utils";
@@ -10,7 +9,6 @@ import {
   mockDerived,
   mockSnsSummaryList,
   mockSummary,
-  mockSwap,
   mockSwapInit,
   mockSwapState,
 } from "../../mocks/sns-projects.mock";
@@ -19,21 +17,27 @@ import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 describe("sns-utils", () => {
   describe("concat sns summaries", () => {
     it("should return empty for undefined summary", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([[], []]);
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [],
+        swaps: [],
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should return empty for undefined swap query", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([[mockSummary], []]);
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [],
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should return empty for undefined swap init", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [
           {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -44,17 +48,18 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should return empty for undefined swap state", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [
           {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -65,17 +70,18 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should return empty for undefined derived info", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [
           {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -86,17 +92,18 @@ describe("sns-utils", () => {
               },
             ],
             derived: [],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should return empty if no root id are matching between summaries and swaps", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [
           {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -107,17 +114,18 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(0);
     });
 
     it("should concat summaries and swaps", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [{ ...mockSummary, certified: true }],
+        swaps: [
           {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -128,9 +136,10 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(1);
     });
@@ -138,9 +147,12 @@ describe("sns-utils", () => {
 
   describe("sort sns summaries", () => {
     it("should sort summaries and swaps", () => {
-      const summaries = mapAndSortSnsQueryToSummaries([
-        [mockSummary, mockSnsSummaryList[1]],
-        [
+      const summaries = mapAndSortSnsQueryToSummaries({
+        summaries: [
+          { ...mockSummary, certified: true },
+          { ...mockSnsSummaryList[1], certified: true },
+        ],
+        swaps: [
           {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
@@ -161,6 +173,7 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
           {
             rootCanisterId: mockSnsSummaryList[1].rootCanisterId.toText(),
@@ -182,113 +195,16 @@ describe("sns-utils", () => {
               },
             ],
             derived: [mockDerived],
+            certified: true,
           },
         ],
-      ]);
+      });
 
       expect(summaries.length).toEqual(2);
 
       expect(summaries[0].rootCanisterId.toText()).toEqual(
         mockSnsSummaryList[1].rootCanisterId.toText()
       );
-    });
-  });
-
-  describe("concat a sns summary", () => {
-    it("should throw error for undefined summary", () => {
-      const call = () => concatSnsSummary([undefined, undefined]);
-
-      expect(call).toThrow();
-    });
-
-    it("should throw error for undefined swap query", () => {
-      const call = () => concatSnsSummary([mockSummary, undefined]);
-
-      expect(call).toThrow();
-    });
-
-    it("should throw error for undefined swap init", () => {
-      const call = () =>
-        concatSnsSummary([
-          mockSummary,
-          {
-            rootCanisterId: "1234",
-            swapCanisterId: Principal.fromText("aaaaa-aa"),
-            swap: [
-              {
-                init: [],
-                state: [],
-              },
-            ],
-            derived: [mockDerived],
-          },
-        ]);
-
-      expect(call).toThrow();
-    });
-
-    it("should throw error for undefined swap state", () => {
-      const call = () =>
-        concatSnsSummary([
-          mockSummary,
-          {
-            rootCanisterId: "1234",
-            swapCanisterId: Principal.fromText("aaaaa-aa"),
-            swap: [
-              {
-                init: [mockSwapInit],
-                state: [],
-              },
-            ],
-            derived: [mockDerived],
-          },
-        ]);
-
-      expect(call).toThrow();
-    });
-
-    it("should throw error for undefined derived info", () => {
-      const call = () =>
-        concatSnsSummary([
-          mockSummary,
-          {
-            rootCanisterId: "1234",
-            swapCanisterId: Principal.fromText("aaaaa-aa"),
-            swap: [
-              {
-                init: [mockSwapInit],
-                state: [mockSwapState],
-              },
-            ],
-            derived: [],
-          },
-        ]);
-
-      expect(call).toThrow();
-    });
-
-    it("should concat summary and swap", () => {
-      const swapCanisterId = Principal.fromText("aaaaa-aa");
-      const summary = concatSnsSummary([
-        mockSummary,
-        {
-          rootCanisterId: "1234",
-          swapCanisterId,
-          swap: [
-            {
-              init: [mockSwapInit],
-              state: [mockSwapState],
-            },
-          ],
-          derived: [mockDerived],
-        },
-      ]);
-
-      expect(summary).toEqual({
-        ...mockSummary,
-        swap: mockSwap,
-        swapCanisterId,
-      });
     });
   });
 

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -21,30 +21,26 @@ export const snsResponsesForLifecycle = ({
 }: {
   lifecycles: SnsSwapLifecycle[];
   certified?: boolean;
-}): {
-  response: [QuerySnsSummary[], QuerySnsSwapState[]];
-  certified: boolean;
-} => ({
-  response: [
-    [
-      ...lifecycles.map((lifecycle, i) => ({
-        ...mockSnsFullProject.summary,
-        rootCanisterId: principal(i),
-      })),
-    ],
-    [
-      ...lifecycles.map((lifecycle, i) => ({
-        rootCanisterId: principal(i).toText(),
-        swapCanisterId: swapCanisterIdMock,
-        swap: [
-          {
-            init: [summaryForLifecycle(lifecycle).swap.init],
-            state: [summaryForLifecycle(lifecycle).swap.state],
-          },
-        ] as [SnsSwap],
-        derived: [mockDerived] as [SnsSwapDerivedState],
-      })),
-    ],
+}): [QuerySnsSummary[], QuerySnsSwapState[]] => [
+  [
+    ...lifecycles.map((lifecycle, i) => ({
+      ...mockSnsFullProject.summary,
+      rootCanisterId: principal(i),
+      certified,
+    })),
   ],
-  certified,
-});
+  [
+    ...lifecycles.map((lifecycle, i) => ({
+      rootCanisterId: principal(i).toText(),
+      swapCanisterId: swapCanisterIdMock,
+      swap: [
+        {
+          init: [summaryForLifecycle(lifecycle).swap.init],
+          state: [summaryForLifecycle(lifecycle).swap.state],
+        },
+      ] as [SnsSwap],
+      derived: [mockDerived] as [SnsSwapDerivedState],
+      certified,
+    })),
+  ],
+];

--- a/frontend/src/tests/routes/ProjectDetail.spec.ts
+++ b/frontend/src/tests/routes/ProjectDetail.spec.ts
@@ -24,6 +24,8 @@ jest.mock("../../lib/services/sns.services", () => {
   return {
     loadSnsSummaries: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsSwapCommitments: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadSnsSummary: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadSnsSwapCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
     routePathRootCanisterId: jest
       .fn()
       .mockImplementation(() => mockSnsFullProject.rootCanisterId.toText()),
@@ -39,6 +41,27 @@ describe("ProjectDetail", () => {
       )
     );
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    snsQueryStore.setData(
+        snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open],
+          certified: true,
+        })
+    );
+    snsSwapCommitmentsStore.setSwapCommitment({
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      certified: true,
+    });
+  });
+
+  afterEach(() => {
+    snsQueryStore.reset();
+    snsSwapCommitmentsStore.reset();
+    jest.clearAllMocks();
+  });
+
   it("should load summary", () => {
     render(ProjectDetail);
 
@@ -49,84 +72,6 @@ describe("ProjectDetail", () => {
     render(ProjectDetail);
 
     waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
-  });
-
-  describe("getting certified data from summaries and swaps stores", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
-          certified: true,
-        })
-      );
-      snsSwapCommitmentsStore.setSwapCommitment({
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        certified: true,
-      });
-    });
-
-    afterEach(() => {
-      snsQueryStore.reset();
-      snsSwapCommitmentsStore.reset();
-      jest.clearAllMocks();
-    });
-
-    it.only("should not load summary if certified version available", async () => {
-      render(ProjectDetail);
-
-      await tick();
-
-      expect(loadSnsSummary).toBeCalledTimes(0);
-    });
-
-    it("should not load swap state if certified version available", async () => {
-      render(ProjectDetail);
-
-      await tick();
-
-      expect(loadSnsSwapCommitment).toBeCalledTimes(0);
-    });
-  });
-
-  describe("getting uncertified data from summaries and swaps stores", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
-          certified: false,
-        })
-      );
-      snsSwapCommitmentsStore.setSwapCommitment({
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        certified: false,
-      });
-    });
-
-    afterEach(() => {
-      snsQueryStore.reset();
-      snsSwapCommitmentsStore.reset();
-      jest.clearAllMocks();
-    });
-
-    it("should not load summary if certified version available", async () => {
-      render(ProjectDetail);
-
-      await tick();
-
-      expect(loadSnsSummary).toBeCalledTimes(1);
-    });
-
-    it("should not load swap state if certified version available", async () => {
-      render(ProjectDetail);
-
-      await tick();
-
-      expect(loadSnsSwapCommitment).toBeCalledTimes(1);
-    });
   });
 
   it("should render info section", async () => {

--- a/frontend/src/tests/routes/ProjectDetail.spec.ts
+++ b/frontend/src/tests/routes/ProjectDetail.spec.ts
@@ -4,7 +4,6 @@
 
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
-import { tick } from "svelte";
 import {
   loadSnsSummary,
   loadSnsSwapCommitment,
@@ -45,10 +44,10 @@ describe("ProjectDetail", () => {
     jest.clearAllMocks();
 
     snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
-          certified: true,
-        })
+      snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+        certified: true,
+      })
     );
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,

--- a/frontend/src/tests/routes/ProjectDetail.spec.ts
+++ b/frontend/src/tests/routes/ProjectDetail.spec.ts
@@ -17,24 +17,13 @@ import {
 import type { SnsSwapCommitment } from "../../lib/types/sns";
 import ProjectDetail from "../../routes/ProjectDetail.svelte";
 import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
-import {
-  mockQuerySnsSwapState,
-  mockSnsFullProject,
-} from "../mocks/sns-projects.mock";
+import { mockSnsFullProject } from "../mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "../mocks/sns-response.mock";
 
 jest.mock("../../lib/services/sns.services", () => {
   return {
-    loadSnsSummary: jest.fn().mockImplementation(({ onLoad }) =>
-      onLoad({
-        response: [mockSnsFullProject.summary, mockQuerySnsSwapState],
-      })
-    ),
-    loadSnsSwapCommitment: jest
-      .fn()
-      .mockImplementation(({ onLoad }) =>
-        onLoad({ response: mockSnsFullProject.swapCommitment })
-      ),
+    loadSnsSummaries: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadSnsSwapCommitments: jest.fn().mockResolvedValue(Promise.resolve()),
     routePathRootCanisterId: jest
       .fn()
       .mockImplementation(() => mockSnsFullProject.rootCanisterId.toText()),
@@ -66,7 +55,7 @@ describe("ProjectDetail", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({
           lifecycles: [SnsSwapLifecycle.Open],
           certified: true,
@@ -105,7 +94,7 @@ describe("ProjectDetail", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      snsQueryStore.setResponse(
+      snsQueryStore.setData(
         snsResponsesForLifecycle({
           lifecycles: [SnsSwapLifecycle.Open],
           certified: false,


### PR DESCRIPTION
# Motivation

Issues:

- because we moved away from `currentCommitment` to `derived` information (#1196), the "overall current commitment" information was not updated anymore after user participate to a swap

- we have moved the loading of the sns on the app scale (#1172) but the project detail was still loading a particular sns if directly accessed. as a result the same sns project could have been queried twice (actually four times, 2 query calls, 2 update calls)

Solution:

- query sns summary and swap state after user participate to swap and update the root store that contains the fetched sns data from the backend - the one store that is the source for all derived store

- do not (re)load particular sns when the detail page is accessed but use the global store which already load these information

# Notes

- both solution are provided in a single PR because these are tight to each other.

- when it comes to reloading the data after sale participation, we might not need to reload the summary - i.e. we probably only need the reload of the swap and commitment. for simplicity reason I just reloaded summary and swap as in any case, the loading of the summary is still mocked and will be implemented soon

# Changes

- move `certified` information from global sns query store level to each data contained in store (`QuerySnsSwapState` and `QuerySnsSummary`)
- update `sns.store` to contain an object rather than an array, easier to handle
- add `updateData` to `sns-store`
- adapt consumer of `sns-store` according above changes
- modify `ProjectDetail` and `ReviewParticipate` for the above described solution
- remove `loadSnsSwapCommitment` from function `loadSnsSwapCommitment` in `sns.service`
- add `reload` fonction to project store detail context
- use relad function to well, reload the data after participation

# Screenshots

<img width="1510" alt="Capture d’écran 2022-08-03 à 16 45 30" src="https://user-images.githubusercontent.com/16886711/182638127-f940a98c-117f-483d-9587-90d6ad316b3f.png">

