### PR TITLE
GIX-1025: Sns Account Text Representation

### DIFF
--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -3,6 +3,7 @@ import { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { Account } from "../types/account";
 import { logWithTimestamp } from "../utils/dev.utils";
+import { encodeSnsAccount } from "../utils/sns-accounts.utils";
 import { mapOptionalToken } from "../utils/sns.utils";
 import { wrapper } from "./sns-wrapper.api";
 
@@ -28,10 +29,12 @@ export const getSnsAccounts = async ({
     ledgerMetadata({}),
   ]);
 
+  const defaultAccount = {
+    owner: identity.getPrincipal(),
+  };
   const mainAccount: Account = {
-    // TODO: Implement string representation https://dfinity.atlassian.net/browse/GIX-1025
-    identifier: "sns-main-account-identifier",
-    principal: identity.getPrincipal(),
+    identifier: encodeSnsAccount(defaultAccount),
+    principal: defaultAccount.owner,
     balance: TokenAmount.fromE8s({
       amount: mainBalanceE8s,
       token: mapOptionalToken(metadata),

--- a/frontend/src/lib/utils/sns-accounts.utils.ts
+++ b/frontend/src/lib/utils/sns-accounts.utils.ts
@@ -1,0 +1,80 @@
+import { Principal } from "@dfinity/principal";
+
+interface SnsAccount {
+  owner: Principal;
+  subaccount?: Uint8Array;
+}
+
+const shrink = (bytes: Uint8Array): Uint8Array => {
+  const shrinked = Array.from(bytes);
+  while (shrinked[0] === 0) {
+    shrinked.shift();
+  }
+  return Uint8Array.from(shrinked);
+};
+
+// Reference: https://github.com/dfinity/ICRC-1/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238
+export const encodeSnsAccount = ({ owner, subaccount }: SnsAccount): string => {
+  if (subaccount === undefined) {
+    return owner.toText();
+  }
+
+  const subaccountBytes = shrink(subaccount);
+
+  if (subaccountBytes.length === 0) {
+    return owner.toText();
+  }
+
+  const bytes = Uint8Array.from([
+    ...owner.toUint8Array(),
+    ...subaccountBytes,
+    subaccountBytes.length,
+    parseInt("FF", 16),
+  ]);
+
+  return Principal.fromUint8Array(bytes).toText();
+};
+
+// Reference: https://github.com/dfinity/ICRC-1/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R268
+export const decodeSnsAccount = (accountString: string): SnsAccount => {
+  const principal = Principal.fromText(accountString);
+
+  const [ff, nonZeroLength, ...restReversed] = principal
+    .toUint8Array()
+    .reverse();
+
+  if (ff !== parseInt("FF", 16)) {
+    return {
+      owner: Principal.fromText(accountString),
+    };
+  }
+
+  if (
+    nonZeroLength > 32 ||
+    nonZeroLength === 0 ||
+    nonZeroLength === undefined
+  ) {
+    throw new Error("Invalid account string");
+  }
+
+  const subaccountBytesReversed = restReversed.slice(0, nonZeroLength);
+  if (
+    subaccountBytesReversed[0] === 0 ||
+    subaccountBytesReversed.length !== nonZeroLength
+  ) {
+    throw new Error("Invalid account string");
+  }
+  while (subaccountBytesReversed.length < 32) {
+    subaccountBytesReversed.push(0);
+  }
+  const subaccount = Uint8Array.from(subaccountBytesReversed.reverse());
+
+  const principalBytes = restReversed
+    .reverse()
+    .filter((_, i) => i < restReversed.length - nonZeroLength);
+
+  return {
+    owner: Principal.fromUint8Array(Uint8Array.from(principalBytes)),
+    subaccount,
+  };
+};

--- a/frontend/src/tests/lib/utils/sns-accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-accounts.utils.spec.ts
@@ -1,0 +1,95 @@
+import { Principal } from "@dfinity/principal";
+import {
+  decodeSnsAccount,
+  encodeSnsAccount,
+} from "../../../lib/utils/sns-accounts.utils";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+
+describe("sns-accounts utils", () => {
+  describe("encodeSnsAccount", () => {
+    it("should return the principal text for main accounts", () => {
+      const owner = mockPrincipal;
+      expect(encodeSnsAccount({ owner })).toEqual(owner.toText());
+    });
+
+    it("should return the principal text for subaccount 0", () => {
+      const owner = mockPrincipal;
+      const account = {
+        owner,
+        subaccount: new Uint8Array(32).fill(0),
+      };
+      expect(encodeSnsAccount(account)).toEqual(owner.toText());
+    });
+
+    it("should return a string representation for subaccounts", () => {
+      const subaccount = new Uint8Array(32).fill(0);
+      subaccount[31] = 1;
+      const account = {
+        owner: Principal.fromText("2vxsx-fae"),
+        subaccount: subaccount,
+      };
+      expect(encodeSnsAccount(account)).toEqual(
+        Principal.fromHex("040101ff").toText()
+      );
+    });
+  });
+
+  describe("decodeSnsAccount", () => {
+    it("should return the owner only for main accounts", () => {
+      const owner = mockPrincipal;
+      expect(decodeSnsAccount(mockPrincipal.toText())).toEqual({ owner });
+    });
+
+    it("should return the account with subaccounts", () => {
+      const subaccount = new Uint8Array(32).fill(0);
+      subaccount[31] = 1;
+      const account1 = {
+        owner: Principal.fromText("2vxsx-fae"),
+        subaccount,
+      };
+      expect(decodeSnsAccount(encodeSnsAccount(account1))).toEqual(account1);
+    });
+
+    it("should raise an error if incorrect subaccount", () => {
+      const call1 = () => decodeSnsAccount(Principal.fromHex("ff").toText());
+      expect(call1).toThrow();
+
+      const call2 = () =>
+        decodeSnsAccount(Principal.fromHex("040001ff").toText());
+      expect(call2).toThrow();
+
+      const call3 = () =>
+        decodeSnsAccount(Principal.fromHex("040103ff").toText());
+      expect(call3).toThrow();
+
+      const call4 = () => decodeSnsAccount(Principal.fromHex("00ff").toText());
+      expect(call4).toThrow();
+    });
+  });
+
+  describe("encode and decode should match", () => {
+    it("decodes, decodes doesn't change the account", () => {
+      const subaccount1 = new Uint8Array(32).fill(0);
+      subaccount1[31] = 1;
+      const account1 = {
+        owner: Principal.fromText("2vxsx-fae"),
+        subaccount: subaccount1,
+      };
+      expect(decodeSnsAccount(encodeSnsAccount(account1))).toEqual(account1);
+
+      const subaccount2 = new Uint8Array(32).fill(0);
+      subaccount2[31] = 1;
+      subaccount2[29] = 4;
+      const account2 = {
+        owner: mockPrincipal,
+        subaccount: subaccount2,
+      };
+      expect(decodeSnsAccount(encodeSnsAccount(account2))).toEqual(account2);
+
+      const account3 = {
+        owner: mockPrincipal,
+      };
+      expect(decodeSnsAccount(encodeSnsAccount(account3))).toEqual(account3);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

User sees the string representation of the SNS Accounts.

# Changes

* New sns-accounts utils to encode and decode the accounts.
* Use the sns utils in sns-ledger api function to encode the default account.

# Tests

* Test new sns-accounts utils.
