### PR TITLE
style: clamp project title and description to x lines

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -46,7 +46,7 @@
     <h3>{title}</h3>
   </div>
 
-  <p class="value">{description}</p>
+  <p class="value description">{description}</p>
 
   <ProjectCardSwapInfo {project} bind:myCommitment />
 
@@ -59,15 +59,18 @@
 </Card>
 
 <style lang="scss">
+  @use "../../themes/mixins/text";
+
   .title {
     display: flex;
     gap: var(--padding-1_5x);
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: var(--padding);
 
     h3 {
       margin: 0;
       line-height: var(--line-height-standard);
+      @include text.clamp(2);
     }
   }
 
@@ -77,5 +80,9 @@
 
   .spinner {
     margin-top: var(--padding-1_5x);
+  }
+
+  .description {
+    @include text.clamp(6);
   }
 </style>


### PR DESCRIPTION
# Motivation

Clamp project title to 2 lines and description to 6 lines in launchpad. Align logo top. Developed with Mischa.

# Changes

- clamp style for title and desc
- align logo top

# Screenshot
<img width="1510" alt="Capture d’écran 2022-08-09 à 11 58 05" src="https://user-images.githubusercontent.com/16886711/183621916-ad3f08b0-ed41-4300-8e23-07f733d33a04.png">


