### PR TITLE
Feat/Update the deploy process to account for the tip of the SNS development

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -305,7 +305,7 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    for canister in root governance ledger swap; do
+    for canister in root governance ledger swap archive; do
       ./target/ic/sns add-sns-wasm-for-tests \
         --network "$DFX_NETWORK" \
         --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \

--- a/dfx.json
+++ b/dfx.json
@@ -60,6 +60,14 @@
       "wasm": "target/ic/ic-icrc1-ledger.wasm",
       "type": "custom"
     },
+    "sns_archive": {
+      "build": [
+        "true"
+      ],
+      "candid": "target/ic/ic-icrc1-archive.did",
+      "wasm": "target/ic/ic-icrc1-archive.wasm",
+      "type": "custom"
+    },
     "sns_swap": {
       "build": [
         "true"

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -119,6 +119,7 @@ get_wasm registry-canister.wasm
 get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
 get_wasm ledger-canister_notify-method.wasm
+get_wasm ic-icrc1-archive.wasm
 get_wasm ic-icrc1-ledger.wasm
 get_wasm ic-ckbtc-minter.wasm
 get_wasm root-canister.wasm


### PR DESCRIPTION
# Motivation

The snsdemo branch depends on checking out a commit on the nns-dapp. These upgrades should allow for the snsdemo to work with the tip of the SNS canisters.

# Changes

- deploy.sh will deploy the ic-icrc1-archive canister to the sns-wasm canister and not require a separate call to the sns-wasm canister.

# Tests

I've tested this locally but I do not believe there are tests in place for this. If I can add tests for this, please feel free to point out and I will add them.
