### PR TITLE
fix: display no proposals found

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-20.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-20.1.tgz",
-      "integrity": "sha512-Z8Cy/KLFJ/JtdQPt5C0Wt+4GlvjA9b1DjomeMygP7hibWhoUmsF4hl09od1diqEKSBFnfkaLuEqZk3fv2GPj+A=="
+      "version": "0.0.1-next-2022-09-21.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-21.1.tgz",
+      "integrity": "sha512-19vwVxj/lEYbtnOuYUWLDF5VT5YbGsXeJwltmxXkvB1ozLIrkIvXf/E9ufWAFUEyMC8ANoCBebNig4EtmlbEdw=="
     },
     "node_modules/@dfinity/identity": {
       "version": "1.0.0-beta.0",
@@ -9959,9 +9959,9 @@
       }
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-09-20.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-20.1.tgz",
-      "integrity": "sha512-Z8Cy/KLFJ/JtdQPt5C0Wt+4GlvjA9b1DjomeMygP7hibWhoUmsF4hl09od1diqEKSBFnfkaLuEqZk3fv2GPj+A=="
+      "version": "0.0.1-next-2022-09-21.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-09-21.1.tgz",
+      "integrity": "sha512-19vwVxj/lEYbtnOuYUWLDF5VT5YbGsXeJwltmxXkvB1ozLIrkIvXf/E9ufWAFUEyMC8ANoCBebNig4EtmlbEdw=="
     },
     "@dfinity/identity": {
       "version": "1.0.0-beta.0",

--- a/frontend/src/routes/Proposals.svelte
+++ b/frontend/src/routes/Proposals.svelte
@@ -25,7 +25,10 @@
   import ProposalsLegacy from "../lib/components/proposals/ProposalsLegacy.svelte";
   import ProposalsModern from "../lib/components/proposals/ProposalsModern.svelte";
   import { VOTING_UI } from "../lib/constants/environment.constants";
-  import { sortedProposals, filteredProposals } from "../lib/derived/proposals.derived";
+  import {
+    sortedProposals,
+    filteredProposals,
+  } from "../lib/derived/proposals.derived";
 
   let loading: boolean = false;
   let hidden: boolean = false;

--- a/frontend/src/routes/Proposals.svelte
+++ b/frontend/src/routes/Proposals.svelte
@@ -25,7 +25,7 @@
   import ProposalsLegacy from "../lib/components/proposals/ProposalsLegacy.svelte";
   import ProposalsModern from "../lib/components/proposals/ProposalsModern.svelte";
   import { VOTING_UI } from "../lib/constants/environment.constants";
-  import { sortedProposals } from "../lib/derived/proposals.derived";
+  import { sortedProposals, filteredProposals } from "../lib/derived/proposals.derived";
 
   let loading: boolean = false;
   let hidden: boolean = false;
@@ -126,7 +126,7 @@
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches
-    if ($sortedProposals.certified === false) {
+    if ($filteredProposals.certified === false) {
       if (loading) nothingFound = false;
       return;
     }
@@ -135,7 +135,7 @@
       initialized &&
       !loading &&
       !hasMatchingProposals({
-        proposals: $sortedProposals.proposals,
+        proposals: $filteredProposals.proposals,
         filters: $proposalsFiltersStore,
         neurons: $definedNeuronsStore,
       });
@@ -145,7 +145,7 @@
   $: initialized,
     loading,
     neuronsLoaded,
-    $sortedProposals,
+    $filteredProposals,
     (() => updateNothingFound())();
 
   let neuronsLoaded: boolean;


### PR DESCRIPTION
# Motivation

The label "No proposals found for filter" was not always displayed or stick to screen.

# Changes

- link refresh of label with appropriate derived store
