### PR TITLE
L2-905: Improve Neuron Id Display

### DIFF
--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -15,8 +15,7 @@
   import NeuronCardContainer from "../neurons/NeuronCardContainer.svelte";
   import NeuronStateInfo from "../neurons/NeuronStateInfo.svelte";
   import NeuronStateRemainingTime from "../neurons/NeuronStateRemainingTime.svelte";
-  import Copy from "../ui/Copy.svelte";
-  import ShortenMiddleEllipsis from "../ui/ShortenMiddleEllipsis.svelte";
+  import Hash from "../ui/Hash.svelte";
 
   export let neuron: SnsNeuron;
   export let role: "link" | undefined = undefined;
@@ -41,13 +40,7 @@
 
 <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
   <div class="identifier" slot="start" data-tid="sns-neuron-card-title">
-    <ShortenMiddleEllipsis
-      id="neuron-id"
-      tagName="h3"
-      testId="neuron-id"
-      text={neuronId}
-    />
-    <Copy value={neuronId} />
+    <Hash id="neuron-id" tagName="h3" testId="neuron-id" text={neuronId} />
     <!-- TODO: Hotkey label https://dfinity.atlassian.net/browse/L2-899 -->
   </div>
 
@@ -69,10 +62,6 @@
   @use "../../themes/mixins/media";
 
   .identifier {
-    display: flex;
-    align-items: center;
-    gap: var(--padding);
-
     :global(h3) {
       margin: 0;
     }

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -15,6 +15,8 @@
   import NeuronCardContainer from "../neurons/NeuronCardContainer.svelte";
   import NeuronStateInfo from "../neurons/NeuronStateInfo.svelte";
   import NeuronStateRemainingTime from "../neurons/NeuronStateRemainingTime.svelte";
+  import Copy from "../ui/Copy.svelte";
+  import ShortenMiddleEllipsis from "../ui/ShortenMiddleEllipsis.svelte";
 
   export let neuron: SnsNeuron;
   export let role: "link" | undefined = undefined;
@@ -38,8 +40,14 @@
 </script>
 
 <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
-  <div slot="start" data-tid="sns-neuron-card-title">
-    <h3 data-tid="neuron-id">{neuronId}</h3>
+  <div class="identifier" slot="start" data-tid="sns-neuron-card-title">
+    <ShortenMiddleEllipsis
+      id="neuron-id"
+      tagName="h3"
+      testId="neuron-id"
+      text={neuronId}
+    />
+    <Copy value={neuronId} />
     <!-- TODO: Hotkey label https://dfinity.atlassian.net/browse/L2-899 -->
   </div>
 
@@ -59,6 +67,16 @@
 
 <style lang="scss">
   @use "../../themes/mixins/media";
+
+  .identifier {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+
+    :global(h3) {
+      margin: 0;
+    }
+  }
 
   .currency {
     display: flex;

--- a/frontend/src/lib/components/ui/Copy.svelte
+++ b/frontend/src/lib/components/ui/Copy.svelte
@@ -23,7 +23,6 @@
   button {
     height: 30px;
     width: 30px;
-    padding: var(--padding-0_5x) var(--padding-0_5x) 0;
 
     color: var(--primary-tint);
   }

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { shortenWithMiddleEllipsis } from "../../utils/format.utils";
+  import Copy from "./Copy.svelte";
 
   import Tooltip from "./Tooltip.svelte";
 
@@ -12,7 +13,19 @@
   $: shortenText = shortenWithMiddleEllipsis(text);
 </script>
 
-<Tooltip {id} {text}>
-  <svelte:element this={tagName} data-tid={testId}>{shortenText}</svelte:element
-  >
-</Tooltip>
+<span>
+  <Tooltip {id} {text}>
+    <svelte:element this={tagName} data-tid={testId}
+      >{shortenText}</svelte:element
+    >
+  </Tooltip>
+  <Copy value={text} />
+</span>
+
+<style lang="scss">
+  span {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+  }
+</style>

--- a/frontend/src/lib/components/ui/Identifier.svelte
+++ b/frontend/src/lib/components/ui/Identifier.svelte
@@ -27,5 +27,7 @@
 
   p {
     margin: 0;
+    display: flex;
+    align-items: center;
   }
 </style>

--- a/frontend/src/lib/components/ui/ShortenMiddleEllipsis.svelte
+++ b/frontend/src/lib/components/ui/ShortenMiddleEllipsis.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { shortenWithMiddleEllipsis } from "../../utils/format.utils";
+
+  import Tooltip from "./Tooltip.svelte";
+
+  export let tagName: "h3" | "p" = "h3";
+  export let testId: string | undefined = undefined;
+  export let id: string;
+  export let text: string;
+
+  let shortenText: string;
+  $: shortenText = shortenWithMiddleEllipsis(text);
+</script>
+
+<Tooltip {id} {text}>
+  <svelte:element this={tagName} data-tid={testId}>{shortenText}</svelte:element
+  >
+</Tooltip>

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -110,6 +110,7 @@
     white-space: pre-wrap;
     max-width: 240px;
     width: max-content;
+    overflow-wrap: break-word;
 
     &.noWrap {
       white-space: nowrap;

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -26,3 +26,11 @@ export const formatPercentage = (
   const { minFraction = 3, maxFraction = 3 } = options || {};
   return `${formatNumber(value * 100, { minFraction, maxFraction })}%`;
 };
+
+/**
+ * Shortens the text from the middle. Ex: "12345678901234567890" -> "1234567...5678901"
+ * @param text
+ * @returns text
+ */
+export const shortenWithMiddleEllipsis = (text: string): string =>
+  text.length > 16 ? `${text.slice(0, 7)}...${text.slice(-7)}` : text;

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -61,7 +61,7 @@ describe("SnsNeuronCard", () => {
   });
 
   it("renders the neuron stake and identifier", async () => {
-    const { getByText } = render(SnsNeuronCard, {
+    const { queryAllByText, getByText } = render(SnsNeuronCard, {
       props: {
         neuron: mockSnsNeuron,
         ...defaultProps,
@@ -75,8 +75,8 @@ describe("SnsNeuronCard", () => {
     });
     expect(getByText(stakeText)).toBeInTheDocument();
     expect(
-      getByText(getSnsNeuronIdAsHexString(mockSnsNeuron))
-    ).toBeInTheDocument();
+      queryAllByText(getSnsNeuronIdAsHexString(mockSnsNeuron)).length
+    ).toBeGreaterThan(0);
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   formatNumber,
   formatPercentage,
+  shortenWithMiddleEllipsis,
 } from "../../../lib/utils/format.utils";
 
 describe("format.utils", () => {
@@ -45,6 +46,20 @@ describe("format.utils", () => {
 
     expect(formatPercentage(0.123, { minFraction: 0, maxFraction: 0 })).toEqual(
       "12%"
+    );
+  });
+
+  it("should format with ellipsis in the middle", () => {
+    expect(shortenWithMiddleEllipsis("123456789")).toEqual("123456789");
+    expect(shortenWithMiddleEllipsis("1234567890123456")).toEqual(
+      "1234567890123456"
+    );
+    expect(shortenWithMiddleEllipsis("12345678901234567")).toEqual(
+      "1234567...1234567"
+    );
+
+    expect(shortenWithMiddleEllipsis("123456789012345678901234")).toEqual(
+      "1234567...8901234"
     );
   });
 });


### PR DESCRIPTION
# Motivation

Improve the display of sns neuron id.

# Changes

* New component ShortenMiddleEllipsis that shortens and adds tooltip with all the text.
* New format util that shortens text.
* Use new ShortenMiddleEllipsis in SNSNeuronCard.
* Add the copy icon and functoinality in the SNS Neuron Card for the id.

# Tests

* Test new format util.
* Fix broken SNSNeuronCard test.
