### PR TITLE
Chore: Add no-console rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -61,5 +61,6 @@ module.exports = {
         "ts-ignore": "allow-with-description",
       },
     ],
+    "no-console": ["error", { allow: ["warn", "error", "debug"] }],
   },
 };

--- a/frontend/scripts/i18n.types.js
+++ b/frontend/scripts/i18n.types.js
@@ -24,7 +24,7 @@ const assertUniqueKeys = ({ governance, core }) => {
   const diff = governance.filter(({ key }) => coreKeys.includes(key));
 
   if (diff.length) {
-    console.log("Duplicate keys:", diff.map(({ key }) => key).join(","));
+    console.error("Duplicate keys:", diff.map(({ key }) => key).join(","));
     throw new Error("Some i18n governance keys are declared in the core keys.");
   }
 };

--- a/frontend/scripts/i18n.types.js
+++ b/frontend/scripts/i18n.types.js
@@ -24,7 +24,7 @@ const assertUniqueKeys = ({ governance, core }) => {
   const diff = governance.filter(({ key }) => coreKeys.includes(key));
 
   if (diff.length) {
-    console.error("Duplicate keys:", diff.map(({ key }) => key).join(","));
+    console.log("Duplicate keys:", diff.map(({ key }) => key).join(","));
     throw new Error("Some i18n governance keys are declared in the core keys.");
   }
 };

--- a/frontend/src/lib/utils/dev.utils.ts
+++ b/frontend/src/lib/utils/dev.utils.ts
@@ -5,7 +5,7 @@ export const isNode = (): boolean =>
 
 /**
  *
- * console.log with time prefix (e.g. "[15:22:55.438] message text")
+ * console.debug with time prefix (e.g. "[15:22:55.438] message text")
  */
 export const logWithTimestamp = <T>(...args: T[]): void => {
   if (isNode() === true) return;


### PR DESCRIPTION
# Motivation

Avoid leaving debugging logs in production.

# Changes

* Add `no-console` to eslint.

# Tests

Not applicable.
