### PR TITLE
GIX-1017: Menu items keep context

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -95,7 +95,7 @@
   ];
 </script>
 
-{#each routes as { context, label, href, icon, statusIcon, selected }}
+{#each routes as { context, label, href, icon, statusIcon, selected } (context)}
   <MenuItem {href} testId={`menuitem-${context}`} {selected}>
     <svelte:component this={icon} slot="icon" />
     <svelte:fragment>{$i18n.navigation[label]}</svelte:fragment>

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -19,21 +19,28 @@
   } from "../../constants/environment.constants";
   import BadgeNew from "../ui/BadgeNew.svelte";
   import GetICPs from "../ic/GetICPs.svelte";
+  import {
+    accountsPathStore,
+    neuronsPathStore,
+  } from "../../derived/paths.derived";
 
   const baseUrl: string = baseHref();
 
   const isSelectedPath = (paths: AppPath[]): boolean =>
     isRoutePath({ paths, routePath: $routeStore.path });
 
-  const routes: {
+  let routes: {
     context: string;
+    href: string;
     selected: boolean;
     label: string;
     icon: typeof SvelteComponent;
     statusIcon?: typeof SvelteComponent;
-  }[] = [
+  }[];
+  $: routes = [
     {
       context: "accounts",
+      href: $accountsPathStore,
       selected: isSelectedPath([
         AppPath.Accounts,
         AppPath.LegacyAccounts,
@@ -45,6 +52,7 @@
     },
     {
       context: "neurons",
+      href: $neuronsPathStore,
       selected: isSelectedPath([
         AppPath.LegacyNeurons,
         AppPath.LegacyNeuronDetail,
@@ -56,12 +64,14 @@
     },
     {
       context: "proposals",
+      href: `${baseUrl}#/proposals`,
       selected: isSelectedPath([AppPath.Proposals, AppPath.ProposalDetail]),
       label: "voting",
       icon: IconHowToVote,
     },
     {
       context: "canisters",
+      href: `${baseUrl}#/canisters`,
       selected: isSelectedPath([AppPath.Canisters, AppPath.CanisterDetail]),
       label: "canisters",
       icon: IconEngineering,
@@ -71,6 +81,7 @@
       ? [
           {
             context: "launchpad",
+            href: `${baseUrl}#/launchpad`,
             selected: isSelectedPath([
               AppPath.Launchpad,
               AppPath.ProjectDetail,
@@ -84,12 +95,8 @@
   ];
 </script>
 
-{#each routes as { context, label, icon, statusIcon, selected }}
-  <MenuItem
-    href={`${baseUrl}#/${context}`}
-    testId={`menuitem-${context}`}
-    {selected}
-  >
+{#each routes as { context, label, href, icon, statusIcon, selected }}
+  <MenuItem {href} testId={`menuitem-${context}`} {selected}>
     <svelte:component this={icon} slot="icon" />
     <svelte:fragment>{$i18n.navigation[label]}</svelte:fragment>
     <svelte:component this={statusIcon} slot="statusIcon" />

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -1,5 +1,3 @@
-import { ENABLE_SNS } from "./environment.constants";
-
 export enum AppPath {
   Authentication = "/",
   LegacyAccounts = "/#/accounts",
@@ -17,24 +15,5 @@ export enum AppPath {
   ProjectDetail = "/#/u",
   NeuronDetail = "/#/u/:rootCanisterId/neuron",
 }
-
-export const paths = {
-  neuronDetail: (rootCanisterId: string) =>
-    ENABLE_SNS
-      ? `${CONTEXT_PATH}/${rootCanisterId}/neuron`
-      : AppPath.LegacyNeuronDetail,
-  neurons: (rootCanisterId: string) =>
-    ENABLE_SNS
-      ? `${CONTEXT_PATH}/${rootCanisterId}/neurons`
-      : AppPath.LegacyNeurons,
-  accounts: (rootCanisterId: string) =>
-    ENABLE_SNS
-      ? `${CONTEXT_PATH}/${rootCanisterId}/accounts`
-      : AppPath.LegacyAccounts,
-  wallet: (rootCanisterId: string) =>
-    ENABLE_SNS
-      ? `${CONTEXT_PATH}/${rootCanisterId}/wallet`
-      : AppPath.LegacyWallet,
-};
 
 export const CONTEXT_PATH = "/#/u";

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -1,3 +1,5 @@
+import { ENABLE_SNS } from "./environment.constants";
+
 export enum AppPath {
   Authentication = "/",
   LegacyAccounts = "/#/accounts",
@@ -15,5 +17,24 @@ export enum AppPath {
   ProjectDetail = "/#/u",
   NeuronDetail = "/#/u/:rootCanisterId/neuron",
 }
+
+export const paths = {
+  neuronDetail: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/neuron`
+      : AppPath.LegacyNeuronDetail,
+  neurons: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/neurons`
+      : AppPath.LegacyNeurons,
+  accounts: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/accounts`
+      : AppPath.LegacyAccounts,
+  wallet: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/wallet`
+      : AppPath.LegacyWallet,
+};
 
 export const CONTEXT_PATH = "/#/u";

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -1,0 +1,25 @@
+import { derived } from "svelte/store";
+import { paths } from "../constants/routes.constants";
+import { snsProjectSelectedStore } from "./selected-project.derived";
+
+export const accountsPathStore = derived(
+  snsProjectSelectedStore,
+  ($snsProjectSelectedStore) =>
+    paths.accounts($snsProjectSelectedStore.toText())
+);
+
+export const walletPathStore = derived(
+  snsProjectSelectedStore,
+  ($snsProjectSelectedStore) => paths.wallet($snsProjectSelectedStore.toText())
+);
+
+export const neuronsPathStore = derived(
+  snsProjectSelectedStore,
+  ($snsProjectSelectedStore) => paths.neurons($snsProjectSelectedStore.toText())
+);
+
+export const neuronPathStore = derived(
+  snsProjectSelectedStore,
+  ($snsProjectSelectedStore) =>
+    paths.neuronDetail($snsProjectSelectedStore.toText())
+);

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -1,5 +1,5 @@
 import { derived } from "svelte/store";
-import { paths } from "../constants/routes.constants";
+import { paths } from "../utils/app-path.utils";
 import { snsProjectSelectedStore } from "./selected-project.derived";
 
 export const accountsPathStore = derived(

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -6,11 +6,11 @@
   import AccountCard from "../components/accounts/AccountCard.svelte";
   import { i18n } from "../stores/i18n";
   import { routeStore } from "../stores/route.store";
-  import { AppPath } from "../constants/routes.constants";
   import type { TokenAmount } from "@dfinity/nns";
   import { sumTokenAmounts } from "../utils/icp.utils";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
+  import { walletPathStore } from "../derived/paths.derived";
 
   let accounts: AccountsStore | undefined;
 
@@ -18,10 +18,8 @@
     async (storeData: AccountsStore) => (accounts = storeData)
   );
 
-  // TODO: Point to context based path when enabling SNS accounts
-  // https://dfinity.atlassian.net/browse/GIX-1013
   const cardClick = (identifier: string) =>
-    routeStore.navigate({ path: `${AppPath.LegacyWallet}/${identifier}` });
+    routeStore.navigate({ path: `${$walletPathStore}/${identifier}` });
 
   onDestroy(unsubscribe);
 

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -23,6 +23,7 @@
   import NeuronJoinFundCard from "../components/neuron-detail/NeuronJoinFundCard.svelte";
   import { toastsError } from "../stores/toasts.store";
   import { voteRegistrationStore } from "../stores/vote-registration.store";
+  import { neuronsPathStore } from "../derived/paths.derived";
 
   // Neurons are fetch on page load. No need to do it in the route.
 
@@ -84,7 +85,7 @@
     unsubscribe();
 
     routeStore.navigate({
-      path: AppPath.LegacyNeurons,
+      path: $neuronsPathStore,
     });
   };
 

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -8,11 +8,11 @@
   import type { NeuronId } from "@dfinity/nns";
   import { neuronsStore, sortedNeuronStore } from "../stores/neurons.store";
   import { routeStore } from "../stores/route.store";
-  import { AppPath } from "../constants/routes.constants";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import Tooltip from "../components/ui/Tooltip.svelte";
   import { isSpawning } from "../utils/neuron.utils";
   import Value from "../components/ui/Value.svelte";
+  import { neuronPathStore } from "../derived/paths.derived";
 
   // Neurons are fetch on page load. No need to do it in the route.
 
@@ -30,7 +30,7 @@
 
   const goToNeuronDetails = (id: NeuronId) => () => {
     routeStore.navigate({
-      path: `${AppPath.LegacyNeuronDetail}/${id}`,
+      path: `${$neuronPathStore}/${id}`,
     });
   };
 </script>

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -28,6 +28,7 @@
   import { debugSelectedAccountStore } from "../stores/debug.store";
   import { layoutBackStore } from "../stores/layout.store";
   import IcpTransactionModal from "../modals/accounts/IcpTransactionModal.svelte";
+  import { accountsPathStore } from "../derived/paths.derived";
   import type {
     AccountIdentifierString,
     Transaction,
@@ -35,7 +36,7 @@
 
   const goBack = () =>
     routeStore.navigate({
-      path: AppPath.LegacyAccounts,
+      path: $accountsPathStore,
     });
 
   layoutBackStore.set(goBack);

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -4,7 +4,6 @@
   import { Toolbar } from "@dfinity/gix-components";
   import Footer from "../components/common/Footer.svelte";
   import { routeStore } from "../stores/route.store";
-  import { AppPath } from "../constants/routes.constants";
   import {
     getAccountTransactions,
     routePathAccountIdentifier,

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -11,6 +11,8 @@
   import type { Account } from "../types/account";
   import { sumTokenAmounts } from "../utils/icp.utils";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
+  import { routeStore } from "../stores/route.store";
+  import { walletPathStore } from "../derived/paths.derived";
 
   let loading: boolean = false;
   const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
@@ -35,9 +37,7 @@
         );
 
   const goToDetails = (account: Account) => {
-    // TODO: Wallet details https://dfinity.atlassian.net/browse/GIX-995
-    // eslint-disable-next-line no-console
-    console.log("goToDetails", account);
+    routeStore.navigate({ path: `${$walletPathStore}/${account.identifier}` });
   };
 </script>
 

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -21,6 +21,7 @@
   import { setContext } from "svelte";
   import { toastsError } from "../stores/toasts.store";
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
+  import { neuronsPathStore } from "../derived/paths.derived";
 
   const loadNeuron = async (
     { forceFetch }: { forceFetch: boolean } = { forceFetch: false }
@@ -95,7 +96,7 @@
 
   const goBack = () =>
     routeStore.navigate({
-      path: AppPath.LegacyNeurons,
+      path: $neuronsPathStore,
     });
 
   layoutBackStore.set(goBack);

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -7,10 +7,7 @@
   import { loadSnsNeurons } from "../services/sns-neurons.services";
   import SnsNeuronCard from "../components/sns-neurons/SnsNeuronCard.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
-  import {
-    snsOnlyProjectStore,
-    snsProjectSelectedStore,
-  } from "../derived/selected-project.derived";
+  import { snsOnlyProjectStore } from "../derived/selected-project.derived";
   import { getSnsNeuronIdAsHexString } from "../utils/sns-neuron.utils";
   import type { Unsubscriber } from "svelte/store";
   import { onDestroy } from "svelte";

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -15,7 +15,7 @@
   import type { Unsubscriber } from "svelte/store";
   import { onDestroy } from "svelte";
   import { routeStore } from "../stores/route.store";
-  import { AppPath } from "../constants/routes.constants";
+  import { neuronPathStore } from "../derived/paths.derived";
 
   let loading = true;
 
@@ -36,9 +36,8 @@
 
   const goToNeuronDetails = (neuron: SnsNeuron) => () => {
     const neuronId = getSnsNeuronIdAsHexString(neuron);
-    // TODO: Create a path creator helper
     routeStore.navigate({
-      path: `${AppPath.ProjectDetail}/${$snsProjectSelectedStore}/neuron/${neuronId}`,
+      path: `${$neuronPathStore}/${neuronId}`,
     });
   };
 </script>

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -1,3 +1,4 @@
+import { ENABLE_SNS } from "../constants/environment.constants";
 import { AppPath, CONTEXT_PATH } from "../constants/routes.constants";
 import { routePathAccountIdentifier } from "../services/accounts.services";
 import { routePathNeuronId } from "../services/neurons.services";
@@ -15,6 +16,29 @@ const mapper: Record<string, string> = {
   [AppPath.CanisterDetail]: `${AppPath.CanisterDetail}/${IDENTIFIER_REGEX}`,
   [AppPath.ProjectDetail]: `${AppPath.ProjectDetail}/${IDENTIFIER_REGEX}`,
   [AppPath.NeuronDetail]: `${CONTEXT_PATH}/${IDENTIFIER_REGEX}/neuron/${IDENTIFIER_REGEX}`,
+};
+
+/**
+ * Helpers to build the paths for the app.
+ * It interpolates the context and returns the path.
+ */
+export const paths = {
+  neuronDetail: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/neuron`
+      : AppPath.LegacyNeuronDetail,
+  neurons: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/neurons`
+      : AppPath.LegacyNeurons,
+  accounts: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/accounts`
+      : AppPath.LegacyAccounts,
+  wallet: (rootCanisterId: string) =>
+    ENABLE_SNS
+      ? `${CONTEXT_PATH}/${rootCanisterId}/wallet`
+      : AppPath.LegacyWallet,
 };
 
 const pathValidation = (path: AppPath): string => mapper[path] ?? path;

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -3,11 +3,7 @@
  */
 import { get } from "svelte/store";
 import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
-import {
-  AppPath,
-  CONTEXT_PATH,
-  paths,
-} from "../../../lib/constants/routes.constants";
+import { AppPath, CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import {
   accountsPathStore,
   neuronPathStore,
@@ -15,6 +11,7 @@ import {
   walletPathStore,
 } from "../../../lib/derived/paths.derived";
 import { routeStore } from "../../../lib/stores/route.store";
+import { paths } from "../../../lib/utils/app-path.utils";
 
 describe("paths derived stores", () => {
   describe("accountsPathStore", () => {

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import { get } from "svelte/store";
+import { OWN_CANISTER_ID } from "../../../lib/constants/canister-ids.constants";
+import {
+  AppPath,
+  CONTEXT_PATH,
+  paths,
+} from "../../../lib/constants/routes.constants";
+import {
+  accountsPathStore,
+  neuronPathStore,
+  neuronsPathStore,
+  walletPathStore,
+} from "../../../lib/derived/paths.derived";
+import { routeStore } from "../../../lib/stores/route.store";
+
+describe("paths derived stores", () => {
+  describe("accountsPathStore", () => {
+    beforeEach(() => {
+      routeStore.update({ path: AppPath.LegacyAccounts });
+    });
+    it("should return NNS accounts path as default", () => {
+      const $store = get(accountsPathStore);
+
+      expect($store).toBe(paths.accounts(OWN_CANISTER_ID.toText()));
+    });
+
+    it("should return SNS accounts path", () => {
+      const context = "aaaaa-aa";
+      routeStore.update({ path: `${CONTEXT_PATH}/${context}/neuron/12344` });
+      const $store = get(accountsPathStore);
+
+      expect($store).toBe(paths.accounts(context));
+    });
+  });
+
+  describe("walletPathStore", () => {
+    beforeEach(() => {
+      routeStore.update({ path: AppPath.LegacyAccounts });
+    });
+    it("should return NNS accounts path as default", () => {
+      const $store = get(walletPathStore);
+
+      expect($store).toBe(paths.wallet(OWN_CANISTER_ID.toText()));
+    });
+
+    it("should return SNS accounts path", () => {
+      const context = "aaaaa-aa";
+      routeStore.update({ path: `${CONTEXT_PATH}/${context}/neuron/12344` });
+      const $store = get(walletPathStore);
+
+      expect($store).toBe(paths.wallet(context));
+    });
+  });
+
+  describe("neuronsPathStore", () => {
+    beforeEach(() => {
+      routeStore.update({ path: AppPath.LegacyAccounts });
+    });
+    it("should return NNS accounts path as default", () => {
+      const $store = get(neuronsPathStore);
+
+      expect($store).toBe(paths.neurons(OWN_CANISTER_ID.toText()));
+    });
+
+    it("should return SNS accounts path", () => {
+      const context = "aaaaa-aa";
+      routeStore.update({ path: `${CONTEXT_PATH}/${context}/neuron/12344` });
+      const $store = get(neuronsPathStore);
+
+      expect($store).toBe(paths.neurons(context));
+    });
+  });
+
+  describe("neuronPathStore", () => {
+    beforeEach(() => {
+      routeStore.update({ path: AppPath.LegacyAccounts });
+    });
+    it("should return NNS accounts path as default", () => {
+      const $store = get(neuronPathStore);
+
+      expect($store).toBe(paths.neuronDetail(OWN_CANISTER_ID.toText()));
+    });
+
+    it("should return SNS accounts path", () => {
+      const context = "aaaaa-aa";
+      routeStore.update({ path: `${CONTEXT_PATH}/${context}/neuron/12344` });
+      const $store = get(neuronPathStore);
+
+      expect($store).toBe(paths.neuronDetail(context));
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Menu items and back buttons should keep the same context.

# Changes

* New paths.derived store with four new derived stores for neurons, neuronDetails, accounts and wallet. The idea is to read the selectedProject (as well as the feature flag for now) and return the according path.
* routes inside MenuItems is dynamic and use new paths.derived.
* new paths helper in app-path.utils to return a path interpolating the context.
* Use the new paths.derived when navigating back from Wallet and NeuronDetail pages.
* Use the new paths.derived when navigation from NeuronCard or AccountCard.

# Tests

* New tests for the new paths.derived.
