### PR TITLE
style: fix tooltip footer button width

### DIFF
--- a/frontend/src/lib/components/neurons/NnsNeuronsFooter.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronsFooter.svelte
@@ -41,7 +41,7 @@
         <button
           disabled
           data-tid="merge-neurons-button"
-          class="primary full-width"
+          class="primary full-width tooltip-button"
           on:click={() => openModal("merge-neurons")}
           >{$i18n.neurons.merge_neurons}</button
         >
@@ -63,7 +63,7 @@
     --tooltip-width: 50%;
   }
 
-  :global(footer .tooltip-wrapper button) {
+  .tooltip-button {
     width: 100%;
   }
 </style>


### PR DESCRIPTION
# Motivation

If displayed in a tooltip, the footer button "merge neurons" does not inherit the proper width.

# Changes

- replace global style with scoped style

# Screenshots

Is:

<img width="1510" alt="Capture d’écran 2022-08-16 à 17 25 50" src="https://user-images.githubusercontent.com/16886711/184921335-c159a70f-65bc-4864-87f5-f451a0485c53.png">

Fixed:

<img width="1510" alt="Capture d’écran 2022-08-16 à 17 40 47" src="https://user-images.githubusercontent.com/16886711/184921418-f67c322a-ec78-4fca-be83-380824f1e74a.png">


<img width="1264" alt="Capture d’écran 2022-08-16 à 17 41 02" src="https://user-images.githubusercontent.com/16886711/184921427-9c3bc42b-4cd8-47fe-9e36-711d335f02dc.png">