### PR TITLE
feat: proposer voting history neuron card info

### DIFF
--- a/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -39,7 +39,7 @@
 
   {#if neuron !== undefined}
     <div class="content">
-      <NeuronCard proposerNeuron {neuron} />
+      <NeuronCard proposerNeuron {neuron} cardType="info" />
 
       <VotingHistoryCard {neuron} />
     </div>


### PR DESCRIPTION
# Motivation

There is a text overflow on the proposer "voting history" neuron info.

# Changes

- instead of displaying a card use the info layout

# Screenshots

issue:

<img width="1510" alt="Capture d’écran 2022-09-14 à 15 24 05" src="https://user-images.githubusercontent.com/16886711/190166930-cbe9d8a2-e9d8-45e8-9096-1cb54f00f172.png">

new:

<img width="1510" alt="Capture d’écran 2022-09-14 à 15 24 25" src="https://user-images.githubusercontent.com/16886711/190167034-f5408eb2-eac7-4b70-8826-85d4e19c197c.png">
<img width="1510" alt="Capture d’écran 2022-09-14 à 15 24 41" src="https://user-images.githubusercontent.com/16886711/190167050-e9aab1aa-b2d7-41c4-a9bd-afe492dcb608.png">
<img width="1510" alt="Capture d’écran 2022-09-14 à 15 28 38" src="https://user-images.githubusercontent.com/16886711/190167093-f48eb7cc-d587-431a-bcb0-c02d90230d24.png">

