### PR TITLE
L2-1001: Allow pending transactions only caller

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -445,8 +445,7 @@ export const participateInSnsSwap = async ({
   const { canister: nnsDapp } = await nnsDappCanister({ identity });
   await nnsDapp.addPendingNotifySwap({
     swap_canister_id: swapCanisterId,
-    buyer: controller,
-    buyer_sub_account: toNullable(fromSubAccount),
+    from_sub_account: toNullable(fromSubAccount),
   });
 
   // Send amount to the ledger

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -4,8 +4,7 @@ export const idlFactory = ({ IDL }) => {
   const SubAccount = IDL.Vec(IDL.Nat8);
   const AddPendingNotifySwapRequest = IDL.Record({
     swap_canister_id: IDL.Principal,
-    buyer_sub_account: IDL.Opt(SubAccount),
-    buyer: IDL.Principal,
+    from_sub_account: IDL.Opt(SubAccount),
   });
   const AddPendingTransactionResponse = IDL.Variant({
     Ok: IDL.Null,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -157,8 +157,7 @@ type AttachCanisterResponse =
 
 type AddPendingNotifySwapRequest =
     record {
-        buyer: principal;
-        buyer_sub_account: opt SubAccount;
+        from_sub_account: opt SubAccount;
         swap_canister_id: principal;
     };
 

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -4,8 +4,7 @@ export const idlFactory = ({ IDL }) => {
   const SubAccount = IDL.Vec(IDL.Nat8);
   const AddPendingNotifySwapRequest = IDL.Record({
     swap_canister_id: IDL.Principal,
-    buyer_sub_account: IDL.Opt(SubAccount),
-    buyer: IDL.Principal,
+    from_sub_account: IDL.Opt(SubAccount),
   });
   const AddPendingTransactionResponse = IDL.Variant({
     Ok: IDL.Null,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -11,8 +11,7 @@ export interface AccountDetails {
 export type AccountIdentifierString = string;
 export interface AddPendingNotifySwapRequest {
   swap_canister_id: Principal;
-  buyer_sub_account: [] | [SubAccountArray];
-  buyer: Principal;
+  from_sub_account: [] | [SubAccountArray];
 }
 export type AddPendingTransactionResponse = { Ok: null };
 export interface AttachCanisterRequest {

--- a/rs/nns-dapp.did
+++ b/rs/nns-dapp.did
@@ -156,8 +156,7 @@ type AttachCanisterResponse =
 
 type AddPendingNotifySwapRequest =
     record {
-        buyer: principal;
-        buyer_sub_account: opt SubAccount;
+        from_sub_account: opt SubAccount;
         swap_canister_id: principal;
     };
 

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -232,8 +232,7 @@ pub enum DetachCanisterResponse {
 #[derive(CandidType, Deserialize)]
 pub struct AddPendingNotifySwapRequest {
     pub swap_canister_id: CanisterId,
-    pub buyer: PrincipalId,
-    pub buyer_sub_account: Option<Subaccount>,
+    pub from_sub_account: Option<Subaccount>,
 }
 
 #[derive(CandidType)]

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -202,10 +202,11 @@ pub fn add_pending_notify_swap() {
 }
 
 fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPendingTransactionResponse {
+    let principal = dfn_core::api::caller();
     STATE.with(|s| {
         s.accounts_store.borrow_mut().add_pending_transaction(
-            AccountIdentifier::new(request.buyer, request.buyer_sub_account),
-            AccountIdentifier::new(request.swap_canister_id.get(), Some((&request.buyer).into())),
+            AccountIdentifier::new(principal, request.from_sub_account),
+            AccountIdentifier::new(request.swap_canister_id.get(), Some((&principal).into())),
             TransactionType::ParticipateSwap(request.swap_canister_id),
         )
     })


### PR DESCRIPTION
# Motivation

We only add pending transaction from the caller instead of expecting the principal as parameter.

# Changes

* Remove "buyer" from the AddPendingNotifySwapRequest and use caller instead.
* Adapt all candid and related files.

# Tests

Only interface has changed. Functionality stays the same.
