### PR TITLE
Commit only if there are changes

### DIFF
--- a/scripts/testnet-set-canister-ids
+++ b/scripts/testnet-set-canister-ids
@@ -41,8 +41,7 @@ git fetch
 git reset --hard origin/testnets
 jq -s '.[0] * .[1]' testnets/canister_ids.json "$to_add" >testnets/canister_ids.json.new
 mv testnets/canister_ids.json.new testnets/canister_ids.json
-if git status --porcelain | grep -q .
-then
+if git status --porcelain | grep -q .; then
   git add testnets/canister_ids.json
   git commit -a -m "Update canister IDs" || true
   git push

--- a/scripts/testnet-set-canister-ids
+++ b/scripts/testnet-set-canister-ids
@@ -41,7 +41,10 @@ git fetch
 git reset --hard origin/testnets
 jq -s '.[0] * .[1]' testnets/canister_ids.json "$to_add" >testnets/canister_ids.json.new
 mv testnets/canister_ids.json.new testnets/canister_ids.json
-git add testnets/canister_ids.json
-git commit -a -m "Update canister IDs"
-git push
+if git status --porcelain | grep -q .
+then
+  git add testnets/canister_ids.json
+  git commit -a -m "Update canister IDs" || true
+  git push
+fi
 echo "Published canister IDs to: https://github.com/dfinity/nns-dapp/blob/testnets/testnets/canister_ids.json"


### PR DESCRIPTION
# Motivation
The script that saves canister_ids fails if they haven't changed.  This isn't wanted.

# Changes
- If there have been no changes, don't commit the changes.

# Tests
Verify that if there are no changes, everything works:
```
max@sinkpad:~/dfn/nns-dapp/branches/no-change-ok (14:02)$ git show origin/testnets:testnets/canister_ids.json > canister_ids.json
max@sinkpad:~/dfn/nns-dapp/branches/no-change-ok (14:11)$ bash -x scripts/testnet-set-canister-ids
+ set -euo pipefail
+ : 'Print help, if applicable...'
+ (( 0 > 0 ))
+ : Get the absolute path
++ realpath canister_ids.json
+ to_add=/home/max/dfn/nns-dapp/branches/no-change-ok/canister_ids.json
+ : Assuming that the testnets worktree already exists:
++ git worktree list --porcelain
++ awk '/^worktree .*branches[/]testnets$/{print $2}'
+ cd /home/max/dfn/nns-dapp/branches/testnets
+ git fetch
+ git reset --hard origin/testnets
HEAD is now at 38b7e89f4 ++
+ jq -s '.[0] * .[1]' testnets/canister_ids.json /home/max/dfn/nns-dapp/branches/no-change-ok/canister_ids.json
+ mv testnets/canister_ids.json.new testnets/canister_ids.json
+ git status --porcelain
+ grep -q .
+ echo 'Published canister IDs to: https://github.com/dfinity/nns-dapp/blob/testnets/testnets/canister_ids.json'
Published canister IDs to: https://github.com/dfinity/nns-dapp/blob/testnets/testnets/canister_ids.json
max@sinkpad:~/dfn/nns-dapp/branches/no-change-ok (14:36)$ 
```

Now, add a canister that doesnt exist and it also works.