### PR TITLE
L2-841: New transaction flow

### DIFF
--- a/frontend/src/lib/components/accounts/Address.svelte
+++ b/frontend/src/lib/components/accounts/Address.svelte
@@ -1,30 +1,14 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../constants/accounts.constants";
   import { invalidAddress } from "../../utils/accounts.utils";
-  import InputWithError from "../ui/InputWithError.svelte";
+  import AddressInput from "./AddressInput.svelte";
 
   export let address: string = "";
-
-  let showError = false;
-  const showErrorIfAny = () => {
-    showError = address.length > 0 && invalidAddress(address);
-  };
-  // Hide error on change
-  $: address, (showError = false);
 </script>
 
 <article>
   <form on:submit|preventDefault>
-    <InputWithError
-      inputType="text"
-      placeholderLabelKey="accounts.address"
-      name="accounts-address"
-      bind:value={address}
-      minLength={ACCOUNT_ADDRESS_MIN_LENGTH}
-      errorMessage={showError ? $i18n.error.address_not_valid : undefined}
-      on:blur={showErrorIfAny}
-    />
+    <AddressInput bind:address />
     <button
       class="primary small"
       type="submit"

--- a/frontend/src/lib/components/accounts/AddressInput.svelte
+++ b/frontend/src/lib/components/accounts/AddressInput.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../constants/accounts.constants";
+  import { i18n } from "../../stores/i18n";
+  import { invalidAddress } from "../../utils/accounts.utils";
+
+  import InputWithError from "../ui/InputWithError.svelte";
+
+  export let address: string = "";
+
+  let showError = false;
+  const dispatcher = createEventDispatcher();
+  const showErrorIfAny = () => {
+    showError = address.length > 0 && invalidAddress(address);
+    dispatcher("nnsBlur");
+  };
+  // Hide error on change
+  $: address, (showError = false);
+</script>
+
+<InputWithError
+  inputType="text"
+  placeholderLabelKey="accounts.address"
+  name="accounts-address"
+  bind:value={address}
+  minLength={ACCOUNT_ADDRESS_MIN_LENGTH}
+  errorMessage={showError ? $i18n.error.address_not_valid : undefined}
+  on:blur={showErrorIfAny}
+/>

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { accountsStore } from "../../stores/accounts.store";
-  import { accountsList } from "../../derived/accounts-list.derived";
+  import { accountsListStore } from "../../derived/accounts-list.derived";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { getAccountFromStore } from "../../utils/accounts.utils";
@@ -19,7 +19,7 @@
     accountsStore: $accountsStore,
   });
 
-  $: selectableAccounts = $accountsList.filter(filterAccounts);
+  $: selectableAccounts = $accountsListStore.filter(filterAccounts);
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -10,26 +10,16 @@
   export let selectedAccount: Account | undefined = undefined;
   export let filterAccounts: (account: Account) => boolean = () => true;
 
-  let selectedAccountIdentifier: string;
+  // In case the component is already initialized with a selectedAccount
+  // To avoid cyclical dependencies, we don't update this if `selectedAccount` changes
+  let selectedAccountIdentifier: string | undefined =
+    selectedAccount?.identifier;
   $: selectedAccount = getAccountFromStore({
     identifier: selectedAccountIdentifier,
     accountsStore: $accountsStore,
   });
 
   $: selectableAccounts = $accountsList.filter(filterAccounts);
-
-  // If the selected account is not in the list of accounts
-  // Set the selected account to the first account in the list
-  // It covers the case to select the main account by default
-  $: {
-    if (
-      selectableAccounts.find(
-        ({ identifier }) => identifier === selectedAccountIdentifier
-      ) === undefined
-    ) {
-      selectedAccountIdentifier = selectableAccounts[0]?.identifier;
-    }
-  }
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -8,7 +8,7 @@
   import DropdownItem from "../ui/DropdownItem.svelte";
 
   export let selectedAccount: Account | undefined = undefined;
-  export let skipHardwareWallets: boolean = false;
+  export let filterAccounts: (account: Account) => boolean = () => true;
 
   let selectedAccountIdentifier: string;
   $: selectedAccount = getAccountFromStore({
@@ -16,20 +16,27 @@
     accountsStore: $accountsStore,
   });
 
-  let selectableAccounts: Account[] = [];
+  let accounts: Account[] = [];
+  $: selectableAccounts = accounts.filter(filterAccounts);
   const unsubscribe = accountsStore.subscribe(
     ({ main, subAccounts, hardwareWallets }) => {
       if (main !== undefined) {
         selectedAccountIdentifier =
           selectedAccountIdentifier ?? main.identifier;
-        selectableAccounts = [
-          main,
-          ...(subAccounts ?? []),
-          ...(skipHardwareWallets ? [] : hardwareWallets ?? []),
-        ];
+        accounts = [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])];
       }
     }
   );
+
+  $: {
+    if (
+      selectableAccounts.find(
+        ({ identifier }) => identifier === selectedAccountIdentifier
+      ) === undefined
+    ) {
+      selectedAccountIdentifier = selectableAccounts[0]?.identifier;
+    }
+  }
 
   onDestroy(unsubscribe);
 </script>

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -41,14 +41,27 @@
   onDestroy(unsubscribe);
 </script>
 
-<Dropdown
-  name="account"
-  bind:selectedValue={selectedAccountIdentifier}
-  testId="select-account-dropdown"
->
-  {#each selectableAccounts as { identifier, name } (identifier)}
-    <DropdownItem value={identifier}>
-      {name ?? $i18n.accounts.main}
+{#if selectableAccounts.length === 0}
+  <Dropdown
+    name="account"
+    disabled
+    selectedValue="no-accounts"
+    testId="select-account-dropdown"
+  >
+    <DropdownItem value="no-accounts">
+      {$i18n.accounts.no_account_select}
     </DropdownItem>
-  {/each}
-</Dropdown>
+  </Dropdown>
+{:else}
+  <Dropdown
+    name="account"
+    bind:selectedValue={selectedAccountIdentifier}
+    testId="select-account-dropdown"
+  >
+    {#each selectableAccounts as { identifier, name } (identifier)}
+      <DropdownItem value={identifier}>
+        {name ?? $i18n.accounts.main}
+      </DropdownItem>
+    {/each}
+  </Dropdown>
+{/if}

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
   import { accountsStore } from "../../stores/accounts.store";
+  import { accountsList } from "../../derived/accounts-list.derived";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import { getAccountFromStore } from "../../utils/accounts.utils";
@@ -16,18 +16,11 @@
     accountsStore: $accountsStore,
   });
 
-  let accounts: Account[] = [];
-  $: selectableAccounts = accounts.filter(filterAccounts);
-  const unsubscribe = accountsStore.subscribe(
-    ({ main, subAccounts, hardwareWallets }) => {
-      if (main !== undefined) {
-        selectedAccountIdentifier =
-          selectedAccountIdentifier ?? main.identifier;
-        accounts = [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])];
-      }
-    }
-  );
+  $: selectableAccounts = $accountsList.filter(filterAccounts);
 
+  // If the selected account is not in the list of accounts
+  // Set the selected account to the first account in the list
+  // It covers the case to select the main account by default
   $: {
     if (
       selectableAccounts.find(
@@ -37,8 +30,6 @@
       selectedAccountIdentifier = selectableAccounts[0]?.identifier;
     }
   }
-
-  onDestroy(unsubscribe);
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -14,10 +14,19 @@
   export let filterAccounts: (account: Account) => boolean = () => true;
   export let showManualAddress: boolean = true;
 
+  // If the component is already initialized with a selectedDestinationAddress
+  let selectedAccount: Account | undefined = getAccountFromStore({
+    identifier: selectedDestinationAddress,
+    accountsStore: $accountsStore,
+  });
   let address: string;
   $: {
     if (!invalidAddress(address)) {
       selectedDestinationAddress = address;
+    }
+    // Keep in sync the selected destination address
+    if (selectedAccount !== undefined) {
+      selectedDestinationAddress = selectedAccount.identifier;
     }
   }
 
@@ -26,18 +35,6 @@
     selectedDestinationAddress = undefined;
     selectedAccount = undefined;
   };
-
-  // If the component is already initialized with a selectedDestinationAddress
-  let selectedAccount: Account | undefined = getAccountFromStore({
-    identifier: selectedDestinationAddress,
-    accountsStore: $accountsStore,
-  });
-  // Keep in sync the selected destination addres
-  $: {
-    if (selectedAccount !== undefined) {
-      selectedDestinationAddress = selectedAccount.identifier;
-    }
-  }
 </script>
 
 <div data-tid="select-destination">
@@ -71,9 +68,5 @@
       align-items: center;
       gap: var(--padding);
     }
-  }
-
-  .label {
-    color: var(--label-color);
   }
 </style>

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { accountsStore } from "../../stores/accounts.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
+  import { getAccountFromStore } from "../../utils/accounts.utils";
   import Toggle from "../ui/Toggle.svelte";
   import AddressInput from "./AddressInput.svelte";
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
@@ -20,7 +22,12 @@
     selectedAccount = undefined;
   };
 
-  let selectedAccount: Account | undefined = undefined;
+  // If the component is already initialized with a selectedDestinationAddress
+  let selectedAccount: Account | undefined = getAccountFromStore({
+    identifier: selectedDestinationAddress,
+    accountsStore: $accountsStore,
+  });
+  // Keep in sync the selected destination addres
   $: {
     if (selectedAccount !== undefined) {
       selectedDestinationAddress = selectedAccount.identifier;

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -2,7 +2,10 @@
   import { accountsStore } from "../../stores/accounts.store";
   import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
-  import { getAccountFromStore } from "../../utils/accounts.utils";
+  import {
+    getAccountFromStore,
+    invalidAddress,
+  } from "../../utils/accounts.utils";
   import Toggle from "../ui/Toggle.svelte";
   import AddressInput from "./AddressInput.svelte";
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
@@ -12,9 +15,11 @@
   export let showManualAddress: boolean = true;
 
   let address: string;
-  const setDestination = () => {
-    selectedDestinationAddress = address;
-  };
+  $: {
+    if (!invalidAddress(address)) {
+      selectedDestinationAddress = address;
+    }
+  }
 
   const onToggleManualInput = () => {
     showManualAddress = !showManualAddress;
@@ -49,7 +54,7 @@
     </div>
   </div>
   {#if showManualAddress}
-    <AddressInput bind:address on:nnsBlur={setDestination} />
+    <AddressInput bind:address={selectedDestinationAddress} />
   {:else}
     <SelectAccountDropdown {filterAccounts} bind:selectedAccount />
   {/if}

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -7,15 +7,15 @@
 
   export let selectedDestinationAddress: string | undefined = undefined;
   export let filterAccounts: (account: Account) => boolean = () => true;
+  export let showManualAddress: boolean = true;
 
   let address: string;
   const setDestination = () => {
     selectedDestinationAddress = address;
   };
 
-  let showManualInput: boolean = true;
   const onToggleManualInput = () => {
-    showManualInput = !showManualInput;
+    showManualAddress = !showManualAddress;
     selectedDestinationAddress = undefined;
     selectedAccount = undefined;
   };
@@ -34,14 +34,14 @@
     <div class="toggle">
       <p>{$i18n.accounts.select}</p>
       <Toggle
-        bind:checked={showManualInput}
+        bind:checked={showManualAddress}
         on:nnsToggle={onToggleManualInput}
         ariaLabel="change"
       />
       <p>{$i18n.accounts.manual}</p>
     </div>
   </div>
-  {#if showManualInput}
+  {#if showManualAddress}
     <AddressInput bind:address on:nnsBlur={setDestination} />
   {:else}
     <SelectAccountDropdown {filterAccounts} bind:selectedAccount />

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -13,7 +13,7 @@
     selectedDestinationAddress = address;
   };
 
-  let showManualInput: boolean = false;
+  let showManualInput: boolean = true;
   const onToggleManualInput = () => {
     showManualInput = !showManualInput;
     selectedDestinationAddress = undefined;
@@ -28,7 +28,7 @@
   }
 </script>
 
-<div>
+<div data-tid="select-destination">
   <div class="title">
     <p class="label">{$i18n.accounts.destination}</p>
     <div class="toggle">

--- a/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import { i18n } from "../../stores/i18n";
   import type { Account } from "../../types/account";
   import Toggle from "../ui/Toggle.svelte";
-
-  import Address from "./Address.svelte";
+  import AddressInput from "./AddressInput.svelte";
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
 
   export let selectedDestinationAddress: string | undefined = undefined;
+  export let filterAccounts: (account: Account) => boolean = () => true;
 
   let address: string;
-  const onEnterAddress = () => (selectedDestinationAddress = address);
+  const setDestination = () => {
+    selectedDestinationAddress = address;
+  };
 
   let showManualInput: boolean = false;
   const onToggleManualInput = () => (showManualInput = !showManualInput);
@@ -22,21 +25,35 @@
 </script>
 
 <div>
-  <div>
-    <p>Manual Address</p>
-    <Toggle
-      bind:checked={showManualInput}
-      on:nnsToggle={onToggleManualInput}
-      ariaLabel="change"
-    />
-    <p>Select Account</p>
+  <div class="title">
+    <p>{$i18n.accounts.select_destination}</p>
+    <div class="toggle">
+      <p>{$i18n.accounts.dropdown}</p>
+      <Toggle
+        bind:checked={showManualInput}
+        on:nnsToggle={onToggleManualInput}
+        ariaLabel="change"
+      />
+      <p>{$i18n.accounts.manual}</p>
+    </div>
   </div>
   {#if showManualInput}
-    <Address
-      bind:address={selectedDestinationAddress}
-      on:submit={onEnterAddress}
-    />
+    <AddressInput bind:address on:nnsBlur={setDestination} />
   {:else}
-    <SelectAccountDropdown bind:selectedAccount />
+    <SelectAccountDropdown {filterAccounts} bind:selectedAccount />
   {/if}
 </div>
+
+<style lang="scss">
+  .title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .toggle {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: var(--padding);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
@@ -14,7 +14,11 @@
   };
 
   let showManualInput: boolean = false;
-  const onToggleManualInput = () => (showManualInput = !showManualInput);
+  const onToggleManualInput = () => {
+    showManualInput = !showManualInput;
+    selectedDestinationAddress = undefined;
+    selectedAccount = undefined;
+  };
 
   let selectedAccount: Account | undefined = undefined;
   $: {
@@ -26,9 +30,9 @@
 
 <div>
   <div class="title">
-    <p>{$i18n.accounts.select_destination}</p>
+    <p class="label">{$i18n.accounts.destination}</p>
     <div class="toggle">
-      <p>{$i18n.accounts.dropdown}</p>
+      <p>{$i18n.accounts.select}</p>
       <Toggle
         bind:checked={showManualInput}
         on:nnsToggle={onToggleManualInput}
@@ -55,5 +59,9 @@
       align-items: center;
       gap: var(--padding);
     }
+  }
+
+  .label {
+    color: var(--label-color);
   }
 </style>

--- a/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelecteDestinationAddress.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { Account } from "../../types/account";
+  import Toggle from "../ui/Toggle.svelte";
+
+  import Address from "./Address.svelte";
+  import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
+
+  export let selectedDestinationAddress: string | undefined = undefined;
+
+  let address: string;
+  const onEnterAddress = () => (selectedDestinationAddress = address);
+
+  let showManualInput: boolean = false;
+  const onToggleManualInput = () => (showManualInput = !showManualInput);
+
+  let selectedAccount: Account | undefined = undefined;
+  $: {
+    if (selectedAccount !== undefined) {
+      selectedDestinationAddress = selectedAccount.identifier;
+    }
+  }
+</script>
+
+<div>
+  <div>
+    <p>Manual Address</p>
+    <Toggle
+      bind:checked={showManualInput}
+      on:nnsToggle={onToggleManualInput}
+      ariaLabel="change"
+    />
+    <p>Select Account</p>
+  </div>
+  {#if showManualInput}
+    <Address
+      bind:address={selectedDestinationAddress}
+      on:submit={onEnterAddress}
+    />
+  {:else}
+    <SelectAccountDropdown bind:selectedAccount />
+  {/if}
+</div>

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -6,10 +6,11 @@
   export let selectedValue: string | undefined = undefined;
   export let name: string;
   export let testId: string | undefined = undefined;
+  export let disabled: boolean = false;
 </script>
 
 <div>
-  <select bind:value={selectedValue} {name} data-tid={testId}>
+  <select {disabled} bind:value={selectedValue} {name} data-tid={testId}>
     <slot />
   </select>
   <span class="icon">
@@ -33,7 +34,7 @@
     border-radius: var(--element-border-radius);
     box-shadow: var(--box-shadow);
 
-    padding: var(--padding-2x) var(--padding-3x);
+    padding: var(--padding-2x);
     // Click on <select> does not trigger "focus" on parent div.
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within
     // Matches an element if the element or any of its descendants are focused.

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -50,6 +50,8 @@
 
       appearance: none;
 
+      font-size: inherit;
+
       &:focus {
         outline: none;
       }
@@ -65,9 +67,10 @@
       // Place the caret inside the select.
       margin-left: calc(-1 * var(--padding-3x));
 
+      // To match the line-height when font-size is 16px
       :global(svg) {
-        width: 24px;
-        height: 24px;
+        width: 20px;
+        height: 20px;
       }
     }
   }

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -14,7 +14,8 @@
     <slot />
   </select>
   <span class="icon">
-    <IconExpandMore />
+    <!-- size to match the line-height when font-size is 16px -->
+    <IconExpandMore size="20px" />
   </span>
 </div>
 
@@ -67,12 +68,6 @@
 
       // Place the caret inside the select.
       margin-left: calc(-1 * var(--padding-3x));
-
-      // To match the line-height when font-size is 16px
-      :global(svg) {
-        width: 20px;
-        height: 20px;
-      }
     }
   }
 </style>

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -14,8 +14,7 @@
     <slot />
   </select>
   <span class="icon">
-    <!-- size to match the line-height when font-size is 16px -->
-    <IconExpandMore size="20px" />
+    <IconExpandMore />
   </span>
 </div>
 
@@ -68,6 +67,12 @@
 
       // Place the caret inside the select.
       margin-left: calc(-1 * var(--padding-3x));
+
+      // Size to match the line-height when font-size is 16px
+      :global(svg) {
+        width: 20px;
+        height: 20px;
+      }
     }
   }
 </style>

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -16,10 +16,15 @@
   export let max: number | undefined = undefined;
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
   export let autocomplete: "off" | "on" | undefined = undefined;
-
   export let value: string | number | undefined = undefined;
-
   export let placeholderLabelKey: string;
+  // When forwarding slots, they always appear as true
+  // This is a known issue in Svelte
+  // https://github.com/sveltejs/svelte/issues/6059
+  // To hack this, we pass a prop to avoid showing info element when not needed
+  // Ideally, this would be calculated
+  // showInfo = $$slots.label || $$slots.additional
+  export let showInfo: boolean = true;
 
   let inputElement: HTMLInputElement | undefined;
 
@@ -116,10 +121,12 @@
 </script>
 
 <div class="input-block" class:disabled>
-  <div class="info">
-    <label for={name}><slot name="label" /></label>
-    <slot name="additional" />
-  </div>
+  {#if showInfo}
+    <div class="info">
+      <label for={name}><slot name="label" /></label>
+      <slot name="additional" />
+    </div>
+  {/if}
   <input
     data-tid="input-ui-element"
     type={inputType === "icp" ? "text" : inputType}

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -123,7 +123,7 @@
 <div class="input-block" class:disabled>
   {#if showInfo}
     <div class="info">
-      <label for={name}><slot name="label" /></label>
+      <label class="label" for={name}><slot name="label" /></label>
       <slot name="additional" />
     </div>
   {/if}
@@ -179,10 +179,6 @@
   .info {
     display: flex;
     justify-content: space-between;
-
-    label {
-      color: var(--label-color);
-    }
   }
 
   input {

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -179,6 +179,10 @@
   .info {
     display: flex;
     justify-content: space-between;
+
+    label {
+      color: var(--label-color);
+    }
   }
 
   input {

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -32,6 +32,7 @@
     {placeholderLabelKey}
     {max}
     {autocomplete}
+    showInfo={$$slots.label !== undefined || $$slots.additional !== undefined}
     bind:value
     on:blur
     on:input

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -5,7 +5,7 @@
 import { derived } from "svelte/store";
 import { accountsStore } from "../stores/accounts.store";
 
-export const accountsList = derived(
+export const accountsListStore = derived(
   accountsStore,
   ({ main, subAccounts, hardwareWallets }) =>
     main === undefined

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -1,0 +1,14 @@
+/**
+ * A derived store that returns the accounts as an array of accounts.
+ */
+
+import { derived } from "svelte/store";
+import { accountsStore } from "../stores/accounts.store";
+
+export const accountsList = derived(
+  accountsStore,
+  ({ main, subAccounts, hardwareWallets }) =>
+    main === undefined
+      ? []
+      : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])]
+);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -128,8 +128,11 @@
   "accounts": {
     "total": "Total",
     "main": "Main",
-    "main_account": "Main Account $identifier",
+    "main_account": "Main Account",
+    "account_name": "Account $name",
     "new_transaction": "New Transaction",
+    "icp_transaction_description": "ICP Transaction",
+    "review_action": "Review",
     "add_account": "Add Account",
     "new_linked_title": "New Linked Account",
     "new_linked_subtitle": "Create a new linked account",
@@ -181,6 +184,8 @@
     "description": "Description",
     "edit_transaction": "Edit Transaction",
     "execute": "Execute",
+    "dropdown": "Dropdown",
+    "manual": "Manual",
     "current_balance_detail": "Current balance: $amount ICP"
   },
   "neurons": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -184,6 +184,7 @@
     "execute": "Execute",
     "select": "Select",
     "manual": "Manual",
+    "no_account_select": "No accounts to select",
     "current_balance_detail": "Current balance: $amount ICP"
   },
   "neurons": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -128,8 +128,6 @@
   "accounts": {
     "total": "Total",
     "main": "Main",
-    "main_account": "Main Account",
-    "account_name": "Account $name",
     "new_transaction": "New Transaction",
     "icp_transaction_description": "ICP Transaction",
     "review_action": "Review",
@@ -184,7 +182,7 @@
     "description": "Description",
     "edit_transaction": "Edit Transaction",
     "execute": "Execute",
-    "dropdown": "Dropdown",
+    "select": "Select",
     "manual": "Manual",
     "current_balance_detail": "Current balance: $amount ICP"
   },

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import { ICPToken, TokenAmount } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
-
   import { transferICP } from "../../services/accounts.services";
-
   import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import type { Step } from "../../stores/steps.state";
   import { toastsStore } from "../../stores/toasts.store";
+  import type { Account } from "../../types/account";
   import type { NewTransaction } from "../../types/transaction.context";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
+
+  export let selectedAccount: Account | undefined = undefined;
 
   let currentStep: Step;
 
@@ -56,7 +57,12 @@
   };
 </script>
 
-<TransactionModal on:nnsSubmit={transfer} on:nnsClose bind:currentStep>
+<TransactionModal
+  on:nnsSubmit={transfer}
+  on:nnsClose
+  bind:currentStep
+  sourceAccount={selectedAccount}
+>
   <svelte:fragment slot="title"
     >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
   >

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
+
+  import { transferICP } from "../../services/accounts.services";
+
+  import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
-
   import type { Step } from "../../stores/steps.state";
-
+  import { toastsStore } from "../../stores/toasts.store";
+  import type { NewTransaction } from "../../types/transaction.context";
+  import { isAccountHardwareWallet } from "../../utils/accounts.utils";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
 
   let currentStep: Step;
@@ -12,8 +19,40 @@
       ? $i18n.accounts.new_transaction
       : $i18n.accounts.review_transaction;
 
-  const transfer = () => {
-    console.log("transferring");
+  const dispatcher = createEventDispatcher();
+  const transfer = async ({
+    detail: { sourceAccount, amount, destinationAddress },
+  }: CustomEvent<NewTransaction>) => {
+    startBusy({
+      initiator: "accounts",
+      ...(isAccountHardwareWallet(sourceAccount) && {
+        labelKey: "busy_screen.pending_approval_hw",
+      }),
+    });
+
+    // Errors in amount already handled by TransactionModal
+    const tokenAmount = TokenAmount.fromNumber({
+      amount,
+      token: ICPToken,
+    }) as TokenAmount;
+
+    const { success } = await transferICP({
+      selectedAccount: sourceAccount,
+      destinationAddress,
+      amount: tokenAmount,
+    });
+
+    if (success) {
+      toastsStore.success({ labelKey: "accounts.transaction_success" });
+    }
+
+    stopBusy("accounts");
+
+    // We close the modal in case of success or error if the selected source is not a hardware wallet.
+    // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    if (success || !isAccountHardwareWallet(sourceAccount)) {
+      dispatcher("nnsClose");
+    }
   };
 </script>
 
@@ -21,4 +60,7 @@
   <svelte:fragment slot="title"
     >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
   >
+  <p slot="description">
+    {$i18n.accounts.icp_transaction_description}
+  </p>
 </TransactionModal>

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+
+  import type { Step } from "../../stores/steps.state";
+
+  import TransactionModal from "./NewTransaction/TransactionModal.svelte";
+
+  let currentStep: Step;
+
+  $: title =
+    currentStep?.name === "Form"
+      ? $i18n.accounts.new_transaction
+      : $i18n.accounts.review_transaction;
+
+  const transfer = () => {
+    console.log("transferring");
+  };
+</script>
+
+<TransactionModal on:nnsSubmit={transfer} on:nnsClose bind:currentStep>
+  <svelte:fragment slot="title"
+    >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+  >
+</TransactionModal>

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -5,7 +5,7 @@
   import { startBusy, stopBusy } from "../../stores/busy.store";
   import { i18n } from "../../stores/i18n";
   import type { Step } from "../../stores/steps.state";
-  import { toastsStore } from "../../stores/toasts.store";
+  import { toastsSuccess } from "../../stores/toasts.store";
   import type { Account } from "../../types/account";
   import type { NewTransaction } from "../../types/transaction.context";
   import { isAccountHardwareWallet } from "../../utils/accounts.utils";
@@ -44,7 +44,7 @@
     });
 
     if (success) {
-      toastsStore.success({ labelKey: "accounts.transaction_success" });
+      toastsSuccess({ labelKey: "accounts.transaction_success" });
     }
 
     stopBusy("accounts");

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -167,10 +167,6 @@
     }
   }
 
-  .label {
-    color: var(--label-color);
-  }
-
   .account-identifier {
     word-break: break-all;
   }

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -21,11 +21,12 @@
   import AmountDisplay from "../../../components/ic/AmountDisplay.svelte";
   import AmountInput from "../../../components/ui/AmountInput.svelte";
   import KeyValuePair from "../../../components/ui/KeyValuePair.svelte";
-  import SelecteDestinationAddress from "../../../components/accounts/SelecteDestinationAddress.svelte";
+  import SelectDestinationAddress from "../../../components/accounts/SelectDestinationAddress.svelte";
 
   // Tested in the TransactionModal
   export let selectedAccount: Account | undefined = undefined;
   export let canSelectDestination: boolean;
+  export let canSelectSource: boolean;
   export let selectedDestinationAddress: string | undefined = undefined;
   export let amount: number | undefined = undefined;
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
@@ -103,14 +104,25 @@
         />
       </KeyValuePair>
     {/if}
-    <SelectAccountDropdown bind:selectedAccount />
+    {#if canSelectSource}
+      <SelectAccountDropdown bind:selectedAccount />
+    {:else}
+      <div>
+        <p class="label">
+          {selectedAccount?.name ?? $i18n.accounts.main}
+        </p>
+        <p class="account-identifier">
+          {selectedAccount?.identifier}
+        </p>
+      </div>
+    {/if}
   </div>
   <div class="wrapper info">
     <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
     <slot name="additional-info" />
   </div>
   {#if canSelectDestination}
-    <SelecteDestinationAddress
+    <SelectDestinationAddress
       filterAccounts={filterDestinationAccounts}
       bind:selectedDestinationAddress
     />
@@ -155,5 +167,9 @@
 
   .label {
     color: var(--label-color);
+  }
+
+  .account-identifier {
+    word-break: break-all;
   }
 </style>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -17,10 +17,12 @@
   import AmountDisplay from "../../../components/ic/AmountDisplay.svelte";
   import AmountInput from "../../../components/ui/AmountInput.svelte";
   import KeyValuePair from "../../../components/ui/KeyValuePair.svelte";
+  import SelecteDestinationAddress from "../../../components/accounts/SelecteDestinationAddress.svelte";
 
   // Tested in the TransactionModal
-
   export let selectedAccount: Account | undefined = undefined;
+  export let canSelectDestination: boolean;
+  export let selectedDestinationAddress: string | undefined = undefined;
   export let amount: number | undefined = undefined;
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
   export let maxAmount: bigint | undefined = undefined;
@@ -92,6 +94,10 @@
     <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
     <slot name="additional-info" />
   </div>
+  {#if canSelectDestination}
+    <SelecteDestinationAddress bind:selectedDestinationAddress />
+  {/if}
+
   <FooterModal>
     <button
       class="small secondary"

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -32,6 +32,7 @@
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets: boolean = false;
+  export let showManualAddress: boolean = true;
 
   let filterDestinationAccounts: (account: Account) => boolean;
   $: filterDestinationAccounts = (account: Account) => {
@@ -125,6 +126,7 @@
     <SelectDestinationAddress
       filterAccounts={filterDestinationAccounts}
       bind:selectedDestinationAddress
+      bind:showManualAddress
     />
   {/if}
 

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -10,6 +10,7 @@
   import { InvalidAmountError } from "../../../types/neurons.errors";
   import {
     assertEnoughAccountFunds,
+    invalidAddress,
     isAccountHardwareWallet,
   } from "../../../utils/accounts.utils";
   import {
@@ -52,6 +53,7 @@
     selectedAccount === undefined ||
     amount === 0 ||
     amount === undefined ||
+    invalidAddress(selectedDestinationAddress) ||
     errorMessage !== undefined;
 
   let errorMessage: string | undefined = undefined;
@@ -67,6 +69,7 @@
         account: selectedAccount,
         amountE8s: icp.toE8s() + $mainTransactionFeeStoreAsIcp.toE8s(),
       });
+      errorMessage = undefined;
     } catch (error) {
       if (error instanceof InvalidAmountError) {
         errorMessage = $i18n.error.amount_not_valid;
@@ -92,7 +95,7 @@
   <div class="select-account">
     {#if selectedAccount !== undefined}
       <KeyValuePair>
-        <span slot="key">{$i18n.accounts.source}</span>
+        <span slot="key" class="label">{$i18n.accounts.source}</span>
         <AmountDisplay
           slot="value"
           singleLine
@@ -148,5 +151,9 @@
     &.info {
       gap: var(--padding-2x);
     }
+  }
+
+  .label {
+    color: var(--label-color);
   }
 </style>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -10,6 +10,7 @@
   export let disableSubmit: boolean = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
+  export let skipHardwareWallets: boolean = false;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
   let selectedDestinationAddress: string | undefined = destinationAddress;
@@ -47,6 +48,7 @@
       bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount
+      {skipHardwareWallets}
       {maxAmount}
       on:nnsNext={goNext}
       on:nnsClose
@@ -54,10 +56,10 @@
       <slot name="additional-info-form" slot="additional-info" />
     </TransactionForm>
   {/if}
-  {#if currentStep?.name === "Review" && selectedAccount !== undefined && amount !== undefined && destinationAddress !== undefined}
+  {#if currentStep?.name === "Review" && selectedAccount !== undefined && amount !== undefined && selectedDestinationAddress !== undefined}
     <TransactionReview
       transaction={{
-        destinationAddress,
+        destinationAddress: selectedDestinationAddress,
         sourceAccount: selectedAccount,
         amount,
       }}

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -37,6 +37,7 @@
   let selectedAccount: Account | undefined = sourceAccount;
   let canSelectSource: boolean = sourceAccount === undefined;
   let amount: number | undefined;
+  let showManualAddress: boolean = true;
 
   const goNext = () => {
     modal.next();
@@ -55,6 +56,7 @@
       bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount
+      bind:showManualAddress
       {skipHardwareWallets}
       {maxAmount}
       on:nnsNext={goNext}

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -6,12 +6,13 @@
   import TransactionReview from "./TransactionReview.svelte";
 
   export let currentStep: Step | undefined = undefined;
-  export let destinationAddress: string;
+  export let destinationAddress: string | undefined = undefined;
   export let disableSubmit: boolean = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
+  let selectedDestinationAddress: string | undefined = destinationAddress;
   const steps: Steps = [
     {
       name: "Form",
@@ -42,6 +43,8 @@
   <slot name="title" slot="title" />
   {#if currentStep?.name === "Form"}
     <TransactionForm
+      canSelectDestination={destinationAddress === undefined}
+      bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount
       {maxAmount}
@@ -51,7 +54,7 @@
       <slot name="additional-info-form" slot="additional-info" />
     </TransactionForm>
   {/if}
-  {#if currentStep?.name === "Review" && selectedAccount !== undefined && amount !== undefined}
+  {#if currentStep?.name === "Review" && selectedAccount !== undefined && amount !== undefined && destinationAddress !== undefined}
     <TransactionReview
       transaction={{
         destinationAddress,

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -7,13 +7,13 @@
 
   export let currentStep: Step | undefined = undefined;
   export let destinationAddress: string | undefined = undefined;
+  export let sourceAccount: Account | undefined = undefined;
   export let disableSubmit: boolean = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets: boolean = false;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
-  let selectedDestinationAddress: string | undefined = destinationAddress;
   const steps: Steps = [
     {
       name: "Form",
@@ -29,7 +29,13 @@
 
   let modal: WizardModal;
 
-  let selectedAccount: Account | undefined;
+  // If destination or source are passed as prop, they are used.
+  // But the component doesn't bind them to the props.
+  // This way we can identify whether to show a dropdown to select destination or source.
+  let selectedDestinationAddress: string | undefined = destinationAddress;
+  let canSelectDestination: boolean = destinationAddress === undefined;
+  let selectedAccount: Account | undefined = sourceAccount;
+  let canSelectSource: boolean = sourceAccount === undefined;
   let amount: number | undefined;
 
   const goNext = () => {
@@ -44,7 +50,8 @@
   <slot name="title" slot="title" />
   {#if currentStep?.name === "Form"}
     <TransactionForm
-      canSelectDestination={destinationAddress === undefined}
+      {canSelectDestination}
+      {canSelectSource}
       bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -7,7 +7,6 @@
   import { i18n } from "../../../stores/i18n";
   import { mainTransactionFeeStoreAsToken } from "../../../derived/main-transaction-fee.derived";
   import type { Account } from "../../../types/account";
-  import { replacePlaceholders } from "../../../utils/i18n.utils";
   import AmountDisplay from "../../../components/ic/AmountDisplay.svelte";
   import KeyValuePair from "../../../components/ui/KeyValuePair.svelte";
   import type { NewTransaction } from "../../../types/transaction.context";

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -41,10 +41,15 @@
       <AmountDisplay slot="value" singleLine amount={sourceAccount.balance} />
     </KeyValuePair>
     <div>
-      <p class="label" data-tid="transaction-review-source-account">
+      <p class="label">
         {sourceAccount.name ?? $i18n.accounts.main}
       </p>
-      <p class="account-identifier">{sourceAccount.identifier}</p>
+      <p
+        data-tid="transaction-review-source-account"
+        class="account-identifier"
+      >
+        {sourceAccount.identifier}
+      </p>
     </div>
     <div class="highlight">
       <span class="icon">

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -135,8 +135,4 @@
 
     --select-padding: var(--padding-2x) 0;
   }
-
-  .label {
-    color: var(--label-color);
-  }
 </style>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -37,20 +37,14 @@
 <div data-tid="transaction-step-2">
   <div class="info">
     <KeyValuePair>
-      <span slot="key">{$i18n.accounts.source}</span>
+      <span class="label" slot="key">{$i18n.accounts.source}</span>
       <AmountDisplay slot="value" singleLine amount={sourceAccount.balance} />
     </KeyValuePair>
     <div>
-      <p data-tid="transaction-review-source-account">
-        {#if sourceAccount.type === "main"}
-          {$i18n.accounts.main_account}
-        {:else}
-          {replacePlaceholders($i18n.accounts.account_name, {
-            $name: sourceAccount.name ?? "",
-          })}
-        {/if}
-        <span class="account-identifier">{sourceAccount.identifier}</span>
+      <p class="label" data-tid="transaction-review-source-account">
+        {sourceAccount.name ?? $i18n.accounts.main}
       </p>
+      <p class="account-identifier">{sourceAccount.identifier}</p>
     </div>
     <div class="highlight">
       <span class="icon">
@@ -65,12 +59,13 @@
       </div>
     </div>
     <div>
-      <h5>{$i18n.accounts.destination}</h5>
+      <p class="label">{$i18n.accounts.destination}</p>
+      <p />
       <slot name="destination-info" />
       <p class="account-identifier">{destinationAddress}</p>
     </div>
     <div>
-      <h5>{$i18n.accounts.description}</h5>
+      <p class="label">{$i18n.accounts.description}</p>
       <slot name="description" />
     </div>
   </div>
@@ -135,5 +130,9 @@
     gap: var(--padding);
 
     --select-padding: var(--padding-2x) 0;
+  }
+
+  .label {
+    color: var(--label-color);
   }
 </style>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -8,10 +8,8 @@
   import { mainTransactionFeeStoreAsToken } from "../../../derived/main-transaction-fee.derived";
   import type { Account } from "../../../types/account";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
-  import { valueSpan } from "../../../utils/utils";
   import AmountDisplay from "../../../components/ic/AmountDisplay.svelte";
   import KeyValuePair from "../../../components/ui/KeyValuePair.svelte";
-  import { sanitize } from "../../../utils/html.utils";
   import type { NewTransaction } from "../../../types/transaction.context";
 
   export let transaction: NewTransaction;
@@ -44,9 +42,14 @@
     </KeyValuePair>
     <div>
       <p data-tid="transaction-review-source-account">
-        {@html replacePlaceholders($i18n.accounts.main_account, {
-          $identifier: valueSpan(sanitize(destinationAddress)),
-        })}
+        {#if sourceAccount.type === "main"}
+          {$i18n.accounts.main_account}
+        {:else}
+          {replacePlaceholders($i18n.accounts.account_name, {
+            $name: sourceAccount.name ?? "",
+          })}
+        {/if}
+        <span class="account-identifier">{sourceAccount.identifier}</span>
       </p>
     </div>
     <div class="highlight">
@@ -64,7 +67,7 @@
     <div>
       <h5>{$i18n.accounts.destination}</h5>
       <slot name="destination-info" />
-      <p class="value">{destinationAddress}</p>
+      <p class="account-identifier">{destinationAddress}</p>
     </div>
     <div>
       <h5>{$i18n.accounts.description}</h5>
@@ -91,6 +94,10 @@
 
 <style lang="scss">
   @use "../../../themes/mixins/modal";
+
+  .account-identifier {
+    word-break: break-all;
+  }
 
   .highlight {
     padding: var(--padding-2x);

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -115,6 +115,7 @@
     on:nnsSubmit={participate}
     {destinationAddress}
     disableSubmit={!accepted}
+    skipHardwareWallets
     maxAmount={projectRemainingAmount(summary)}
   >
     <svelte:fragment slot="title"

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -193,6 +193,7 @@ interface I18nAccounts {
   execute: string;
   select: string;
   manual: string;
+  no_account_select: string;
   current_balance_detail: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -138,7 +138,10 @@ interface I18nAccounts {
   total: string;
   main: string;
   main_account: string;
+  account_name: string;
   new_transaction: string;
+  icp_transaction_description: string;
+  review_action: string;
   add_account: string;
   new_linked_title: string;
   new_linked_subtitle: string;
@@ -190,6 +193,8 @@ interface I18nAccounts {
   description: string;
   edit_transaction: string;
   execute: string;
+  dropdown: string;
+  manual: string;
   current_balance_detail: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -137,8 +137,6 @@ interface I18nAuth {
 interface I18nAccounts {
   total: string;
   main: string;
-  main_account: string;
-  account_name: string;
   new_transaction: string;
   icp_transaction_description: string;
   review_action: string;
@@ -193,7 +191,7 @@ interface I18nAccounts {
   description: string;
   edit_transaction: string;
   execute: string;
-  dropdown: string;
+  select: string;
   manual: string;
   current_balance_detail: string;
 }

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -105,7 +105,6 @@
   <AddAcountModal on:nnsClose={closeModal} />
 {/if}
 {#if modal === "NewTransaction"}
-  <!-- <NewTransactionModal on:nnsClose={closeModal} /> -->
   <IcpTransactionModal on:nnsClose={closeModal} />
 {/if}
 

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -17,6 +17,8 @@
   import Footer from "../lib/components/common/Footer.svelte";
   import Tooltip from "../lib/components/ui/Tooltip.svelte";
   import { replacePlaceholders } from "../lib/utils/i18n.utils";
+  import TransactionModal from "../lib/modals/accounts/NewTransaction/TransactionModal.svelte";
+  import IcpTransactionModal from "../lib/modals/accounts/IcpTransactionModal.svelte";
 
   let accounts: AccountsStore | undefined;
 
@@ -103,7 +105,8 @@
   <AddAcountModal on:nnsClose={closeModal} />
 {/if}
 {#if modal === "NewTransaction"}
-  <NewTransactionModal on:nnsClose={closeModal} />
+  <!-- <NewTransactionModal on:nnsClose={closeModal} /> -->
+  <IcpTransactionModal on:nnsClose={closeModal} />
 {/if}
 
 {#if accounts}

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -12,12 +12,10 @@
   import AddAcountModal from "../lib/modals/accounts/AddAccountModal.svelte";
   import { TokenAmount } from "@dfinity/nns";
   import { formatICP, sumTokenAmounts } from "../lib/utils/icp.utils";
-  import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
   import Footer from "../lib/components/common/Footer.svelte";
   import Tooltip from "../lib/components/ui/Tooltip.svelte";
   import { replacePlaceholders } from "../lib/utils/i18n.utils";
-  import TransactionModal from "../lib/modals/accounts/NewTransaction/TransactionModal.svelte";
   import IcpTransactionModal from "../lib/modals/accounts/IcpTransactionModal.svelte";
 
   let accounts: AccountsStore | undefined;

--- a/frontend/src/routes/Wallet.svelte
+++ b/frontend/src/routes/Wallet.svelte
@@ -29,6 +29,7 @@
   import { getAccountFromStore } from "../lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "../lib/stores/debug.store";
   import { layoutBackStore } from "../lib/stores/layout.store";
+  import IcpTransactionModal from "../lib/modals/accounts/IcpTransactionModal.svelte";
 
   const goBack = () =>
     routeStore.navigate({
@@ -145,7 +146,7 @@
 </Footer>
 
 {#if showNewTransactionModal}
-  <NewTransactionModal
+  <IcpTransactionModal
     on:nnsClose={() => (showNewTransactionModal = false)}
     selectedAccount={$selectedAccountStore.account}
   />

--- a/frontend/src/routes/Wallet.svelte
+++ b/frontend/src/routes/Wallet.svelte
@@ -5,7 +5,6 @@
   import Footer from "../lib/components/common/Footer.svelte";
   import { routeStore } from "../lib/stores/route.store";
   import { AppPath } from "../lib/constants/routes.constants";
-  import NewTransactionModal from "../lib/modals/accounts/NewTransactionModal.svelte";
   import {
     getAccountTransactions,
     routePathAccountIdentifier,

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import AddressInput from "../../../../lib/components/accounts/AddressInput.svelte";
+import { ACCOUNT_ADDRESS_MIN_LENGTH } from "../../../../lib/constants/accounts.constants";
+
+describe("AddressInput", () => {
+  const props = { props: { address: undefined } };
+
+  it("should render an input with a minimal length of 40", () => {
+    const { container } = render(AddressInput, props);
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute("minlength")).toEqual(
+      `${ACCOUNT_ADDRESS_MIN_LENGTH}`
+    );
+  });
+
+  it("should show error message on blur when invalid address", async () => {
+    const { container, queryByTestId } = render(AddressInput, props);
+
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: "invalid-address" } });
+    await fireEvent.blur(input);
+    expect(queryByTestId("input-error-message")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -5,6 +5,7 @@
 import { fireEvent, render } from "@testing-library/svelte";
 import SelectAccountDropdown from "../../../../lib/components/accounts/SelectAccountDropdown.svelte";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
+import { isAccountHardwareWallet } from "../../../../lib/utils/accounts.utils";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
@@ -45,7 +46,7 @@ describe("SelectAccountDropdown", () => {
 
   it("should not render accounts hardware wallets", () => {
     const { container } = render(SelectAccountDropdown, {
-      skipHardwareWallets: true,
+      filterAccounts: (account) => !isAccountHardwareWallet(account),
     });
 
     // main + subaccounts

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import SelectDestinationAddress from "../../../../lib/components/accounts/SelectDestinationAddress.svelte";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import {
+  mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+
+describe("SelectDestinationAddress", () => {
+  const mockSubAccount2 = {
+    ...mockSubAccount,
+    identifier: "test-identifier",
+  };
+  const subaccounts = [mockSubAccount, mockSubAccount2];
+  const hardwareWallets = [mockHardwareWalletAccount];
+
+  jest
+    .spyOn(accountsStore, "subscribe")
+    .mockImplementation(
+      mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
+    );
+
+  it("should render address input as default", () => {
+    const { container } = render(SelectDestinationAddress);
+
+    expect(
+      container.querySelector("input[name='accounts-address']")
+    ).toBeInTheDocument();
+  });
+
+  it("should render toggle", () => {
+    const { container } = render(SelectDestinationAddress);
+
+    const toggle = container.querySelector("input[id='toggle']");
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("should render select account dropdown when toggle is clicked", async () => {
+    const { container, queryByTestId } = render(SelectDestinationAddress);
+
+    expect(
+      container.querySelector("input[name='accounts-address']")
+    ).toBeInTheDocument();
+
+    const toggle = container.querySelector("input[id='toggle']");
+    toggle && fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(queryByTestId("select-account-dropdown")).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -1,0 +1,11 @@
+import { get } from "svelte/store";
+import { accountsListStore } from "../../../lib/derived/accounts-list.derived";
+import { accountsStore } from "../../../lib/stores/accounts.store";
+
+describe("accounts", () => {
+  it("should return empty array if main is not set", () => {
+    accountsStore.reset();
+    const value = get(accountsListStore);
+    expect(value.length).toBe(0);
+  });
+});

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, waitFor } from "@testing-library/svelte";
+import IcpTransactionModal from "../../../../lib/modals/accounts/IcpTransactionModal.svelte";
+import { transferICP } from "../../../../lib/services/accounts.services";
+import { accountsStore } from "../../../../lib/stores/accounts.store";
+import {
+  mockAccountsStoreSubscribe,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
+import { renderModal } from "../../../mocks/modal.mock";
+
+jest.mock("../../../../lib/services/accounts.services", () => {
+  return {
+    transferICP: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+describe("IcpTransactionModal", () => {
+  const renderTransactionModal = () =>
+    renderModal({
+      component: IcpTransactionModal,
+      props: {},
+    });
+
+  beforeEach(() => {
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+  });
+
+  it("should transfer icps", async () => {
+    const { queryAllByText, getByTestId, container } =
+      await renderTransactionModal();
+
+    await waitFor(() =>
+      expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+    const participateButton = getByTestId("transaction-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    // Enter amount
+    const icpAmount = "10";
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: icpAmount } });
+
+    // Choose select account
+    // It will choose the fist subaccount as default
+    const toggle = container.querySelector("input[id='toggle']");
+    toggle && fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+
+    fireEvent.click(participateButton);
+
+    await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());
+    expect(queryAllByText(icpAmount, { exact: false }).length).toBeGreaterThan(
+      0
+    );
+
+    const confirmButton = getByTestId("transaction-button-execute");
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(transferICP).toBeCalled());
+  });
+});

--- a/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
@@ -6,27 +6,40 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../../lib/constants/icp.constants";
 import TransactionModal from "../../../../lib/modals/accounts/NewTransaction/TransactionModal.svelte";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
+import type { Account } from "../../../../lib/types/account";
 import { formattedTransactionFeeICP } from "../../../../lib/utils/icp.utils";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
+  mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import { clickByTestId } from "../../testHelpers/clickByTestId";
 
 describe("TransactionModal", () => {
-  const renderTransactionModal = () =>
+  const renderTransactionModal = (props?: {
+    destinationAddress?: string;
+    sourceAccount?: Account;
+  }) =>
     renderModal({
       component: TransactionModal,
-      props: {
-        destinationAddress: mockMainAccount.identifier,
-      },
+      props: props ?? {},
     });
 
-  const renderEnter10ICPAndNext = async (): Promise<RenderResult> => {
-    const result = await renderTransactionModal();
+  beforeEach(() => {
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+  });
 
-    const { queryByText, getByTestId, container } = result;
+  const renderEnter10ICPAndNext = async (
+    destination?: string
+  ): Promise<RenderResult> => {
+    const result = await renderTransactionModal({
+      destinationAddress: destination,
+    });
+
+    const { queryAllByText, getByTestId, container } = result;
 
     const participateButton = getByTestId("transaction-button-next");
     expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
@@ -34,6 +47,12 @@ describe("TransactionModal", () => {
     const icpAmount = "10";
     const input = container.querySelector("input[name='amount']");
     input && fireEvent.input(input, { target: { value: icpAmount } });
+
+    // Choose select account
+    // It will choose the fist subaccount as default
+    const toggle = container.querySelector("input[id='toggle']");
+    toggle && fireEvent.click(toggle);
+
     await waitFor(() =>
       expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
     );
@@ -41,106 +60,147 @@ describe("TransactionModal", () => {
     fireEvent.click(participateButton);
 
     await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());
-    expect(queryByText(icpAmount, { exact: false })).toBeInTheDocument();
+    expect(queryAllByText(icpAmount, { exact: false }).length).toBe(2);
 
     return result;
   };
 
-  beforeEach(() => {
-    jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
+  describe("when destination is not provided", () => {
+    it("should display modal", async () => {
+      const { container } = await renderTransactionModal();
+
+      expect(container.querySelector("div.modal")).not.toBeNull();
+    });
+
+    it("should display dropdown to select account, input to add amount and select destination account", async () => {
+      const { queryByTestId, container } = await renderTransactionModal();
+
+      expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
+      expect(
+        container.querySelector("input[name='amount']")
+      ).toBeInTheDocument();
+    });
+
+    it("should trigger close on cancel", async () => {
+      const { getByTestId, component } = await renderTransactionModal();
+
+      const onClose = jest.fn();
+      component.$on("nnsClose", onClose);
+
+      await clickByTestId(getByTestId, "transaction-button-cancel");
+
+      await waitFor(() => expect(onClose).toBeCalled());
+    });
+
+    it("should have disabled button by default", async () => {
+      const { getByTestId } = await renderTransactionModal();
+
+      const participateButton = getByTestId("transaction-button-next");
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+    });
+
+    it("should enable button when input value and select a destination changes", async () => {
+      const { getByTestId, container } = await renderTransactionModal();
+
+      const participateButton = getByTestId("transaction-button-next");
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: "10" } });
+
+      // Choose select account
+      // It will choose the fist subaccount as default
+      const toggle = container.querySelector("input[id='toggle']");
+      toggle && fireEvent.click(toggle);
+
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+    });
+
+    it("should move to the last step and render review info", async () => {
+      const { getByText, getByTestId } = await renderEnter10ICPAndNext();
+
+      expect(
+        (
+          getByTestId("transaction-review-source-account").textContent ?? ""
+        ).includes(mockMainAccount.identifier)
+      ).toBeTruthy();
+      expect(
+        getByText(formattedTransactionFeeICP(DEFAULT_TRANSACTION_FEE_E8S))
+      ).toBeInTheDocument();
+    });
+
+    it("should move to the last step and trigger nnsSubmit event", async () => {
+      const { getByTestId, component } = await renderEnter10ICPAndNext();
+
+      const onSubmit = jest.fn();
+      component.$on("nnsSubmit", onSubmit);
+
+      const confirmButton = getByTestId("transaction-button-execute");
+
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => expect(onSubmit).toBeCalled());
+    });
+
+    it("should move to the last step and go back", async () => {
+      const { getByTestId, container } = await renderTransactionModal();
+
+      const participateButton = getByTestId("transaction-button-next");
+
+      expect(participateButton).toBeInTheDocument();
+
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: "10" } });
+
+      // Choose select account
+      // It will choose the fist subaccount as default
+      const toggle = container.querySelector("input[id='toggle']");
+      toggle && fireEvent.click(toggle);
+
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+
+      fireEvent.click(participateButton);
+      await waitFor(() =>
+        expect(getByTestId("transaction-step-2")).toBeTruthy()
+      );
+
+      await clickByTestId(getByTestId, "transaction-button-back");
+      await waitFor(() =>
+        expect(getByTestId("transaction-step-1")).toBeTruthy()
+      );
+    });
   });
 
-  it("should display modal", async () => {
-    const { container } = await renderTransactionModal();
+  describe("when destination address is provided", () => {
+    it("should not show the select destination component", async () => {
+      const { queryByTestId, container } = await renderTransactionModal({
+        destinationAddress: mockMainAccount.identifier,
+      });
 
-    expect(container.querySelector("div.modal")).not.toBeNull();
+      expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
+      expect(queryByTestId("select-destination")).not.toBeInTheDocument();
+      expect(
+        container.querySelector("input[name='amount']")
+      ).toBeInTheDocument();
+    });
   });
 
-  it("should display dropdown to select account and input to add amount", async () => {
-    const { queryByTestId, container } = await renderTransactionModal();
+  describe("when source account is provided", () => {
+    it("should not show the select account component", async () => {
+      const { queryByTestId, container } = await renderTransactionModal({
+        sourceAccount: mockMainAccount,
+      });
 
-    expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
-    expect(container.querySelector("input[name='amount']")).toBeInTheDocument();
-  });
-
-  it("should trigger close on cancel", async () => {
-    const { getByTestId, component } = await renderTransactionModal();
-
-    const onClose = jest.fn();
-    component.$on("nnsClose", onClose);
-
-    await clickByTestId(getByTestId, "transaction-button-cancel");
-
-    await waitFor(() => expect(onClose).toBeCalled());
-  });
-
-  it("should have disabled button by default", async () => {
-    const { getByTestId } = await renderTransactionModal();
-
-    const participateButton = getByTestId("transaction-button-next");
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-  });
-
-  it("should enable button when input value changes", async () => {
-    const { getByTestId, container } = await renderTransactionModal();
-
-    const participateButton = getByTestId("transaction-button-next");
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-
-    const input = container.querySelector("input[name='amount']");
-    input && fireEvent.input(input, { target: { value: "10" } });
-    await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
-    );
-  });
-
-  it("should move to the last step and render review info", async () => {
-    const { getByText, getByTestId } = await renderEnter10ICPAndNext();
-
-    expect(
-      (
-        getByTestId("transaction-review-source-account").textContent ?? ""
-      ).includes(mockMainAccount.identifier)
-    ).toBeTruthy();
-    expect(
-      getByText(formattedTransactionFeeICP(DEFAULT_TRANSACTION_FEE_E8S))
-    ).toBeInTheDocument();
-  });
-
-  it("should move to the last step and trigger nnsSubmit event", async () => {
-    const { getByTestId, component } = await renderEnter10ICPAndNext();
-
-    const onSubmit = jest.fn();
-    component.$on("nnsSubmit", onSubmit);
-
-    const confirmButton = getByTestId("transaction-button-execute");
-
-    fireEvent.click(confirmButton);
-
-    await waitFor(() => expect(onSubmit).toBeCalled());
-  });
-
-  it("should move to the last step and go back", async () => {
-    const { getByTestId, container } = await renderTransactionModal();
-
-    const participateButton = getByTestId("transaction-button-next");
-
-    expect(participateButton).toBeInTheDocument();
-
-    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
-
-    const input = container.querySelector("input[name='amount']");
-    input && fireEvent.input(input, { target: { value: "10" } });
-    await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
-    );
-
-    fireEvent.click(participateButton);
-    await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());
-
-    await clickByTestId(getByTestId, "transaction-button-back");
-    await waitFor(() => expect(getByTestId("transaction-step-1")).toBeTruthy());
+      expect(queryByTestId("select-account-dropdown")).not.toBeInTheDocument();
+      expect(
+        container.querySelector("input[name='amount']")
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/accounts.store.mock.ts
@@ -22,7 +22,7 @@ export const mockMainAccount: Account = {
 
 export const mockSubAccount: Account = {
   identifier:
-    "aaaa5b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+    "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
   balance: TokenAmount.fromString({
     amount: "1234567.8901",
     token: ICPToken,

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -170,19 +170,13 @@ describe("Accounts", () => {
   });
 
   it("should open transaction modal", async () => {
-    const { container, getByText } = render(Accounts);
+    const { getByTestId } = render(Accounts);
 
-    const button = container.querySelector(
-      '[data-tid="open-new-transaction"]'
-    ) as HTMLButtonElement;
+    const button = getByTestId("open-new-transaction");
     await fireEvent.click(button);
 
     await waitFor(() => {
-      expect(container.querySelector("div.modal")).not.toBeNull();
-
-      expect(
-        getByText(en.accounts.select_source, { exact: false })
-      ).toBeInTheDocument();
+      expect(getByTestId("transaction-step-1")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/tests/routes/Wallet.spec.ts
+++ b/frontend/src/tests/routes/Wallet.spec.ts
@@ -14,7 +14,6 @@ import {
   mockMainAccount,
 } from "../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
-import en from "../mocks/i18n.mock";
 import { mockRouteStoreSubscribe } from "../mocks/route.store.mock";
 
 jest.mock("../../lib/services/accounts.services", () => ({
@@ -129,13 +128,13 @@ describe("Wallet", () => {
     });
 
     it("should open transaction modal on step select destination because selected account is current account", async () => {
-      const { container, getByText } = render(Wallet);
+      const { container, getByTestId } = render(Wallet);
 
       await testModal(container);
 
-      expect(
-        getByText(en.accounts.select_destination, { exact: false })
-      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+      );
     });
 
     it("should display SkeletonCard while loading transactions", async () => {


### PR DESCRIPTION
# Motivation

Implement the new transaction flow.

This will also allow us to implement the new modal UI.

# Changes

* Change TransactionModal so that the user can select a destination or pass a selected account.
* New IcpTransactionModal to transafer ICPs.
* New SelectDestinationAddress to select a destination from current accounts with dropdown or address input.
* Extract AdressInput from Adress to be used in SelectDestinationAddress.
* Changed skipHardwareWallets prop in SelectAccountDropdown for a function to filter accounts. Used to filter the already selected account and also hardware wallets.
* Change UI of the dropdown to make it look more similar to the input.
* New prop showInfo in Input component. There was an extra space from the gap otherwise.

# Tests

* Add test cases in Transaction modal when user passes a destination or a source account initially.
* Test for IcpTransactionModal
* Test for SelectDestinationAddress
* Test for AddressInput
* New test in SelectAccountDropdown to check new filterAccounts prop.
