### PR TITLE
L2-833: Store filters in local storage

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -4,6 +4,7 @@ import { configure } from "@testing-library/svelte";
 // Polyfill the encoders with node
 import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
+import localStorageMock from "./src/tests/mocks/local-storage.mock";
 
 global.TextEncoder = TextEncoder;
 (global as { TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder;
@@ -24,6 +25,8 @@ process.env.FEATURE_FLAGS = JSON.stringify({
   ENABLE_SNS: true,
   VOTING_UI: "modern",
 });
+
+global.localStorage = localStorageMock;
 
 // testing-library setup
 configure({

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -87,7 +87,7 @@
         "(prefers-color-scheme: dark)"
       ).matches;
       const currentTheme =
-        localStorage.nnsTheme === null
+        localStorage.nnsTheme === null || localStorage.nnsTheme === undefined
           ? undefined
           : JSON.parse(localStorage.nnsTheme);
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -87,11 +87,11 @@
         "(prefers-color-scheme: dark)"
       ).matches;
       const currentTheme =
-        localStorage.theme !== null
-          ? JSON.parse(localStorage.theme)
-          : undefined;
+        localStorage.nnsTheme === null
+          ? undefined
+          : JSON.parse(localStorage.nnsTheme);
 
-      // `theme` must match storeLocalStorageKey.Theme
+      // Attribute is the value of THEME_ATTRIBUTE constant
       document.documentElement.setAttribute(
         "theme",
         currentTheme ?? (isDarkPreferred ? "dark" : "light")

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -86,11 +86,15 @@
       const isDarkPreferred = window.matchMedia(
         "(prefers-color-scheme: dark)"
       ).matches;
+      const currentTheme =
+        localStorage.theme !== null
+          ? JSON.parse(localStorage.theme)
+          : undefined;
 
       // `theme` must match storeLocalStorageKey.Theme
       document.documentElement.setAttribute(
         "theme",
-        localStorage.theme ?? (isDarkPreferred ? "dark" : "light")
+        currentTheme ?? (isDarkPreferred ? "dark" : "light")
       );
     </script>
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -87,6 +87,7 @@
         "(prefers-color-scheme: dark)"
       ).matches;
 
+      // `theme` must match storeLocalStorageKey.Theme
       document.documentElement.setAttribute(
         "theme",
         localStorage.theme ?? (isDarkPreferred ? "dark" : "light")

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -83,19 +83,26 @@
 
     <!-- Init theme as fast as possible -->
     <script>
-      const isDarkPreferred = window.matchMedia(
-        "(prefers-color-scheme: dark)"
-      ).matches;
-      const currentTheme =
-        localStorage.nnsTheme === null || localStorage.nnsTheme === undefined
-          ? undefined
-          : JSON.parse(localStorage.nnsTheme);
+      try {
+        const isDarkPreferred = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+        const currentTheme =
+          localStorage.nnsTheme === null ||
+          localStorage.nnsTheme === undefined ||
+          localStorage.nnsTheme === ""
+            ? undefined
+            : JSON.parse(localStorage.nnsTheme);
 
-      // Attribute is the value of THEME_ATTRIBUTE constant
-      document.documentElement.setAttribute(
-        "theme",
-        currentTheme ?? (isDarkPreferred ? "dark" : "light")
-      );
+        // Attribute is the value of THEME_ATTRIBUTE constant
+        document.documentElement.setAttribute(
+          "theme",
+          currentTheme ?? (isDarkPreferred ? "dark" : "light")
+        );
+      } catch (error) {
+        console.log("Error initializing theme");
+        console.log(error);
+      }
     </script>
 
     <script>

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,3 +1,4 @@
 export enum storeLocalStorageKey {
   ProposalFilters = "nnsProposalFilters",
+  Theme = "theme",
 }

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,4 +1,4 @@
 export enum storeLocalStorageKey {
   ProposalFilters = "nnsProposalFilters",
-  Theme = "theme",
+  Theme = "nnsTheme",
 }

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,0 +1,3 @@
+export enum storeLocalStorageKey {
+  ProposalFilters = "nnsProposalFilters",
+}

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -9,6 +9,7 @@ import type {
 } from "@dfinity/nns";
 import { writable } from "svelte/store";
 import { DEFAULT_PROPOSALS_FILTERS } from "../constants/proposals.constants";
+import { storeLocalStorageKey } from "../constants/stores.constants";
 import {
   concatenateUniqueProposals,
   excludeProposals,
@@ -16,6 +17,7 @@ import {
   replaceAndConcatenateProposals,
   replaceProposals,
 } from "../utils/proposals.utils";
+import { writableStored } from "./writable-stored";
 
 export interface ProposalsFiltersStore {
   topics: Topic[];
@@ -124,9 +126,10 @@ const initProposalsStore = () => {
  *
  */
 const initProposalsFiltersStore = () => {
-  const { subscribe, update, set } = writable<ProposalsFiltersStore>(
-    DEFAULT_PROPOSALS_FILTERS
-  );
+  const { subscribe, update, set } = writableStored<ProposalsFiltersStore>({
+    key: storeLocalStorageKey.ProposalFilters,
+    defaultValue: DEFAULT_PROPOSALS_FILTERS,
+  });
 
   return {
     subscribe,

--- a/frontend/src/lib/stores/theme.store.ts
+++ b/frontend/src/lib/stores/theme.store.ts
@@ -1,17 +1,24 @@
-import { writable } from "svelte/store";
+import { storeLocalStorageKey } from "../constants/stores.constants";
 import type { Theme } from "../types/theme";
 import { applyTheme, initTheme } from "../utils/theme.utils";
+import { writableStored } from "./writable-stored";
 
 const initialTheme: Theme = initTheme();
 
 export const initThemeStore = () => {
-  const { subscribe, set } = writable<Theme>(initialTheme);
+  const { subscribe, set } = writableStored<Theme>({
+    key: storeLocalStorageKey.Theme,
+    defaultValue: initialTheme,
+  });
+
+  subscribe((theme: Theme) => {
+    applyTheme({ theme });
+  });
 
   return {
     subscribe,
 
     select: (theme: Theme) => {
-      applyTheme({ theme, preserve: true });
       set(theme);
     },
   };

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -1,0 +1,26 @@
+import { writable } from "svelte/store";
+import type { storeLocalStorageKey } from "../constants/stores.constants";
+
+export const writableStored = <T>({
+  key,
+  defaultValue,
+}: {
+  key: storeLocalStorageKey;
+  defaultValue: T;
+}) => {
+  const getInitialValue = (): T => {
+    const filters = localStorage.getItem(key);
+    if (filters !== null) {
+      return JSON.parse(filters) as T;
+    }
+    return defaultValue;
+  };
+
+  const store = writable<T>(getInitialValue());
+
+  store.subscribe((store) => {
+    localStorage.setItem(key, JSON.stringify(store));
+  });
+
+  return store;
+};

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -1,5 +1,9 @@
-import { writable } from "svelte/store";
+import { writable, type Writable } from "svelte/store";
 import type { storeLocalStorageKey } from "../constants/stores.constants";
+
+type StoredWritable<T> = Writable<T> & {
+  unsubscribeStorage: () => void;
+};
 
 export const writableStored = <T>({
   key,
@@ -7,7 +11,7 @@ export const writableStored = <T>({
 }: {
   key: storeLocalStorageKey;
   defaultValue: T;
-}) => {
+}): StoredWritable<T> => {
   const getInitialValue = (): T => {
     // Do not break UI if local storage fails
     try {
@@ -28,7 +32,7 @@ export const writableStored = <T>({
 
   const store = writable<T>(getInitialValue());
 
-  store.subscribe((store: T) => {
+  const unsubscribeStorage = store.subscribe((store: T) => {
     // Do not break UI if local storage fails
     try {
       localStorage.setItem(key, JSON.stringify(store));
@@ -37,5 +41,8 @@ export const writableStored = <T>({
     }
   });
 
-  return store;
+  return {
+    ...store,
+    unsubscribeStorage,
+  };
 };

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -1,8 +1,8 @@
-import { writable, type Writable } from "svelte/store";
+import { writable, type Unsubscriber, type Writable } from "svelte/store";
 import type { storeLocalStorageKey } from "../constants/stores.constants";
 
 type StoredWritable<T> = Writable<T> & {
-  unsubscribeStorage: () => void;
+  unsubscribeStorage: Unsubscriber;
 };
 
 export const writableStored = <T>({

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -9,17 +9,32 @@ export const writableStored = <T>({
   defaultValue: T;
 }) => {
   const getInitialValue = (): T => {
-    const filters = localStorage.getItem(key);
-    if (filters !== null) {
-      return JSON.parse(filters) as T;
+    // Do not break UI if local storage fails
+    try {
+      const storedValue = localStorage.getItem(key);
+      // `theme` stored "undefined" string which is not a valid JSON string.
+      if (
+        storedValue !== null &&
+        storedValue !== undefined &&
+        storedValue !== "undefined"
+      ) {
+        return JSON.parse(storedValue) as T;
+      }
+    } catch (error) {
+      console.error(error);
     }
     return defaultValue;
   };
 
   const store = writable<T>(getInitialValue());
 
-  store.subscribe((store) => {
-    localStorage.setItem(key, JSON.stringify(store));
+  store.subscribe((store: T) => {
+    // Do not break UI if local storage fails
+    try {
+      localStorage.setItem(key, JSON.stringify(store));
+    } catch (error) {
+      console.error(error);
+    }
   });
 
   return store;

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -1,7 +1,7 @@
 import { writable, type Unsubscriber, type Writable } from "svelte/store";
 import type { storeLocalStorageKey } from "../constants/stores.constants";
 
-type StoredWritable<T> = Writable<T> & {
+type WritableStored<T> = Writable<T> & {
   unsubscribeStorage: Unsubscriber;
 };
 
@@ -11,7 +11,7 @@ export const writableStored = <T>({
 }: {
   key: storeLocalStorageKey;
   defaultValue: T;
-}): StoredWritable<T> => {
+}): WritableStored<T> => {
   const getInitialValue = (): T => {
     // Do not break UI if local storage fails
     try {

--- a/frontend/src/lib/utils/theme.utils.ts
+++ b/frontend/src/lib/utils/theme.utils.ts
@@ -2,6 +2,8 @@ import { Theme } from "../types/theme";
 import { isNode } from "./dev.utils";
 import { enumFromStringExists } from "./enum.utils";
 
+export const THEME_ATTRIBUTE = "theme";
+
 export const initTheme = (): Theme => {
   // Jest NodeJS environment has no document
   if (isNode()) {
@@ -9,7 +11,8 @@ export const initTheme = (): Theme => {
   }
 
   // This is set in the index.html file
-  const theme: string | null = document.documentElement.getAttribute("theme");
+  const theme: string | null =
+    document.documentElement.getAttribute(THEME_ATTRIBUTE);
 
   const initialTheme: Theme = enumFromStringExists({
     obj: Theme as unknown as Theme,
@@ -24,7 +27,7 @@ export const initTheme = (): Theme => {
 export const applyTheme = ({ theme }: { theme: Theme }) => {
   const { documentElement, head } = document;
 
-  documentElement.setAttribute("theme", theme);
+  documentElement.setAttribute(THEME_ATTRIBUTE, theme);
 
   const color: string =
     getComputedStyle(documentElement).getPropertyValue("--card-background");

--- a/frontend/src/lib/utils/theme.utils.ts
+++ b/frontend/src/lib/utils/theme.utils.ts
@@ -10,7 +10,7 @@ export const initTheme = (): Theme => {
     return Theme.DARK;
   }
 
-  // This is set in the index.html file
+  // Initial attribute value is set in the index.html
   const theme: string | null =
     document.documentElement.getAttribute(THEME_ATTRIBUTE);
 

--- a/frontend/src/lib/utils/theme.utils.ts
+++ b/frontend/src/lib/utils/theme.utils.ts
@@ -8,6 +8,7 @@ export const initTheme = (): Theme => {
     return Theme.DARK;
   }
 
+  // This is set in the index.html file
   const theme: string | null = document.documentElement.getAttribute("theme");
 
   const initialTheme: Theme = enumFromStringExists({
@@ -17,18 +18,10 @@ export const initTheme = (): Theme => {
     ? (theme as Theme)
     : Theme.DARK;
 
-  applyTheme({ theme: initialTheme, preserve: false });
-
   return initialTheme;
 };
 
-export const applyTheme = ({
-  theme,
-  preserve = true,
-}: {
-  theme: Theme;
-  preserve?: boolean;
-}) => {
+export const applyTheme = ({ theme }: { theme: Theme }) => {
   const { documentElement, head } = document;
 
   documentElement.setAttribute("theme", theme);
@@ -41,8 +34,4 @@ export const applyTheme = ({
   head?.children
     ?.namedItem("theme-color")
     ?.setAttribute("content", color.trim());
-
-  if (preserve) {
-    localStorage.setItem("theme", theme);
-  }
 };

--- a/frontend/src/routes/Proposals.svelte
+++ b/frontend/src/routes/Proposals.svelte
@@ -82,8 +82,6 @@
       return;
     }
 
-    proposalsFiltersStore.reset();
-
     await findProposals();
 
     initDebounceFindProposals();

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -48,4 +48,23 @@ describe("writableStored", () => {
 
     expect(get(store)).toEqual(defaultValue);
   });
+
+  it("unsubscribes storing in local storage", async () => {
+    const defaultValue = { filter: "all" };
+    const store = writableStored({
+      key: storeLocalStorageKey.ProposalFilters,
+      defaultValue,
+    });
+    const newState = { filter: "active" };
+    store.set(newState);
+    expect(
+      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+    ).toEqual(JSON.stringify(newState));
+
+    store.unsubscribeStorage();
+    store.set(defaultValue);
+    expect(
+      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+    ).toEqual(JSON.stringify(newState));
+  });
 });

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { get } from "svelte/store";
+import { storeLocalStorageKey } from "../../../lib/constants/stores.constants";
+import { writableStored } from "../../../lib/stores/writable-stored";
+
+describe("writableStored", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("writes to local storage when state changes", () => {
+    const store = writableStored({
+      key: storeLocalStorageKey.ProposalFilters,
+      defaultValue: { filter: "all" },
+    });
+
+    const newState = { filter: "active" };
+    store.set(newState);
+
+    expect(
+      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+    ).toEqual(JSON.stringify(newState));
+  });
+
+  it("loads initial value from local storage if present", () => {
+    const storedState = { filter: "active" };
+    window.localStorage.setItem(
+      storeLocalStorageKey.ProposalFilters,
+      JSON.stringify(storedState)
+    );
+    const store = writableStored({
+      key: storeLocalStorageKey.ProposalFilters,
+      defaultValue: { filter: "all" },
+    });
+
+    expect(get(store)).toEqual(storedState);
+  });
+
+  it("loads default value if no value in local storage", () => {
+    const defaultValue = { filter: "all" };
+    const store = writableStored({
+      key: storeLocalStorageKey.ProposalFilters,
+      defaultValue,
+    });
+
+    expect(get(store)).toEqual(defaultValue);
+  });
+});

--- a/frontend/src/tests/lib/utils/theme.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/theme.utils.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { Theme } from "../../../lib/types/theme";
-import { applyTheme } from "../../../lib/utils/theme.utils";
+import { applyTheme, THEME_ATTRIBUTE } from "../../../lib/utils/theme.utils";
 
 describe("theme-utils", () => {
   it("should apply theme to root html element", () => {
@@ -11,8 +11,10 @@ describe("theme-utils", () => {
 
     const { documentElement } = document;
 
-    expect(documentElement).toHaveAttribute("theme");
-    expect(documentElement.getAttribute("theme")).toContain(`${Theme.DARK}`);
+    expect(documentElement).toHaveAttribute(THEME_ATTRIBUTE);
+    expect(documentElement.getAttribute(THEME_ATTRIBUTE)).toContain(
+      `${Theme.DARK}`
+    );
   });
 
   it("should update meta theme color in head element", () => {

--- a/frontend/src/tests/mocks/local-storage.mock.ts
+++ b/frontend/src/tests/mocks/local-storage.mock.ts
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class LocalStorageMock {
+  store: any;
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key] ?? null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index) {
+    return Object.keys(this.store)[index] ?? null;
+  }
+}
+
+export default new LocalStorageMock();


### PR DESCRIPTION
# Motivation

Proposals filters are persisted across browser refresh.

# Changes

* New util to create a store that gets stored in local storage "writableStored".
* Use writableStored in themStore
* Use writableStored in proposalsFiltersStore.

# Tests

* Add tests for writableStored
* Mock localStorage in jest.
