### PR TITLE
Kill earlier runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ name: Native build
 on:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
       NNS_CACHING_KEY: dv-0004

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   formatting:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   builder:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,10 @@ on:
       # Commit to the nightly branch and push to test.
       - nightly
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-ii:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -7,6 +7,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tag_tip:
     if: github.event.pull_request.merged


### PR DESCRIPTION
# Motivation

If a developer (e.g. myself) pushes a branch, then notices a change that needs to be made and pushes again, the earlier job still runs to completion even though it is no longer of interest.  It would be nice to kill the earlier job when it is superseded.

Github's concurrency provides setting to do just this:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

I have opted for the configuration where each workflow has its own groups, so that a kill command from one workflow doesn't kill others.  This lets us choose for which workflows this policy is applied.  I have applied the concurrency limit to every workflow but we may decide that it is only appropriate for some.

# Changes
* Set each workflow to kill earlier runs of the same workflow on the same branch.

# Tests
* Feel free to push empty commits to this PR and watch CI: `git commit -m bump --allow-empty`
  * I personally have observed this working.