### PR TITLE
style: fix legacy modal spacing

### DIFF
--- a/frontend/src/lib/themes/legacy.scss
+++ b/frontend/src/lib/themes/legacy.scss
@@ -4,8 +4,7 @@
 
 @use "@dfinity/gix-components/styles/mixins/media";
 
-main.legacy,
-div.modal.legacy {
+main.legacy {
   margin: inherit;
   padding: inherit;
   max-width: inherit;
@@ -24,7 +23,10 @@ div.modal.legacy {
   @include media.min-width(medium) {
     padding: inherit;
   }
+}
 
+main.legacy,
+div.modal.legacy {
   .card {
     // solve title|icp line (e.g. neuron card)
     .meta {


### PR DESCRIPTION
# Motivation

Not all the `.legacy` style should be inherited.

# Screenshots

<img width="1510" alt="Capture d’écran 2022-09-16 à 08 30 35" src="https://user-images.githubusercontent.com/16886711/190572031-ec895e20-37ba-41e8-8ddd-d509fededb60.png">
<img width="1510" alt="Capture d’écran 2022-09-16 à 08 31 09" src="https://user-images.githubusercontent.com/16886711/190572041-8db06fee-5c89-4fd4-a80f-ba5d114f1dfb.png">

