### PR TITLE
L2-870: SNS Add Hotkey

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
   import { ICON_SIZE_LARGE } from "../../constants/style.constants";
   import IconClose from "../../icons/IconClose.svelte";
   import IconInfo from "../../icons/IconInfo.svelte";
   import IconWarning from "../../icons/IconWarning.svelte";
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
+  import { fromNullable } from "../../utils/did.utils";
   import {
     getSnsNeuronHotkeys,
     canIdentityManageHotkeys,
@@ -16,6 +17,9 @@
   import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
 
   export let neuron: SnsNeuron;
+
+  let neuronId: SnsNeuronId | undefined;
+  $: neuronId = fromNullable(neuron.id);
 
   let canManageHotkeys: boolean = true;
   $: canManageHotkeys = canIdentityManageHotkeys({
@@ -70,9 +74,9 @@
       {/each}
     </ul>
   {/if}
-  {#if canManageHotkeys}
+  {#if canManageHotkeys && neuronId !== undefined}
     <div class="actions">
-      <AddSnsHotkeyButton />
+      <AddSnsHotkeyButton {neuronId} />
     </div>
   {/if}
 </CardInfo>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte
@@ -1,8 +1,20 @@
 <script lang="ts">
+  import type { SnsNeuronId } from "@dfinity/sns";
+  import AddSnsHotkeyModal from "../../../modals/sns/AddSnsHotkeyModal.svelte";
+
   import { i18n } from "../../../stores/i18n";
-  // TODO: https://dfinity.atlassian.net/browse/L2-870
+
+  export let neuronId: SnsNeuronId;
+
+  let showModal: boolean = false;
+  const openModal = () => (showModal = true);
+  const closeModal = () => (showModal = false);
 </script>
 
-<button data-tid="add-hotkey-button" class="primary small"
+<button data-tid="add-hotkey-button" class="primary small" on:click={openModal}
   >{$i18n.neuron_detail.add_hotkey}</button
 >
+
+{#if showModal}
+  <AddSnsHotkeyModal {neuronId} on:nnsClose={closeModal} />
+{/if}

--- a/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
+++ b/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import Modal from "../Modal.svelte";
+  import type { Principal } from "@dfinity/principal";
+  import { i18n } from "../../stores/i18n";
+  import { stopBusy } from "../../stores/busy.store";
+  import { addHotkey } from "../../services/sns-neurons.services";
+  import { createEventDispatcher } from "svelte";
+  import { startBusyNeuron } from "../../services/busy.services";
+  import { toastsStore } from "../../stores/toasts.store";
+  import AddPrincipal from "../../components/common/AddPrincipal.svelte";
+  import type { SnsNeuronId } from "@dfinity/sns";
+  import { snsProjectSelectedStore } from "../../stores/projects.store";
+
+  export let neuronId: SnsNeuronId;
+
+  let principal: Principal | undefined = undefined;
+  const dispatcher = createEventDispatcher();
+
+  const add = async () => {
+    // Edge case: button is only enabled when principal is defined
+    if (principal === undefined) {
+      toastsStore.error({
+        labelKey: "error.principal_not_valid",
+      });
+      return;
+    }
+    startBusyNeuron({ initiator: "add-sns-hotkey-neuron", neuronId });
+    await addHotkey({
+      neuronId,
+      hotkey: principal,
+      rootCanisterId: $snsProjectSelectedStore,
+    });
+    stopBusy("add-sns-hotkey-neuron");
+    dispatcher("nnsClose");
+  };
+</script>
+
+<Modal on:nnsClose size="big">
+  <span slot="title" data-tid="add-hotkey-neuron-modal"
+    >{$i18n.neuron_detail.add_hotkey_modal_title}</span
+  >
+  <section>
+    <AddPrincipal bind:principal on:nnsSelectPrincipal={add} on:nnsClose>
+      <span slot="title">{$i18n.neuron_detail.enter_hotkey}</span>
+      <span slot="button">{$i18n.core.confirm}</span>
+    </AddPrincipal>
+  </section>
+</Modal>
+
+<style lang="scss">
+  @use "../../themes/mixins/modal";
+  section {
+    @include modal.section;
+  }
+</style>

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -1,5 +1,5 @@
 import type { Identity } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import {
   SnsNeuronPermissionType,
   type SnsNeuron,
@@ -135,17 +135,16 @@ export const addHotkey = async ({
   rootCanisterId,
 }: {
   neuronId: SnsNeuronId;
-  hotkey: string;
+  hotkey: Principal;
   rootCanisterId: Principal;
 }): Promise<{ success: boolean }> => {
   try {
     const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
     const identity = await getNeuronIdentity(neuronId);
-    const principal = Principal.fromText(hotkey);
     await addNeuronPermissions({
       permissions,
       identity,
-      principal,
+      principal: hotkey,
       rootCanisterId,
       neuronId,
     });

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -25,6 +25,7 @@ export type BusyStateInitiatorType =
   | "spawn-neuron"
   | "claim_seed_neurons"
   | "project-participate"
+  | "add-sns-hotkey-neuron"
   | "disburse-neuron";
 
 export interface BusyState {

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -7,6 +7,7 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import { getSnsNeuron } from "../lib/services/sns-neurons.services";
   import { layoutBackStore } from "../lib/stores/layout.store";
+  import { snsProjectSelectedStore } from "../lib/stores/projects.store";
   import { routeStore } from "../lib/stores/route.store";
   import { isRoutePath } from "../lib/utils/app-path.utils";
   import {
@@ -28,6 +29,7 @@
       return;
     }
     const rootCanisterId = Principal.fromText(rootCanisterIdMaybe);
+    snsProjectSelectedStore.set(rootCanisterId);
 
     getSnsNeuron({
       rootCanisterId,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import AddSnsHotkeyButton from "../../../../../lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte";
+import en from "../../../../mocks/i18n.mock";
+import { mockSnsNeuron } from "../../../../mocks/sns-neurons.mock";
+
+describe("AddSnsHotkeyButton", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders add hotkey message", () => {
+    const { getByText } = render(AddSnsHotkeyButton, {
+      props: {
+        neuronId: mockSnsNeuron.id[0],
+      },
+    });
+
+    expect(getByText(en.neuron_detail.add_hotkey)).toBeInTheDocument();
+  });
+
+  it("opens Add Hotkey Neuron Modal", async () => {
+    const { container, queryByTestId } = render(AddSnsHotkeyButton, {
+      props: {
+        neuronId: mockSnsNeuron.id[0],
+      },
+    });
+
+    const buttonElement = container.querySelector("button");
+    expect(buttonElement).not.toBeNull();
+
+    buttonElement && (await fireEvent.click(buttonElement));
+
+    const modal = queryByTestId("add-hotkey-neuron-modal");
+    expect(modal).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
+import AddSnsHotkeyModal from "../../../../lib/modals/sns/AddSnsHotkeyModal.svelte";
+import { addHotkey } from "../../../../lib/services/sns-neurons.services";
+import en from "../../../mocks/i18n.mock";
+import { renderModal } from "../../../mocks/modal.mock";
+import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+
+jest.mock("../../../../lib/services/sns-neurons.services", () => {
+  return {
+    addHotkey: jest.fn().mockResolvedValue(BigInt(10)),
+  };
+});
+
+describe("AddSnsHotkeyModal", () => {
+  const renderAddSnsHotkeyModal = async (): Promise<RenderResult> => {
+    return renderModal({
+      component: AddSnsHotkeyModal,
+      props: { neuronId: mockSnsNeuron.id[0] },
+    });
+  };
+
+  it("should display modal", async () => {
+    const { container } = await renderAddSnsHotkeyModal();
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should display error if principal is not valid on blur", async () => {
+    const { container, queryByText } = await renderAddSnsHotkeyModal();
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: "not a principal" },
+      }));
+    inputElement && (await fireEvent.blur(inputElement));
+    expect(queryByText(en.error.principal_not_valid)).toBeInTheDocument();
+  });
+
+  it("should have disabled button if principal not valid", async () => {
+    const { container, queryByTestId } = await renderAddSnsHotkeyModal();
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: "not a principal" },
+      }));
+
+    const buttonElement = queryByTestId("add-principal-button");
+    expect(buttonElement).not.toBeNull();
+    expect(buttonElement?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("should call addHotkey service and close modal", async () => {
+    const principalString = "aaaaa-aa";
+    const { container, queryByTestId, component } =
+      await renderAddSnsHotkeyModal();
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: principalString },
+      }));
+
+    const buttonElement = queryByTestId("add-principal-button");
+    expect(buttonElement).not.toBeNull();
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+    buttonElement && (await fireEvent.click(buttonElement));
+    expect(addHotkey).toBeCalled();
+
+    await waitFor(() => expect(onClose).toBeCalled());
+  });
+});

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -135,7 +135,7 @@ describe("sns-neurons-services", () => {
       const spyAdd = jest
         .spyOn(api, "addNeuronPermissions")
         .mockImplementation(() => Promise.resolve());
-      const hotkey = "aaaaa-aa";
+      const hotkey = Principal.fromText("aaaaa-aa");
       const { success } = await addHotkey({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         hotkey,
@@ -145,7 +145,7 @@ describe("sns-neurons-services", () => {
       expect(spyAdd).toBeCalledWith({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         identity: mockIdentity,
-        principal: Principal.fromText(hotkey),
+        principal: hotkey,
         rootCanisterId: mockPrincipal,
         permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
       });


### PR DESCRIPTION
# Motivation

User can add a hotkey to an SNS neuron.

# Changes

* New modal AddSnsHotkeyModal. Implements same UI as adding a hotkey for NNS.
* AddSnsHotkeyButton opens AddSnsHotkeyModal.

# Tests

* Test that AddSnsHotkeyButton opens modal.
* Test the flow in AddSnsHotkeyModal
