### PR TITLE
L2-993: User can see SNS main balance account

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.7.0-next-2022-09-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-03.tgz",
-      "integrity": "sha512-RDmiIa5LQ3DSMGmzhia5pfL76UCXlHgHfX3bg678fAaJpo5gk8eEFU4Ot1c8pvagCAeKPYiPExITsep3DZWY0w==",
+      "version": "0.7.0-next-2022-09-20",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-20.tgz",
+      "integrity": "sha512-aeZoppMIlRc1UHVBhzZ30qt+HlwvGPqLBuEw1BtsHlzDZgRlqqvrTeRd/DQFePMnJU+jrpbGf7CE3LAIKxssXQ==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.3-next-2022-09-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-03.tgz",
-      "integrity": "sha512-C4nWNMUdFZno2NTqnaCl+0avwiTkSJbAZ0ESrsgT2R/CTg8fjqnW+F56GybqdRj3YqSyuCHYeuklql3hQaF7Wg==",
+      "version": "0.0.3-next-2022-09-20",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-20.tgz",
+      "integrity": "sha512-HfHkzbHaJ+guPNMGu3feAk1F3D2JXRfCA6mVeaCvg7ciHoNv+voiZ0PxJMDUT+MH8y08UEdLHgf7Pak9fy/PNw==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.1-next"
       }
@@ -9978,9 +9978,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.7.0-next-2022-09-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-03.tgz",
-      "integrity": "sha512-RDmiIa5LQ3DSMGmzhia5pfL76UCXlHgHfX3bg678fAaJpo5gk8eEFU4Ot1c8pvagCAeKPYiPExITsep3DZWY0w==",
+      "version": "0.7.0-next-2022-09-20",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.7.0-next-2022-09-20.tgz",
+      "integrity": "sha512-aeZoppMIlRc1UHVBhzZ30qt+HlwvGPqLBuEw1BtsHlzDZgRlqqvrTeRd/DQFePMnJU+jrpbGf7CE3LAIKxssXQ==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -10016,9 +10016,9 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.3-next-2022-09-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-03.tgz",
-      "integrity": "sha512-C4nWNMUdFZno2NTqnaCl+0avwiTkSJbAZ0ESrsgT2R/CTg8fjqnW+F56GybqdRj3YqSyuCHYeuklql3hQaF7Wg==",
+      "version": "0.0.3-next-2022-09-20",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.3-next-2022-09-20.tgz",
+      "integrity": "sha512-HfHkzbHaJ+guPNMGu3feAk1F3D2JXRfCA6mVeaCvg7ciHoNv+voiZ0PxJMDUT+MH8y08UEdLHgf7Pak9fy/PNw==",
       "requires": {}
     },
     "@dfinity/utils": {

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,0 +1,44 @@
+import type { Identity } from "@dfinity/agent";
+import { TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import type { Account } from "../types/account";
+import { logWithTimestamp } from "../utils/dev.utils";
+import { mapOptionalToken } from "../utils/sns.utils";
+import { wrapper } from "./sns.api";
+
+export const getSnsAccounts = async ({
+  rootCanisterId,
+  identity,
+  certified,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+}): Promise<Account[]> => {
+  // TODO: Support subaccounts
+  logWithTimestamp("Getting sns accounts: call...");
+  const { balance, ledgerMetadata } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+
+  const [mainBalanceE8s, metadata] = await Promise.all([
+    balance({ owner: identity.getPrincipal() }),
+    ledgerMetadata({}),
+  ]);
+
+  const mainAccount: Account = {
+    // TODO: Implement string representation https://dfinity.atlassian.net/browse/GIX-1025
+    identifier: "sns-main-account-identifier",
+    principal: identity.getPrincipal(),
+    balance: TokenAmount.fromE8s({
+      amount: mainBalanceE8s,
+      token: mapOptionalToken(metadata),
+    }),
+    type: "main",
+  };
+
+  logWithTimestamp("Getting sns neuron: done");
+  return [mainAccount];
+};

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -4,7 +4,7 @@ import type { Principal } from "@dfinity/principal";
 import type { Account } from "../types/account";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { mapOptionalToken } from "../utils/sns.utils";
-import { wrapper } from "./sns.api";
+import { wrapper } from "./sns-wrapper.api";
 
 export const getSnsAccounts = async ({
   rootCanisterId,

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -1,0 +1,178 @@
+import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { DeployedSns, SnsWasmCanister } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
+import type { InitSnsWrapper, SnsWrapper } from "@dfinity/sns";
+import { HOST, WASM_CANISTER_ID } from "../constants/environment.constants";
+import {
+  importInitSnsWrapper,
+  importSnsWasmCanister,
+  type SnsWasmCanisterCreate,
+} from "../proxy/api.import.proxy";
+import { snsesCountStore } from "../stores/sns.store";
+import { ApiErrorKey } from "../types/api.errors";
+import type { QueryRootCanisterId } from "../types/sns.query";
+import { createAgent } from "../utils/agent.utils";
+import { logWithTimestamp } from "../utils/dev.utils";
+
+let snsQueryWrappers: Promise<Map<QueryRootCanisterId, SnsWrapper>> | undefined;
+let snsUpdateWrappers:
+  | Promise<Map<QueryRootCanisterId, SnsWrapper>>
+  | undefined;
+
+/**
+ * List all deployed Snses - i.e list all Sns projects
+ *
+ * @param {Object} params
+ * @param params.agent
+ * @param params.certified
+ * @return The list of root canister id of each deployed Sns project
+ */
+const listSnses = async ({
+  agent,
+  certified,
+}: {
+  agent: HttpAgent;
+  certified: boolean;
+}): Promise<Principal[]> => {
+  logWithTimestamp(`Loading list of Snses certified:${certified} call...`);
+
+  const SnsWasmCanister: SnsWasmCanisterCreate = await importSnsWasmCanister();
+
+  const { listSnses: getSnses }: SnsWasmCanister = SnsWasmCanister.create({
+    canisterId: Principal.fromText(WASM_CANISTER_ID),
+    agent,
+  });
+
+  const snses: DeployedSns[] = await getSnses({ certified });
+
+  logWithTimestamp(`Loading list of Snses certified:${certified} complete.`);
+
+  return snses.reduce(
+    (acc: Principal[], { root_canister_id }: DeployedSns) => [
+      ...acc,
+      ...root_canister_id,
+    ],
+    []
+  );
+};
+
+const initSns = async ({
+  agent,
+  rootCanisterId,
+  certified,
+}: {
+  agent: HttpAgent;
+  rootCanisterId: Principal;
+  certified: boolean;
+}): Promise<SnsWrapper> => {
+  logWithTimestamp(
+    `Initializing Sns ${rootCanisterId.toText()} certified:${certified} call...`
+  );
+
+  const initSnsWrapper: InitSnsWrapper = await importInitSnsWrapper();
+
+  const snsWrapper: SnsWrapper = await initSnsWrapper({
+    rootOptions: {
+      canisterId: rootCanisterId,
+    },
+    agent,
+    certified,
+  });
+
+  logWithTimestamp(
+    `Initializing Sns ${rootCanisterId.toText()} certified:${certified} complete.`
+  );
+
+  return snsWrapper;
+};
+
+const loadSnsWrappers = async ({
+  identity,
+  certified,
+}: {
+  certified: boolean;
+  identity: Identity;
+}): Promise<SnsWrapper[]> => {
+  const agent = await createAgent({
+    identity,
+    host: HOST,
+  });
+
+  const rootCanisterIds: Principal[] = await listSnses({ agent, certified });
+
+  snsesCountStore.set(rootCanisterIds.length);
+
+  const results: PromiseSettledResult<SnsWrapper>[] = await Promise.allSettled(
+    rootCanisterIds.map((rootCanisterId: Principal) =>
+      initSns({ agent, rootCanisterId, certified })
+    )
+  );
+
+  // TODO(L2-837): do no throw an error but emit or display only an error while continuing loading and displaying Sns projects that could be successfully fetched
+  const error: boolean =
+    results.find(({ status }) => status === "rejected") !== undefined;
+  if (error) {
+    throw new ApiErrorKey("error__sns.init");
+  }
+
+  return results
+    .filter(({ status }) => status === "fulfilled")
+    .map(({ value: wrapper }: PromiseFulfilledResult<SnsWrapper>) => wrapper);
+};
+
+const initWrappers = async ({
+  identity,
+  certified,
+}: {
+  certified: boolean;
+  identity: Identity;
+}): Promise<Map<QueryRootCanisterId, SnsWrapper>> =>
+  new Map(
+    (await loadSnsWrappers({ identity, certified })).map(
+      (wrapper: SnsWrapper) => [
+        wrapper.canisterIds.rootCanisterId.toText(),
+        wrapper,
+      ]
+    )
+  );
+
+export const wrappers = async ({
+  identity,
+  certified,
+}: {
+  certified: boolean;
+  identity: Identity;
+}): Promise<Map<QueryRootCanisterId, SnsWrapper>> => {
+  switch (certified) {
+    case false:
+      if (!snsQueryWrappers) {
+        snsQueryWrappers = initWrappers({ identity, certified: false });
+      }
+      return snsQueryWrappers;
+    default:
+      if (!snsUpdateWrappers) {
+        snsUpdateWrappers = initWrappers({ identity, certified: true });
+      }
+      return snsUpdateWrappers;
+  }
+};
+
+export const wrapper = async ({
+  identity,
+  rootCanisterId,
+  certified,
+}: {
+  identity: Identity;
+  rootCanisterId: QueryRootCanisterId;
+  certified: boolean;
+}): Promise<SnsWrapper> => {
+  const snsWrapper: SnsWrapper | undefined = (
+    await wrappers({ identity, certified })
+  ).get(rootCanisterId);
+
+  if (snsWrapper === undefined) {
+    throw new ApiErrorKey("error__sns.undefined_project");
+  }
+
+  return snsWrapper;
+};

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -1,8 +1,7 @@
-import type { HttpAgent, Identity } from "@dfinity/agent";
-import type { DeployedSns, ICP, SnsWasmCanister } from "@dfinity/nns";
+import type { Identity } from "@dfinity/agent";
+import type { ICP } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type {
-  InitSnsWrapper,
   SnsNeuron,
   SnsNeuronId,
   SnsNeuronPermissionType,
@@ -11,188 +10,17 @@ import type {
 } from "@dfinity/sns";
 import { toNullable } from "@dfinity/utils";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
-import { HOST, WASM_CANISTER_ID } from "../constants/environment.constants";
-import {
-  importInitSnsWrapper,
-  importSnsWasmCanister,
-  type SnsWasmCanisterCreate,
-} from "../proxy/api.import.proxy";
-import { snsesCountStore } from "../stores/sns.store";
-import { ApiErrorKey } from "../types/api.errors";
 import type { SnsSwapCommitment } from "../types/sns";
 import type {
   QueryRootCanisterId,
   QuerySnsMetadata,
   QuerySnsSwapState,
 } from "../types/sns.query";
-import { createAgent } from "../utils/agent.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { getSwapCanisterAccount } from "../utils/sns.utils";
 import { ledgerCanister } from "./ledger.api";
 import { nnsDappCanister } from "./nns-dapp.api";
-
-let snsQueryWrappers: Promise<Map<QueryRootCanisterId, SnsWrapper>> | undefined;
-let snsUpdateWrappers:
-  | Promise<Map<QueryRootCanisterId, SnsWrapper>>
-  | undefined;
-
-/**
- * List all deployed Snses - i.e list all Sns projects
- *
- * @param {Object} params
- * @param params.agent
- * @param params.certified
- * @return The list of root canister id of each deployed Sns project
- */
-const listSnses = async ({
-  agent,
-  certified,
-}: {
-  agent: HttpAgent;
-  certified: boolean;
-}): Promise<Principal[]> => {
-  logWithTimestamp(`Loading list of Snses certified:${certified} call...`);
-
-  const SnsWasmCanister: SnsWasmCanisterCreate = await importSnsWasmCanister();
-
-  const { listSnses }: SnsWasmCanister = SnsWasmCanister.create({
-    canisterId: Principal.fromText(WASM_CANISTER_ID),
-    agent,
-  });
-
-  const snses: DeployedSns[] = await listSnses({ certified });
-
-  logWithTimestamp(`Loading list of Snses certified:${certified} complete.`);
-
-  return snses.reduce(
-    (acc: Principal[], { root_canister_id }: DeployedSns) => [
-      ...acc,
-      ...root_canister_id,
-    ],
-    []
-  );
-};
-
-const initSns = async ({
-  agent,
-  rootCanisterId,
-  certified,
-}: {
-  agent: HttpAgent;
-  rootCanisterId: Principal;
-  certified: boolean;
-}): Promise<SnsWrapper> => {
-  logWithTimestamp(
-    `Initializing Sns ${rootCanisterId.toText()} certified:${certified} call...`
-  );
-
-  const initSnsWrapper: InitSnsWrapper = await importInitSnsWrapper();
-
-  const snsWrapper: SnsWrapper = await initSnsWrapper({
-    rootOptions: {
-      canisterId: rootCanisterId,
-    },
-    agent,
-    certified,
-  });
-
-  logWithTimestamp(
-    `Initializing Sns ${rootCanisterId.toText()} certified:${certified} complete.`
-  );
-
-  return snsWrapper;
-};
-
-const loadSnsWrappers = async ({
-  identity,
-  certified,
-}: {
-  certified: boolean;
-  identity: Identity;
-}): Promise<SnsWrapper[]> => {
-  const agent = await createAgent({
-    identity,
-    host: HOST,
-  });
-
-  const rootCanisterIds: Principal[] = await listSnses({ agent, certified });
-
-  snsesCountStore.set(rootCanisterIds.length);
-
-  const results: PromiseSettledResult<SnsWrapper>[] = await Promise.allSettled(
-    rootCanisterIds.map((rootCanisterId: Principal) =>
-      initSns({ agent, rootCanisterId, certified })
-    )
-  );
-
-  // TODO(L2-837): do no throw an error but emit or display only an error while continuing loading and displaying Sns projects that could be successfully fetched
-  const error: boolean =
-    results.find(({ status }) => status === "rejected") !== undefined;
-  if (error) {
-    throw new ApiErrorKey("error__sns.init");
-  }
-
-  return results
-    .filter(({ status }) => status === "fulfilled")
-    .map(({ value: wrapper }: PromiseFulfilledResult<SnsWrapper>) => wrapper);
-};
-
-const initWrappers = async ({
-  identity,
-  certified,
-}: {
-  certified: boolean;
-  identity: Identity;
-}): Promise<Map<QueryRootCanisterId, SnsWrapper>> =>
-  new Map(
-    (await loadSnsWrappers({ identity, certified })).map(
-      (wrapper: SnsWrapper) => [
-        wrapper.canisterIds.rootCanisterId.toText(),
-        wrapper,
-      ]
-    )
-  );
-
-const wrappers = async ({
-  identity,
-  certified,
-}: {
-  certified: boolean;
-  identity: Identity;
-}): Promise<Map<QueryRootCanisterId, SnsWrapper>> => {
-  switch (certified) {
-    case false:
-      if (!snsQueryWrappers) {
-        snsQueryWrappers = initWrappers({ identity, certified: false });
-      }
-      return snsQueryWrappers;
-    default:
-      if (!snsUpdateWrappers) {
-        snsUpdateWrappers = initWrappers({ identity, certified: true });
-      }
-      return snsUpdateWrappers;
-  }
-};
-
-export const wrapper = async ({
-  identity,
-  rootCanisterId,
-  certified,
-}: {
-  identity: Identity;
-  rootCanisterId: QueryRootCanisterId;
-  certified: boolean;
-}): Promise<SnsWrapper> => {
-  const snsWrapper: SnsWrapper | undefined = (
-    await wrappers({ identity, certified })
-  ).get(rootCanisterId);
-
-  if (snsWrapper === undefined) {
-    throw new ApiErrorKey("error__sns.undefined_project");
-  }
-
-  return snsWrapper;
-};
+import { wrapper, wrappers } from "./sns-wrapper.api";
 
 export const queryAllSnsMetadata = async ({
   identity,

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -174,7 +174,7 @@ const wrappers = async ({
   }
 };
 
-const wrapper = async ({
+export const wrapper = async ({
   identity,
   rootCanisterId,
   certified,

--- a/frontend/src/lib/derived/sns/sns-project-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-project-accounts.derived.ts
@@ -1,0 +1,28 @@
+import { derived, type Readable } from "svelte/store";
+import { snsAccountsStore } from "../../stores/sns-accounts.store";
+import type { Account } from "../../types/account";
+import { snsProjectSelectedStore } from "../selected-project.derived";
+
+/**
+ * Main account is put in the first position. The rest of the accounts keep the same order.
+ *
+ * @param accounts: Array of accounts
+ * @returns accounts
+ */
+const sortAccounts = (accounts: Account[]): Account[] => {
+  const nonMainAccounts: Account[] = accounts.filter(
+    ({ type }) => type !== "main"
+  );
+  const mainAccount = accounts.find((account) => account.type === "main");
+  return [...(mainAccount ? [mainAccount] : []), ...nonMainAccounts];
+};
+
+export const snsProjectAccountsStore: Readable<Account[] | undefined> = derived(
+  [snsAccountsStore, snsProjectSelectedStore],
+  ([store, selectedSnsRootCanisterId]) => {
+    const projectStore = store[selectedSnsRootCanisterId.toText()];
+    return projectStore === undefined
+      ? undefined
+      : sortAccounts(projectStore.accounts);
+  }
+);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -37,6 +37,7 @@
     "neuron_spawning": "Neuron is spawning, the details are not accessible until it has spawned.",
     "neuron_load": "An error occurred while loading the neuron.",
     "sns_neurons_load": "An error occurred while loading the neurons.",
+    "sns_accounts_load": "An error occurred while loading the accounts.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",
     "missing_identity": "The operation cannot be executed without any identity.",

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -7,7 +7,7 @@
   import { i18n } from "../stores/i18n";
   import { routeStore } from "../stores/route.store";
   import { AppPath } from "../constants/routes.constants";
-  import { TokenAmount } from "@dfinity/nns";
+  import type { TokenAmount } from "@dfinity/nns";
   import { sumTokenAmounts } from "../utils/icp.utils";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import AccountsTitle from "../components/accounts/AccountsTitle.svelte";

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -8,7 +8,7 @@
   import { routeStore } from "../stores/route.store";
   import { AppPath } from "../constants/routes.constants";
   import { TokenAmount } from "@dfinity/nns";
-  import { formatICP, sumTokenAmounts } from "../utils/icp.utils";
+  import { sumTokenAmounts } from "../utils/icp.utils";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
 
@@ -23,28 +23,19 @@
 
   onDestroy(unsubscribe);
 
-  let totalBalance: TokenAmount;
-  let totalICP: string;
-  const zeroICPs = TokenAmount.fromE8s({
-    amount: BigInt(0),
-    token: accounts?.main?.balance.token,
-  });
-  $: {
-    totalBalance = sumTokenAmounts(
-      accounts?.main?.balance || zeroICPs,
-      ...(accounts?.subAccounts || []).map(({ balance }) => balance),
-      ...(accounts?.hardwareWallets || []).map(({ balance }) => balance)
-    );
-    totalICP = formatICP({
-      value: totalBalance.toE8s(),
-      detailed: true,
-    });
-  }
+  let totalBalance: TokenAmount | undefined;
+  $: totalBalance =
+    accounts?.main?.balance !== undefined
+      ? sumTokenAmounts(
+          accounts?.main?.balance,
+          ...(accounts?.subAccounts || []).map(({ balance }) => balance),
+          ...(accounts?.hardwareWallets || []).map(({ balance }) => balance)
+        )
+      : undefined;
 </script>
 
 <section data-tid="accounts-body">
   <AccountsTitle balance={totalBalance} />
-
   {#if accounts?.main?.identifier}
     <AccountCard
       role="link"

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -16,6 +16,7 @@
   const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
     async (selectedProjectCanisterId) => {
       if (selectedProjectCanisterId !== undefined) {
+        // TODO: improve loading and use in memory sns neurons or load from backend
         loading = true;
         await loadSnsAccounts(selectedProjectCanisterId);
         loading = false;

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -33,8 +33,9 @@
           ...$snsProjectAccountsStore.map(({ balance }) => balance)
         );
 
-  // TODO: Wallet details https://dfinity.atlassian.net/browse/GIX-995
   const goToDetails = (account: Account) => {
+    // TODO: Wallet details https://dfinity.atlassian.net/browse/GIX-995
+    // eslint-disable-next-line no-console
     console.log("goToDetails", account);
   };
 </script>

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -1,17 +1,56 @@
 <script lang="ts">
-  import { TokenAmount } from "@dfinity/nns";
+  import type { TokenAmount } from "@dfinity/nns";
+  import { onDestroy } from "svelte";
+  import type { Unsubscriber } from "svelte/store";
   import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
+  import { snsOnlyProjectStore } from "../derived/selected-project.derived";
+  import { loadSnsAccounts } from "../services/sns-accounts.services";
+  import { snsProjectAccountsStore } from "../derived/sns/sns-project-accounts.derived";
+  import AccountCard from "../components/accounts/AccountCard.svelte";
+  import { i18n } from "../stores/i18n";
+  import type { Account } from "../types/account";
+  import { sumTokenAmounts } from "../utils/icp.utils";
+  import SkeletonCard from "../components/ui/SkeletonCard.svelte";
 
-  // TODO: Implement https://dfinity.atlassian.net/browse/GIX-993
-  let totalAmountToken = TokenAmount.fromE8s({
-    amount: BigInt(0),
-    token: {
-      symbol: "test",
-      name: "todo",
-    },
-  });
+  let loading: boolean = false;
+  const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
+    async (selectedProjectCanisterId) => {
+      if (selectedProjectCanisterId !== undefined) {
+        loading = true;
+        await loadSnsAccounts(selectedProjectCanisterId);
+        loading = false;
+      }
+    }
+  );
+
+  onDestroy(unsubscribe);
+
+  let totalAmountToken: TokenAmount | undefined;
+  $: totalAmountToken =
+    $snsProjectAccountsStore === undefined
+      ? undefined
+      : sumTokenAmounts(
+          ...$snsProjectAccountsStore.map(({ balance }) => balance)
+        );
+
+  // TODO: Wallet details https://dfinity.atlassian.net/browse/GIX-995
+  const goToDetails = (account: Account) => {
+    console.log("goToDetails", account);
+  };
 </script>
 
 <section data-tid="sns-accounts-body">
   <AccountsTitle balance={totalAmountToken} />
+  {#if loading}
+    <SkeletonCard />
+  {:else}
+    {#each $snsProjectAccountsStore ?? [] as account}
+      <AccountCard
+        role="link"
+        on:click={() => goToDetails(account)}
+        showCopy
+        {account}>{account.name ?? $i18n.accounts.main}</AccountCard
+      >
+    {/each}
+  {/if}
 </section>

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -1,7 +1,9 @@
 import type { Principal } from "@dfinity/principal";
 import { getSnsAccounts } from "../api/sns-ledger.api";
 import { snsAccountsStore } from "../stores/sns-accounts.store";
+import { toastsError } from "../stores/toasts.store";
 import type { Account } from "../types/account";
+import { toToastError } from "../utils/error.utils";
 import { queryAndUpdate } from "./utils.services";
 
 export const loadSnsAccounts = async (
@@ -16,9 +18,23 @@ export const loadSnsAccounts = async (
         rootCanisterId,
         certified,
       }),
-    onError: (error) => {
-      // TODO: Manage errors https://dfinity.atlassian.net/browse/GIX-1026
-      console.error("in da error", error);
+    onError: ({ error: err, certified }) => {
+      console.error(err);
+
+      if (certified !== true) {
+        return;
+      }
+
+      // hide unproven data
+      snsAccountsStore.resetProject(rootCanisterId);
+
+      toastsError(
+        toToastError({
+          err,
+          fallbackErrorLabelKey: "error.sns_neurons_load",
+        })
+      );
     },
+    logMessage: "Syncing Sns Accounts",
   });
 };

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -1,0 +1,24 @@
+import type { Principal } from "@dfinity/principal";
+import { getSnsAccounts } from "../api/sns-ledger.api";
+import { snsAccountsStore } from "../stores/sns-accounts.store";
+import type { Account } from "../types/account";
+import { queryAndUpdate } from "./utils.services";
+
+export const loadSnsAccounts = async (
+  rootCanisterId: Principal
+): Promise<void> => {
+  return queryAndUpdate<Account[], unknown>({
+    request: ({ certified, identity }) =>
+      getSnsAccounts({ rootCanisterId, identity, certified }),
+    onLoad: ({ response: accounts, certified }) =>
+      snsAccountsStore.setAccounts({
+        accounts,
+        rootCanisterId,
+        certified,
+      }),
+    onError: (error) => {
+      // TODO: Manage errors https://dfinity.atlassian.net/browse/GIX-1026
+      console.error("in da error", error);
+    },
+  });
+};

--- a/frontend/src/lib/stores/sns-accounts.store.ts
+++ b/frontend/src/lib/stores/sns-accounts.store.ts
@@ -1,0 +1,62 @@
+import type { Principal } from "@dfinity/principal";
+import { writable } from "svelte/store";
+import type { Account } from "../types/account";
+
+interface SnsAccount {
+  accounts: Account[];
+  certified: boolean;
+}
+
+export interface SnsAccountsStore {
+  // Each SNS Project is an entry in this Store.
+  // We use the root canister id as the key to identify the accounts for a specific project.
+  [rootCanisterId: string]: SnsAccount;
+}
+
+/**
+ * A store that contains the sns accounts for each project.
+ *
+ * - setAccounts: replace the current list of accounts for a specific sns project with a new list.
+ * - reset: reset the store to an empty state.
+ * - resetProject: removed the accounts for a specific project.
+ */
+const initSnsAccountsStore = () => {
+  const { subscribe, update, set } = writable<SnsAccountsStore>({});
+
+  return {
+    subscribe,
+
+    setAccounts({
+      rootCanisterId,
+      accounts,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      accounts: Account[];
+      certified: boolean;
+    }) {
+      update((currentState: SnsAccountsStore) => ({
+        ...currentState,
+        [rootCanisterId.toText()]: {
+          accounts,
+          certified,
+        },
+      }));
+    },
+
+    // Used in tests
+    reset() {
+      set({});
+    },
+
+    resetProject(rootCanisterId: Principal) {
+      update((currentState: SnsAccountsStore) =>
+        Object.entries(currentState)
+          .filter(([key]) => key !== rootCanisterId.toText())
+          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
+      );
+    },
+  };
+};
+
+export const snsAccountsStore = initSnsAccountsStore();

--- a/frontend/src/lib/stores/sns-accounts.store.ts
+++ b/frontend/src/lib/stores/sns-accounts.store.ts
@@ -1,6 +1,7 @@
 import type { Principal } from "@dfinity/principal";
 import { writable } from "svelte/store";
 import type { Account } from "../types/account";
+import { removeKeys } from "../utils/utils";
 
 interface SnsAccount {
   accounts: Account[];
@@ -51,9 +52,7 @@ const initSnsAccountsStore = () => {
 
     resetProject(rootCanisterId: Principal) {
       update((currentState: SnsAccountsStore) =>
-        Object.entries(currentState)
-          .filter(([key]) => key !== rootCanisterId.toText())
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
+        removeKeys(currentState, [rootCanisterId.toText()])
       );
     },
   };

--- a/frontend/src/lib/stores/sns-accounts.store.ts
+++ b/frontend/src/lib/stores/sns-accounts.store.ts
@@ -52,7 +52,10 @@ const initSnsAccountsStore = () => {
 
     resetProject(rootCanisterId: Principal) {
       update((currentState: SnsAccountsStore) =>
-        removeKeys(currentState, [rootCanisterId.toText()])
+        removeKeys({
+          obj: currentState,
+          keysToRemove: [rootCanisterId.toText()],
+        })
       );
     },
   };

--- a/frontend/src/lib/stores/sns-neurons.store.ts
+++ b/frontend/src/lib/stores/sns-neurons.store.ts
@@ -50,7 +50,10 @@ const initSnsNeuronsStore = () => {
 
     resetProject(rootCanisterId: Principal) {
       update((currentState: NeuronsStore) =>
-        removeKeys(currentState, [rootCanisterId.toText()])
+        removeKeys({
+          obj: currentState,
+          keysToRemove: [rootCanisterId.toText()],
+        })
       );
     },
   };

--- a/frontend/src/lib/stores/sns-neurons.store.ts
+++ b/frontend/src/lib/stores/sns-neurons.store.ts
@@ -1,6 +1,7 @@
 import type { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
 import { writable } from "svelte/store";
+import { removeKeys } from "../utils/utils";
 
 export interface ProjectNeuronStore {
   neurons: SnsNeuron[];
@@ -49,9 +50,7 @@ const initSnsNeuronsStore = () => {
 
     resetProject(rootCanisterId: Principal) {
       update((currentState: NeuronsStore) =>
-        Object.entries(currentState)
-          .filter(([key]) => key !== rootCanisterId.toText())
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
+        removeKeys(currentState, [rootCanisterId.toText()])
       );
     },
   };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -41,6 +41,7 @@ interface I18nError {
   neuron_spawning: string;
   neuron_load: string;
   sns_neurons_load: string;
+  sns_accounts_load: string;
   list_proposals: string;
   list_canisters: string;
   missing_identity: string;

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -89,7 +89,7 @@ const mapOptionalMetadata = ({
 /**
  * Token metadata is given only if the properties NNS-dapp needs (name and symbol) are defined.
  */
-const mapOptionalToken = (
+export const mapOptionalToken = (
   response: SnsTokenMetadataResponse
 ): SnsTokenMetadata | undefined => {
   const nullishToken: Partial<SnsTokenMetadata> = response.reduce(

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -270,10 +270,13 @@ export const valueSpan = (text: string): string =>
  * @param keysToRemove keys to remove
  * @returns new object with entries removed
  */
-export const removeKeys = <T extends Record<string, unknown>>(
-  obj: T,
-  keysToRemove: string[]
-): T =>
+export const removeKeys = <T extends Record<string, unknown>>({
+  obj,
+  keysToRemove,
+}: {
+  obj: T;
+  keysToRemove: string[];
+}): T =>
   Object.entries(obj)
     .filter(([key]) => keysToRemove.indexOf(key) === -1)
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {} as T);

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -262,3 +262,18 @@ export const poll = async <T>({
  */
 export const valueSpan = (text: string): string =>
   `<span class="value">${text}</span>`;
+
+/**
+ * Removes entries from an object given a list of keys.
+ *
+ * @param obj object to remove entries from
+ * @param keysToRemove keys to remove
+ * @returns new object with entries removed
+ */
+export const removeKeys = <T extends Record<string, unknown>>(
+  obj: T,
+  keysToRemove: string[]
+): T =>
+  Object.entries(obj)
+    .filter(([key]) => keysToRemove.indexOf(key) === -1)
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {} as T);

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -1,0 +1,7 @@
+describe("sns-ledger api", () => {
+  describe("getSnsAccounts", () => {
+    it("returns main account with balance and project token metadata", () => {
+      // TODO
+    });
+  });
+});

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -1,7 +1,50 @@
+import { getSnsAccounts } from "../../../lib/api/sns-ledger.api";
+import { importInitSnsWrapper } from "../../../lib/proxy/api.import.proxy";
+import { mockIdentity } from "../../mocks/auth.store.mock";
+import { mockQueryTokenResponse } from "../../mocks/sns-projects.mock";
+import {
+  governanceCanisterIdMock,
+  ledgerCanisterIdMock,
+  rootCanisterIdMock,
+  swapCanisterIdMock,
+} from "../../mocks/sns.api.mock";
+
 describe("sns-ledger api", () => {
+  const mainBalance = BigInt(10_000_000);
+  const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
+  const metadataSpy = jest.fn().mockResolvedValue(mockQueryTokenResponse);
+
+  beforeEach(() => {
+    (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
+      Promise.resolve({
+        canisterIds: {
+          rootCanisterId: rootCanisterIdMock,
+          ledgerCanisterId: ledgerCanisterIdMock,
+          governanceCanisterId: governanceCanisterIdMock,
+          swapCanisterId: swapCanisterIdMock,
+        },
+        balance: balanceSpy,
+        ledgerMetadata: metadataSpy,
+      })
+    );
+  });
   describe("getSnsAccounts", () => {
-    it("returns main account with balance and project token metadata", () => {
-      // TODO
+    it("returns main account with balance and project token metadata", async () => {
+      const accounts = await getSnsAccounts({
+        certified: true,
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+      });
+
+      expect(accounts.length).toBeGreaterThan(0);
+
+      const main = accounts.find(({ type }) => type === "main");
+      expect(main).not.toBeUndefined();
+
+      expect(main?.balance).toEqual(mainBalance);
+
+      expect(balanceSpy).toBeCalled();
+      expect(metadataSpy).toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -1,0 +1,44 @@
+import { wrappers } from "../../../lib/api/sns-wrapper.api";
+import {
+  importInitSnsWrapper,
+  importSnsWasmCanister,
+} from "../../../lib/proxy/api.import.proxy";
+import { mockIdentity } from "../../mocks/auth.store.mock";
+import {
+  deployedSnsMock,
+  governanceCanisterIdMock,
+  ledgerCanisterIdMock,
+  rootCanisterIdMock,
+  swapCanisterIdMock,
+} from "../../mocks/sns.api.mock";
+
+jest.mock("../../../lib/proxy/api.import.proxy");
+
+describe("sns-wrapper api", () => {
+  describe("wrappers", () => {
+    const listSnsesSpy = jest.fn().mockResolvedValue(deployedSnsMock);
+    beforeEach(() => {
+      (importSnsWasmCanister as jest.Mock).mockResolvedValue({
+        create: () => ({
+          listSnses: listSnsesSpy,
+        }),
+      });
+
+      (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
+        Promise.resolve({
+          canisterIds: {
+            rootCanisterId: rootCanisterIdMock,
+            ledgerCanisterId: ledgerCanisterIdMock,
+            governanceCanisterId: governanceCanisterIdMock,
+            swapCanisterId: swapCanisterIdMock,
+          },
+        })
+      );
+    });
+    it("calls list to all Snses", async () => {
+      await wrappers({ identity: mockIdentity, certified: false });
+
+      expect(listSnsesSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
@@ -44,4 +44,18 @@ describe("sns-project-accounts store", () => {
     const value = get(snsProjectAccountsStore);
     expect(value?.length).toEqual(2);
   });
+
+  it("should retun first the main account", () => {
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+    });
+    const accounts = [mockSnsSubAccount, mockSnsMainAccount];
+    snsAccountsStore.setAccounts({
+      rootCanisterId: mockPrincipal,
+      accounts,
+      certified: true,
+    });
+    const value = get(snsProjectAccountsStore);
+    expect(value?.[0]?.type).toEqual("main");
+  });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { get } from "svelte/store";
+import {
+  AppPath,
+  CONTEXT_PATH,
+} from "../../../../lib/constants/routes.constants";
+import { snsProjectAccountsStore } from "../../../../lib/derived/sns/sns-project-accounts.derived";
+import { routeStore } from "../../../../lib/stores/route.store";
+import { snsAccountsStore } from "../../../../lib/stores/sns-accounts.store";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+} from "../../../mocks/sns-accounts.mock";
+
+describe("sns-project-accounts store", () => {
+  afterEach(() => {
+    routeStore.update({
+      path: AppPath.LegacyAccounts,
+    });
+  });
+  it("should return undefined if project is not set in the store", () => {
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+    });
+    snsAccountsStore.reset();
+    const value = get(snsProjectAccountsStore);
+    expect(value).toBeUndefined();
+  });
+
+  it("should retun array of accounts of the selected project", () => {
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+    });
+    const accounts = [mockSnsMainAccount, mockSnsSubAccount];
+    snsAccountsStore.setAccounts({
+      rootCanisterId: mockPrincipal,
+      accounts,
+      certified: true,
+    });
+    const value = get(snsProjectAccountsStore);
+    expect(value?.length).toEqual(2);
+  });
+});

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -3,9 +3,12 @@
  */
 
 import { render } from "@testing-library/svelte";
+import type { Subscriber } from "svelte/store";
 import NnsAccounts from "../../../lib/pages/NnsAccounts.svelte";
-import { accountsStore } from "../../../lib/stores/accounts.store";
-import { authStore } from "../../../lib/stores/auth.store";
+import {
+  accountsStore,
+  type AccountsStore,
+} from "../../../lib/stores/accounts.store";
 import { replacePlaceholders } from "../../../lib/utils/i18n.utils";
 import { formatICP } from "../../../lib/utils/icp.utils";
 import {
@@ -14,99 +17,98 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "../../mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 
 describe("NnsAccounts", () => {
-  let accountsStoreMock: jest.SpyInstance;
+  afterEach(() => jest.clearAllMocks());
 
-  beforeEach(() => {
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-  });
+  describe("when there are accounts", () => {
+    let accountsStoreMock: jest.SpyInstance;
 
-  it("should render title and account icp", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(NnsAccounts);
+    it("should render title and account icp", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+      const { container } = render(NnsAccounts);
 
-    const titleRow = container.querySelector("section > div");
+      const titleRow = container.querySelector("section > div");
 
-    expect(
-      titleRow?.textContent?.startsWith(
-        `${en.accounts.total} ${formatICP({
-          value: mockMainAccount.balance.toE8s(),
-        })} ICP`
-      )
-    ).toBeTruthy();
-  });
+      expect(
+        titleRow?.textContent?.startsWith(
+          `${en.accounts.total} ${formatICP({
+            value: mockMainAccount.balance.toE8s(),
+          })} ICP`
+        )
+      ).toBeTruthy();
+    });
 
-  it("should render a main card", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(NnsAccounts);
+    it("should render a main card", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+      const { container } = render(NnsAccounts);
 
-    const article = container.querySelector("article");
-    expect(article).not.toBeNull();
-  });
+      const article = container.querySelector("article");
+      expect(article).not.toBeNull();
+    });
 
-  it("should render account icp in card too", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { container } = render(NnsAccounts);
+    it("should render account icp in card too", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+      const { container } = render(NnsAccounts);
 
-    const cardTitleRow = container.querySelector(
-      "article > div div:last-of-type"
-    );
-
-    expect(cardTitleRow?.textContent).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
-    );
-  });
-
-  it("should render account identifier", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    const { getByText } = render(NnsAccounts);
-    getByText(mockMainAccount.identifier);
-  });
-
-  it("should render subaccount cards", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
-    const { container } = render(NnsAccounts);
-
-    const articles = container.querySelectorAll("article");
-
-    expect(articles).not.toBeNull();
-    expect(articles.length).toBe(2);
-  });
-
-  it("should render hardware wallet account cards", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(
-        mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
+      const cardTitleRow = container.querySelector(
+        "article > div div:last-of-type"
       );
-    const { container } = render(NnsAccounts);
 
-    const articles = container.querySelectorAll("article");
+      expect(cardTitleRow?.textContent).toEqual(
+        `${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+      );
+    });
 
-    expect(articles).not.toBeNull();
-    expect(articles.length).toBe(2);
-  });
+    it("should render account identifier", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+      const { getByText } = render(NnsAccounts);
+      getByText(mockMainAccount.identifier);
+    });
 
-  it("should subscribe to store", () => {
-    accountsStoreMock = jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe());
-    expect(accountsStoreMock).toHaveBeenCalled();
+    it("should render subaccount cards", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+      const { container } = render(NnsAccounts);
+
+      const articles = container.querySelectorAll("article");
+
+      expect(articles).not.toBeNull();
+      expect(articles.length).toBe(2);
+    });
+
+    it("should render hardware wallet account cards", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(
+          mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
+        );
+      const { container } = render(NnsAccounts);
+
+      const articles = container.querySelectorAll("article");
+
+      expect(articles).not.toBeNull();
+      expect(articles.length).toBe(2);
+    });
+
+    it("should subscribe to store", () => {
+      accountsStoreMock = jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(mockAccountsStoreSubscribe());
+      render(NnsAccounts);
+
+      expect(accountsStoreMock).toHaveBeenCalled();
+    });
   });
 
   describe("Total ICPs", () => {
@@ -115,16 +117,15 @@ describe("NnsAccounts", () => {
       mockSubAccount.balance.toE8s() +
       mockHardwareWalletAccount.balance.toE8s();
 
-    beforeAll(
-      () =>
-        (accountsStoreMock = jest
-          .spyOn(accountsStore, "subscribe")
-          .mockImplementation(
-            mockAccountsStoreSubscribe(
-              [mockSubAccount],
-              [mockHardwareWalletAccount]
-            )
-          ))
+    beforeAll(() =>
+      jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation(
+          mockAccountsStoreSubscribe(
+            [mockSubAccount],
+            [mockHardwareWalletAccount]
+          )
+        )
     );
 
     afterAll(jest.clearAllMocks);
@@ -166,6 +167,30 @@ describe("NnsAccounts", () => {
           })}`,
         })
       );
+    });
+  });
+
+  describe("when no accounts", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(accountsStore, "subscribe")
+        .mockImplementation((run: Subscriber<AccountsStore>): (() => void) => {
+          run({
+            main: undefined,
+            subAccounts: undefined,
+            hardwareWallets: undefined,
+          });
+
+          return () => undefined;
+        });
+    });
+    it("should not render a token amount component nor zero", () => {
+      const { container } = render(NnsAccounts);
+
+      // The tooltip wraps the total amount
+      expect(
+        container.querySelector(".tooltip-wrapper")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -2,10 +2,33 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
+import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
+import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsAccounts from "../../../lib/pages/SnsAccounts.svelte";
+import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
+import { routeStore } from "../../../lib/stores/route.store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import en from "../../mocks/i18n.mock";
+import { mockSnsAccountsStoreSubscribe } from "../../mocks/sns-accounts.mock";
+
+jest.mock("../../../lib/services/sns-accounts.services", () => {
+  return {
+    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
 
 describe("SnsAccounts", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(snsProjectAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe());
+    // Context needs to match the mocked sns accounts
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+    });
+  });
+
   it("should render accounts title", () => {
     const { getByTestId } = render(SnsAccounts);
 
@@ -16,5 +39,27 @@ describe("SnsAccounts", () => {
     const { container } = render(SnsAccounts);
 
     expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
+  });
+
+  it("should render a main Account", async () => {
+    const { getByText } = render(SnsAccounts);
+
+    await waitFor(() =>
+      expect(getByText(en.accounts.main)).toBeInTheDocument()
+    );
+  });
+
+  it("should render account cards", async () => {
+    const { getAllByTestId } = render(SnsAccounts);
+
+    await waitFor(() =>
+      expect(getAllByTestId("account-card").length).toBeGreaterThan(0)
+    );
+  });
+
+  it("should load sns accounts of the project", () => {
+    render(SnsAccounts);
+
+    expect(loadSnsAccounts).toHaveBeenCalledWith(mockPrincipal);
   });
 });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { render, waitFor } from "@testing-library/svelte";
+import type { Subscriber } from "svelte/store";
 import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsAccounts from "../../../lib/pages/SnsAccounts.svelte";
@@ -19,47 +20,68 @@ jest.mock("../../../lib/services/sns-accounts.services", () => {
 });
 
 describe("SnsAccounts", () => {
-  beforeEach(() => {
-    jest
-      .spyOn(snsProjectAccountsStore, "subscribe")
-      .mockImplementation(mockSnsAccountsStoreSubscribe());
-    // Context needs to match the mocked sns accounts
-    routeStore.update({
-      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+  describe("when there are accounts in the store", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(snsProjectAccountsStore, "subscribe")
+        .mockImplementation(mockSnsAccountsStoreSubscribe());
+      // Context needs to match the mocked sns accounts
+      routeStore.update({
+        path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+      });
+    });
+
+    it("should render accounts title", () => {
+      const { getByTestId } = render(SnsAccounts);
+
+      expect(getByTestId("accounts-title")).toBeInTheDocument();
+    });
+
+    it("should contain a tooltip", () => {
+      const { container } = render(SnsAccounts);
+
+      expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
+    });
+
+    it("should render a main Account", async () => {
+      const { getByText } = render(SnsAccounts);
+
+      await waitFor(() =>
+        expect(getByText(en.accounts.main)).toBeInTheDocument()
+      );
+    });
+
+    it("should render account cards", async () => {
+      const { getAllByTestId } = render(SnsAccounts);
+
+      await waitFor(() =>
+        expect(getAllByTestId("account-card").length).toBeGreaterThan(0)
+      );
+    });
+
+    it("should load sns accounts of the project", () => {
+      render(SnsAccounts);
+
+      expect(loadSnsAccounts).toHaveBeenCalledWith(mockPrincipal);
     });
   });
 
-  it("should render accounts title", () => {
-    const { getByTestId } = render(SnsAccounts);
+  describe("when no accounts", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(snsProjectAccountsStore, "subscribe")
+        .mockImplementation((run: Subscriber<undefined>): (() => void) => {
+          run(undefined);
+          return () => undefined;
+        });
+    });
+    it("should not render a token amount component nor zero", () => {
+      const { container } = render(SnsAccounts);
 
-    expect(getByTestId("accounts-title")).toBeInTheDocument();
-  });
-
-  it("should contain a tooltip", () => {
-    const { container } = render(SnsAccounts);
-
-    expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
-  });
-
-  it("should render a main Account", async () => {
-    const { getByText } = render(SnsAccounts);
-
-    await waitFor(() =>
-      expect(getByText(en.accounts.main)).toBeInTheDocument()
-    );
-  });
-
-  it("should render account cards", async () => {
-    const { getAllByTestId } = render(SnsAccounts);
-
-    await waitFor(() =>
-      expect(getAllByTestId("account-card").length).toBeGreaterThan(0)
-    );
-  });
-
-  it("should load sns accounts of the project", () => {
-    render(SnsAccounts);
-
-    expect(loadSnsAccounts).toHaveBeenCalledWith(mockPrincipal);
+      // Tooltip wraps the amount
+      expect(
+        container.querySelector(".tooltip-wrapper")
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -1,0 +1,49 @@
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import * as api from "../../../lib/api/sns-ledger.api";
+import * as services from "../../../lib/services/sns-accounts.services";
+import { snsAccountsStore } from "../../../lib/stores/sns-accounts.store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
+
+const { loadSnsAccounts } = services;
+
+describe("sns-accounts-services", () => {
+  describe("loadSnsAccounts", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      snsAccountsStore.reset();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    it("should call api.getSnsAccounts and load neurons in store", async () => {
+      const spyQuery = jest
+        .spyOn(api, "getSnsAccounts")
+        .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
+
+      await loadSnsAccounts(mockPrincipal);
+
+      await tick();
+      const store = get(snsAccountsStore);
+      expect(store[mockPrincipal.toText()]?.accounts).toHaveLength(1);
+      expect(spyQuery).toBeCalled();
+    });
+
+    it("should empty store if update call fails", async () => {
+      snsAccountsStore.setAccounts({
+        rootCanisterId: mockPrincipal,
+        accounts: [mockSnsMainAccount],
+        certified: true,
+      });
+      const spyQuery = jest
+        .spyOn(api, "getSnsAccounts")
+        .mockImplementation(() => Promise.reject(undefined));
+
+      await loadSnsAccounts(mockPrincipal);
+
+      await tick();
+      const store = get(snsAccountsStore);
+      expect(store[mockPrincipal.toText()]).toBeUndefined();
+      expect(spyQuery).toBeCalled();
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-accounts.store.spec.ts
@@ -1,0 +1,62 @@
+import { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
+import { snsAccountsStore } from "../../../lib/stores/sns-accounts.store";
+import type { Account } from "../../../lib/types/account";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+} from "../../mocks/sns-accounts.mock";
+
+describe("SNS Accounts store", () => {
+  describe("snsAccountsStore", () => {
+    afterEach(() => snsAccountsStore.reset());
+    it("should set accounts for a project", () => {
+      const accounts: Account[] = [mockSnsMainAccount, mockSnsSubAccount];
+      snsAccountsStore.setAccounts({
+        rootCanisterId: mockPrincipal,
+        accounts,
+        certified: true,
+      });
+
+      const accountsInStore = get(snsAccountsStore);
+      expect(accountsInStore[mockPrincipal.toText()].accounts).toEqual(
+        accounts
+      );
+    });
+
+    it("should reset accounts for a project", () => {
+      const accounts: Account[] = [mockSnsMainAccount, mockSnsSubAccount];
+      snsAccountsStore.setAccounts({
+        rootCanisterId: mockPrincipal,
+        accounts,
+        certified: true,
+      });
+      snsAccountsStore.resetProject(mockPrincipal);
+
+      const accountsInStore = get(snsAccountsStore);
+      expect(accountsInStore[mockPrincipal.toText()]).toBeUndefined();
+    });
+
+    it("should add accounts for another project", () => {
+      const accounts1: Account[] = [mockSnsMainAccount, mockSnsSubAccount];
+      snsAccountsStore.setAccounts({
+        rootCanisterId: mockPrincipal,
+        accounts: accounts1,
+        certified: true,
+      });
+      const accounts2: Account[] = [mockSnsMainAccount];
+      const principal2 = Principal.fromText("aaaaa-aa");
+      snsAccountsStore.setAccounts({
+        rootCanisterId: principal2,
+        accounts: accounts2,
+        certified: true,
+      });
+      const accountsInStore = get(snsAccountsStore);
+      expect(accountsInStore[mockPrincipal.toText()].accounts).toEqual(
+        accounts1
+      );
+      expect(accountsInStore[principal2.toText()].accounts).toEqual(accounts2);
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -4,12 +4,14 @@ import { SnsMetadataResponseEntries } from "@dfinity/sns";
 import {
   getSwapCanisterAccount,
   mapAndSortSnsQueryToSummaries,
+  mapOptionalToken,
 } from "../../../lib/utils/sns.utils";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   mockDerived,
   mockQueryMetadata,
   mockQueryMetadataResponse,
+  mockQueryTokenResponse,
   mockSnsSummaryList,
   mockSummary,
   mockSwapInit,
@@ -276,6 +278,14 @@ describe("sns-utils", () => {
         controller: mockIdentity.getPrincipal(),
       });
       expect(expectedAccount).toBeInstanceOf(AccountIdentifier);
+    });
+  });
+
+  describe("mapOptionalToken", () => {
+    it("should return token", () => {
+      const token = mapOptionalToken(mockQueryTokenResponse);
+      expect(token?.name).toBeDefined();
+      expect(token?.symbol).toBeDefined();
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   nonNullish,
   poll,
   PollingLimitExceededError,
+  removeKeys,
   smallerVersion,
   stringifyJson,
   uniqueObjects,
@@ -393,6 +394,35 @@ describe("utils", () => {
       // Without the `await`, the line didn't wait the `poll` to throw to move to the next line
       await expect(call).rejects.toThrowError(PollingLimitExceededError);
       expect(counter).toBe(maxAttempts);
+    });
+  });
+
+  describe("removeKeys", () => {
+    it("removes the keys passed", () => {
+      const obj = {
+        a: 1,
+        b: 2,
+        c: 3,
+      };
+      const expected = {
+        a: 1,
+        c: 3,
+      };
+      expect(removeKeys(obj, ["b"])).toEqual(expected);
+      expect(Object.keys(removeKeys(obj, ["b", "a", "c"])).length).toBe(0);
+    });
+
+    it("should ignore keys that are not present", () => {
+      const obj = {
+        a: 1,
+        b: 2,
+        c: 3,
+      };
+      const expected = {
+        a: 1,
+        c: 3,
+      };
+      expect(removeKeys(obj, ["b", "d"])).toEqual(expected);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -408,8 +408,10 @@ describe("utils", () => {
         a: 1,
         c: 3,
       };
-      expect(removeKeys(obj, ["b"])).toEqual(expected);
-      expect(Object.keys(removeKeys(obj, ["b", "a", "c"])).length).toBe(0);
+      expect(removeKeys({ obj, keysToRemove: ["b"] })).toEqual(expected);
+      expect(
+        Object.keys(removeKeys({ obj, keysToRemove: ["b", "a", "c"] })).length
+      ).toBe(0);
     });
 
     it("should ignore keys that are not present", () => {
@@ -422,7 +424,7 @@ describe("utils", () => {
         a: 1,
         c: 3,
       };
-      expect(removeKeys(obj, ["b", "d"])).toEqual(expected);
+      expect(removeKeys({ obj, keysToRemove: ["b", "d"] })).toEqual(expected);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,0 +1,45 @@
+import { TokenAmount } from "@dfinity/nns";
+import type { Subscriber } from "svelte/store";
+import type { Account } from "../../lib/types/account";
+import { mockPrincipal } from "./auth.store.mock";
+
+export const mockSnsMainAccount: Account = {
+  // TODO: String representation https://dfinity.atlassian.net/browse/GIX-1025
+  identifier:
+    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+  balance: TokenAmount.fromString({
+    amount: "1234567.8901",
+    token: {
+      name: "Test",
+      symbol: "TST",
+    },
+  }) as TokenAmount,
+  principal: mockPrincipal,
+  type: "main",
+};
+
+export const mockSnsSubAccount: Account = {
+  // TODO: String representation https://dfinity.atlassian.net/browse/GIX-1025
+  identifier:
+    "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
+  balance: TokenAmount.fromString({
+    amount: "1234567.8901",
+    token: {
+      name: "Test",
+      symbol: "TST",
+    },
+  }) as TokenAmount,
+  subAccount: [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 1,
+  ],
+  name: "test subaccount",
+  type: "subAccount",
+};
+
+export const mockSnsAccountsStoreSubscribe =
+  (accounts: Account[] = [mockSnsMainAccount]) =>
+  (run: Subscriber<Account[]>): (() => void) => {
+    run(accounts);
+    return () => undefined;
+  };


### PR DESCRIPTION
# Motivation

User can see the balance of the main account in an SNS project.

# Changes

* New store: snsAccountsStore.
* New derived store: snsProjectAccountsStore which combines the selectedProject and the snsAccountsStore.
* New sns api in "sns-ledger.api": getSnsAccounts. For now it returns only a Main account.
* New sns accounts service: loadSnsAccounts that users getSnsAccounts api and snsAccountsStore.
* loadSnsAccounts service is called in SnsAccounts page.
* Render AccountCard for each account in SnsAccounts and the total of tokens.

# Tests

* Test new store and derived.
* Test new sns api function
* Test new sns service
* Test new functionality in SnsAccounts.
