### PR TITLE
L2-1024: Fix dropdown hidden content

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -28,6 +28,7 @@
     disabled
     selectedValue="no-accounts"
     testId="select-account-dropdown"
+    fullWidth
   >
     <DropdownItem value="no-accounts">
       {$i18n.accounts.no_account_select}

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -28,7 +28,6 @@
     disabled
     selectedValue="no-accounts"
     testId="select-account-dropdown"
-    fullWidth
   >
     <DropdownItem value="no-accounts">
       {$i18n.accounts.no_account_select}

--- a/frontend/src/lib/components/ic/SelectProjectDropdownHeader.svelte
+++ b/frontend/src/lib/components/ic/SelectProjectDropdownHeader.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import SelectProjectDropdown from "../neurons/SelectProjectDropdown.svelte";
+</script>
+
+<div class="dropdown-wrapper">
+  <!-- Extra div is needed to fit to the content size instead of the whole width -->
+  <div>
+    <SelectProjectDropdown />
+  </div>
+</div>
+
+<style lang="scss">
+  .dropdown-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    margin-top: var(--padding-4x);
+  }
+</style>

--- a/frontend/src/lib/components/ic/SelectProjectDropdownHeader.svelte
+++ b/frontend/src/lib/components/ic/SelectProjectDropdownHeader.svelte
@@ -3,10 +3,7 @@
 </script>
 
 <div class="dropdown-wrapper">
-  <!-- Extra div is needed to fit to the content size instead of the whole width -->
-  <div>
-    <SelectProjectDropdown />
-  </div>
+  <SelectProjectDropdown />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -7,10 +7,9 @@
   export let name: string;
   export let testId: string | undefined = undefined;
   export let disabled: boolean = false;
-  export let fullWidth: boolean = false;
 </script>
 
-<div class:fullWidth>
+<div>
   <select {disabled} bind:value={selectedValue} {name} data-tid={testId}>
     <slot />
   </select>
@@ -36,9 +35,7 @@
 
     padding: var(--padding-2x);
 
-    &.fullWidth {
-      width: 100%;
-    }
+    width: var(--dropdown-width, auto);
 
     // Click on <select> does not trigger "focus" on parent div.
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -42,7 +42,10 @@
       outline: 2px solid var(--primary);
     }
     select {
+      // Needed to keep the clickable area of the dropdown the whole width of the div.
       width: 100%;
+      // Apply the width to the content
+      box-sizing: content-box;
       // Space for the caret icon.
       padding-right: var(--padding-4x);
       background: var(--card-background);

--- a/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/frontend/src/lib/components/ui/Dropdown.svelte
@@ -7,9 +7,10 @@
   export let name: string;
   export let testId: string | undefined = undefined;
   export let disabled: boolean = false;
+  export let fullWidth: boolean = false;
 </script>
 
-<div>
+<div class:fullWidth>
   <select {disabled} bind:value={selectedValue} {name} data-tid={testId}>
     <slot />
   </select>
@@ -23,7 +24,6 @@
   div {
     @include form.input;
 
-    width: 100%;
     position: relative;
     box-sizing: border-box;
 
@@ -35,6 +35,11 @@
     box-shadow: var(--box-shadow);
 
     padding: var(--padding-2x);
+
+    &.fullWidth {
+      width: 100%;
+    }
+
     // Click on <select> does not trigger "focus" on parent div.
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within
     // Matches an element if the element or any of its descendants are focused.

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -149,6 +149,10 @@
 <style lang="scss">
   @use "../../../themes/mixins/modal";
 
+  form {
+    --dropdown-width: 100%;
+  }
+
   .select-account {
     display: flex;
     flex-direction: column;

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -13,6 +13,7 @@
   import { AppPath } from "../lib/constants/routes.constants";
   import { OWN_CANISTER_ID } from "../lib/constants/canister-ids.constants";
   import SnsAccounts from "../lib/pages/SnsAccounts.svelte";
+  import SelectProjectDropdownHeader from "../lib/components/ic/SelectProjectDropdownHeader.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -27,11 +28,7 @@
 
 <main class="legacy">
   {#if ENABLE_SNS}
-    <div class="dropdown-wrapper">
-      <div class="fit-content">
-        <SelectProjectDropdown />
-      </div>
-    </div>
+    <SelectProjectDropdownHeader />
   {/if}
 
   {#if $isNnsProjectStore}
@@ -44,17 +41,3 @@
 {#if $isNnsProjectStore}
   <NnsAccountsFooter />
 {/if}
-
-<style lang="scss">
-  .dropdown-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    margin-top: var(--padding-4x);
-
-    .fit-content {
-      width: fit-content;
-    }
-  }
-</style>

--- a/frontend/src/routes/Accounts.svelte
+++ b/frontend/src/routes/Accounts.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import SelectProjectDropdown from "../lib/components/neurons/SelectProjectDropdown.svelte";
   import { ENABLE_SNS } from "../lib/constants/environment.constants";
   import NnsAccounts from "../lib/pages/NnsAccounts.svelte";
   import NnsAccountsFooter from "../lib/components/accounts/NnsAccountsFooter.svelte";

--- a/frontend/src/routes/Neurons.svelte
+++ b/frontend/src/routes/Neurons.svelte
@@ -13,6 +13,7 @@
   import { isRoutePath } from "../lib/utils/app-path.utils";
   import { AppPath } from "../lib/constants/routes.constants";
   import { OWN_CANISTER_ID } from "../lib/constants/canister-ids.constants";
+  import SelectProjectDropdownHeader from "../lib/components/ic/SelectProjectDropdownHeader.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -27,11 +28,7 @@
 
 <main class="legacy">
   {#if ENABLE_SNS}
-    <div class="dropdown-wrapper">
-      <div class="fit-content">
-        <SelectProjectDropdown />
-      </div>
-    </div>
+    <SelectProjectDropdownHeader />
   {/if}
 
   {#if $isNnsProjectStore}
@@ -44,17 +41,3 @@
 {#if $isNnsProjectStore}
   <NnsNeuronsFooter />
 {/if}
-
-<style lang="scss">
-  .dropdown-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    margin-top: var(--padding-4x);
-
-    .fit-content {
-      width: fit-content;
-    }
-  }
-</style>

--- a/frontend/src/routes/Neurons.svelte
+++ b/frontend/src/routes/Neurons.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import SelectProjectDropdown from "../lib/components/neurons/SelectProjectDropdown.svelte";
   import { ENABLE_SNS } from "../lib/constants/environment.constants";
   import NnsNeurons from "../lib/pages/NnsNeurons.svelte";
   import SnsNeurons from "../lib/pages/SnsNeurons.svelte";


### PR DESCRIPTION
# Motivation

Fix the hidden slice of word in the Project Dropdown selector of Accounts and Neurons.

# Changes

* Refactor the Dropdown used in the pages to its own component: SelectProjectDropdownHeader.
* Apply the width of the `select` of the dropdown as content-box not as border-box.

# Tests

Not applicable.
