### PR TITLE
style: fix title color

### DIFF
--- a/frontend/src/lib/components/common/Layout.svelte
+++ b/frontend/src/lib/components/common/Layout.svelte
@@ -6,7 +6,7 @@
     layoutBackStore,
     layoutMainStyleStore,
   } from "../../stores/layout.store";
-  import { Layout, Title } from "@dfinity/gix-components";
+  import { Layout, HeaderTitle } from "@dfinity/gix-components";
   import AccountMenu from "../header/AccountMenu.svelte";
   import { triggerDebugReport } from "../../services/debug.services";
 
@@ -22,7 +22,7 @@
   on:nnsBack={() => $layoutBackStore?.()}
 >
   <div use:triggerDebugReport slot="title">
-    <Title>{$layoutTitleStore}</Title>
+    <HeaderTitle>{$layoutTitleStore}</HeaderTitle>
   </div>
 
   <MenuItems slot="menu-items" />

--- a/frontend/src/lib/components/common/Layout.svelte
+++ b/frontend/src/lib/components/common/Layout.svelte
@@ -6,7 +6,7 @@
     layoutBackStore,
     layoutMainStyleStore,
   } from "../../stores/layout.store";
-  import { Layout } from "@dfinity/gix-components";
+  import { Layout, Title } from "@dfinity/gix-components";
   import AccountMenu from "../header/AccountMenu.svelte";
   import { triggerDebugReport } from "../../services/debug.services";
 
@@ -21,7 +21,9 @@
   modern={$layoutMainStyleStore === "modern"}
   on:nnsBack={() => $layoutBackStore?.()}
 >
-  <h4 use:triggerDebugReport slot="title">{$layoutTitleStore}</h4>
+  <div use:triggerDebugReport slot="title">
+    <Title>{$layoutTitleStore}</Title>
+  </div>
 
   <MenuItems slot="menu-items" />
 


### PR DESCRIPTION
# Motivation

The title in the header in light mode does not inherit the original contrasting color we had set.

# Related PR

- [x] https://github.com/dfinity/gix-components/pull/37

# Changes

- use `HeaderTitle` gix-components

# Screenshot

Is:

<img width="1510" alt="Capture d’écran 2022-08-16 à 12 01 22" src="https://user-images.githubusercontent.com/16886711/184855896-bb32484c-82a3-4216-b24e-4862e4414953.png">

Will be:

<img width="1510" alt="Capture d’écran 2022-08-16 à 12 03 16" src="https://user-images.githubusercontent.com/16886711/184855959-43e2da43-2aac-460f-bb68-02fc3c174c77.png">

