### PR TITLE
fix: modal back button on canister

### DIFF
--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -40,7 +40,7 @@
     </div>
     <div>
       <h5>{$i18n.accounts.source}</h5>
-      <p class="value">{account.identifier}</p>
+      <p class="value identifier">{account.identifier}</p>
     </div>
     <slot />
   </div>
@@ -89,5 +89,9 @@
       align-items: center;
       gap: var(--padding);
     }
+  }
+
+  .identifier {
+    word-break: break-word;
   }
 </style>

--- a/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -33,7 +33,7 @@
     {
       name: "SelectAccount",
       title: $i18n.canister_detail.top_up_canister,
-      showBackButton: true,
+      showBackButton: false,
     },
     {
       name: "SelectCycles",

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -28,7 +28,7 @@
     {
       name: "SelectAccount",
       title: $i18n.accounts.select_source,
-      showBackButton: true,
+      showBackButton: false,
     },
     {
       name: "SelectCycles",


### PR DESCRIPTION
# Motivation

Back buttons are displayed on the first step of the canisters' related modal.

# Changes

- don't display back button on such steps
