### PR TITLE
feat: Upload sns archive canister

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -305,7 +305,7 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    for canister in root governance ledger swap; do
+    for canister in root governance ledger swap ic-icrc1-archive; do
       ./target/ic/sns add-sns-wasm-for-tests \
         --network "$DFX_NETWORK" \
         --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -305,7 +305,7 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    for canister in root governance ledger swap ic-icrc1-archive; do
+    for canister in root governance ledger swap sns_ledger_archive; do
       ./target/ic/sns add-sns-wasm-for-tests \
         --network "$DFX_NETWORK" \
         --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \

--- a/dfx.json
+++ b/dfx.json
@@ -59,6 +59,14 @@
       "wasm": "target/ic/ic-icrc1-ledger.wasm",
       "type": "custom"
     },
+    "sns_ledger_archive": {
+      "build": [
+        "true"
+      ],
+      "candid": "target/ic/ic-icrc1-archive.did",
+      "wasm": "target/ic/ic-icrc1-archive.wasm",
+      "type": "custom"
+    },
     "sns_swap": {
       "build": [
         "true"

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -119,6 +119,7 @@ get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
 get_wasm ledger-canister_notify-method.wasm
 get_wasm ic-icrc1-ledger.wasm
+get_wasm ic-icrc1-archive.wasm
 get_wasm root-canister.wasm
 get_wasm cycles-minting-canister.wasm
 get_wasm lifeline.wasm

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -50,6 +50,7 @@ COPY --from=builder /ic/rs/nns/governance/canister/governance.did /governance.di
 COPY --from=builder /ic/rs/rosetta-api/ledger.did /ledger.private.did
 COPY --from=builder /ic/rs/rosetta-api/ledger_canister/ledger.did /ledger.did
 COPY --from=builder /ic/rs/rosetta-api/icrc1/ledger/icrc1.did /ic-icrc1-ledger.did
+COPY --from=builder /ic/rs/rosetta-api/icrc1/archive/archive.did /ic-icrc1-archive.did
 COPY --from=builder /ic/rs/nns/gtc/canister/gtc.did /genesis_token.did
 COPY --from=builder /ic/rs/nns/cmc/cmc.did /cmc.did
 COPY --from=builder /ic/rs/nns/sns-wasm/canister/sns-wasm.did /sns_wasm.did


### PR DESCRIPTION
# Motivation
The sns ledger now needs an sns archive canister.

# Changes
- Get the ledger archive wasm and did files.
- Upload the archive wasm after creating an `nns-sns-wasm` canister.

# Tests
