### PR TITLE
GIX-990: Remove ICP class dependency v3

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -4,9 +4,10 @@ import type {
   KnownNeuron,
   NeuronId,
   NeuronInfo,
+  TokenAmount,
   Topic,
 } from "@dfinity/nns";
-import { GovernanceCanister, ICP } from "@dfinity/nns";
+import { GovernanceCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type { SubAccountArray } from "../canisters/nns-dapp/nns-dapp.types";
 import { DFINITY_NEURON, IC_NEURON } from "../constants/api.constants";
@@ -191,7 +192,7 @@ export const splitNeuron = async ({
   identity,
 }: {
   neuronId: NeuronId;
-  amount: ICP;
+  amount: TokenAmount;
   identity: Identity;
 }): Promise<NeuronId> => {
   logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) call...`);
@@ -309,7 +310,7 @@ export const stakeNeuron = async ({
   identity,
   fromSubAccount,
 }: {
-  stake: ICP;
+  stake: TokenAmount;
   controller: Principal;
   ledgerCanisterIdentity: Identity;
   identity: Identity;

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -1,5 +1,5 @@
 import type { Identity } from "@dfinity/agent";
-import type { ICP } from "@dfinity/nns";
+import type { TokenAmount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type {
   SnsNeuron,
@@ -247,7 +247,7 @@ export const participateInSnsSwap = async ({
   rootCanisterId,
   fromSubAccount,
 }: {
-  amount: ICP;
+  amount: TokenAmount;
   controller: Principal;
   identity: Identity;
   rootCanisterId: Principal;

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { ICP } from "@dfinity/nns";
   import { createEventDispatcher, onMount } from "svelte";
   import FooterModal from "../../modals/FooterModal.svelte";
   import { i18n } from "../../stores/i18n";

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -57,9 +57,7 @@
 
   const dispatcher = createEventDispatcher();
   const selectAmount = () => {
-    dispatcher("nnsSelectAmount", {
-      amount: ICP.fromString(String(amount)),
-    });
+    dispatcher("nnsSelectAmount");
   };
 
   let enoughCycles: boolean;

--- a/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ICP, type NeuronInfo } from "@dfinity/nns";
+  import { ICPToken, TokenAmount, type NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { i18n } from "../../stores/i18n";
   import { replacePlaceholders } from "../../utils/i18n.utils";
@@ -18,7 +18,10 @@
 
   let disabled: boolean;
   $: disabled = !isEnoughToStakeNeuron({
-    stake: ICP.fromE8s(neuron.fullNeuron?.maturityE8sEquivalent ?? BigInt(0)),
+    stake: TokenAmount.fromE8s({
+      amount: neuron.fullNeuron?.maturityE8sEquivalent ?? BigInt(0),
+      token: ICPToken,
+    }),
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -23,7 +23,6 @@
   } from "../../../services/sns.services";
   import { toastsSuccess } from "../../../stores/toasts.store";
   import type { NewTransaction } from "../../../types/transaction.context";
-  import { convertNumberToICP } from "../../../utils/icp.utils";
   import AdditionalInfoForm from "./AdditionalInfoForm.svelte";
   import AdditionalInfoReview from "./AdditionalInfoReview.svelte";
 
@@ -91,7 +90,9 @@
       });
       const { success } = await participateInSwap({
         account: sourceAccount,
-        amount: convertNumberToICP(amount),
+        // If we made it here, we know that the amount is valid
+        // TODO: change fromNumber return type
+        amount: TokenAmount.fromNumber({ amount }) as TokenAmount,
         rootCanisterId: $projectDetailStore.summary.rootCanisterId,
       });
       if (success) {

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1,5 +1,11 @@
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
-import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
+import {
+  ICPToken,
+  TokenAmount,
+  Topic,
+  type NeuronId,
+  type NeuronInfo,
+} from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { makeDummyProposals as makeDummyProposalsApi } from "../api/dev.api";
@@ -47,7 +53,6 @@ import {
 import { getLastPathDetailId, isRoutePath } from "../utils/app-path.utils";
 import { mapNeuronErrorToToastMessage } from "../utils/error.utils";
 import { translate } from "../utils/i18n.utils";
-import { convertNumberToICP } from "../utils/icp.utils";
 import {
   canBeMerged,
   followeesByTopic,
@@ -191,7 +196,11 @@ export const stakeNeuron = async ({
   loadNeuron?: boolean;
 }): Promise<NeuronId | undefined> => {
   try {
-    const stake = convertNumberToICP(amount);
+    // TODO: https://dfinity.atlassian.net/browse/GIX-1005
+    const stake = TokenAmount.fromNumber({
+      amount,
+      token: ICPToken,
+    }) as TokenAmount;
     assertEnoughAccountFunds({
       account,
       amountE8s: stake.toE8s(),
@@ -521,7 +530,10 @@ export const splitNeuron = async ({
 
     const fee = get(mainTransactionFeeStore);
     const transactionFeeAmount = fee / E8S_PER_ICP;
-    const stake = convertNumberToICP(amount + transactionFeeAmount);
+    const stake = TokenAmount.fromNumber({
+      amount: amount + transactionFeeAmount,
+      token: ICPToken,
+    }) as TokenAmount;
 
     if (!isEnoughToStakeNeuron({ stake, fee })) {
       throw new InsufficientAmountError();

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -1,8 +1,8 @@
 import {
-  ICP,
   Topic,
   type AccountIdentifier,
   type ProposalInfo,
+  type TokenAmount,
 } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
@@ -249,7 +249,7 @@ export const participateInSwap = async ({
   rootCanisterId,
   account,
 }: {
-  amount: ICP;
+  amount: TokenAmount;
   rootCanisterId: Principal;
   account: Account;
 }): Promise<{ success: boolean }> => {

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -1,4 +1,3 @@
-import { ICP } from "@dfinity/nns";
 import { derived, writable } from "svelte/store";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../constants/icp.constants";
 
@@ -38,9 +37,4 @@ export const transactionsFeesStore = initTransactionFeesStore();
 export const mainTransactionFeeStore = derived(
   transactionsFeesStore,
   ($store) => Number($store.main)
-);
-
-export const mainTransactionFeeStoreAsIcp = derived(
-  transactionsFeesStore,
-  ($store) => ICP.fromE8s($store.main)
 );

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -1,5 +1,4 @@
 import {
-  ICP,
   TokenAmount,
   type Ballot,
   type Followees,
@@ -51,13 +50,16 @@ export const anonymizeAmount = async (
     : BigInt(((await anonymize(amount)) as string).replace(/[A-z]/g, ""));
 
 export const anonymizeICP = async (
-  icp: ICP | TokenAmount | undefined
-): Promise<ICP | undefined> =>
-  icp === undefined
+  tokens: TokenAmount | undefined
+): Promise<TokenAmount | undefined> =>
+  tokens === undefined
     ? undefined
-    : icp.toE8s() === BigInt(0)
-    ? ICP.fromE8s(BigInt(0))
-    : ICP.fromE8s((await anonymizeAmount(icp.toE8s())) as bigint);
+    : tokens.toE8s() === BigInt(0)
+    ? TokenAmount.fromE8s({ amount: BigInt(0), token: tokens.token })
+    : TokenAmount.fromE8s({
+        amount: (await anonymizeAmount(tokens.toE8s())) as bigint,
+        token: tokens.token,
+      });
 
 export const anonymizeBallot = async (
   ballot: Ballot | undefined | null

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -1,10 +1,9 @@
-import { ICP, TokenAmount } from "@dfinity/nns";
+import { ICPToken, TokenAmount } from "@dfinity/nns";
 import {
   E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
   ICP_DISPLAYED_DECIMALS_DETAILED,
 } from "../constants/icp.constants";
-import { InvalidAmountError } from "../types/neurons.errors";
 
 const countDecimals = (value: number): number => {
   // "1e-7" -> 0.00000001
@@ -71,7 +70,10 @@ export const sumTokenAmounts = (
 // e.g. not 0.00010000 but 0.0001
 export const formattedTransactionFeeICP = (fee: number): string =>
   formatToken({
-    value: ICP.fromE8s(BigInt(fee)).toE8s(),
+    value: TokenAmount.fromE8s({
+      amount: BigInt(fee),
+      token: ICPToken,
+    }).toE8s(),
   });
 
 /**
@@ -102,17 +104,6 @@ export const getMaxTransactionAmount = ({
 
 export const isValidICPFormat = (text: string) =>
   /^[\d]*(\.[\d]{0,8})?$/.test(text);
-
-const ICP_DECIMAL_ACCURACY = 8;
-export const convertNumberToICP = (amount: number): ICP => {
-  const stake = ICP.fromString(amount.toFixed(ICP_DECIMAL_ACCURACY));
-
-  if (!(stake instanceof ICP) || stake === undefined) {
-    throw new InvalidAmountError();
-  }
-
-  return stake;
-};
 
 // `exchangeRate` is the number of 10,000ths of IMF SDR (currency code XDR) that corresponds to 1 ICP.
 // This value reflects the current market price of one ICP token.

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -5,8 +5,8 @@ import {
   IconLockOpen,
 } from "@dfinity/gix-components";
 import {
-  ICP,
   NeuronState,
+  TokenAmount,
   Topic,
   Vote,
   votedNeurons,
@@ -302,7 +302,7 @@ export const isEnoughToStakeNeuron = ({
   stake,
   fee = 0,
 }: {
-  stake: ICP;
+  stake: TokenAmount;
   fee?: number;
 }): boolean => stake.toE8s() >= MIN_NEURON_STAKE + fee;
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,4 +1,4 @@
-import type { ICP } from "@dfinity/nns";
+import type { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { OWN_CANISTER_ID } from "../constants/canister-ids.constants";
@@ -131,7 +131,7 @@ const commitmentTooSmall = ({
   amount,
 }: {
   project: SnsFullProject;
-  amount: ICP;
+  amount: TokenAmount;
 }): boolean =>
   summary.swap.params.min_participant_icp_e8s >
   amount.toE8s() + (getCommitmentE8s(swapCommitment) ?? BigInt(0));
@@ -189,7 +189,7 @@ export const validParticipation = ({
   amount,
 }: {
   project: SnsFullProject | undefined;
-  amount: ICP;
+  amount: TokenAmount;
 }): {
   valid: boolean;
   labelKey?: string;

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -1,4 +1,10 @@
-import { GovernanceCanister, ICP, LedgerCanister, Topic } from "@dfinity/nns";
+import {
+  GovernanceCanister,
+  ICPToken,
+  LedgerCanister,
+  TokenAmount,
+  Topic,
+} from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 import {
@@ -52,7 +58,10 @@ describe("neurons-api", () => {
       .mockImplementation(() => mock<LedgerCanister>());
 
     await stakeNeuron({
-      stake: ICP.fromString("2") as ICP,
+      stake: TokenAmount.fromString({
+        amount: "2",
+        token: ICPToken,
+      }) as TokenAmount,
       controller: mockIdentity.getPrincipal(),
       ledgerCanisterIdentity: mockIdentity,
       identity: mockIdentity,
@@ -485,6 +494,10 @@ describe("neurons-api", () => {
   });
 
   describe("splitNeuron", () => {
+    const amount = TokenAmount.fromString({
+      amount: "2.2",
+      token: ICPToken,
+    }) as TokenAmount;
     it("updates neuron successfully", async () => {
       mockGovernanceCanister.splitNeuron.mockImplementation(
         jest.fn().mockResolvedValue(BigInt(11))
@@ -493,7 +506,7 @@ describe("neurons-api", () => {
       await splitNeuron({
         identity: mockIdentity,
         neuronId: BigInt(10),
-        amount: ICP.fromString("2.2") as ICP,
+        amount,
       });
 
       expect(mockGovernanceCanister.splitNeuron).toBeCalled();
@@ -511,7 +524,7 @@ describe("neurons-api", () => {
         splitNeuron({
           identity: mockIdentity,
           neuronId: BigInt(10),
-          amount: ICP.fromString("2.2") as ICP,
+          amount,
         });
       expect(mockGovernanceCanister.splitNeuron).not.toBeCalled();
       await expect(call).rejects.toThrow(error);

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -3,7 +3,12 @@
  */
 
 import type { HttpAgent } from "@dfinity/agent";
-import { ICP, LedgerCanister, type SnsWasmCanisterOptions } from "@dfinity/nns";
+import {
+  ICPToken,
+  LedgerCanister,
+  TokenAmount,
+  type SnsWasmCanisterOptions,
+} from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
@@ -183,7 +188,10 @@ describe("sns-api", () => {
     jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
 
     await participateInSnsSwap({
-      amount: ICP.fromString("10") as ICP,
+      amount: TokenAmount.fromString({
+        amount: "10",
+        token: ICPToken,
+      }) as TokenAmount,
       rootCanisterId: rootCanisterIdMock,
       identity: mockIdentity,
       controller: Principal.fromText("aaaaa-aa"),
@@ -203,7 +211,10 @@ describe("sns-api", () => {
 
     const call = () =>
       participateInSnsSwap({
-        amount: ICP.fromString("10") as ICP,
+        amount: TokenAmount.fromString({
+          amount: "10",
+          token: ICPToken,
+        }) as TokenAmount,
         rootCanisterId: rootCanisterIdMock,
         identity: mockIdentity,
         controller: Principal.fromText("aaaaa-aa"),

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,11 +1,5 @@
 import type { Identity } from "@dfinity/agent";
-import {
-  ICP,
-  ICPToken,
-  LedgerCanister,
-  TokenAmount,
-  Topic,
-} from "@dfinity/nns";
+import { ICPToken, LedgerCanister, TokenAmount, Topic } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 import { tick } from "svelte/internal";
@@ -889,7 +883,10 @@ describe("neurons-services", () => {
       expect(spySplitNeuron).toHaveBeenCalledWith({
         identity: mockIdentity,
         neuronId: controlledNeuron.neuronId,
-        amount: ICP.fromE8s(BigInt(Math.round(amountWithFee * E8S_PER_ICP))),
+        amount: TokenAmount.fromE8s({
+          amount: BigInt(Math.round(amountWithFee * E8S_PER_ICP)),
+          token: ICPToken,
+        }),
       });
     });
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { AccountIdentifier, ICP, ICPToken, TokenAmount } from "@dfinity/nns";
+import { AccountIdentifier, ICPToken, TokenAmount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import * as api from "../../../lib/api/sns.api";
@@ -43,6 +43,10 @@ describe("sns-services", () => {
     querySnsSwapStates[0].swap[0]!.params[0]!.max_icp_e8s =
       BigInt(200_000_000_000);
 
+    beforeEach(() => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
     afterEach(() => {
       jest.clearAllMocks();
       snsQueryStore.reset();
@@ -55,7 +59,10 @@ describe("sns-services", () => {
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
-        amount: ICP.fromString("3") as ICP,
+        amount: TokenAmount.fromString({
+          amount: "3",
+          token: ICPToken,
+        }) as TokenAmount,
         rootCanisterId,
         account: mockMainAccount,
       });
@@ -64,7 +71,7 @@ describe("sns-services", () => {
       expect(syncAccounts).toBeCalled();
     });
 
-    it.only("should return true when last commitment and still sync accounts", async () => {
+    it("should return true when last commitment and still sync accounts", async () => {
       const maxE8s = BigInt(1_000_000_000);
       const participationE8s = BigInt(150_000_000);
       const currentE8s = BigInt(850_000_000);
@@ -91,7 +98,10 @@ describe("sns-services", () => {
           )
         );
       const { success } = await participateInSwap({
-        amount: ICP.fromE8s(participationE8s),
+        amount: TokenAmount.fromE8s({
+          amount: participationE8s,
+          token: ICPToken,
+        }),
         rootCanisterId,
         account: mockMainAccount,
       });
@@ -105,9 +115,12 @@ describe("sns-services", () => {
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
-        .mockImplementation(() => Promise.reject(undefined));
+        .mockImplementation(() => Promise.reject(new Error("test")));
       const { success } = await participateInSwap({
-        amount: ICP.fromString("3") as ICP,
+        amount: TokenAmount.fromString({
+          amount: "3",
+          token: ICPToken,
+        }) as TokenAmount,
         rootCanisterId,
         account: mockMainAccount,
       });
@@ -134,7 +147,10 @@ describe("sns-services", () => {
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
-        amount: ICP.fromE8s(minimumE8s - BigInt(10_000)),
+        amount: TokenAmount.fromE8s({
+          amount: minimumE8s - BigInt(10_000),
+          token: ICPToken,
+        }),
         rootCanisterId,
         account: mockMainAccount,
       });
@@ -161,7 +177,10 @@ describe("sns-services", () => {
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
-        amount: ICP.fromE8s(maximumE8s + BigInt(10_000)),
+        amount: TokenAmount.fromE8s({
+          amount: maximumE8s + BigInt(10_000),
+          token: ICPToken,
+        }),
         rootCanisterId,
         account: mockMainAccount,
       });
@@ -183,11 +202,13 @@ describe("sns-services", () => {
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
-        amount: ICP.fromE8s(
-          account.balance.toE8s() +
+        amount: TokenAmount.fromE8s({
+          amount:
+            account.balance.toE8s() +
             BigInt(DEFAULT_TRANSACTION_FEE_E8S) +
-            BigInt(10_000)
-        ),
+            BigInt(10_000),
+          token: ICPToken,
+        }),
         rootCanisterId,
         account,
       });
@@ -203,7 +224,10 @@ describe("sns-services", () => {
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
-        amount: ICP.fromString("3") as ICP,
+        amount: TokenAmount.fromString({
+          amount: "3",
+          token: ICPToken,
+        }) as TokenAmount,
         rootCanisterId,
         account: mockMainAccount,
       });

--- a/frontend/src/tests/lib/utils/icp.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp.utils.spec.ts
@@ -1,9 +1,7 @@
 import { TokenAmount } from "@dfinity/nns";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
-import { InvalidAmountError } from "../../../lib/types/neurons.errors";
 import {
   convertIcpToTCycles,
-  convertNumberToICP,
   convertTCyclesToIcpNumber,
   formattedTransactionFeeICP,
   formatToken,
@@ -159,20 +157,6 @@ describe("icp-utils", () => {
         fee,
       })
     ).toEqual(0);
-  });
-
-  describe("convertNumberToICP", () => {
-    it("returns ICP from number", () => {
-      expect(convertNumberToICP(10)?.toE8s()).toBe(BigInt(1_000_000_000));
-      expect(convertNumberToICP(10.1234)?.toE8s()).toBe(BigInt(1_012_340_000));
-      expect(convertNumberToICP(0.004)?.toE8s()).toBe(BigInt(400_000));
-      expect(convertNumberToICP(0.00000001)?.toE8s()).toBe(BigInt(1));
-    });
-
-    it("raises error on negative numbers", () => {
-      const call = () => convertNumberToICP(-10);
-      expect(call).toThrow(InvalidAmountError);
-    });
   });
 
   describe("convertIcpToTCycles", () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1,4 +1,11 @@
-import { ICP, NeuronState, Topic, Vote, type BallotInfo } from "@dfinity/nns";
+import {
+  ICPToken,
+  NeuronState,
+  TokenAmount,
+  Topic,
+  Vote,
+  type BallotInfo,
+} from "@dfinity/nns";
 import { get } from "svelte/store";
 import {
   SECONDS_IN_EIGHT_YEARS,
@@ -77,6 +84,10 @@ describe("neuron-utils", () => {
   afterAll(() => jest.useRealTimers());
 
   describe("votingPower", () => {
+    const tokenStake = TokenAmount.fromString({
+      amount: "2.2",
+      token: ICPToken,
+    }) as TokenAmount;
     it("should return zero for delays less than six months", () => {
       expect(
         votingPower({ stake: BigInt(2), dissolveDelayInSeconds: 100 })
@@ -84,37 +95,31 @@ describe("neuron-utils", () => {
     });
 
     it("should return more than stake when delay more than six months", () => {
-      const stake = "2.2";
-      const icp = ICP.fromString(stake) as ICP;
       expect(
         votingPower({
-          stake: icp.toE8s(),
+          stake: tokenStake.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
         })
-      ).toBeGreaterThan(icp.toE8s());
+      ).toBeGreaterThan(tokenStake.toE8s());
     });
 
     it("should return the double when delay is eight years", () => {
-      const stake = "2.2";
-      const icp = ICP.fromString(stake) as ICP;
       expect(
         votingPower({
-          stake: icp.toE8s(),
+          stake: tokenStake.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
         })
-      ).toBe(icp.toE8s() * BigInt(2));
+      ).toBe(tokenStake.toE8s() * BigInt(2));
     });
 
     it("should add age multiplier", () => {
-      const stake = "2.2";
-      const icp = ICP.fromString(stake) as ICP;
       const powerWithAge = votingPower({
-        stake: icp.toE8s(),
+        stake: tokenStake.toE8s(),
         dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
         ageSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
       });
       const powerWithoutAge = votingPower({
-        stake: icp.toE8s(),
+        stake: tokenStake.toE8s(),
         dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
       });
       expect(powerWithAge).toBeGreaterThan(powerWithoutAge);
@@ -321,7 +326,10 @@ describe("neuron-utils", () => {
     });
 
     it("returns maturity of stake with two decimals", () => {
-      const stake = ICP.fromString("2") as ICP;
+      const stake = TokenAmount.fromString({
+        amount: "2",
+        token: ICPToken,
+      }) as TokenAmount;
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -334,7 +342,10 @@ describe("neuron-utils", () => {
     });
 
     it("returns 0 when maturity is 0", () => {
-      const stake = ICP.fromString("3") as ICP;
+      const stake = TokenAmount.fromString({
+        amount: "3",
+        token: ICPToken,
+      }) as TokenAmount;
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -744,11 +755,17 @@ describe("neuron-utils", () => {
 
   describe("isEnoughToStakeNeuron", () => {
     it("return true if enough ICP to create a neuron", () => {
-      const stake = ICP.fromString("3") as ICP;
+      const stake = TokenAmount.fromString({
+        amount: "3",
+        token: ICPToken,
+      }) as TokenAmount;
       expect(isEnoughToStakeNeuron({ stake })).toBe(true);
     });
     it("returns false if not enough ICP to create a neuron", () => {
-      const stake = ICP.fromString("0.000001") as ICP;
+      const stake = TokenAmount.fromString({
+        amount: "0.000001",
+        token: ICPToken,
+      }) as TokenAmount;
       expect(isEnoughToStakeNeuron({ stake })).toBe(false);
     });
   });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,4 +1,4 @@
-import { ICP } from "@dfinity/nns";
+import { ICPToken, TokenAmount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
@@ -462,7 +462,10 @@ describe("project-utils", () => {
     it("returns true if valid participation", () => {
       const { valid } = validParticipation({
         project: validProject,
-        amount: ICP.fromE8s(validAmountE8s),
+        amount: TokenAmount.fromE8s({
+          amount: validAmountE8s,
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(true);
     });
@@ -480,7 +483,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(validAmountE8s),
+        amount: TokenAmount.fromE8s({
+          amount: validAmountE8s,
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -498,7 +504,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(validAmountE8s),
+        amount: TokenAmount.fromE8s({
+          amount: validAmountE8s,
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -519,7 +528,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
+        amount: TokenAmount.fromE8s({
+          amount: validAmountE8s + BigInt(10_000),
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -546,7 +558,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(validAmountE8s + BigInt(10_000)),
+        amount: TokenAmount.fromE8s({
+          amount: validAmountE8s + BigInt(10_000),
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -574,7 +589,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(participationE8s),
+        amount: TokenAmount.fromE8s({
+          amount: participationE8s,
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -613,7 +631,10 @@ describe("project-utils", () => {
       };
       const { valid } = validParticipation({
         project,
-        amount: ICP.fromE8s(newParticipation),
+        amount: TokenAmount.fromE8s({
+          amount: newParticipation,
+          token: ICPToken,
+        }),
       });
       expect(valid).toBe(false);
     });
@@ -649,7 +670,10 @@ describe("project-utils", () => {
       const initialAmountUser = minPerUser;
       const { valid: v1 } = validParticipation({
         project,
-        amount: ICP.fromE8s(initialAmountUser),
+        amount: TokenAmount.fromE8s({
+          amount: initialAmountUser,
+          token: ICPToken,
+        }),
       });
       expect(v1).toBe(true);
 
@@ -665,21 +689,30 @@ describe("project-utils", () => {
       const secondAmountUser = BigInt(10);
       const { valid: v2 } = validParticipation({
         project,
-        amount: ICP.fromE8s(secondAmountUser),
+        amount: TokenAmount.fromE8s({
+          amount: secondAmountUser,
+          token: ICPToken,
+        }),
       });
       expect(v2).toBe(true);
 
       // User can't participate if amount is greater than max per user
       const { valid: v3 } = validParticipation({
         project,
-        amount: ICP.fromE8s(maxPerUser),
+        amount: TokenAmount.fromE8s({
+          amount: maxPerUser,
+          token: ICPToken,
+        }),
       });
       expect(v3).toBe(false);
 
       // User can participate to user max
       const { valid: v4 } = validParticipation({
         project,
-        amount: ICP.fromE8s(maxPerUser - initialAmountUser),
+        amount: TokenAmount.fromE8s({
+          amount: maxPerUser - initialAmountUser,
+          token: ICPToken,
+        }),
       });
       expect(v4).toBe(true);
 
@@ -689,23 +722,30 @@ describe("project-utils", () => {
       // User can't participate to user max
       const { valid: v5 } = validParticipation({
         project,
-        amount: ICP.fromE8s(maxPerUser - initialAmountUser),
+        amount: TokenAmount.fromE8s({
+          amount: maxPerUser - initialAmountUser,
+          token: ICPToken,
+        }),
       });
       expect(v5).toBe(false);
 
       // User can participate to project max
       const { valid: v6 } = validParticipation({
         project,
-        amount: ICP.fromE8s(
-          maxProject - project.summary.derived.buyer_total_icp_e8s
-        ),
+        amount: TokenAmount.fromE8s({
+          amount: maxProject - project.summary.derived.buyer_total_icp_e8s,
+          token: ICPToken,
+        }),
       });
       expect(v6).toBe(true);
 
       // User can't participate to above project max
       const { valid: v7 } = validParticipation({
         project,
-        amount: ICP.fromE8s(maxPerUser - initialAmountUser + BigInt(10_000)),
+        amount: TokenAmount.fromE8s({
+          amount: maxPerUser - initialAmountUser + BigInt(10_000),
+          token: ICPToken,
+        }),
       });
       expect(v7).toBe(false);
     });

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -19,7 +19,7 @@ import { swapCanisterIdMock } from "./sns.api.mock";
 const swapToQuerySwap = (swap: SnsSummarySwap): [SnsSwap] => [
   {
     ...swap,
-    params: [swap.params],
+    params: [{ ...swap.params }],
   },
 ];
 


### PR DESCRIPTION
# Motivation

Keep cleaning the usage of deprecated ICP class.

# Changes

* Change usage of ICP class for TokenAmount class.
* Remove convertNumberToICP and use TokenAmount.fromNumber instead.

# Tests

* Fix broken tests.
