### PR TITLE
feat: feature flags clean up and new flag

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -72,7 +72,8 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false
+          "ENABLE_SNS_NEURONS": false,
+          "VOTING_UI": "legacy"
         }
       },
       "providers": ["https://ic0.app/"],
@@ -85,7 +86,8 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false
+          "ENABLE_SNS_NEURONS": false,
+          "VOTING_UI": "legacy"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
@@ -98,7 +100,8 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true
+          "ENABLE_SNS_NEURONS": true,
+          "VOTING_UI": "modern"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
@@ -111,7 +114,8 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small13.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true
+          "ENABLE_SNS_NEURONS": true,
+          "VOTING_UI": "modern"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"],
@@ -124,7 +128,8 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small12.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true
+          "ENABLE_SNS_NEURONS": true,
+          "VOTING_UI": "modern"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:54ff:fef3:eb8]:8080"],
@@ -137,7 +142,8 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small11.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true
+          "ENABLE_SNS_NEURONS": true,
+          "VOTING_UI": "modern"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:eeff:feae:ab37]:8080"],
@@ -150,7 +156,8 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small06.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true
+          "ENABLE_SNS_NEURONS": true,
+          "VOTING_UI": "modern"
         }
       },
       "providers": ["http://[2a00:fb01:400:42:5000:caff:fed1:b2e7]:8080"],
@@ -163,7 +170,8 @@
         "REDIRECT_TO_LEGACY": "svelte",
         "HOST": "http://localhost:8080",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false
+          "ENABLE_SNS_NEURONS": false,
+          "VOTING_UI": "modern"
         }
       },
       "bind": "127.0.0.1:8080",

--- a/dfx.json
+++ b/dfx.json
@@ -72,7 +72,6 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": false
         }
       },
@@ -86,7 +85,6 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": false
         }
       },
@@ -100,7 +98,6 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": true
         }
       },
@@ -114,7 +111,6 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small13.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": true
         }
       },
@@ -128,7 +124,6 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small12.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": true
         }
       },
@@ -142,7 +137,6 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small11.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": true
         }
       },
@@ -156,7 +150,6 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small06.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": true
         }
       },
@@ -170,7 +163,6 @@
         "REDIRECT_TO_LEGACY": "svelte",
         "HOST": "http://localhost:8080",
         "FEATURE_FLAGS": {
-          "ENABLE_NEW_SPAWN_FEATURE": true,
           "ENABLE_SNS_NEURONS": false
         }
       },

--- a/dfx.json
+++ b/dfx.json
@@ -72,7 +72,7 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false,
+          "ENABLE_SNS": false,
           "VOTING_UI": "legacy"
         }
       },
@@ -86,7 +86,7 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false,
+          "ENABLE_SNS": false,
           "VOTING_UI": "legacy"
         }
       },
@@ -100,7 +100,7 @@
         "REDIRECT_TO_LEGACY": "prod",
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true,
+          "ENABLE_SNS": true,
           "VOTING_UI": "modern"
         }
       },
@@ -114,7 +114,7 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small13.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true,
+          "ENABLE_SNS": true,
           "VOTING_UI": "modern"
         }
       },
@@ -128,7 +128,7 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small12.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true,
+          "ENABLE_SNS": true,
           "VOTING_UI": "modern"
         }
       },
@@ -142,7 +142,7 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small11.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true,
+          "ENABLE_SNS": true,
           "VOTING_UI": "modern"
         }
       },
@@ -156,7 +156,7 @@
         "REDIRECT_TO_LEGACY": "both",
         "HOST": "https://small06.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": true,
+          "ENABLE_SNS": true,
           "VOTING_UI": "modern"
         }
       },
@@ -170,7 +170,7 @@
         "REDIRECT_TO_LEGACY": "svelte",
         "HOST": "http://localhost:8080",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_NEURONS": false,
+          "ENABLE_SNS": false,
           "VOTING_UI": "modern"
         }
       },

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -21,7 +21,7 @@ process.env.IDENTITY_SERVICE_URL =
   "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network";
 process.env.WASM_CANISTER_ID = "u7xn3-ciaaa-aaaaa-aaa4a-cai";
 process.env.FEATURE_FLAGS = JSON.stringify({
-  ENABLE_SNS_NEURONS: true,
+  ENABLE_SNS: true,
   VOTING_UI: "modern"
 });
 

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -22,6 +22,7 @@ process.env.IDENTITY_SERVICE_URL =
 process.env.WASM_CANISTER_ID = "u7xn3-ciaaa-aaaaa-aaa4a-cai";
 process.env.FEATURE_FLAGS = JSON.stringify({
   ENABLE_SNS_NEURONS: true,
+  VOTING_UI: "modern"
 });
 
 // testing-library setup

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -21,7 +21,6 @@ process.env.IDENTITY_SERVICE_URL =
   "https://qjdve-lqaaa-aaaaa-aaaeq-cai.nnsdapp.dfinity.network";
 process.env.WASM_CANISTER_ID = "u7xn3-ciaaa-aaaaa-aaa4a-cai";
 process.env.FEATURE_FLAGS = JSON.stringify({
-  ENABLE_NEW_SPAWN_FEATURE: true,
   ENABLE_SNS_NEURONS: true,
 });
 

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -11,7 +11,7 @@
   import { AppPath } from "../../constants/routes.constants";
   import { routeStore } from "../../stores/route.store";
   import IconRocketLaunch from "../../icons/IconRocketLaunch.svelte";
-  import { ENABLE_SNS_NEURONS } from "../../constants/environment.constants";
+  import { ENABLE_SNS } from "../../constants/environment.constants";
   import BadgeNew from "../ui/BadgeNew.svelte";
 
   const baseUrl: string = baseHref();
@@ -53,7 +53,7 @@
       icon: IconSettingsApplications,
     },
     // Launchpad should not be visible on mainnet
-    ...(ENABLE_SNS_NEURONS
+    ...(ENABLE_SNS
       ? [
           {
             context: "launchpad",

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -19,8 +19,8 @@
   export let neuron: NeuronInfo;
 
   let isOpen: boolean = false;
-  let controlledByHarwareWallet: boolean;
-  $: controlledByHarwareWallet = isNeuronControlledByHardwareWallet({
+  let controlledByHardwareWallet: boolean;
+  $: controlledByHardwareWallet = isNeuronControlledByHardwareWallet({
     neuron,
     accounts: $accountsStore,
   });
@@ -72,6 +72,6 @@
   <SpawnNeuronModal
     on:nnsClose={closeModal}
     {neuron}
-    {controlledByHarwareWallet}
+    {controlledByHardwareWallet}
   />
 {/if}

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -5,12 +5,11 @@ export const FETCH_ROOT_KEY: boolean = process.env.FETCH_ROOT_KEY === "true";
 export const WASM_CANISTER_ID: string = String(process.env.WASM_CANISTER_ID);
 
 // TypeScript definition "Record" is used for simplicity reason but, if we would expose the flags object, we could improve the description
-export const {
-  ENABLE_SNS_NEURONS,
-}: Record<string, boolean> = JSON.parse(
-  process.env.FEATURE_FLAGS ??
-    '{"ENABLE_SNS_NEURONS":false}'
-);
+export const { ENABLE_SNS_NEURONS, VOTING_UI }: Record<string, boolean | string> =
+  JSON.parse(
+    process.env.FEATURE_FLAGS ??
+      '{"ENABLE_SNS_NEURONS":false,"VOTING_UI":"legacy"}'
+  );
 
 export const IS_TESTNET: boolean =
   DFX_NETWORK !== "mainnet" &&

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -5,10 +5,10 @@ export const FETCH_ROOT_KEY: boolean = process.env.FETCH_ROOT_KEY === "true";
 export const WASM_CANISTER_ID: string = String(process.env.WASM_CANISTER_ID);
 
 // TypeScript definition "Record" is used for simplicity reason but, if we would expose the flags object, we could improve the description
-export const { ENABLE_SNS_NEURONS, VOTING_UI }: Record<string, boolean | string> =
+export const { ENABLE_SNS, VOTING_UI }: Record<string, boolean | string> =
   JSON.parse(
     process.env.FEATURE_FLAGS ??
-      '{"ENABLE_SNS_NEURONS":false,"VOTING_UI":"legacy"}'
+      '{"ENABLE_SNS":false,"VOTING_UI":"legacy"}'
   );
 
 export const IS_TESTNET: boolean =

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -6,11 +6,10 @@ export const WASM_CANISTER_ID: string = String(process.env.WASM_CANISTER_ID);
 
 // TypeScript definition "Record" is used for simplicity reason but, if we would expose the flags object, we could improve the description
 export const {
-  ENABLE_NEW_SPAWN_FEATURE,
   ENABLE_SNS_NEURONS,
 }: Record<string, boolean> = JSON.parse(
   process.env.FEATURE_FLAGS ??
-    '{"ENABLE_NEW_SPAWN_FEATURE":true,"ENABLE_SNS_NEURONS":false}'
+    '{"ENABLE_SNS_NEURONS":false}'
 );
 
 export const IS_TESTNET: boolean =

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -4,12 +4,12 @@ export const ROLLUP_WATCH: boolean = process.env.ROLLUP_WATCH === "true";
 export const FETCH_ROOT_KEY: boolean = process.env.FETCH_ROOT_KEY === "true";
 export const WASM_CANISTER_ID: string = String(process.env.WASM_CANISTER_ID);
 
-// TypeScript definition "Record" is used for simplicity reason but, if we would expose the flags object, we could improve the description
-export const { ENABLE_SNS, VOTING_UI }: Record<string, boolean | string> =
-  JSON.parse(
-    process.env.FEATURE_FLAGS ??
-      '{"ENABLE_SNS":false,"VOTING_UI":"legacy"}'
-  );
+export const {
+  ENABLE_SNS,
+  VOTING_UI,
+}: { ENABLE_SNS: boolean; VOTING_UI: "legacy" | "modern" } = JSON.parse(
+  process.env.FEATURE_FLAGS ?? '{"ENABLE_SNS":false,"VOTING_UI":"legacy"}'
+);
 
 export const IS_TESTNET: boolean =
   DFX_NETWORK !== "mainnet" &&

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -4,20 +4,16 @@
   import SelectPercentage from "../../components/neuron-detail/SelectPercentage.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
   import WizardModal from "../WizardModal.svelte";
-  import ConfirmActionScreen from "../../components/ui/ConfirmActionScreen.svelte";
   import { formatPercentage } from "../../utils/format.utils";
   import { stopBusy } from "../../stores/busy.store";
   import { createEventDispatcher } from "svelte";
   import { spawnNeuron } from "../../services/neurons.services";
   import { toastsStore } from "../../stores/toasts.store";
-  import { replacePlaceholders } from "../../utils/i18n.utils";
   import { isEnoughMaturityToSpawn } from "../../utils/neuron.utils";
   import { startBusyNeuron } from "../../services/busy.services";
-  import { ENABLE_NEW_SPAWN_FEATURE } from "../../constants/environment.constants";
   import ConfirmSpawnHW from "../../components/neuron-detail/ConfirmSpawnHW.svelte";
   import { routeStore } from "../../stores/route.store";
   import { AppPath } from "../../constants/routes.constants";
-  import { valueSpan } from "../../utils/utils";
 
   export let neuron: NeuronInfo;
   export let controlledByHarwareWallet: boolean;
@@ -99,21 +95,7 @@
     >{currentStep?.title ??
       $i18n.neuron_detail.spawn_maturity_modal_title}</svelte:fragment
   >
-  {#if currentStep.name === "SelectPercentage" && !ENABLE_NEW_SPAWN_FEATURE}
-    <SelectPercentage
-      {neuron}
-      buttonText={$i18n.neuron_detail.spawn}
-      on:nnsSelectPercentage={goToConfirm}
-      on:nnsBack={close}
-      bind:percentage={percentageToSpawn}
-      disabled={!enoughMaturityToSpawn}
-    >
-      <svelte:fragment slot="text">
-        <h5>{$i18n.neuron_detail.spawn_maturity_modal_title}</h5>
-        <p>{$i18n.neuron_detail.spawn_maturity_modal_description}</p>
-      </svelte:fragment>
-    </SelectPercentage>
-  {:else if currentStep.name === "SelectPercentage" && ENABLE_NEW_SPAWN_FEATURE}
+  {#if currentStep.name === "SelectPercentage"}
     <SelectPercentage
       {neuron}
       buttonText={$i18n.neuron_detail.spawn}
@@ -132,25 +114,8 @@
         </p>
       </div>
     </SelectPercentage>
-  {:else if currentStep.name === "ConfirmSpawn" && ENABLE_NEW_SPAWN_FEATURE}
+  {:else if currentStep.name === "ConfirmSpawn"}
     <ConfirmSpawnHW {neuron} on:nnsConfirm={spawnNeuronFromMaturity} />
-  {:else if currentStep.name === "ConfirmSpawn" && !ENABLE_NEW_SPAWN_FEATURE}
-    <ConfirmActionScreen on:nnsConfirm={spawnNeuronFromMaturity}>
-      <div class="confirm" slot="main-info">
-        <h4>{$i18n.neuron_detail.spawn_maturity_confirmation_q}</h4>
-        <p class="confirm-answer">
-          {replacePlaceholders(
-            $i18n.neuron_detail.spawn_maturity_confirmation_a,
-            {
-              $percentage: valueSpan(percentageMessage),
-            }
-          )}
-        </p>
-      </div>
-      <svelte:fragment slot="button-content"
-        >{$i18n.core.confirm}</svelte:fragment
-      >
-    </ConfirmActionScreen>
   {/if}
 </WizardModal>
 

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -41,7 +41,6 @@
     : nnsDappAccountSteps;
 
   let currentStep: Step;
-  let modal: WizardModal;
 
   let percentageToSpawn: number = 0;
 
@@ -78,7 +77,7 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<WizardModal {steps} bind:currentStep on:nnsClose>
   <svelte:fragment slot="title"
     >{currentStep?.title ??
       $i18n.neuron_detail.spawn_maturity_modal_title}</svelte:fragment
@@ -108,16 +107,6 @@
 </WizardModal>
 
 <style lang="scss">
-  p {
-    // For the link inside "i18n.neuron_detail.spawn_maturity_explanation"
-    :global(a) {
-      color: var(--primary);
-      text-decoration: none;
-      font-size: inherit;
-      line-height: inherit;
-    }
-  }
-
   .confirm-answer {
     margin: 0;
     text-align: center;

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -105,15 +105,3 @@
     <ConfirmSpawnHW {neuron} on:nnsConfirm={spawnNeuronFromMaturity} />
   {/if}
 </WizardModal>
-
-<style lang="scss">
-  .confirm-answer {
-    margin: 0;
-    text-align: center;
-  }
-
-  .confirm {
-    display: flex;
-    flex-direction: column;
-  }
-</style>

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -4,7 +4,6 @@
   import SelectPercentage from "../../components/neuron-detail/SelectPercentage.svelte";
   import type { Step, Steps } from "../../stores/steps.state";
   import WizardModal from "../WizardModal.svelte";
-  import { formatPercentage } from "../../utils/format.utils";
   import { stopBusy } from "../../stores/busy.store";
   import { createEventDispatcher } from "svelte";
   import { spawnNeuron } from "../../services/neurons.services";
@@ -16,7 +15,7 @@
   import { AppPath } from "../../constants/routes.constants";
 
   export let neuron: NeuronInfo;
-  export let controlledByHarwareWallet: boolean;
+  export let controlledByHardwareWallet: boolean;
 
   const hardwareWalletSteps: Steps = [
     {
@@ -37,7 +36,7 @@
       title: $i18n.neuron_detail.spawn_confirmation_modal_title,
     },
   ];
-  const steps: Steps = controlledByHarwareWallet
+  const steps: Steps = controlledByHardwareWallet
     ? hardwareWalletSteps
     : nnsDappAccountSteps;
 
@@ -52,14 +51,6 @@
     percentage: percentageToSpawn,
   });
 
-  let percentageMessage: string;
-  $: percentageMessage = controlledByHarwareWallet
-    ? "100%"
-    : formatPercentage(percentageToSpawn / 100, {
-        minFraction: 0,
-        maxFraction: 0,
-      });
-
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");
   const spawnNeuronFromMaturity = async () => {
@@ -67,7 +58,7 @@
 
     const newNeuronId = await spawnNeuron({
       neuronId: neuron.neuronId,
-      percentageToSpawn: controlledByHarwareWallet
+      percentageToSpawn: controlledByHardwareWallet
         ? undefined
         : percentageToSpawn,
     });
@@ -84,9 +75,6 @@
     }
 
     stopBusy("spawn-neuron");
-  };
-  const goToConfirm = () => {
-    modal.next();
   };
 </script>
 
@@ -120,10 +108,6 @@
 </WizardModal>
 
 <style lang="scss">
-  h4 {
-    text-align: center;
-  }
-
   p {
     // For the link inside "i18n.neuron_detail.spawn_maturity_explanation"
     :global(a) {

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,4 +1,4 @@
-import { ENABLE_SNS_NEURONS } from "../constants/environment.constants";
+import { ENABLE_SNS } from "../constants/environment.constants";
 import {
   loadSnsSummariesProxy,
   loadSnsSwapCommitmentsProxy,
@@ -17,7 +17,7 @@ export const initApp = (): Promise<
   ];
 
   // Sns in an initiative currently under development and not proposed on mainnet yet
-  const initSns: Promise<void>[] = ENABLE_SNS_NEURONS
+  const initSns: Promise<void>[] = ENABLE_SNS
     ? [loadSnsSummariesProxy(), loadSnsSwapCommitmentsProxy()]
     : [];
 

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -256,5 +256,9 @@ export const poll = async <T>({
   });
 };
 
+/**
+ * Use to highlight a placeholder in a text rendered from i18n labels.
+ * TODO: can maybe be replaced with a more meaningful semantic such as <mark></mark>
+ */
 export const valueSpan = (text: string): string =>
   `<span class="value">${text}</span>`;

--- a/frontend/src/routes/Neurons.svelte
+++ b/frontend/src/routes/Neurons.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import MainContentWrapper from "../lib/components/ui/MainContentWrapper.svelte";
   import SelectProjectDropdown from "../lib/components/neurons/SelectProjectDropdown.svelte";
-  import { ENABLE_SNS_NEURONS } from "../lib/constants/environment.constants";
+  import { ENABLE_SNS } from "../lib/constants/environment.constants";
   import NnsNeurons from "../lib/pages/NnsNeurons.svelte";
   import SnsNeurons from "../lib/pages/SnsNeurons.svelte";
   import {
@@ -11,7 +11,7 @@
 </script>
 
 <MainContentWrapper>
-  {#if ENABLE_SNS_NEURONS}
+  {#if ENABLE_SNS}
     <div class="dropdown-wrapper">
       <div class="fit-content">
         <SelectProjectDropdown />

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -32,7 +32,7 @@ describe("SpawnNeuronModal", () => {
       component: SpawnNeuronModal,
       props: {
         neuron,
-        controlledByHarwareWallet: false,
+        controlledByHardwareWallet: false,
       },
     });
 
@@ -44,7 +44,7 @@ describe("SpawnNeuronModal", () => {
       component: SpawnNeuronModal,
       props: {
         neuron,
-        controlledByHarwareWallet: false,
+        controlledByHardwareWallet: false,
       },
     });
 
@@ -62,7 +62,7 @@ describe("SpawnNeuronModal", () => {
             maturityE8sEquivalent: BigInt(1_000_000),
           },
         },
-        controlledByHarwareWallet: false,
+        controlledByHardwareWallet: false,
       },
     });
 
@@ -83,7 +83,7 @@ describe("SpawnNeuronModal", () => {
       component: SpawnNeuronModal,
       props: {
         neuron,
-        controlledByHarwareWallet: false,
+        controlledByHardwareWallet: false,
       },
     });
 
@@ -106,7 +106,7 @@ describe("SpawnNeuronModal", () => {
       component: SpawnNeuronModal,
       props: {
         neuron,
-        controlledByHarwareWallet: true,
+        controlledByHardwareWallet: true,
       },
     });
 


### PR DESCRIPTION
# Motivation

1. remove `ENABLE_NEW_SPAWN_FEATURE` active in production
2. rename `ENABLE_SNS_NEURONS` to `ENABLE_SNS` because flag is used generally speaking for sns
3. add `VOTING_UI`

# Changes

- update `dfx.json` and `environment.constant` accordingly
- remove deprecated code in `<SpawnNeuronModal />`

