### PR TITLE
L2-997: Remove ICP from Transaction Modal

### DIFF
--- a/frontend/src/lib/components/accounts/AccountsTitle.svelte
+++ b/frontend/src/lib/components/accounts/AccountsTitle.svelte
@@ -2,7 +2,7 @@
   import type { TokenAmount } from "@dfinity/nns";
   import { i18n } from "../../stores/i18n";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
 
@@ -11,7 +11,7 @@
   let totalTokens: string;
   totalTokens =
     balance !== undefined
-      ? formatICP({
+      ? formatToken({
           value: balance.toE8s(),
           detailed: true,
         })
@@ -42,11 +42,11 @@
 
     margin-bottom: var(--padding-2x);
 
-    --icp-font-size: var(--font-size-h1);
+    --token-font-size: var(--font-size-h1);
 
     // Minimum height of ICP value + ICP label (ICP component)
     min-height: calc(
-      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
+      var(--line-height-standard) * (var(--token-font-size) + 1rem)
     );
 
     @include media.min-width(medium) {

--- a/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "../../stores/i18n";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import HardwareWalletNeuronAddHotkeyButton from "./HardwareWalletNeuronAddHotkeyButton.svelte";
   import { getContext } from "svelte";
   import type {
@@ -32,7 +32,7 @@
     </p>
 
     <p>
-      {formatICP({ value: fullNeuron?.cachedNeuronStake ?? BigInt(0) })}
+      {formatToken({ value: fullNeuron?.cachedNeuronStake ?? BigInt(0) })}
     </p>
 
     <p class="hotkey">

--- a/frontend/src/lib/components/accounts/NewTransactionReview.svelte
+++ b/frontend/src/lib/components/accounts/NewTransactionReview.svelte
@@ -100,7 +100,7 @@
     padding: var(--padding) 0;
 
     @include media.min-width(medium) {
-      --icp-font-size: var(--font-size-huge);
+      --token-font-size: var(--font-size-huge);
       @include modal.header;
     }
   }

--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -10,7 +10,7 @@
     SELECTED_ACCOUNT_CONTEXT_KEY,
     type SelectedAccountContext,
   } from "../../types/selected-account.context";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import Tooltip from "../ui/Tooltip.svelte";
   import { replacePlaceholders } from "../../utils/i18n.utils";
 
@@ -30,7 +30,7 @@
     (TokenAmount.fromString({ amount: "0", token: ICPToken }) as TokenAmount);
 
   let detailedICP: string;
-  $: detailedICP = formatICP({
+  $: detailedICP = formatToken({
     value: accountBalance.toE8s(),
     detailed: true,
   });
@@ -72,12 +72,12 @@
 
     margin: 0 0 var(--padding-2x);
 
-    --icp-font-size: var(--font-size-h1);
+    --token-font-size: var(--font-size-h1);
     --tooltip-display: inline-block;
 
     // Minimum height of ICP value + ICP label (ICP component)
     min-height: calc(
-      var(--line-height-standard) * (var(--icp-font-size) + 1rem)
+      var(--line-height-standard) * (var(--token-font-size) + 1rem)
     );
 
     @include media.min-width(medium) {

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TokenAmount } from "@dfinity/nns";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
 
   export let amount: TokenAmount;
   export let label: string | undefined = undefined;
@@ -17,8 +17,8 @@
   class:inheritSize
   class:plus-sign={sign === "+"}
 >
-  <span data-tid="icp-value" class="value"
-    >{`${sign}${formatICP({ value: amount.toE8s(), detailed })}`}</span
+  <span data-tid="token-value" class="value"
+    >{`${sign}${formatToken({ value: amount.toE8s(), detailed })}`}</span
   >
   <span class="label">{label !== undefined ? label : amount.token.symbol}</span>
 </div>
@@ -34,7 +34,7 @@
 
     span:first-of-type {
       font-weight: 700;
-      font-size: var(--icp-font-size, var(--font-size-h3));
+      font-size: var(--token-font-size, var(--font-size-h3));
     }
 
     &.singleLine span:first-of-type {

--- a/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -84,7 +84,7 @@
 
     flex-grow: 1;
 
-    --icp-font-size: var(--font-size-huge);
+    --token-font-size: var(--font-size-huge);
 
     @include modal.header;
   }

--- a/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
@@ -3,7 +3,7 @@
   import { createEventDispatcher } from "svelte";
   import { i18n } from "../../stores/i18n";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import {
     formattedMaturity,
     isEnoughToStakeNeuron,
@@ -37,7 +37,7 @@
       <h5>{$i18n.neuron_detail.current_stake}</h5>
       <p data-tid="neuron-stake">
         {@html replacePlaceholders($i18n.neurons.icp_stake, {
-          $amount: valueSpan(formatICP({ value: neuronICP, detailed: true })),
+          $amount: valueSpan(formatToken({ value: neuronICP, detailed: true })),
         })}
       </p>
     </div>

--- a/frontend/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronMetaInfoCard.svelte
@@ -5,7 +5,7 @@
   import { i18n } from "../../stores/i18n";
   import { secondsToDate } from "../../utils/date.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import NeuronCard from "../neurons/NeuronCard.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
   import IncreaseDissolveDelayButton from "./actions/IncreaseDissolveDelayButton.svelte";
@@ -65,7 +65,7 @@
             text={replacePlaceholders(
               $i18n.neuron_detail.voting_power_tooltip,
               {
-                $stake: formatICP({
+                $stake: formatToken({
                   value: neuron.fullNeuron.cachedNeuronStake,
                   detailed: true,
                 }),

--- a/frontend/src/lib/components/neuron-detail/SelectPercentage.svelte
+++ b/frontend/src/lib/components/neuron-detail/SelectPercentage.svelte
@@ -5,7 +5,7 @@
   import { formatPercentage } from "../../utils/format.utils";
   import { Card } from "@dfinity/gix-components";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import InputRange from "../ui/InputRange.svelte";
   import { createEventDispatcher } from "svelte";
   import FooterModal from "../../modals/FooterModal.svelte";
@@ -34,7 +34,7 @@
     <h5>{$i18n.neuron_detail.current_stake}</h5>
     <p data-tid="neuron-stake">
       {@html replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: valueSpan(formatICP({ value: neuronICP, detailed: true })),
+        $amount: valueSpan(formatToken({ value: neuronICP, detailed: true })),
       })}
     </p>
   </div>

--- a/frontend/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/MergeMaturityButton.svelte
@@ -4,7 +4,7 @@
   import MergeMaturityModal from "../../../modals/neurons/MergeMaturityModal.svelte";
   import Tooltip from "../../ui/Tooltip.svelte";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
-  import { formatICP } from "../../../utils/icp.utils";
+  import { formatToken } from "../../../utils/icp.utils";
   import {
     hasEnoughMaturityToMerge,
     minMaturityMerge,
@@ -34,7 +34,7 @@
     text={replacePlaceholders(
       $i18n.neuron_detail.merge_maturity_disabled_tooltip,
       {
-        $amount: formatICP({
+        $amount: formatToken({
           value: BigInt(minMaturityMerge($mainTransactionFeeStore)),
           detailed: true,
         }),

--- a/frontend/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SplitNeuronButton.svelte
@@ -7,7 +7,7 @@
   } from "../../../utils/neuron.utils";
   import { i18n } from "../../../stores/i18n";
   import { replacePlaceholders } from "../../../utils/i18n.utils";
-  import { formatICP } from "../../../utils/icp.utils";
+  import { formatToken } from "../../../utils/icp.utils";
   import Tooltip from "../../ui/Tooltip.svelte";
   import { mainTransactionFeeStore } from "../../../stores/transaction-fees.store";
 
@@ -35,7 +35,7 @@
     text={replacePlaceholders(
       $i18n.neuron_detail.split_neuron_disabled_tooltip,
       {
-        $amount: formatICP({
+        $amount: formatToken({
           value: BigInt(minNeuronSplittable($mainTransactionFeeStore)),
           detailed: true,
         }),

--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -5,7 +5,7 @@
   import { i18n } from "../../stores/i18n";
   import { secondsToDuration } from "../../utils/date.utils";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import {
     formatVotingPower,
     neuronStake,
@@ -53,7 +53,7 @@
     <h5>{$i18n.neurons.neuron_balance}</h5>
     <p>
       {@html replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: valueSpan(formatICP({ value: neuronICP, detailed: true })),
+        $amount: valueSpan(formatToken({ value: neuronICP, detailed: true })),
       })}
     </p>
   </div>

--- a/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -9,7 +9,7 @@
   import { i18n } from "../../stores/i18n";
   import { toastsError, toastsSuccess } from "../../stores/toasts.store";
   import { replacePlaceholders } from "../../utils/i18n.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import { neuronStake } from "../../utils/neuron.utils";
   import { valueSpan } from "../../utils/utils";
 
@@ -69,7 +69,7 @@
         <p>
           {@html replacePlaceholders($i18n.neurons.icp_stake, {
             $amount: valueSpan(
-              formatICP({ value: neuronStake(neuron), detailed: true })
+              formatToken({ value: neuronStake(neuron), detailed: true })
             ),
           })}
         </p>

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -9,7 +9,7 @@
   } from "../../constants/constants";
   import { i18n } from "../../stores/i18n";
   import { secondsToDuration } from "../../utils/date.utils";
-  import { formatICP } from "../../utils/icp.utils";
+  import { formatToken } from "../../utils/icp.utils";
   import {
     formatVotingPower,
     neuronStake,
@@ -56,7 +56,7 @@
     <h5>{$i18n.neurons.neuron_balance}</h5>
     <p data-tid="neuron-stake">
       {@html replacePlaceholders($i18n.neurons.icp_stake, {
-        $amount: valueSpan(formatICP({ value: neuronICP, detailed: true })),
+        $amount: valueSpan(formatToken({ value: neuronICP, detailed: true })),
       })}
     </p>
 

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -4,10 +4,14 @@
   import type { Account } from "../../../types/account";
   import TransactionForm from "./TransactionForm.svelte";
   import TransactionReview from "./TransactionReview.svelte";
+  import { ICPToken, TokenAmount, type Token } from "@dfinity/nns";
+  import { mainTransactionFeeStoreAsToken } from "../../../derived/main-transaction-fee.derived";
 
   export let currentStep: Step | undefined = undefined;
   export let destinationAddress: string | undefined = undefined;
   export let sourceAccount: Account | undefined = undefined;
+  export let token: Token = ICPToken;
+  export let transactionFee: TokenAmount = $mainTransactionFeeStoreAsToken;
   export let disableSubmit: boolean = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
@@ -53,12 +57,14 @@
     <TransactionForm
       {canSelectDestination}
       {canSelectSource}
+      {transactionFee}
       bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount
       bind:showManualAddress
       {skipHardwareWallets}
       {maxAmount}
+      {token}
       on:nnsNext={goNext}
       on:nnsClose
     >
@@ -72,6 +78,7 @@
         sourceAccount: selectedAccount,
         amount,
       }}
+      {transactionFee}
       {disableSubmit}
       on:nnsBack={goBack}
       on:nnsSubmit

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -5,7 +5,6 @@
   import FooterModal from "../../FooterModal.svelte";
   import { busy } from "../../../stores/busy.store";
   import { i18n } from "../../../stores/i18n";
-  import { mainTransactionFeeStoreAsToken } from "../../../derived/main-transaction-fee.derived";
   import type { Account } from "../../../types/account";
   import AmountDisplay from "../../../components/ic/AmountDisplay.svelte";
   import KeyValuePair from "../../../components/ui/KeyValuePair.svelte";
@@ -13,6 +12,7 @@
 
   export let transaction: NewTransaction;
   export let disableSubmit: boolean;
+  export let transactionFee: TokenAmount;
 
   let sourceAccount: Account;
   let amount: number;
@@ -20,8 +20,8 @@
   $: ({ sourceAccount, amount, destinationAddress } = transaction);
 
   // If we made it this far, the number is valid.
-  let icpAmount: TokenAmount;
-  $: icpAmount = TokenAmount.fromNumber({ amount }) as TokenAmount;
+  let tokenAmount: TokenAmount;
+  $: tokenAmount = TokenAmount.fromNumber({ amount }) as TokenAmount;
 
   const dispatcher = createEventDispatcher();
   const submit = () => {
@@ -58,9 +58,9 @@
         <IconSouth />
       </span>
       <div class="align-right">
-        <AmountDisplay amount={icpAmount} inline />
+        <AmountDisplay amount={tokenAmount} inline />
         <span>
-          <AmountDisplay amount={$mainTransactionFeeStoreAsToken} singleLine />
+          <AmountDisplay amount={transactionFee} singleLine />
           {$i18n.accounts.new_transaction_fee}
         </span>
       </div>

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -21,7 +21,7 @@ const countDecimals = (value: number): number => {
  * - ICP should be displayed with max. 2 decimals (12.1 → 12.10, 12.12353 → 12.12, 12.00003 → 12.00) in Accounts, but with up to 8 decimals without tailing 0s in transaction details.
  * - However, if ICP value is lower than 0.01 then it should be as it is without tailing 0s up to 8 decimals (e.g., 0.000003 is displayed as 0.000003)
  */
-export const formatICP = ({
+export const formatToken = ({
   value,
   detailed = false,
 }: {
@@ -70,7 +70,7 @@ export const sumTokenAmounts = (
 // To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
 // e.g. not 0.00010000 but 0.0001
 export const formattedTransactionFeeICP = (fee: number): string =>
-  formatICP({
+  formatToken({
     value: ICP.fromE8s(BigInt(fee)).toE8s(),
   });
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -45,7 +45,7 @@ import {
 import { nowInSeconds } from "./date.utils";
 import { enumValues } from "./enum.utils";
 import { formatNumber } from "./format.utils";
-import { formatICP } from "./icp.utils";
+import { formatToken } from "./icp.utils";
 import { getVotingBallot, getVotingPower } from "./proposals.utils";
 import { isDefined, isNullish, nonNullish } from "./utils";
 
@@ -160,7 +160,7 @@ export const formattedMaturity = (neuron: NeuronInfo): string => {
     value = BigInt(0);
   }
 
-  return formatICP({
+  return formatToken({
     value,
   });
 };

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -11,7 +11,7 @@ import type {
 } from "../types/sns";
 import { nowInSeconds } from "./date.utils";
 import type { I18nSubstitutions } from "./i18n.utils";
-import { formatICP } from "./icp.utils";
+import { formatToken } from "./icp.utils";
 
 const filterProjectsStatus = ({
   swapLifecycle,
@@ -229,7 +229,7 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.not_enough_amount",
       substitutions: {
-        $amount: formatICP({
+        $amount: formatToken({
           value: project.summary.swap.init.min_participant_icp_e8s,
         }),
       },
@@ -245,8 +245,8 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.commitment_too_large",
       substitutions: {
-        $commitment: formatICP({ value: totalCommitment }),
-        $maxCommitment: formatICP({
+        $commitment: formatToken({ value: totalCommitment }),
+        $maxCommitment: formatToken({
           value: project.summary.swap.init.max_participant_icp_e8s,
         }),
       },
@@ -262,8 +262,8 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.commitment_exceeds_current_allowed",
       substitutions: {
-        $commitment: formatICP({ value: totalCommitment }),
-        $remainingCommitment: formatICP({
+        $commitment: formatToken({ value: totalCommitment }),
+        $remainingCommitment: formatToken({
           value:
             project.summary.swap.init.max_icp_e8s -
             project.summary.derived.buyer_total_icp_e8s,

--- a/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -5,7 +5,7 @@
 import { render } from "@testing-library/svelte";
 import AccountCard from "../../../../lib/components/accounts/AccountCard.svelte";
 import type { Account } from "../../../../lib/types/account";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 
 describe("AccountCard", () => {
@@ -29,7 +29,7 @@ describe("AccountCard", () => {
     const balance = container.querySelector("article > div span:first-of-type");
 
     expect(balance?.textContent).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -4,7 +4,7 @@
 
 import { render } from "@testing-library/svelte";
 import CurrentBalance from "../../../../lib/components/accounts/CurrentBalance.svelte";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 
@@ -22,10 +22,10 @@ describe("CurrentBalance", () => {
   it("should render a balance in ICP", () => {
     const { getByText, queryByTestId } = render(CurrentBalance, { props });
 
-    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
+    const icp: HTMLSpanElement | null = queryByTestId("token-value");
 
     expect(icp?.innerHTML).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
     expect(getByText(`ICP`)).toBeTruthy();
   });

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
@@ -5,7 +5,7 @@
 import type { Neuron } from "@dfinity/nns/dist/types/types/governance_converters";
 import { render } from "@testing-library/svelte";
 import HardwareWalletNeurons from "../../../../lib/components/accounts/HardwareWalletNeurons.svelte";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mockNeuronStake } from "../../../mocks/hardware-wallet-neurons.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../mocks/neurons.mock";
@@ -43,14 +43,14 @@ describe("HardwareWalletNeurons", () => {
 
     expect(
       getByText(
-        formatICP({
+        formatToken({
           value: (mockNeuron.fullNeuron as Neuron).cachedNeuronStake,
         })
       )
     ).toBeInTheDocument();
     expect(
       getByText(
-        formatICP({
+        formatToken({
           value: (mockNeuronStake.fullNeuron as Neuron).cachedNeuronStake,
         })
       )

--- a/frontend/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NewTransactionAmount.spec.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_TRANSACTION_FEE_E8S,
   E8S_PER_ICP,
 } from "../../../../lib/constants/icp.constants";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import {
   mockMainAccount,
   mockSubAccount,
@@ -47,10 +47,10 @@ describe("NewTransactionAmount", () => {
   it("should render current balance", () => {
     const { queryByTestId } = render(NewTransactionTest, { props });
 
-    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
+    const icp: HTMLSpanElement | null = queryByTestId("token-value");
 
     expect(icp?.innerHTML).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NewTransactionReview.spec.ts
@@ -8,7 +8,7 @@ import { NNSDappCanister } from "../../../../lib/canisters/nns-dapp/nns-dapp.can
 import NewTransactionReview from "../../../../lib/components/accounts/NewTransactionReview.svelte";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
 import { authStore } from "../../../../lib/stores/auth.store";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import {
   mockMainAccount,
   mockSubAccount,
@@ -76,9 +76,9 @@ describe("NewTransactionReview", () => {
   it("should render the amount the user has entered", () => {
     const { queryByTestId } = render(NewTransactionTest, { props });
 
-    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
+    const icp: HTMLSpanElement | null = queryByTestId("token-value");
     expect(icp?.innerHTML).toEqual(
-      `${formatICP({ value: amount.toE8s(), detailed: true })}`
+      `${formatToken({ value: amount.toE8s(), detailed: true })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -4,7 +4,7 @@
 
 import { render } from "@testing-library/svelte";
 import TransactionCard from "../../../../lib/components/accounts/TransactionCard.svelte";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mapTransaction } from "../../../../lib/utils/transactions.utils";
 import {
   mockMainAccount,
@@ -56,8 +56,8 @@ describe("Address", () => {
     const { getByTestId } = renderTransactionCard(account, transaction);
     const { displayAmount } = mapTransaction({ account, transaction });
 
-    expect(getByTestId("icp-value")?.textContent).toBe(
-      `-${formatICP({ value: displayAmount.toE8s(), detailed: true })}`
+    expect(getByTestId("token-value")?.textContent).toBe(
+      `-${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
     );
   });
 
@@ -67,8 +67,8 @@ describe("Address", () => {
     const { getByTestId } = renderTransactionCard(account, transaction);
     const { displayAmount } = mapTransaction({ account, transaction });
 
-    expect(getByTestId("icp-value")?.textContent).toBe(
-      `+${formatICP({ value: displayAmount.toE8s(), detailed: true })}`
+    expect(getByTestId("token-value")?.textContent).toBe(
+      `+${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -11,7 +11,7 @@ import {
   type SelectedAccountStore,
 } from "../../../../lib/types/selected-account.context";
 import { replacePlaceholders } from "../../../../lib/utils/i18n.utils";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import ContextWrapperTest from "../ContextWrapperTest.svelte";
@@ -48,10 +48,10 @@ describe("WalletSummary", () => {
   it("should render a balance in ICP", () => {
     const { getByText, queryByTestId } = renderWalletSummary();
 
-    const icp: HTMLSpanElement | null = queryByTestId("icp-value");
+    const icp: HTMLSpanElement | null = queryByTestId("token-value");
 
     expect(icp?.innerHTML).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
     expect(getByText(`ICP`)).toBeTruthy();
   });
@@ -71,7 +71,7 @@ describe("WalletSummary", () => {
 
     expect(icp?.textContent).toEqual(
       replacePlaceholders(en.accounts.current_balance_detail, {
-        $amount: `${formatICP({
+        $amount: `${formatToken({
           value: mockMainAccount.balance.toE8s(),
           detailed: true,
         })}`,

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -5,7 +5,7 @@
 import type { TokenAmount } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import AmountDisplay from "../../../../lib/components/ic/AmountDisplay.svelte";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 
 describe("AmountDisplay", () => {
@@ -19,7 +19,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
   });
 
@@ -41,7 +41,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `+${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `+${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
     expect(container.querySelector(".plus-sign")).toBeInTheDocument();
   });
@@ -56,7 +56,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `-${formatICP({ value: mockMainAccount.balance.toE8s() })}`
+      `-${formatToken({ value: mockMainAccount.balance.toE8s() })}`
     );
   });
 
@@ -71,7 +71,10 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `${formatICP({ value: mockMainAccount.balance.toE8s(), detailed: true })}`
+      `${formatToken({
+        value: mockMainAccount.balance.toE8s(),
+        detailed: true,
+      })}`
     );
   });
 });

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -6,7 +6,7 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import ProjectCardSwapInfo from "../../../../lib/components/launchpad/ProjectCardSwapInfo.svelte";
 import { secondsToDuration } from "../../../../lib/utils/date.utils";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import en from "../../../mocks/i18n.mock";
 import {
   mockSnsFullProject,
@@ -80,7 +80,7 @@ describe("ProjectCardSwapInfo", () => {
       },
     });
 
-    const icpValue = formatICP({
+    const icpValue = formatToken({
       value: mockSnsFullProject.swapCommitment?.myCommitment
         ?.amount_icp_e8s as bigint,
     });

--- a/frontend/src/tests/lib/components/neurons/NeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronCard.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronCard from "../../../../lib/components/neurons/NeuronCard.svelte";
 import { SECONDS_IN_YEAR } from "../../../../lib/constants/constants";
 import { authStore } from "../../../../lib/stores/auth.store";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -73,7 +73,7 @@ describe("NeuronCard", () => {
       },
     });
 
-    const stakeText = formatICP({
+    const stakeText = formatToken({
       value:
         (mockNeuron.fullNeuron as Neuron).cachedNeuronStake -
         (mockNeuron.fullNeuron as Neuron).neuronFees,
@@ -205,7 +205,7 @@ describe("NeuronCard", () => {
         proposerNeuron: true,
       },
     });
-    const votingValue = formatICP({
+    const votingValue = formatToken({
       value: mockNeuron.votingPower,
       detailed: true,
     });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -5,7 +5,7 @@
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import ProjectCommitment from "../../../../lib/components/project-detail/ProjectCommitment.svelte";
 import type { SnsSwapCommitment } from "../../../../lib/types/sns";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import en from "../../../mocks/i18n.mock";
 import {
   mockSnsFullProject,
@@ -24,10 +24,10 @@ describe("ProjectCommitment", () => {
     });
     expect(
       queryByTestId("commitment-max-indicator-value")?.textContent
-    ).toEqual(`${formatICP({ value: summary.swap.init.max_icp_e8s })} ICP`);
+    ).toEqual(`${formatToken({ value: summary.swap.init.max_icp_e8s })} ICP`);
     expect(
       queryByTestId("commitment-min-indicator-value")?.textContent
-    ).toEqual(`${formatICP({ value: summary.swap.init.min_icp_e8s })} ICP`);
+    ).toEqual(`${formatToken({ value: summary.swap.init.min_icp_e8s })} ICP`);
   });
 
   it("should render overall current commitment", () => {
@@ -39,7 +39,7 @@ describe("ProjectCommitment", () => {
     expect(
       queryByTestId("sns-project-current-commitment")?.textContent
     ).toEqual(
-      `${en.sns_project_detail.current_overall_commitment} ${formatICP({
+      `${en.sns_project_detail.current_overall_commitment} ${formatToken({
         value: summary.derived.buyer_total_icp_e8s,
       })} ICP`
     );

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -21,7 +21,7 @@ describe("ProjectSwapDetails", () => {
     });
 
     const element = Array.from(
-      container.querySelectorAll('[data-tid="icp-value"]')
+      container.querySelectorAll('[data-tid="token-value"]')
     )[0];
 
     expect(element?.innerHTML).toEqual(
@@ -37,7 +37,7 @@ describe("ProjectSwapDetails", () => {
     });
 
     const element = Array.from(
-      container.querySelectorAll('[data-tid="icp-value"]')
+      container.querySelectorAll('[data-tid="token-value"]')
     )[1];
 
     expect(element?.innerHTML).toEqual(

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -20,7 +20,7 @@ import { authStore } from "../../../../lib/stores/auth.store";
 import { routeStore } from "../../../../lib/stores/route.store";
 import { snsQueryStore } from "../../../../lib/stores/sns.store";
 import { nowInSeconds } from "../../../../lib/utils/date.utils";
-import { formatICP } from "../../../../lib/utils/icp.utils";
+import { formatToken } from "../../../../lib/utils/icp.utils";
 import { getSnsNeuronIdAsHexString } from "../../../../lib/utils/sns-neuron.utils";
 import {
   mockAuthStoreSubscribe,
@@ -114,7 +114,7 @@ describe("SnsNeuronCard", () => {
     token !== undefined && expect(getByText(token.symbol)).toBeInTheDocument();
     expect(queryAllByText(en.core.icp).length).toBe(0);
 
-    const stakeText = formatICP({
+    const stakeText = formatToken({
       value:
         mockSnsNeuron.cached_neuron_stake_e8s - mockSnsNeuron.neuron_fees_e8s,
       detailed: true,

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -10,7 +10,7 @@ import {
   type AccountsStore,
 } from "../../../lib/stores/accounts.store";
 import { replacePlaceholders } from "../../../lib/utils/i18n.utils";
-import { formatICP } from "../../../lib/utils/icp.utils";
+import { formatToken } from "../../../lib/utils/icp.utils";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
@@ -35,7 +35,7 @@ describe("NnsAccounts", () => {
 
       expect(
         titleRow?.textContent?.startsWith(
-          `${en.accounts.total} ${formatICP({
+          `${en.accounts.total} ${formatToken({
             value: mockMainAccount.balance.toE8s(),
           })} ICP`
         )
@@ -63,7 +63,7 @@ describe("NnsAccounts", () => {
       );
 
       expect(cardTitleRow?.textContent).toEqual(
-        `${formatICP({ value: mockMainAccount.balance.toE8s() })} ICP`
+        `${formatToken({ value: mockMainAccount.balance.toE8s() })} ICP`
       );
     });
 
@@ -137,7 +137,7 @@ describe("NnsAccounts", () => {
 
       expect(
         titleRow?.textContent?.startsWith(
-          `${en.accounts.total} ${formatICP({ value: totalBalance })} ICP`
+          `${en.accounts.total} ${formatToken({ value: totalBalance })} ICP`
         )
       ).toBeTruthy();
     });
@@ -161,7 +161,7 @@ describe("NnsAccounts", () => {
 
       expect(icp?.textContent).toEqual(
         replacePlaceholders(en.accounts.current_balance_total, {
-          $amount: `${formatICP({
+          $amount: `${formatToken({
             value: totalBalance,
             detailed: true,
           })}`,

--- a/frontend/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp.utils.spec.ts
@@ -5,58 +5,58 @@ import {
   convertIcpToTCycles,
   convertNumberToICP,
   convertTCyclesToIcpNumber,
-  formatICP,
   formattedTransactionFeeICP,
+  formatToken,
   getMaxTransactionAmount,
   sumTokenAmounts,
 } from "../../../lib/utils/icp.utils";
 
 describe("icp-utils", () => {
   it("should format icp", () => {
-    expect(formatICP({ value: BigInt(0) })).toEqual("0");
+    expect(formatToken({ value: BigInt(0) })).toEqual("0");
     // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-    // expect(formatICP({value: BigInt(10)})).toEqual("0.0000001");
-    expect(formatICP({ value: BigInt(100) })).toEqual("0.000001");
-    expect(formatICP({ value: BigInt(100000000) })).toEqual("1.00");
-    expect(formatICP({ value: BigInt(1000000000) })).toEqual("10.00");
-    expect(formatICP({ value: BigInt(1010000000) })).toEqual("10.10");
-    expect(formatICP({ value: BigInt(1012300000) })).toEqual("10.12");
-    expect(formatICP({ value: BigInt(20000000000) })).toEqual("200.00");
-    expect(formatICP({ value: BigInt(20000000001) })).toEqual("200.00");
-    expect(formatICP({ value: BigInt(200000000000) })).toEqual(`2'000.00`);
-    expect(formatICP({ value: BigInt(200000000000000) })).toEqual(
+    // expect(formatToken({value: BigInt(10)})).toEqual("0.0000001");
+    expect(formatToken({ value: BigInt(100) })).toEqual("0.000001");
+    expect(formatToken({ value: BigInt(100000000) })).toEqual("1.00");
+    expect(formatToken({ value: BigInt(1000000000) })).toEqual("10.00");
+    expect(formatToken({ value: BigInt(1010000000) })).toEqual("10.10");
+    expect(formatToken({ value: BigInt(1012300000) })).toEqual("10.12");
+    expect(formatToken({ value: BigInt(20000000000) })).toEqual("200.00");
+    expect(formatToken({ value: BigInt(20000000001) })).toEqual("200.00");
+    expect(formatToken({ value: BigInt(200000000000) })).toEqual(`2'000.00`);
+    expect(formatToken({ value: BigInt(200000000000000) })).toEqual(
       `2'000'000.00`
     );
   });
 
   it("should format icp detailed", () => {
-    expect(formatICP({ value: BigInt(0), detailed: true })).toEqual("0");
-    expect(formatICP({ value: BigInt(100), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(0), detailed: true })).toEqual("0");
+    expect(formatToken({ value: BigInt(100), detailed: true })).toEqual(
       "0.000001"
     );
-    expect(formatICP({ value: BigInt(100000000), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(100000000), detailed: true })).toEqual(
       "1.00"
     );
-    expect(formatICP({ value: BigInt(1000000000), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(1000000000), detailed: true })).toEqual(
       "10.00"
     );
-    expect(formatICP({ value: BigInt(1010000000), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(1010000000), detailed: true })).toEqual(
       "10.10"
     );
-    expect(formatICP({ value: BigInt(1012300000), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(1012300000), detailed: true })).toEqual(
       "10.123"
     );
-    expect(formatICP({ value: BigInt(20000000000), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(20000000000), detailed: true })).toEqual(
       "200.00"
     );
-    expect(formatICP({ value: BigInt(20000000001), detailed: true })).toEqual(
+    expect(formatToken({ value: BigInt(20000000001), detailed: true })).toEqual(
       "200.00000001"
     );
-    expect(formatICP({ value: BigInt(200000000000), detailed: true })).toEqual(
-      `2'000.00`
-    );
     expect(
-      formatICP({ value: BigInt(200000000000000), detailed: true })
+      formatToken({ value: BigInt(200000000000), detailed: true })
+    ).toEqual(`2'000.00`);
+    expect(
+      formatToken({ value: BigInt(200000000000000), detailed: true })
     ).toEqual(`2'000'000.00`);
   });
 

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -15,6 +15,12 @@ import {
   mockSnsFullProject,
 } from "../mocks/sns-projects.mock";
 
+jest.mock("../../lib/services/sns-accounts.services", () => {
+  return {
+    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe("Accounts", () => {
   jest
     .spyOn(committedProjectsStore, "subscribe")


### PR DESCRIPTION
# Motivation

Remove the dependency of ICP of the TransactionModal.

# Changes

* TransactionModal: Transaction fee as a prop instead of hardcoded NNS ledger fee.
* TransactionModal: Token as a prop instead of hardcoded ICP when showing it in display.
* Rename util "formatICP" to "formatToken"
* Rename css var "--icp-font-size" to "--token-font-size"

# Tests

* Add a test that the transaction fee prop is used.
* Rename also in tests.
