### PR TITLE
L2-1001: Allow pending transactions only caller

### DIFF
--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -14,6 +14,7 @@ import {
   CanisterNotFoundError,
   HardwareWalletAttachError,
   NameTooLongError,
+  NotAuthorizedError,
   ProposalPayloadNotFoundError,
   ProposalPayloadTooLargeError,
   SubAccountLimitExceededError,
@@ -339,6 +340,9 @@ export class NNSDappCanister {
     );
     if ("Ok" in response) {
       return;
+    }
+    if ("NotAuthorized" in response) {
+      throw new NotAuthorizedError();
     }
     // Edge case
     throw new Error(

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -9,6 +9,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const AddPendingTransactionResponse = IDL.Variant({
     Ok: IDL.Null,
+    NotAuthorized: IDL.Null,
   });
   const AttachCanisterRequest = IDL.Record({
     name: IDL.Text,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -165,6 +165,7 @@ type AddPendingNotifySwapRequest =
 type AddPendingTransactionResponse =
     variant {
         Ok;
+        NotAuthorized;
     };
 
 type DetachCanisterRequest =

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.errors.ts
@@ -66,3 +66,5 @@ export class UnknownProposalPayloadError extends Error {
 
 export class ProposalPayloadNotFoundError extends Error {}
 export class ProposalPayloadTooLargeError extends Error {}
+
+export class NotAuthorizedError extends Error {}

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -9,6 +9,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const AddPendingTransactionResponse = IDL.Variant({
     Ok: IDL.Null,
+    NotAuthorized: IDL.Null,
   });
   const AttachCanisterRequest = IDL.Record({
     name: IDL.Text,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -14,7 +14,9 @@ export interface AddPendingNotifySwapRequest {
   buyer_sub_account: [] | [SubAccountArray];
   buyer: Principal;
 }
-export type AddPendingTransactionResponse = { Ok: null };
+export type AddPendingTransactionResponse =
+  | { Ok: null }
+  | { NotAuthorized: null };
 export interface AttachCanisterRequest {
   name: string;
   canister_id: Principal;

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -11,6 +11,7 @@ import {
   CanisterNotFoundError,
   HardwareWalletAttachError,
   NameTooLongError,
+  NotAuthorizedError,
   ProposalPayloadNotFoundError,
   ProposalPayloadTooLargeError,
   SubAccountLimitExceededError,
@@ -159,6 +160,43 @@ describe("NNSDapp", () => {
       const res = await nnsDapp.getCanisters({ certified: true });
 
       expect(res).toEqual(mockCanisters);
+    });
+  });
+
+  describe("NNSDapp.addPendingNotifySwap", () => {
+    afterEach(() => jest.clearAllMocks());
+    it("should call add_pending_notify_swap successfully", async () => {
+      const service = mock<NNSDappService>();
+      service.add_pending_notify_swap.mockResolvedValue({ Ok: null });
+
+      const nnsDapp = await createNnsDapp(service);
+
+      const res = await nnsDapp.addPendingNotifySwap({
+        swap_canister_id: mockCanister.canister_id,
+        buyer: mockPrincipal,
+        buyer_sub_account: [],
+      });
+
+      expect(res).toBeUndefined();
+      expect(service.add_pending_notify_swap).toBeCalled();
+    });
+
+    it("should raise error if add_pending_notify_swap returns error", async () => {
+      const service = mock<NNSDappService>();
+      service.add_pending_notify_swap.mockResolvedValue({
+        NotAuthorized: null,
+      });
+
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.addPendingNotifySwap({
+          swap_canister_id: mockCanister.canister_id,
+          buyer: mockPrincipal,
+          buyer_sub_account: [],
+        });
+
+      expect(call).rejects.toThrow(NotAuthorizedError);
     });
   });
 

--- a/rs/nns-dapp.did
+++ b/rs/nns-dapp.did
@@ -164,6 +164,7 @@ type AddPendingNotifySwapRequest =
 type AddPendingTransactionResponse =
     variant {
         Ok;
+        NotAuthorized;
     };
 
 type DetachCanisterRequest =

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -239,6 +239,7 @@ pub struct AddPendingNotifySwapRequest {
 #[derive(CandidType)]
 pub enum AddPendingTransactionResponse {
     Ok,
+    NotAuthorized,
 }
 
 impl AccountsStore {
@@ -471,6 +472,11 @@ impl AccountsStore {
     ) -> AddPendingTransactionResponse {
         self.pending_transactions.insert((from, to), transaction_type);
         AddPendingTransactionResponse::Ok
+    }
+
+    pub fn check_pending_transaction_buyer(&mut self, caller: PrincipalId, buyer: PrincipalId) -> bool {
+        // TODO: To support hardware wallets, check that the buyer is a principal of the caller's hardware walleet.
+        caller == buyer
     }
 
     // Get pending transaction

--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -475,7 +475,7 @@ impl AccountsStore {
     }
 
     pub fn check_pending_transaction_buyer(&mut self, caller: PrincipalId, buyer: PrincipalId) -> bool {
-        // TODO: To support hardware wallets, check that the buyer is a principal of the caller's hardware walleet.
+        // TODO: To support hardware wallets, check that the buyer is either the caller's principal or the principal of a hardware wallet linked to the caller's account.
         caller == buyer
     }
 

--- a/rs/src/accounts_store/tests.rs
+++ b/rs/src/accounts_store/tests.rs
@@ -341,9 +341,9 @@ fn only_caller_can_add_pending_transaction() {
     let mut store = setup_test_store();
 
     let is_allowed1 = store.check_pending_transaction_buyer(buyer, buyer);
-    assert_eq!(is_allowed1, true);
+    assert!(is_allowed1);
     let is_allowed2 = store.check_pending_transaction_buyer(buyer, buyer2);
-    assert_eq!(is_allowed2, false)
+    assert!(!is_allowed2)
 }
 
 #[test]

--- a/rs/src/accounts_store/tests.rs
+++ b/rs/src/accounts_store/tests.rs
@@ -335,6 +335,18 @@ fn add_and_complete_multiple_pending_transactions() {
 }
 
 #[test]
+fn only_caller_can_add_pending_transaction() {
+    let buyer = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let buyer2 = PrincipalId::from_str(TEST_ACCOUNT_2).unwrap();
+    let mut store = setup_test_store();
+
+    let is_allowed1 = store.check_pending_transaction_buyer(buyer, buyer);
+    assert_eq!(is_allowed1, true);
+    let is_allowed2 = store.check_pending_transaction_buyer(buyer, buyer2);
+    assert_eq!(is_allowed2, false)
+}
+
+#[test]
 fn rename_sub_account() {
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
     let mut store = setup_test_store();

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -208,13 +208,14 @@ fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPend
             .borrow_mut()
             .check_pending_transaction_buyer(caller, request.buyer)
         {
-            return s.accounts_store.borrow_mut().add_pending_transaction(
+            s.accounts_store.borrow_mut().add_pending_transaction(
                 AccountIdentifier::new(request.buyer, request.buyer_sub_account),
                 AccountIdentifier::new(request.swap_canister_id.get(), Some((&request.buyer).into())),
                 TransactionType::ParticipateSwap(request.swap_canister_id),
-            );
+            )
+        } else {
+            AddPendingTransactionResponse::NotAuthorized
         }
-        AddPendingTransactionResponse::NotAuthorized
     })
 }
 

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -202,12 +202,19 @@ pub fn add_pending_notify_swap() {
 }
 
 fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPendingTransactionResponse {
+    let caller = dfn_core::api::caller();
     STATE.with(|s| {
-        s.accounts_store.borrow_mut().add_pending_transaction(
-            AccountIdentifier::new(request.buyer, request.buyer_sub_account),
-            AccountIdentifier::new(request.swap_canister_id.get(), Some((&request.buyer).into())),
-            TransactionType::ParticipateSwap(request.swap_canister_id),
-        )
+        if s.accounts_store
+            .borrow_mut()
+            .check_pending_transaction_buyer(caller, request.buyer)
+        {
+            return s.accounts_store.borrow_mut().add_pending_transaction(
+                AccountIdentifier::new(request.buyer, request.buyer_sub_account),
+                AccountIdentifier::new(request.swap_canister_id.get(), Some((&request.buyer).into())),
+                TransactionType::ParticipateSwap(request.swap_canister_id),
+            );
+        }
+        AddPendingTransactionResponse::NotAuthorized
     })
 }
 


### PR DESCRIPTION
# Motivation

We only add pending transaction from the caller instead of expecting the principal as parameter.

# Changes

* Add a check "check_pending_transaction_buyer" before adding pending transaction.
* Return NotAuthorized if false.
* Adapt all candid and related files to new response.

# Tests

* New test for check_pending_transaction_buyer.