### PR TITLE
Fix: Max button in sale participation

### DIFF
--- a/frontend/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -9,9 +9,12 @@
   import { toastsStore } from "../../stores/toasts.store";
   import NewTransactionInfo from "./NewTransactionInfo.svelte";
   import { ICP } from "@dfinity/nns";
-  import { convertNumberToICP, maxE8sToNumber } from "../../utils/icp.utils";
+  import {
+    convertNumberToICP,
+    getMaxTransactionAmount,
+  } from "../../utils/icp.utils";
   import { isValidInputAmount } from "../../utils/neuron.utils";
-  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
+  import { transactionsFeesStore } from "../../stores/transaction-fees.store";
   import FooterModal from "../../modals/FooterModal.svelte";
 
   const context: TransactionContext = getContext<TransactionContext>(
@@ -24,9 +27,9 @@
     : undefined;
 
   let max: number = 0;
-  $: max = maxE8sToNumber({
-    e8s: $store.selectedAccount?.balance.toE8s(),
-    fee: $mainTransactionFeeStore,
+  $: max = getMaxTransactionAmount({
+    balance: $store.selectedAccount?.balance.toE8s(),
+    fee: $transactionsFeesStore.main,
   });
 
   let validForm: boolean;

--- a/frontend/src/lib/components/accounts/NewTransactionAmount.svelte
+++ b/frontend/src/lib/components/accounts/NewTransactionAmount.svelte
@@ -9,7 +9,7 @@
   import { toastsStore } from "../../stores/toasts.store";
   import NewTransactionInfo from "./NewTransactionInfo.svelte";
   import { ICP } from "@dfinity/nns";
-  import { convertNumberToICP, maxICP } from "../../utils/icp.utils";
+  import { convertNumberToICP, maxE8sToNumber } from "../../utils/icp.utils";
   import { isValidInputAmount } from "../../utils/neuron.utils";
   import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
   import FooterModal from "../../modals/FooterModal.svelte";
@@ -24,8 +24,8 @@
     : undefined;
 
   let max: number = 0;
-  $: max = maxICP({
-    icp: $store.selectedAccount?.balance,
+  $: max = maxE8sToNumber({
+    e8s: $store.selectedAccount?.balance.toE8s(),
     fee: $mainTransactionFeeStore,
   });
 

--- a/frontend/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/StakeNeuron.svelte
@@ -7,12 +7,15 @@
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
   import {
     formattedTransactionFeeICP,
-    maxE8sToNumber,
+    getMaxTransactionAmount,
   } from "../../utils/icp.utils";
   import AmountInput from "../ui/AmountInput.svelte";
   import CurrentBalance from "../accounts/CurrentBalance.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
-  import { mainTransactionFeeStore } from "../../stores/transaction-fees.store";
+  import {
+    mainTransactionFeeStore,
+    transactionsFeesStore,
+  } from "../../stores/transaction-fees.store";
   import FooterModal from "../../modals/FooterModal.svelte";
   import Value from "../ui/Value.svelte";
 
@@ -48,9 +51,9 @@
   };
 
   let max: number = 0;
-  $: max = maxE8sToNumber({
-    e8s: account.balance.toE8s(),
-    fee: $mainTransactionFeeStore,
+  $: max = getMaxTransactionAmount({
+    balance: account.balance.toE8s(),
+    fee: $transactionsFeesStore.main,
   });
 
   const stakeMaximum = () => (amount = max);

--- a/frontend/src/lib/components/neurons/StakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/StakeNeuron.svelte
@@ -5,7 +5,10 @@
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { busy, startBusy, stopBusy } from "../../stores/busy.store";
-  import { formattedTransactionFeeICP, maxICP } from "../../utils/icp.utils";
+  import {
+    formattedTransactionFeeICP,
+    maxE8sToNumber,
+  } from "../../utils/icp.utils";
   import AmountInput from "../ui/AmountInput.svelte";
   import CurrentBalance from "../accounts/CurrentBalance.svelte";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
@@ -45,8 +48,8 @@
   };
 
   let max: number = 0;
-  $: max = maxICP({
-    icp: account.balance,
+  $: max = maxE8sToNumber({
+    e8s: account.balance.toE8s(),
     fee: $mainTransactionFeeStore,
   });
 

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -4,15 +4,14 @@
   import { i18n } from "../../../stores/i18n";
   import {
     mainTransactionFeeStoreAsIcp,
-    mainTransactionFeeStore,
+    transactionsFeesStore,
   } from "../../../stores/transaction-fees.store";
   import type { Account } from "../../../types/account";
   import { InvalidAmountError } from "../../../types/neurons.errors";
   import { assertEnoughAccountFunds } from "../../../utils/accounts.utils";
   import {
     convertNumberToICP,
-    maxE8sToNumber,
-    minE8s,
+    getMaxTransactionAmount,
   } from "../../../utils/icp.utils";
   import SelectAccountDropdown from "../../../components/accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../../../components/ic/ICP.svelte";
@@ -27,12 +26,10 @@
   export let maxAmount: bigint | undefined = undefined;
 
   let max: number = 0;
-  $: max = maxE8sToNumber({
-    e8s: minE8s(
-      selectedAccount?.balance.toE8s(),
-      (maxAmount ?? BigInt(0)) + $mainTransactionFeeStoreAsIcp.toE8s()
-    ),
-    fee: $mainTransactionFeeStore,
+  $: max = getMaxTransactionAmount({
+    balance: selectedAccount?.balance.toE8s(),
+    fee: $transactionsFeesStore.main,
+    maxAmount,
   });
   const addMax = () => (amount = max);
 

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -9,7 +9,11 @@
   import type { Account } from "../../../types/account";
   import { InvalidAmountError } from "../../../types/neurons.errors";
   import { assertEnoughAccountFunds } from "../../../utils/accounts.utils";
-  import { convertNumberToICP, maxICP } from "../../../utils/icp.utils";
+  import {
+    convertNumberToICP,
+    maxE8sToNumber,
+    minE8s,
+  } from "../../../utils/icp.utils";
   import SelectAccountDropdown from "../../../components/accounts/SelectAccountDropdown.svelte";
   import IcpComponent from "../../../components/ic/ICP.svelte";
   import AmountInput from "../../../components/ui/AmountInput.svelte";
@@ -20,10 +24,14 @@
   export let selectedAccount: Account | undefined = undefined;
   export let amount: number | undefined = undefined;
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
+  export let maxAmount: bigint | undefined = undefined;
 
   let max: number = 0;
-  $: max = maxICP({
-    icp: selectedAccount?.balance,
+  $: max = maxE8sToNumber({
+    e8s: minE8s(
+      selectedAccount?.balance.toE8s(),
+      (maxAmount ?? BigInt(0)) + $mainTransactionFeeStoreAsIcp.toE8s()
+    ),
     fee: $mainTransactionFeeStore,
   });
   const addMax = () => (amount = max);

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -8,6 +8,9 @@
   export let currentStep: Step | undefined = undefined;
   export let destinationAddress: string;
   export let disableSubmit: boolean = false;
+  // Max amount accepted by the transaction wihout fees
+  export let maxAmount: bigint | undefined = undefined;
+  // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
   const steps: Steps = [
     {
@@ -41,6 +44,7 @@
     <TransactionForm
       bind:selectedAccount
       bind:amount
+      {maxAmount}
       on:nnsNext={goNext}
       on:nnsClose
     >

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -11,6 +11,7 @@
   import {
     currentUserMaxCommitment,
     hasUserParticipatedToSwap,
+    projectRemainingAmount,
   } from "../../../utils/projects.utils";
   import type { SnsSummary, SnsSwapCommitment } from "../../../types/sns";
   import TransactionModal from "../../accounts/NewTransaction/TransactionModal.svelte";
@@ -112,6 +113,7 @@
     on:nnsSubmit={participate}
     {destinationAddress}
     disableSubmit={!accepted}
+    maxAmount={projectRemainingAmount(summary)}
   >
     <svelte:fragment slot="title"
       >{title ?? $i18n.sns_project_detail.participate}</svelte:fragment

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -58,22 +58,28 @@ export const formattedTransactionFeeICP = (fee: number): string =>
     value: ICP.fromE8s(BigInt(fee)).toE8s(),
   });
 
-export const maxE8sToNumber = ({
-  e8s,
-  fee,
+/**
+ * Calculates the maximum amount for a transaction.
+ *
+ * @param balanceE8s The balance of the account in E8S.
+ * @param fee The fee of the transaction in E8S.
+ * @param maxAmount The maximum amount of the transaction not counting the fees.
+ * @returns
+ */
+export const getMaxTransactionAmount = ({
+  balance = BigInt(0),
+  fee = BigInt(0),
+  maxAmount,
 }: {
-  e8s?: bigint;
-  fee: number;
-}): number => Math.max((Number(e8s ?? 0) - fee) / E8S_PER_ICP, 0);
-
-export const minE8s = (e8s1?: bigint, e8s2?: bigint): bigint =>
-  e8s1 === undefined
-    ? e8s2 ?? BigInt(0)
-    : e8s2 === undefined
-    ? e8s1
-    : e8s1 > e8s2
-    ? e8s2
-    : e8s1;
+  balance?: bigint;
+  fee?: bigint;
+  maxAmount?: bigint;
+}): number => {
+  if (maxAmount === undefined) {
+    return Math.max(Number(balance - fee), 0) / E8S_PER_ICP;
+  }
+  return Math.min(Number(maxAmount), Number(balance - fee)) / E8S_PER_ICP;
+};
 
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -58,8 +58,22 @@ export const formattedTransactionFeeICP = (fee: number): string =>
     value: ICP.fromE8s(BigInt(fee)).toE8s(),
   });
 
-export const maxICP = ({ icp, fee }: { icp?: ICP; fee: number }): number =>
-  Math.max((Number(icp?.toE8s() ?? 0) - fee) / E8S_PER_ICP, 0);
+export const maxE8sToNumber = ({
+  e8s,
+  fee,
+}: {
+  e8s?: bigint;
+  fee: number;
+}): number => Math.max((Number(e8s ?? 0) - fee) / E8S_PER_ICP, 0);
+
+export const minE8s = (e8s1?: bigint, e8s2?: bigint): bigint =>
+  e8s1 === undefined
+    ? e8s2 ?? BigInt(0)
+    : e8s2 === undefined
+    ? e8s1
+    : e8s1 > e8s2
+    ? e8s2
+    : e8s1;
 
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -78,7 +78,10 @@ export const getMaxTransactionAmount = ({
   if (maxAmount === undefined) {
     return Math.max(Number(balance - fee), 0) / E8S_PER_ICP;
   }
-  return Math.min(Number(maxAmount), Number(balance - fee)) / E8S_PER_ICP;
+  return (
+    Math.min(Number(maxAmount), Math.max(Number(balance - fee), 0)) /
+    E8S_PER_ICP
+  );
 };
 
 export const isValidICPFormat = (text: string) =>

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -137,6 +137,9 @@ export const currentUserMaxCommitment = ({
     : remainingUserCommitment;
 };
 
+export const projectRemainingAmount = ({ swap, derived }: SnsSummary): bigint =>
+  swap.init.max_icp_e8s - derived.buyer_total_icp_e8s;
+
 const isProjectOpen = (summary: SnsSummary): boolean =>
   summary.swap.state.lifecycle === SnsSwapLifecycle.Open;
 // Checks whether the amount that the user wants to contiribute is lower than the minimum for the project.
@@ -161,12 +164,12 @@ const commitmentTooLarge = ({
 // plus the amount that all users have contributed so far
 // exceeds the maximum amount that the project can accept.
 export const commitmentExceedsAmountLeft = ({
-  summary: { swap, derived },
+  summary,
   amountE8s,
 }: {
   summary: SnsSummary;
   amountE8s: bigint;
-}): boolean => swap.init.max_icp_e8s - derived.buyer_total_icp_e8s < amountE8s;
+}): boolean => projectRemainingAmount(summary) < amountE8s;
 
 /**
  * To participate to a swap:

--- a/frontend/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp.utils.spec.ts
@@ -127,6 +127,19 @@ describe("icp-utils", () => {
         maxAmount: BigInt(500_000_000),
       })
     ).toEqual(0.9999);
+    expect(
+      getMaxTransactionAmount({
+        balance: BigInt(0),
+        fee,
+        maxAmount: BigInt(500_000_000),
+      })
+    ).toEqual(0);
+    expect(
+      getMaxTransactionAmount({
+        balance: BigInt(0),
+        fee,
+      })
+    ).toEqual(0);
   });
 
   describe("convertNumberToICP", () => {

--- a/frontend/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp.utils.spec.ts
@@ -7,7 +7,8 @@ import {
   convertTCyclesToIcpNumber,
   formatICP,
   formattedTransactionFeeICP,
-  maxICP,
+  maxE8sToNumber,
+  minE8s,
   sumICPs,
 } from "../../../lib/utils/icp.utils";
 
@@ -80,32 +81,41 @@ describe("icp-utils", () => {
       "0.0001"
     ));
 
-  it("should max ICP value", () => {
-    expect(maxICP({ fee: DEFAULT_TRANSACTION_FEE_E8S })).toEqual(0);
+  it("should max taking into account fee and converted to a number", () => {
+    expect(maxE8sToNumber({ fee: DEFAULT_TRANSACTION_FEE_E8S })).toEqual(0);
     expect(
-      maxICP({
-        icp: ICP.fromString("0") as ICP,
+      maxE8sToNumber({
+        e8s: BigInt(0),
         fee: DEFAULT_TRANSACTION_FEE_E8S,
       })
     ).toEqual(0);
     expect(
-      maxICP({
-        icp: ICP.fromString("0.0001") as ICP,
+      maxE8sToNumber({
+        e8s: BigInt(10_000),
         fee: DEFAULT_TRANSACTION_FEE_E8S,
       })
     ).toEqual(0);
     expect(
-      maxICP({
-        icp: ICP.fromString("0.00011") as ICP,
+      maxE8sToNumber({
+        e8s: BigInt(11_000),
         fee: DEFAULT_TRANSACTION_FEE_E8S,
       })
     ).toEqual(0.00001);
     expect(
-      maxICP({
-        icp: ICP.fromString("1") as ICP,
+      maxE8sToNumber({
+        e8s: BigInt(100_000_000),
         fee: DEFAULT_TRANSACTION_FEE_E8S,
       })
     ).toEqual(0.9999);
+  });
+
+  it("should return the minimum of two bigints ignoring undefined", () => {
+    expect(minE8s(undefined, undefined)).toEqual(BigInt(0));
+    expect(minE8s(BigInt(10), undefined)).toEqual(BigInt(10));
+    expect(minE8s(undefined, BigInt(12))).toEqual(BigInt(12));
+    expect(minE8s(BigInt(10), BigInt(12))).toEqual(BigInt(10));
+    expect(minE8s(BigInt(15), BigInt(12))).toEqual(BigInt(12));
+    expect(minE8s(BigInt(15), BigInt(15))).toEqual(BigInt(15));
   });
 
   describe("convertNumberToICP", () => {

--- a/frontend/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp.utils.spec.ts
@@ -7,8 +7,7 @@ import {
   convertTCyclesToIcpNumber,
   formatICP,
   formattedTransactionFeeICP,
-  maxE8sToNumber,
-  minE8s,
+  getMaxTransactionAmount,
   sumICPs,
 } from "../../../lib/utils/icp.utils";
 
@@ -81,41 +80,53 @@ describe("icp-utils", () => {
       "0.0001"
     ));
 
-  it("should max taking into account fee and converted to a number", () => {
-    expect(maxE8sToNumber({ fee: DEFAULT_TRANSACTION_FEE_E8S })).toEqual(0);
+  it("getMaxTransactionAmount should max taking into account fee, maxAmount and converte it to a number", () => {
+    const fee = BigInt(DEFAULT_TRANSACTION_FEE_E8S);
+    expect(getMaxTransactionAmount({ fee })).toEqual(0);
     expect(
-      maxE8sToNumber({
-        e8s: BigInt(0),
-        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      getMaxTransactionAmount({
+        balance: BigInt(0),
+        fee,
       })
     ).toEqual(0);
     expect(
-      maxE8sToNumber({
-        e8s: BigInt(10_000),
-        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      getMaxTransactionAmount({
+        balance: BigInt(10_000),
+        fee,
       })
     ).toEqual(0);
     expect(
-      maxE8sToNumber({
-        e8s: BigInt(11_000),
-        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      getMaxTransactionAmount({
+        balance: BigInt(11_000),
+        fee,
       })
     ).toEqual(0.00001);
     expect(
-      maxE8sToNumber({
-        e8s: BigInt(100_000_000),
-        fee: DEFAULT_TRANSACTION_FEE_E8S,
+      getMaxTransactionAmount({
+        balance: BigInt(100_000_000),
+        fee,
       })
     ).toEqual(0.9999);
-  });
-
-  it("should return the minimum of two bigints ignoring undefined", () => {
-    expect(minE8s(undefined, undefined)).toEqual(BigInt(0));
-    expect(minE8s(BigInt(10), undefined)).toEqual(BigInt(10));
-    expect(minE8s(undefined, BigInt(12))).toEqual(BigInt(12));
-    expect(minE8s(BigInt(10), BigInt(12))).toEqual(BigInt(10));
-    expect(minE8s(BigInt(15), BigInt(12))).toEqual(BigInt(12));
-    expect(minE8s(BigInt(15), BigInt(15))).toEqual(BigInt(15));
+    expect(
+      getMaxTransactionAmount({
+        balance: BigInt(1_000_000_000),
+        maxAmount: BigInt(500_000_000),
+      })
+    ).toEqual(5);
+    expect(
+      getMaxTransactionAmount({
+        balance: BigInt(1_000_000_000),
+        fee,
+        maxAmount: BigInt(500_000_000),
+      })
+    ).toEqual(5);
+    expect(
+      getMaxTransactionAmount({
+        balance: BigInt(100_000_000),
+        fee,
+        maxAmount: BigInt(500_000_000),
+      })
+    ).toEqual(0.9999);
   });
 
   describe("convertNumberToICP", () => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -20,6 +20,7 @@ import {
   hasUserParticipatedToSwap,
   isNnsProject,
   openTimeWindow,
+  projectRemainingAmount,
   swapDuration,
   validParticipation,
 } from "../../../lib/utils/projects.utils";
@@ -455,6 +456,32 @@ describe("project-utils", () => {
       };
       expect(currentUserMaxCommitment(validProject)).toEqual(
         userMax - userCommitment
+      );
+    });
+  });
+
+  describe("projectRemainingAmount", () => {
+    it("returns remaining amount taking into account current commitment", () => {
+      const projectMax = BigInt(10_000_000_000);
+      const projectCommitment = BigInt(9_200_000_000);
+      const summary: SnsSummary = {
+        ...mockSnsFullProject.summary,
+        derived: {
+          buyer_total_icp_e8s: projectCommitment,
+          sns_tokens_per_icp: 1,
+        },
+        swap: {
+          ...mockSnsFullProject.summary.swap,
+          init: {
+            ...mockSnsFullProject.summary.swap.init,
+            min_participant_icp_e8s: BigInt(100_000_000),
+            max_participant_icp_e8s: BigInt(1_000_000_000),
+            max_icp_e8s: projectMax,
+          },
+        },
+      };
+      expect(projectRemainingAmount(summary)).toEqual(
+        projectMax - projectCommitment
       );
     });
   });


### PR DESCRIPTION
# Motivation

Max button in sale participation didn't consider the remaining amount of the project.

# Changes

* Add maxAmount parameter to TransactionModal.
* Use new maxAmount when calculating the max of the transaction amount.
* Rename and refactor maxICP to use e8s to getMaxTransactionAmount
* New project util to expose the remaining amount of a project projectRemainingAmount

# Tests

* New tests for project util projectRemainingAmount
* Create new test cases for refactored util getMaxTransactionAmount
