### PR TITLE
Fix: Force sns neuron fetch after hotkey mgt

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -61,7 +61,7 @@
       rootCanisterId: $snsProjectSelectedStore,
     });
     if (success) {
-      await reload();
+      await reload({ forceFetch: true });
     }
     stopBusy("remove-sns-hotkey-neuron");
   };

--- a/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
+++ b/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
@@ -39,7 +39,7 @@
       rootCanisterId: $snsProjectSelectedStore,
     });
     if (success) {
-      await reload();
+      await reload({ forceFetch: true });
     }
     stopBusy("add-sns-hotkey-neuron");
     if (success) {

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -87,24 +87,28 @@ const getNeuronFromStoreByIdHex = ({
 export const getSnsNeuron = async ({
   neuronIdHex,
   rootCanisterId,
+  forceFetch = false,
   onLoad,
   onError,
 }: {
   neuronIdHex: string;
   rootCanisterId: Principal;
+  forceFetch?: boolean;
   onLoad: ({ certified: boolean, neuron: SnsNeuron }) => void;
   onError?: ({ certified, error }) => void;
 }): Promise<void> => {
-  const { neuron, certified } = getNeuronFromStoreByIdHex({
-    neuronIdHex,
-    rootCanisterId,
-  });
-  if (neuron !== undefined) {
-    onLoad({
-      neuron,
-      certified,
+  if (!forceFetch) {
+    const { neuron, certified } = getNeuronFromStoreByIdHex({
+      neuronIdHex,
+      rootCanisterId,
     });
-    return;
+    if (neuron !== undefined) {
+      onLoad({
+        neuron,
+        certified,
+      });
+      return;
+    }
   }
   const neuronId = hexStringToBytes(neuronIdHex);
   return queryAndUpdate<SnsNeuron, Error>({

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -17,7 +17,7 @@ export interface SelectedSnsNeuronStore {
 
 export interface SelectedSnsNeuronContext {
   store: Writable<SelectedSnsNeuronStore>;
-  reload: () => Promise<void>;
+  reload: ({ forceFetch: boolean }?) => Promise<void>;
 }
 
 export const SELECTED_SNS_NEURON_CONTEXT_KEY = Symbol("selected-sns-neuron");

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -22,10 +22,13 @@
   import { writable } from "svelte/store";
   import { setContext } from "svelte";
 
-  const loadNeuron = async () => {
+  const loadNeuron = async (
+    { forceFetch }: { forceFetch: boolean } = { forceFetch: false }
+  ) => {
     const { selected } = $selectedSnsNeuronStore;
     if (selected !== undefined) {
       await getSnsNeuron({
+        forceFetch,
         rootCanisterId: selected.rootCanisterId,
         neuronIdHex: selected.neuronIdHex,
         onLoad: ({ neuron: snsNeuron }: { neuron: SnsNeuron }) => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -91,6 +91,6 @@ describe("SnsNeuronHotkeysCard", () => {
     fireEvent.click(removeButtons[0]);
 
     expect(removeHotkey).toBeCalled();
-    await waitFor(() => expect(reload).toBeCalled());
+    await waitFor(() => expect(reload).toBeCalledWith({ forceFetch: true }));
   });
 });

--- a/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/AddSnsHotkeyModal.spec.ts
@@ -83,6 +83,6 @@ describe("AddSnsHotkeyModal", () => {
     expect(addHotkey).toBeCalled();
 
     await waitFor(() => expect(onClose).toBeCalled());
-    expect(reload).toBeCalled();
+    expect(reload).toBeCalledWith({ forceFetch: true });
   });
 });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -109,6 +109,36 @@ describe("sns-neurons-services", () => {
       });
     });
 
+    it("should call api even if it's in the store when forceFetch", (done) => {
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve({ ...mockSnsNeuron }));
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: mockPrincipal,
+        neurons: [mockSnsNeuron],
+        certified: true,
+      });
+      const onLoad = ({
+        neuron,
+        certified,
+      }: {
+        neuron: SnsNeuron;
+        certified: boolean;
+      }) => {
+        expect(spyQuery).toBeCalled();
+        expect(neuron).not.toBe(mockSnsNeuron);
+        if (certified) {
+          done();
+        }
+      };
+      getSnsNeuron({
+        forceFetch: true,
+        neuronIdHex: bytesToHexString(mockSnsNeuron.id[0]?.id as number[]),
+        rootCanisterId: mockPrincipal,
+        onLoad,
+      });
+    });
+
     it("should call onError callback when call failes", (done) => {
       const spyQuery = jest
         .spyOn(api, "querySnsNeuron")


### PR DESCRIPTION
# Motivation

If the user arrived to the sns neuron detail page from the neurons page, the neuron was loaded from the store. Reloading meant to get the same neuron from the store.

That meant that after updating the neuron, we still got the old one.

# Changes

* Add a "forceFetch" flag to the getSnsNeuron service that forces call to the api.
* Use the new flag after adding or removing hotkeys in sns neurons.

# Tests

* Change tests to check that the flag is properly set after adding or removing hotkeys.
* Check that the flag calls api instead of retrieving from the store.
