### PR TITLE
feat: support txtmime types

### DIFF
--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -163,6 +163,8 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
         "ico" => Some("image/x-icon"),
         "ttf" => Some("font/ttf"),
         "woff2" => Some("font/woff2"),
+        "txt" => Some("text/plain"),
+        "xml" => Some("application/xml"),
         _ => None,
     })
 }

--- a/rs/src/assets.rs
+++ b/rs/src/assets.rs
@@ -164,7 +164,6 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
         "ttf" => Some("font/ttf"),
         "woff2" => Some("font/woff2"),
         "txt" => Some("text/plain"),
-        "xml" => Some("application/xml"),
         _ => None,
     })
 }


### PR DESCRIPTION
# Motivation

Add mime types for new `robots.txt`.

Follow-up of #1377.
