### PR TITLE
L2-933: Sync accounts after participating in Sale

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -33,7 +33,7 @@ import { getLastPathDetail, isRoutePath } from "../utils/app-path.utils";
 import { toToastError } from "../utils/error.utils";
 import { validParticipation } from "../utils/projects.utils";
 import { getSwapCanisterAccount } from "../utils/sns.utils";
-import { getAccountIdentity } from "./accounts.services";
+import { getAccountIdentity, syncAccounts } from "./accounts.services";
 import { getIdentity } from "./auth.services";
 import { loadProposalsByTopic } from "./proposals.services";
 import { queryAndUpdate } from "./utils.services";
@@ -250,6 +250,7 @@ export const participateInSwap = async ({
   rootCanisterId: Principal;
   account: Account;
 }): Promise<{ success: boolean }> => {
+  let success = false;
   try {
     const transactionFee = get(transactionsFeesStore).main;
     assertEnoughAccountFunds({
@@ -276,7 +277,10 @@ export const participateInSwap = async ({
       fromSubAccount: "subAccount" in account ? account.subAccount : undefined,
     });
 
-    return { success: true };
+    success = true;
+    await syncAccounts();
+
+    return { success };
   } catch (error) {
     toastsStore.error(
       toToastError({
@@ -284,6 +288,6 @@ export const participateInSwap = async ({
         fallbackErrorLabelKey: "error__sns.cannot_participate",
       })
     );
-    return { success: false };
+    return { success };
   }
 };

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -4,6 +4,7 @@ import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import * as api from "../../../lib/api/sns.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
+import { syncAccounts } from "../../../lib/services/accounts.services";
 import * as services from "../../../lib/services/sns.services";
 import { snsQueryStore } from "../../../lib/stores/sns.store";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
@@ -23,6 +24,7 @@ jest.mock("../../../lib/services/accounts.services", () => {
     getAccountIdentity: jest
       .fn()
       .mockImplementation(() => testGetIdentityReturn),
+    syncAccounts: jest.fn(),
   };
 });
 
@@ -46,7 +48,7 @@ describe("sns-services", () => {
       snsQueryStore.reset();
     });
 
-    it("should call api.participateInSnsSwap and return success true", async () => {
+    it("should call api.participateInSnsSwap, sync accounts and return success true", async () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest
@@ -59,6 +61,7 @@ describe("sns-services", () => {
       });
       expect(success).toBe(true);
       expect(spyParticipate).toBeCalled();
+      expect(syncAccounts).toBeCalled();
     });
 
     it("should return success false if api call fails", async () => {


### PR DESCRIPTION
# Motivation

Account balance is updated after participating in a decentralized sale.

# Changes

* Call `syncAccounts` in sns service participate.

# Tests

* Add expected new call.
