### PR TITLE
style: fix modal height on android devices

### DIFF
--- a/frontend/src/lib/modals/Modal.svelte
+++ b/frontend/src/lib/modals/Modal.svelte
@@ -121,7 +121,12 @@
       max-width: var(--modal-big-max-width);
 
       height: var(--modal-big-height);
-      max-height: var(--modal-big-max-height);
+
+      max-height: var(--modal-big-max-height, 100%);
+
+      @supports (-webkit-touch-callout: none) {
+        max-height: -webkit-fill-available;
+      }
 
       border-radius: var(--modal-big-border-radius);
     }


### PR DESCRIPTION
# Motivation

Modal on Android devices are presented behind footer and url bar when used in the browser - i.e. not in standalone

# Changes

- set a modal max-height of `100%`
- goodie: set the proper modal max-height `-webkit-fill-available` for ios

# Issue Screenshots

![image](https://user-images.githubusercontent.com/16886711/185077601-d5ee306e-db17-4dea-aab3-d40b2f9c18af.png)

![image](https://user-images.githubusercontent.com/16886711/185077632-cc5cd57c-55c7-47a4-b53c-348e9b7939a0.png)
