### PR TITLE
feat: proposal new UI more system info

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-08-23.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-23.2.tgz",
-      "integrity": "sha512-60yook2qJNYurQHX5NKo4ZNnIiHGuyxoMZx4JAT7pi1F8RDwyUymN7ib37mWVQGjj9qKr6WwrlDdqQWiJ3mstg=="
+      "version": "0.0.1-next-2022-08-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-25.1.tgz",
+      "integrity": "sha512-7lwrXr+FAW8JnxlrmuTtdpaWm9RvEvPbmoMIISBVapcyqWoqkVVEPeztST8TDLXqqjgONfagHbGQ90Cp8Xyx8g=="
     },
     "node_modules/@dfinity/identity": {
       "version": "0.13.2",
@@ -9937,9 +9937,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-08-23.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-23.2.tgz",
-      "integrity": "sha512-60yook2qJNYurQHX5NKo4ZNnIiHGuyxoMZx4JAT7pi1F8RDwyUymN7ib37mWVQGjj9qKr6WwrlDdqQWiJ3mstg=="
+      "version": "0.0.1-next-2022-08-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-08-25.1.tgz",
+      "integrity": "sha512-7lwrXr+FAW8JnxlrmuTtdpaWm9RvEvPbmoMIISBVapcyqWoqkVVEPeztST8TDLXqqjgONfagHbGQ90Cp8Xyx8g=="
     },
     "@dfinity/identity": {
       "version": "0.13.2",

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -37,15 +37,15 @@
   <div data-tid="sns-project-detail-info">
     <div class="title">
       <Logo src={metadata.logo} alt={$i18n.sns_launchpad.project_logo} />
-      <h1>{metadata.name}</h1>
+      <h1 class="content-cell-title">{metadata.name}</h1>
     </div>
-    <p class="value">
+    <p class="value content-cell-details">
       {metadata.description}
     </p>
     <a href={metadata.url} target="_blank" rel="noopener noreferrer"
       >{metadata.url}</a
     >
-    <div class="details">
+    <div>
       <KeyValuePair>
         <svelte:fragment slot="key"
           >{$i18n.sns_project_detail.token_name}</svelte:fragment
@@ -77,24 +77,11 @@
     display: flex;
     gap: var(--padding-1_5x);
     align-items: center;
-    margin-bottom: var(--padding);
-
-    h1 {
-      margin: 0;
-      line-height: var(--line-height-standard);
-    }
   }
+
   a {
     font-size: inherit;
 
     color: var(--primary);
-  }
-
-  .details {
-    margin-top: var(--padding-2x);
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding);
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectStatus.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatus.svelte
@@ -33,19 +33,16 @@
 </script>
 
 <div>
-  <h2>{$i18n.sns_project_detail.status}</h2>
+  <h2 class="content-cell-title">{$i18n.sns_project_detail.status}</h2>
   <Tag>{statusTextMapper[lifecycle]}</Tag>
 </div>
 
 <style lang="scss">
-  h2 {
-    margin: 0;
-    line-height: var(--line-height-standard);
-  }
-
   div {
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    margin-top: calc(var(--padding-0_5x) / 2);
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -56,14 +56,15 @@
 <!-- Because information might not be displayed once loaded - according the state - we do no display a spinner or skeleton -->
 
 {#if displayStatusSection}
-  <div class="wrapper" data-tid="sns-project-detail-status">
+  <div data-tid="sns-project-detail-status">
     <ProjectStatus />
 
-    <div class="content">
+    <div class="content content-cell-details">
       <ProjectCommitment />
 
       <ProjectTimeline />
     </div>
+
     <div class="actions">
       {#if myCommitmentIcp !== undefined}
         <div>
@@ -87,13 +88,6 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
-
-  .wrapper {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-3x);
-  }
 
   .content {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/ProposalDetailCard/NnsFunctionDetails.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalDetailCard/NnsFunctionDetails.svelte
@@ -22,6 +22,8 @@
       proposalId,
     });
   }
+
+  // TODO(L2-965): delete legacy component - duplicated by the new component <ProposalPayload />
 </script>
 
 <dt>{$i18n.proposal_detail.nns_function_name}</dt>

--- a/frontend/src/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte
@@ -21,6 +21,8 @@
 
   let nnsFunctionId: number | undefined;
   $: nnsFunctionId = getExecuteNnsFunctionId(proposal);
+
+  // TODO(L2-965): delete legacy component - duplicated by the new component <ProposalActions />
 </script>
 
 <CardBlock limitHeight={false}>

--- a/frontend/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalDetailCard/ProposalSummary.svelte
@@ -16,15 +16,10 @@
   @use "@dfinity/gix-components/styles/mixins/media";
 
   .markdown {
-    font-size: var(--font-size-small);
     overflow-wrap: break-word;
 
-    @include media.min-width(medium) {
-      font-size: var(--font-size-small);
-    }
-
     :global(a) {
-      font-size: var(--font-size-small);
+      font-size: inherit;
       color: var(--primary-tint);
       text-decoration: none;
     }
@@ -32,6 +27,15 @@
     :global(pre) {
       // make the <code> scrollable
       overflow-x: auto;
+    }
+
+    :global(h1),
+    :global(h2),
+    :global(h3),
+    :global(h4),
+    :global(h5),
+    :global(h6) {
+      line-height: var(--line-height-standard);
     }
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/ProposalModern.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalModern.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import Spinner from "../ui/Spinner.svelte";
   import { i18n } from "../../stores/i18n";
-  import ProjectSystemInfoSection from "./ProposalSystemInfoSection.svelte";
+  import ProposalSystemInfoSection from "./ProposalSystemInfoSection.svelte";
+  import ProposalProposerInfoSection from "./ProposalProposerInfoSection.svelte";
+  import ProposalProposerDataSection from "./ProposalProposerDataSection.svelte";
   import { getContext } from "svelte";
   import {
     SELECTED_PROPOSAL_CONTEXT_KEY,
@@ -19,15 +21,19 @@
   {#if $store?.proposal !== undefined}
     <div class="content-grid" data-tid="proposal-details-grid">
       <div class="content-a">
-        <ProjectSystemInfoSection proposalInfo={$store.proposal} />
+        <ProposalSystemInfoSection proposalInfo={$store.proposal} />
       </div>
-      <div class="content-b">TODO: Vote Info</div>
-      <div class="content-c">TODO: Proposal User Info</div>
-      <div class="content-d">TODO: Cast Vote</div>
+      <div class="content-b">TODO: Vote Info and Cast Vote</div>
+      <div class="content-c">
+        <ProposalProposerInfoSection proposalInfo={$store.proposal} />
+      </div>
+      <div class="content-e">
+        <ProposalProposerDataSection proposalInfo={$store.proposal} />
+      </div>
     </div>
   {:else}
     <div class="content-grid">
-      <div class="content-a">TODO skeleton</div>
+      <div class="content-a">TODO skeleton - use SkeletonDetails component</div>
     </div>
   {/if}
 {:else}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import {
+    proposalActionFields,
+    proposalFirstActionKey,
+  } from "../../utils/proposals.utils";
+  import type { Proposal } from "@dfinity/nns";
+  import Json from "../common/Json.svelte";
+  import KeyValuePair from "../ui/KeyValuePair.svelte";
+
+  export let proposal: Proposal | undefined;
+
+  let actionKey: string | undefined;
+  let actionFields: [string, unknown][] = [];
+  $: actionKey =
+    proposal !== undefined ? proposalFirstActionKey(proposal) : undefined;
+  $: actionFields =
+    (proposal !== undefined && proposalActionFields(proposal)) || [];
+</script>
+
+<h2 class="content-cell-title" data-tid="proposal-proposer-actions-entry-title">
+  {actionKey ?? ""}
+</h2>
+
+<div class="content-cell-details">
+  {#each actionFields as [key, value]}
+    <KeyValuePair>
+      <span slot="key">{key}</span>
+      <span class="value" slot="value">
+        {#if typeof value === "object"}
+          <Json json={value} />
+        {:else}
+          {value}
+        {/if}
+      </span>
+    </KeyValuePair>
+  {/each}
+</div>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerDataSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerDataSection.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { ProposalInfo } from "@dfinity/nns";
+  import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
+  import ProposalProposerActionsEntry from "./ProposalProposerActionsEntry.svelte";
+  import type { Proposal, ProposalId } from "@dfinity/nns";
+  import { mapProposalInfo } from "../../utils/proposals.utils";
+
+  export let proposalInfo: ProposalInfo;
+
+  let id: ProposalId | undefined;
+  let proposal: Proposal | undefined;
+  $: ({ id, proposal } = mapProposalInfo(proposalInfo));
+</script>
+
+{#if proposal !== undefined}
+  <ProposalProposerActionsEntry {proposal} />
+
+  <ProposalProposerPayloadEntry {proposal} proposalId={id} />
+{/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { mapProposalInfo } from "../../utils/proposals.utils";
+  import ProposalSummary from "./ProposalDetailCard/ProposalSummary.svelte";
+  import type { Proposal } from "@dfinity/nns";
+
+  export let proposalInfo: ProposalInfo;
+
+  let title: string | undefined;
+  let proposal: Proposal | undefined;
+
+  $: ({ title, proposal } = mapProposalInfo(proposalInfo));
+</script>
+
+<h2 class="content-cell-title" data-tid="proposal-proposer-info-title">
+  {title ?? ""}
+</h2>
+
+<div class="content-cell-details">
+  <ProposalSummary {proposal} />
+</div>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { ProposalId } from "@dfinity/nns";
+  import Json from "../common/Json.svelte";
+  import { loadProposalPayload } from "../../services/proposals.services";
+  import { proposalPayloadsStore } from "../../stores/proposals.store";
+  import { i18n } from "../../stores/i18n";
+  import SkeletonParagraph from "../ui/SkeletonParagraph.svelte";
+  import type { Proposal } from "@dfinity/nns";
+  import { getExecuteNnsFunctionId } from "../../utils/proposals.utils";
+
+  export let proposalId: ProposalId | undefined;
+  export let proposal: Proposal | undefined;
+
+  let payload: object | undefined | null;
+
+  $: $proposalPayloadsStore,
+    (payload =
+      proposalId !== undefined
+        ? $proposalPayloadsStore.get(proposalId)
+        : undefined);
+  $: if (
+    proposalId !== undefined &&
+    nnsFunctionId !== undefined &&
+    !$proposalPayloadsStore.has(proposalId)
+  ) {
+    loadProposalPayload({
+      proposalId,
+    });
+  }
+
+  let nnsFunctionId: number | undefined;
+  $: nnsFunctionId = getExecuteNnsFunctionId(proposal);
+</script>
+
+{#if nnsFunctionId !== undefined && proposalId !== undefined}
+  <h2
+    class="content-cell-title"
+    data-tid="proposal-proposer-payload-entry-title"
+  >
+    {$i18n.proposal_detail.payload}
+  </h2>
+
+  <div class="content-cell-details">
+    {#if payload !== undefined}
+      <div>
+        <Json json={payload} />
+      </div>
+    {:else}
+      <SkeletonParagraph />
+      <SkeletonParagraph />
+      <SkeletonParagraph />
+    {/if}
+  </div>
+{/if}
+
+<style lang="scss">
+  .content-cell-title {
+    margin-top: var(--padding-8x);
+  }
+</style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -6,13 +6,13 @@
   export let labelKey: string;
   export let testId: string;
   export let value: string;
-  export let description: string;
+  export let description: string | undefined;
 
   let sanitizedDescription = "";
 
   $: description,
     (async () =>
-      (sanitizedDescription = await sanitizeHTML(description ?? "")))();
+      (sanitizedDescription = await sanitizeHTML(description ?? $i18n.proposal_detail.no_more_info)))();
 </script>
 
 <KeyValuePairInfo>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import KeyValuePairInfo from "../ui/KeyValuePairInfo.svelte";
+  import { sanitizeHTML } from "../../utils/html.utils";
+  import { i18n } from "../../stores/i18n";
+
+  export let labelKey: string;
+  export let testId: string;
+  export let value: string;
+  export let description: string;
+
+  let sanitizedDescription = "";
+
+  $: description,
+    (async () =>
+      (sanitizedDescription = await sanitizeHTML(description ?? "")))();
+</script>
+
+<KeyValuePairInfo>
+  <svelte:fragment slot="key">{$i18n.proposal_detail[labelKey]}</svelte:fragment>
+  <span class="value" slot="value" data-tid={`${testId}-value`}>{value}</span>
+  <p slot="info" data-tid={`${testId}-description`}>
+    {@html sanitizedDescription}
+  </p>
+</KeyValuePairInfo>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -16,7 +16,8 @@
 </script>
 
 <KeyValuePairInfo>
-  <svelte:fragment slot="key">{$i18n.proposal_detail[labelKey]}</svelte:fragment>
+  <svelte:fragment slot="key">{$i18n.proposal_detail[labelKey]}</svelte:fragment
+  >
   <span class="value" slot="value" data-tid={`${testId}-value`}>{value}</span>
   <p slot="info" data-tid={`${testId}-description`}>
     {@html sanitizedDescription}

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -12,7 +12,9 @@
 
   $: description,
     (async () =>
-      (sanitizedDescription = await sanitizeHTML(description ?? $i18n.proposal_detail.no_more_info)))();
+      (sanitizedDescription = await sanitizeHTML(
+        description ?? $i18n.proposal_detail.no_more_info
+      )))();
 </script>
 
 <KeyValuePairInfo>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -41,9 +41,9 @@
   } = mapProposalInfo(proposalInfo));
 </script>
 
-<h1>{type ?? ""}</h1>
+<h1 class="content-cell-title">{type ?? ""}</h1>
 
-<div class="details" data-tid="proposal-system-info-details">
+<div class="content-cell-details" data-tid="proposal-system-info-details">
   {#if type !== undefined}
     <ProposalSystemInfoEntry
       labelKey="type_prefix"
@@ -121,18 +121,3 @@
     />
   {/if}
 </div>
-
-<style lang="scss">
-  h1 {
-    margin: 0;
-    line-height: var(--line-height-standard);
-  }
-
-  .details {
-    margin-top: var(--padding-2x);
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding);
-  }
-</style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -4,6 +4,7 @@
   import ProposalSystemInfoEntry from "./ProposalSystemInfoEntry.svelte";
   import { secondsToDateTime } from "../../utils/date.utils";
   import { i18n } from "../../stores/i18n";
+  import type { NeuronId } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 
@@ -21,6 +22,8 @@
   let executed: bigint | undefined;
   let failed: bigint | undefined;
 
+  let proposer: NeuronId | undefined;
+
   $: ({
     type,
     topic,
@@ -34,6 +37,7 @@
     decided,
     executed,
     failed,
+    proposer
   } = mapProposalInfo(proposalInfo));
 </script>
 
@@ -101,6 +105,15 @@
       testId="proposal-system-info-failed"
       value={secondsToDateTime(failed)}
       description={$i18n.proposal_detail.failed_description}
+    />
+  {/if}
+
+  {#if proposer !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="proposer_prefix"
+      testId="proposal-system-info-proposer"
+      value={`${proposer}`}
+      description={$i18n.proposal_detail.proposer_description}
     />
   {/if}
 </div>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import type { ProposalInfo } from "@dfinity/nns";
   import { mapProposalInfo } from "../../utils/proposals.utils";
-  import KeyValuePairInfo from "../ui/KeyValuePairInfo.svelte";
-  import { i18n } from "../../stores/i18n";
-  import { sanitizeHTML } from "../../utils/html.utils";
+  import ProposalSystemInfoEntry from "./ProposalSystemInfoEntry.svelte";
 
   export let proposalInfo: ProposalInfo;
 
@@ -11,42 +9,42 @@
   let typeDescription: string | undefined;
   let topic: string | undefined;
   let topicDescription: string | undefined;
-  $: ({ type, topic, typeDescription, topicDescription } =
-    mapProposalInfo(proposalInfo));
+  let statusString: string;
+  let statusDescription: string | undefined;
 
-  // We sanitize the type description because unlike the topic, it can contain HTML tags
-  let sanitizedTypeDescription = "";
-  $: typeDescription,
-    (async () =>
-      (sanitizedTypeDescription = await sanitizeHTML(typeDescription ?? "")))();
+  $: ({
+    type,
+    topic,
+    statusString,
+    typeDescription,
+    topicDescription,
+    statusDescription,
+  } = mapProposalInfo(proposalInfo));
 </script>
 
 <h1>{type ?? ""}</h1>
 
 <div class="details" data-tid="proposal-system-info-details">
-  <KeyValuePairInfo>
-    <svelte:fragment slot="key"
-      >{$i18n.proposal_detail.type_prefix}</svelte:fragment
-    >
-    <span class="value" slot="value" data-tid="proposal-system-info-type"
-      >{type}</span
-    >
-    <p slot="info" data-tid="proposal-system-info-type-description">
-      {@html sanitizedTypeDescription}
-    </p>
-  </KeyValuePairInfo>
+  <ProposalSystemInfoEntry
+    labelKey="type_prefix"
+    testId="proposal-system-info-type"
+    value={type}
+    description={typeDescription}
+  />
 
-  <KeyValuePairInfo>
-    <svelte:fragment slot="key"
-      >{$i18n.proposal_detail.topic_prefix}</svelte:fragment
-    >
-    <span class="value" slot="value" data-tid="proposal-system-info-topic"
-      >{topic}</span
-    >
-    <p slot="info" data-tid="proposal-system-info-topic-description">
-      {topicDescription}
-    </p>
-  </KeyValuePairInfo>
+  <ProposalSystemInfoEntry
+    labelKey="topic_prefix"
+    testId="proposal-system-info-topic"
+    value={topic}
+    description={topicDescription}
+  />
+
+  <ProposalSystemInfoEntry
+    labelKey="status_prefix"
+    testId="proposal-system-info-status"
+    value={statusString}
+    description={statusDescription}
+  />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -11,14 +11,18 @@
   let topicDescription: string | undefined;
   let statusString: string;
   let statusDescription: string | undefined;
+  let rewardStatusString: string;
+  let rewardStatusDescription: string | undefined;
 
   $: ({
     type,
     topic,
     statusString,
+    rewardStatusString,
     typeDescription,
     topicDescription,
     statusDescription,
+    rewardStatusDescription,
   } = mapProposalInfo(proposalInfo));
 </script>
 
@@ -44,6 +48,13 @@
     testId="proposal-system-info-status"
     value={statusString}
     description={statusDescription}
+  />
+
+  <ProposalSystemInfoEntry
+    labelKey="reward_prefix"
+    testId="proposal-system-info-reward"
+    value={rewardStatusString}
+    description={rewardStatusDescription}
   />
 </div>
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -2,6 +2,8 @@
   import type { ProposalInfo } from "@dfinity/nns";
   import { mapProposalInfo } from "../../utils/proposals.utils";
   import ProposalSystemInfoEntry from "./ProposalSystemInfoEntry.svelte";
+  import { secondsToDateTime } from "../../utils/date.utils";
+  import { i18n } from "../../stores/i18n";
 
   export let proposalInfo: ProposalInfo;
 
@@ -14,6 +16,11 @@
   let rewardStatusString: string;
   let rewardStatusDescription: string | undefined;
 
+  let created: bigint | undefined;
+  let decided: bigint | undefined;
+  let executed: bigint | undefined;
+  let failed: bigint | undefined;
+
   $: ({
     type,
     topic,
@@ -23,6 +30,10 @@
     topicDescription,
     statusDescription,
     rewardStatusDescription,
+    created,
+    decided,
+    executed,
+    failed,
   } = mapProposalInfo(proposalInfo));
 </script>
 
@@ -56,6 +67,42 @@
     value={rewardStatusString}
     description={rewardStatusDescription}
   />
+
+  {#if created !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="created_prefix"
+      testId="proposal-system-info-created"
+      value={secondsToDateTime(created)}
+      description={$i18n.proposal_detail.created_description}
+    />
+  {/if}
+
+  {#if decided !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="decided_prefix"
+      testId="proposal-system-info-decided"
+      value={secondsToDateTime(decided)}
+      description={$i18n.proposal_detail.decided_description}
+    />
+  {/if}
+
+  {#if executed !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="executed_prefix"
+      testId="proposal-system-info-executed"
+      value={secondsToDateTime(executed)}
+      description={$i18n.proposal_detail.executed_description}
+    />
+  {/if}
+
+  {#if failed !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="failed_prefix"
+      testId="proposal-system-info-failed"
+      value={secondsToDateTime(failed)}
+      description={$i18n.proposal_detail.failed_description}
+    />
+  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -37,26 +37,30 @@
     decided,
     executed,
     failed,
-    proposer
+    proposer,
   } = mapProposalInfo(proposalInfo));
 </script>
 
 <h1>{type ?? ""}</h1>
 
 <div class="details" data-tid="proposal-system-info-details">
-  <ProposalSystemInfoEntry
-    labelKey="type_prefix"
-    testId="proposal-system-info-type"
-    value={type}
-    description={typeDescription}
-  />
+  {#if type !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="type_prefix"
+      testId="proposal-system-info-type"
+      value={type}
+      description={typeDescription}
+    />
+  {/if}
 
-  <ProposalSystemInfoEntry
-    labelKey="topic_prefix"
-    testId="proposal-system-info-topic"
-    value={topic}
-    description={topicDescription}
-  />
+  {#if topic !== undefined}
+    <ProposalSystemInfoEntry
+      labelKey="topic_prefix"
+      testId="proposal-system-info-topic"
+      value={topic}
+      description={topicDescription}
+    />
+  {/if}
 
   <ProposalSystemInfoEntry
     labelKey="status_prefix"

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -469,7 +469,15 @@
     "nns_function_name": "nnsFunctionName",
     "payload": "Payload",
     "summary_toggle_view": "$toggleView summary",
-    "vote": "Vote"
+    "vote": "Vote",
+    "created_prefix": "Created",
+    "created_description": "The date when this proposal was created.",
+    "decided_prefix": "Decided",
+    "decided_description": "The date when this proposal was adopted or rejected.",
+    "executed_prefix": "Executed",
+    "executed_description": "The date when this adopted proposal was executed.",
+    "failed_prefix": "Failed",
+    "failed_description": "The date when this adopted proposal failed to be executed."
   },
   "proposal_detail__vote": {
     "headline": "Cast Vote",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -380,6 +380,13 @@
     "PROPOSAL_REWARD_STATUS_SETTLED": "Settled",
     "PROPOSAL_REWARD_STATUS_INELIGIBLE": "Ineligible"
   },
+  "rewards_description": {
+    "PROPOSAL_REWARD_STATUS_UNKNOWN": "",
+    "PROPOSAL_REWARD_STATUS_ACCEPT_VOTES": "The proposal is still accepting votes, for the purpose of voting rewards.",
+    "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE": "The proposal is no longer accepting votes. It is due to settle in the next reward event.",
+    "PROPOSAL_REWARD_STATUS_SETTLED": "The proposal has been taken into account in a reward event.",
+    "PROPOSAL_REWARD_STATUS_INELIGIBLE": "The proposal is not eligible to be taken into account in a reward event."
+  },
   "status": {
     "PROPOSAL_STATUS_UNKNOWN": "Unknown",
     "PROPOSAL_STATUS_OPEN": "Open",
@@ -450,6 +457,7 @@
     "topic_prefix": "Topic",
     "status_prefix": "Status",
     "type_prefix": "Type",
+    "reward_prefix": "Reward Status",
     "id_prefix": "ID",
     "proposer_prefix": "Proposer",
     "open_voting_prefix": "Voting open:",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -460,6 +460,7 @@
     "reward_prefix": "Reward Status",
     "id_prefix": "ID",
     "proposer_prefix": "Proposer",
+    "proposer_description": "The ID of the neuron that submitted the proposal.",
     "open_voting_prefix": "Voting open:",
     "adopt": "Adopt",
     "reject": "Reject",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -478,7 +478,8 @@
     "executed_prefix": "Executed",
     "executed_description": "The date when this adopted proposal was executed.",
     "failed_prefix": "Failed",
-    "failed_description": "The date when this adopted proposal failed to be executed."
+    "failed_description": "The date when this adopted proposal failed to be executed.",
+    "no_more_info": "No particular information."
   },
   "proposal_detail__vote": {
     "headline": "Cast Vote",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -388,6 +388,14 @@
     "PROPOSAL_STATUS_EXECUTED": "Executed",
     "PROPOSAL_STATUS_FAILED": "Failed"
   },
+  "status_description": {
+    "PROPOSAL_STATUS_UNKNOWN": "",
+    "PROPOSAL_STATUS_OPEN": "A decision has not yet been made to adopt or reject the proposal.",
+    "PROPOSAL_STATUS_REJECTED": "The proposal has been rejected.",
+    "PROPOSAL_STATUS_ACCEPTED": "The proposal has been adopted. Either execution has not yet started, or it has started but the outcome is not yet known.",
+    "PROPOSAL_STATUS_EXECUTED": "The proposal was adopted and successfully executed.",
+    "PROPOSAL_STATUS_FAILED": "The proposal was adopted, but execution failed."
+  },
   "actions": {
     "RegisterKnownNeuron": "Register Known Neuron",
     "ManageNeuron": "Manage Neuron",
@@ -440,6 +448,7 @@
     "title": "Proposal",
     "summary": "Proposal Summary",
     "topic_prefix": "Topic",
+    "status_prefix": "Status",
     "type_prefix": "Type",
     "id_prefix": "ID",
     "proposer_prefix": "Proposer",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -399,6 +399,14 @@ interface I18nRewards {
   PROPOSAL_REWARD_STATUS_INELIGIBLE: string;
 }
 
+interface I18nRewards_description {
+  PROPOSAL_REWARD_STATUS_UNKNOWN: string;
+  PROPOSAL_REWARD_STATUS_ACCEPT_VOTES: string;
+  PROPOSAL_REWARD_STATUS_READY_TO_SETTLE: string;
+  PROPOSAL_REWARD_STATUS_SETTLED: string;
+  PROPOSAL_REWARD_STATUS_INELIGIBLE: string;
+}
+
 interface I18nStatus {
   PROPOSAL_STATUS_UNKNOWN: string;
   PROPOSAL_STATUS_OPEN: string;
@@ -476,6 +484,7 @@ interface I18nProposal_detail {
   topic_prefix: string;
   status_prefix: string;
   type_prefix: string;
+  reward_prefix: string;
   id_prefix: string;
   proposer_prefix: string;
   open_voting_prefix: string;
@@ -816,6 +825,7 @@ interface I18n {
   topics: I18nTopics;
   topics_description: I18nTopics_description;
   rewards: I18nRewards;
+  rewards_description: I18nRewards_description;
   status: I18nStatus;
   status_description: I18nStatus_description;
   actions: I18nActions;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -487,6 +487,7 @@ interface I18nProposal_detail {
   reward_prefix: string;
   id_prefix: string;
   proposer_prefix: string;
+  proposer_description: string;
   open_voting_prefix: string;
   adopt: string;
   reject: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -506,6 +506,7 @@ interface I18nProposal_detail {
   executed_description: string;
   failed_prefix: string;
   failed_description: string;
+  no_more_info: string;
 }
 
 interface I18nProposal_detail__vote {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -497,6 +497,14 @@ interface I18nProposal_detail {
   payload: string;
   summary_toggle_view: string;
   vote: string;
+  created_prefix: string;
+  created_description: string;
+  decided_prefix: string;
+  decided_description: string;
+  executed_prefix: string;
+  executed_description: string;
+  failed_prefix: string;
+  failed_description: string;
 }
 
 interface I18nProposal_detail__vote {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -408,6 +408,15 @@ interface I18nStatus {
   PROPOSAL_STATUS_FAILED: string;
 }
 
+interface I18nStatus_description {
+  PROPOSAL_STATUS_UNKNOWN: string;
+  PROPOSAL_STATUS_OPEN: string;
+  PROPOSAL_STATUS_REJECTED: string;
+  PROPOSAL_STATUS_ACCEPTED: string;
+  PROPOSAL_STATUS_EXECUTED: string;
+  PROPOSAL_STATUS_FAILED: string;
+}
+
 interface I18nActions {
   RegisterKnownNeuron: string;
   ManageNeuron: string;
@@ -465,6 +474,7 @@ interface I18nProposal_detail {
   title: string;
   summary: string;
   topic_prefix: string;
+  status_prefix: string;
   type_prefix: string;
   id_prefix: string;
   proposer_prefix: string;
@@ -807,6 +817,7 @@ interface I18n {
   topics_description: I18nTopics_description;
   rewards: I18nRewards;
   status: I18nStatus;
+  status_description: I18nStatus_description;
   actions: I18nActions;
   actions_description: I18nActions_description;
   transaction_names: I18nTransaction_names;

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -44,15 +44,8 @@ export const secondsToDuration = (seconds: bigint): string => {
     .join(", ");
 };
 
-export const secondsToDateTime = (seconds: bigint): string => {
-  const options: Intl.DateTimeFormatOptions = {
-    dateStyle: "long",
-    timeStyle: "short",
-  };
-  const milliseconds = Number(seconds) * 1000;
-  // We only support english for now.
-  return new Intl.DateTimeFormat("en", options).format(new Date(milliseconds));
-};
+export const secondsToDateTime = (seconds: bigint): string =>
+  `${secondsToDate(Number(seconds))} ${secondsToTime(Number(seconds))}`;
 
 export const secondsToDate = (seconds: number): string => {
   const options: Intl.DateTimeFormatOptions = {

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -44,6 +44,16 @@ export const secondsToDuration = (seconds: bigint): string => {
     .join(", ");
 };
 
+export const secondsToDateTime = (seconds: bigint): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    dateStyle: "long",
+    timeStyle: "short",
+  };
+  const milliseconds = Number(seconds) * 1000;
+  // We only support english for now.
+  return new Intl.DateTimeFormat('en', options).format(new Date(milliseconds));
+};
+
 export const secondsToDate = (seconds: number): string => {
   const options: Intl.DateTimeFormatOptions = {
     month: "long",

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -51,7 +51,7 @@ export const secondsToDateTime = (seconds: bigint): string => {
   };
   const milliseconds = Number(seconds) * 1000;
   // We only support english for now.
-  return new Intl.DateTimeFormat('en', options).format(new Date(milliseconds));
+  return new Intl.DateTimeFormat("en", options).format(new Date(milliseconds));
 };
 
 export const secondsToDate = (seconds: number): string => {

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -306,26 +306,31 @@ export const excludeProposals = ({
   return proposals.filter(({ id }) => !excludeIds.has(id as ProposalId));
 };
 
-export const mapProposalInfo = (
-  proposalInfo: ProposalInfo
-): {
+export type ProposalInfoMap = {
   id: ProposalId | undefined;
   proposal: Proposal | undefined;
   proposer: NeuronId | undefined;
   title: string | undefined;
   url: string | undefined;
+  color: Color | undefined;
+  deadline: bigint | undefined;
+
   topic: string | undefined;
   topicDescription: string | undefined;
-  color: Color | undefined;
-  status: ProposalStatus;
-  deadline: bigint | undefined;
   type: string | undefined;
   typeDescription: string | undefined;
-} => {
+  status: ProposalStatus;
+  statusString: string;
+  statusDescription: string | undefined;
+};
+
+export const mapProposalInfo = (
+  proposalInfo: ProposalInfo
+): ProposalInfoMap => {
   const { proposal, proposer, id, status, deadlineTimestampSeconds } =
     proposalInfo;
 
-  const { topics, topics_description } = get(i18n);
+  const { topics, topics_description, status_description, status: statusLabels } = get(i18n);
   const deadline =
     deadlineTimestampSeconds === undefined
       ? undefined
@@ -333,17 +338,21 @@ export const mapProposalInfo = (
 
   const topicKey: string = Topic[proposalInfo?.topic];
 
+  const statusKey: string = ProposalStatus[status];
+
   return {
     id,
     proposer,
     proposal,
     title: proposal?.title,
-    topic: topics[topicKey],
-    topicDescription: topics_description[topicKey],
     url: proposal?.url,
     color: PROPOSAL_COLOR[status],
-    status,
     deadline,
+    topic: topics[topicKey],
+    topicDescription: topics_description[topicKey],
+    status,
+    statusString: statusLabels[statusKey],
+    statusDescription: status_description[statusKey],
     ...mapProposalType(proposal),
   };
 };
@@ -356,7 +365,7 @@ export const mapProposalInfo = (
  */
 const mapProposalType = (
   proposal: Proposal | undefined
-): { type: string | undefined; typeDescription: string | undefined } => {
+): Pick<ProposalInfoMap, "type" | "typeDescription"> => {
   const {
     actions,
     actions_description,

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -8,7 +8,12 @@ import type {
   ProposalInfo,
   Tally,
 } from "@dfinity/nns";
-import {ProposalRewardStatus, ProposalStatus, Topic, Vote} from "@dfinity/nns";
+import {
+  ProposalRewardStatus,
+  ProposalStatus,
+  Topic,
+  Vote,
+} from "@dfinity/nns";
 import { get } from "svelte/store";
 import { PROPOSAL_COLOR } from "../constants/proposals.constants";
 import { i18n } from "../stores/i18n";
@@ -313,6 +318,11 @@ export type ProposalInfoMap = {
   title: string | undefined;
   url: string | undefined;
   color: Color | undefined;
+
+  created: bigint;
+  decided: bigint | undefined;
+  executed: bigint | undefined;
+  failed: bigint | undefined;
   deadline: bigint | undefined;
 
   topic: string | undefined;
@@ -330,10 +340,27 @@ export type ProposalInfoMap = {
 export const mapProposalInfo = (
   proposalInfo: ProposalInfo
 ): ProposalInfoMap => {
-  const { proposal, proposer, id, status, rewardStatus, deadlineTimestampSeconds } =
-    proposalInfo;
+  const {
+    proposal,
+    proposer,
+    id,
+    status,
+    rewardStatus,
+    deadlineTimestampSeconds,
+    proposalTimestampSeconds,
+    decidedTimestampSeconds,
+    executedTimestampSeconds,
+    failedTimestampSeconds,
+  } = proposalInfo;
 
-  const { topics, topics_description, status_description, status: statusLabels, rewards, rewards_description } = get(i18n);
+  const {
+    topics,
+    topics_description,
+    status_description,
+    status: statusLabels,
+    rewards,
+    rewards_description,
+  } = get(i18n);
   const deadline =
     deadlineTimestampSeconds === undefined
       ? undefined
@@ -351,7 +378,14 @@ export const mapProposalInfo = (
     title: proposal?.title,
     url: proposal?.url,
     color: PROPOSAL_COLOR[status],
+
+    created: proposalTimestampSeconds,
+    decided: decidedTimestampSeconds > 0 ? decidedTimestampSeconds : undefined,
+    executed:
+      executedTimestampSeconds > 0 ? executedTimestampSeconds : undefined,
+    failed: failedTimestampSeconds > 0 ? failedTimestampSeconds : undefined,
     deadline,
+
     topic: topics[topicKey],
     topicDescription: topics_description[topicKey],
     status,

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -8,7 +8,7 @@ import type {
   ProposalInfo,
   Tally,
 } from "@dfinity/nns";
-import { ProposalStatus, Topic, Vote } from "@dfinity/nns";
+import {ProposalRewardStatus, ProposalStatus, Topic, Vote} from "@dfinity/nns";
 import { get } from "svelte/store";
 import { PROPOSAL_COLOR } from "../constants/proposals.constants";
 import { i18n } from "../stores/i18n";
@@ -322,15 +322,18 @@ export type ProposalInfoMap = {
   status: ProposalStatus;
   statusString: string;
   statusDescription: string | undefined;
+  rewardStatus: ProposalRewardStatus;
+  rewardStatusString: string;
+  rewardStatusDescription: string | undefined;
 };
 
 export const mapProposalInfo = (
   proposalInfo: ProposalInfo
 ): ProposalInfoMap => {
-  const { proposal, proposer, id, status, deadlineTimestampSeconds } =
+  const { proposal, proposer, id, status, rewardStatus, deadlineTimestampSeconds } =
     proposalInfo;
 
-  const { topics, topics_description, status_description, status: statusLabels } = get(i18n);
+  const { topics, topics_description, status_description, status: statusLabels, rewards, rewards_description } = get(i18n);
   const deadline =
     deadlineTimestampSeconds === undefined
       ? undefined
@@ -339,6 +342,7 @@ export const mapProposalInfo = (
   const topicKey: string = Topic[proposalInfo?.topic];
 
   const statusKey: string = ProposalStatus[status];
+  const rewardStatusKey: string = ProposalRewardStatus[rewardStatus];
 
   return {
     id,
@@ -353,6 +357,9 @@ export const mapProposalInfo = (
     status,
     statusString: statusLabels[statusKey],
     statusDescription: status_description[statusKey],
+    rewardStatus,
+    rewardStatusString: rewards[rewardStatusKey],
+    rewardStatusDescription: rewards_description[rewardStatusKey],
     ...mapProposalType(proposal),
   };
 };

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoEntry.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {render, waitFor} from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import ProposalSystemInfoEntry from "../../../../lib/components/proposal-detail/ProposalSystemInfoEntry.svelte";
 import en from "../../../mocks/i18n.mock";
 
@@ -22,8 +22,10 @@ describe("ProjectSystemInfoEntry", () => {
     });
 
     const { getByTestId } = renderResult;
-    await waitFor(() => expect(getByTestId(`test-description`)?.textContent).toEqual(
+    await waitFor(() =>
+      expect(getByTestId(`test-description`)?.textContent).toEqual(
         en.proposal_detail.no_more_info
-    ));
+      )
+    );
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoEntry.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {render, waitFor} from "@testing-library/svelte";
+import ProposalSystemInfoEntry from "../../../../lib/components/proposal-detail/ProposalSystemInfoEntry.svelte";
+import en from "../../../mocks/i18n.mock";
+
+jest.mock("../../../../lib/utils/html.utils", () => ({
+  sanitizeHTML: (value) => Promise.resolve(value),
+}));
+
+describe("ProjectSystemInfoEntry", () => {
+  it("should render a description placeholder if no description", async () => {
+    const renderResult = render(ProposalSystemInfoEntry, {
+      props: {
+        labelKey: "test",
+        testId: "test",
+        value: "",
+        description: undefined,
+      },
+    });
+
+    const { getByTestId } = renderResult;
+    await waitFor(() => expect(getByTestId(`test-description`)?.textContent).toEqual(
+        en.proposal_detail.no_more_info
+    ));
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
@@ -24,7 +24,7 @@ describe("ProposalSystemInfoSection", () => {
     statusString,
     rewardStatusString,
     rewardStatusDescription,
-      proposer
+    proposer,
   } = mapProposalInfo(mockProposalInfo);
 
   it("should render type title", () => {
@@ -230,7 +230,6 @@ describe("ProposalSystemInfoSection", () => {
     });
   });
 
-
   it("should render proposer info", async () => {
     const renderResult = render(ProposalSystemInfoSection, {
       props: {
@@ -252,7 +251,7 @@ describe("ProposalSystemInfoSection", () => {
       props: {
         proposalInfo: {
           ...mockProposalInfo,
-          proposer: undefined
+          proposer: undefined,
         },
       },
     });

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
@@ -24,6 +24,7 @@ describe("ProposalSystemInfoSection", () => {
     statusString,
     rewardStatusString,
     rewardStatusDescription,
+      proposer
   } = mapProposalInfo(mockProposalInfo);
 
   it("should render type title", () => {
@@ -227,5 +228,37 @@ describe("ProposalSystemInfoSection", () => {
       description: en.proposal_detail.failed_description,
       testId: "proposal-system-info-failed",
     });
+  });
+
+
+  it("should render proposer info", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    await expectRenderedInfo({
+      renderResult,
+      label: en.proposal_detail.proposer_prefix,
+      value: `${proposer}`,
+      description: en.proposal_detail.proposer_description,
+      testId: "proposal-system-info-proposer",
+    });
+  });
+
+  it("should not render proposer if no defined", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          proposer: undefined
+        },
+      },
+    });
+
+    const { getByTestId } = renderResult;
+
+    expect(() => getByTestId(`proposal-system-info-proposer-value`)).toThrow();
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
@@ -5,6 +5,7 @@
 import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
 import ProposalSystemInfoSection from "../../../../lib/components/proposal-detail/ProposalSystemInfoSection.svelte";
+import { secondsToDateTime } from "../../../../lib/utils/date.utils";
 import { mapProposalInfo } from "../../../../lib/utils/proposals.utils";
 import en from "../../../mocks/i18n.mock";
 import { mockProposalInfo } from "../../../mocks/proposal.mock";
@@ -14,8 +15,6 @@ jest.mock("../../../../lib/utils/html.utils", () => ({
 }));
 
 describe("ProposalSystemInfoSection", () => {
-  let renderResult: RenderResult;
-
   const {
     type,
     typeDescription,
@@ -27,15 +26,13 @@ describe("ProposalSystemInfoSection", () => {
     rewardStatusDescription,
   } = mapProposalInfo(mockProposalInfo);
 
-  beforeEach(() => {
-    renderResult = render(ProposalSystemInfoSection, {
+  it("should render type title", () => {
+    const renderResult = render(ProposalSystemInfoSection, {
       props: {
         proposalInfo: mockProposalInfo,
       },
     });
-  });
 
-  it("should render type title", () => {
     const { container } = renderResult;
     expect(container.querySelector("h1")).not.toBeNull();
     expect(container.querySelector("h1")?.textContent).toEqual(type);
@@ -46,11 +43,13 @@ describe("ProposalSystemInfoSection", () => {
     value,
     description,
     testId,
+    renderResult,
   }: {
     label: string;
     value: string | undefined;
     description: string | undefined;
     testId: string;
+    renderResult: RenderResult;
   }) => {
     const { getByText, getByTestId } = renderResult;
     expect(getByText(label)).toBeInTheDocument();
@@ -68,35 +67,165 @@ describe("ProposalSystemInfoSection", () => {
     );
   };
 
-  it("should render type info", async () =>
+  it("should render type info", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
     await expectRenderedInfo({
+      renderResult,
       label: en.proposal_detail.type_prefix,
       value: type,
       description: typeDescription,
       testId: "proposal-system-info-type",
-    }));
+    });
+  });
 
-  it("should render topic info", async () =>
+  it("should render topic info", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
     await expectRenderedInfo({
+      renderResult,
       label: en.proposal_detail.topic_prefix,
       value: topic,
       description: topicDescription,
       testId: "proposal-system-info-topic",
-    }));
+    });
+  });
 
-  it("should render status info", async () =>
+  it("should render status info", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
     await expectRenderedInfo({
+      renderResult,
       label: en.proposal_detail.status_prefix,
       value: statusString,
       description: statusDescription,
       testId: "proposal-system-info-status",
-    }));
+    });
+  });
 
-  it("should render reward status info", async () =>
+  it("should render reward status info", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
     await expectRenderedInfo({
+      renderResult,
       label: en.proposal_detail.reward_prefix,
       value: rewardStatusString,
       description: rewardStatusDescription,
       testId: "proposal-system-info-reward",
-    }));
+    });
+  });
+
+  const timestampSeconds = (): bigint =>
+    BigInt(Math.round(new Date().getTime() / 1000 + 10000));
+
+  it("should render created timestamp", async () => {
+    const proposalTimestampSeconds = timestampSeconds();
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          proposalTimestampSeconds,
+        },
+      },
+    });
+
+    await expectRenderedInfo({
+      renderResult,
+      label: en.proposal_detail.created_prefix,
+      value: secondsToDateTime(proposalTimestampSeconds),
+      description: en.proposal_detail.created_description,
+      testId: "proposal-system-info-created",
+    });
+  });
+
+  it("should not render any timestamps", async () => {
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByTestId } = renderResult;
+
+    expect(() => getByTestId(`proposal-system-info-created-value`)).toThrow();
+    expect(() => getByTestId(`proposal-system-info-decided-value`)).toThrow();
+    expect(() => getByTestId(`proposal-system-info-executed-value`)).toThrow();
+    expect(() => getByTestId(`proposal-system-info-failed-value`)).toThrow();
+  });
+
+  it("should render decided timestamp", async () => {
+    const decidedTimestampSeconds = timestampSeconds();
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          decidedTimestampSeconds,
+        },
+      },
+    });
+
+    await expectRenderedInfo({
+      renderResult,
+      label: en.proposal_detail.decided_prefix,
+      value: secondsToDateTime(decidedTimestampSeconds),
+      description: en.proposal_detail.decided_description,
+      testId: "proposal-system-info-decided",
+    });
+  });
+
+  it("should render executed timestamp", async () => {
+    const executedTimestampSeconds = timestampSeconds();
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          executedTimestampSeconds,
+        },
+      },
+    });
+
+    await expectRenderedInfo({
+      renderResult,
+      label: en.proposal_detail.executed_prefix,
+      value: secondsToDateTime(executedTimestampSeconds),
+      description: en.proposal_detail.executed_description,
+      testId: "proposal-system-info-executed",
+    });
+  });
+
+  it("should render failed timestamp", async () => {
+    const failedTimestampSeconds = timestampSeconds();
+    const renderResult = render(ProposalSystemInfoSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          failedTimestampSeconds,
+        },
+      },
+    });
+
+    await expectRenderedInfo({
+      renderResult,
+      label: en.proposal_detail.failed_prefix,
+      value: secondsToDateTime(failedTimestampSeconds),
+      description: en.proposal_detail.failed_description,
+      testId: "proposal-system-info-failed",
+    });
+  });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
@@ -16,8 +16,14 @@ jest.mock("../../../../lib/utils/html.utils", () => ({
 describe("ProposalSystemInfoSection", () => {
   let renderResult: RenderResult;
 
-  const { type, typeDescription, topicDescription, topic } =
-    mapProposalInfo(mockProposalInfo);
+  const {
+    type,
+    typeDescription,
+    topicDescription,
+    topic,
+    statusDescription,
+    statusString,
+  } = mapProposalInfo(mockProposalInfo);
 
   beforeEach(() => {
     renderResult = render(ProposalSystemInfoSection, {
@@ -33,41 +39,54 @@ describe("ProposalSystemInfoSection", () => {
     expect(container.querySelector("h1")?.textContent).toEqual(type);
   });
 
-  it("should render type info", async () => {
+  const expectRenderedInfo = async ({
+    label,
+    value,
+    description,
+    testId,
+  }: {
+    label: string;
+    value: string | undefined;
+    description: string | undefined;
+    testId: string;
+  }) => {
     const { getByText, getByTestId } = renderResult;
-    expect(getByText(en.proposal_detail.type_prefix)).toBeInTheDocument();
+    expect(getByText(label)).toBeInTheDocument();
 
-    expect(type).not.toBeUndefined();
-    expect(typeDescription).not.toBeUndefined();
+    expect(value).not.toBeUndefined();
+    expect(description).not.toBeUndefined();
 
     await waitFor(() =>
-      expect(getByTestId("proposal-system-info-type")?.textContent).toEqual(
-        type
+      expect(getByTestId(`${testId}-value`)?.textContent).toEqual(value)
+    );
+    await waitFor(() =>
+      expect(getByTestId(`${testId}-description`)?.textContent).toEqual(
+        description
       )
     );
-    await waitFor(() =>
-      expect(
-        getByTestId("proposal-system-info-type-description")?.textContent
-      ).toEqual(typeDescription)
-    );
-  });
+  };
 
-  it("should render topic info", async () => {
-    const { getByText, getByTestId } = renderResult;
-    expect(getByText(en.proposal_detail.type_prefix)).toBeInTheDocument();
+  it("should render type info", async () =>
+    await expectRenderedInfo({
+      label: en.proposal_detail.type_prefix,
+      value: type,
+      description: typeDescription,
+      testId: "proposal-system-info-type",
+    }));
 
-    expect(topic).not.toBeUndefined();
-    expect(topicDescription).not.toBeUndefined();
+  it("should render topic info", async () =>
+    await expectRenderedInfo({
+      label: en.proposal_detail.topic_prefix,
+      value: topic,
+      description: topicDescription,
+      testId: "proposal-system-info-topic",
+    }));
 
-    await waitFor(() =>
-      expect(getByTestId("proposal-system-info-topic")?.textContent).toEqual(
-        topic
-      )
-    );
-    await waitFor(() =>
-      expect(
-        getByTestId("proposal-system-info-topic-description")?.textContent
-      ).toEqual(topicDescription)
-    );
-  });
+  it("should render status info", async () =>
+      await expectRenderedInfo({
+        label: en.proposal_detail.status_prefix,
+        value: statusString,
+        description: statusDescription,
+        testId: "proposal-system-info-status",
+      }));
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProjectSystemInfoSection.spec.ts
@@ -23,6 +23,8 @@ describe("ProposalSystemInfoSection", () => {
     topic,
     statusDescription,
     statusString,
+    rewardStatusString,
+    rewardStatusDescription,
   } = mapProposalInfo(mockProposalInfo);
 
   beforeEach(() => {
@@ -83,10 +85,18 @@ describe("ProposalSystemInfoSection", () => {
     }));
 
   it("should render status info", async () =>
-      await expectRenderedInfo({
-        label: en.proposal_detail.status_prefix,
-        value: statusString,
-        description: statusDescription,
-        testId: "proposal-system-info-status",
-      }));
+    await expectRenderedInfo({
+      label: en.proposal_detail.status_prefix,
+      value: statusString,
+      description: statusDescription,
+      testId: "proposal-system-info-status",
+    }));
+
+  it("should render reward status info", async () =>
+    await expectRenderedInfo({
+      label: en.proposal_detail.reward_prefix,
+      value: rewardStatusString,
+      description: rewardStatusDescription,
+      testId: "proposal-system-info-reward",
+    }));
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalModern.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalModern.spec.ts
@@ -8,6 +8,7 @@ import ProposalModernTest from "./ProposalModernTest.svelte";
 
 jest.mock("../../../../lib/utils/html.utils", () => ({
   sanitizeHTML: (value) => Promise.resolve(value),
+  markdownToSanitizedHTML: (value) => Promise.resolve(value),
 }));
 
 describe("ProposalModern", () => {
@@ -37,6 +38,22 @@ describe("ProposalModern", () => {
     const { queryByTestId } = renderProposalModern(true);
     await waitFor(() =>
       expect(queryByTestId("proposal-system-info-details")).toBeInTheDocument()
+    );
+  });
+
+  it("should render proposer proposal info", async () => {
+    const { queryByTestId } = renderProposalModern(true);
+    await waitFor(() =>
+      expect(queryByTestId("proposal-proposer-info-title")).toBeInTheDocument()
+    );
+  });
+
+  it("should render proposer proposal data", async () => {
+    const { queryByTestId } = renderProposalModern(true);
+    await waitFor(() =>
+      expect(
+        queryByTestId("proposal-proposer-actions-entry-title")
+      ).toBeInTheDocument()
     );
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { Proposal } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import ProposalActions from "../../../../lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte";
+import { proposalFirstActionKey } from "../../../../lib/utils/proposals.utils";
+import {
+  mockProposalInfo,
+  proposalActionMotion,
+  proposalActionRewardNodeProvider,
+} from "../../../mocks/proposal.mock";
+
+const proposalWithMotionAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionMotion,
+} as Proposal;
+
+const proposalWithRewardNodeProviderAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionRewardNodeProvider,
+} as Proposal;
+
+describe("ProposalProposerActionsEntry", () => {
+  it("should render action key", () => {
+    const { getByText } = render(ProposalActions, {
+      props: {
+        proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    const key = proposalFirstActionKey(proposalWithMotionAction) as string;
+    expect(getByText(key)).toBeInTheDocument();
+  });
+
+  it("should render action fields", () => {
+    const { getByText } = render(ProposalActions, {
+      props: {
+        proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    const [key, value] = Object.entries(
+      (proposalWithMotionAction?.action as { Motion: object }).Motion
+    )[0];
+    expect(getByText(key)).toBeInTheDocument();
+    expect(getByText(value)).toBeInTheDocument();
+  });
+
+  it("should render object fields as JSON", () => {
+    const nodeProviderActions = render(ProposalActions, {
+      props: {
+        proposal: proposalWithRewardNodeProviderAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    expect(nodeProviderActions.queryAllByTestId("json").length).toBe(2);
+  });
+
+  it("should render text fields as plane text", () => {
+    const motionActions = render(ProposalActions, {
+      props: {
+        proposal: proposalWithMotionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    expect(motionActions.queryAllByTestId("json").length).toBe(0);
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerDataSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerDataSection.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { Proposal } from "@dfinity/nns";
+import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
+import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.canister";
+import ProposalProposerDataSection from "../../../../lib/components/proposal-detail/ProposalProposerDataSection.svelte";
+import {
+  mockProposalInfo,
+  proposalActionNnsFunction21,
+} from "../../../mocks/proposal.mock";
+
+describe("ProposalProposerDataSection", () => {
+  const nnsDappMock = mock<NNSDappCanister>();
+  nnsDappMock.getProposalPayload.mockResolvedValue({});
+  jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+
+  const proposalWithNnsFunctionAction = {
+    ...mockProposalInfo.proposal,
+    action: proposalActionNnsFunction21,
+  } as Proposal;
+
+  it("should render entries", async () => {
+    const renderResult = render(ProposalProposerDataSection, {
+      props: {
+        proposalInfo: {
+          ...mockProposalInfo,
+          proposal: proposalWithNnsFunctionAction,
+        },
+      },
+    });
+
+    const { getByTestId } = renderResult;
+    await waitFor(() =>
+      expect(
+        getByTestId("proposal-proposer-actions-entry-title")
+      ).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(
+        getByTestId("proposal-proposer-payload-entry-title")
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerInfoSection.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/svelte";
+import ProposalProposerInfoSection from "../../../../lib/components/proposal-detail/ProposalProposerInfoSection.svelte";
+import { mapProposalInfo } from "../../../../lib/utils/proposals.utils";
+import { mockProposalInfo } from "../../../mocks/proposal.mock";
+
+jest.mock("../../../../lib/utils/html.utils", () => ({
+  markdownToSanitizedHTML: (value) => Promise.resolve(value),
+}));
+
+describe("ProposalProposerInfoSection", () => {
+  const { title, proposal } = mapProposalInfo(mockProposalInfo);
+
+  it("should render title", () => {
+    const renderResult = render(ProposalProposerInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByText } = renderResult;
+    expect(getByText(title as string)).toBeInTheDocument();
+  });
+
+  it("should render summary", async () => {
+    const renderResult = render(ProposalProposerInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByText } = renderResult;
+    await waitFor(() =>
+      expect(getByText(proposal?.summary as string)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { Proposal } from "@dfinity/nns";
+import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
+import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.canister";
+import ProposalActions from "../../../../lib/components/proposal-detail/ProposalDetailCard/ProposalActions.svelte";
+import { proposalPayloadsStore } from "../../../../lib/stores/proposals.store";
+import { getExecuteNnsFunctionId } from "../../../../lib/utils/proposals.utils";
+import en from "../../../mocks/i18n.mock";
+import {
+  mockProposalInfo,
+  proposalActionNnsFunction21,
+} from "../../../mocks/proposal.mock";
+
+const proposalWithNnsFunctionAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionNnsFunction21,
+} as Proposal;
+
+describe("ProposalProposerActionsEntry", () => {
+  const nnsDappMock = mock<NNSDappCanister>();
+  nnsDappMock.getProposalPayload.mockResolvedValue({});
+  jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+
+  beforeEach(() => proposalPayloadsStore.reset);
+
+  afterAll(jest.clearAllMocks);
+
+  it("should render nnsFunction id", () => {
+    const { getByText } = render(ProposalActions, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    const [key, value] = Object.entries(
+      (
+        proposalWithNnsFunctionAction?.action as {
+          ExecuteNnsFunction: object;
+        }
+      ).ExecuteNnsFunction
+    )[0];
+
+    expect(getByText(key)).toBeInTheDocument();
+    expect(getByText(value)).toBeInTheDocument();
+  });
+
+  it("should render nnsFunction name", () => {
+    const { getByText } = render(ProposalActions, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    const id = getExecuteNnsFunctionId(proposalWithNnsFunctionAction);
+    const fnName = en.execute_nns_functions[`${id}`];
+
+    expect(getByText(fnName)).toBeInTheDocument();
+  });
+
+  it("should trigger getProposalPayload", async () => {
+    const spyGetProposalPayload = jest
+      .spyOn(nnsDappMock, "getProposalPayload")
+      .mockImplementation(async () => ({}));
+
+    render(ProposalActions, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+        proposalId: BigInt(0),
+      },
+    });
+
+    await waitFor(() => expect(spyGetProposalPayload).toBeCalledTimes(1));
+  });
+});

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -45,14 +45,14 @@ describe("secondsToDate", () => {
 
 describe("secondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(secondsToDateTime(BigInt(0))).toEqual("January 1, 1970 at 12:00 AM");
+    expect(secondsToDateTime(BigInt(0))).toEqual("January 1, 1970 12:00 AM");
   });
 
   it("should return formatted date and time", () => {
     // We only support english for now
     const march25of2022InSeconds = Math.round(1648200639061 / 1000);
     const expectedDateText = secondsToDateTime(BigInt(march25of2022InSeconds));
-    expect(expectedDateText).toEqual("March 25, 2022 at 9:30 AM");
+    expect(expectedDateText).toEqual("March 25, 2022 9:30 AM");
   });
 });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -1,5 +1,5 @@
 import {
-  secondsToDate,
+  secondsToDate, secondsToDateTime,
   secondsToDuration,
   secondsToTime,
 } from "../../../lib/utils/date.utils";
@@ -39,6 +39,19 @@ describe("secondsToDate", () => {
     expect(expectedDateText).toContain("March");
     expect(expectedDateText).toContain("2022");
     expect(expectedDateText).toContain("25");
+  });
+});
+
+describe("secondsToDateTime", () => {
+  it("should return formatted start date and time in 1970", () => {
+    expect(secondsToDateTime(BigInt(0))).toEqual("January 1, 1970 at 12:00 AM");
+  });
+
+  it("should return formatted date and time", () => {
+    // We only support english for now
+    const march25of2022InSeconds = Math.round(1648200639061 / 1000);
+    const expectedDateText = secondsToDateTime(BigInt(march25of2022InSeconds));
+    expect(expectedDateText).toEqual('March 25, 2022 at 9:30 AM')
   });
 });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -1,5 +1,6 @@
 import {
-  secondsToDate, secondsToDateTime,
+  secondsToDate,
+  secondsToDateTime,
   secondsToDuration,
   secondsToTime,
 } from "../../../lib/utils/date.utils";
@@ -51,7 +52,7 @@ describe("secondsToDateTime", () => {
     // We only support english for now
     const march25of2022InSeconds = Math.round(1648200639061 / 1000);
     const expectedDateText = secondsToDateTime(BigInt(march25of2022InSeconds));
-    expect(expectedDateText).toEqual('March 25, 2022 at 9:30 AM')
+    expect(expectedDateText).toEqual("March 25, 2022 at 9:30 AM");
   });
 });
 

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -759,6 +759,7 @@ describe("proposals-utils", () => {
     const [proposalInfo] = generateMockProposals(1, {
       topic: Topic.Governance,
       status: ProposalStatus.PROPOSAL_STATUS_OPEN,
+      rewardStatus: ProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
       deadlineTimestampSeconds,
       proposer: BigInt(1234),
     });
@@ -769,11 +770,24 @@ describe("proposals-utils", () => {
     } as Proposal;
 
     it("should map proposalInfo fields", () => {
-      const { topic, topicDescription, color, deadline, proposer, title, url } =
-        mapProposalInfo({
-          ...proposalInfo,
-          proposal,
-        });
+      const {
+        topic,
+        topicDescription,
+        color,
+        deadline,
+        proposer,
+        title,
+        url,
+        status,
+        statusString,
+        statusDescription,
+        rewardStatus,
+        rewardStatusString,
+        rewardStatusDescription,
+      } = mapProposalInfo({
+        ...proposalInfo,
+        proposal,
+      });
 
       expect(topic).toEqual(en.topics.Governance);
       expect(topicDescription).toEqual(en.topics_description.Governance);
@@ -786,6 +800,22 @@ describe("proposals-utils", () => {
       expect(proposer).toEqual(BigInt(1234));
       expect(title).toEqual(proposal.title);
       expect(url).toEqual(proposal.url);
+
+      expect(status).toEqual(proposalInfo.status);
+      expect(statusString).toEqual(
+        en.status[ProposalStatus[proposalInfo.status]]
+      );
+      expect(statusDescription).toEqual(
+        en.status_description[ProposalStatus[proposalInfo.status]]
+      );
+
+      expect(rewardStatus).toEqual(proposalInfo.rewardStatus);
+      expect(rewardStatusString).toEqual(
+        en.rewards[ProposalRewardStatus[proposalInfo.rewardStatus]]
+      );
+      expect(rewardStatusDescription).toEqual(
+        en.rewards_description[ProposalRewardStatus[proposalInfo.rewardStatus]]
+      );
     });
 
     it("should map action to undefined", () => {


### PR DESCRIPTION
# Motivation

Add more system information to proposal detail new UI.

# Changes

- add timestamps, proposer, status and reward status
- map above dynamic info with `proposal.utils`
- sync description with dashboard
- extract a component to avoid to duplicate `KeyValuePairInfo` and sanitizer code
- new date + time formatter

# Screenshots

<img width="1510" alt="Capture d’écran 2022-08-24 à 10 57 29" src="https://user-images.githubusercontent.com/16886711/186376700-e135eb34-6858-43cd-b45b-04ec22cd6128.png">
<img width="1510" alt="Capture d’écran 2022-08-24 à 10 57 45" src="https://user-images.githubusercontent.com/16886711/186376718-7ac42754-c952-4f61-b9ef-ba95849b4fdb.png">

