### PR TITLE
L2-865 and L2-868: SNS Neuron detail page setup

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -53,6 +53,7 @@
   <PrivateRoute path={AppPath.CanisterDetail} />
   <PrivateRoute path={AppPath.Launchpad} />
   <PrivateRoute path={AppPath.ProjectDetail} />
+  <PrivateRoute path={AppPath.SnsNeuronDetail} />
 </Guard>
 
 <Toasts />

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -4,6 +4,7 @@ import { Principal } from "@dfinity/principal";
 import type {
   InitSnsWrapper,
   SnsNeuron,
+  SnsNeuronId,
   SnsSwapBuyerState,
   SnsWrapper,
 } from "@dfinity/sns";
@@ -485,8 +486,35 @@ export const querySnsNeurons = async ({
     rootCanisterId: rootCanisterId.toText(),
     certified,
   });
-  const neurons = await listNeurons({});
+  const neurons = await listNeurons({
+    principal: identity.getPrincipal(),
+  });
 
   logWithTimestamp("Getting sns neurons: done");
   return neurons;
+};
+
+export const querySnsNeuron = async ({
+  identity,
+  rootCanisterId,
+  certified,
+  neuronId,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+  neuronId: SnsNeuronId;
+}): Promise<SnsNeuron> => {
+  logWithTimestamp("Getting sns neuron: call...");
+  const { getNeuron } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+  const neuron = await getNeuron({
+    neuronId,
+  });
+
+  logWithTimestamp("Getting sns neuron: done");
+  return neuron;
 };

--- a/frontend/src/lib/components/common/RouteModule.svelte
+++ b/frontend/src/lib/components/common/RouteModule.svelte
@@ -35,6 +35,8 @@
         return (await import("../../../routes/Launchpad.svelte")).default;
       case AppPath.ProjectDetail:
         return (await import("../../../routes/ProjectDetail.svelte")).default;
+      case AppPath.SnsNeuronDetail:
+        return (await import("../../../routes/SnsNeuronDetail.svelte")).default;
       default:
         return (await import("../../../routes/Auth.svelte")).default;
     }
@@ -51,6 +53,7 @@
     [AppPath.NeuronDetail]: $i18n.neuron_detail.title,
     [AppPath.CanisterDetail]: $i18n.canister_detail.title,
     [AppPath.Launchpad]: $i18n.sns_launchpad.header,
+    [AppPath.SnsNeuronDetail]: $i18n.sns_neuron_detail.header,
     [AppPath.ProjectDetail]: "",
   };
 

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -10,4 +10,5 @@ export enum AppPath {
   CanisterDetail = "/#/canister",
   Launchpad = "/#/launchpad",
   ProjectDetail = "/#/project",
+  SnsNeuronDetail = "/#/project/:rootCanisterId/neuron",
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -579,6 +579,9 @@
     "sale_end": "Sale End",
     "max_user_commitment_reached": "Maximum commitment reached"
   },
+  "sns_neuron_detail": {
+    "header": "Neuron"
+  },
   "time": {
     "year": "year",
     "year_plural": "years",

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -11,6 +11,8 @@
   import { getSnsNeuronIdAsHexString } from "../utils/sns-neuron.utils";
   import type { Unsubscriber } from "svelte/store";
   import { onDestroy } from "svelte";
+  import { routeStore } from "../stores/route.store";
+  import { AppPath } from "../constants/routes.constants";
 
   let loading = true;
 
@@ -28,8 +30,11 @@
   $: principalText = $authStore.identity?.getPrincipal().toText() ?? "";
 
   const goToNeuronDetails = (neuron: SnsNeuron) => () => {
-    // TODO: Go to neuron details
-    console.log("Going to details:", neuron.id);
+    const neuronId = getSnsNeuronIdAsHexString(neuron);
+    // TODO: Create a path creator helper
+    routeStore.navigate({
+      path: `${AppPath.ProjectDetail}/${$snsProjectSelectedStore}/neuron/${neuronId}`,
+    });
   };
 </script>
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -2,7 +2,10 @@ import type { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
 import { get } from "svelte/store";
 import { querySnsNeuron, querySnsNeurons } from "../api/sns.api";
-import { snsNeuronsStore } from "../stores/sns-neurons.store";
+import {
+  snsNeuronsStore,
+  type ProjectNeuronStore,
+} from "../stores/sns-neurons.store";
 import { toastsStore } from "../stores/toasts.store";
 import { toToastError } from "../utils/error.utils";
 import { getSnsNeuronByHexId } from "../utils/sns-neuron.utils";
@@ -47,6 +50,11 @@ export const loadSnsNeurons = async (
   });
 };
 
+const getSnsNeuronsFromStoreByProject = (
+  rootCanisterId: Principal
+): ProjectNeuronStore | undefined =>
+  get(snsNeuronsStore)[rootCanisterId.toText()];
+
 const getNeuronFromStoreByIdHex = ({
   neuronIdHex,
   rootCanisterId,
@@ -54,8 +62,7 @@ const getNeuronFromStoreByIdHex = ({
   neuronIdHex: string;
   rootCanisterId: Principal;
 }): { neuron?: SnsNeuron; certified?: boolean } => {
-  const store = get(snsNeuronsStore);
-  const projectData = store[rootCanisterId.toText()];
+  const projectData = getSnsNeuronsFromStoreByProject(rootCanisterId);
   const neuron = getSnsNeuronByHexId({
     neuronIdHex,
     neurons: projectData?.neurons,

--- a/frontend/src/lib/stores/sns-neurons.store.ts
+++ b/frontend/src/lib/stores/sns-neurons.store.ts
@@ -4,14 +4,15 @@ import { derived, writable, type Readable } from "svelte/store";
 import { sortSnsNeuronsByCreatedTimestamp } from "../utils/sns-neuron.utils";
 import { snsProjectSelectedStore } from "./projects.store";
 
+export interface ProjectNeuronStore {
+  neurons: SnsNeuron[];
+  // certified is an optimistic value - i.e. it represents the last value that has been pushed in store
+  certified: boolean | undefined;
+}
 export interface NeuronsStore {
   // Each SNS Project is an entry in this Store.
   // We use the root canister id as the key to identify the neurons for a specific project.
-  [rootCanisterId: string]: {
-    neurons: SnsNeuron[];
-    // certified is an optimistic value - i.e. it represents the last value that has been pushed in store
-    certified: boolean | undefined;
-  };
+  [rootCanisterId: string]: ProjectNeuronStore;
 }
 
 /**

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -609,6 +609,10 @@ interface I18nSns_project_detail {
   max_user_commitment_reached: string;
 }
 
+interface I18nSns_neuron_detail {
+  header: string;
+}
+
 interface I18nTime {
   year: string;
   year_plural: string;
@@ -714,6 +718,7 @@ interface I18n {
   sns_launchpad: I18nSns_launchpad;
   sns_project: I18nSns_project;
   sns_project_detail: I18nSns_project_detail;
+  sns_neuron_detail: I18nSns_neuron_detail;
   time: I18nTime;
   error__ledger: I18nError__ledger;
   error__attach_wallet: I18nError__attach_wallet;

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -8,6 +8,7 @@ const mapper: Record<string, string> = {
   [AppPath.NeuronDetail]: `${AppPath.NeuronDetail}/[0-9]+`,
   [AppPath.CanisterDetail]: `${AppPath.CanisterDetail}/[a-zA-Z0-9-]+`,
   [AppPath.ProjectDetail]: `${AppPath.ProjectDetail}/[a-zA-Z0-9-]+`,
+  [AppPath.SnsNeuronDetail]: `${AppPath.ProjectDetail}/[a-zA-Z0-9-]+/neuron/[a-zA-Z0-9-]+`,
 };
 
 const pathValidation = (path: AppPath): string => mapper[path] ?? path;
@@ -44,3 +45,18 @@ export const getLastPathDetailId = (path: string): bigint | undefined => {
 export const getLastPathDetail = (
   path: string | undefined
 ): string | undefined => path?.split("/").pop();
+
+/**
+ * Returns the third last path detail not taking into account trailing slashes
+ * @param path: string
+ * Ex: /#/project/sp3hj-caaaa-aaaaa-aaajq-cai/neuron/9aaefb31ec11d
+ * @returns string
+ * Ex: sp3hj-caaaa-aaaaa-aaajq-cai
+ */
+export const getThirdLastPathDetail = (
+  path: string | undefined
+): string | undefined => {
+  const steps = path?.replace(/\/+$/, "").split("/") ?? [];
+  // Do not return empty strings
+  return steps[steps.length - 3] === "" ? undefined : steps[steps.length - 3];
+};

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -53,7 +53,7 @@ export const getLastPathDetail = (
  * @returns string
  * Ex: sp3hj-caaaa-aaaaa-aaajq-cai
  */
-export const getThirdLastPathDetail = (
+export const getParentPathDetail = (
   path: string | undefined
 ): string | undefined => {
   const steps = path?.replace(/\/+$/, "").split("/") ?? [];

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -1,6 +1,12 @@
 import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
+import { AppPath } from "../constants/routes.constants";
 import type { SnsNeuronState } from "../types/sns";
+import {
+  getLastPathDetail,
+  getThirdLastPathDetail,
+  isRoutePath,
+} from "./app-path.utils";
 import { nowInSeconds } from "./date.utils";
 import { stateTextMapper, type StateInfo } from "./neuron.utils";
 import { bytesToHexString } from "./utils";
@@ -72,6 +78,15 @@ export const getSnsNeuronStake = ({
   neuron_fees_e8s,
 }: SnsNeuron): bigint => cached_neuron_stake_e8s - neuron_fees_e8s;
 
+export const getSnsNeuronByHexId = ({
+  neuronIdHex,
+  neurons,
+}: {
+  neuronIdHex: string;
+  neurons: SnsNeuron[] | undefined;
+}): SnsNeuron | undefined =>
+  neurons?.find(({ id }) => bytesToHexString(id[0]?.id ?? []) === neuronIdHex);
+
 /**
  * Get the neuron id as string instead of its type
  * type Neuron {
@@ -81,3 +96,19 @@ export const getSnsNeuronStake = ({
 export const getSnsNeuronIdAsHexString = (neuron: SnsNeuron): string =>
   // TODO: use upcoming fromDefinedNullable
   bytesToHexString(neuron.id[0]?.id ?? []);
+
+export const routePathSnsNeuronId = (path: string): string | undefined => {
+  if (!isRoutePath({ path: AppPath.SnsNeuronDetail, routePath: path })) {
+    return undefined;
+  }
+  return getLastPathDetail(path);
+};
+
+export const routePathSnsNeuronCanisterId = (
+  path: string
+): string | undefined => {
+  if (!isRoutePath({ path: AppPath.SnsNeuronDetail, routePath: path })) {
+    return undefined;
+  }
+  return getThirdLastPathDetail(path);
+};

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -4,7 +4,7 @@ import { AppPath } from "../constants/routes.constants";
 import type { SnsNeuronState } from "../types/sns";
 import {
   getLastPathDetail,
-  getThirdLastPathDetail,
+  getParentPathDetail,
   isRoutePath,
 } from "./app-path.utils";
 import { nowInSeconds } from "./date.utils";
@@ -104,11 +104,11 @@ export const routePathSnsNeuronId = (path: string): string | undefined => {
   return getLastPathDetail(path);
 };
 
-export const routePathSnsNeuronCanisterId = (
+export const routePathSnsNeuronRootCanisterId = (
   path: string
 ): string | undefined => {
   if (!isRoutePath({ path: AppPath.SnsNeuronDetail, routePath: path })) {
     return undefined;
   }
-  return getThirdLastPathDetail(path);
+  return getParentPathDetail(path);
 };

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -131,6 +131,15 @@ export const bytesToHexString = (bytes: number[]): string =>
     ""
   );
 
+// Convert a hex string to a byte array
+export const hexStringToBytes = (hexString: string): number[] => {
+  const bytes: number[] = [];
+  for (let c = 0; c < hexString.length; c += 2) {
+    bytes.push(parseInt(hexString.substring(c, c + 2), 16));
+  }
+  return bytes;
+};
+
 /** Is null or undefined */
 export const isNullish = <T>(
   argument: T | undefined | null

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -135,8 +135,12 @@ export const bytesToHexString = (bytes: number[]): string =>
 // Source: https://stackoverflow.com/a/34356351
 export const hexStringToBytes = (hexString: string): number[] => {
   const bytes: number[] = [];
+  // Loop through each pair of hex digits
   for (let c = 0; c < hexString.length; c += 2) {
-    bytes.push(parseInt(hexString.substring(c, c + 2), 16));
+    const hexDigit = hexString.substring(c, c + 2);
+    // Parse a base 16
+    const byte = parseInt(hexDigit, 16);
+    bytes.push(byte);
   }
   return bytes;
 };

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -132,6 +132,7 @@ export const bytesToHexString = (bytes: number[]): string =>
   );
 
 // Convert a hex string to a byte array
+// Source: https://stackoverflow.com/a/34356351
 export const hexStringToBytes = (hexString: string): number[] => {
   const bytes: number[] = [];
   for (let c = 0; c < hexString.length; c += 2) {

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { Principal } from "@dfinity/principal";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { AppPath } from "../lib/constants/routes.constants";
+  import { getSnsNeuron } from "../lib/services/sns-neurons.services";
+  import { layoutBackStore } from "../lib/stores/layout.store";
+  import { routeStore } from "../lib/stores/route.store";
+  import { isRoutePath } from "../lib/utils/app-path.utils";
+  import {
+    getSnsNeuronIdAsHexString,
+    routePathSnsNeuronCanisterId,
+    routePathSnsNeuronId,
+  } from "../lib/utils/sns-neuron.utils";
+
+  let snsNeuron: SnsNeuron | undefined;
+
+  const unsubscribe = routeStore.subscribe(async ({ path }) => {
+    if (!isRoutePath({ path: AppPath.SnsNeuronDetail, routePath: path })) {
+      return;
+    }
+    const rootCanisterIdMaybe = routePathSnsNeuronCanisterId(path);
+    const neuronIdMaybe = routePathSnsNeuronId(path);
+    if (neuronIdMaybe === undefined || rootCanisterIdMaybe === undefined) {
+      unsubscribe();
+      routeStore.replace({ path: AppPath.Neurons });
+      return;
+    }
+    const rootCanisterId = Principal.fromText(rootCanisterIdMaybe);
+
+    getSnsNeuron({
+      rootCanisterId,
+      neuronIdHex: neuronIdMaybe,
+      onLoad: ({ neuron }: { neuron: SnsNeuron }) => {
+        snsNeuron = neuron;
+      },
+      onError: () => {
+        console.error("Error loading neuron");
+      },
+    });
+  });
+
+  const goBack = () =>
+    routeStore.navigate({
+      path: AppPath.Neurons,
+    });
+
+  layoutBackStore.set(goBack);
+</script>
+
+<!-- TODO: Implement UI https://dfinity.atlassian.net/browse/L2-866 -->
+<div data-tid="sns-neuron-detail-page">
+  {`Neuron detail ${
+    snsNeuron === undefined ? "" : getSnsNeuronIdAsHexString(snsNeuron)
+  }`}
+</div>

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -8,7 +8,7 @@
   import { isRoutePath } from "../lib/utils/app-path.utils";
   import {
     getSnsNeuronIdAsHexString,
-    routePathSnsNeuronCanisterId,
+    routePathSnsNeuronRootCanisterId,
     routePathSnsNeuronId,
   } from "../lib/utils/sns-neuron.utils";
 
@@ -18,7 +18,7 @@
     if (!isRoutePath({ path: AppPath.SnsNeuronDetail, routePath: path })) {
       return;
     }
-    const rootCanisterIdMaybe = routePathSnsNeuronCanisterId(path);
+    const rootCanisterIdMaybe = routePathSnsNeuronRootCanisterId(path);
     const neuronIdMaybe = routePathSnsNeuronId(path);
     if (neuronIdMaybe === undefined || rootCanisterIdMaybe === undefined) {
       unsubscribe();

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -9,6 +9,7 @@ import mock from "jest-mock-extended/lib/Mock";
 import { get } from "svelte/store";
 import {
   participateInSnsSwap,
+  querySnsNeuron,
   querySnsNeurons,
   querySnsSummaries,
   querySnsSwapCommitment,
@@ -63,6 +64,7 @@ describe("sns-api", () => {
   const getUserCommitmentSpy = jest.fn().mockResolvedValue(mockUserCommitment);
   const ledgerCanisterMock = mock<LedgerCanister>();
   const queryNeuronsSpy = jest.fn().mockResolvedValue([mockSnsNeuron]);
+  const queryNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron);
 
   beforeEach(() => {
     jest
@@ -89,6 +91,7 @@ describe("sns-api", () => {
         notifyParticipation: notifyParticipationSpy,
         getUserCommitment: getUserCommitmentSpy,
         listNeurons: queryNeuronsSpy,
+        getNeuron: queryNeuronSpy,
       })
     );
   });
@@ -176,5 +179,17 @@ describe("sns-api", () => {
     expect(neurons).not.toBeNull();
     expect(neurons.length).toEqual(1);
     expect(queryNeuronsSpy).toBeCalled();
+  });
+
+  it("should query one sns neurons", async () => {
+    const neuron = await querySnsNeuron({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      certified: false,
+      neuronId: { id: [1, 2, 3] },
+    });
+
+    expect(neuron).not.toBeNull();
+    expect(queryNeuronSpy).toBeCalled();
   });
 });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1,12 +1,14 @@
+import type { SnsNeuron } from "@dfinity/sns";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/sns.api";
 import * as services from "../../../lib/services/sns-neurons.services";
 import { snsNeuronsStore } from "../../../lib/stores/sns-neurons.store";
+import { bytesToHexString } from "../../../lib/utils/utils";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
 
-const { loadSnsNeurons } = services;
+const { loadSnsNeurons, getSnsNeuron } = services;
 
 describe("sns-neurons-services", () => {
   describe("loadSnsNeurons", () => {
@@ -43,6 +45,86 @@ describe("sns-neurons-services", () => {
       const store = get(snsNeuronsStore);
       expect(store[mockPrincipal.toText()]).toBeUndefined();
       expect(spyQuery).toBeCalled();
+    });
+  });
+
+  describe("getSnsNeuron", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      snsNeuronsStore.reset();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    it("should call api.querySnsNeuron and call load neuron when neuron not in store", (done) => {
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(mockSnsNeuron));
+      const onLoad = ({
+        neuron,
+        certified,
+      }: {
+        neuron: SnsNeuron;
+        certified: boolean;
+      }) => {
+        expect(spyQuery).toBeCalled();
+        expect(neuron).toEqual(mockSnsNeuron);
+        if (certified) {
+          done();
+        }
+      };
+      getSnsNeuron({
+        neuronIdHex: bytesToHexString(mockSnsNeuron.id[0]?.id as number[]),
+        rootCanisterId: mockPrincipal,
+        onLoad,
+      });
+    });
+
+    it("should return neuron if it's in the store", (done) => {
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(mockSnsNeuron));
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: mockPrincipal,
+        neurons: [mockSnsNeuron],
+        certified: true,
+      });
+      const onLoad = ({
+        neuron,
+        certified,
+      }: {
+        neuron: SnsNeuron;
+        certified: boolean;
+      }) => {
+        expect(spyQuery).not.toBeCalled();
+        expect(neuron).toEqual(mockSnsNeuron);
+        if (certified) {
+          done();
+        }
+      };
+      getSnsNeuron({
+        neuronIdHex: bytesToHexString(mockSnsNeuron.id[0]?.id as number[]),
+        rootCanisterId: mockPrincipal,
+        onLoad,
+      });
+    });
+
+    it("should call onError callback when call failes", (done) => {
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.reject());
+      const onLoad = jest.fn();
+      const onError = ({ certified }: { certified: boolean }) => {
+        expect(spyQuery).toBeCalled();
+        expect(onLoad).not.toBeCalled();
+        if (certified) {
+          done();
+        }
+      };
+      getSnsNeuron({
+        neuronIdHex: bytesToHexString(mockSnsNeuron.id[0]?.id as number[]),
+        rootCanisterId: mockPrincipal,
+        onLoad,
+        onError,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/utils/app-path.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/app-path.utils.spec.ts
@@ -2,6 +2,7 @@ import { AppPath } from "../../../lib/constants/routes.constants";
 import {
   getLastPathDetail,
   getLastPathDetailId,
+  getThirdLastPathDetail,
   isAppPath,
   isRoutePath,
 } from "../../../lib/utils/app-path.utils";
@@ -66,6 +67,31 @@ describe("routes", () => {
       expect(getLastPathDetail("/#/neuron/")).toEqual("");
       expect(getLastPathDetail("/neuron/")).toEqual("");
       expect(getLastPathDetail("/")).toEqual("");
+    });
+
+    it("should not get detail for an undefined path", () => {
+      expect(getLastPathDetail(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("getThirdLastPathDetail", () => {
+    beforeAll(() => {
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterAll(() => jest.clearAllMocks());
+    it("should get detail from valid path", () => {
+      expect(getThirdLastPathDetail("/#/123/neuron/123_abc")).toBe("123");
+      expect(getThirdLastPathDetail("/project/123/neuron/123_abc")).toBe("123");
+      expect(getThirdLastPathDetail("/project/123/proposal/123_abc")).toBe(
+        "123"
+      );
+    });
+
+    it("should get empty detail for an invalid path", () => {
+      expect(getThirdLastPathDetail("/#/neuron/")).toBeUndefined();
+      expect(getThirdLastPathDetail("/neuron/")).toBeUndefined();
+      expect(getThirdLastPathDetail("/")).toBeUndefined();
     });
 
     it("should not get detail for an undefined path", () => {

--- a/frontend/src/tests/lib/utils/app-path.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/app-path.utils.spec.ts
@@ -2,7 +2,7 @@ import { AppPath } from "../../../lib/constants/routes.constants";
 import {
   getLastPathDetail,
   getLastPathDetailId,
-  getThirdLastPathDetail,
+  getParentPathDetail,
   isAppPath,
   isRoutePath,
 } from "../../../lib/utils/app-path.utils";
@@ -74,24 +74,22 @@ describe("routes", () => {
     });
   });
 
-  describe("getThirdLastPathDetail", () => {
+  describe("getParentPathDetail", () => {
     beforeAll(() => {
       // Avoid to print errors during test
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
     afterAll(() => jest.clearAllMocks());
     it("should get detail from valid path", () => {
-      expect(getThirdLastPathDetail("/#/123/neuron/123_abc")).toBe("123");
-      expect(getThirdLastPathDetail("/project/123/neuron/123_abc")).toBe("123");
-      expect(getThirdLastPathDetail("/project/123/proposal/123_abc")).toBe(
-        "123"
-      );
+      expect(getParentPathDetail("/#/123/neuron/123_abc")).toBe("123");
+      expect(getParentPathDetail("/project/123/neuron/123_abc")).toBe("123");
+      expect(getParentPathDetail("/project/123/proposal/123_abc")).toBe("123");
     });
 
     it("should get empty detail for an invalid path", () => {
-      expect(getThirdLastPathDetail("/#/neuron/")).toBeUndefined();
-      expect(getThirdLastPathDetail("/neuron/")).toBeUndefined();
-      expect(getThirdLastPathDetail("/")).toBeUndefined();
+      expect(getParentPathDetail("/#/neuron/")).toBeUndefined();
+      expect(getParentPathDetail("/neuron/")).toBeUndefined();
+      expect(getParentPathDetail("/")).toBeUndefined();
     });
 
     it("should not get detail for an undefined path", () => {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -8,8 +8,8 @@ import {
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
-  routePathSnsNeuronCanisterId,
   routePathSnsNeuronId,
+  routePathSnsNeuronRootCanisterId,
   sortSnsNeuronsByCreatedTimestamp,
 } from "../../../lib/utils/sns-neuron.utils";
 import { bytesToHexString } from "../../../lib/utils/utils";
@@ -212,25 +212,27 @@ describe("sns-neuron utils", () => {
     });
   });
 
-  describe("routePathSnsNeuronCanisterId", () => {
+  describe("routePathSnsNeuronRootCanisterId", () => {
     afterAll(() => jest.clearAllMocks());
     it("should get root canister id from valid path", async () => {
-      expect(routePathSnsNeuronCanisterId("/#/project/222/neuron/123")).toBe(
-        "222"
-      );
-      expect(routePathSnsNeuronCanisterId("/#/project/0ff/neuron/0")).toBe(
+      expect(
+        routePathSnsNeuronRootCanisterId("/#/project/222/neuron/123")
+      ).toBe("222");
+      expect(routePathSnsNeuronRootCanisterId("/#/project/0ff/neuron/0")).toBe(
         "0ff"
       );
     });
 
     it("should not get root canister id from invalid path", async () => {
-      expect(routePathSnsNeuronCanisterId("/#/neuron/")).toBeUndefined();
-      expect(routePathSnsNeuronCanisterId("/#/project/123")).toBeUndefined();
+      expect(routePathSnsNeuronRootCanisterId("/#/neuron/")).toBeUndefined();
       expect(
-        routePathSnsNeuronCanisterId("/#/project/124/neuron")
+        routePathSnsNeuronRootCanisterId("/#/project/123")
       ).toBeUndefined();
-      expect(routePathSnsNeuronCanisterId("/#/neurons/")).toBeUndefined();
-      expect(routePathSnsNeuronCanisterId("/#/accounts/")).toBeUndefined();
+      expect(
+        routePathSnsNeuronRootCanisterId("/#/project/124/neuron")
+      ).toBeUndefined();
+      expect(routePathSnsNeuronRootCanisterId("/#/neurons/")).toBeUndefined();
+      expect(routePathSnsNeuronRootCanisterId("/#/accounts/")).toBeUndefined();
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -4,11 +4,15 @@ import { SECONDS_IN_YEAR } from "../../../lib/constants/constants";
 import {
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
+  getSnsNeuronByHexId,
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
+  routePathSnsNeuronCanisterId,
+  routePathSnsNeuronId,
   sortSnsNeuronsByCreatedTimestamp,
 } from "../../../lib/utils/sns-neuron.utils";
+import { bytesToHexString } from "../../../lib/utils/utils";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -139,6 +143,94 @@ describe("sns-neuron utils", () => {
       expect(getSnsNeuronIdAsHexString(neuron)).toBe(
         "9aaefb31ec11d6bdc38c3a593d1d8a714f308825603dd732b641c6610813ee24"
       );
+    });
+  });
+
+  describe("getSnsNeuronByHexId", () => {
+    it("returns the neuron with the matching id", () => {
+      const neuronId = [1, 2, 3, 4];
+      const neuron1 = createMockSnsNeuron({
+        id: neuronId,
+      });
+      const neuron2 = createMockSnsNeuron({
+        id: [5, 6, 7, 8],
+      });
+      const neurons = [neuron1, neuron2];
+      expect(
+        getSnsNeuronByHexId({
+          neurons,
+          neuronIdHex: bytesToHexString(neuronId),
+        })
+      ).toBe(neuron1);
+    });
+
+    it("returns undefined when no matching id", () => {
+      const neuron1 = createMockSnsNeuron({
+        id: [1, 2, 3, 4],
+      });
+      const neuron2 = createMockSnsNeuron({
+        id: [5, 6, 7, 8],
+      });
+      const neurons = [neuron1, neuron2];
+      expect(
+        getSnsNeuronByHexId({
+          neurons,
+          neuronIdHex: bytesToHexString([1, 1, 1, 1]),
+        })
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when no neurons", () => {
+      expect(
+        getSnsNeuronByHexId({
+          neurons: [],
+          neuronIdHex: bytesToHexString([1, 1, 1, 1]),
+        })
+      ).toBeUndefined();
+      expect(
+        getSnsNeuronByHexId({
+          neurons: undefined,
+          neuronIdHex: bytesToHexString([1, 1, 1, 1]),
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe("routePathSnsNeuronId", () => {
+    afterAll(() => jest.clearAllMocks());
+    it("should get neuronId from valid path", async () => {
+      expect(routePathSnsNeuronId("/#/project/222/neuron/123")).toBe("123");
+      expect(routePathSnsNeuronId("/#/project/222/neuron/0")).toBe("0");
+    });
+
+    it("should not get neuronId from invalid path", async () => {
+      expect(routePathSnsNeuronId("/#/neuron/")).toBeUndefined();
+      expect(routePathSnsNeuronId("/#/project/123")).toBeUndefined();
+      expect(routePathSnsNeuronId("/#/project/124/neuron")).toBeUndefined();
+      expect(routePathSnsNeuronId("/#/neurons/")).toBeUndefined();
+      expect(routePathSnsNeuronId("/#/accounts/")).toBeUndefined();
+    });
+  });
+
+  describe("routePathSnsNeuronCanisterId", () => {
+    afterAll(() => jest.clearAllMocks());
+    it("should get root canister id from valid path", async () => {
+      expect(routePathSnsNeuronCanisterId("/#/project/222/neuron/123")).toBe(
+        "222"
+      );
+      expect(routePathSnsNeuronCanisterId("/#/project/0ff/neuron/0")).toBe(
+        "0ff"
+      );
+    });
+
+    it("should not get root canister id from invalid path", async () => {
+      expect(routePathSnsNeuronCanisterId("/#/neuron/")).toBeUndefined();
+      expect(routePathSnsNeuronCanisterId("/#/project/123")).toBeUndefined();
+      expect(
+        routePathSnsNeuronCanisterId("/#/project/124/neuron")
+      ).toBeUndefined();
+      expect(routePathSnsNeuronCanisterId("/#/neurons/")).toBeUndefined();
+      expect(routePathSnsNeuronCanisterId("/#/accounts/")).toBeUndefined();
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -2,6 +2,7 @@ import {
   bytesToHexString,
   createChunks,
   debounce,
+  hexStringToBytes,
   isDefined,
   isHash,
   isNullish,
@@ -160,14 +161,16 @@ describe("utils", () => {
     });
   });
 
-  describe("bytesToHexString", () => {
-    it("converts bytes to string", () => {
-      expect(bytesToHexString([])).toBe("");
-      expect(bytesToHexString([0])).toBe("00");
-      expect(bytesToHexString([1])).toBe("01");
-      expect(bytesToHexString([15])).toBe("0f");
-      expect(bytesToHexString([255])).toBe("ff");
-      expect(bytesToHexString([1, 255, 3, 0])).toBe("01ff0300");
+  describe("bytesToHexString and hexStringToBytes", () => {
+    it("converts bytes to string and back", () => {
+      expect(hexStringToBytes(bytesToHexString([]))).toEqual([]);
+      expect(hexStringToBytes(bytesToHexString([0]))).toEqual([0]);
+      expect(hexStringToBytes(bytesToHexString([1]))).toEqual([1]);
+      expect(hexStringToBytes(bytesToHexString([15]))).toEqual([15]);
+      expect(hexStringToBytes(bytesToHexString([255]))).toEqual([255]);
+      expect(hexStringToBytes(bytesToHexString([1, 255, 3, 0]))).toEqual([
+        1, 255, 3, 0,
+      ]);
     });
   });
 

--- a/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import { routeStore } from "../../lib/stores/route.store";
+import { getSnsNeuronIdAsHexString } from "../../lib/utils/sns-neuron.utils";
+import SnsNeuronDetail from "../../routes/SnsNeuronDetail.svelte";
+import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
+import { mockSnsNeuron } from "../mocks/sns-neurons.mock";
+import { rootCanisterIdMock } from "../mocks/sns.api.mock";
+
+jest.mock("../../lib/services/sns-neurons.services", () => {
+  return {
+    getSnsNeuron: jest.fn(),
+  };
+});
+
+describe("SnsNeuronDetail", () => {
+  jest
+    .spyOn(routeStore, "subscribe")
+    .mockImplementation(
+      mockRouteStoreSubscribe(
+        `/#/project/${rootCanisterIdMock.toText()}/neuron/${getSnsNeuronIdAsHexString(
+          mockSnsNeuron
+        )}`
+      )
+    );
+
+  it("should render div", async () => {
+    const { queryByTestId } = render(SnsNeuronDetail);
+
+    expect(queryByTestId("sns-neuron-detail-page")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Motivation

Setup the SNS Neuron Detail page and connect it to the SNS governance canister.

# Changes

* New route SnsNeuronDetail
* New AppPath SnsNeuronDetail which means adding it to a few helpers.
* New utils to interact with the new path: routePathSnsNeuronId, routePathSnsNeuronCanisterId and getThirdLastPathDetail
* New sns neuron service to get neuron details.
* New sns api to get the neuron data.

# Tests

* Test the new route.
* Test the new utils.
* Test the new sns api function.
* Test the new sns neuron service.
