### PR TITLE
style: redo toast max-height

### DIFF
--- a/frontend/src/lib/components/ui/Toast.svelte
+++ b/frontend/src/lib/components/ui/Toast.svelte
@@ -98,9 +98,6 @@
     align-items: flex-start;
     gap: var(--padding-1_5x);
 
-    // (>=3 lines x 1rem) + top/bottom paddings
-    height: calc(8.5 * var(--padding));
-
     border-radius: var(--border-radius);
     background: var(--card-background);
     box-shadow: var(--strong-shadow, 8px 8px 16px 0 rgba(0, 0, 0, 0.25));
@@ -133,7 +130,9 @@
       flex-grow: 1;
       align-self: center;
       word-break: break-word;
-      max-height: 100%;
+
+      // (>=3 lines x 1rem) + top/bottom paddings
+      max-height: calc(8.5 * var(--padding));
       overflow-y: auto;
     }
 

--- a/frontend/src/lib/components/ui/Toast.svelte
+++ b/frontend/src/lib/components/ui/Toast.svelte
@@ -90,11 +90,16 @@
 </div>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/text";
+
   .toast {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     gap: var(--padding-1_5x);
+
+    // (>=3 lines x 1rem) + top/bottom paddings
+    height: calc(8.5 * var(--padding));
 
     border-radius: var(--border-radius);
     background: var(--card-background);
@@ -128,6 +133,8 @@
       flex-grow: 1;
       align-self: center;
       word-break: break-word;
+      max-height: 100%;
+      overflow-y: auto;
     }
 
     button.close {

--- a/frontend/src/lib/components/ui/Toast.svelte
+++ b/frontend/src/lib/components/ui/Toast.svelte
@@ -90,8 +90,6 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/text";
-
   .toast {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
# Motivation

Redo max-height for toast content.

# Notes

Previously height was set on the all toast, I reused same value for the content so that one line still remains displayed in a compact way. Per extension the toast max height is then a bit bigger than before but it's fine in my opinion.

# Changes

- redo max height but set to toast content

# Screenshots

<img width="1510" alt="Capture d’écran 2022-08-23 à 11 10 53" src="https://user-images.githubusercontent.com/16886711/186120063-7fa0bb62-7aab-495a-a0c3-8f7f6cac61f6.png">

