### PR TITLE
style: fix project info and action spacing

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -44,7 +44,7 @@
     <a href={metadata.url} target="_blank" rel="noopener noreferrer"
       >{metadata.url}</a
     >
-    <div>
+    <div class="content-cell-details">
       <KeyValuePair>
         <svelte:fragment slot="key"
           >{$i18n.sns_project_detail.token_name}</svelte:fragment

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -99,10 +99,10 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
-    padding-top: var(--padding-2x);
+    padding-top: var(--padding-4x);
 
     @include media.min-width(medium) {
-      padding: 0;
+      padding-top: var(--padding-2x);
       align-items: flex-start;
     }
   }

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -65,7 +65,7 @@
       <ProjectTimeline />
     </div>
 
-    <div class="actions">
+    <div class="actions content-cell-details">
       {#if myCommitmentIcp !== undefined}
         <div>
           <KeyValuePair>
@@ -99,10 +99,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
-    padding-top: var(--padding-4x);
 
     @include media.min-width(medium) {
-      padding-top: var(--padding-2x);
       align-items: flex-start;
     }
   }


### PR DESCRIPTION
# Motivation

Following the introduction of the last utility classes and improvements to the grid, the "Participate" button and the summary data of the project have a lack of spacing.

# Changes

- set padding with utility class for grid `.content-cell-details`

# Screenshot

is:

![image](https://user-images.githubusercontent.com/16886711/187440453-3d6b14ad-f733-4c9d-a0c1-5f0219001fb8.png)

will be:
<img width="1510" alt="Capture d’écran 2022-08-30 à 15 07 26" src="https://user-images.githubusercontent.com/16886711/187444728-daf9fb16-0ee0-4667-a096-f4af4a8e1904.png">
<img width="1510" alt="Capture d’écran 2022-08-30 à 15 07 34" src="https://user-images.githubusercontent.com/16886711/187444750-3c746e78-71fa-4106-b37b-2ce71b74ff53.png">

