### PR TITLE
L2-921: Manage error sns neuron detail page

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -27,7 +27,7 @@
   const { reload, store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
 
-  let neuron: SnsNeuron | undefined;
+  let neuron: SnsNeuron | undefined | null;
   $: neuron = $store.neuron;
   let neuronId: SnsNeuronId | undefined;
   $: neuronId =
@@ -67,7 +67,7 @@
   };
 </script>
 
-{#if neuron !== undefined}
+{#if neuron !== undefined && neuron !== null}
   <CardInfo testId="sns-hotkeys-card">
     <div class="title" slot="start">
       <h3>{$i18n.neuron_detail.hotkeys_title}</h3>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -35,14 +35,15 @@
 
   let canManageHotkeys: boolean = true;
   $: canManageHotkeys =
-    neuron !== undefined
+    neuron !== undefined && neuron !== null
       ? canIdentityManageHotkeys({
           neuron,
           identity: $authStore.identity,
         })
       : false;
   let hotkeys: string[];
-  $: hotkeys = neuron !== undefined ? getSnsNeuronHotkeys(neuron) : [];
+  $: hotkeys =
+    neuron !== undefined && neuron !== null ? getSnsNeuronHotkeys(neuron) : [];
 
   let showTooltip: boolean;
   $: showTooltip = hotkeys.length > 0 && canManageHotkeys;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -13,11 +13,11 @@
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
 
-  let neuron: SnsNeuron | undefined;
+  let neuron: SnsNeuron | undefined | null;
   $: neuron = $store.neuron;
 </script>
 
-{#if neuron !== undefined}
+{#if neuron !== undefined && neuron !== null}
   <SnsNeuronCard {neuron} cardType="info">
     <section>
       <p>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -743,6 +743,7 @@
     "commitment_too_large": "Sorry, your commitment of $commitment ICP is too high. The maximum is $maxCommitment ICP.",
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
     "cannot_participate": "Sorry, There was an unexpected error while participating.",
+    "invalid_root_canister_id": "Sorry, the project ID $canisterId is invalid.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   }
 }

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -72,7 +72,7 @@ const getNeuronFromStoreByIdHex = ({
 }: {
   neuronIdHex: string;
   rootCanisterId: Principal;
-}): { neuron?: SnsNeuron; certified?: boolean } => {
+}): { neuron?: SnsNeuron; certified: boolean } => {
   const projectData = getSnsNeuronsFromStoreByProject(rootCanisterId);
   const neuron = getSnsNeuronByHexId({
     neuronIdHex,
@@ -94,8 +94,20 @@ export const getSnsNeuron = async ({
   neuronIdHex: string;
   rootCanisterId: Principal;
   forceFetch?: boolean;
-  onLoad: ({ certified: boolean, neuron: SnsNeuron }) => void;
-  onError?: ({ certified, error }) => void;
+  onLoad: ({
+    certified,
+    neuron,
+  }: {
+    certified: boolean;
+    neuron: SnsNeuron;
+  }) => void;
+  onError?: ({
+    certified,
+    error,
+  }: {
+    certified: boolean;
+    error: unknown;
+  }) => void;
 }): Promise<void> => {
   if (!forceFetch) {
     const { neuron, certified } = getNeuronFromStoreByIdHex({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -784,6 +784,7 @@ interface I18nError__sns {
   commitment_too_large: string;
   commitment_exceeds_current_allowed: string;
   cannot_participate: string;
+  invalid_root_canister_id: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/lib/types/sns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.context.ts
@@ -4,6 +4,9 @@ import type { Writable } from "svelte/store";
 
 /**
  * A store that contains the selected sns neuron.
+ *
+ * `null` is the initial value.
+ * `undefined` means not found
  */
 export interface SelectedSnsNeuronStore {
   selected:
@@ -12,7 +15,7 @@ export interface SelectedSnsNeuronStore {
         neuronIdHex: string;
       }
     | undefined;
-  neuron: SnsNeuron | undefined;
+  neuron: SnsNeuron | undefined | null;
 }
 
 export interface SelectedSnsNeuronContext {

--- a/frontend/src/routes/SnsNeuronDetail.svelte
+++ b/frontend/src/routes/SnsNeuronDetail.svelte
@@ -75,7 +75,10 @@
       rootCanisterId = Principal.fromText(rootCanisterIdMaybe);
     } catch (error) {
       toastsStore.error({
-        labelKey: "error__sns.project_not_found",
+        labelKey: "error__sns.invalid_root_canister_id",
+        substitutions: {
+          $canisterId: rootCanisterIdMaybe,
+        },
       });
       routeStore.replace({ path: AppPath.Neurons });
       return;

--- a/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
@@ -75,7 +75,7 @@ describe("SnsNeuronDetail", () => {
       jest.spyOn(routeStore, "replace");
     });
 
-    it("should get neuron", async () => {
+    it("should redirect", async () => {
       render(SnsNeuronDetail);
 
       await waitFor(() => expect(routeStore.replace).toBeCalled());
@@ -96,7 +96,7 @@ describe("SnsNeuronDetail", () => {
       jest.spyOn(routeStore, "replace");
     });
 
-    it("should get neuron", async () => {
+    it("should redirect", async () => {
       validNeuron = false;
       render(SnsNeuronDetail);
 

--- a/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/routes/SnsNeuronDetail.spec.ts
@@ -11,40 +11,96 @@ import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
 import { mockSnsNeuron } from "../mocks/sns-neurons.mock";
 import { rootCanisterIdMock } from "../mocks/sns.api.mock";
 
+let validNeuron = true;
 jest.mock("../../lib/services/sns-neurons.services", () => {
   return {
-    getSnsNeuron: jest
-      .fn()
-      .mockImplementation(({ onLoad }) => onLoad({ neuron: mockSnsNeuron })),
+    getSnsNeuron: jest.fn().mockImplementation(({ onLoad, onError }) => {
+      if (validNeuron) {
+        onLoad({ neuron: mockSnsNeuron });
+      } else {
+        onError();
+      }
+    }),
   };
 });
 
 describe("SnsNeuronDetail", () => {
-  jest
-    .spyOn(routeStore, "subscribe")
-    .mockImplementation(
-      mockRouteStoreSubscribe(
-        `/#/project/${rootCanisterIdMock.toText()}/neuron/${getSnsNeuronIdAsHexString(
-          mockSnsNeuron
-        )}`
-      )
-    );
+  afterEach(() => {
+    jest.clearAllMocks();
+    validNeuron = true;
+  });
+  describe("when neuron and projects are valid and present", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(routeStore, "subscribe")
+        .mockImplementation(
+          mockRouteStoreSubscribe(
+            `/#/project/${rootCanisterIdMock.toText()}/neuron/${getSnsNeuronIdAsHexString(
+              mockSnsNeuron
+            )}`
+          )
+        );
+    });
 
-  it("should get neuron", async () => {
-    render(SnsNeuronDetail);
+    it("should get neuron", async () => {
+      render(SnsNeuronDetail);
 
-    await waitFor(() => expect(getSnsNeuron).toBeCalled());
+      await waitFor(() => expect(getSnsNeuron).toBeCalled());
+    });
+
+    it("should render main information card", async () => {
+      const { queryByTestId } = render(SnsNeuronDetail);
+
+      expect(queryByTestId("sns-neuron-card-title")).toBeInTheDocument();
+    });
+
+    it("should render hotkeys card", async () => {
+      const { queryByTestId } = render(SnsNeuronDetail);
+
+      expect(queryByTestId("sns-hotkeys-card")).toBeInTheDocument();
+    });
   });
 
-  it("should render main information card", async () => {
-    const { queryByTestId } = render(SnsNeuronDetail);
+  describe("when project is an invalid canister id", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(routeStore, "subscribe")
+        .mockImplementation(
+          mockRouteStoreSubscribe(
+            `/#/project/invalid-project-id/neuron/${getSnsNeuronIdAsHexString(
+              mockSnsNeuron
+            )}`
+          )
+        );
+      jest.spyOn(routeStore, "replace");
+    });
 
-    expect(queryByTestId("sns-neuron-card-title")).toBeInTheDocument();
+    it("should get neuron", async () => {
+      render(SnsNeuronDetail);
+
+      await waitFor(() => expect(routeStore.replace).toBeCalled());
+    });
   });
 
-  it("should render hotkeys card", async () => {
-    const { queryByTestId } = render(SnsNeuronDetail);
+  describe("when neuron is not found", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(routeStore, "subscribe")
+        .mockImplementation(
+          mockRouteStoreSubscribe(
+            `/#/project/invalid-project-id/neuron/${getSnsNeuronIdAsHexString(
+              mockSnsNeuron
+            )}`
+          )
+        );
+      jest.spyOn(routeStore, "replace");
+    });
 
-    expect(queryByTestId("sns-hotkeys-card")).toBeInTheDocument();
+    it("should get neuron", async () => {
+      validNeuron = false;
+      render(SnsNeuronDetail);
+
+      await waitFor(() => expect(routeStore.replace).toBeCalled());
+    });
   });
 });


### PR DESCRIPTION
# Motivation

User should be redirected to neurons if trying to access a wrong sns neuron page.

# Changes

* Check for valid root canister id and redirect to neurons in SnsNeuronDetail page.
* Add skeleton while loading.

# Tests

* Add test cases to SnsNeuronDetail test.
