### PR TITLE
L2-991: Upgrade nns-js with breaking changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.7.0-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-01.1.tgz",
-      "integrity": "sha512-apXmXOIq3m16+OAoG7EXF5f7CArYaNbPOwFUGvCHJ/Xkn6cbhrhm++FRTdg2f1GsohM4ii2jZjtse4b82HCIaQ==",
+      "version": "0.7.0-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-03.tgz",
+      "integrity": "sha512-RDmiIa5LQ3DSMGmzhia5pfL76UCXlHgHfX3bg678fAaJpo5gk8eEFU4Ot1c8pvagCAeKPYiPExITsep3DZWY0w==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -849,17 +849,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.3-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-01.1.tgz",
-      "integrity": "sha512-lWRPoqKyLO288Jpi9wZP4oSN9p5b3AFP3INa7wY6kiKhNnP8ECQfgdTUjuFYckOkHF1DqpCgMukye/qrW+p4RA==",
+      "version": "0.0.3-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-03.tgz",
+      "integrity": "sha512-C4nWNMUdFZno2NTqnaCl+0avwiTkSJbAZ0ESrsgT2R/CTg8fjqnW+F56GybqdRj3YqSyuCHYeuklql3hQaF7Wg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.1-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.1-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.1-next-2022-09-01.1.tgz",
-      "integrity": "sha512-PNRGJnVXvgOsDRMXYAS+UeInGpjMKtyH4Z6QEUQwQBWqPPHtsoP8lq3aBRTmGSsKo4m9UPgnlEBLXyfwnUNe6A=="
+      "version": "0.0.1-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.1-next-2022-09-03.tgz",
+      "integrity": "sha512-MVmM8l/gMuwKGUOwCNkVSE2tX+fq828FzUK+l09w7ctAOAE3o+Bp4qqOODd3MeZx8bQBYYb8e3EUfs3qDmaqxg=="
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.14.54",
@@ -9978,9 +9978,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.7.0-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-01.1.tgz",
-      "integrity": "sha512-apXmXOIq3m16+OAoG7EXF5f7CArYaNbPOwFUGvCHJ/Xkn6cbhrhm++FRTdg2f1GsohM4ii2jZjtse4b82HCIaQ==",
+      "version": "0.7.0-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-03.tgz",
+      "integrity": "sha512-RDmiIa5LQ3DSMGmzhia5pfL76UCXlHgHfX3bg678fAaJpo5gk8eEFU4Ot1c8pvagCAeKPYiPExITsep3DZWY0w==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -10016,15 +10016,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.3-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-01.1.tgz",
-      "integrity": "sha512-lWRPoqKyLO288Jpi9wZP4oSN9p5b3AFP3INa7wY6kiKhNnP8ECQfgdTUjuFYckOkHF1DqpCgMukye/qrW+p4RA==",
+      "version": "0.0.3-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-03.tgz",
+      "integrity": "sha512-C4nWNMUdFZno2NTqnaCl+0avwiTkSJbAZ0ESrsgT2R/CTg8fjqnW+F56GybqdRj3YqSyuCHYeuklql3hQaF7Wg==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.1-next-2022-09-01.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.1-next-2022-09-01.1.tgz",
-      "integrity": "sha512-PNRGJnVXvgOsDRMXYAS+UeInGpjMKtyH4Z6QEUQwQBWqPPHtsoP8lq3aBRTmGSsKo4m9UPgnlEBLXyfwnUNe6A=="
+      "version": "0.0.1-next-2022-09-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.1-next-2022-09-03.tgz",
+      "integrity": "sha512-MVmM8l/gMuwKGUOwCNkVSE2tX+fq828FzUK+l09w7ctAOAE3o+Bp4qqOODd3MeZx8bQBYYb8e3EUfs3qDmaqxg=="
     },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",

--- a/frontend/src/lib/api/accounts.api.ts
+++ b/frontend/src/lib/api/accounts.api.ts
@@ -21,11 +21,13 @@ export const loadAccounts = async ({
   certified: boolean;
 }): Promise<AccountsStore> => {
   // Helper
-  const getAccountBalance = async (identifierString: string): Promise<ICP> =>
-    ledger.accountBalance({
+  const getAccountBalance = async (identifierString: string): Promise<ICP> => {
+    const e8sBalance = await ledger.accountBalance({
       accountIdentifier: AccountIdentifier.fromHex(identifierString),
       certified,
     });
+    return ICP.fromE8s(e8sBalance);
+  };
 
   logWithTimestamp(`Loading Accounts certified:${certified} call...`);
 

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -2,7 +2,7 @@ import type { Identity } from "@dfinity/agent";
 import { HttpAgent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
-import { AccountIdentifier, ICP, LedgerCanister } from "@dfinity/nns";
+import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { HOST, IS_TESTNET } from "../constants/environment.constants";
 import { governanceCanister } from "./governance.api";
 
@@ -40,7 +40,7 @@ export const acquireICPTs = async ({
   const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
 
   return ledgerCanister.transfer({
-    amount: ICP.fromE8s(e8s),
+    amount: e8s,
     to: AccountIdentifier.fromHex(accountIdentifier),
   });
 };

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -199,7 +199,7 @@ export const splitNeuron = async ({
 
   const response = await canister.splitNeuron({
     neuronId,
-    amount,
+    amount: amount.toE8s(),
   });
   logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) complete.`);
   return response;
@@ -324,7 +324,7 @@ export const stakeNeuron = async ({
   });
 
   const response = await canister.stakeNeuron({
-    stake,
+    stake: stake.toE8s(),
     principal: controller,
     fromSubAccount,
     ledgerCanister,

--- a/frontend/src/lib/api/ledger.api.ts
+++ b/frontend/src/lib/api/ledger.api.ts
@@ -35,7 +35,7 @@ export const sendICP = async ({
 
   const response = await canister.transfer({
     to: AccountIdentifier.fromHex(to),
-    amount,
+    amount: amount.toE8s(),
     fromSubAccount,
     memo,
   });

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -451,7 +451,7 @@ export const participateInSnsSwap = async ({
 
   // Send amount to the ledger
   await nnsLedger.transfer({
-    amount,
+    amount: amount.toE8s(),
     fromSubAccount,
     to: accountIdentifier,
   });

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -1,4 +1,4 @@
-import { ICP, LedgerCanister } from "@dfinity/nns";
+import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import {
   createSubAccount,
@@ -25,7 +25,7 @@ describe("accounts-api", () => {
   it("should call ledger and nnsdapp to get account and balance", async () => {
     // Ledger mock
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.accountBalance.mockResolvedValue(ICP.fromString("1") as ICP);
+    ledgerMock.accountBalance.mockResolvedValue(BigInt(100_000_000));
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation((): LedgerCanister => ledgerMock);
@@ -45,7 +45,7 @@ describe("accounts-api", () => {
   it("should get balances of subaccounts", async () => {
     // Ledger mock
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.accountBalance.mockResolvedValue(ICP.fromString("1") as ICP);
+    ledgerMock.accountBalance.mockResolvedValue(BigInt(100_000_000));
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation((): LedgerCanister => ledgerMock);
@@ -68,7 +68,7 @@ describe("accounts-api", () => {
   it("should get balances of hardware wallet accounts", async () => {
     // Ledger mock
     const ledgerMock = mock<LedgerCanister>();
-    ledgerMock.accountBalance.mockResolvedValue(ICP.fromString("1") as ICP);
+    ledgerMock.accountBalance.mockResolvedValue(BigInt(100_000_000));
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation((): LedgerCanister => ledgerMock);

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -234,7 +234,7 @@ describe("canisters-api", () => {
       expect(mockLedgerCanister.transfer).toBeCalledWith({
         memo: CREATE_CANISTER_MEMO,
         to: AccountIdentifier.fromHex(recipient.toHex()),
-        amount,
+        amount: amount.toE8s(),
         fromSubAccount: mockSubAccount.subAccount,
       });
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
@@ -318,7 +318,7 @@ describe("canisters-api", () => {
       expect(mockLedgerCanister.transfer).toBeCalledWith({
         memo: TOP_UP_CANISTER_MEMO,
         to: AccountIdentifier.fromHex(recipient.toHex()),
-        amount,
+        amount: amount.toE8s(),
         fromSubAccount: mockSubAccount.subAccount,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();

--- a/frontend/src/tests/lib/api/ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ledger.api.spec.ts
@@ -33,7 +33,7 @@ describe("ledger-api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount,
+        amount: amount.toE8s(),
       });
     });
 
@@ -51,7 +51,7 @@ describe("ledger-api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount,
+        amount: amount.toE8s(),
         fromSubAccount,
       });
     });
@@ -67,7 +67,7 @@ describe("ledger-api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount,
+        amount: amount.toE8s(),
         memo,
       });
     });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,4 +1,4 @@
-import { GovernanceCanister, ICP, LedgerCanister } from "@dfinity/nns";
+import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import { NNSDappCanister } from "../../../lib/canisters/nns-dapp/nns-dapp.canister";
 import { initApp } from "../../../lib/services/app.services";
@@ -39,9 +39,7 @@ describe("app-services", () => {
 
   const mockCanisters = () => {
     mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
-    mockLedgerCanister.accountBalance.mockResolvedValue(
-      ICP.fromString("1") as ICP
-    );
+    mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
     mockGovernanceCanister.listNeurons.mockResolvedValue([mockNeuron]);
   };
 

--- a/frontend/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/src/tests/mocks/governance.canister.mock.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
-  ICP,
   LedgerCanister,
   ListProposalsRequest,
   ListProposalsResponse,
@@ -97,7 +96,7 @@ export class MockGovernanceCanister extends GovernanceCanister {
     principal,
     ledgerCanister,
   }: {
-    stake: ICP;
+    stake: bigint;
     principal: Principal;
     ledgerCanister: LedgerCanister;
   }): Promise<NeuronId> => {

--- a/frontend/src/tests/mocks/ledger.canister.mock.ts
+++ b/frontend/src/tests/mocks/ledger.canister.mock.ts
@@ -1,5 +1,5 @@
 import type { AccountIdentifier, BlockHeight } from "@dfinity/nns";
-import { ICP, LedgerCanister } from "@dfinity/nns";
+import { LedgerCanister } from "@dfinity/nns";
 
 // eslint-disable-next-line
 // @ts-ignore: test file
@@ -16,14 +16,14 @@ export class MockLedgerCanister extends LedgerCanister {
   public accountBalance = async (_: {
     accountIdentifier: AccountIdentifier;
     certified?: boolean | undefined;
-  }): Promise<ICP> => {
-    return ICP.fromE8s(BigInt(1));
+  }): Promise<bigint> => {
+    return BigInt(1);
   };
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   public transfer = async (_: {
     to: AccountIdentifier;
-    amount: ICP;
+    amount: bigint;
     memo?: bigint | undefined;
     fee?: bigint | undefined;
     fromSubAccount?: number[] | undefined;


### PR DESCRIPTION
# Motivation

Upgrade nns-js. Fix broken changes in nns-dapp.

This is in preparation for the refactor to start using AmountToken instead of ICP.

# Changes

* Upgrade nns-js, sns-js and utils to latest next version.
* LedgerCanister and GovernanceCanister don't expect ICP anymore but bigint.

# Tests

* Fix broken tests.
