### PR TITLE
Consistent wasm canister name

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -49,8 +49,8 @@ local_deployment_data="$(
   : "Get the SNS wasm canister ID, if it exists"
   : "- may be set as an env var"
   : "Note: If you want to use a wasm canister deployed by someone else, add the canister ID to the remote section in dfx.json:"
-  : "      dfx.json -> canisters -> wasm_canister -> remote -> id -> your DFX_NETWORK -> THE_WASM_CANISTER_ID"
-  LOCALLY_DEPLOYED_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister 2>/dev/null || echo "NO_SNS_WASM_CANISTER_SPECIFIED")"
+  : "      dfx.json -> canisters -> nns-sns-wasm -> remote -> id -> your DFX_NETWORK -> THE_WASM_CANISTER_ID"
+  LOCALLY_DEPLOYED_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm 2>/dev/null || echo "NO_SNS_WASM_CANISTER_SPECIFIED")"
   test -n "${WASM_CANISTER_ID:-}" || WASM_CANISTER_ID="$LOCALLY_DEPLOYED_WASM_CANISTER_ID"
   export WASM_CANISTER_ID
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -291,7 +291,7 @@ fi
 if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
   # If the wasm canister has not been installed already, install it.
   echo Checking whether sns wasm is installed
-  SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister 2>/dev/null || echo NOPE)"
+  SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm 2>/dev/null || echo NOPE)"
   [[ "${SNS_WASM_CANISTER_ID:-}" == "NOPE" ]] || {
     echo "SNS wasm/management canister already installed at: $SNS_WASM_CANISTER_ID"
   }
@@ -301,8 +301,8 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     echo "Deploying SNS wasm canister..."
     NNS_URL="$(./e2e-tests/scripts/nns-dashboard --dfx-network "$DFX_NETWORK")"
     SNS_SUBNETS="$(ic-admin --nns-url "$NNS_URL" get-subnet-list | jq -r '. | map("principal \"" + . + "\"") | join("; ")')"
-    dfx deploy --network "$DFX_NETWORK" wasm_canister --argument '( record { sns_subnet_ids = vec { '"$SNS_SUBNETS"' }; access_controls_enabled = false; } )' --no-wallet
-    SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id wasm_canister)"
+    dfx deploy --network "$DFX_NETWORK" nns-sns-wasm --argument '( record { sns_subnet_ids = vec { '"$SNS_SUBNETS"' }; access_controls_enabled = false; } )' --no-wallet
+    SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
     for canister in root governance ledger swap; do

--- a/dfx.json
+++ b/dfx.json
@@ -30,7 +30,7 @@
       "candid": "internet_identity.did",
       "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm\" -o internet_identity.wasm"
     },
-    "wasm_canister": {
+    "nns-sns-wasm": {
       "build": [
         "true"
       ],

--- a/scripts/sns/wasm_canister/list_deployed_snses
+++ b/scripts/sns/wasm_canister/list_deployed_snses
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 DFX_NETWORK="${DFX_NETWORK:-$1}"
-dfx canister --network "${DFX_NETWORK}" call wasm_canister list_deployed_snses '( record { } )'
+dfx canister --network "${DFX_NETWORK}" call nns-sns-wasm list_deployed_snses '( record { } )'


### PR DESCRIPTION
# Motivation
Governance canisters are listed upstream [here](https://github.com/dfinity/ic/blob/master/rs/nns/dfx.json) as governance, ledger and so on.  Per the draft SNS deployment spec, nns governance canisters should be imported with the `nns-` prefix, chosen to be minimally disruptive with the existing use of `nns-governance`.  However the wasm canister in the nns-dapp dfx file does not match this pattern

# Changes
- Rename `wasm_canister` to `nns-` + `sns-wasm` == `nns-sns-wasm`

# Tests
See CI.  This is not expected to break any code but MAY break some demos.