### PR TITLE
feat: script loader

### DIFF
--- a/frontend/scripts/build.index.mjs
+++ b/frontend/scripts/build.index.mjs
@@ -40,7 +40,7 @@ const updateBaseHref = (content) =>
  * 2. nns-js auto-generated proto js code (base_types_pb.js and ledger_pb.js) require 'unsafe-eval' as well
  *
  * - script-src and usage of 'integrity':
- * Ideally we would like to secure the scripts that are loaded with the 'integrity=sha256-...' hashes - e.g. https://stackoverflow.com/a/68492689/5404186.
+ * Ideally we would like to secure the scripts that are loaded with the 'integrity=sha256-...' hashes attributes - e.g. https://stackoverflow.com/a/68492689/5404186.
  * However, this is currently only supported by Chrome. Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
  * To overcome this, we include within the index.html a first script which, when executed at app boot time, add a script that actually loads the main.js.
  * We generate the hash for that particular first script and set 'strict-dynamic' to trust those scripts that will be loaded per extension - the chunks used by the app.

--- a/frontend/scripts/build.index.mjs
+++ b/frontend/scripts/build.index.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+import { createHash } from "crypto";
 import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
 import { envConfig } from "../env.config.mjs";
 
 /**
@@ -37,6 +39,12 @@ const updateBaseHref = (content) =>
  *    source: II https://github.com/dfinity/internet-identity/blob/c5709518ce3daaf7fdd9c7994120b66bd613f01b/src/internet_identity/src/main.rs#L824
  * 2. nns-js auto-generated proto js code (base_types_pb.js and ledger_pb.js) require 'unsafe-eval' as well
  *
+ * - script-src and usage of 'integrity':
+ * Ideally we would like to secure the scripts that are loaded with the 'integrity=sha256-...' hashes - e.g. https://stackoverflow.com/a/68492689/5404186.
+ * However, this is currently only supported by Chrome. Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
+ * To overcome this, we include within the index.html a first script which, when executed at app boot time, add a script that actually loads the main.js.
+ * We generate the hash for that particular first script and set 'strict-dynamic' to trust those scripts that will be loaded per extension - the chunks used by the app.
+ *
  * - style-src 'unsafe-inline' is required because:
  * 1. svelte uses inline style for animation (scale, fly, fade, etc.)
  *    source: https://github.com/sveltejs/svelte/issues/6662
@@ -47,6 +55,23 @@ const updateCSP = (content) => {
     return content.replace("<!-- CONTENT_SECURITY_POLICY -->", "");
   }
 
+  const indexHtml = readFileSync(
+    join(process.cwd(), "src", "index.html"),
+    "utf-8"
+  );
+  const sw = /<script[\s\S]*?>([\s\S]*?)<\/script>/gm;
+
+  const indexHashes = [];
+
+  let m;
+  while ((m = sw.exec(indexHtml))) {
+    const content = m[1];
+
+    indexHashes.push(
+      `'sha256-${createHash("sha256").update(content).digest("base64")}'`
+    );
+  }
+
   const csp = `<meta
         http-equiv="Content-Security-Policy"
         content="default-src 'none';
@@ -54,7 +79,7 @@ const updateCSP = (content) => {
         img-src 'self' data: https://nns.raw.ic0.app/;
         child-src 'self';
         manifest-src 'self';
-        script-src 'unsafe-eval' 'strict-dynamic' 'nonce-main-31858fd0-b02b-4e0b-bf0b-c49e9b515a25' 'nonce-main-bc619616-7c54-4009-abff-493dd9b42bac';
+        script-src 'unsafe-eval' 'strict-dynamic' ${indexHashes.join(" ")};
         base-uri 'self';
         form-action 'none';
         style-src 'self' 'unsafe-inline';

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -77,8 +77,11 @@
 
     <link rel="stylesheet" href="./build/bundle.css" />
 
+    <!-- BASE_HREF -->
+    <!-- CONTENT_SECURITY_POLICY -->
+
     <!-- Init theme as fast as possible -->
-    <script nonce="main-bc619616-7c54-4009-abff-493dd9b42bac">
+    <script>
       const isDarkPreferred = window.matchMedia(
         "(prefers-color-scheme: dark)"
       ).matches;
@@ -89,14 +92,12 @@
       );
     </script>
 
-    <script
-      type="module"
-      src="./build/main.js"
-      nonce="main-31858fd0-b02b-4e0b-bf0b-c49e9b515a25"
-    ></script>
-
-    <!-- BASE_HREF -->
-    <!-- CONTENT_SECURITY_POLICY -->
+    <script>
+      const loader = document.createElement('script');
+      loader.type = "module";
+      loader.src = './build/main.js';
+      document.head.appendChild(loader);
+    </script>
   </head>
 
   <body></body>


### PR DESCRIPTION
# Motivation

As in II, use a script loader for main script.

# Changes

- add a script that load `main.js` in `index.html`
- adapt csp accordingly with hashes instead of nonce

