### PR TITLE
style: fix modal meta overflow

### DIFF
--- a/frontend/src/lib/modals/Modal.svelte
+++ b/frontend/src/lib/modals/Modal.svelte
@@ -26,7 +26,7 @@
 
 {#if visible}
   <div
-    class="modal"
+    class="modal legacy"
     transition:fade
     role="dialog"
     data-tid={testId}

--- a/frontend/src/lib/themes/legacy.scss
+++ b/frontend/src/lib/themes/legacy.scss
@@ -4,7 +4,8 @@
 
 @use "@dfinity/gix-components/styles/mixins/media";
 
-main.legacy, div.modal.legacy {
+main.legacy,
+div.modal.legacy {
   margin: inherit;
   padding: inherit;
   max-width: inherit;

--- a/frontend/src/lib/themes/legacy.scss
+++ b/frontend/src/lib/themes/legacy.scss
@@ -4,7 +4,7 @@
 
 @use "@dfinity/gix-components/styles/mixins/media";
 
-main.legacy {
+main.legacy, div.modal.legacy {
   margin: inherit;
   padding: inherit;
   max-width: inherit;
@@ -29,6 +29,7 @@ main.legacy {
     .meta {
       flex-wrap: wrap;
       column-gap: var(--padding);
+      word-break: break-word;
     }
 
     &[data-tid="proposal-card"] > .meta {


### PR DESCRIPTION
# Motivation

Fix modal `.meta` information overflow

# Changes

- apply legacy meta style to modal as well
- add break word

# Screenshot

issue:

<img width="1510" alt="Capture d’écran 2022-09-15 à 18 58 02" src="https://user-images.githubusercontent.com/16886711/190465802-d0371c28-1192-4d76-8c2e-b4cd767ef441.png">

fix:

<img width="1510" alt="Capture d’écran 2022-09-15 à 19 00 55" src="https://user-images.githubusercontent.com/16886711/190465881-2ffde8cf-c014-480e-8722-3bc8c4ba5f41.png">

