### PR TITLE
fix: sanitize proposal title and account identifier for placeholders

### DIFF
--- a/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
+++ b/frontend/src/lib/components/project-detail/ReviewParticipate.svelte
@@ -25,6 +25,7 @@
   import Checkbox from "../ui/Checkbox.svelte";
   import KeyValuePair from "../ui/KeyValuePair.svelte";
   import { ICON_SIZE_LARGE } from "../../constants/style.constants";
+  import { sanitizeHTML } from "../../utils/html.utils";
 
   export let account: Account;
   export let amount: number;
@@ -72,6 +73,11 @@
   const back = () => {
     dispatcher("nnsBack");
   };
+
+  let sanitizedIdentifier = "";
+  $: account,
+    (async () =>
+      (sanitizedIdentifier = await sanitizeHTML(account.identifier)))();
 </script>
 
 <div data-tid="sns-swap-participate-step-2">
@@ -83,7 +89,7 @@
     <div>
       <p data-tid="sns-swap-participate-main-account">
         {@html replacePlaceholders($i18n.accounts.main_account, {
-          $identifier: valueSpan(account.identifier),
+          $identifier: valueSpan(sanitizedIdentifier),
         })}
       </p>
     </div>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -12,6 +12,7 @@
   import { busy } from "../../../stores/busy.store";
   import type { VoteInProgress } from "../../../stores/voting.store";
   import Spinner from "../../ui/Spinner.svelte";
+  import { sanitizeHTML } from "../../../utils/html.utils";
 
   const dispatch = createEventDispatcher();
 
@@ -53,13 +54,26 @@
       voteType: selectedVoteType,
     });
   };
+
+  let sanitizedTitle = "";
+  let sanitizedTopic = "";
+  $: title, topic,
+    (async () => {
+      const [cleanTitle, cleanTopic] = await Promise.all([
+        sanitizeHTML(title ?? ""),
+        sanitizeHTML(topic ?? ""),
+      ]);
+
+      sanitizedTopic = cleanTopic;
+      sanitizedTitle = cleanTitle;
+    })();
 </script>
 
 <p class="question">
   {@html replacePlaceholders($i18n.proposal_detail__vote.accept_or_reject, {
     $id: `${id ?? ""}`,
-    $title: `${title ?? ""}`,
-    $topic: topic ?? "",
+    $title: sanitizedTitle,
+    $topic: sanitizedTopic,
   })}
 </p>
 

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -57,7 +57,8 @@
 
   let sanitizedTitle = "";
   let sanitizedTopic = "";
-  $: title, topic,
+  $: title,
+    topic,
     (async () => {
       const [cleanTitle, cleanTopic] = await Promise.all([
         sanitizeHTML(title ?? ""),

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -90,4 +90,4 @@ export const markdownToSanitizedHTML = async (
 export const sanitizeHTML = async (text: string): Promise<string> => {
   const sanitizeText = await sanitize();
   return sanitizeText(text);
-}
+};

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -86,3 +86,8 @@ export const markdownToSanitizedHTML = async (
   ]);
   return convertMarkdownToHTML(sanitizeText(text ?? ""));
 };
+
+export const sanitizeHTML = async (text: string): Promise<string> => {
+  const sanitizeText = await sanitize();
+  return sanitizeText(text);
+}

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
@@ -17,6 +17,10 @@ import { mockNeuron } from "../../../../mocks/neurons.mock";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
 import VotingCardTest from "./VotingCardTest.svelte";
 
+jest.mock("../../../../../lib/utils/html.utils", () => ({
+  sanitizeHTML: (value) => Promise.resolve(value),
+}));
+
 describe("VotingCard", () => {
   const neuronIds = [111, 222].map(BigInt);
   const proposalInfo: ProposalInfo = {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -15,6 +15,10 @@ import en from "../../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import { mockProposalInfo } from "../../../../mocks/proposal.mock";
 
+jest.mock("../../../../../lib/utils/html.utils", () => ({
+  sanitizeHTML: (value) => Promise.resolve(value),
+}));
+
 describe("VotingConfirmationToolbar", () => {
   const votingPower = BigInt(100 * E8S_PER_ICP);
   const neuron = {
@@ -137,7 +141,7 @@ describe("VotingConfirmationToolbar", () => {
     expect(calledVoteType).toBe(Vote.NO);
   });
 
-  it("should display a question that repeats id and topic", () => {
+  it("should display a question that repeats id and topic", async () => {
     const { container } = render(VotingConfirmationToolbar, {
       props,
     });
@@ -154,10 +158,11 @@ describe("VotingConfirmationToolbar", () => {
       .replace(/<\/strong>/g, "")
       .replace("&ndash;", "–");
 
-    const { textContent }: HTMLParagraphElement = container.querySelector(
-      ".question"
-    ) as HTMLParagraphElement;
-
-    expect(textContent).toEqual(testLabel);
+    await waitFor(() => {
+      const { textContent }: HTMLParagraphElement = container.querySelector(
+        ".question"
+      ) as HTMLParagraphElement;
+      expect(textContent).toEqual(testLabel);
+    });
   });
 });

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -34,6 +34,10 @@ jest.mock("../../../../lib/services/sns.services", () => {
   };
 });
 
+jest.mock("../../../../lib/utils/html.utils", () => ({
+  sanitizeHTML: (value) => Promise.resolve(value),
+}));
+
 describe("ParticipateSwapModal", () => {
   const reload = jest.fn();
 

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -17,6 +17,10 @@ import {
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
 import en from "../mocks/i18n.mock";
 
+jest.mock("../../lib/utils/html.utils", () => ({
+  sanitizeHTML: (value) => Promise.resolve(value),
+}));
+
 describe("Accounts", () => {
   let accountsStoreMock: jest.SpyInstance;
 


### PR DESCRIPTION
# Motivation

Sanitize proposal title and account identifier for placeholders.

# Note

Deployed with https://github.com/dfinity/nns-dapp/releases/tag/proposal-76202

# Changes

- expose function `sanitizeHTML` with `purify`
- sanitize proposal title and topic for voting card
- sanitize account identifier when participate to a sns sale

