### PR TITLE
style: revert smooth transition

### DIFF
--- a/frontend/src/lib/components/common/Layout.svelte
+++ b/frontend/src/lib/components/common/Layout.svelte
@@ -5,27 +5,9 @@
   import { Layout, HeaderTitle } from "@dfinity/gix-components";
   import AccountMenu from "../header/AccountMenu.svelte";
   import { triggerDebugReport } from "../../services/debug.services";
-  import { cubicIn } from "svelte/easing";
 
   let back = false;
   $: back = $layoutBackStore !== undefined;
-
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  // smoothness the content transition - i.e. the navigation
-  const content = (
-    _node: Element,
-    { duration = 200 }: { duration?: number }
-  ) => ({
-    duration,
-    css: (t: number) => {
-      const opacityAnimation = cubicIn(t);
-
-      return `
-        opacity: ${opacityAnimation};
-      );`;
-    },
-  });
-  /* eslint-enable */
 </script>
 
 <Banner />
@@ -39,9 +21,7 @@
 
   <AccountMenu slot="toolbar-end" />
 
-  <div transition:content>
-    <slot />
-  </div>
+  <slot />
 </Layout>
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

Revert "smooth transition". It has for effect to briefly adds two split pane and header in the tree which make the ui a bit shaky on smaller screen. Note the user icon not in place in enclosed screenshot.

# Changes

- revert PR #1368

# Screenshots

<img width="1470" alt="Capture d’écran 2022-10-03 à 17 37 38" src="https://user-images.githubusercontent.com/16886711/193619496-c49fa79b-c027-484e-8f3f-a12f68a14ee5.png">

