### PR TITLE
L2-919: Manage Errors In Sale Participation

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -9,7 +9,7 @@
   } from "../../stores/transaction-fees.store";
   import type { Account } from "../../types/account";
   import { InvalidAmountError } from "../../types/neurons.errors";
-  import { assertEnoughBalance } from "../../utils/accounts.utils";
+  import { assertEnoughAccountFunds } from "../../utils/accounts.utils";
   import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../ic/ICP.svelte";
@@ -46,7 +46,7 @@
     }
     try {
       const icp = convertNumberToICP(amount);
-      assertEnoughBalance({
+      assertEnoughAccountFunds({
         account: selectedAccount,
         amountE8s: icp.toE8s() + $mainTransactionFeeStoreAsIcp.toE8s(),
       });

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -40,6 +40,7 @@
 
   let errorMessage: string | undefined = undefined;
   $: (() => {
+    // Remove error message when resetting amount or source account
     if (amount === undefined || selectedAccount === undefined) {
       errorMessage = undefined;
       return;

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -8,6 +8,8 @@
     mainTransactionFeeStore,
   } from "../../stores/transaction-fees.store";
   import type { Account } from "../../types/account";
+  import { InvalidAmountError } from "../../types/neurons.errors";
+  import { assertEnoughBalance } from "../../utils/accounts.utils";
   import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../ic/ICP.svelte";
@@ -44,13 +46,15 @@
     }
     try {
       const icp = convertNumberToICP(amount);
-      errorMessage =
-        icp.toE8s() + $mainTransactionFeeStoreAsIcp.toE8s() >
-        selectedAccount.balance.toE8s()
-          ? $i18n.error.insufficient_funds
-          : undefined;
+      assertEnoughBalance({
+        account: selectedAccount,
+        amountE8s: icp.toE8s() + $mainTransactionFeeStoreAsIcp.toE8s(),
+      });
     } catch (error) {
-      errorMessage = $i18n.error.amount_not_valid;
+      if (error instanceof InvalidAmountError) {
+        errorMessage = $i18n.error.amount_not_valid;
+      }
+      errorMessage = $i18n.error.insufficient_funds;
     }
   })();
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -8,7 +8,7 @@
     mainTransactionFeeStore,
   } from "../../stores/transaction-fees.store";
   import type { Account } from "../../types/account";
-  import { maxICP } from "../../utils/icp.utils";
+  import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../ic/ICP.svelte";
   import AmountInput from "../ui/AmountInput.svelte";
@@ -18,7 +18,7 @@
 
   export let selectedAccount: Account | undefined = undefined;
   export let amount: number | undefined = undefined;
-  // TODO: Handle min and max validations: https://dfinity.atlassian.net/browse/L2-798
+  // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
   export let minAmount: ICP;
   export let maxAmount: ICP;
 
@@ -31,8 +31,28 @@
 
   let disableButton: boolean;
   $: disableButton =
-    selectedAccount === undefined || amount === 0 || amount === undefined;
+    selectedAccount === undefined ||
+    amount === 0 ||
+    amount === undefined ||
+    errorMessage !== undefined;
 
+  let errorMessage: string | undefined = undefined;
+  $: (() => {
+    if (amount === undefined || selectedAccount === undefined) {
+      errorMessage = undefined;
+      return;
+    }
+    try {
+      const icp = convertNumberToICP(amount);
+      errorMessage =
+        icp.toE8s() + $mainTransactionFeeStoreAsIcp.toE8s() >
+        selectedAccount.balance.toE8s()
+          ? $i18n.error.insufficient_funds
+          : undefined;
+    } catch (error) {
+      errorMessage = $i18n.error.amount_not_valid;
+    }
+  })();
   const dispatcher = createEventDispatcher();
   const close = () => {
     dispatcher("nnsClose");
@@ -43,7 +63,11 @@
   };
 </script>
 
-<div class="wrapper" data-tid="sns-swap-participate-step-1">
+<form
+  on:submit|preventDefault={goNext}
+  class="wrapper"
+  data-tid="sns-swap-participate-step-1"
+>
   <div class="select-account">
     {#if selectedAccount !== undefined}
       <KeyValuePair>
@@ -54,7 +78,7 @@
     <SelectAccountDropdown bind:selectedAccount skipHardwareWallets />
   </div>
   <div class="wrapper info">
-    <AmountInput bind:amount on:nnsMax={addMax} {max} />
+    <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
     <KeyValuePair>
       <span slot="key"
         >{$i18n.core.min} <IcpComponent singleLine icp={minAmount} /></span
@@ -72,16 +96,17 @@
     <button
       class="small secondary"
       data-tid="sns-swap-participate-button-cancel"
+      type="button"
       on:click={close}>{$i18n.core.cancel}</button
     >
     <button
       class="small primary"
       data-tid="sns-swap-participate-button-next"
       disabled={disableButton}
-      on:click={goNext}>{$i18n.sns_project_detail.participate}</button
+      type="submit">{$i18n.sns_project_detail.participate}</button
     >
   </FooterModal>
-</div>
+</form>
 
 <style lang="scss">
   @use "../../themes/mixins/modal";

--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -48,7 +48,6 @@
 
   const dispatcher = createEventDispatcher();
   const participate = async () => {
-    // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-798
     if (nonNullish($store.summary)) {
       startBusy({
         initiator: "project-participate",

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -1,23 +1,25 @@
 <script lang="ts">
-  import Input from "./Input.svelte";
   import { i18n } from "../../stores/i18n";
   import { createEventDispatcher } from "svelte";
   import MaxButton from "../common/MaxButton.svelte";
+  import InputWithError from "./InputWithError.svelte";
 
   export let amount: number | undefined = undefined;
   export let max: number | undefined = undefined;
+  export let errorMessage: string | undefined = undefined;
 
   const dispatch = createEventDispatcher();
   const setMax = () => dispatch("nnsMax");
 </script>
 
-<Input
+<InputWithError
   placeholderLabelKey="core.amount"
   name="amount"
   bind:value={amount}
   {max}
   inputType="icp"
+  {errorMessage}
 >
   <svelte:fragment slot="label">{$i18n.core.amount}</svelte:fragment>
   <MaxButton on:click={setMax} slot="additional" />
-</Input>
+</InputWithError>

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -4,7 +4,7 @@
 
   // Same props as Input
   export let name: string;
-  export let inputType: "number" | "text" = "number";
+  export let inputType: "number" | "text" | "icp" = "number";
   export let required: boolean = true;
   export let spellcheck: boolean | undefined = undefined;
   export let step: number | "any" | undefined = undefined;
@@ -36,6 +36,7 @@
     on:blur
     on:input
   >
+    <slot name="label" slot="label" />
     <slot name="additional" slot="additional" />
   </Input>
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -659,7 +659,7 @@
     "project_not_found": "Sorry, the project was not found. Please refresh and try again",
     "project_not_open": "Sorry, the project does not accept participations yet.",
     "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
-    "commitment_too_large": "Sorry, your commitment of $commitment ICP is too large. The maximum is $maxCommitment ICP.",
+    "commitment_too_large": "Sorry, your commitment of $commitment ICP is too high. The maximum is $maxCommitment ICP.",
     "cannot_participate": "Sorry, There was an unexpected error while participating.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -59,7 +59,7 @@
     "update_delay": "Sorry, there was an error updating the delay of the neuron",
     "unknown": "Sorry, there was an unexpected error. Please try again later.",
     "amount_not_valid": "Sorry, the amount is not valid",
-    "amount_not_enough_stake_neuron": "Sorry, the amount is too smal. You need a minimum of 1 ICP to stake a neuron",
+    "amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need a minimum of 1 ICP to stake a neuron",
     "amount_not_enough_top_up_neuron": "Sorry, the amount is too small. The amount plus the current stake need to be at least 1 ICP",
     "stake_neuron": "Sorry, there was an unexpected error staking the neuron. Please try again later.",
     "transaction_invalid_amount": "The amount is less than zero or exceeds the amount of available funds for the selected account.",
@@ -656,6 +656,11 @@
     "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
     "load_swap_commitment": "There was an unexpected error while loading the commitment of of the project.",
     "sns_remove_hotkey": "There was an error removing the hotkey.",
+    "project_not_found": "Sorry, the project was not found. Please refresh and try again",
+    "project_not_open": "Sorry, the project does not accept participations yet.",
+    "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
+    "commitment_too_large": "Sorry, the total commitment of $commitment ICP is too large. The maximum is $maxCommitment ICP.",
+    "cannot_participate": "Sorry, There was an unexpected error while participating.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -659,7 +659,7 @@
     "project_not_found": "Sorry, the project was not found. Please refresh and try again",
     "project_not_open": "Sorry, the project does not accept participations yet.",
     "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
-    "commitment_too_large": "Sorry, the total commitment of $commitment ICP is too large. The maximum is $maxCommitment ICP.",
+    "commitment_too_large": "Sorry, your commitment of $commitment ICP is too large. The maximum is $maxCommitment ICP.",
     "cannot_participate": "Sorry, There was an unexpected error while participating.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   }

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -1,4 +1,3 @@
-import type { ICP } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import {
   attachCanister as attachCanisterApi,
@@ -19,7 +18,7 @@ import { AppPath } from "../constants/routes.constants";
 import { canistersStore } from "../stores/canisters.store";
 import { toastsStore } from "../stores/toasts.store";
 import type { Account } from "../types/account";
-import { InsufficientAmountError } from "../types/common.errors";
+import { assertEnoughAccountFunds } from "../utils/accounts.utils";
 import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { isController } from "../utils/canisters.utils";
 import {
@@ -63,21 +62,6 @@ export const listCanisters = async ({
   });
 };
 
-/**
- * @throws InsufficientAmountError
- */
-const assertEnoughBalance = ({
-  amount,
-  account,
-}: {
-  amount: ICP;
-  account: Account;
-}): void => {
-  if (amount.toE8s() > account.balance.toE8s()) {
-    throw new InsufficientAmountError();
-  }
-};
-
 export const createCanister = async ({
   amount,
   account,
@@ -87,7 +71,7 @@ export const createCanister = async ({
 }): Promise<Principal | undefined> => {
   try {
     const icpAmount = convertNumberToICP(amount);
-    assertEnoughBalance({ amount: icpAmount, account });
+    assertEnoughAccountFunds({ amountE8s: icpAmount.toE8s(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     const canisterId = await createCanisterApi({
@@ -119,7 +103,7 @@ export const topUpCanister = async ({
 }): Promise<{ success: boolean }> => {
   try {
     const icpAmount = convertNumberToICP(amount);
-    assertEnoughBalance({ amount: icpAmount, account });
+    assertEnoughAccountFunds({ amountE8s: icpAmount.toE8s(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     await topUpCanisterApi({

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -41,7 +41,7 @@ import {
   NotFoundError,
 } from "../types/neurons.errors";
 import {
-  assertEnoughBalance,
+  assertEnoughAccountFunds,
   isAccountHardwareWallet,
 } from "../utils/accounts.utils";
 import { getLastPathDetailId, isRoutePath } from "../utils/app-path.utils";
@@ -192,7 +192,7 @@ export const stakeNeuron = async ({
 }): Promise<NeuronId | undefined> => {
   try {
     const stake = convertNumberToICP(amount);
-    assertEnoughBalance({
+    assertEnoughAccountFunds({
       account,
       amountE8s: stake.toE8s(),
     });

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -40,7 +40,10 @@ import {
   NotAuthorizedNeuronError,
   NotFoundError,
 } from "../types/neurons.errors";
-import { isAccountHardwareWallet } from "../utils/accounts.utils";
+import {
+  assertEnoughBalance,
+  isAccountHardwareWallet,
+} from "../utils/accounts.utils";
 import { getLastPathDetailId, isRoutePath } from "../utils/app-path.utils";
 import { mapNeuronErrorToToastMessage } from "../utils/error.utils";
 import { translate } from "../utils/i18n.utils";
@@ -189,6 +192,10 @@ export const stakeNeuron = async ({
 }): Promise<NeuronId | undefined> => {
   try {
     const stake = convertNumberToICP(amount);
+    assertEnoughBalance({
+      account,
+      amountE8s: stake.toE8s(),
+    });
 
     if (!isEnoughToStakeNeuron({ stake })) {
       toastsStore.error({

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -28,10 +28,11 @@ import type { Account } from "../types/account";
 import { LedgerErrorKey } from "../types/ledger.errors";
 import type { SnsSwapCommitment } from "../types/sns";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "../types/sns.query";
-import { assertEnoughBalance } from "../utils/accounts.utils";
+import { assertEnoughAccountFunds } from "../utils/accounts.utils";
 import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
-import { getSwapCanisterAccount, validParticipation } from "../utils/sns.utils";
+import { validParticipation } from "../utils/projects.utils";
+import { getSwapCanisterAccount } from "../utils/sns.utils";
 import { getAccountIdentity } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
@@ -251,7 +252,7 @@ export const participateInSwap = async ({
 }): Promise<{ success: boolean }> => {
   try {
     const transactionFee = get(transactionsFeesStore).main;
-    assertEnoughBalance({
+    assertEnoughAccountFunds({
       account,
       amountE8s: amount.toE8s() + transactionFee,
     });

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -5,6 +5,7 @@ import {
   type ProposalInfo,
 } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
 import {
   participateInSnsSwap,
   queryAllSnsMetadata,
@@ -15,18 +16,22 @@ import {
   querySnsSwapStates,
 } from "../api/sns.api";
 import { AppPath } from "../constants/routes.constants";
+import { projectsStore, type SnsFullProject } from "../stores/projects.store";
 import {
   snsProposalsStore,
   snsQueryStore,
   snsSwapCommitmentsStore,
 } from "../stores/sns.store";
 import { toastsStore } from "../stores/toasts.store";
+import { transactionsFeesStore } from "../stores/transaction-fees.store";
 import type { Account } from "../types/account";
+import { LedgerErrorKey } from "../types/ledger.errors";
 import type { SnsSwapCommitment } from "../types/sns";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "../types/sns.query";
+import { assertEnoughBalance } from "../utils/accounts.utils";
 import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
-import { getSwapCanisterAccount } from "../utils/sns.utils";
+import { getSwapCanisterAccount, validParticipation } from "../utils/sns.utils";
 import { getAccountIdentity } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
@@ -228,6 +233,13 @@ export const getSwapAccount = async (
   });
 };
 
+const getProjectFromStore = (
+  rootCanisterId: Principal
+): SnsFullProject | undefined =>
+  get(projectsStore)?.find(
+    ({ rootCanisterId: id }) => id.toText() === rootCanisterId.toText()
+  );
+
 export const participateInSwap = async ({
   amount,
   rootCanisterId,
@@ -238,6 +250,21 @@ export const participateInSwap = async ({
   account: Account;
 }): Promise<{ success: boolean }> => {
   try {
+    const transactionFee = get(transactionsFeesStore).main;
+    assertEnoughBalance({
+      account,
+      amountE8s: amount.toE8s() + transactionFee,
+    });
+    const project = getProjectFromStore(rootCanisterId);
+    const { valid, labelKey, substitutions } = validParticipation({
+      project,
+      amount,
+    });
+    if (!valid) {
+      // TODO: Rename LedgerErroKey to NnsDappErrorKey?
+      throw new LedgerErrorKey(labelKey, substitutions);
+    }
+
     const accountIdentity = await getAccountIdentity(account.identifier);
 
     await participateInSnsSwap({
@@ -250,7 +277,12 @@ export const participateInSwap = async ({
 
     return { success: true };
   } catch (error) {
-    // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-798
+    toastsStore.error(
+      toToastError({
+        err: error,
+        fallbackErrorLabelKey: "error__sns.cannot_participate",
+      })
+    );
     return { success: false };
   }
 };

--- a/frontend/src/lib/stores/projects.store.ts
+++ b/frontend/src/lib/stores/projects.store.ts
@@ -22,7 +22,7 @@ export interface SnsFullProject {
  *
  * @return SnsFullProject[] | undefined What we called project - i.e. the summary and swap of a Sns with the user commitment
  */
-const projectsStore: Readable<SnsFullProject[] | undefined> = derived(
+export const projectsStore: Readable<SnsFullProject[] | undefined> = derived(
   [snsSummariesStore, snsSwapCommitmentsStore],
   ([summaries, $snsSwapStatesStore]): SnsFullProject[] | undefined =>
     summaries?.map((summary) => {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -693,6 +693,11 @@ interface I18nError__sns {
   list_swap_commitments: string;
   load_swap_commitment: string;
   sns_remove_hotkey: string;
+  project_not_found: string;
+  project_not_open: string;
+  not_enough_amount: string;
+  commitment_too_large: string;
+  cannot_participate: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/lib/types/ledger.errors.ts
+++ b/frontend/src/lib/types/ledger.errors.ts
@@ -1,4 +1,15 @@
-export class LedgerErrorKey extends Error {}
+import type { I18nSubstitutions } from "../utils/i18n.utils";
+
+export class LedgerErrorKey extends Error {
+  // Optional substitutions values that can be used to fill the error message
+  substitutions?: I18nSubstitutions;
+
+  constructor(message?: string, substitutions?: I18nSubstitutions) {
+    super(message);
+
+    this.substitutions = substitutions;
+  }
+}
 
 export class LedgerErrorMessage extends Error {}
 

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -2,6 +2,7 @@ import { checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
+import { LedgerErrorKey } from "../types/ledger.errors";
 
 /*
  * Returns the principal's main or hardware account
@@ -90,4 +91,19 @@ export const getAccountFromStore = ({
   return hardwareWallets?.find(
     (account: Account) => account.identifier === identifier
   );
+};
+
+/**
+ * Throws error if the account doesn't have enough balance.
+ */
+export const assertEnoughBalance = ({
+  account,
+  amountE8s,
+}: {
+  account: Account;
+  amountE8s: bigint;
+}): void => {
+  if (account.balance.toE8s() < amountE8s) {
+    throw new LedgerErrorKey("error.insufficient_funds");
+  }
 };

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -2,7 +2,7 @@ import { checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { AccountsStore } from "../stores/accounts.store";
 import type { Account } from "../types/account";
-import { LedgerErrorKey } from "../types/ledger.errors";
+import { InsufficientAmountError } from "../types/common.errors";
 
 /*
  * Returns the principal's main or hardware account
@@ -95,8 +95,9 @@ export const getAccountFromStore = ({
 
 /**
  * Throws error if the account doesn't have enough balance.
+ * @throws InsufficientAmountError
  */
-export const assertEnoughBalance = ({
+export const assertEnoughAccountFunds = ({
   account,
   amountE8s,
 }: {
@@ -104,6 +105,6 @@ export const assertEnoughBalance = ({
   amountE8s: bigint;
 }): void => {
   if (account.balance.toE8s() < amountE8s) {
-    throw new LedgerErrorKey("error.insufficient_funds");
+    throw new InsufficientAmountError("error.insufficient_funds");
   }
 };

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -115,14 +115,14 @@ export const durationTillSwapStart = (
 
 const isProjectOpen = (summary: SnsSummary): boolean =>
   summary.swap.state.lifecycle === SnsSwapLifecycle.Open;
-const isEnoughAmount = ({
+const commitmentTooSmall = ({
   project,
   amount,
 }: {
   project: SnsFullProject;
   amount: ICP;
 }): boolean =>
-  project.summary.swap.init.min_participant_icp_e8s <= amount.toE8s();
+  project.summary.swap.init.min_participant_icp_e8s > amount.toE8s();
 const commitmentTooLarge = ({
   summary,
   amountE8s,
@@ -152,7 +152,7 @@ export const canUserParticipateToSwap = ({
     summary !== undefined &&
     summary !== null &&
     isProjectOpen(summary) &&
-    // Can still participate with 1 e8?
+    // Whether user can still participate with 1 e8
     !commitmentTooLarge({ summary, amountE8s: myCommitment + BigInt(1) })
   );
 };
@@ -184,7 +184,7 @@ export const validParticipation = ({
       labelKey: "error__sns.project_not_open",
     };
   }
-  if (!isEnoughAmount({ project, amount })) {
+  if (commitmentTooSmall({ project, amount })) {
     return {
       valid: false,
       labelKey: "error__sns.not_enough_amount",

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,17 +1,17 @@
-import { AccountIdentifier, SubAccount } from "@dfinity/nns";
+import { AccountIdentifier, ICP, SubAccount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import type {
-  SnsGetMetadataResponse,
-  SnsSwap,
-  SnsSwapDerivedState,
-  SnsSwapInit,
-  SnsSwapState,
-} from "@dfinity/sns";
 import {
   SnsMetadataResponseEntries,
+  SnsSwapLifecycle,
+  type SnsGetMetadataResponse,
+  type SnsSwap,
+  type SnsSwapDerivedState,
+  type SnsSwapInit,
+  type SnsSwapState,
   type SnsTokenMetadataResponse,
 } from "@dfinity/sns";
 import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
+import type { SnsFullProject } from "../stores/projects.store";
 import type {
   SnsSummary,
   SnsSummaryMetadata,
@@ -22,6 +22,8 @@ import type {
   QuerySnsMetadata,
   QuerySnsSwapState,
 } from "../types/sns.query";
+import type { I18nSubstitutions } from "./i18n.utils";
+import { formatICP } from "./icp.utils";
 
 type OptionalSummary = QuerySns & {
   metadata?: SnsSummaryMetadata;
@@ -197,4 +199,71 @@ export const getSwapCanisterAccount = ({
   });
 
   return accountIdentifier;
+};
+
+const isProjectOpen = (project: SnsFullProject): boolean =>
+  project.summary.swap.state.lifecycle === SnsSwapLifecycle.Open;
+const isEnoughAmount = ({
+  project,
+  amount,
+}: {
+  project: SnsFullProject;
+  amount: ICP;
+}): boolean =>
+  project.summary.swap.init.min_participant_icp_e8s <= amount.toE8s();
+const commitmentTooLarge = ({
+  project,
+  amountE8s,
+}: {
+  project: SnsFullProject;
+  amountE8s: bigint;
+}): boolean => project.summary.swap.init.max_participant_icp_e8s < amountE8s;
+
+export const validParticipation = ({
+  project,
+  amount,
+}: {
+  project: SnsFullProject | undefined;
+  amount: ICP;
+}): {
+  valid: boolean;
+  labelKey?: string;
+  substitutions?: I18nSubstitutions;
+} => {
+  if (project === undefined) {
+    return { valid: false, labelKey: "error__sns.project_not_found" };
+  }
+  if (!isProjectOpen(project)) {
+    return {
+      valid: false,
+      labelKey: "error__sns.project_not_open",
+    };
+  }
+  if (!isEnoughAmount({ project, amount })) {
+    return {
+      valid: false,
+      labelKey: "error__sns.not_enough_amount",
+      substitutions: {
+        $amount: formatICP({
+          value: project.summary.swap.init.min_participant_icp_e8s,
+        }),
+      },
+    };
+  }
+  const totalCommitment =
+    (project.swapCommitment?.myCommitment?.amount_icp_e8s ?? BigInt(0)) +
+    amount.toE8s();
+  if (commitmentTooLarge({ project, amountE8s: totalCommitment })) {
+    return {
+      valid: false,
+      labelKey: "error__sns.commitment_too_large",
+      substitutions: {
+        $commitment: formatICP({ value: totalCommitment }),
+        $maxCommitment: formatICP({
+          value: project.summary.swap.init.max_participant_icp_e8s,
+        }),
+      },
+    };
+  }
+  return { valid: true };
 };

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -260,6 +260,25 @@ describe("neurons-services", () => {
       expect(toastsStore.show).toBeCalled();
     });
 
+    it("stake neuron should return undefined if not enough funds in account", async () => {
+      jest
+        .spyOn(LedgerCanister, "create")
+        .mockImplementation(() => mock<LedgerCanister>());
+
+      // 10 ICPs
+      const amount = 10;
+      const response = await stakeNeuron({
+        amount,
+        account: {
+          ...mockMainAccount,
+          balance: ICP.fromString(String(amount - 1)) as ICP,
+        },
+      });
+
+      expect(response).toBeUndefined();
+      expect(toastsStore.show).toBeCalled();
+    });
+
     it("should not stake neuron if no identity", async () => {
       setNoAccountIdentity();
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -1,8 +1,14 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { AccountIdentifier, ICP } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import * as api from "../../../lib/api/sns.api";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
 import * as services from "../../../lib/services/sns.services";
+import { snsQueryStore } from "../../../lib/stores/sns.store";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
+import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
 const { participateInSwap, getSwapAccount } = services;
 
@@ -22,15 +28,33 @@ jest.mock("../../../lib/services/accounts.services", () => {
 
 describe("sns-services", () => {
   describe("participateInSwap", () => {
-    afterEach(() => jest.clearAllMocks());
+    const [metadatas, querySnsSwapStates] = snsResponsesForLifecycle({
+      certified: true,
+      lifecycles: [SnsSwapLifecycle.Open],
+    });
+    // Prepare project data
+    querySnsSwapStates[0].derived[0]!.buyer_total_icp_e8s = BigInt(0);
+    querySnsSwapStates[0].swap[0]!.init[0]!.max_participant_icp_e8s =
+      BigInt(20_000_000_000);
+    querySnsSwapStates[0].swap[0]!.init[0]!.min_participant_icp_e8s =
+      BigInt(10_000_000);
+    querySnsSwapStates[0].swap[0]!.init[0]!.max_icp_e8s =
+      BigInt(200_000_000_000);
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      snsQueryStore.reset();
+    });
 
     it("should call api.participateInSnsSwap and return success true", async () => {
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
         amount: ICP.fromString("3") as ICP,
-        rootCanisterId: mockPrincipal,
+        rootCanisterId,
         account: mockMainAccount,
       });
       expect(success).toBe(true);
@@ -38,26 +62,107 @@ describe("sns-services", () => {
     });
 
     it("should return success false if api call fails", async () => {
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.reject(undefined));
       const { success } = await participateInSwap({
         amount: ICP.fromString("3") as ICP,
-        rootCanisterId: mockPrincipal,
+        rootCanisterId,
         account: mockMainAccount,
       });
       expect(success).toBe(false);
       expect(spyParticipate).toBeCalled();
     });
 
+    it("should return success false and not call api if amount lower than minimum", async () => {
+      // Prepare data
+      const [metadatas, querySnsSwapStates] = snsResponsesForLifecycle({
+        certified: true,
+        lifecycles: [SnsSwapLifecycle.Open],
+      });
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_participant_icp_e8s =
+        BigInt(20_000_000_000);
+      const minimumE8s = BigInt(10_000_000);
+      querySnsSwapStates[0].swap[0]!.init[0]!.min_participant_icp_e8s =
+        minimumE8s;
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_icp_e8s =
+        BigInt(200_000_000_000);
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      const spyParticipate = jest
+        .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() => Promise.resolve(undefined));
+      const { success } = await participateInSwap({
+        amount: ICP.fromE8s(minimumE8s - BigInt(10_000)),
+        rootCanisterId,
+        account: mockMainAccount,
+      });
+      expect(success).toBe(false);
+      expect(spyParticipate).not.toBeCalled();
+    });
+
+    it("should return success false and not call api if amount higher than maximum", async () => {
+      // Prepare data
+      const [metadatas, querySnsSwapStates] = snsResponsesForLifecycle({
+        certified: true,
+        lifecycles: [SnsSwapLifecycle.Open],
+      });
+      const maximumE8s = BigInt(20_000_000_000);
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_participant_icp_e8s =
+        maximumE8s;
+      querySnsSwapStates[0].swap[0]!.init[0]!.min_participant_icp_e8s =
+        BigInt(10_000_000);
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_icp_e8s =
+        BigInt(200_000_000_000);
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      const spyParticipate = jest
+        .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() => Promise.resolve(undefined));
+      const { success } = await participateInSwap({
+        amount: ICP.fromE8s(maximumE8s + BigInt(10_000)),
+        rootCanisterId,
+        account: mockMainAccount,
+      });
+      expect(success).toBe(false);
+      expect(spyParticipate).not.toBeCalled();
+    });
+
+    it("should return success false and not call api if not enough amount in account balance", async () => {
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      const account = {
+        ...mockMainAccount,
+        balance: ICP.fromE8s(BigInt(100_000_000)),
+      };
+      const spyParticipate = jest
+        .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() => Promise.resolve(undefined));
+      const { success } = await participateInSwap({
+        amount: ICP.fromE8s(
+          account.balance.toE8s() +
+            BigInt(DEFAULT_TRANSACTION_FEE_E8S) +
+            BigInt(10_000)
+        ),
+        rootCanisterId,
+        account,
+      });
+      expect(success).toBe(false);
+      expect(spyParticipate).not.toBeCalled();
+    });
+
     it("should return success false if no identity", async () => {
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
       setNoAccountIdentity();
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
         amount: ICP.fromString("3") as ICP,
-        rootCanisterId: mockPrincipal,
+        rootCanisterId,
         account: mockMainAccount,
       });
       expect(success).toBe(false);

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -6,6 +6,7 @@ import {
   activePadProjectsStore,
   committedProjectsStore,
   isNnsProjectStore,
+  projectsStore,
   snsProjectSelectedStore,
 } from "../../../lib/stores/projects.store";
 import {
@@ -19,6 +20,32 @@ import {
 import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
 describe("projects.store", () => {
+  describe("projectsStore", () => {
+    beforeAll(() => {
+      snsQueryStore.reset();
+    });
+
+    afterAll(() => {
+      snsQueryStore.reset();
+    });
+
+    const principalRootCanisterId = mockSnsSummaryList[0].rootCanisterId;
+
+    snsSwapCommitmentsStore.setSwapCommitment({
+      swapCommitment: mockSnsSwapCommitment(principalRootCanisterId),
+      certified: true,
+    });
+
+    it("should set projects of all statuses", () => {
+      snsQueryStore.setData(
+        snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
+        })
+      );
+      const projects = get(projectsStore);
+      expect(projects).toHaveLength(2);
+    });
+  });
   describe("filter projects store", () => {
     beforeAll(() => {
       snsQueryStore.reset();

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,5 +1,7 @@
+import { ICP } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
+  assertEnoughBalance,
   emptyAddress,
   getAccountByPrincipal,
   getAccountFromStore,
@@ -129,6 +131,34 @@ describe("accounts-utils", () => {
           accountsStore,
         })
       ).toEqual(mockSubAccount);
+    });
+  });
+
+  describe("assertEnoughBalance", () => {
+    it("should throw if not enough balance", () => {
+      const amountE8s = BigInt(1_000_000_000);
+      expect(() => {
+        assertEnoughBalance({
+          account: {
+            ...mockMainAccount,
+            balance: ICP.fromE8s(amountE8s),
+          },
+          amountE8s: amountE8s + BigInt(10_000),
+        });
+      }).toThrow();
+    });
+
+    it("should not throw if not enough balance", () => {
+      const amountE8s = BigInt(1_000_000_000);
+      expect(() => {
+        assertEnoughBalance({
+          account: {
+            ...mockMainAccount,
+            balance: ICP.fromE8s(amountE8s),
+          },
+          amountE8s: amountE8s - BigInt(10_000),
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,7 +1,7 @@
 import { ICP } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
-  assertEnoughBalance,
+  assertEnoughAccountFunds,
   emptyAddress,
   getAccountByPrincipal,
   getAccountFromStore,
@@ -134,11 +134,11 @@ describe("accounts-utils", () => {
     });
   });
 
-  describe("assertEnoughBalance", () => {
+  describe("assertEnoughAccountFunds", () => {
     it("should throw if not enough balance", () => {
       const amountE8s = BigInt(1_000_000_000);
       expect(() => {
-        assertEnoughBalance({
+        assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
             balance: ICP.fromE8s(amountE8s),
@@ -151,7 +151,7 @@ describe("accounts-utils", () => {
     it("should not throw if not enough balance", () => {
       const amountE8s = BigInt(1_000_000_000);
       expect(() => {
-        assertEnoughBalance({
+        assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
             balance: ICP.fromE8s(amountE8s),

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,15 +1,20 @@
-import { AccountIdentifier } from "@dfinity/nns";
+import { AccountIdentifier, ICP } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { SnsMetadataResponseEntries } from "@dfinity/sns";
+import { SnsMetadataResponseEntries, SnsSwapLifecycle } from "@dfinity/sns";
+import type { BuyerState } from "@dfinity/sns/dist/candid/sns_swap";
+import type { SnsFullProject } from "../../../lib/stores/projects.store";
+import type { SnsSwapCommitment } from "../../../lib/types/sns";
 import {
   getSwapCanisterAccount,
   mapAndSortSnsQueryToSummaries,
+  validParticipation,
 } from "../../../lib/utils/sns.utils";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   mockDerived,
   mockQueryMetadata,
   mockQueryMetadataResponse,
+  mockSnsFullProject,
   mockSnsSummaryList,
   mockSummary,
   mockSwapInit,
@@ -276,6 +281,134 @@ describe("sns-utils", () => {
         controller: mockIdentity.getPrincipal(),
       });
       expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
+    });
+  });
+
+  describe("validParticipation", () => {
+    const validAmountE8s = BigInt(1_000_000_000);
+    const validProject: SnsFullProject = {
+      ...mockSnsFullProject,
+      summary: {
+        ...mockSnsFullProject.summary,
+        swap: {
+          ...mockSnsFullProject.summary.swap,
+          state: {
+            ...mockSnsFullProject.summary.swap.state,
+            lifecycle: SnsSwapLifecycle.Open,
+          },
+          init: {
+            ...mockSnsFullProject.summary.swap.init,
+            min_participant_icp_e8s: validAmountE8s - BigInt(10_000),
+            max_participant_icp_e8s: validAmountE8s + BigInt(10_000),
+            max_icp_e8s: validAmountE8s + BigInt(10_000),
+          },
+        },
+      },
+      swapCommitment: {
+        ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
+        myCommitment: {
+          ...(mockSnsFullProject.swapCommitment?.myCommitment as BuyerState),
+          amount_icp_e8s: BigInt(0),
+        },
+      },
+    };
+    it("returns true if valid participation", () => {
+      const { valid } = validParticipation({
+        project: validProject,
+        amount: ICP.fromE8s(validAmountE8s),
+      });
+      expect(valid).toBe(true);
+    });
+
+    it("returns false if project committed", () => {
+      const project = {
+        ...validProject,
+        summary: {
+          ...validProject.summary,
+          swap: {
+            ...validProject.summary.swap,
+            state: {
+              ...validProject.summary.swap.state,
+              lifecycle: SnsSwapLifecycle.Committed,
+            },
+          },
+        },
+      };
+      const { valid } = validParticipation({
+        project,
+        amount: ICP.fromE8s(validAmountE8s),
+      });
+      expect(valid).toBe(false);
+    });
+
+    it("returns false if project pending", () => {
+      const project = {
+        ...validProject,
+        summary: {
+          ...validProject.summary,
+          swap: {
+            ...validProject.summary.swap,
+            state: {
+              ...validProject.summary.swap.state,
+              lifecycle: SnsSwapLifecycle.Pending,
+            },
+          },
+        },
+      };
+      const { valid } = validParticipation({
+        project,
+        amount: ICP.fromE8s(validAmountE8s),
+      });
+      expect(valid).toBe(false);
+    });
+
+    it("returns false if amount is larger than maximum per participant", () => {
+      const project = {
+        ...validProject,
+        summary: {
+          ...validProject.summary,
+          swap: {
+            ...validProject.summary.swap,
+            init: {
+              ...validProject.summary.swap.init,
+              max_participant_icp_e8s: validAmountE8s,
+            },
+          },
+        },
+      };
+      const { valid } = validParticipation({
+        project,
+        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
+      });
+      expect(valid).toBe(false);
+    });
+
+    it("takes into account current participation to calculate the maximum per participant", () => {
+      const project = {
+        ...validProject,
+        summary: {
+          ...validProject.summary,
+          swap: {
+            ...validProject.summary.swap,
+            init: {
+              ...validProject.summary.swap.init,
+              max_participant_icp_e8s: validAmountE8s * BigInt(2),
+            },
+          },
+        },
+        swapCommitment: {
+          ...(validProject.swapCommitment as SnsSwapCommitment),
+          myCommitment: {
+            ...(validProject.swapCommitment?.myCommitment as BuyerState),
+            amount_icp_e8s: validAmountE8s,
+          },
+        },
+      };
+      const { valid } = validParticipation({
+        project,
+        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
+      });
+      expect(valid).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,20 +1,15 @@
-import { AccountIdentifier, ICP } from "@dfinity/nns";
+import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { SnsMetadataResponseEntries, SnsSwapLifecycle } from "@dfinity/sns";
-import type { BuyerState } from "@dfinity/sns/dist/candid/sns_swap";
-import type { SnsFullProject } from "../../../lib/stores/projects.store";
-import type { SnsSwapCommitment } from "../../../lib/types/sns";
+import { SnsMetadataResponseEntries } from "@dfinity/sns";
 import {
   getSwapCanisterAccount,
   mapAndSortSnsQueryToSummaries,
-  validParticipation,
 } from "../../../lib/utils/sns.utils";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   mockDerived,
   mockQueryMetadata,
   mockQueryMetadataResponse,
-  mockSnsFullProject,
   mockSnsSummaryList,
   mockSummary,
   mockSwapInit,
@@ -281,134 +276,6 @@ describe("sns-utils", () => {
         controller: mockIdentity.getPrincipal(),
       });
       expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
-    });
-  });
-
-  describe("validParticipation", () => {
-    const validAmountE8s = BigInt(1_000_000_000);
-    const validProject: SnsFullProject = {
-      ...mockSnsFullProject,
-      summary: {
-        ...mockSnsFullProject.summary,
-        swap: {
-          ...mockSnsFullProject.summary.swap,
-          state: {
-            ...mockSnsFullProject.summary.swap.state,
-            lifecycle: SnsSwapLifecycle.Open,
-          },
-          init: {
-            ...mockSnsFullProject.summary.swap.init,
-            min_participant_icp_e8s: validAmountE8s - BigInt(10_000),
-            max_participant_icp_e8s: validAmountE8s + BigInt(10_000),
-            max_icp_e8s: validAmountE8s + BigInt(10_000),
-          },
-        },
-      },
-      swapCommitment: {
-        ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
-        myCommitment: {
-          ...(mockSnsFullProject.swapCommitment?.myCommitment as BuyerState),
-          amount_icp_e8s: BigInt(0),
-        },
-      },
-    };
-    it("returns true if valid participation", () => {
-      const { valid } = validParticipation({
-        project: validProject,
-        amount: ICP.fromE8s(validAmountE8s),
-      });
-      expect(valid).toBe(true);
-    });
-
-    it("returns false if project committed", () => {
-      const project = {
-        ...validProject,
-        summary: {
-          ...validProject.summary,
-          swap: {
-            ...validProject.summary.swap,
-            state: {
-              ...validProject.summary.swap.state,
-              lifecycle: SnsSwapLifecycle.Committed,
-            },
-          },
-        },
-      };
-      const { valid } = validParticipation({
-        project,
-        amount: ICP.fromE8s(validAmountE8s),
-      });
-      expect(valid).toBe(false);
-    });
-
-    it("returns false if project pending", () => {
-      const project = {
-        ...validProject,
-        summary: {
-          ...validProject.summary,
-          swap: {
-            ...validProject.summary.swap,
-            state: {
-              ...validProject.summary.swap.state,
-              lifecycle: SnsSwapLifecycle.Pending,
-            },
-          },
-        },
-      };
-      const { valid } = validParticipation({
-        project,
-        amount: ICP.fromE8s(validAmountE8s),
-      });
-      expect(valid).toBe(false);
-    });
-
-    it("returns false if amount is larger than maximum per participant", () => {
-      const project = {
-        ...validProject,
-        summary: {
-          ...validProject.summary,
-          swap: {
-            ...validProject.summary.swap,
-            init: {
-              ...validProject.summary.swap.init,
-              max_participant_icp_e8s: validAmountE8s,
-            },
-          },
-        },
-      };
-      const { valid } = validParticipation({
-        project,
-        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
-      });
-      expect(valid).toBe(false);
-    });
-
-    it("takes into account current participation to calculate the maximum per participant", () => {
-      const project = {
-        ...validProject,
-        summary: {
-          ...validProject.summary,
-          swap: {
-            ...validProject.summary.swap,
-            init: {
-              ...validProject.summary.swap.init,
-              max_participant_icp_e8s: validAmountE8s * BigInt(2),
-            },
-          },
-        },
-        swapCommitment: {
-          ...(validProject.swapCommitment as SnsSwapCommitment),
-          myCommitment: {
-            ...(validProject.swapCommitment?.myCommitment as BuyerState),
-            amount_icp_e8s: validAmountE8s,
-          },
-        },
-      };
-      const { valid } = validParticipation({
-        project,
-        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
-      });
-      expect(valid).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -209,11 +209,11 @@ export const mockSwapCommitment = mockSnsSwapCommitment(
   principal(0)
 ) as SnsSwapCommitment;
 
-export const mockSnsFullProject = {
+export const mockSnsFullProject: SnsFullProject = {
   rootCanisterId: principal(0),
   summary: mockSummary,
   swapCommitment: mockSwapCommitment,
-} as SnsFullProject;
+};
 
 export const summaryForLifecycle = (
   lifecycle: SnsSwapLifecycle


### PR DESCRIPTION
# Motivation

Avoid sale participation that won't succeed.

# Changes

* New sns util validParticipation.
* Use new util in sns service "participate".
* Check selected account balance with amount inline.
* New account util that raises error if account doesn't have enough balance.
* Use new account util in stake neuron service.

# Tests

* Add test for the new sns util validParticipation.
* Add test cases for sns service.
* Test for new accout util.
* Add test case when staking neurons.
