### PR TITLE
L2-1020: Decode pending_transactions

### DIFF
--- a/rs/src/accounts_store.rs
+++ b/rs/src/accounts_store.rs
@@ -1357,6 +1357,7 @@ impl StableState for AccountsStore {
         let (
             mut accounts,
             mut hardware_wallets_and_sub_accounts,
+            pending_transactions,
             transactions,
             neuron_accounts,
             block_height_synced_up_to,
@@ -1366,6 +1367,7 @@ impl StableState for AccountsStore {
         ): (
             HashMap<Vec<u8>, Account>,
             HashMap<AccountIdentifier, AccountWrapper>,
+            HashMap<(AccountIdentifier, AccountIdentifier), TransactionType>,
             VecDeque<Transaction>,
             HashMap<AccountIdentifier, NeuronDetails>,
             Option<BlockHeight>,
@@ -1398,7 +1400,7 @@ impl StableState for AccountsStore {
         Ok(AccountsStore {
             accounts,
             hardware_wallets_and_sub_accounts,
-            pending_transactions: HashMap::new(),
+            pending_transactions,
             transactions,
             neuron_accounts,
             block_height_synced_up_to,


### PR DESCRIPTION
# Motivation

Do not lose the pending_transactions when upgrading canisters.

# Changes

* When decoding, expect also the pending_transactions Hashmap.
* Use the decoded to create the AccountsStore.

# Tests

Not applicable
