### PR TITLE
Fake timer for tests

### DIFF
--- a/frontend/src/tests/lib/components/launchpad/ProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProposalCard.spec.ts
@@ -48,9 +48,10 @@ describe("ProposalCard", () => {
     const deadlineIn = BigInt(1000);
 
     beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(Number(now) * 1000);
+      jest.useFakeTimers("modern").setSystemTime(Date.now());
     });
-    afterAll(() => jest.clearAllTimers());
+
+    afterAll(() => jest.useRealTimers());
 
     it("should render proposal deadline", () => {
       const { getByText } = render(ProposalCard, {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../lib/constants/neurons.constants";
 import { neuronsStore } from "../../../lib/stores/neurons.store";
 import type { Step } from "../../../lib/stores/steps.state";
+import { nowInSeconds } from "../../../lib/utils/date.utils";
 import { enumValues } from "../../../lib/utils/enum.utils";
 import {
   ageMultiplier,
@@ -71,6 +72,10 @@ import {
 import { mockProposalInfo } from "../../mocks/proposal.mock";
 
 describe("neuron-utils", () => {
+  beforeAll(() => jest.useFakeTimers("modern").setSystemTime(Date.now()));
+
+  afterAll(() => jest.useRealTimers());
+
   describe("votingPower", () => {
     it("should return zero for delays less than six months", () => {
       expect(
@@ -254,7 +259,7 @@ describe("neuron-utils", () => {
     });
 
     it("returns duration from today until dissolving time", () => {
-      const todayInSeconds = BigInt(Math.round(Date.now() / 1000));
+      const todayInSeconds = BigInt(nowInSeconds());
       const delayInSeconds = todayInSeconds + BigInt(SECONDS_IN_YEAR);
       const neuron = {
         ...mockNeuron,

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -16,17 +16,15 @@ import {
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 
 describe("utils", () => {
-  const callback = jest.fn();
+  let callback: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers("modern");
     jest.spyOn(global, "setTimeout");
+    callback = jest.fn();
   });
 
-  beforeAll(() => {
-    jest.useFakeTimers("modern").setSystemTime(Date.now());
-  });
-
-  afterAll(() => jest.useRealTimers());
+  afterEach(() => jest.useRealTimers());
 
   it("should debounce function with timeout", () => {
     const testDebounce = debounce(callback, 100);
@@ -37,6 +35,11 @@ describe("utils", () => {
 
     expect(setTimeout).toHaveBeenCalledTimes(3);
     expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 100);
+    expect(callback).not.toBeCalled();
+
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it("should debounce one function call", () => {

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -19,9 +19,14 @@ describe("utils", () => {
   const callback = jest.fn();
 
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.spyOn(global, "setTimeout");
   });
+
+  beforeAll(() => {
+    jest.useFakeTimers("modern").setSystemTime(Date.now());
+  });
+
+  afterAll(() => jest.useRealTimers());
 
   it("should debounce function with timeout", () => {
     const testDebounce = debounce(callback, 100);


### PR DESCRIPTION
# Motivation

Optimistic (failed to reproduce the problem locally) attempt to make tests more reliable (related to [the issue](https://github.com/dfinity/nns-dapp/runs/7979317538?check_suite_focus=true)).

# Changes

- set static system time for `dissolving time` spec
- switch to `nowInSeconds` to mimic the implementation
- extended `debounce` test



