### PR TITLE
Feat: Add hotkey debug flow

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -239,6 +239,10 @@
     "need_two_to_merge": "You need at least two neurons to merge",
     "irreversible_action": "This action is irreversible.",
     "claim_seed_neurons_success": "Seed neurons claimed successfully: $neurons",
+    "enter_neuron_id_prompt": "Enter neuron id",
+    "enter_hotkey_principal_prompt": "Enter hotkey",
+    "add_hotkey_prompt_error": "Error adding hotkey.",
+    "add_hotkey_prompt_success": "Hotkey added successfully.",
     "stake_amount": "Stake Amount"
   },
   "new_followee": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -240,7 +240,6 @@
     "irreversible_action": "This action is irreversible.",
     "claim_seed_neurons_success": "Seed neurons claimed successfully: $neurons",
     "enter_neuron_id_prompt": "Enter neuron id",
-    "enter_hotkey_principal_prompt": "Enter hotkey",
     "add_hotkey_prompt_error": "Error adding hotkey.",
     "add_hotkey_prompt_success": "Hotkey added successfully.",
     "stake_amount": "Stake Amount"

--- a/frontend/src/lib/services/debug.services.ts
+++ b/frontend/src/lib/services/debug.services.ts
@@ -1,5 +1,4 @@
 import type { NeuronId } from "@dfinity/nns";
-import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { addHotkey } from "../api/governance.api";
 import type { Transaction } from "../canisters/nns-dapp/nns-dapp.types";
@@ -73,10 +72,7 @@ export function triggerDebugReport(node: HTMLElement) {
           const neuronIdString = prompt(
             get(i18n).neurons.enter_neuron_id_prompt
           );
-          const hotkey = prompt(
-            get(i18n).neurons.enter_hotkey_principal_prompt
-          );
-          addHotkeyFromPrompt(neuronIdString, hotkey);
+          addHotkeyFromPrompt(neuronIdString);
           return;
         }
 
@@ -99,21 +95,14 @@ export function triggerDebugReport(node: HTMLElement) {
   };
 }
 
-const addHotkeyFromPrompt = async (
-  neuronIdString: string | null,
-  hotkey: string | null
-) => {
+const addHotkeyFromPrompt = async (neuronIdString: string | null) => {
   try {
     if (neuronIdString === null) {
       throw new Error("You need to provide a neuron id.");
     }
-    if (hotkey === null) {
-      throw new Error("You need to provide a hotkey.");
-    }
     const neuronId = BigInt(neuronIdString) as NeuronId;
-    const principal = Principal.fromText(hotkey);
     const identity = await getIdentity();
-    await addHotkey({ neuronId, principal, identity });
+    await addHotkey({ neuronId, principal: identity.getPrincipal(), identity });
     toastsStore.success({
       labelKey: "neurons.add_hotkey_prompt_success",
     });

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -249,6 +249,10 @@ interface I18nNeurons {
   need_two_to_merge: string;
   irreversible_action: string;
   claim_seed_neurons_success: string;
+  enter_neuron_id_prompt: string;
+  enter_hotkey_principal_prompt: string;
+  add_hotkey_prompt_error: string;
+  add_hotkey_prompt_success: string;
   stake_amount: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -250,7 +250,6 @@ interface I18nNeurons {
   irreversible_action: string;
   claim_seed_neurons_success: string;
   enter_neuron_id_prompt: string;
-  enter_hotkey_principal_prompt: string;
   add_hotkey_prompt_error: string;
   add_hotkey_prompt_success: string;
   stake_amount: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -234,7 +234,8 @@ export const isHotKeyControllable = ({
 }): boolean =>
   fullNeuron?.hotKeys.find(
     (hotkey) => hotkey === identity?.getPrincipal().toText()
-  ) !== undefined;
+  ) !== undefined &&
+  fullNeuron.controller !== identity?.getPrincipal().toText();
 
 /**
  * Calculate neuron stake (cachedNeuronStake - neuronFees)

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -814,6 +814,21 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
         })
       ).toBe(false));
+
+    it("returns false if identity is in hotkeys and is the controller", () =>
+      expect(
+        isHotKeyControllable({
+          neuron: {
+            ...mockNeuron,
+            fullNeuron: {
+              ...mockFullNeuron,
+              hotKeys: [mockIdentity.getPrincipal().toText()],
+              controller: mockIdentity.getPrincipal().toText(),
+            },
+          },
+          identity: mockIdentity,
+        })
+      ).toBe(false));
   });
 
   describe("isIdentityController", () => {


### PR DESCRIPTION
# Motivation

Context: A user is the controller of a neuron. The same user adds the principal as hotkey.
Edge case: If the user then removes the hotkey, the neuron disappears.

Added a new flow in the debug store to add the user as a hotkey again.

More info here: https://forum.dfinity.org/t/8-year-locked-neuron-missing-from-neurons-tab/9619/42?u=ielashi

# Changes

* Add new LogType "ah" in the debug flow that adds the user's principal to a neuron.
* Take care of the edge case in the neuron util is "isHotKeyControllable"

# Tests

* No tests for the debug flow.
* Test for the edge case added in isHotKeyControllable
