### PR TITLE
feat: use new proposals card on launchpad

### DIFF
--- a/frontend/src/lib/components/launchpad/ProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProposalCard.svelte
@@ -30,8 +30,10 @@
 
     <ProposalMeta {proposalInfo} />
 
-    <button data-tid="vote-for-sns" class="primary small" on:click={showProposal}
-    >{$i18n.proposal_detail.vote}</button
+    <button
+      data-tid="vote-for-sns"
+      class="primary small"
+      on:click={showProposal}>{$i18n.proposal_detail.vote}</button
     >
   </Card>
 </li>

--- a/frontend/src/lib/components/launchpad/ProposalCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProposalCard.svelte
@@ -20,21 +20,26 @@
       path: `${AppPath.ProposalDetail}/${id}`,
     });
   };
+
+  // TODO(L2-965): delete legacy component
 </script>
 
-<Card testId="sns-proposal-card">
-  <h3 slot="start">{title}</h3>
+<li>
+  <Card testId="sns-proposal-card">
+    <h3 slot="start">{title}</h3>
 
-  <ProposalMeta {proposalInfo} />
+    <ProposalMeta {proposalInfo} />
 
-  <button data-tid="vote-for-sns" class="primary small" on:click={showProposal}
+    <button data-tid="vote-for-sns" class="primary small" on:click={showProposal}
     >{$i18n.proposal_detail.vote}</button
-  >
-</Card>
+    >
+  </Card>
+</li>
 
 <style lang="scss">
   h3 {
     line-height: var(--line-height-standard);
+    word-break: break-word;
   }
 
   button {

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -8,7 +8,9 @@
   } from "../../stores/sns.store";
   import { isNullish } from "../../utils/utils";
   import SkeletonProposalCard from "../ui/SkeletonProposalCard.svelte";
-  import ProposalCard from "./ProposalCard.svelte";
+  import ProjectProposalCard from "./ProposalCard.svelte";
+  import ProposalCard from "../proposals/ProposalCard.svelte";
+  import { VOTING_UI } from "../../constants/environment.constants";
 
   let loading: boolean = false;
   $: loading = isNullish($snsProposalsStore);
@@ -30,16 +32,26 @@
 {:else if $openSnsProposalsStore.length === 0}
   <p class="no-proposals">{$i18n.voting.nothing_found}</p>
 {:else}
-  <div class="card-grid">
+  <ul class="card-grid">
     {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}
-      <ProposalCard {proposalInfo} />
+      {#if VOTING_UI === "legacy"}
+        <ProjectProposalCard {proposalInfo} />
+      {:else}
+        <ProposalCard {proposalInfo} layout="modern " />
+      {/if}
     {/each}
-  </div>
+  </ul>
 {/if}
 
 <style lang="scss">
   .no-proposals {
     text-align: center;
     margin: var(--padding-2x) 0;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 </style>

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -37,7 +37,7 @@
       {#if VOTING_UI === "legacy"}
         <ProjectProposalCard {proposalInfo} />
       {:else}
-        <ProposalCard {proposalInfo} layout="modern " />
+        <ProposalCard {proposalInfo} layout="modern" />
       {/if}
     {/each}
   </ul>

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -19,6 +19,7 @@
 
   export let proposalInfo: ProposalInfo;
   export let hidden: boolean = false;
+  // TODO(L2-965): delete property and use modern
   export let layout: "modern" | "legacy" = "legacy";
   import Value from "../ui/Value.svelte";
 

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -61,7 +61,7 @@ describe("Proposals", () => {
     const { queryAllByTestId } = render(Proposals);
 
     await waitFor(() =>
-      expect(queryAllByTestId("sns-proposal-card").length).toBeGreaterThan(0)
+      expect(queryAllByTestId("proposal-card").length).toBeGreaterThan(0)
     );
   });
 
@@ -72,7 +72,7 @@ describe("Proposals", () => {
 
     await waitFor(() =>
       expect(
-        container.querySelectorAll('[data-tid="sns-proposal-card"]').length
+        container.querySelectorAll('[data-tid="proposal-card"]').length
       ).toBeGreaterThan(0)
     );
 


### PR DESCRIPTION
# Motivation

For consistency reason, use the new proposals' cards layout on launchpad.

# Changes

- use new cards "modern" layout
- `li` for the grid

# Screenshots

<img width="1510" alt="Capture d’écran 2022-09-05 à 08 21 19" src="https://user-images.githubusercontent.com/16886711/188373632-f6cddeb2-4352-4d2e-bf91-1a321c0b9254.png">

