### PR TITLE
Generate local wasms for the next version of dfx

### DIFF
--- a/scripts/mk-sdk-build
+++ b/scripts/mk-sdk-build
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "INFO: In the upcoming dfx, canister IDs are changing so the usual _local build no longer works."
+echo "WARNING: This is for developers working against the head of master of the dfx repo."
+echo "WARNING: For a normal local wasm, use deploy.sh"
+read -rp "Are you sure this is the right tool for you? (ctrl-c to escape) "
+
+set -euxo pipefail
+rm -f nns-dapp.wasm nns-dapp_local.wasm
+jq '.networks.local.config.OWN_CANISTER_ID="qhbym-qaaaa-aaaaa-aaafq-cai"|.canisters["nns-dapp"].remote.id.local="qhbym-qaaaa-aaaaa-aaafq-cai"|.canisters.internet_identity.remote.id.local="qhbym-qaaaa-aaaaa-aaafq-cai"| .canisters["nns-sns-wasm"].remote.id.local="qaa6y-5yaaa-aaaaa-aaafa-cai"' dfx.json | sponge dfx.json
+export FEATURE_FLAGS='{"ENABLE_SNS":true,"VOTING_UI":"modern"}'
+export DFX_NETWORK=local
+./config.sh
+dfx build nns-dapp
+cp nns-dapp.wasm nns-dapp_local_v2.wasm
+echo FIN


### PR DESCRIPTION
# Motivation
When we switch to dfx v 0.12.0 our tests and local builds will break because canister IDs move around.

This script generates a local build for 0.12.0, which is needed for testing.  Once v0.12.0 has been released we can switch, update the code and delete this script.

# Changes
* Add a script to generate a local wasm suitable for next-gen dfx.

# Tests
I have deployed the wasm against the dfx in [this PR](https://github.com/dfinity/sdk/pull/2564) which in turn is needed for the next dfx.