### PR TITLE
test: e2e launchpad list projects

### DIFF
--- a/e2e-tests/components/launchpad.ts
+++ b/e2e-tests/components/launchpad.ts
@@ -1,0 +1,3 @@
+import { MyNavigator } from "../common/navigator";
+
+export class Launchpad extends MyNavigator {}

--- a/e2e-tests/components/nav.ts
+++ b/e2e-tests/components/nav.ts
@@ -5,3 +5,4 @@ export const NAV_ACCOUNTS_SELECTOR: string = `[data-tid="menuitem-accounts"]`;
 export const NAV_NEURONS_SELECTOR: string = `[data-tid="menuitem-neurons"]`;
 export const NAV_PROPOSALS_SELECTOR: string = `[data-tid="menuitem-proposals"]`;
 export const NAV_CANISTERS_SELECTOR: string = `[data-tid="menuitem-canisters"]`;
+export const NAV_LAUNCHPAD_SELECTOR: string = `[data-tid="menuitem-launchpad"]`;

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "wdio run ./wdio.conf.ts",
+    "test": "wdio run ./wdio.conf.ts --exclude ./specs/launchpad.e2e.ts",
+    "launchpad": "wdio run ./wdio.conf.ts --spec ./specs/launchpad.e2e.ts",
     "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },

--- a/e2e-tests/specs/launchpad.e2e.ts
+++ b/e2e-tests/specs/launchpad.e2e.ts
@@ -41,11 +41,13 @@ describe("Launchpad", () => {
 
     await launchpad.getElement(cardGridSelector, "Getting the card grid", {
       timeout: 30_000,
-    })
+    });
 
     await browser.waitUntil(async () => {
-      const elements = await browser.$$(`${cardGridSelector} article:not([data-tid="skeleton-card"])`);
-      return elements.length > 0
+      const elements = await browser.$$(
+        `${cardGridSelector} article:not([data-tid="skeleton-card"])`
+      );
+      return elements.length > 0;
     });
   });
 });

--- a/e2e-tests/specs/launchpad.e2e.ts
+++ b/e2e-tests/specs/launchpad.e2e.ts
@@ -1,0 +1,51 @@
+import { MyNavigator } from "../common/navigator";
+import { register } from "../common/register";
+import { skipUnlessBrowserIs } from "../common/test";
+import { Launchpad } from "../components/launchpad";
+import { NAV_LAUNCHPAD_SELECTOR } from "../components/nav";
+
+describe("Launchpad", () => {
+  before(function () {
+    skipUnlessBrowserIs.bind(this)(["chrome"]);
+  });
+
+  it("Setup: Register user", async () => {
+    await browser.url("/");
+    const userId = await register(browser);
+    console.warn(`Created user: ${JSON.stringify(userId)}`);
+  });
+
+  it("Go to launchpad", async () => {
+    const navigator = new MyNavigator(browser);
+    await navigator.navigate({
+      selector: NAV_LAUNCHPAD_SELECTOR,
+      description: "Go to the launchpad",
+    });
+  });
+
+  it("Loading spinner should disappear", async () => {
+    const launchpad = new Launchpad(browser);
+    await launchpad.waitForGone(
+      `[data-tid="spinner"]`,
+      "Wait for spinner to disappear",
+      {
+        timeout: 30_000,
+      }
+    );
+  });
+
+  it("Should render Sns projects", async () => {
+    const launchpad = new Launchpad(browser);
+
+    const cardGridSelector = `div.split-pane main > div`;
+
+    await launchpad.getElement(cardGridSelector, "Getting the card grid", {
+      timeout: 30_000,
+    })
+
+    await browser.waitUntil(async () => {
+      const elements = await browser.$$(`${cardGridSelector} article:not([data-tid="skeleton-card"])`);
+      return elements.length > 0
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

e2e test that creates an identity, sign in NNS-dapp, open launchpad and expect to find Sns projects listed.

# Changes

- new `launchpad.e2e.ts` test
- exclude particular test from main test suite
- add a target `npm run launchpad` to run test only

# Tests

![Enregistrement de l’écran 2022-09-05 à 12 03 01](https://user-images.githubusercontent.com/16886711/188424353-dbd6a572-2a23-413b-94c5-a5c29f8978d2.gif)

