### PR TITLE
L2-934: Fix error coming back to NNS neurons

### DIFF
--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -13,14 +13,18 @@
   import { onDestroy } from "svelte";
   import { routeStore } from "../stores/route.store";
   import { AppPath } from "../constants/routes.constants";
+  import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 
   let loading = true;
 
   const unsubscribe: Unsubscriber = snsProjectSelectedStore.subscribe(
     async (selectedProjectCanisterId) => {
-      loading = true;
-      await loadSnsNeurons(selectedProjectCanisterId);
-      loading = false;
+      // Load only when selected project is not NNS
+      if (selectedProjectCanisterId.toText() !== OWN_CANISTER_ID.toText()) {
+        loading = true;
+        await loadSnsNeurons(selectedProjectCanisterId);
+        loading = false;
+      }
     }
   );
 

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -7,20 +7,21 @@
   import { loadSnsNeurons } from "../services/sns-neurons.services";
   import SnsNeuronCard from "../components/sns-neurons/SnsNeuronCard.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { snsProjectSelectedStore } from "../stores/projects.store";
+  import {
+    snsOnlyProjectStore,
+    snsProjectSelectedStore,
+  } from "../stores/projects.store";
   import { getSnsNeuronIdAsHexString } from "../utils/sns-neuron.utils";
   import type { Unsubscriber } from "svelte/store";
   import { onDestroy } from "svelte";
   import { routeStore } from "../stores/route.store";
   import { AppPath } from "../constants/routes.constants";
-  import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 
   let loading = true;
 
-  const unsubscribe: Unsubscriber = snsProjectSelectedStore.subscribe(
+  const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
     async (selectedProjectCanisterId) => {
-      // Load only when selected project is not NNS
-      if (selectedProjectCanisterId.toText() !== OWN_CANISTER_ID.toText()) {
+      if (selectedProjectCanisterId !== undefined) {
         loading = true;
         await loadSnsNeurons(selectedProjectCanisterId);
         loading = false;

--- a/frontend/src/lib/stores/projects.store.ts
+++ b/frontend/src/lib/stores/projects.store.ts
@@ -5,6 +5,7 @@ import type { SnsSummary, SnsSwapCommitment } from "../types/sns";
 import {
   filterActiveProjects,
   filterCommittedProjects,
+  isNnsProject,
 } from "../utils/projects.utils";
 import { snsSummariesStore, snsSwapCommitmentsStore } from "./sns.store";
 
@@ -73,7 +74,7 @@ export const snsProjectSelectedStore = initSnsProjectSelectedStore();
 export const isNnsProjectStore = derived(
   snsProjectSelectedStore,
   ($snsProjectSelectedStore: Principal) =>
-    $snsProjectSelectedStore.toText() === OWN_CANISTER_ID.toText()
+    isNnsProject($snsProjectSelectedStore)
 );
 
 /***
@@ -82,7 +83,7 @@ export const isNnsProjectStore = derived(
 export const snsOnlyProjectStore = derived(
   snsProjectSelectedStore,
   ($snsProjectSelectedStore: Principal) =>
-    $snsProjectSelectedStore.toText() === OWN_CANISTER_ID.toText()
+    isNnsProject($snsProjectSelectedStore)
       ? undefined
       : $snsProjectSelectedStore
 );

--- a/frontend/src/lib/stores/projects.store.ts
+++ b/frontend/src/lib/stores/projects.store.ts
@@ -75,3 +75,14 @@ export const isNnsProjectStore = derived(
   ($snsProjectSelectedStore: Principal) =>
     $snsProjectSelectedStore.toText() === OWN_CANISTER_ID.toText()
 );
+
+/***
+ * Returns undefined if the selected project is NNS, otherwise returns the selected project principal.
+ */
+export const snsOnlyProjectStore = derived(
+  snsProjectSelectedStore,
+  ($snsProjectSelectedStore: Principal) =>
+    $snsProjectSelectedStore.toText() === OWN_CANISTER_ID.toText()
+      ? undefined
+      : $snsProjectSelectedStore
+);

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,6 +1,8 @@
 import type { ICP } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsSwapTimeWindow } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
+import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
 import type { SnsFullProject } from "../stores/projects.store";
 import type {
   SnsSummary,
@@ -214,3 +216,6 @@ export const validParticipation = ({
   }
   return { valid: true };
 };
+
+export const isNnsProject = (canisterId: Principal): boolean =>
+  canisterId.toText() === OWN_CANISTER_ID.toText();

--- a/frontend/src/tests/lib/stores/projects.store.spec.ts
+++ b/frontend/src/tests/lib/stores/projects.store.spec.ts
@@ -7,6 +7,7 @@ import {
   committedProjectsStore,
   isNnsProjectStore,
   projectsStore,
+  snsOnlyProjectStore,
   snsProjectSelectedStore,
 } from "../../../lib/stores/projects.store";
 import {
@@ -116,6 +117,38 @@ describe("projects.store", () => {
       const $store = get(isNnsProjectStore);
 
       expect($store).toBe(false);
+    });
+  });
+
+  describe("snsOnlyProjectStore", () => {
+    beforeEach(() => {
+      snsProjectSelectedStore.set(OWN_CANISTER_ID);
+    });
+
+    it("should be set by default undefined", () => {
+      const $store = get(snsOnlyProjectStore);
+
+      expect($store).toBeUndefined();
+    });
+
+    it("should return project principal if an sns project is selected", () => {
+      const principal = Principal.fromText("aaaaa-aa");
+      snsProjectSelectedStore.set(principal);
+      const $store = get(snsOnlyProjectStore);
+
+      expect($store).toBe(principal);
+    });
+
+    it("should return undefined if nns is selected after sns project", () => {
+      const principal = Principal.fromText("aaaaa-aa");
+
+      snsProjectSelectedStore.set(principal);
+      const $store = get(snsOnlyProjectStore);
+      expect($store).toBe(principal);
+
+      snsProjectSelectedStore.set(OWN_CANISTER_ID);
+      const $store2 = get(snsOnlyProjectStore);
+      expect($store2).toBeUndefined();
     });
   });
 

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,9 +1,11 @@
 import { ICP } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
 import {
   SnsSwapLifecycle,
   type SnsSwapBuyerState,
   type SnsSwapTimeWindow,
 } from "@dfinity/sns";
+import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
 import type { SnsFullProject } from "../../../lib/stores/projects.store";
 import type { SnsSwapCommitment } from "../../../lib/types/sns";
 import { nowInSeconds } from "../../../lib/utils/date.utils";
@@ -14,6 +16,7 @@ import {
   filterActiveProjects,
   filterCommittedProjects,
   hasUserParticipatedToSwap,
+  isNnsProject,
   openTimeWindow,
   swapDuration,
   validParticipation,
@@ -450,6 +453,16 @@ describe("project-utils", () => {
         amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
       });
       expect(valid).toBe(false);
+    });
+  });
+
+  describe("isNnsProject", () => {
+    it("returns true if nns dapp principal", () => {
+      expect(isNnsProject(OWN_CANISTER_ID)).toBeTruthy();
+    });
+
+    it("returns true if nns dapp principal", () => {
+      expect(isNnsProject(Principal.from("aaaaa-aa"))).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User should not get an error message when selecting NNS project in neurons dropdown.

# Changes

* Load sns project when selected project store changes, but only if new one is not OWN_CANISTER_ID

# Tests

* Not applicable.
