### PR TITLE
Fix: Upgrade failing with new canister state

### DIFF
--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -1358,7 +1358,6 @@ impl StableState for AccountsStore {
         let (
             mut accounts,
             mut hardware_wallets_and_sub_accounts,
-            pending_transactions,
             transactions,
             neuron_accounts,
             block_height_synced_up_to,
@@ -1368,7 +1367,6 @@ impl StableState for AccountsStore {
         ): (
             HashMap<Vec<u8>, Account>,
             HashMap<AccountIdentifier, AccountWrapper>,
-            HashMap<(AccountIdentifier, AccountIdentifier), TransactionType>,
             VecDeque<Transaction>,
             HashMap<AccountIdentifier, NeuronDetails>,
             Option<BlockHeight>,
@@ -1401,7 +1399,7 @@ impl StableState for AccountsStore {
         Ok(AccountsStore {
             accounts,
             hardware_wallets_and_sub_accounts,
-            pending_transactions,
+            pending_transactions: HashMap::new(),
             transactions,
             neuron_accounts,
             block_height_synced_up_to,


### PR DESCRIPTION
# Motivation

Upgrading the canister was failing due to the change in the state.

The problem was that when decoding, the code was expecting the new state of `pending_transactions` to be already present.

# Changes

* Remove `pending_transactions` when decoding the state and add it as a hash map when creating the new state.

# Tests

No extra test.
