### PR TITLE
feat: integrate "my votes" in collapsible section of proposal detail new design

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-07.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-07.2.tgz",
-      "integrity": "sha512-I7aBQ5hK5oVHOkuZYJjBbhxGP147EDzOSnl049skyYpx58Nx6knI3yprS/DKjsyMqpfFQywha/egdfZo8MArJg=="
+      "version": "0.0.1-next-2022-09-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-09.1.tgz",
+      "integrity": "sha512-GtMLN+5O2Z2rPh6GG48yZWTRIs+kOydCmTXZXAanJybX96wY0/4ROT3AnWQFnJ0LRJJWQUuAVQdSBUCpSwk/aA=="
     },
     "node_modules/@dfinity/identity": {
       "version": "1.0.0-beta.0",
@@ -9959,9 +9959,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-07.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-07.2.tgz",
-      "integrity": "sha512-I7aBQ5hK5oVHOkuZYJjBbhxGP147EDzOSnl049skyYpx58Nx6knI3yprS/DKjsyMqpfFQywha/egdfZo8MArJg=="
+      "version": "0.0.1-next-2022-09-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-09.1.tgz",
+      "integrity": "sha512-GtMLN+5O2Z2rPh6GG48yZWTRIs+kOydCmTXZXAanJybX96wY0/4ROT3AnWQFnJ0LRJJWQUuAVQdSBUCpSwk/aA=="
     },
     "@dfinity/identity": {
       "version": "1.0.0-beta.0",

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -53,7 +53,7 @@
 
 {#if neuronsVotedForProposal.length}
   <svelte:component this={cmp}>
-    <h4 class="my-votes">{$i18n.proposal_detail.my_votes}</h4>
+    <h4 slot="start">{$i18n.proposal_detail.my_votes}</h4>
     <ul>
       {#each neuronsVotedForProposal as neuron}
         <li
@@ -76,10 +76,6 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
-
-  .my-votes {
-    padding-top: var(--padding-3x);
-  }
 
   ul {
     list-style-type: none;

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -53,7 +53,7 @@
 
 {#if neuronsVotedForProposal.length}
   <svelte:component this={cmp}>
-    <h2 class="my-votes">{$i18n.proposal_detail.my_votes}</h2>
+    <h4 class="my-votes">{$i18n.proposal_detail.my_votes}</h4>
     <ul>
       {#each neuronsVotedForProposal as neuron}
         <li

--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { ProposalInfo } from "@dfinity/nns";
   import VotesResults from "./VotesResults.svelte";
-  import MyVotes from "./MyVotes.svelte";
   import VotingCard from "./VotingCard/VotingCard.svelte";
 
   export let proposalInfo: ProposalInfo;
@@ -9,4 +8,3 @@
 
 <VotesResults {proposalInfo} />
 <VotingCard {proposalInfo} />
-<MyVotes {proposalInfo} />

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -78,8 +78,8 @@
   // TODO(L2-965): delete legacy component <CardInfo />
 </script>
 
-{#if visible}
-  {#if VOTING_UI === "legacy"}
+{#if VOTING_UI === "legacy"}
+  {#if visible}
     <CardInfo>
       <h2 slot="start">{$i18n.proposal_detail__vote.headline}</h2>
       <VotingNeuronSelect {proposalInfo} {voteInProgress} />
@@ -90,15 +90,18 @@
         layout="legacy"
       />
     </CardInfo>
-  {:else}
-    <BottomSheet>
+  {/if}
+{:else}
+  <BottomSheet>
+    {#if visible}
       <VotingConfirmationToolbar
         {proposalInfo}
         {voteInProgress}
         on:nnsConfirm={vote}
         layout="modern"
       />
-      <VotingNeuronSelect {proposalInfo} {voteInProgress} />
-    </BottomSheet>
-  {/if}
+    {/if}
+
+    <VotingNeuronSelect {proposalInfo} {voteInProgress} />
+  </BottomSheet>
 {/if}

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -24,18 +24,18 @@
   // TODO(L2-965): delete legacy component - VotingNeuronSelectLegacy - (and inline VotingNeuronSelectModern?)
 </script>
 
-{#if $votingNeuronSelectStore.neurons.length > 0}
-  {#if VOTING_UI === "legacy"}
+{#if VOTING_UI === "legacy"}
+  {#if $votingNeuronSelectStore.neurons.length > 0}
     <VotingNeuronSelectLegacy
       {proposalInfo}
       {disabled}
       {totalNeuronsVotingPower}
     />
-  {:else}
-    <VotingNeuronSelectModern
-      {proposalInfo}
-      {disabled}
-      {totalNeuronsVotingPower}
-    />
   {/if}
+{:else}
+  <VotingNeuronSelectModern
+    {proposalInfo}
+    {disabled}
+    {totalNeuronsVotingPower}
+  />
 {/if}

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
@@ -40,6 +40,10 @@
     @include media.min-width(large) {
       max-height: inherit;
       padding: var(--padding) 0;
+
+      &:before {
+        width: 100%;
+      }
     }
 
     :global(div.content-cell-title) {

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
@@ -3,6 +3,7 @@
   import type { ProposalInfo } from "@dfinity/nns";
   import IneligibleNeuronsCard from "../IneligibleNeuronsCard.svelte";
   import { definedNeuronsStore } from "../../../stores/neurons.store";
+  import MyVotes from "../MyVotes.svelte";
 
   export let proposalInfo: ProposalInfo;
   export let disabled: boolean;
@@ -12,6 +13,8 @@
 
 <div class="neurons">
   <VotingNeuronSelectList {proposalInfo} {disabled} />
+
+  <MyVotes {proposalInfo} />
 
   <IneligibleNeuronsCard {proposalInfo} neurons={$definedNeuronsStore} />
 </div>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
@@ -58,7 +58,7 @@
 
   ul {
     list-style: none;
-    padding: 0;
+    padding: 0 0 var(--padding-1_5x);
 
     // checkbox restyling
     :global(.neuron-checkbox) {

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
@@ -34,9 +34,8 @@
 >
   <div slot="header" class="total" class:expanded>
     <div class="total-neurons">
-      <span class="value"
-        >{$i18n.proposal_detail__vote.neurons}
-        {#if displayNeuronsInfo}
+      <span class="value" data-tid="voting-collapsible-toolbar-neurons"
+        >{$i18n.proposal_detail__vote.neurons}{#if displayNeuronsInfo}
           &nbsp;({selectedVotingNeurons} / {totalVotingNeurons})
         {/if}
       </span>
@@ -50,7 +49,10 @@
     </div>
 
     {#if displayNeuronsInfo}
-      <div class="total-voting-power">
+      <div
+        class="total-voting-power"
+        data-tid="voting-collapsible-toolbar-voting-power"
+      >
         <span class="label">{$i18n.proposal_detail__vote.voting_power}</span>
         <Value
           >{formatVotingPower(

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
@@ -36,7 +36,7 @@
     <div class="total-neurons">
       <span class="value" data-tid="voting-collapsible-toolbar-neurons"
         >{$i18n.proposal_detail__vote.neurons}{#if displayNeuronsInfo}
-          &nbsp;({selectedVotingNeurons} / {totalVotingNeurons})
+          &nbsp;({selectedVotingNeurons}/{totalVotingNeurons})
         {/if}
       </span>
       <button

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte
@@ -15,8 +15,14 @@
   let toggleContent: () => void;
   let expanded: boolean;
 
-  let totalNeurons: number;
-  $: totalNeurons = $votingNeuronSelectStore.neurons.length;
+  let totalVotingNeurons: number;
+  $: totalVotingNeurons = $votingNeuronSelectStore.neurons.length;
+
+  let selectedVotingNeurons: number;
+  $: selectedVotingNeurons = $votingNeuronSelectStore.selectedIds.length;
+
+  let displayNeuronsInfo: boolean;
+  $: displayNeuronsInfo = totalVotingNeurons > 0;
 </script>
 
 <Collapsible
@@ -29,8 +35,11 @@
   <div slot="header" class="total" class:expanded>
     <div class="total-neurons">
       <span class="value"
-        >{$i18n.proposal_detail__vote.neurons} ({totalNeurons})</span
-      >
+        >{$i18n.proposal_detail__vote.neurons}
+        {#if displayNeuronsInfo}
+          &nbsp;({selectedVotingNeurons} / {totalVotingNeurons})
+        {/if}
+      </span>
       <button
         class="icon"
         class:expanded
@@ -40,14 +49,16 @@
       </button>
     </div>
 
-    <div class="total-voting-power">
-      <span class="label">{$i18n.proposal_detail__vote.voting_power}</span>
-      <Value
-        >{formatVotingPower(
-          totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
-        )}</Value
-      >
-    </div>
+    {#if displayNeuronsInfo}
+      <div class="total-voting-power">
+        <span class="label">{$i18n.proposal_detail__vote.voting_power}</span>
+        <Value
+          >{formatVotingPower(
+            totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
+          )}</Value
+        >
+      </div>
+    {/if}
   </div>
 
   <VotingNeuronSelectContainer {proposalInfo} {disabled} />

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
@@ -61,7 +61,7 @@ describe("VotingNeuronSelectModern", () => {
       expect(
         getByTestId("voting-collapsible-toolbar-neurons")
           ?.textContent?.trim()
-          .includes(`(${neurons.length} / ${neurons.length})`)
+          .includes(`(${neurons.length}/${neurons.length})`)
       ).toBeTruthy();
     });
   });

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
@@ -49,7 +49,7 @@ describe("VotingNeuronSelectModern", () => {
       ).not.toBeNull();
     });
 
-    it("should display voting power", () => {
+    it("should display selectable neurons for voting power", () => {
       const { getByTestId } = render(VotingNeuronSelectModern, {
         props: {
           proposalInfo: mockProposalInfo,

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import VotingNeuronSelectModern from "../../../../../lib/components/proposal-detail/VotingCard/VotingNeuronSelectModern.svelte";
+import { votingNeuronSelectStore } from "../../../../../lib/stores/proposals.store";
+import en from "../../../../mocks/i18n.mock";
+import { mockNeuron } from "../../../../mocks/neurons.mock";
+import { mockProposalInfo } from "../../../../mocks/proposal.mock";
+
+describe("VotingNeuronSelectModern", () => {
+  describe("No selectable neurons", () => {
+    it("should display no neurons information", () => {
+      const { getByTestId } = render(VotingNeuronSelectModern, {
+        props: {
+          proposalInfo: mockProposalInfo,
+          disabled: false,
+          totalNeuronsVotingPower: BigInt(1),
+        },
+      });
+
+      expect(
+        getByTestId("voting-collapsible-toolbar-neurons")?.textContent?.trim()
+      ).toEqual(en.proposal_detail__vote.neurons);
+      expect(() =>
+        getByTestId("voting-collapsible-toolbar-voting-power")
+      ).toThrow();
+    });
+  });
+
+  describe("Has selected neurons", () => {
+    const neuronIds = [0, 1, 2].map(BigInt);
+    const neurons = neuronIds.map((neuronId) => ({ ...mockNeuron, neuronId }));
+
+    beforeAll(() => votingNeuronSelectStore.set(neurons));
+
+    it("should display voting power", () => {
+      const { getByTestId } = render(VotingNeuronSelectModern, {
+        props: {
+          proposalInfo: mockProposalInfo,
+          disabled: false,
+          totalNeuronsVotingPower: BigInt(1),
+        },
+      });
+
+      expect(
+        getByTestId("voting-collapsible-toolbar-voting-power")
+      ).not.toBeNull();
+    });
+
+    it("should display voting power", () => {
+      const { getByTestId } = render(VotingNeuronSelectModern, {
+        props: {
+          proposalInfo: mockProposalInfo,
+          disabled: false,
+          totalNeuronsVotingPower: BigInt(1),
+        },
+      });
+
+      expect(
+        getByTestId("voting-collapsible-toolbar-neurons")
+          ?.textContent?.trim()
+          .includes(`(${neurons.length} / ${neurons.length})`)
+      ).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Integrating the "my votes" section into the collapsible section of the proposal detail in new design makes the screen even more readable. Following this integration, we also discussed with Mischa how the "Voting Power" and number of selected should be displayed. This PR implements this too.

# Changes

- integrate "My votes" in collapsible between the selection of the neurons and the ineligible neurons
- display "Neurons (A/B)" where A is the number of selected neurons and B the number of selectable neurons
- display "(A/B)" and "Voting Power: XXX" only of the number of selectable neurons > 0
- in new design the collapsible should always be visible even if voting period is over otherwise user looses the information
- some minor style / spacing improvements

# Screenshots

<img width="1510" alt="Capture d’écran 2022-09-08 à 14 41 14" src="https://user-images.githubusercontent.com/16886711/189124544-db3b08ce-c40a-4a50-92e0-80c7e5a006dc.png">
<img width="1510" alt="Capture d’écran 2022-09-08 à 14 41 17" src="https://user-images.githubusercontent.com/16886711/189124563-526b32cc-c548-48c6-b781-4650377bdb93.png">
<img width="628" alt="Capture d’écran 2022-09-08 à 14 43 00" src="https://user-images.githubusercontent.com/16886711/189124647-c5e3b8d4-be4f-466f-b0fb-6d45da7db79a.png">
<img width="628" alt="Capture d’écran 2022-09-08 à 14 43 04" src="https://user-images.githubusercontent.com/16886711/189124661-fa76ea2d-c906-40fe-bf5f-4d4f0979361e.png">
