### PR TITLE
style: fix popover z-index

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-14.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.1.tgz",
-      "integrity": "sha512-PBjyxPtNvkawPugNE+2buP6bxEVEe4wf9pzFOvVP37+FpImCwQ5IlSXxc+aGyeP88XprO6TcAtqIs8c+SyWV3g=="
+      "version": "0.0.1-next-2022-09-14.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.2.tgz",
+      "integrity": "sha512-cn0q185WjaTyTqS+H6Dr3n/jy9Avy3PKDTvFYBNrZKQPxjT7AeQSyeVsWCRFeopF8UNEfe6R4KKgzvY27RXukg=="
     },
     "node_modules/@dfinity/identity": {
       "version": "1.0.0-beta.0",
@@ -9959,9 +9959,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-14.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.1.tgz",
-      "integrity": "sha512-PBjyxPtNvkawPugNE+2buP6bxEVEe4wf9pzFOvVP37+FpImCwQ5IlSXxc+aGyeP88XprO6TcAtqIs8c+SyWV3g=="
+      "version": "0.0.1-next-2022-09-14.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.2.tgz",
+      "integrity": "sha512-cn0q185WjaTyTqS+H6Dr3n/jy9Avy3PKDTvFYBNrZKQPxjT7AeQSyeVsWCRFeopF8UNEfe6R4KKgzvY27RXukg=="
     },
     "@dfinity/identity": {
       "version": "1.0.0-beta.0",

--- a/frontend/src/lib/themes/mixins/_overlay.scss
+++ b/frontend/src/lib/themes/mixins/_overlay.scss
@@ -9,7 +9,7 @@
   position: fixed;
   @include display.inset;
 
-  z-index: var(--overlay-z-index);
+  z-index: var(--modal-z-index);
 
   .wrapper {
     cursor: initial;


### PR DESCRIPTION
# Motivation

More z-index issue following the introduction of the new bottom sheet

# PR

- [x] need https://github.com/dfinity/gix-components/pull/65

# Changes

- integrate last z-index changes of `gix-components`
- set popover to same z-indexes as modals

# Screenshots

Issues:

<img width="922" alt="Capture d’écran 2022-09-14 à 10 44 06" src="https://user-images.githubusercontent.com/16886711/190119217-1fdb9c98-ef3d-46e3-89de-5eebf4b66f8e.png">
<img width="922" alt="Capture d’écran 2022-09-14 à 10 44 09" src="https://user-images.githubusercontent.com/16886711/190119231-f8fb8546-69e7-4e80-a146-e84dce2e4d94.png">

Afterwards:

<img width="1404" alt="Capture d’écran 2022-09-14 à 10 57 51" src="https://user-images.githubusercontent.com/16886711/190119274-1e7940bf-7941-42d1-8215-fc085a24d55f.png">
<img width="1404" alt="Capture d’écran 2022-09-14 à 10 57 55" src="https://user-images.githubusercontent.com/16886711/190119299-5ecb9c9f-e43e-4320-a147-79241e941927.png">
<img width="1404" alt="Capture d’écran 2022-09-14 à 10 57 58" src="https://user-images.githubusercontent.com/16886711/190119308-83b1ec34-b485-4262-8567-966b6510674e.png">
<img width="1404" alt="Capture d’écran 2022-09-14 à 10 58 03" src="https://user-images.githubusercontent.com/16886711/190119320-bdf71b4c-a1dc-43a4-b028-d6ae699a1c6b.png">
<img width="1510" alt="Capture d’écran 2022-09-14 à 11 31 08" src="https://user-images.githubusercontent.com/16886711/190119323-f2f217fe-0c10-4a50-93ca-b817bd47cd33.png">
<img width="1510" alt="Capture d’écran 2022-09-14 à 11 31 12" src="https://user-images.githubusercontent.com/16886711/190119328-7f861402-0d21-40b8-bd82-f78f3b4f45d7.png">

