### PR TITLE
Remove remote canister ID for small11

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.11.0",
+  "dfx": "0.11.1",
   "canisters": {
     "nns-governance": {
       "type": "custom",

--- a/dfx.json
+++ b/dfx.json
@@ -36,12 +36,7 @@
       ],
       "candid": "target/ic/sns_wasm.did",
       "wasm": "target/ic/sns-wasm-canister.wasm",
-      "type": "custom",
-      "remote": {
-        "id": {
-          "small11": "qjdve-lqaaa-aaaaa-aaaeq-cai"
-        }
-      }
+      "type": "custom"
     },
     "sns_governance": {
       "build": [


### PR DESCRIPTION
# Motivation
If a remote canister Id is specified, the canister is not deployed.

# Changes
- Don't specify the wasm canister ID on small11

# Tests
- deploying...