### PR TITLE
feat: move csp rules at the top of the <head/>

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- CONTENT_SECURITY_POLICY -->
+
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
@@ -78,7 +80,6 @@
     <link rel="stylesheet" href="./build/bundle.css" />
 
     <!-- BASE_HREF -->
-    <!-- CONTENT_SECURITY_POLICY -->
 
     <!-- Init theme as fast as possible -->
     <script>


### PR DESCRIPTION
# Motivation

Neat pick from @tmu0 would rather like to have the csp added as first child of the `<head />` tag

# Changes

- move csp placeholder to first child of `<head />` tag in `index.html`
