### PR TITLE
L2-899: Add Hotey label to SNS Neuron Card

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NeuronCard.svelte
@@ -59,10 +59,10 @@
     <h3 data-tid="neuron-id">{neuron.neuronId}</h3>
 
     {#if isCommunityFund}
-      <span class="neuron-control">{$i18n.neurons.community_fund}</span>
+      <span>{$i18n.neurons.community_fund}</span>
     {/if}
     {#if isHotKeyControl}
-      <span class="neuron-control">{$i18n.neurons.hotkey_control}</span>
+      <span>{$i18n.neurons.hotkey_control}</span>
     {/if}
   </div>
 

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -12,7 +12,7 @@
     getSnsNeuronStake,
     getSnsNeuronState,
     getSnsStateInfo,
-    isHotkeyControllable,
+    isUserHotkey,
   } from "../../utils/sns-neuron.utils";
   import IcpComponent from "../ic/ICP.svelte";
   import NeuronCardContainer from "../neurons/NeuronCardContainer.svelte";
@@ -27,7 +27,7 @@
   export let ariaLabel: string | undefined = undefined;
 
   let isHotkey: boolean;
-  $: isHotkey = isHotkeyControllable({
+  $: isHotkey = isUserHotkey({
     neuron,
     identity: $authStore.identity,
   });

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { ICP } from "@dfinity/nns";
   import type { SnsNeuron } from "@dfinity/sns";
+  import { authStore } from "../../stores/auth.store";
+  import { i18n } from "../../stores/i18n";
   import type { CardType } from "../../types/card";
   import type { StateInfo } from "../../utils/neuron.utils";
   import {
@@ -10,6 +12,7 @@
     getSnsNeuronStake,
     getSnsNeuronState,
     getSnsStateInfo,
+    isHotkeyControllable,
   } from "../../utils/sns-neuron.utils";
   import IcpComponent from "../ic/ICP.svelte";
   import NeuronCardContainer from "../neurons/NeuronCardContainer.svelte";
@@ -22,6 +25,12 @@
   export let role: "link" | undefined = undefined;
   export let cardType: CardType = "card";
   export let ariaLabel: string | undefined = undefined;
+
+  let isHotkey: boolean;
+  $: isHotkey = isHotkeyControllable({
+    neuron,
+    identity: $authStore.identity,
+  });
 
   let neuronId: string;
   $: neuronId = getSnsNeuronIdAsHexString(neuron);
@@ -42,7 +51,9 @@
 <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
   <div class="identifier" slot="start" data-tid="sns-neuron-card-title">
     <Hash id="neuron-id" tagName="h3" testId="neuron-id" text={neuronId} />
-    <!-- TODO: Hotkey label https://dfinity.atlassian.net/browse/L2-899 -->
+    {#if isHotkey}
+      <span>{$i18n.neurons.hotkey_control}</span>
+    {/if}
   </div>
 
   <div slot="end" class="currency">
@@ -65,8 +76,10 @@
 
 <style lang="scss">
   @use "../../themes/mixins/media";
+  @use "../../themes/mixins/card";
 
   .identifier {
+    @include card.stacked-title;
     :global(h3) {
       margin: 0;
     }

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -153,3 +153,14 @@ export const getSnsNeuronHotkeys = ({ permissions }: SnsNeuron): string[] =>
     )
     .map(({ principal }) => fromNullable(principal)?.toText())
     .filter(nonNullish);
+
+export const isHotkeyControllable = ({
+  neuron,
+  identity,
+}: {
+  neuron: SnsNeuron;
+  identity: Identity | null | undefined;
+}) =>
+  identity === null || identity === undefined
+    ? false
+    : getSnsNeuronHotkeys(neuron).includes(identity.getPrincipal().toText());

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -154,7 +154,7 @@ export const getSnsNeuronHotkeys = ({ permissions }: SnsNeuron): string[] =>
     .map(({ principal }) => fromNullable(principal)?.toText())
     .filter(nonNullish);
 
-export const isHotkeyControllable = ({
+export const isUserHotkey = ({
   neuron,
   identity,
 }: {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -12,7 +12,7 @@ import {
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
-  isHotkeyControllable,
+  isUserHotkey,
   routePathSnsNeuronId,
   routePathSnsNeuronRootCanisterId,
   sortSnsNeuronsByCreatedTimestamp,
@@ -338,7 +338,7 @@ describe("sns-neuron utils", () => {
     });
   });
 
-  describe("isHotkeyControllable", () => {
+  describe("isUserHotkey", () => {
     it("returns true if user only has voting permissions but not all permissions", () => {
       const hotkeyneuron: SnsNeuron = {
         ...mockSnsNeuron,
@@ -352,7 +352,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })
@@ -372,7 +372,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })
@@ -389,7 +389,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })
@@ -409,7 +409,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })
@@ -430,7 +430,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })
@@ -447,7 +447,7 @@ describe("sns-neuron utils", () => {
         ],
       };
       expect(
-        isHotkeyControllable({
+        isUserHotkey({
           neuron: hotkeyneuron,
           identity: mockIdentity,
         })

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
+  isHotkeyControllable,
   routePathSnsNeuronId,
   routePathSnsNeuronRootCanisterId,
   sortSnsNeuronsByCreatedTimestamp,
@@ -333,6 +334,123 @@ describe("sns-neuron utils", () => {
       const expectedHotkeys = getSnsNeuronHotkeys(controlledNeuron);
       expect(
         expectedHotkeys.includes(mockIdentity.getPrincipal().toText())
+      ).toBe(false);
+    });
+  });
+
+  describe("isHotkeyControllable", () => {
+    it("returns true if user only has voting permissions but not all permissions", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: [
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+            ],
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
+      ).toBe(true);
+    });
+    it("returns true if user has voting permissions but not all permissions", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: [
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE,
+            ],
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
+      ).toBe(true);
+    });
+    it("returns false if user has all the voting permissions", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: enumValues(SnsNeuronPermissionType),
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
+      ).toBe(false);
+    });
+    it("returns false if user has permissions but not the voting one", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: [
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SPLIT,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE,
+            ],
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
+      ).toBe(false);
+    });
+
+    it("returns false if user is not in the permissions", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [Principal.fromText("aaaaa-aa")],
+            permission_type: [
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SPLIT,
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE,
+            ],
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
+      ).toBe(false);
+    });
+    it("returns false if user is has empty permissions", () => {
+      const hotkeyneuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: [],
+          },
+        ],
+      };
+      expect(
+        isHotkeyControllable({
+          neuron: hotkeyneuron,
+          identity: mockIdentity,
+        })
       ).toBe(false);
     });
   });


### PR DESCRIPTION
# Motivation

User can easily identify SNS neurons managed by hotkeys.

# Changes

* New sns neuron util isHotkeyControllable that returns true if neuron is hotkey.
* Use new util in SnsNeuronCard.

# Tests

* Add test case in SnsNeuronCard.
* Test new sns neuron util.
