### PR TITLE
style: inline amount display

### DIFF
--- a/frontend/src/lib/components/accounts/CurrentBalance.svelte
+++ b/frontend/src/lib/components/accounts/CurrentBalance.svelte
@@ -8,7 +8,7 @@
 
 <div>
   <p>{$i18n.accounts.current_balance}:</p>
-  <AmountDisplay inline={true} amount={balance} />
+  <AmountDisplay amount={balance} />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/src/lib/components/accounts/NewTransactionReview.svelte
@@ -65,7 +65,7 @@
 
 <form on:submit|preventDefault={executeTransaction} class="wizard-wrapper">
   <div class="amount">
-    <AmountDisplay inline={true} {amount} detailed />
+    <AmountDisplay {amount} detailed />
   </div>
 
   <NewTransactionInfo />

--- a/frontend/src/lib/components/canister-detail/CyclesCard.svelte
+++ b/frontend/src/lib/components/canister-detail/CyclesCard.svelte
@@ -22,7 +22,7 @@
   }
 
   .cycles {
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
     font-size: var(--font-size-h3);
   }
 </style>

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -4,19 +4,11 @@
 
   export let amount: TokenAmount;
   export let label: string | undefined = undefined;
-  export let inline: boolean = false;
-  export let singleLine: boolean = false;
-  export let inheritSize: boolean = false;
   export let sign: "+" | "-" | "" = "";
   export let detailed: boolean = false;
 </script>
 
-<div
-  class:inline
-  class:singleLine
-  class:inheritSize
-  class:plus-sign={sign === "+"}
->
+<div class={$$props.class} class:plus-sign={sign === "+"}>
   <span data-tid="icp-value" class="value"
     >{`${sign}${formatICP({ value: amount.toE8s(), detailed })}`}</span
   >
@@ -27,32 +19,26 @@
   @use "@dfinity/gix-components/styles/mixins/media";
 
   div {
-    display: inline-grid;
-    grid-template-columns: repeat(2, auto);
-    grid-gap: 5px;
     align-items: baseline;
 
+    overflow-wrap: break-word;
+
+    span {
+      word-break: break-word;
+    }
+
     span:first-of-type {
-      font-weight: 700;
+      font-weight: var(--icp-font-weight, var(--font-weight-bold));
       font-size: var(--icp-font-size, var(--font-size-h3));
+      line-height: var(--line-height-title);
     }
 
-    &.singleLine span:first-of-type {
-      font-weight: normal;
-      font-size: var(--font-size-h5);
-    }
+    &.small {
+      --icp-font-weight: normal;
+      --icp-font-size: var(--font-size-h5);
 
-    &.inheritSize span:first-of-type {
-      font-size: inherit;
-    }
-
-    &:not(.inline, .singleLine) {
-      @include media.min-width(medium) {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        justify-content: flex-end;
-        grid-gap: 0;
+      span:first-of-type {
+        line-height: inherit;
       }
     }
 

--- a/frontend/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/src/lib/components/ic/GetICPs.svelte
@@ -137,4 +137,8 @@
 
     padding: var(--padding-2x) var(--padding);
   }
+
+  .primary {
+    min-width: calc(48px + (2 * var(--padding-2x)));
+  }
 </style>

--- a/frontend/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/src/lib/components/ic/GetICPs.svelte
@@ -106,7 +106,7 @@
     align-items: center;
 
     font-size: var(--font-size-h5);
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
 
     letter-spacing: var(--letter-spacing-title);
 

--- a/frontend/src/lib/components/ic/ICPText.svelte
+++ b/frontend/src/lib/components/ic/ICPText.svelte
@@ -5,4 +5,4 @@
   export let amount: TokenAmount;
 </script>
 
-<span><slot /> <AmountDisplay singleLine {amount} /></span>
+<span><slot /> <AmountDisplay singleLine {amount} class="small" /></span>

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -78,7 +78,7 @@
 
   {#if myCommitment !== undefined}
     <dt><ProjectUserCommitmentLabel {summary} {swapCommitment} /></dt>
-    <dd><AmountDisplay amount={myCommitment} singleLine inheritSize /></dd>
+    <dd><AmountDisplay amount={myCommitment} class="small" /></dd>
   {/if}
 </dl>
 

--- a/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -50,7 +50,6 @@
 >
   <div class="amount">
     <AmountDisplay
-      inline
       amount={TokenAmount.fromE8s({ amount: neuronStake(neuron) })}
     />
   </div>

--- a/frontend/src/lib/components/neurons/NeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NeuronCard.svelte
@@ -95,11 +95,6 @@
     margin-bottom: 0;
   }
 
-  h3 {
-    line-height: var(--line-height-standard);
-    margin-bottom: 0;
-  }
-
   .lock {
     @include card.stacked-title;
   }

--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -27,7 +27,7 @@
         <span data-tid="commitment-max-indicator-value">
           <AmountDisplay
             amount={TokenAmount.fromE8s({ amount: max })}
-            singleLine
+            class="small"
           />
         </span>
       </p>
@@ -55,7 +55,7 @@
           <span data-tid="commitment-min-indicator-value">
             <AmountDisplay
               amount={TokenAmount.fromE8s({ amount: minimumIndicator })}
-              singleLine
+              class="small"
             />
           </span>
         </p>

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -43,7 +43,7 @@
     {$i18n.sns_project_detail.current_overall_commitment}
   </span>
 
-  <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
+  <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} class="small" />
 </KeyValuePair>
 <div data-tid="sns-project-commitment-progress">
   <CommitmentProgressBar

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -76,7 +76,11 @@
               summary={$projectDetailStore.summary}
               {swapCommitment}
             />
-            <AmountDisplay slot="value" amount={myCommitmentIcp} class="small" />
+            <AmountDisplay
+              slot="value"
+              amount={myCommitmentIcp}
+              class="small"
+            />
           </KeyValuePair>
         </div>
       {/if}

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -76,7 +76,7 @@
               summary={$projectDetailStore.summary}
               {swapCommitment}
             />
-            <AmountDisplay slot="value" amount={myCommitmentIcp} singleLine />
+            <AmountDisplay slot="value" amount={myCommitmentIcp} class="small" />
           </KeyValuePair>
         </div>
       {/if}

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -47,11 +47,11 @@
 
 <KeyValuePair>
   <span slot="key">{$i18n.sns_project_detail.min_commitment} </span>
-  <AmountDisplay slot="value" amount={minCommitmentIcp} singleLine />
+  <AmountDisplay slot="value" amount={minCommitmentIcp} class="small" />
 </KeyValuePair>
 <KeyValuePair>
   <span slot="key">{$i18n.sns_project_detail.max_commitment} </span>
-  <AmountDisplay slot="value" amount={maxCommitmentIcp} singleLine />
+  <AmountDisplay slot="value" amount={maxCommitmentIcp} class="small" />
 </KeyValuePair>
 <KeyValuePair>
   <span slot="key">{$i18n.sns_project_detail.sale_start} </span>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -100,7 +100,7 @@
         <span slot="key" class="label">{$i18n.accounts.source}</span>
         <AmountDisplay
           slot="value"
-          singleLine
+          class="small"
           amount={selectedAccount?.balance}
         />
       </KeyValuePair>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -60,7 +60,10 @@
       <div class="align-right">
         <AmountDisplay amount={icpAmount} />
         <span>
-          <AmountDisplay amount={$mainTransactionFeeStoreAsToken} class="small" />
+          <AmountDisplay
+            amount={$mainTransactionFeeStoreAsToken}
+            class="small"
+          />
           {$i18n.accounts.new_transaction_fee}
         </span>
       </div>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -39,7 +39,7 @@
       <span class="label" slot="key">{$i18n.accounts.source}</span>
       <div class="balance" slot="value">
         <span class="label">{$i18n.accounts.balance}</span>
-        <AmountDisplay singleLine amount={sourceAccount.balance} />
+        <AmountDisplay class="small" amount={sourceAccount.balance} />
       </div>
     </KeyValuePair>
     <div>
@@ -58,9 +58,9 @@
         <IconSouth />
       </span>
       <div class="align-right">
-        <AmountDisplay amount={icpAmount} inline />
+        <AmountDisplay amount={icpAmount} />
         <span>
-          <AmountDisplay amount={$mainTransactionFeeStoreAsToken} singleLine />
+          <AmountDisplay amount={$mainTransactionFeeStoreAsToken} class="small" />
           {$i18n.accounts.new_transaction_fee}
         </span>
       </div>

--- a/frontend/src/lib/modals/sns/SwapModal/AdditionalInfoForm.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/AdditionalInfoForm.svelte
@@ -14,7 +14,7 @@
 {#if userHasParticipated}
   <p class="right">
     {$i18n.sns_project_detail.max_left}
-    <AmountDisplay singleLine amount={maxCommitment} />
+    <AmountDisplay class="small" amount={maxCommitment} />
   </p>
 {:else}
   <KeyValuePair>
@@ -28,7 +28,7 @@
 {/if}
 <p class="right">
   <span>{$i18n.accounts.transaction_fee}</span>
-  <AmountDisplay singleLine amount={$mainTransactionFeeStoreAsToken} />
+  <AmountDisplay class="small" amount={$mainTransactionFeeStoreAsToken} />
 </p>
 
 <style lang="scss">

--- a/frontend/src/routes/Auth.svelte
+++ b/frontend/src/routes/Auth.svelte
@@ -107,7 +107,7 @@
     border: 2px solid var(--login-button-color);
     border-radius: var(--border-radius);
 
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
     color: white;
     text-indent: 4px; /* The text looks off centre otherwise, although technically it is centred. */
 


### PR DESCRIPTION
# Motivation

Inline the display of all amount.

is:

123'456.65
            ICP
            
will be:

123'456.65 ICP

# Note

- in accordance with Mischa
- need it for the new tasks I have to develop

# Changes

- inline display in `AmountDisplay`
- replace JS properties in `AmountDisplay` that have style and display goals with the usage of style `class`
- replace hardcoded `700` with CSS variable for bold text
