### PR TITLE
Use current ic-admin

### DIFF
--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -114,6 +114,7 @@ get_wasm() {
 
 get_binary ic-nns-init
 get_binary sns
+get_binary ic-admin
 get_wasm registry-canister.wasm
 get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm

--- a/scripts/propose
+++ b/scripts/propose
@@ -2,6 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 PROPOSALS_DIR="scripts/propose-to"
+PATH="$PWD/target/ic:$PATH"
 
 help_text() {
   cat <<-EOF


### PR DESCRIPTION
# Motivation
There has been a breaking change in the NNS manage neuron API, so we need to be careful to use a version of ic-admin that matches the canisters.

# Changes
- When downloading NNS canisters, download ic-admin as well.
- When making a proposal with ic-admin, use the downloaded tool.

# Tests
I have used this to deploy small14