### PR TITLE
L2-956: Ignore last commitment error on notify

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -285,15 +285,15 @@ export const participateInSwap = async ({
       // The last commitment might trigger this error
       // because the backend is faster than the frontend at notifying the commitment.
       // Backend error line: https://github.com/dfinity/ic/blob/6ccf23ec7096b117c476bdcd34caa6fada84a3dd/rs/sns/swap/src/swap.rs#L461
-      if (
-        error.message?.includes("'open' state") !== true ||
-        (project?.summary !== undefined &&
-          // If it's the last commitment, it means that one more e8 is not a valid participation.
-          !commitmentExceedsAmountLeft({
-            summary: project?.summary,
-            amountE8s: amount.toE8s() + BigInt(1),
-          }))
-      ) {
+      const openStateError = error.message?.includes("'open' state") === true;
+      // If it's the last commitment, it means that one more e8 is not a valid participation.
+      const lastCommitment =
+        project?.summary !== undefined &&
+        commitmentExceedsAmountLeft({
+          summary: project?.summary,
+          amountE8s: amount.toE8s() + BigInt(1),
+        });
+      if (!(openStateError && lastCommitment)) {
         throw error;
       }
     }

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -254,14 +254,13 @@ export const participateInSwap = async ({
   account: Account;
 }): Promise<{ success: boolean }> => {
   let success = false;
-  let project: SnsFullProject | undefined;
   try {
     const transactionFee = get(transactionsFeesStore).main;
     assertEnoughAccountFunds({
       account,
       amountE8s: amount.toE8s() + transactionFee,
     });
-    project = getProjectFromStore(rootCanisterId);
+    const project = getProjectFromStore(rootCanisterId);
     const { valid, labelKey, substitutions } = validParticipation({
       project,
       amount,
@@ -285,6 +284,7 @@ export const participateInSwap = async ({
     } catch (error) {
       // The last commitment might trigger this error
       // because the backend is faster than the frontend at notifying the commitment.
+      // Backend error line: https://github.com/dfinity/ic/blob/6ccf23ec7096b117c476bdcd34caa6fada84a3dd/rs/sns/swap/src/swap.rs#L461
       if (
         error.message?.includes("'open' state") !== true ||
         (project?.summary !== undefined &&

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -289,9 +289,7 @@ export const participateInSwap = async ({
     // The last commitment might trigger this error
     // because the backend is faster than the frontend at notifying the commitment.
     if (
-      error !== undefined &&
-      "message" in error &&
-      error.message.includes("'open' state") &&
+      error.message?.includes("'open' state") === true &&
       project?.summary !== undefined &&
       // If it's the last commitment, it means that one more e8 is not a valid participation.
       commitmentExceedsAmountLeft({

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -157,10 +157,10 @@ const commitmentTooLarge = ({
   summary: SnsSummary;
   amountE8s: bigint;
 }): boolean => summary.swap.init.max_participant_icp_e8s < amountE8s;
-// Checks whether the amount that the user wants to contiribute
+// Checks whether the amount that the user wants to contribute
 // plus the amount that all users have contributed so far
 // exceeds the maximum amount that the project can accept.
-const commitmentExceedsAmountLeft = ({
+export const commitmentExceedsAmountLeft = ({
   summary: { swap, derived },
   amountE8s,
 }: {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -64,6 +64,42 @@ describe("sns-services", () => {
       expect(syncAccounts).toBeCalled();
     });
 
+    it.only("should return true when last commitment and still sync accounts", async () => {
+      const maxE8s = BigInt(1_000_000_000);
+      const participationE8s = BigInt(150_000_000);
+      const currentE8s = BigInt(850_000_000);
+      const [metadatas, querySnsSwapStates] = snsResponsesForLifecycle({
+        certified: true,
+        lifecycles: [SnsSwapLifecycle.Open],
+      });
+      // Prepare project data
+      querySnsSwapStates[0].derived[0]!.buyer_total_icp_e8s = currentE8s;
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_participant_icp_e8s =
+        BigInt(20_000_000_000);
+      querySnsSwapStates[0].swap[0]!.init[0]!.min_participant_icp_e8s =
+        BigInt(10_000_000);
+      querySnsSwapStates[0].swap[0]!.init[0]!.max_icp_e8s = maxE8s;
+      const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
+      snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      const spyParticipate = jest
+        .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() =>
+          Promise.reject(
+            new Error(
+              "Sorry, There was an unexpected error while participating. Call was rejected: Request ID: a26e17bac91489a89f8b1aef858efeebe9993654ee1ace64efc46a60f3a219c8 Reject code: 5 Reject text: Canister tcvdh-niaaa-aaaaa-aaaoa-cai trapped explicitly: Panicked at 'The token amount can only be refreshed when the canister is in the 'open' state', sns/swap/canister/canister.rs:165:21"
+            )
+          )
+        );
+      const { success } = await participateInSwap({
+        amount: ICP.fromE8s(participationE8s),
+        rootCanisterId,
+        account: mockMainAccount,
+      });
+      expect(success).toBe(true);
+      expect(spyParticipate).toBeCalled();
+      expect(syncAccounts).toBeCalled();
+    });
+
     it("should return success false if api call fails", async () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);


### PR DESCRIPTION
# Motivation

User of the last commitment received an error notification because the notify was failing. The problem is that the backend might be faster to notify than the frontend. That causes the project to change state to Committed and the subsequent notify to fail.

Catch that error specifically and ignore it.

# Changes

* Check for last commitment notify error in the participateInSwap sns service.
* Export project util commitmentExceedsAmountLeft to be used in participateInSwap.

# Tests

* Test exported project util commitmentExceedsAmountLeft
* Test the service for the new use case.
