### PR TITLE
Fix/legacy card meta and grid

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-08-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-18.1.tgz",
-      "integrity": "sha512-76u6EfpJp3PaPf8UPmIwpf9pImdnaJMygKihsb8VxVOUi8Av0RWeJco/aflU3Dzf9yQpAEWb5hjFJSG2ETcYYQ=="
+      "version": "0.0.1-next-2022-08-23.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-23.2.tgz",
+      "integrity": "sha512-60yook2qJNYurQHX5NKo4ZNnIiHGuyxoMZx4JAT7pi1F8RDwyUymN7ib37mWVQGjj9qKr6WwrlDdqQWiJ3mstg=="
     },
     "node_modules/@dfinity/identity": {
       "version": "0.12.2",
@@ -9896,9 +9896,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-08-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-18.1.tgz",
-      "integrity": "sha512-76u6EfpJp3PaPf8UPmIwpf9pImdnaJMygKihsb8VxVOUi8Av0RWeJco/aflU3Dzf9yQpAEWb5hjFJSG2ETcYYQ=="
+      "version": "0.0.1-next-2022-08-23.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-23.2.tgz",
+      "integrity": "sha512-60yook2qJNYurQHX5NKo4ZNnIiHGuyxoMZx4JAT7pi1F8RDwyUymN7ib37mWVQGjj9qKr6WwrlDdqQWiJ3mstg=="
     },
     "@dfinity/identity": {
       "version": "0.12.2",

--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -31,14 +31,14 @@
       <Spinner inline />
     </div>
   {:else}
-    <div class="grid">
+    <div class="card-grid">
       {#each Array(projectCount) as _}
         <SkeletonProjectCard />
       {/each}
     </div>
   {/if}
 {:else if projects !== undefined}
-  <div class="grid">
+  <div class="card-grid">
     {#each projects as project (project.rootCanisterId.toText())}
       <ProjectCard {project} />
     {/each}

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -23,14 +23,14 @@
 </script>
 
 {#if loading}
-  <div class="grid">
+  <div class="card-grid">
     <SkeletonProposalCard />
     <SkeletonProposalCard />
   </div>
 {:else if $openSnsProposalsStore.length === 0}
   <p class="no-proposals">{$i18n.voting.nothing_found}</p>
 {:else}
-  <div class="grid">
+  <div class="card-grid">
     {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}
       <ProposalCard {proposalInfo} />
     {/each}

--- a/frontend/src/lib/components/proposals/ProposalsModern.svelte
+++ b/frontend/src/lib/components/proposals/ProposalsModern.svelte
@@ -27,7 +27,7 @@
 {/if}
 
 {#if loading || !neuronsLoaded}
-  <div class="grid" data-tid="proposals-loading">
+  <div class="card-grid" data-tid="proposals-loading">
     <SkeletonCard />
     <SkeletonCard />
     <SkeletonCard />

--- a/frontend/src/lib/themes/legacy.scss
+++ b/frontend/src/lib/themes/legacy.scss
@@ -12,4 +12,12 @@ main.legacy {
   @include media.min-width(medium) {
     padding: inherit;
   }
+
+  .card {
+    // solve title|icp line (e.g. neuron card)
+    .meta {
+      flex-wrap: wrap;
+      column-gap: var(--padding);
+    }
+  }
 }


### PR DESCRIPTION
# Motivation

1. fix neuron card title (meta) on mobile:
<img width="387" alt="Screenshot 2022-08-23 at 11 37 22" src="https://user-images.githubusercontent.com/98811342/186144587-7d8ab7ae-cc3d-42e9-adcd-c39affe62284.png">
2. rename `grid` class to apply latest `gix-component` changes.

# Changes

- add legacy card `.meta` styling
- rename `grid` to `card-grid`

# Tests

## After

<img width="375" alt="image" src="https://user-images.githubusercontent.com/98811342/186145613-4afe3364-471b-4d46-8e58-930643101597.png">

<img width="720" alt="image" src="https://user-images.githubusercontent.com/98811342/186145683-299740ca-ce19-489c-8dd3-2e34f218d91c.png">

## card-grid

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/98811342/186145792-fd694119-7f62-4264-8728-d545d37111ce.png">

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/98811342/186145844-5e3cbd56-c730-4074-ab86-a46560ed26d1.png">


