### PR TITLE
feat: replace IS_TESTNET to ENABLE_SNS_NEURONS flag for launchpad men…

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -11,7 +11,7 @@
   import { AppPath } from "../../constants/routes.constants";
   import { routeStore } from "../../stores/route.store";
   import IconRocketLaunch from "../../icons/IconRocketLaunch.svelte";
-  import { IS_TESTNET } from "../../constants/environment.constants";
+  import { ENABLE_SNS_NEURONS } from "../../constants/environment.constants";
   import BadgeNew from "../ui/BadgeNew.svelte";
 
   const baseUrl: string = baseHref();
@@ -53,7 +53,7 @@
       icon: IconSettingsApplications,
     },
     // Launchpad should not be visible on mainnet
-    ...(IS_TESTNET
+    ...(ENABLE_SNS_NEURONS
       ? [
           {
             context: "launchpad",


### PR DESCRIPTION
# Motivation

To be more flexible with the `launchpad` menu entry visibility `IS_TESTNET` was replaced with `ENABLE_SNS_NEURONS`.

# Changes

`IS_TESTNET` -> `ENABLE_SNS_NEURONS`
