### PR TITLE
L2-943: Improve Increase Participation Flow

### DIFF
--- a/frontend/src/lib/components/ic/ICPText.svelte
+++ b/frontend/src/lib/components/ic/ICPText.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { ICP } from "@dfinity/nns";
+  import Icp from "./ICP.svelte";
+
+  export let icp: ICP;
+</script>
+
+<span><slot /> <Icp singleLine {icp} /></span>

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -23,7 +23,7 @@
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
   export let minAmount: ICP;
   export let maxAmount: ICP;
-  export let increasingParticipation: boolean = false;
+  export let userHasParticipatedToSwap: boolean = false;
 
   let max: number = 0;
   $: max = maxICP({
@@ -85,7 +85,7 @@
   </div>
   <div class="wrapper info">
     <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
-    {#if increasingParticipation}
+    {#if userHasParticipatedToSwap}
       <p class="right">
         {$i18n.sns_project_detail.max_left}
         <IcpComponent singleLine icp={maxAmount} />

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -13,6 +13,7 @@
   import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
   import SelectAccountDropdown from "../accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../ic/ICP.svelte";
+  import IcpText from "../ic/ICPText.svelte";
   import AmountInput from "../ui/AmountInput.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
 
@@ -92,12 +93,12 @@
       </p>
     {:else}
       <KeyValuePair>
-        <span slot="key"
-          >{$i18n.core.min} <IcpComponent singleLine icp={minAmount} /></span
-        >
-        <span slot="value"
-          >{$i18n.core.max} <IcpComponent singleLine icp={maxAmount} /></span
-        >
+        <IcpText slot="key" icp={minAmount}>
+          {$i18n.core.min}
+        </IcpText>
+        <IcpText slot="value" icp={maxAmount}>
+          {$i18n.core.max}
+        </IcpText>
       </KeyValuePair>
     {/if}
     <p class="right">

--- a/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateScreen.svelte
@@ -23,6 +23,7 @@
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
   export let minAmount: ICP;
   export let maxAmount: ICP;
+  export let increasingParticipation: boolean = false;
 
   let max: number = 0;
   $: max = maxICP({
@@ -84,14 +85,21 @@
   </div>
   <div class="wrapper info">
     <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
-    <KeyValuePair>
-      <span slot="key"
-        >{$i18n.core.min} <IcpComponent singleLine icp={minAmount} /></span
-      >
-      <span slot="value"
-        >{$i18n.core.max} <IcpComponent singleLine icp={maxAmount} /></span
-      >
-    </KeyValuePair>
+    {#if increasingParticipation}
+      <p class="right">
+        {$i18n.sns_project_detail.max_left}
+        <IcpComponent singleLine icp={maxAmount} />
+      </p>
+    {:else}
+      <KeyValuePair>
+        <span slot="key"
+          >{$i18n.core.min} <IcpComponent singleLine icp={minAmount} /></span
+        >
+        <span slot="value"
+          >{$i18n.core.max} <IcpComponent singleLine icp={maxAmount} /></span
+        >
+      </KeyValuePair>
+    {/if}
     <p class="right">
       <span>{$i18n.accounts.transaction_fee}</span>
       <IcpComponent singleLine icp={$mainTransactionFeeStoreAsIcp} />

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -601,6 +601,7 @@
     "completed": "Completed",
     "sale_start": "Sale Start",
     "sale_end": "Sale End",
+    "max_left": "max left",
     "max_user_commitment_reached": "Maximum commitment reached"
   },
   "sns_neuron_detail": {

--- a/frontend/src/lib/modals/sns/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/ParticipateSwapModal.svelte
@@ -23,12 +23,10 @@
   );
 
   let summary: SnsSummary;
-  let swapCommitment: SnsSwapCommitment | undefined;
+  let swapCommitment: SnsSwapCommitment | undefined | null;
   // type safety validation is done in ProjectDetail component
   $: summary = $projectDetailStore.summary as SnsSummary;
-  $: swapCommitment = $projectDetailStore.swapCommitment as
-    | SnsSwapCommitment
-    | undefined;
+  $: swapCommitment = $projectDetailStore.swapCommitment;
   let userHasParticipatedToSwap: boolean = false;
   $: userHasParticipatedToSwap = hasUserParticipatedToSwap({
     swapCommitment,

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -631,6 +631,7 @@ interface I18nSns_project_detail {
   completed: string;
   sale_start: string;
   sale_end: string;
+  max_left: string;
   max_user_commitment_reached: string;
 }
 

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -1,10 +1,7 @@
 import type { Writable } from "svelte/store";
-import type { SnsSummary, SnsSwapCommitment } from "./sns";
+import type { SnsFullProject } from "../stores/projects.store";
 
-export interface ProjectDetailStore {
-  summary: SnsSummary | undefined | null;
-  swapCommitment: SnsSwapCommitment | undefined | null;
-}
+export type ProjectDetailStore = Partial<SnsFullProject>;
 
 export interface ProjectDetailContext {
   store: Writable<ProjectDetailStore>;

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -1,7 +1,10 @@
 import type { Writable } from "svelte/store";
-import type { SnsFullProject } from "../stores/projects.store";
+import type { SnsSummary, SnsSwapCommitment } from "./sns";
 
-export type ProjectDetailStore = Partial<SnsFullProject>;
+export type ProjectDetailStore = {
+  summary: SnsSummary | undefined | null;
+  swapCommitment: SnsSwapCommitment | undefined | null;
+};
 
 export interface ProjectDetailContext {
   store: Writable<ProjectDetailStore>;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -115,9 +115,11 @@ export const durationTillSwapStart = (
   return BigInt(nowInSeconds()) - start_timestamp_seconds;
 };
 
-// Returns the minimum between:
-// - user remaining commitment to reach user maximum
-// - remamining commitment to reach project maximum
+/**
+ * Returns the minimum between:
+ * - user remaining commitment to reach user maximum
+ * - remaining commitment to reach project maximum
+ */
 export const currentUserMaxCommitment = ({
   summary: { swap, derived },
   swapCommitment,

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -123,7 +123,7 @@ export const currentUserMaxCommitment = ({
   swapCommitment,
 }: {
   summary: SnsSummary;
-  swapCommitment: SnsSwapCommitment | undefined;
+  swapCommitment: SnsSwapCommitment | undefined | null;
 }): bigint => {
   const remainingProjectCommitment =
     swap.init.max_icp_e8s - derived.buyer_total_icp_e8s;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -121,7 +121,10 @@ export const durationTillSwapStart = (
 export const currentUserMaxCommitment = ({
   summary: { swap, derived },
   swapCommitment,
-}: SnsFullProject): bigint => {
+}: {
+  summary: SnsSummary;
+  swapCommitment: SnsSwapCommitment | undefined;
+}): bigint => {
   const remainingProjectCommitment =
     swap.init.max_icp_e8s - derived.buyer_total_icp_e8s;
   const remainingUserCommitment =

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Principal } from "@dfinity/principal";
   import { onDestroy, onMount, setContext } from "svelte";
   import ProjectInfoSection from "../lib/components/project-detail/ProjectInfoSection.svelte";
   import ProjectStatusSection from "../lib/components/project-detail/ProjectStatusSection.svelte";

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -38,7 +38,7 @@
       rootCanisterId,
       onError: () => {
         // hide unproven data
-        $projectDetailStore.summary = undefined;
+        $projectDetailStore.summary = null;
         goBack();
       },
     });
@@ -48,7 +48,7 @@
       rootCanisterId,
       onError: () => {
         // hide unproven data
-        $projectDetailStore.swapCommitment = undefined;
+        $projectDetailStore.swapCommitment = null;
         goBack();
       },
     });

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -64,8 +64,6 @@
       return;
     }
     try {
-      $projectDetailStore.rootCanisterId = Principal.fromText(rootCanisterId);
-
       await Promise.all([
         loadSummary(rootCanisterId),
         loadSwapState(rootCanisterId),
@@ -79,7 +77,6 @@
   const projectDetailStore = writable<ProjectDetailStore>({
     summary: undefined,
     swapCommitment: undefined,
-    rootCanisterId: undefined,
   });
 
   // TODO: add projectDetailStore to debug store

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -20,7 +20,6 @@ import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
 } from "../../../mocks/accounts.store.mock";
-import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { renderModalContextWrapper } from "../../../mocks/modal.mock";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 import { clickByTestId } from "../../testHelpers/clickByTestId";
@@ -52,7 +51,6 @@ describe("ParticipateSwapModal", () => {
         store: writable<ProjectDetailStore>({
           summary: mockSnsFullProject.summary,
           swapCommitment,
-          rootCanisterId: mockPrincipal,
         }),
         reload,
       } as ProjectDetailContext,
@@ -239,7 +237,6 @@ describe("ParticipateSwapModal", () => {
           store: writable<ProjectDetailStore>({
             summary: mockSnsFullProject.summary,
             swapCommitment: undefined,
-            rootCanisterId: mockPrincipal,
           }),
           reload,
         } as ProjectDetailContext,

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -14,11 +14,13 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "../../../../lib/types/project-detail.context";
+import type { SnsSwapCommitment } from "../../../../lib/types/sns";
 import { formattedTransactionFeeICP } from "../../../../lib/utils/icp.utils";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
 } from "../../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { renderModalContextWrapper } from "../../../mocks/modal.mock";
 import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
 import { clickByTestId } from "../../testHelpers/clickByTestId";
@@ -40,21 +42,50 @@ jest.mock("../../../../lib/utils/html.utils", () => ({
 
 describe("ParticipateSwapModal", () => {
   const reload = jest.fn();
-
-  const renderSwapModal = () =>
+  const renderSwapModal = (
+    swapCommitment: SnsSwapCommitment | undefined = undefined
+  ) =>
     renderModalContextWrapper({
       Component: ParticipateSwapModal,
       contextKey: PROJECT_DETAIL_CONTEXT_KEY,
       contextValue: {
         store: writable<ProjectDetailStore>({
           summary: mockSnsFullProject.summary,
-          swapCommitment: mockSnsFullProject.swapCommitment,
+          swapCommitment,
+          rootCanisterId: mockPrincipal,
         }),
         reload,
       } as ProjectDetailContext,
     });
 
-  describe("when accountsStore is populated", () => {
+  const renderEnter10ICPAndNext = async (
+    swapCommitment: SnsSwapCommitment | undefined = undefined
+  ): Promise<RenderResult> => {
+    const result = await renderSwapModal(swapCommitment);
+
+    const { queryByText, getByTestId, container } = result;
+
+    const participateButton = getByTestId("sns-swap-participate-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    const icpAmount = "10";
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: icpAmount } });
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+
+    fireEvent.click(participateButton);
+
+    await waitFor(() =>
+      expect(getByTestId("sns-swap-participate-step-2")).toBeTruthy()
+    );
+    expect(queryByText(icpAmount, { exact: false })).toBeInTheDocument();
+
+    return result;
+  };
+
+  describe("when user has not participated", () => {
     beforeEach(() => {
       jest
         .spyOn(accountsStore, "subscribe")
@@ -106,31 +137,6 @@ describe("ParticipateSwapModal", () => {
         expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
       );
     });
-
-    const renderEnter10ICPAndNext = async (): Promise<RenderResult> => {
-      const result = await renderSwapModal();
-
-      const { queryByText, getByTestId, container } = result;
-
-      const participateButton = getByTestId("sns-swap-participate-button-next");
-      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-
-      const icpAmount = "10";
-      const input = container.querySelector("input[name='amount']");
-      input && fireEvent.input(input, { target: { value: icpAmount } });
-      await waitFor(() =>
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
-      );
-
-      fireEvent.click(participateButton);
-
-      await waitFor(() =>
-        expect(getByTestId("sns-swap-participate-step-2")).toBeTruthy()
-      );
-      expect(queryByText(icpAmount, { exact: false })).toBeInTheDocument();
-
-      return result;
-    };
 
     it("should move to the last step with ICP and disabled button", async () => {
       const { getByTestId } = await renderEnter10ICPAndNext();
@@ -202,7 +208,42 @@ describe("ParticipateSwapModal", () => {
     });
   });
 
+  describe("when user has participated", () => {
+    it("should move to the last step, enable button when accepting terms and call participate in swap service", async () => {
+      const { getByTestId, container } = await renderEnter10ICPAndNext(
+        mockSnsFullProject.swapCommitment
+      );
+
+      const confirmButton = getByTestId("sns-swap-participate-button-execute");
+      expect(confirmButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const acceptInput = container.querySelector("[type='checkbox']");
+      acceptInput && (await fireEvent.click(acceptInput));
+      await waitFor(() =>
+        expect(confirmButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => expect(participateInSwap).toBeCalled());
+      await waitFor(() => expect(reload).toHaveBeenCalled());
+    });
+  });
+
   describe("when accountsStore is empty", () => {
+    const renderSwapModal = () =>
+      renderModalContextWrapper({
+        Component: ParticipateSwapModal,
+        contextKey: PROJECT_DETAIL_CONTEXT_KEY,
+        contextValue: {
+          store: writable<ProjectDetailStore>({
+            summary: mockSnsFullProject.summary,
+            swapCommitment: undefined,
+            rootCanisterId: mockPrincipal,
+          }),
+          reload,
+        } as ProjectDetailContext,
+      });
     it("should have disabled button if no account is selected", async () => {
       const { getByTestId, container } = await renderSwapModal();
 


### PR DESCRIPTION
# Motivation

Improve UI when user increases participation.

Fix also the minimum to participate. If the user has already participated, the increase can be as small as wished.

# Changes 

* Check whether the user is participating in the Participate Modal and change UI slightly.
* New project util currentUserMaxCommitment to calculate the maximum participation allowed for that user for that project.
* commitmentTooSmall util takes into account current commitment.
* Fix a bug in validParticipation when user wanted to participate until max.

# Tests

* Test new participation and increasing in ParticipateSwapModal
* Test for new util currentUserMaxCommitment
* Add more tests to validParticipation to cover the bug and more test cases.
