### PR TITLE
feat: apply translate to toast error messages

### DIFF
--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -22,14 +22,19 @@ import {
 import type { ToastMsg } from "../types/toast";
 import { translate, type I18nSubstitutions } from "./i18n.utils";
 
-export const errorToString = (err?: unknown): string | undefined =>
-  typeof err === "string"
-    ? (err as string)
-    : err instanceof GovernanceError
-    ? (err as GovernanceError)?.detail?.error_message
-    : err instanceof Error
-    ? (err as Error).message
-    : undefined;
+export const errorToString = (err?: unknown): string | undefined => {
+  const text =
+    typeof err === "string"
+      ? (err as string)
+      : err instanceof GovernanceError
+      ? (err as GovernanceError)?.detail?.error_message
+      : err instanceof Error
+      ? (err as Error).message
+      : undefined;
+
+  // replace with i18n version if available
+  return typeof text === "string" ? translate({ labelKey: text }) : text;
+};
 
 const factoryMappingErrorToToastMessage =
   (collection: Array<[Function, string]>) =>

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -1,5 +1,6 @@
 import { HardwareWalletAttachError } from "../../../lib/canisters/nns-dapp/nns-dapp.errors";
 import { errorToString, toToastError } from "../../../lib/utils/error.utils";
+import en from "../../mocks/i18n.mock";
 
 class TestError extends Error {
   constructor(msg: string) {
@@ -21,6 +22,12 @@ describe("error-utils", () => {
 
     it("should not parse error", () => {
       expect(errorToString(undefined)).toBeUndefined();
+    });
+
+    it("should translate error", () => {
+      expect(errorToString(new Error("error__sns.undefined_project"))).toEqual(
+        en.error__sns.undefined_project
+      );
     });
   });
 


### PR DESCRIPTION
# Motivation

Localise toast error prop to fix the current `undefined_project` issue.

# Changes

- Apply translate to the error text

# Tests

- "should translate error"

# Screenshots

## Before
<img width="845" alt="Screenshot 2022-09-28 at 16 47 50" src="https://user-images.githubusercontent.com/98811342/192823265-1b4bd3a4-38ac-4ed3-be5f-ae1947d192b8.png">

## After
<img width="846" alt="Screenshot 2022-09-28 at 16 57 44" src="https://user-images.githubusercontent.com/98811342/192823239-90a34d08-d5b9-43d1-8031-1750c85fc8a6.png">

