### PR TITLE
GIX-995: Transactions out of SelectedAccountStore

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -27,9 +27,9 @@
   $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
-{#if account === undefined || extendedTransactions === undefined}
+{#if account === undefined || transactions === undefined}
   <SkeletonCard cardType="info" />
-{:else if extendedTransactions.length === 0}
+{:else if transactions.length === 0}
   {$i18n.wallet.no_transactions}
 {:else}
   {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}

--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -11,27 +11,28 @@
   } from "../../types/selected-account.context";
   import { mapToSelfTransaction } from "../../utils/transactions.utils";
 
+  export let transactions: Transaction[] | undefined;
+
   const { store } = getContext<SelectedAccountContext>(
     SELECTED_ACCOUNT_CONTEXT_KEY
   );
 
   let account: Account | undefined;
-  let storeTransactions: Transaction[] | undefined;
-  $: ({ account, transactions: storeTransactions } = $store);
+  $: ({ account } = $store);
 
-  let transactions: {
+  let extendedTransactions: {
     transaction: Transaction;
     toSelfTransaction: boolean;
   }[];
-  $: transactions = mapToSelfTransaction(storeTransactions ?? []);
+  $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
-{#if account === undefined || storeTransactions === undefined}
+{#if account === undefined || transactions === undefined}
   <SkeletonCard cardType="info" />
-{:else if storeTransactions.length === 0}
+{:else if transactions.length === 0}
   {$i18n.wallet.no_transactions}
 {:else}
-  {#each transactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}
+  {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}
     <TransactionCard {account} {transaction} {toSelfTransaction} />
   {/each}
 {/if}

--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -27,9 +27,9 @@
   $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
-{#if account === undefined || transactions === undefined}
+{#if account === undefined || extendedTransactions === undefined}
   <SkeletonCard cardType="info" />
-{:else if transactions.length === 0}
+{:else if extendedTransactions.length === 0}
   {$i18n.wallet.no_transactions}
 {:else}
   {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -61,6 +61,7 @@
     account: undefined,
   });
 
+  // TODO: Add transactions to debug store https://dfinity.atlassian.net/browse/GIX-1043
   debugSelectedAccountStore(selectedAccountStore);
 
   setContext<SelectedAccountContext>(SELECTED_ACCOUNT_CONTEXT_KEY, {

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -11,7 +11,6 @@
   } from "../services/accounts.services";
   import { accountsStore } from "../stores/accounts.store";
   import { Spinner } from "@dfinity/gix-components";
-  import type { AccountIdentifier } from "@dfinity/nns/dist/types/types/common";
   import { toastsError } from "../stores/toasts.store";
   import { replacePlaceholders } from "../utils/i18n.utils";
   import type { Account } from "../types/account";
@@ -29,6 +28,10 @@
   import { debugSelectedAccountStore } from "../stores/debug.store";
   import { layoutBackStore } from "../stores/layout.store";
   import IcpTransactionModal from "../modals/accounts/IcpTransactionModal.svelte";
+  import type {
+    AccountIdentifierString,
+    Transaction,
+  } from "../canisters/nns-dapp/nns-dapp.types";
 
   const goBack = () =>
     routeStore.navigate({
@@ -37,22 +40,25 @@
 
   layoutBackStore.set(goBack);
 
-  const reloadTransactions = async (accountIdentifier: AccountIdentifier) =>
+  let transactions: Transaction[] | undefined;
+
+  const reloadTransactions = async (
+    accountIdentifier: AccountIdentifierString
+  ) =>
     await getAccountTransactions({
       accountIdentifier,
-      onLoad: ({ accountIdentifier, transactions }) => {
+      onLoad: ({ accountIdentifier, transactions: loadedTransactions }) => {
         // avoid using outdated transactions
         if (accountIdentifier !== $selectedAccountStore.account?.identifier) {
           return;
         }
 
-        $selectedAccountStore.transactions = transactions;
+        transactions = loadedTransactions;
       },
     });
 
   const selectedAccountStore = writable<SelectedAccountStore>({
     account: undefined,
-    transactions: undefined,
   });
 
   debugSelectedAccountStore(selectedAccountStore);
@@ -92,10 +98,11 @@
           selectedAccount !== undefined &&
           storeAccount?.identifier === selectedAccount.identifier;
 
-        selectedAccountStore.update(({ transactions }) => ({
+        selectedAccountStore.update(() => ({
           account: selectedAccount,
-          transactions: sameAccount ? transactions : undefined,
         }));
+
+        transactions = sameAccount ? transactions : undefined;
 
         if (selectedAccount !== undefined) {
           reloadTransactions(selectedAccount.identifier);
@@ -126,7 +133,7 @@
       <div class="actions">
         <WalletActions />
       </div>
-      <TransactionList />
+      <TransactionList {transactions} />
     {:else}
       <Spinner />
     {/if}

--- a/frontend/src/lib/services/debug.services.ts
+++ b/frontend/src/lib/services/debug.services.ts
@@ -1,7 +1,6 @@
 import type { NeuronId } from "@dfinity/nns";
 import { get } from "svelte/store";
 import { addHotkey } from "../api/governance.api";
-import type { Transaction } from "../canisters/nns-dapp/nns-dapp.types";
 import { generateDebugLogProxy } from "../proxy/debug.services.proxy";
 import { initDebugStore } from "../stores/debug.store";
 import { i18n } from "../stores/i18n";
@@ -15,7 +14,6 @@ import {
   anonymizeProposal,
   anonymizeSnsSummary,
   anonymizeSnsSwapCommitment,
-  anonymizeTransaction,
   cutAndAnonymize,
 } from "../utils/anonymize.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
@@ -185,14 +183,6 @@ const anonymiseStoreState = async () => {
     },
     selectedAccount: {
       account: await anonymizeAccount(selectedAccount?.account),
-      transactions: await mapPromises(
-        selectedAccount?.transactions,
-        (transaction: Transaction) =>
-          anonymizeTransaction({
-            transaction,
-            account: selectedAccount?.account,
-          })
-      ),
     },
     selectedProject: {
       summary: await anonymizeSnsSummary(selectedProject.summary),

--- a/frontend/src/lib/stores/debug.store.ts
+++ b/frontend/src/lib/stores/debug.store.ts
@@ -40,7 +40,6 @@ export const debugTransactionStore = (store: Writable<TransactionStore>) =>
 // Therefore, we need to initialize them here.
 let selectedAccountStore: Readable<SelectedAccountStore> = readable({
   account: undefined,
-  transactions: undefined,
 });
 export const debugSelectedAccountStore = (
   store: Writable<SelectedAccountStore>

--- a/frontend/src/lib/types/selected-account.context.ts
+++ b/frontend/src/lib/types/selected-account.context.ts
@@ -1,5 +1,4 @@
 import type { Writable } from "svelte/store";
-import type { Transaction } from "../canisters/nns-dapp/nns-dapp.types";
 import type { Account } from "./account";
 
 /**
@@ -7,7 +6,6 @@ import type { Account } from "./account";
  */
 export interface SelectedAccountStore {
   account: Account | undefined;
-  transactions: Transaction[] | undefined;
 }
 
 export interface SelectedAccountContext {

--- a/frontend/src/tests/lib/components/accounts/TransactionList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionList.spec.ts
@@ -23,9 +23,9 @@ describe("TransactionList", () => {
         contextValue: {
           store: writable<SelectedAccountStore>({
             account,
-            transactions,
           }),
         } as SelectedAccountContext,
+        props: { transactions },
         Component: TransactionList,
       },
     });

--- a/frontend/src/tests/lib/components/accounts/WalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletActions.spec.ts
@@ -24,7 +24,6 @@ describe("WalletActions", () => {
         contextValue: {
           store: writable<SelectedAccountStore>({
             account,
-            transactions: undefined,
           }),
         } as SelectedAccountContext,
         Component: WalletActions,

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -24,7 +24,6 @@ describe("WalletSummary", () => {
         contextValue: {
           store: writable<SelectedAccountStore>({
             account: mockMainAccount,
-            transactions: undefined,
           }),
         } as SelectedAccountContext,
         Component: WalletSummary,

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -46,7 +46,6 @@ export const renderSelectedAccountContext = ({
     contextValue: {
       store: writable<SelectedAccountStore>({
         account,
-        transactions: undefined,
       }),
     },
     Component,

--- a/frontend/src/tests/mocks/modal.mock.ts
+++ b/frontend/src/tests/mocks/modal.mock.ts
@@ -78,7 +78,6 @@ export const renderModalSelectedAccountContextWrapper = ({
     contextValue: {
       store: writable<SelectedAccountStore>({
         account,
-        transactions: undefined,
       }),
     },
     Component,

--- a/frontend/src/tests/mocks/selected-account.store.mock.ts
+++ b/frontend/src/tests/mocks/selected-account.store.mock.ts
@@ -4,5 +4,4 @@ import { mockMainAccount } from "./accounts.store.mock";
 
 export const mockSelectedAccountStore = writable<SelectedAccountStore>({
   account: mockMainAccount,
-  transactions: undefined,
 });


### PR DESCRIPTION
# Motivation

Remove "transactions" from SelectedAccountStore to make it more reusable for SNS Wallet.

# Changes

* Remove "transactions" from SelectedAccountStore.
* Add "transactions" prop in TransactionsList.
* Use a local variable in NnsWallet to track transactions.

# Tests

* Fix broken tests after refactor.
