### PR TITLE
L2-914: Sync neuron after hotkey mgt

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
   import { fromDefinedNullable } from "@dfinity/utils";
+  import { getContext } from "svelte";
   import { ICON_SIZE_LARGE } from "../../constants/style.constants";
   import IconClose from "../../icons/IconClose.svelte";
   import IconInfo from "../../icons/IconInfo.svelte";
@@ -11,6 +12,10 @@
   import { i18n } from "../../stores/i18n";
   import { snsProjectSelectedStore } from "../../stores/projects.store";
   import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "../../types/sns-neuron-detail.context";
+  import {
     getSnsNeuronHotkeys,
     canIdentityManageHotkeys,
   } from "../../utils/sns-neuron.utils";
@@ -19,78 +24,98 @@
   import Value from "../ui/Value.svelte";
   import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
 
-  export let neuron: SnsNeuron;
+  const { reload, store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
 
+  let neuron: SnsNeuron | undefined;
+  $: neuron = $store.neuron;
   let neuronId: SnsNeuronId | undefined;
-
-  $: neuronId = fromDefinedNullable(neuron.id);
+  $: neuronId =
+    neuron?.id !== undefined ? fromDefinedNullable(neuron.id) : undefined;
 
   let canManageHotkeys: boolean = true;
-  $: canManageHotkeys = canIdentityManageHotkeys({
-    neuron,
-    identity: $authStore.identity,
-  });
+  $: canManageHotkeys =
+    neuron !== undefined
+      ? canIdentityManageHotkeys({
+          neuron,
+          identity: $authStore.identity,
+        })
+      : false;
   let hotkeys: string[];
-  $: hotkeys = getSnsNeuronHotkeys(neuron);
+  $: hotkeys = neuron !== undefined ? getSnsNeuronHotkeys(neuron) : [];
 
   let showTooltip: boolean;
   $: showTooltip = hotkeys.length > 0 && canManageHotkeys;
 
   const remove = async (hotkey: string) => {
+    // Edge case: Remove button is shwon only when neuron is defined
+    if (neuronId === undefined) {
+      return;
+    }
     startBusy({
       initiator: "remove-sns-hotkey-neuron",
     });
-    await removeHotkey({
-      neuronId: neuron.id[0] as SnsNeuronId,
+    const { success } = await removeHotkey({
+      neuronId,
       hotkey,
       rootCanisterId: $snsProjectSelectedStore,
     });
+    if (success) {
+      await reload();
+    }
     stopBusy("remove-sns-hotkey-neuron");
   };
 </script>
 
-<CardInfo testId="sns-hotkeys-card">
-  <div class="title" slot="start">
-    <h3>{$i18n.neuron_detail.hotkeys_title}</h3>
-    {#if showTooltip}
-      <Tooltip
-        id="sns-hotkeys-info"
-        text={$i18n.sns_neuron_detail.add_hotkey_tooltip}
-      >
-        <span>
-          <IconInfo />
-        </span>
-      </Tooltip>
+{#if neuron !== undefined}
+  <CardInfo testId="sns-hotkeys-card">
+    <div class="title" slot="start">
+      <h3>{$i18n.neuron_detail.hotkeys_title}</h3>
+      {#if showTooltip}
+        <Tooltip
+          id="sns-hotkeys-info"
+          text={$i18n.sns_neuron_detail.add_hotkey_tooltip}
+        >
+          <span>
+            <IconInfo />
+          </span>
+        </Tooltip>
+      {/if}
+    </div>
+    {#if hotkeys.length === 0}
+      {#if canManageHotkeys}
+        <div class="warning">
+          <span class="icon"><IconWarning size={ICON_SIZE_LARGE} /></span>
+          <p class="description">{$i18n.sns_neuron_detail.add_hotkey_info}</p>
+        </div>
+      {:else}
+        <p>{$i18n.neuron_detail.no_notkeys}</p>
+      {/if}
+    {:else}
+      <ul>
+        {#each hotkeys as hotkey (hotkey)}
+          <li>
+            <Value>{hotkey}</Value>
+            {#if canManageHotkeys}
+              <button
+                class="text"
+                aria-label={$i18n.core.remove}
+                on:click={() => remove(hotkey)}
+                data-tid="remove-hotkey-button"
+                ><IconClose size="18px" /></button
+              >
+            {/if}
+          </li>
+        {/each}
+      </ul>
     {/if}
-  </div>
-  {#if hotkeys.length === 0}
-    <div class="warning">
-      <span class="icon"><IconWarning size={ICON_SIZE_LARGE} /></span>
-      <p class="description">{$i18n.sns_neuron_detail.add_hotkey_info}</p>
-    </div>
-  {:else}
-    <ul>
-      {#each hotkeys as hotkey (hotkey)}
-        <li>
-          <Value>{hotkey}</Value>
-          {#if canManageHotkeys}
-            <button
-              class="text"
-              aria-label={$i18n.core.remove}
-              on:click={() => remove(hotkey)}
-              data-tid="remove-hotkey-button"><IconClose size="18px" /></button
-            >
-          {/if}
-        </li>
-      {/each}
-    </ul>
-  {/if}
-  {#if canManageHotkeys && neuronId !== undefined}
-    <div class="actions">
-      <AddSnsHotkeyButton {neuronId} />
-    </div>
-  {/if}
-</CardInfo>
+    {#if canManageHotkeys && neuronId !== undefined}
+      <div class="actions">
+        <AddSnsHotkeyButton />
+      </div>
+    {/if}
+  </CardInfo>
+{/if}
 
 <style lang="scss">
   @use "../../themes/mixins/card";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -4,18 +4,29 @@
   import Value from "../ui/Value.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import SnsNeuronCard from "../sns-neurons/SnsNeuronCard.svelte";
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "../../types/sns-neuron-detail.context";
+  import { getContext } from "svelte";
 
-  export let neuron: SnsNeuron;
+  const { store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let neuron: SnsNeuron | undefined;
+  $: neuron = $store.neuron;
 </script>
 
-<SnsNeuronCard {neuron} cardType="info">
-  <section>
-    <p>
-      <Value>{secondsToDate(Number(neuron.created_timestamp_seconds))}</Value>
-      - {$i18n.neurons.staked}
-    </p>
-  </section>
-</SnsNeuronCard>
+{#if neuron !== undefined}
+  <SnsNeuronCard {neuron} cardType="info">
+    <section>
+      <p>
+        <Value>{secondsToDate(Number(neuron.created_timestamp_seconds))}</Value>
+        - {$i18n.neurons.staked}
+      </p>
+    </section>
+  </SnsNeuronCard>
+{/if}
 
 <style lang="scss">
   @use "../../themes/mixins/media";

--- a/frontend/src/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-  import type { SnsNeuronId } from "@dfinity/sns";
   import AddSnsHotkeyModal from "../../../modals/sns/AddSnsHotkeyModal.svelte";
 
   import { i18n } from "../../../stores/i18n";
-
-  export let neuronId: SnsNeuronId;
 
   let showModal: boolean = false;
   const openModal = () => (showModal = true);
@@ -16,5 +13,5 @@
 >
 
 {#if showModal}
-  <AddSnsHotkeyModal {neuronId} on:nnsClose={closeModal} />
+  <AddSnsHotkeyModal on:nnsClose={closeModal} />
 {/if}

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -1,0 +1,19 @@
+import type { Principal } from "@dfinity/principal";
+import type { SnsNeuron } from "@dfinity/sns";
+import type { Writable } from "svelte/store";
+
+/**
+ * A store that contains the selected proposal.
+ */
+export interface SelectedSnsNeuronStore {
+  rootCanisterId: Principal | undefined;
+  neuronIdHex: string | undefined;
+  neuron: SnsNeuron | undefined;
+}
+
+export interface SelectedSnsNeuronContext {
+  store: Writable<SelectedSnsNeuronStore>;
+  reload: () => Promise<void>;
+}
+
+export const SELECTED_SNS_NEURON_CONTEXT_KEY = Symbol("selected-sns-neuron");

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -6,8 +6,12 @@ import type { Writable } from "svelte/store";
  * A store that contains the selected sns neuron.
  */
 export interface SelectedSnsNeuronStore {
-  rootCanisterId: Principal | undefined;
-  neuronIdHex: string | undefined;
+  selected:
+    | {
+        rootCanisterId: Principal;
+        neuronIdHex: string;
+      }
+    | undefined;
   neuron: SnsNeuron | undefined;
 }
 

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -3,7 +3,7 @@ import type { SnsNeuron } from "@dfinity/sns";
 import type { Writable } from "svelte/store";
 
 /**
- * A store that contains the selected proposal.
+ * A store that contains the selected sns neuron.
  */
 export interface SelectedSnsNeuronStore {
   rootCanisterId: Principal | undefined;

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -67,8 +67,11 @@
     snsProjectSelectedStore.set(rootCanisterId);
 
     // `loadNeuron` relies on neuronId and rootCanisterId to be set in the store
-    $selectedSnsNeuronStore.neuronIdHex = neuronIdMaybe;
-    $selectedSnsNeuronStore.rootCanisterId = rootCanisterId;
+    selectedSnsNeuronStore.set({
+      neuronIdHex: neuronIdMaybe,
+      rootCanisterId,
+      neuron: undefined,
+    });
     loadNeuron();
   });
 

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -23,11 +23,11 @@
   import { setContext } from "svelte";
 
   const loadNeuron = async () => {
-    const { neuronIdHex, rootCanisterId } = $selectedSnsNeuronStore;
-    if (neuronIdHex !== undefined && rootCanisterId !== undefined) {
+    const { selected } = $selectedSnsNeuronStore;
+    if (selected !== undefined) {
       await getSnsNeuron({
-        rootCanisterId,
-        neuronIdHex,
+        rootCanisterId: selected.rootCanisterId,
+        neuronIdHex: selected.neuronIdHex,
         onLoad: ({ neuron: snsNeuron }: { neuron: SnsNeuron }) => {
           selectedSnsNeuronStore.update((store) => ({
             ...store,
@@ -42,8 +42,7 @@
   };
 
   const selectedSnsNeuronStore = writable<SelectedSnsNeuronStore>({
-    rootCanisterId: undefined,
-    neuronIdHex: undefined,
+    selected: undefined,
     neuron: undefined,
   });
 
@@ -68,8 +67,10 @@
 
     // `loadNeuron` relies on neuronId and rootCanisterId to be set in the store
     selectedSnsNeuronStore.set({
-      neuronIdHex: neuronIdMaybe,
-      rootCanisterId,
+      selected: {
+        neuronIdHex: neuronIdMaybe,
+        rootCanisterId,
+      },
       neuron: undefined,
     });
     loadNeuron();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -2,19 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
 import SnsNeuronMetaInfoCard from "../../../../lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
+import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
 describe("SnsNeuronMetaInfoCard", () => {
-  const props = {
-    neuron: mockSnsNeuron,
-  };
-
   it("renders a SnsNeuronCard", () => {
     // We can skip many edge cases tested in the NeuronCard
-    const { queryByTestId } = render(SnsNeuronMetaInfoCard, {
-      props,
+    const { queryByTestId } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronMetaInfoCard,
+      neuron: mockSnsNeuron,
+      reload: jest.fn(),
     });
 
     expect(queryByTestId("sns-neuron-card-title")).toBeInTheDocument();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent } from "@testing-library/svelte";
 import AddSnsHotkeyButton from "../../../../../lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.svelte";
+import { renderSelectedSnsNeuronContext } from "../../../../mocks/context-wrapper.mock";
 import en from "../../../../mocks/i18n.mock";
 import { mockSnsNeuron } from "../../../../mocks/sns-neurons.mock";
 
@@ -12,22 +13,21 @@ describe("AddSnsHotkeyButton", () => {
     jest.clearAllMocks();
   });
 
-  it("renders add hotkey message", () => {
-    const { getByText } = render(AddSnsHotkeyButton, {
-      props: {
-        neuronId: mockSnsNeuron.id[0],
-      },
+  const renderCard = () =>
+    renderSelectedSnsNeuronContext({
+      Component: AddSnsHotkeyButton,
+      neuron: mockSnsNeuron,
+      reload: jest.fn(),
     });
+
+  it("renders add hotkey message", () => {
+    const { getByText } = renderCard();
 
     expect(getByText(en.neuron_detail.add_hotkey)).toBeInTheDocument();
   });
 
   it("opens Add Hotkey Neuron Modal", async () => {
-    const { container, queryByTestId } = render(AddSnsHotkeyButton, {
-      props: {
-        neuronId: mockSnsNeuron.id[0],
-      },
-    });
+    const { container, queryByTestId } = renderCard();
 
     const buttonElement = container.querySelector("button");
     expect(buttonElement).not.toBeNull();

--- a/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
@@ -5,23 +5,25 @@
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import AddSnsHotkeyModal from "../../../../lib/modals/sns/AddSnsHotkeyModal.svelte";
 import { addHotkey } from "../../../../lib/services/sns-neurons.services";
+import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
-import { renderModal } from "../../../mocks/modal.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
 jest.mock("../../../../lib/services/sns-neurons.services", () => {
   return {
-    addHotkey: jest.fn().mockResolvedValue(BigInt(10)),
+    addHotkey: jest.fn().mockResolvedValue({ success: true }),
   };
 });
 
 describe("AddSnsHotkeyModal", () => {
-  const renderAddSnsHotkeyModal = async (): Promise<RenderResult> => {
-    return renderModal({
-      component: AddSnsHotkeyModal,
-      props: { neuronId: mockSnsNeuron.id[0] },
+  const reload = jest.fn();
+
+  const renderAddSnsHotkeyModal = async (): Promise<RenderResult> =>
+    renderSelectedSnsNeuronContext({
+      Component: AddSnsHotkeyModal,
+      reload,
+      neuron: mockSnsNeuron,
     });
-  };
 
   it("should display modal", async () => {
     const { container } = await renderAddSnsHotkeyModal();
@@ -59,7 +61,7 @@ describe("AddSnsHotkeyModal", () => {
     expect(buttonElement?.hasAttribute("disabled")).toBe(true);
   });
 
-  it("should call addHotkey service and close modal", async () => {
+  it("should call addHotkey service, reload and close modal", async () => {
     const principalString = "aaaaa-aa";
     const { container, queryByTestId, component } =
       await renderAddSnsHotkeyModal();
@@ -81,5 +83,6 @@ describe("AddSnsHotkeyModal", () => {
     expect(addHotkey).toBeCalled();
 
     await waitFor(() => expect(onClose).toBeCalled());
+    expect(reload).toBeCalled();
   });
 });

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -1,3 +1,4 @@
+import type { SnsNeuron } from "@dfinity/sns";
 import type { RenderResult } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
@@ -7,7 +8,14 @@ import {
   SELECTED_ACCOUNT_CONTEXT_KEY,
   type SelectedAccountStore,
 } from "../../lib/types/selected-account.context";
+import {
+  SELECTED_SNS_NEURON_CONTEXT_KEY,
+  type SelectedSnsNeuronContext,
+  type SelectedSnsNeuronStore,
+} from "../../lib/types/sns-neuron-detail.context";
+import { getSnsNeuronIdAsHexString } from "../../lib/utils/sns-neuron.utils";
 import ContextWrapperTest from "../lib/components/ContextWrapperTest.svelte";
+import { rootCanisterIdMock } from "./sns.api.mock";
 
 export const renderContextWrapper = <T>({
   Component,
@@ -42,4 +50,26 @@ export const renderSelectedAccountContext = ({
       }),
     },
     Component,
+  });
+
+export const renderSelectedSnsNeuronContext = ({
+  Component,
+  neuron,
+  reload,
+}: {
+  Component: typeof SvelteComponent;
+  neuron: SnsNeuron;
+  reload: () => Promise<void>;
+}) =>
+  renderContextWrapper({
+    Component,
+    contextKey: SELECTED_SNS_NEURON_CONTEXT_KEY,
+    contextValue: {
+      store: writable<SelectedSnsNeuronStore>({
+        neuron,
+        neuronIdHex: getSnsNeuronIdAsHexString(neuron),
+        rootCanisterId: rootCanisterIdMock,
+      }),
+      reload,
+    } as SelectedSnsNeuronContext,
   });

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -66,9 +66,11 @@ export const renderSelectedSnsNeuronContext = ({
     contextKey: SELECTED_SNS_NEURON_CONTEXT_KEY,
     contextValue: {
       store: writable<SelectedSnsNeuronStore>({
+        selected: {
+          neuronIdHex: getSnsNeuronIdAsHexString(neuron),
+          rootCanisterId: rootCanisterIdMock,
+        },
         neuron,
-        neuronIdHex: getSnsNeuronIdAsHexString(neuron),
-        rootCanisterId: rootCanisterIdMock,
       }),
       reload,
     } as SelectedSnsNeuronContext,


### PR DESCRIPTION
# Motivation

User sees new neuron details after adding or removing hotkeys.

# Changes

* Add context in the SnsNeuronDetail "SelectedSnsNeuronContext".
* Children components of SnsNeuronDetail read from context instead of relying on props.
* A function to reload the neuron is added in the SelectedSnsNeuronContext.
* Reload sns neuron is used after successfully removing or adding hotkeys.

# Tests

* Fix and change test components.
* Add check that the reload function is called after adding and removing hotkey.
