### PR TITLE
style: review & refresh of UI look & feel

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-14.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.2.tgz",
-      "integrity": "sha512-cn0q185WjaTyTqS+H6Dr3n/jy9Avy3PKDTvFYBNrZKQPxjT7AeQSyeVsWCRFeopF8UNEfe6R4KKgzvY27RXukg=="
+      "version": "0.0.1-next-2022-09-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-15.1.tgz",
+      "integrity": "sha512-7zDzSNiwjrRwc02rwdrf8HaTBfmMbkBOJqvnLlUNlIFYGBn20rJtqdZj1ZP5LNYNu9sw3NZhJI1K0AfOOMiv1g=="
     },
     "node_modules/@dfinity/identity": {
       "version": "1.0.0-beta.0",
@@ -9959,9 +9959,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-14.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-14.2.tgz",
-      "integrity": "sha512-cn0q185WjaTyTqS+H6Dr3n/jy9Avy3PKDTvFYBNrZKQPxjT7AeQSyeVsWCRFeopF8UNEfe6R4KKgzvY27RXukg=="
+      "version": "0.0.1-next-2022-09-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-15.1.tgz",
+      "integrity": "sha512-7zDzSNiwjrRwc02rwdrf8HaTBfmMbkBOJqvnLlUNlIFYGBn20rJtqdZj1ZP5LNYNu9sw3NZhJI1K0AfOOMiv1g=="
     },
     "@dfinity/identity": {
       "version": "1.0.0-beta.0",

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -37,7 +37,7 @@
     {
       context: "accounts",
       selected: isSelectedPath([AppPath.Accounts, AppPath.Wallet]),
-      label: "accounts",
+      label: "tokens",
       icon: IconWallet,
     },
     {

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -2,10 +2,10 @@
   import {
     MenuItem,
     IconWallet,
-    IconLockOpen,
     IconHowToVote,
-    IconSettingsApplications,
     IconRocketLaunch,
+    IconEngineering,
+    IconPsychology,
   } from "@dfinity/gix-components";
   import type { SvelteComponent } from "svelte";
   import { i18n } from "../../stores/i18n";
@@ -49,7 +49,7 @@
         AppPath.Neurons,
       ]),
       label: "neurons",
-      icon: IconLockOpen,
+      icon: IconPsychology,
     },
     {
       context: "proposals",
@@ -61,7 +61,7 @@
       context: "canisters",
       selected: isSelectedPath([AppPath.Canisters, AppPath.CanisterDetail]),
       label: "canisters",
-      icon: IconSettingsApplications,
+      icon: IconEngineering,
     },
     // Launchpad should not be visible on mainnet
     ...(ENABLE_SNS

--- a/frontend/src/lib/components/common/RouteModule.svelte
+++ b/frontend/src/lib/components/common/RouteModule.svelte
@@ -49,7 +49,7 @@
       title: "",
     },
     [AppPath.Accounts]: {
-      title: $i18n.navigation.accounts,
+      title: $i18n.navigation.tokens,
     },
     [AppPath.LegacyNeurons]: {
       title: $i18n.navigation.neurons,

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -36,16 +36,14 @@
 
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
-
-    @include media.min-width(medium) {
-      gap: var(--padding-0_5x);
-    }
+    gap: var(--padding-3x);
   }
 
   .toggle {
     justify-self: flex-end;
 
     @include header.button(--primary);
+
+    padding: var(--padding-0_5x);
   }
 </style>

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -43,7 +43,5 @@
     justify-self: flex-end;
 
     @include header.button(--primary);
-
-    padding: var(--padding-0_5x);
   }
 </style>

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -42,6 +42,6 @@
   .toggle {
     justify-self: flex-end;
 
-    @include header.button(--primary);
+    @include header.button(--brand-sea-buckthorn);
   }
 </style>

--- a/frontend/src/lib/components/header/Logout.svelte
+++ b/frontend/src/lib/components/header/Logout.svelte
@@ -15,7 +15,7 @@
 
     display: flex;
     align-items: center;
-    gap: var(--padding);
+    gap: var(--padding-0_5x);
 
     :global(svg) {
       width: var(--padding-3x);

--- a/frontend/src/lib/components/header/ThemeToggle.svelte
+++ b/frontend/src/lib/components/header/ThemeToggle.svelte
@@ -14,8 +14,6 @@
 </script>
 
 <div class="theme-toggle" data-tid="theme-toggle">
-  <span>{$i18n.theme.theme}</span>
-
   <div class="toggle">
     <IconLightMode />
     <Toggle

--- a/frontend/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/src/lib/components/ic/GetICPs.svelte
@@ -99,8 +99,10 @@
     justify-content: flex-start;
     align-items: center;
 
-    font-size: var(--font-size-h4);
+    font-size: var(--font-size-h5);
     font-weight: 700;
+
+    letter-spacing: var(--letter-spacing-title);
 
     padding: var(--padding-2x);
 

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -57,8 +57,12 @@
       testId="proposal-card"
       withArrow={true}
     >
-      <div class="card-meta">
+      <div class="card-meta id">
         <Value ariaLabel={$i18n.proposal_detail.id_prefix}>{id}</Value>
+      </div>
+
+      <div class="card-meta">
+        <span>{$i18n.proposal_detail.type_prefix}</span>
         <Value ariaLabel={$i18n.proposal_detail.type_prefix}>{type}</Value>
       </div>
 
@@ -74,7 +78,10 @@
         </div>
       {/if}
 
-      <p class="title-placeholder description">{title}</p>
+      <blockquote class="title-placeholder description">
+        <span class="quote">“</span>
+        <p>{title}</p>
+      </blockquote>
 
       <div class="card-meta">
         <p class={`${color} status`}>
@@ -112,12 +119,34 @@
 
   .card-meta {
     @include card.meta;
+
+    &.id {
+      justify-content: flex-end;
+
+      :global(.value) {
+        color: var(--primary);
+      }
+    }
   }
 
   .title-placeholder {
-    @include text.clamp(6);
-    word-break: break-word;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-column-gap: 0;
+    margin: 0;
+    padding: 0;
+
     flex-grow: 1;
+
+    span {
+      font-size: var(--font-size-h1);
+      opacity: 0.7;
+    }
+
+    p {
+      @include text.clamp(6);
+      word-break: break-word;
+    }
   }
 
   /**

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -83,7 +83,7 @@
       </blockquote>
 
       <div class="card-meta">
-        <p class={`${color} status`}>
+        <p class={`${color ?? ""} status`}>
           {$i18n.status[ProposalStatus[status]] ?? ""}
         </p>
 
@@ -155,6 +155,11 @@
     // Color.SUCCESS
     &.success {
       --badge-color: var(--positive-emphasis);
+    }
+
+    // Color.ERROR
+    &.error {
+      --badge-color: var(--negative-emphasis-light);
     }
   }
 </style>

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -78,9 +78,8 @@
         </div>
       {/if}
 
-      <blockquote class="title-placeholder description">
-        <span class="quote">“</span>
-        <p>{title}</p>
+      <blockquote class="title-placeholder">
+        <p class="description">{title}</p>
       </blockquote>
 
       <div class="card-meta">
@@ -130,18 +129,7 @@
   }
 
   .title-placeholder {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-column-gap: 0;
-    margin: 0;
-    padding: 0;
-
     flex-grow: 1;
-
-    span {
-      font-size: var(--font-size-h1);
-      opacity: 0.7;
-    }
 
     p {
       @include text.clamp(6);

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -27,7 +27,7 @@ export const PROPOSAL_COLOR: Record<ProposalStatus, Color | undefined> = {
   [ProposalStatus.Executed]: Color.SUCCESS,
   [ProposalStatus.Open]: Color.WARNING,
   [ProposalStatus.Unknown]: undefined,
-  [ProposalStatus.Rejected]: undefined,
+  [ProposalStatus.Rejected]: Color.ERROR,
   [ProposalStatus.Accepted]: undefined,
-  [ProposalStatus.Failed]: undefined,
+  [ProposalStatus.Failed]: Color.ERROR,
 };

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -106,7 +106,7 @@
     "auth_sign_out": "You have been logged out because your session has expired."
   },
   "navigation": {
-    "accounts": "Accounts",
+    "accounts": "Tokens",
     "neurons": "Neurons",
     "voting": "Voting",
     "canisters": "Canisters",
@@ -126,7 +126,7 @@
     "on_chain": "100% on-chain Internet Computer"
   },
   "accounts": {
-    "title": "Accounts",
+    "title": "Total",
     "main": "Main",
     "main_account": "Main Account $identifier",
     "new_transaction": "New Transaction",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -126,7 +126,7 @@
     "on_chain": "100% on-chain Internet Computer"
   },
   "accounts": {
-    "title": "Total",
+    "total": "Total",
     "main": "Main",
     "main_account": "Main Account $identifier",
     "new_transaction": "New Transaction",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -106,7 +106,7 @@
     "auth_sign_out": "You have been logged out because your session has expired."
   },
   "navigation": {
-    "accounts": "Tokens",
+    "tokens": "Tokens",
     "neurons": "Neurons",
     "voting": "Voting",
     "canisters": "Canisters",

--- a/frontend/src/lib/themes/mixins/_overlay.scss
+++ b/frontend/src/lib/themes/mixins/_overlay.scss
@@ -33,7 +33,7 @@
     width: fit-content;
     height: auto;
 
-    padding: var(--padding-2x);
+    padding: var(--padding-3x) var(--padding-2x) var(--padding-2x);
     display: flex;
     flex-direction: column;
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -135,7 +135,7 @@ interface I18nAuth {
 }
 
 interface I18nAccounts {
-  title: string;
+  total: string;
   main: string;
   main_account: string;
   new_transaction: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -112,7 +112,7 @@ interface I18nWarning {
 }
 
 interface I18nNavigation {
-  accounts: string;
+  tokens: string;
   neurons: string;
   voting: string;
   canisters: string;

--- a/frontend/src/lib/types/theme.ts
+++ b/frontend/src/lib/types/theme.ts
@@ -7,4 +7,5 @@ export enum Color {
   PRIMARY = "primary",
   SUCCESS = "success",
   WARNING = "warning",
+  ERROR = "error",
 }

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -56,7 +56,7 @@
 <main class="legacy">
   <section data-tid="accounts-body">
     <div class="title">
-      <h1>{$i18n.accounts.title}</h1>
+      <h1>{$i18n.accounts.total}</h1>
 
       {#if accounts?.main}
         <Tooltip

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -7,7 +7,13 @@ import MenuItems from "../../../../lib/components/common/MenuItems.svelte";
 import en from "../../../mocks/i18n.mock";
 
 describe("MenuItems", () => {
-  const shouldRenderMenuItem = ({context, labelKey}: {context: string, labelKey: string}) => {
+  const shouldRenderMenuItem = ({
+    context,
+    labelKey,
+  }: {
+    context: string;
+    labelKey: string;
+  }) => {
     const { getByTestId } = render(MenuItems);
     const link = getByTestId(`menuitem-${context}`) as HTMLElement;
     expect(link).not.toBeNull();
@@ -16,11 +22,13 @@ describe("MenuItems", () => {
   };
 
   it("should render accounts menu item", () =>
-    shouldRenderMenuItem({context: "accounts", labelKey: "tokens"}));
-  it("should render neurons menu item", () => shouldRenderMenuItem({context: "neurons", labelKey: "neurons"}));
-  it("should render voting menu item", () => shouldRenderMenuItem({context: "proposals", labelKey: "voting"}));
+    shouldRenderMenuItem({ context: "accounts", labelKey: "tokens" }));
+  it("should render neurons menu item", () =>
+    shouldRenderMenuItem({ context: "neurons", labelKey: "neurons" }));
+  it("should render voting menu item", () =>
+    shouldRenderMenuItem({ context: "proposals", labelKey: "voting" }));
   it("should render canisters menu item", () =>
-    shouldRenderMenuItem({context: "canisters", labelKey: "canisters"}));
+    shouldRenderMenuItem({ context: "canisters", labelKey: "canisters" }));
 
   it("should not render a get icps feature", async () => {
     const renderResult = render(MenuItems);

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -7,20 +7,20 @@ import MenuItems from "../../../../lib/components/common/MenuItems.svelte";
 import en from "../../../mocks/i18n.mock";
 
 describe("MenuItems", () => {
-  const shouldRenderMenuItem = (context: string) => {
+  const shouldRenderMenuItem = ({context, labelKey}: {context: string, labelKey: string}) => {
     const { getByTestId } = render(MenuItems);
     const link = getByTestId(`menuitem-${context}`) as HTMLElement;
     expect(link).not.toBeNull();
     expect(link).toBeVisible();
-    expect(link.textContent?.trim()).toEqual(en.navigation[context]);
+    expect(link.textContent?.trim()).toEqual(en.navigation[labelKey]);
   };
 
   it("should render accounts menu item", () =>
-    shouldRenderMenuItem("accounts"));
-  it("should render neurons menu item", () => shouldRenderMenuItem("accounts"));
-  it("should render voting menu item", () => shouldRenderMenuItem("accounts"));
+    shouldRenderMenuItem({context: "accounts", labelKey: "tokens"}));
+  it("should render neurons menu item", () => shouldRenderMenuItem({context: "neurons", labelKey: "neurons"}));
+  it("should render voting menu item", () => shouldRenderMenuItem({context: "proposals", labelKey: "voting"}));
   it("should render canisters menu item", () =>
-    shouldRenderMenuItem("accounts"));
+    shouldRenderMenuItem({context: "canisters", labelKey: "canisters"}));
 
   it("should not render a get icps feature", async () => {
     const renderResult = render(MenuItems);

--- a/frontend/src/tests/lib/components/header/ThemeToggle.spec.ts
+++ b/frontend/src/tests/lib/components/header/ThemeToggle.spec.ts
@@ -10,12 +10,6 @@ import { Theme } from "../../../../lib/types/theme";
 import en from "../../../mocks/i18n.mock";
 
 describe("ThemeToggle", () => {
-  it("should render a label", () => {
-    const { getByText } = render(ThemeToggle);
-
-    expect(getByText(en.theme.theme)).toBeInTheDocument();
-  });
-
   it("should render a toggle", () => {
     const { container } = render(ThemeToggle);
 

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -36,7 +36,7 @@ describe("Accounts", () => {
 
     expect(
       titleRow?.textContent?.startsWith(
-        `Accounts ${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+        `${en.accounts.total} ${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
       )
     ).toBeTruthy();
   });
@@ -134,7 +134,7 @@ describe("Accounts", () => {
 
       expect(
         titleRow?.textContent?.startsWith(
-          `Accounts ${formatICP({ value: totalBalance })} ICP`
+          `${en.accounts.total} ${formatICP({ value: totalBalance })} ICP`
         )
       ).toBeTruthy();
     });

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -36,7 +36,9 @@ describe("Accounts", () => {
 
     expect(
       titleRow?.textContent?.startsWith(
-        `${en.accounts.total} ${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+        `${en.accounts.total} ${formatICP({
+          value: mockMainAccount.balance.toE8s(),
+        })} ICP`
       )
     ).toBeTruthy();
   });


### PR DESCRIPTION
# Motivation

Review & refresh of the UI look & feel

# PRs

- [x] need gix-component https://github.com/dfinity/gix-components/pull/66

# Changes

- "Accounts" navigation renamed in "Tokens"
- "Accounts" placeholder renamed in "Total"
- new menu icons for "Neurons" and "Canisters"
- keyword "Theme" in theme switcher removed
- various padding and spacing updated
- those inherited from related gix-component PR
- proposal "Failed" and "Rejected" color light red emphasis
- new proposal card ID moved and colored
- blockquote use for proposal title

# Screenshots

<img width="1510" alt="Capture d’écran 2022-09-15 à 08 06 30" src="https://user-images.githubusercontent.com/16886711/190328057-b6e08561-7cbc-4145-bef9-039bdcf0104d.png">
<img width="1510" alt="Capture d’écran 2022-09-15 à 08 06 49" src="https://user-images.githubusercontent.com/16886711/190328067-7bf5473c-9eff-4738-af20-6b3c9927d6d6.png">
<img width="1510" alt="Capture d’écran 2022-09-15 à 08 06 52" src="https://user-images.githubusercontent.com/16886711/190328074-fd3390e3-d645-4534-a9de-585b68118d4a.png">
<img width="1510" alt="Capture d’écran 2022-09-15 à 08 06 57" src="https://user-images.githubusercontent.com/16886711/190328078-43d6102f-6d92-4eff-812c-f3440082f462.png">
<img width="1510" alt="Capture d’écran 2022-09-15 à 08 07 06" src="https://user-images.githubusercontent.com/16886711/190328085-bf2d8ba5-fe5f-4576-b5d0-f3d187c60d00.png">
<img width="1510" alt="Capture d’écran 2022-09-15 à 08 07 09" src="https://user-images.githubusercontent.com/16886711/190328092-0bf4573f-1474-464e-8df9-8a17b031a441.png">
