### PR TITLE
L2-992: Project dropdown for accounts

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -34,7 +34,7 @@
         return;
       }
       // if the path is unsupported (to mock the flutter dapp) the user will be redirected to the first page (/accounts/) page (unknown path will not be saved in session History)
-      routeStore.replace({ path: AppPath.Accounts });
+      routeStore.replace({ path: AppPath.LegacyAccounts });
     }
   );
 
@@ -53,6 +53,7 @@
 <Guard>
   <Route path={AppPath.Authentication} />
   <PrivateRoute path={AppPath.Accounts} />
+  <PrivateRoute path={AppPath.LegacyAccounts} />
   <PrivateRoute path={AppPath.LegacyNeurons} />
   <PrivateRoute path={AppPath.Neurons} />
   <PrivateRoute path={AppPath.Proposals} />

--- a/frontend/src/lib/components/accounts/AccountsTitle.svelte
+++ b/frontend/src/lib/components/accounts/AccountsTitle.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div class="title">
-  <h1 data-tid="accounts-title">{$i18n.accounts.title}</h1>
+  <h1 data-tid="accounts-title">{$i18n.accounts.total}</h1>
 
   {#if balance !== undefined}
     <Tooltip

--- a/frontend/src/lib/components/accounts/AccountsTitle.svelte
+++ b/frontend/src/lib/components/accounts/AccountsTitle.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div class="title">
-  <h1>{$i18n.accounts.title}</h1>
+  <h1 data-tid="accounts-title">{$i18n.accounts.title}</h1>
 
   {#if balance !== undefined}
     <Tooltip

--- a/frontend/src/lib/components/accounts/AccountsTitle.svelte
+++ b/frontend/src/lib/components/accounts/AccountsTitle.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { TokenAmount } from "@dfinity/nns";
+  import { i18n } from "../../stores/i18n";
+  import { replacePlaceholders } from "../../utils/i18n.utils";
+  import { formatICP } from "../../utils/icp.utils";
+  import AmountDisplay from "../ic/AmountDisplay.svelte";
+  import Tooltip from "../ui/Tooltip.svelte";
+
+  export let balance: TokenAmount | undefined;
+
+  let totalTokens: string;
+  totalTokens =
+    balance !== undefined
+      ? formatICP({
+          value: balance.toE8s(),
+          detailed: true,
+        })
+      : "";
+</script>
+
+<div class="title">
+  <h1>{$i18n.accounts.title}</h1>
+
+  {#if balance !== undefined}
+    <Tooltip
+      id="wallet-total-icp"
+      text={replacePlaceholders($i18n.accounts.current_balance_total, {
+        $amount: totalTokens,
+      })}
+    >
+      <AmountDisplay amount={balance} />
+    </Tooltip>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/media";
+
+  .title {
+    display: block;
+    width: 100%;
+
+    margin-bottom: var(--padding-2x);
+
+    --icp-font-size: var(--font-size-h1);
+
+    // Minimum height of ICP value + ICP label (ICP component)
+    min-height: calc(
+      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
+    );
+
+    @include media.min-width(medium) {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -30,7 +30,7 @@
   <NewTransactionModal on:nnsClose={closeModal} />
 {/if}
 
-{#if accounts}
+{#if accounts !== undefined}
   <Footer>
     <Toolbar>
       <button

--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -6,8 +6,8 @@
   import { i18n } from "../../stores/i18n";
   import { Toolbar } from "@dfinity/gix-components";
   import AddAcountModal from "../../modals/accounts/AddAccountModal.svelte";
-  import NewTransactionModal from "../../modals/accounts/NewTransactionModal.svelte";
   import Footer from "../common/Footer.svelte";
+  import IcpTransactionModal from "../../modals/accounts/IcpTransactionModal.svelte";
 
   let accounts: AccountsStore | undefined;
 
@@ -27,7 +27,7 @@
   <AddAcountModal on:nnsClose={closeModal} />
 {/if}
 {#if modal === "NewTransaction"}
-  <NewTransactionModal on:nnsClose={closeModal} />
+  <IcpTransactionModal on:nnsClose={closeModal} />
 {/if}
 
 {#if accounts !== undefined}

--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import type { Unsubscriber } from "svelte/types/runtime/store";
+  import { accountsStore } from "../../stores/accounts.store";
+  import type { AccountsStore } from "../../stores/accounts.store";
+  import { i18n } from "../../stores/i18n";
+  import { Toolbar } from "@dfinity/gix-components";
+  import AddAcountModal from "../../modals/accounts/AddAccountModal.svelte";
+  import NewTransactionModal from "../../modals/accounts/NewTransactionModal.svelte";
+  import Footer from "../common/Footer.svelte";
+
+  let accounts: AccountsStore | undefined;
+
+  const unsubscribe: Unsubscriber = accountsStore.subscribe(
+    async (storeData: AccountsStore) => (accounts = storeData)
+  );
+
+  onDestroy(unsubscribe);
+
+  let modal: "AddAccountModal" | "NewTransaction" | undefined = undefined;
+  const openAddAccountModal = () => (modal = "AddAccountModal");
+  const openNewTransaction = () => (modal = "NewTransaction");
+  const closeModal = () => (modal = undefined);
+</script>
+
+{#if modal === "AddAccountModal"}
+  <AddAcountModal on:nnsClose={closeModal} />
+{/if}
+{#if modal === "NewTransaction"}
+  <NewTransactionModal on:nnsClose={closeModal} />
+{/if}
+
+{#if accounts}
+  <Footer>
+    <Toolbar>
+      <button
+        class="primary full-width"
+        on:click={openNewTransaction}
+        data-tid="open-new-transaction">{$i18n.accounts.new_transaction}</button
+      >
+      <button
+        class="primary full-width"
+        on:click={openAddAccountModal}
+        data-tid="open-add-account-modal">{$i18n.accounts.add_account}</button
+      >
+    </Toolbar>
+  </Footer>
+{/if}

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -36,8 +36,12 @@
   }[] = [
     {
       context: "accounts",
-      selected: isSelectedPath([AppPath.Accounts, AppPath.Wallet]),
-      label: "tokens",
+      selected: isSelectedPath([
+        AppPath.Accounts,
+        AppPath.LegacyAccounts,
+        AppPath.Wallet,
+      ]),
+      label: "accounts",
       icon: IconWallet,
     },
     {

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -41,7 +41,7 @@
         AppPath.LegacyAccounts,
         AppPath.Wallet,
       ]),
-      label: "accounts",
+      label: "tokens",
       icon: IconWallet,
     },
     {

--- a/frontend/src/lib/components/common/RouteModule.svelte
+++ b/frontend/src/lib/components/common/RouteModule.svelte
@@ -16,6 +16,7 @@
   const loadModule = async (): Promise<typeof SvelteComponent> => {
     switch (path) {
       case AppPath.Accounts:
+      case AppPath.LegacyAccounts:
         return (await import("../../../routes/Accounts.svelte")).default;
       case AppPath.LegacyNeurons:
       case AppPath.Neurons:
@@ -50,6 +51,9 @@
     },
     [AppPath.Accounts]: {
       title: $i18n.navigation.tokens,
+    },
+    [AppPath.LegacyAccounts]: {
+      title: $i18n.navigation.accounts,
     },
     [AppPath.LegacyNeurons]: {
       title: $i18n.navigation.neurons,

--- a/frontend/src/lib/components/common/RouteModule.svelte
+++ b/frontend/src/lib/components/common/RouteModule.svelte
@@ -53,7 +53,7 @@
       title: $i18n.navigation.tokens,
     },
     [AppPath.LegacyAccounts]: {
-      title: $i18n.navigation.accounts,
+      title: $i18n.navigation.tokens,
     },
     [AppPath.LegacyNeurons]: {
       title: $i18n.navigation.neurons,

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -1,6 +1,7 @@
 export enum AppPath {
   Authentication = "/",
-  Accounts = "/#/accounts",
+  LegacyAccounts = "/#/accounts",
+  Accounts = "/#/u/:rootCanisterId/accounts",
   LegacyNeurons = "/#/neurons",
   Neurons = "/#/u/:rootCanisterId/neurons",
   Proposals = "/#/proposals",

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -3,7 +3,6 @@
   import type { Unsubscriber } from "svelte/types/runtime/store";
   import { accountsStore } from "../stores/accounts.store";
   import type { AccountsStore } from "../stores/accounts.store";
-  import AmountDisplay from "../components/ic/AmountDisplay.svelte";
   import AccountCard from "../components/accounts/AccountCard.svelte";
   import { i18n } from "../stores/i18n";
   import { routeStore } from "../stores/route.store";
@@ -11,8 +10,7 @@
   import { TokenAmount } from "@dfinity/nns";
   import { formatICP, sumTokenAmounts } from "../utils/icp.utils";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
-  import Tooltip from "../components/ui/Tooltip.svelte";
-  import { replacePlaceholders } from "../utils/i18n.utils";
+  import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
 
   let accounts: AccountsStore | undefined;
 
@@ -44,72 +42,33 @@
   }
 </script>
 
-<main class="legacy">
-  <section data-tid="accounts-body">
-    <div class="title">
-      <h1>{$i18n.accounts.title}</h1>
+<section data-tid="accounts-body">
+  <AccountsTitle balance={totalBalance} />
 
-      {#if accounts?.main}
-        <Tooltip
-          id="wallet-total-icp"
-          text={replacePlaceholders($i18n.accounts.current_balance_total, {
-            $amount: totalICP,
-          })}
-        >
-          <AmountDisplay amount={totalBalance} />
-        </Tooltip>
-      {/if}
-    </div>
-
-    {#if accounts?.main?.identifier}
+  {#if accounts?.main?.identifier}
+    <AccountCard
+      role="link"
+      on:click={() => cardClick(accounts?.main?.identifier ?? "")}
+      showCopy
+      account={accounts?.main}>{$i18n.accounts.main}</AccountCard
+    >
+    {#each accounts.subAccounts ?? [] as subAccount}
       <AccountCard
         role="link"
-        on:click={() => cardClick(accounts?.main?.identifier ?? "")}
+        on:click={() => cardClick(subAccount.identifier)}
         showCopy
-        account={accounts?.main}>{$i18n.accounts.main}</AccountCard
+        account={subAccount}>{subAccount.name}</AccountCard
       >
-      {#each accounts.subAccounts ?? [] as subAccount}
-        <AccountCard
-          role="link"
-          on:click={() => cardClick(subAccount.identifier)}
-          showCopy
-          account={subAccount}>{subAccount.name}</AccountCard
-        >
-      {/each}
-      {#each accounts.hardwareWallets ?? [] as walletAccount}
-        <AccountCard
-          role="link"
-          on:click={() => cardClick(walletAccount.identifier)}
-          showCopy
-          account={walletAccount}>{walletAccount.name}</AccountCard
-        >
-      {/each}
-    {:else}
-      <SkeletonCard />
-    {/if}
-  </section>
-</main>
-
-<style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-
-  .title {
-    display: block;
-    width: 100%;
-
-    margin-bottom: var(--padding-2x);
-
-    --icp-font-size: var(--font-size-h1);
-
-    // Minimum height of ICP value + ICP label (ICP component)
-    min-height: calc(
-      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
-    );
-
-    @include media.min-width(medium) {
-      display: inline-flex;
-      justify-content: space-between;
-      align-items: baseline;
-    }
-  }
-</style>
+    {/each}
+    {#each accounts.hardwareWallets ?? [] as walletAccount}
+      <AccountCard
+        role="link"
+        on:click={() => cardClick(walletAccount.identifier)}
+        showCopy
+        account={walletAccount}>{walletAccount.name}</AccountCard
+      >
+    {/each}
+  {:else}
+    <SkeletonCard />
+  {/if}
+</section>

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import type { Unsubscriber } from "svelte/types/runtime/store";
+  import { accountsStore } from "../stores/accounts.store";
+  import type { AccountsStore } from "../stores/accounts.store";
+  import AmountDisplay from "../components/ic/AmountDisplay.svelte";
+  import AccountCard from "../components/accounts/AccountCard.svelte";
+  import { i18n } from "../stores/i18n";
+  import { routeStore } from "../stores/route.store";
+  import { AppPath } from "../constants/routes.constants";
+  import { TokenAmount } from "@dfinity/nns";
+  import { formatICP, sumTokenAmounts } from "../utils/icp.utils";
+  import SkeletonCard from "../components/ui/SkeletonCard.svelte";
+  import Tooltip from "../components/ui/Tooltip.svelte";
+  import { replacePlaceholders } from "../utils/i18n.utils";
+
+  let accounts: AccountsStore | undefined;
+
+  const unsubscribe: Unsubscriber = accountsStore.subscribe(
+    async (storeData: AccountsStore) => (accounts = storeData)
+  );
+
+  const cardClick = (identifier: string) =>
+    routeStore.navigate({ path: `${AppPath.Wallet}/${identifier}` });
+
+  onDestroy(unsubscribe);
+
+  let totalBalance: TokenAmount;
+  let totalICP: string;
+  const zeroICPs = TokenAmount.fromE8s({
+    amount: BigInt(0),
+    token: accounts?.main?.balance.token,
+  });
+  $: {
+    totalBalance = sumTokenAmounts(
+      accounts?.main?.balance || zeroICPs,
+      ...(accounts?.subAccounts || []).map(({ balance }) => balance),
+      ...(accounts?.hardwareWallets || []).map(({ balance }) => balance)
+    );
+    totalICP = formatICP({
+      value: totalBalance.toE8s(),
+      detailed: true,
+    });
+  }
+</script>
+
+<main class="legacy">
+  <section data-tid="accounts-body">
+    <div class="title">
+      <h1>{$i18n.accounts.title}</h1>
+
+      {#if accounts?.main}
+        <Tooltip
+          id="wallet-total-icp"
+          text={replacePlaceholders($i18n.accounts.current_balance_total, {
+            $amount: totalICP,
+          })}
+        >
+          <AmountDisplay amount={totalBalance} />
+        </Tooltip>
+      {/if}
+    </div>
+
+    {#if accounts?.main?.identifier}
+      <AccountCard
+        role="link"
+        on:click={() => cardClick(accounts?.main?.identifier ?? "")}
+        showCopy
+        account={accounts?.main}>{$i18n.accounts.main}</AccountCard
+      >
+      {#each accounts.subAccounts ?? [] as subAccount}
+        <AccountCard
+          role="link"
+          on:click={() => cardClick(subAccount.identifier)}
+          showCopy
+          account={subAccount}>{subAccount.name}</AccountCard
+        >
+      {/each}
+      {#each accounts.hardwareWallets ?? [] as walletAccount}
+        <AccountCard
+          role="link"
+          on:click={() => cardClick(walletAccount.identifier)}
+          showCopy
+          account={walletAccount}>{walletAccount.name}</AccountCard
+        >
+      {/each}
+    {:else}
+      <SkeletonCard />
+    {/if}
+  </section>
+</main>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/media";
+
+  .title {
+    display: block;
+    width: 100%;
+
+    margin-bottom: var(--padding-2x);
+
+    --icp-font-size: var(--font-size-h1);
+
+    // Minimum height of ICP value + ICP label (ICP component)
+    min-height: calc(
+      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
+    );
+
+    @include media.min-width(medium) {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+  }
+</style>

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -4,10 +4,10 @@
 
   // TODO: Implement https://dfinity.atlassian.net/browse/GIX-993
   let totalAmountToken = TokenAmount.fromE8s({
-    amount: BigInt(4_530_000_000),
+    amount: BigInt(0),
     token: {
-      symbol: "OC",
-      name: "Open Chat",
+      symbol: "test",
+      name: "todo",
     },
   });
 </script>

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { TokenAmount } from "@dfinity/nns";
+  import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
+
+  // TODO: Implement https://dfinity.atlassian.net/browse/GIX-993
+  let totalAmountToken = TokenAmount.fromE8s({
+    amount: BigInt(4_530_000_000),
+    token: {
+      symbol: "OC",
+      name: "Open Chat",
+    },
+  });
+</script>
+
+<section data-tid="sns-accounts-body">
+  <AccountsTitle balance={totalAmountToken} />
+</section>

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -8,6 +8,7 @@ const mapper: Record<string, string> = {
   [AppPath.ProposalDetail]: `${AppPath.ProposalDetail}/[0-9]+`,
   [AppPath.LegacyNeuronDetail]: `${AppPath.LegacyNeuronDetail}/[0-9]+`,
   [AppPath.Neurons]: `${CONTEXT_PATH}/[a-zA-Z0-9-]+/neurons`,
+  [AppPath.Accounts]: `${CONTEXT_PATH}/[a-zA-Z0-9-]+/accounts`,
   [AppPath.CanisterDetail]: `${AppPath.CanisterDetail}/[a-zA-Z0-9-]+`,
   [AppPath.ProjectDetail]: `${AppPath.ProjectDetail}/[a-zA-Z0-9-]+`,
   [AppPath.NeuronDetail]: `${AppPath.ProjectDetail}/[a-zA-Z0-9-]+/neuron/[a-zA-Z0-9-]+`,
@@ -136,6 +137,9 @@ const checkContextPathExceptions = ({
 }): string => {
   if (isRoutePath({ path: AppPath.LegacyNeurons, routePath: path })) {
     return `${CONTEXT_PATH}/${newContext}/neurons`;
+  }
+  if (isRoutePath({ path: AppPath.LegacyAccounts, routePath: path })) {
+    return `${CONTEXT_PATH}/${newContext}/accounts`;
   }
   if (
     isRoutePath({

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -12,6 +12,7 @@
   import { isRoutePath } from "../lib/utils/app-path.utils";
   import { AppPath } from "../lib/constants/routes.constants";
   import { OWN_CANISTER_ID } from "../lib/constants/canister-ids.constants";
+  import SnsAccounts from "../lib/pages/SnsAccounts.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -36,7 +37,7 @@
   {#if $isNnsProjectStore}
     <NnsAccounts />
   {:else if $snsProjectSelectedStore !== undefined}
-    <div>hi</div>
+    <SnsAccounts />
   {/if}
 </main>
 

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -1,148 +1,59 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
-  import type { Unsubscriber } from "svelte/types/runtime/store";
-  import { accountsStore } from "../lib/stores/accounts.store";
-  import type { AccountsStore } from "../lib/stores/accounts.store";
-  import AmountDisplay from "../lib/components/ic/AmountDisplay.svelte";
-  import AccountCard from "../lib/components/accounts/AccountCard.svelte";
-  import { i18n } from "../lib/stores/i18n";
-  import { Toolbar } from "@dfinity/gix-components";
+  import SelectProjectDropdown from "../lib/components/neurons/SelectProjectDropdown.svelte";
+  import { ENABLE_SNS } from "../lib/constants/environment.constants";
+  import NnsAccounts from "../lib/pages/NnsAccounts.svelte";
+  import NnsAccountsFooter from "../lib/components/accounts/NnsAccountsFooter.svelte";
+  import {
+    isNnsProjectStore,
+    snsProjectSelectedStore,
+  } from "../lib/derived/selected-project.derived";
+  import { onMount } from "svelte";
   import { routeStore } from "../lib/stores/route.store";
+  import { isRoutePath } from "../lib/utils/app-path.utils";
   import { AppPath } from "../lib/constants/routes.constants";
-  import AddAcountModal from "../lib/modals/accounts/AddAccountModal.svelte";
-  import { TokenAmount } from "@dfinity/nns";
-  import { formatICP, sumTokenAmounts } from "../lib/utils/icp.utils";
-  import SkeletonCard from "../lib/components/ui/SkeletonCard.svelte";
-  import Footer from "../lib/components/common/Footer.svelte";
-  import Tooltip from "../lib/components/ui/Tooltip.svelte";
-  import { replacePlaceholders } from "../lib/utils/i18n.utils";
-  import IcpTransactionModal from "../lib/modals/accounts/IcpTransactionModal.svelte";
+  import { OWN_CANISTER_ID } from "../lib/constants/canister-ids.constants";
 
-  let accounts: AccountsStore | undefined;
-
-  const unsubscribe: Unsubscriber = accountsStore.subscribe(
-    async (storeData: AccountsStore) => (accounts = storeData)
-  );
-
-  const cardClick = (identifier: string) =>
-    routeStore.navigate({ path: `${AppPath.Wallet}/${identifier}` });
-
-  onDestroy(unsubscribe);
-
-  let modal: "AddAccountModal" | "NewTransaction" | undefined = undefined;
-  const openAddAccountModal = () => (modal = "AddAccountModal");
-  const openNewTransaction = () => (modal = "NewTransaction");
-  const closeModal = () => (modal = undefined);
-
-  let totalBalance: TokenAmount;
-  let totalICP: string;
-  const zeroICPs = TokenAmount.fromE8s({
-    amount: BigInt(0),
-    token: accounts?.main?.balance.token,
+  // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
+  onMount(() => {
+    if (
+      ENABLE_SNS &&
+      isRoutePath({ path: AppPath.LegacyAccounts, routePath: $routeStore.path })
+    ) {
+      routeStore.changeContext(OWN_CANISTER_ID.toText());
+    }
   });
-  $: {
-    totalBalance = sumTokenAmounts(
-      accounts?.main?.balance || zeroICPs,
-      ...(accounts?.subAccounts || []).map(({ balance }) => balance),
-      ...(accounts?.hardwareWallets || []).map(({ balance }) => balance)
-    );
-    totalICP = formatICP({
-      value: totalBalance.toE8s(),
-      detailed: true,
-    });
-  }
 </script>
 
 <main class="legacy">
-  <section data-tid="accounts-body">
-    <div class="title">
-      <h1>{$i18n.accounts.total}</h1>
-
-      {#if accounts?.main}
-        <Tooltip
-          id="wallet-total-icp"
-          text={replacePlaceholders($i18n.accounts.current_balance_total, {
-            $amount: totalICP,
-          })}
-        >
-          <AmountDisplay amount={totalBalance} />
-        </Tooltip>
-      {/if}
+  {#if ENABLE_SNS}
+    <div class="dropdown-wrapper">
+      <div class="fit-content">
+        <SelectProjectDropdown />
+      </div>
     </div>
+  {/if}
 
-    {#if accounts?.main?.identifier}
-      <AccountCard
-        role="link"
-        on:click={() => cardClick(accounts?.main?.identifier ?? "")}
-        showCopy
-        account={accounts?.main}>{$i18n.accounts.main}</AccountCard
-      >
-      {#each accounts.subAccounts || [] as subAccount}
-        <AccountCard
-          role="link"
-          on:click={() => cardClick(subAccount.identifier)}
-          showCopy
-          account={subAccount}>{subAccount.name}</AccountCard
-        >
-      {/each}
-      {#each accounts.hardwareWallets || [] as walletAccount}
-        <AccountCard
-          role="link"
-          on:click={() => cardClick(walletAccount.identifier)}
-          showCopy
-          account={walletAccount}>{walletAccount.name}</AccountCard
-        >
-      {/each}
-    {:else}
-      <SkeletonCard />
-    {/if}
-  </section>
+  {#if $isNnsProjectStore}
+    <NnsAccounts />
+  {:else if $snsProjectSelectedStore !== undefined}
+    <div>hi</div>
+  {/if}
 </main>
 
-{#if modal === "AddAccountModal"}
-  <AddAcountModal on:nnsClose={closeModal} />
-{/if}
-{#if modal === "NewTransaction"}
-  <IcpTransactionModal on:nnsClose={closeModal} />
-{/if}
-
-{#if accounts}
-  <Footer>
-    <Toolbar>
-      <button
-        class="primary full-width"
-        on:click={openNewTransaction}
-        data-tid="open-new-transaction">{$i18n.accounts.new_transaction}</button
-      >
-      <button
-        class="primary full-width"
-        on:click={openAddAccountModal}
-        data-tid="open-add-account-modal">{$i18n.accounts.add_account}</button
-      >
-    </Toolbar>
-  </Footer>
+{#if $isNnsProjectStore}
+  <NnsAccountsFooter />
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  .dropdown-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-  .title {
-    display: block;
-    width: 100%;
+    margin-top: var(--padding-4x);
 
-    margin-bottom: var(--padding-2x);
-
-    --icp-font-size: var(--font-size-h1);
-
-    // Minimum height of ICP value + ICP label (ICP component)
-    min-height: calc(
-      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
-    );
-
-    @include media.min-width(medium) {
-      display: inline-flex;
-      justify-content: space-between;
-      align-items: baseline;
+    .fit-content {
+      width: fit-content;
     }
   }
 </style>

--- a/frontend/src/routes/Launchpad.svelte
+++ b/frontend/src/routes/Launchpad.svelte
@@ -9,7 +9,7 @@
 
   onMount(() => {
     if (!IS_TESTNET) {
-      routeStore.replace({ path: AppPath.Accounts });
+      routeStore.replace({ path: AppPath.LegacyAccounts });
     }
   });
 </script>

--- a/frontend/src/routes/ProjectDetail.svelte
+++ b/frontend/src/routes/ProjectDetail.svelte
@@ -30,7 +30,7 @@
 
   onMount(() => {
     if (!IS_TESTNET) {
-      routeStore.replace({ path: AppPath.Accounts });
+      routeStore.replace({ path: AppPath.LegacyAccounts });
     }
   });
 

--- a/frontend/src/routes/Wallet.svelte
+++ b/frontend/src/routes/Wallet.svelte
@@ -32,7 +32,7 @@
 
   const goBack = () =>
     routeStore.navigate({
-      path: AppPath.Accounts,
+      path: AppPath.LegacyAccounts,
     });
 
   layoutBackStore.set(goBack);

--- a/frontend/src/tests/lib/derived/selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-project.derived.spec.ts
@@ -14,7 +14,7 @@ import { routeStore } from "../../../lib/stores/route.store";
 describe("selected project derived stores", () => {
   describe("isNnsProjectStore", () => {
     beforeEach(() => {
-      routeStore.update({ path: AppPath.Accounts });
+      routeStore.update({ path: AppPath.LegacyAccounts });
     });
 
     it("should be set by default true", () => {
@@ -33,7 +33,7 @@ describe("selected project derived stores", () => {
 
   describe("snsOnlyProjectStore", () => {
     beforeEach(() => {
-      routeStore.update({ path: AppPath.Accounts });
+      routeStore.update({ path: AppPath.LegacyAccounts });
     });
 
     it("should be set by default undefined", () => {
@@ -61,7 +61,7 @@ describe("selected project derived stores", () => {
       const $store = get(snsOnlyProjectStore);
       expect($store?.toText()).toBe(principalString);
 
-      routeStore.update({ path: AppPath.Accounts });
+      routeStore.update({ path: AppPath.LegacyAccounts });
       const $store2 = get(snsOnlyProjectStore);
       expect($store2).toBeUndefined();
     });
@@ -69,7 +69,7 @@ describe("selected project derived stores", () => {
 
   describe("snsProjectSelectedStore", () => {
     beforeEach(() => {
-      routeStore.update({ path: AppPath.Accounts });
+      routeStore.update({ path: AppPath.LegacyAccounts });
     });
 
     it("should be set by default to own canister id", () => {

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import NnsAccounts from "../../../lib/pages/NnsAccounts.svelte";
+import { accountsStore } from "../../../lib/stores/accounts.store";
+import { authStore } from "../../../lib/stores/auth.store";
+import { replacePlaceholders } from "../../../lib/utils/i18n.utils";
+import { formatICP } from "../../../lib/utils/icp.utils";
+import {
+  mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
+  mockMainAccount,
+  mockSubAccount,
+} from "../../mocks/accounts.store.mock";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import en from "../../mocks/i18n.mock";
+
+describe("NnsAccounts", () => {
+  let accountsStoreMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
+  it("should render title and account icp", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    const { container } = render(NnsAccounts);
+
+    const titleRow = container.querySelector("section > div");
+
+    expect(
+      titleRow?.textContent?.startsWith(
+        `Accounts ${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+      )
+    ).toBeTruthy();
+  });
+
+  it("should render a main card", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    const { container } = render(NnsAccounts);
+
+    const article = container.querySelector("article");
+    expect(article).not.toBeNull();
+  });
+
+  it("should render account icp in card too", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    const { container } = render(NnsAccounts);
+
+    const cardTitleRow = container.querySelector(
+      "article > div div:last-of-type"
+    );
+
+    expect(cardTitleRow?.textContent).toEqual(
+      `${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+    );
+  });
+
+  it("should render account identifier", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    const { getByText } = render(NnsAccounts);
+    getByText(mockMainAccount.identifier);
+  });
+
+  it("should render subaccount cards", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+    const { container } = render(NnsAccounts);
+
+    const articles = container.querySelectorAll("article");
+
+    expect(articles).not.toBeNull();
+    expect(articles.length).toBe(2);
+  });
+
+  it("should render hardware wallet account cards", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(
+        mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
+      );
+    const { container } = render(NnsAccounts);
+
+    const articles = container.querySelectorAll("article");
+
+    expect(articles).not.toBeNull();
+    expect(articles.length).toBe(2);
+  });
+
+  it("should subscribe to store", () => {
+    accountsStoreMock = jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(mockAccountsStoreSubscribe());
+    expect(accountsStoreMock).toHaveBeenCalled();
+  });
+
+  describe("Total ICPs", () => {
+    const totalBalance =
+      mockMainAccount.balance.toE8s() +
+      mockSubAccount.balance.toE8s() +
+      mockHardwareWalletAccount.balance.toE8s();
+
+    beforeAll(
+      () =>
+        (accountsStoreMock = jest
+          .spyOn(accountsStore, "subscribe")
+          .mockImplementation(
+            mockAccountsStoreSubscribe(
+              [mockSubAccount],
+              [mockHardwareWalletAccount]
+            )
+          ))
+    );
+
+    afterAll(jest.clearAllMocks);
+
+    it("should render total accounts icp", () => {
+      const { container } = render(NnsAccounts);
+
+      const titleRow = container.querySelector("section > div");
+
+      expect(
+        titleRow?.textContent?.startsWith(
+          `Accounts ${formatICP({ value: totalBalance })} ICP`
+        )
+      ).toBeTruthy();
+    });
+
+    it("should contain a tooltip", () => {
+      const { container } = render(NnsAccounts);
+
+      expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
+    });
+
+    it("should render a total balance in a tooltip", () => {
+      const { container } = render(NnsAccounts);
+
+      const icp: HTMLDivElement | null =
+        container.querySelector("#wallet-total-icp");
+
+      const totalBalance =
+        mockMainAccount.balance.toE8s() +
+        mockSubAccount.balance.toE8s() +
+        mockHardwareWalletAccount.balance.toE8s();
+
+      expect(icp?.textContent).toEqual(
+        replacePlaceholders(en.accounts.current_balance_total, {
+          $amount: `${formatICP({
+            value: totalBalance,
+            detailed: true,
+          })}`,
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -36,7 +36,9 @@ describe("NnsAccounts", () => {
 
     expect(
       titleRow?.textContent?.startsWith(
-        `Accounts ${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+        `${en.accounts.total} ${formatICP({
+          value: mockMainAccount.balance.toE8s(),
+        })} ICP`
       )
     ).toBeTruthy();
   });
@@ -134,7 +136,7 @@ describe("NnsAccounts", () => {
 
       expect(
         titleRow?.textContent?.startsWith(
-          `Accounts ${formatICP({ value: totalBalance })} ICP`
+          `${en.accounts.total} ${formatICP({ value: totalBalance })} ICP`
         )
       ).toBeTruthy();
     });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import SnsAccounts from "../../../lib/pages/SnsAccounts.svelte";
+
+describe("SnsAccounts", () => {
+  it("should render accounts title", () => {
+    const { getByTestId } = render(SnsAccounts);
+
+    expect(getByTestId("accounts-title")).toBeInTheDocument();
+  });
+
+  it("should contain a tooltip", () => {
+    const { container } = render(SnsAccounts);
+
+    expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/stores/route.store.spec.ts
+++ b/frontend/src/tests/lib/stores/route.store.spec.ts
@@ -13,12 +13,12 @@ import {
 
 describe("route-store", () => {
   it("should set referrer path", () => {
-    routeStore.update({ path: AppPath.Accounts });
+    routeStore.update({ path: AppPath.LegacyAccounts });
 
     routeStore.navigate({ path: AppPath.Proposals });
 
     let referrerPath = get(routeStore).referrerPath;
-    expect(referrerPath).toEqual(AppPath.Accounts);
+    expect(referrerPath).toEqual(AppPath.LegacyAccounts);
 
     routeStore.replace({ path: AppPath.LegacyNeurons });
 

--- a/frontend/src/tests/lib/utils/app-path.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/app-path.utils.spec.ts
@@ -15,7 +15,7 @@ describe("routes", () => {
   describe("isAppPath()", () => {
     it("should translate valid urls", () => {
       expect(isAppPath("/")).toBeTruthy();
-      expect(isAppPath(AppPath.Accounts)).toBeTruthy();
+      expect(isAppPath(AppPath.LegacyAccounts)).toBeTruthy();
       expect(isAppPath(`${AppPath.Wallet}/123`)).toBeTruthy();
       expect(isAppPath(`${AppPath.CanisterDetail}/123`)).toBeTruthy();
       expect(isAppPath(`${AppPath.LegacyNeuronDetail}/123`)).toBeTruthy();
@@ -23,6 +23,7 @@ describe("routes", () => {
       expect(isAppPath(`${AppPath.ProjectDetail}/123`)).toBeTruthy();
       expect(isAppPath(`${CONTEXT_PATH}/123/neurons`)).toBeTruthy();
       expect(isAppPath(`${CONTEXT_PATH}/123/neuron/1234`)).toBeTruthy();
+      expect(isAppPath(`${CONTEXT_PATH}/123/accounts`)).toBeTruthy();
     });
 
     it("should return null for invalid urls", () => {
@@ -116,7 +117,7 @@ describe("routes", () => {
       ).toBeTruthy();
       expect(
         isRoutePath({
-          path: AppPath.Accounts,
+          path: AppPath.LegacyAccounts,
           routePath: "/#/accounts",
         })
       ).toBeTruthy();
@@ -224,6 +225,22 @@ describe("routes", () => {
       const path1 = `${CONTEXT_PATH}/aaaaa-aa/neuron/12344`;
       const path2 = `${CONTEXT_PATH}/aaaaa-aa/neurons`;
       const path3 = `${CONTEXT_PATH}/aaaaa-aa/accounts`;
+      const newContext = "bbbbb-bb";
+      expect(changePathContext({ path: path1, newContext })).toBe(
+        `${CONTEXT_PATH}/${newContext}/neuron/12344`
+      );
+      expect(changePathContext({ path: path2, newContext })).toBe(
+        `${CONTEXT_PATH}/${newContext}/neurons`
+      );
+      expect(changePathContext({ path: path3, newContext })).toBe(
+        `${CONTEXT_PATH}/${newContext}/accounts`
+      );
+    });
+
+    it("returns path with context for exceptions", () => {
+      const path1 = "/#/neuron/12344";
+      const path2 = "/#/neurons";
+      const path3 = "/#/accounts";
       const newContext = "bbbbb-bb";
       expect(changePathContext({ path: path1, newContext })).toBe(
         `${CONTEXT_PATH}/${newContext}/neuron/12344`

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -50,16 +50,9 @@ describe("Accounts", () => {
         target: { value: projectCanisterId },
       });
 
-  it("should render subaccount cards", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
-    const { container } = render(Accounts);
-
-    const articles = container.querySelectorAll("article");
-
-    expect(articles).not.toBeNull();
-    expect(articles.length).toBe(2);
+    await waitFor(() =>
+      expect(queryByTestId("sns-accounts-body")).toBeInTheDocument()
+    );
   });
 
   it("should be able to go back to nns after going to a project", async () => {
@@ -91,7 +84,7 @@ describe("Accounts", () => {
   });
 
   it("should open transaction modal", async () => {
-    const { container, getByText, getByTestId } = render(Accounts);
+    const { getByTestId } = render(Accounts);
 
     const button = getByTestId("open-new-transaction") as HTMLButtonElement;
     await fireEvent.click(button);

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -2,79 +2,53 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import { accountsStore } from "../../lib/stores/accounts.store";
-import { authStore } from "../../lib/stores/auth.store";
-import { replacePlaceholders } from "../../lib/utils/i18n.utils";
-import { formatICP } from "../../lib/utils/icp.utils";
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
+import { OWN_CANISTER_ID } from "../../lib/constants/canister-ids.constants";
+import { AppPath } from "../../lib/constants/routes.constants";
+import { committedProjectsStore } from "../../lib/stores/projects.store";
+import { routeStore } from "../../lib/stores/route.store";
 import Accounts from "../../routes/Accounts.svelte";
-import {
-  mockAccountsStoreSubscribe,
-  mockHardwareWalletAccount,
-  mockMainAccount,
-  mockSubAccount,
-} from "../mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "../mocks/auth.store.mock";
 import en from "../mocks/i18n.mock";
+import {
+  mockProjectSubscribe,
+  mockSnsFullProject,
+} from "../mocks/sns-projects.mock";
 
 describe("Accounts", () => {
-  let accountsStoreMock: jest.SpyInstance;
+  jest
+    .spyOn(committedProjectsStore, "subscribe")
+    .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
+    // Reset to default value
+    routeStore.update({ path: AppPath.LegacyAccounts });
   });
 
-  it("should render title and account icp", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(Accounts);
-
-    const titleRow = container.querySelector("section > div");
-
-    expect(
-      titleRow?.textContent?.startsWith(
-        `${en.accounts.total} ${formatICP({
-          value: mockMainAccount.balance.toE8s(),
-        })} ICP`
-      )
-    ).toBeTruthy();
+  it("should render NnsAccounts by default", () => {
+    const { queryByTestId } = render(Accounts);
+    expect(queryByTestId("accounts-body")).toBeInTheDocument();
   });
 
-  it("should render a main card", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(Accounts);
-
-    const article = container.querySelector("article");
-    expect(article).not.toBeNull();
+  it("should render dropdown to select project", () => {
+    const { queryByTestId } = render(Accounts);
+    expect(queryByTestId("select-project-dropdown")).toBeInTheDocument();
   });
 
-  it("should render account icp in card too", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(Accounts);
+  it("should render sns accounts when a project is selected in the dropdown", async () => {
+    const { queryByTestId } = render(Accounts);
 
-    const cardTitleRow = container.querySelector(
-      "article > div div:last-of-type"
-    );
+    expect(queryByTestId("accounts-body")).toBeInTheDocument();
 
-    expect(cardTitleRow?.textContent).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
-    );
-  });
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
 
-  it("should render account identifier", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { getByText } = render(Accounts);
-    getByText(mockMainAccount.identifier);
-  });
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
 
   it("should render subaccount cards", () => {
     accountsStoreMock = jest
@@ -88,91 +62,38 @@ describe("Accounts", () => {
     expect(articles.length).toBe(2);
   });
 
-  it("should render hardware wallet account cards", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(
-        mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
-      );
-    const { container } = render(Accounts);
+  it("should be able to go back to nns after going to a project", async () => {
+    const { queryByTestId } = render(Accounts);
 
-    const articles = container.querySelectorAll("article");
+    expect(queryByTestId("accounts-body")).toBeInTheDocument();
 
-    expect(articles).not.toBeNull();
-    expect(articles.length).toBe(2);
-  });
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
 
-  it("should subscribe to store", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    expect(accountsStoreMock).toHaveBeenCalled();
-  });
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
 
-  describe("Total ICPs", () => {
-    const totalBalance =
-      mockMainAccount.balance.toE8s() +
-      mockSubAccount.balance.toE8s() +
-      mockHardwareWalletAccount.balance.toE8s();
-
-    beforeAll(
-      () =>
-        (accountsStoreMock = jest
-          .spyOn(accountsStore, "subscribe")
-          .mockImplementation(
-            mockAccountsStoreSubscribe(
-              [mockSubAccount],
-              [mockHardwareWalletAccount]
-            )
-          ))
+    await waitFor(() =>
+      expect(queryByTestId("sns-accounts-body")).toBeInTheDocument()
     );
 
-    afterAll(jest.clearAllMocks);
-
-    it("should render total accounts icp", () => {
-      const { container } = render(Accounts);
-
-      const titleRow = container.querySelector("section > div");
-
-      expect(
-        titleRow?.textContent?.startsWith(
-          `${en.accounts.total} ${formatICP({ value: totalBalance })} ICP`
-        )
-      ).toBeTruthy();
-    });
-
-    it("should contain a tooltip", () => {
-      const { container } = render(Accounts);
-
-      expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
-    });
-
-    it("should render a total balance in a tooltip", () => {
-      const { container } = render(Accounts);
-
-      const icp: HTMLDivElement | null =
-        container.querySelector("#wallet-total-icp");
-
-      const totalBalance =
-        mockMainAccount.balance.toE8s() +
-        mockSubAccount.balance.toE8s() +
-        mockHardwareWalletAccount.balance.toE8s();
-
-      expect(icp?.textContent).toEqual(
-        replacePlaceholders(en.accounts.current_balance_total, {
-          $amount: `${formatICP({
-            value: totalBalance,
-            detailed: true,
-          })}`,
-        })
-      );
-    });
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: OWN_CANISTER_ID.toText() },
+      });
+    await waitFor(() =>
+      expect(queryByTestId("accounts-body")).toBeInTheDocument()
+    );
   });
 
   it("should open transaction modal", async () => {
-    const { getByTestId } = render(Accounts);
+    const { container, getByText, getByTestId } = render(Accounts);
 
-    const button = getByTestId("open-new-transaction");
+    const button = getByTestId("open-new-transaction") as HTMLButtonElement;
     await fireEvent.click(button);
 
     await waitFor(() => {


### PR DESCRIPTION
# Motivation

User can select different sns projects in the accounts page.

# Changes

* Move current Accounts page to `/pages/NnsAccounts`.
* Setup Sns Accounts page in `/pages/SnsAccounts`.
* New component for the footer of the NNS accounts.
* In the route/Accounts we render dropdown component and NnsAccounts or SnsAccounts.
* Add new path LegacyAccounts to AppPath, while `AppPath.Accounts` uses context: `/u/:id/accounts`.
* All redirects to `AppPath.Accounts` redirect for now to `AppPath.LegacyAccounts`.

# Tests

* Moved test for Accounts to pages/NnsAccounts
* routes/Accounts tests dropdown and which component is rendered.
* Setup SnsAccounts test file.
* Changed and added tests for app-path utils after changes.
