### PR TITLE
L2-958: Manage error project not found

### DIFF
--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -1,6 +1,11 @@
 import type { Writable } from "svelte/store";
 import type { SnsSummary, SnsSwapCommitment } from "./sns";
 
+/**
+ * `null` means not initialized
+ * `undefined` means not found
+ * SnsSummary or SnsSwapCommitment is a valid project
+ */
 export type ProjectDetailStore = {
   summary: SnsSummary | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -133,6 +133,7 @@
         return;
       }
 
+      // Edge case, the previous check already ensures that `routePathRootCanisterId` will return a defined value.
       const rootCanisterId = routePathRootCanisterId(path);
       if (rootCanisterId === undefined) {
         return;
@@ -164,7 +165,8 @@
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
 
   let loading: boolean;
-  $: loading = $snsSummariesStore.length === 0;
+  $: loading =
+    $snsSummariesStore.length === 0 || isNullish($snsSwapCommitmentsStore);
   let notFound: boolean;
   $: notFound = $projectDetailStore.summary === undefined;
 

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -25,6 +25,8 @@
   import { isNullish } from "../lib/utils/utils";
   import { writable } from "svelte/store";
   import { snsSummariesStore } from "../lib/stores/sns.store";
+  import { Principal } from "@dfinity/principal";
+  import { toastsStore } from "../lib/stores/toasts.store";
 
   onMount(() => {
     if (!IS_TESTNET) {
@@ -36,8 +38,8 @@
     loadSnsSummary({
       rootCanisterId,
       onError: () => {
-        // hide unproven data
-        $projectDetailStore.summary = null;
+        // Set to not found
+        $projectDetailStore.summary = undefined;
         goBack();
       },
     });
@@ -46,8 +48,8 @@
     loadSnsSwapCommitment({
       rootCanisterId,
       onError: () => {
-        // hide unproven data
-        $projectDetailStore.swapCommitment = null;
+        // Set to not found
+        $projectDetailStore.swapCommitment = undefined;
         goBack();
       },
     });
@@ -61,20 +63,15 @@
       // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
       return;
     }
-    try {
-      await Promise.all([
-        loadSummary(rootCanisterId),
-        loadSwapState(rootCanisterId),
-      ]);
-    } catch (err) {
-      // TODO: Manage errors https://dfinity.atlassian.net/browse/L2-958
-      console.error(err);
-    }
+    await Promise.all([
+      loadSummary(rootCanisterId),
+      loadSwapState(rootCanisterId),
+    ]);
   };
 
   const projectDetailStore = writable<ProjectDetailStore>({
-    summary: undefined,
-    swapCommitment: undefined,
+    summary: null,
+    swapCommitment: null,
   });
 
   // TODO: add projectDetailStore to debug store
@@ -88,7 +85,25 @@
     routeStore.replace({ path: AppPath.Launchpad });
   };
 
-  const mapProjectDetail = (rootCanisterId: string | undefined) => {
+  const mapProjectDetail = (rootCanisterId: string) => {
+    // Check project summaries are loaded in store
+    if (
+      $snsSummariesStore.length === 0 ||
+      isNullish($snsSwapCommitmentsStore)
+    ) {
+      return;
+    }
+    // Check valid rootCanisterId
+    try {
+      if (rootCanisterId !== undefined) {
+        Principal.fromText(rootCanisterId);
+      }
+    } catch (error) {
+      // set values as not found
+      $projectDetailStore.summary = undefined;
+      $projectDetailStore.swapCommitment = undefined;
+      return;
+    }
     $projectDetailStore.summary =
       rootCanisterId !== undefined
         ? $snsSummariesStore.find(
@@ -119,6 +134,9 @@
       }
 
       const rootCanisterId = routePathRootCanisterId(path);
+      if (rootCanisterId === undefined) {
+        return;
+      }
       mapProjectDetail(rootCanisterId);
     })();
 
@@ -145,17 +163,25 @@
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
 
-  let loadingSummary: boolean;
-  $: loadingSummary = isNullish($projectDetailStore.summary);
-  let loadingSwapState: boolean;
-  $: loadingSwapState = isNullish($projectDetailStore.swapCommitment);
+  let loading: boolean;
+  $: loading = $snsSummariesStore.length === 0;
+  let notFound: boolean;
+  $: notFound = $projectDetailStore.summary === undefined;
 
-  // TODO(L2-838): if error redirect to launchpad and display error there
+  $: {
+    if (notFound) {
+      toastsStore.error({
+        labelKey: "error__sns.project_not_found",
+      });
+      routeStore.replace({ path: AppPath.Launchpad });
+    }
+  }
 </script>
 
 <main>
   <div class="stretch-mobile">
-    {#if loadingSummary && loadingSwapState}
+    <!-- notFound redirects to launchpad but we show the spinner until redirection occurs -->
+    {#if loading || notFound}
       <Spinner />
     {:else}
       <div class="content-grid">


### PR DESCRIPTION
# Motivation

User should be redirected to launchpad when trying to access details of a non-existing project.

# Changes

* Changes in the ProjectDetail page to manage edge case. Specifically in mapProjectDetail.

# Tests

* Provide test for not found or wrong canister id in the url of Project Detail.
