### PR TITLE
L2-705: SNS Remove Hotkey

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -527,3 +527,31 @@ export const addNeuronPermissions = async ({
 
   logWithTimestamp("Adding neuron permissions: done");
 };
+
+export const removeNeuronPermissions = async ({
+  identity,
+  rootCanisterId,
+  permissions,
+  principal,
+  neuronId,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  permissions: SnsNeuronPermissionType[];
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}): Promise<void> => {
+  logWithTimestamp("Removing neuron permissions: call...");
+  const { removeNeuronPermissions } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+  await removeNeuronPermissions({
+    permissions,
+    principal,
+    neuronId,
+  });
+
+  logWithTimestamp("Removing neuron permissions: done");
+};

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
+  import { fromDefinedNullable } from "@dfinity/utils";
   import { ICON_SIZE_LARGE } from "../../constants/style.constants";
   import IconClose from "../../icons/IconClose.svelte";
   import IconInfo from "../../icons/IconInfo.svelte";
   import IconWarning from "../../icons/IconWarning.svelte";
+  import { removeHotkey } from "../../services/sns-neurons.services";
   import { authStore } from "../../stores/auth.store";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
+  import { snsProjectSelectedStore } from "../../stores/projects.store";
   import {
     getSnsNeuronHotkeys,
     canIdentityManageHotkeys,
@@ -14,7 +18,6 @@
   import Tooltip from "../ui/Tooltip.svelte";
   import Value from "../ui/Value.svelte";
   import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
-  import { fromDefinedNullable } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
 
@@ -34,8 +37,15 @@
   $: showTooltip = hotkeys.length > 0 && canManageHotkeys;
 
   const remove = async (hotkey: string) => {
-    // TODO: https://dfinity.atlassian.net/browse/L2-910
-    console.log("Removing", hotkey);
+    startBusy({
+      initiator: "remove-sns-hotkey-neuron",
+    });
+    await removeHotkey({
+      neuronId: neuron.id[0] as SnsNeuronId,
+      hotkey,
+      rootCanisterId: $snsProjectSelectedStore,
+    });
+    stopBusy("remove-sns-hotkey-neuron");
   };
 </script>
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -654,6 +654,7 @@
     "load_summary": "There was an unexpected error while loading the project.",
     "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
     "load_swap_commitment": "There was an unexpected error while loading the commitment of of the project.",
+    "sns_remove_hotkey": "There was an error removing the hotkey.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   }
 }

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -10,6 +10,7 @@ import {
   addNeuronPermissions,
   querySnsNeuron,
   querySnsNeurons,
+  removeNeuronPermissions,
 } from "../api/sns.api";
 import {
   snsNeuronsStore,
@@ -145,6 +146,36 @@ export const addHotkey = async ({
       permissions,
       identity,
       principal: hotkey,
+      rootCanisterId,
+      neuronId,
+    });
+    return { success: true };
+  } catch (err) {
+    toastsStore.error({
+      labelKey: "error__sns.sns_add_hotkey",
+      err,
+    });
+    return { success: false };
+  }
+};
+
+export const removeHotkey = async ({
+  neuronId,
+  hotkey,
+  rootCanisterId,
+}: {
+  neuronId: SnsNeuronId;
+  hotkey: string;
+  rootCanisterId: Principal;
+}): Promise<{ success: boolean }> => {
+  try {
+    const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+    const identity = await getNeuronIdentity(neuronId);
+    const principal = Principal.fromText(hotkey);
+    await removeNeuronPermissions({
+      permissions,
+      identity,
+      principal,
       rootCanisterId,
       neuronId,
     });

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -1,5 +1,5 @@
 import type { Identity } from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
 import {
   SnsNeuronPermissionType,
   type SnsNeuron,
@@ -182,7 +182,7 @@ export const removeHotkey = async ({
     return { success: true };
   } catch (err) {
     toastsStore.error({
-      labelKey: "error__sns.sns_add_hotkey",
+      labelKey: "error__sns.sns_remove_hotkey",
       err,
     });
     return { success: false };

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -26,6 +26,7 @@ export type BusyStateInitiatorType =
   | "claim_seed_neurons"
   | "project-participate"
   | "add-sns-hotkey-neuron"
+  | "remove-sns-hotkey-neuron"
   | "disburse-neuron";
 
 export interface BusyState {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -691,6 +691,7 @@ interface I18nError__sns {
   load_summary: string;
   list_swap_commitments: string;
   load_swap_commitment: string;
+  sns_remove_hotkey: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -103,6 +103,7 @@ describe("sns-api", () => {
         listNeurons: queryNeuronsSpy,
         getNeuron: queryNeuronSpy,
         addNeuronPermissions: addNeuronPermissionsSpy,
+        removeNeuronPermissions: removeNeuronPermissionsSpy,
       })
     );
   });

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -18,6 +18,7 @@ import {
   querySnsSwapCommitment,
   querySnsSwapState,
   querySnsSwapStates,
+  removeNeuronPermissions,
 } from "../../../lib/api/sns.api";
 import {
   importInitSnsWrapper,
@@ -72,6 +73,7 @@ describe("sns-api", () => {
   const queryNeuronsSpy = jest.fn().mockResolvedValue([mockSnsNeuron]);
   const queryNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron);
   const addNeuronPermissionsSpy = jest.fn().mockResolvedValue(undefined);
+  const removeNeuronPermissionsSpy = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     jest
@@ -223,5 +225,17 @@ describe("sns-api", () => {
     });
 
     expect(addNeuronPermissionsSpy).toBeCalled();
+  });
+
+  it("should remove neuron permissions", async () => {
+    await removeNeuronPermissions({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      principal: Principal.fromText("aaaaa-aa"),
+      neuronId: { id: [1, 2, 3] },
+      permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
+    });
+
+    expect(removeNeuronPermissionsSpy).toBeCalled();
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -4,8 +4,9 @@
 
 import { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronHotkeysCard from "../../../../lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte";
+import { removeHotkey } from "../../../../lib/services/sns-neurons.services";
 import { authStore } from "../../../../lib/stores/auth.store";
 import {
   mockAuthStoreSubscribe,
@@ -13,6 +14,12 @@ import {
 } from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+
+jest.mock("../../../../lib/services/sns-neurons.services", () => {
+  return {
+    removeHotkey: jest.fn(),
+  };
+});
 
 describe("SnsNeuronHotkeysCard", () => {
   const addVotePermission = (key) => ({
@@ -72,5 +79,16 @@ describe("SnsNeuronHotkeysCard", () => {
     });
     expect(queryByText(hotkeys[0])).toBeInTheDocument();
     expect(queryByText(hotkeys[1])).toBeInTheDocument();
+  });
+
+  it("can remove a hotkey", () => {
+    const { queryAllByTestId } = render(SnsNeuronHotkeysCard, {
+      props: { neuron: controlledNeuron },
+    });
+
+    const removeButtons = queryAllByTestId("remove-hotkey-button");
+    fireEvent.click(removeButtons[0]);
+
+    expect(removeHotkey).toBeCalled();
   });
 });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -10,7 +10,7 @@ import { bytesToHexString } from "../../../lib/utils/utils";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
 
-const { loadSnsNeurons, getSnsNeuron, addHotkey } = services;
+const { loadSnsNeurons, getSnsNeuron, addHotkey, removeHotkey } = services;
 
 describe("sns-neurons-services", () => {
   describe("loadSnsNeurons", () => {
@@ -146,6 +146,28 @@ describe("sns-neurons-services", () => {
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         identity: mockIdentity,
         principal: hotkey,
+        rootCanisterId: mockPrincipal,
+        permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
+      });
+    });
+  });
+
+  describe("removeHotkey", () => {
+    it("should call api.addNeuronPermissions", async () => {
+      const spyAdd = jest
+        .spyOn(api, "removeNeuronPermissions")
+        .mockImplementation(() => Promise.resolve());
+      const hotkey = "aaaaa-aa";
+      const { success } = await removeHotkey({
+        neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
+        hotkey,
+        rootCanisterId: mockPrincipal,
+      });
+      expect(success).toBeTruthy();
+      expect(spyAdd).toBeCalledWith({
+        neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
+        identity: mockIdentity,
+        principal: Principal.fromText(hotkey),
         rootCanisterId: mockPrincipal,
         permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
       });


### PR DESCRIPTION
# Motivation

User is able to remove a hotkey in an SNS neuron.

# Changes

* Add sns api function removeNeuronPermissions.
* Add sns neuron service removeHotkey which uses removeNeuronPermissions.
* Use new sns neuron service in SnsNeuronHotkeysCard.

# Tests

* Test new case in SnsNeuronHotkeysCard.
* Test new sns neuron service
* Test new sns api function.
