### PR TITLE
GIX-1050: Handle error last sns participation

### DIFF
--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -11,7 +11,6 @@
   import {
     currentUserMaxCommitment,
     hasUserParticipatedToSwap,
-    projectRemainingAmount,
   } from "../../../utils/projects.utils";
   import type { SnsSummary, SnsSwapCommitment } from "../../../types/sns";
   import TransactionModal from "../../accounts/NewTransaction/TransactionModal.svelte";
@@ -117,7 +116,7 @@
     {destinationAddress}
     disableSubmit={!accepted}
     skipHardwareWallets
-    maxAmount={projectRemainingAmount(summary)}
+    maxAmount={currentUserMaxCommitment({ summary, swapCommitment })}
   >
     <svelte:fragment slot="title"
       >{title ?? $i18n.sns_project_detail.participate}</svelte:fragment

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -284,8 +284,8 @@ export const participateInSwap = async ({
     } catch (error) {
       // The last commitment might trigger this error
       // because the backend is faster than the frontend at notifying the commitment.
-      // Backend error line: https://github.com/dfinity/ic/blob/6ccf23ec7096b117c476bdcd34caa6fada84a3dd/rs/sns/swap/src/swap.rs#L461
-      const openStateError = error.message?.includes("'open' state") === true;
+      // Backend error line: https://github.com/dfinity/ic/blob/67bea85e48434ef7b4cd2682e4877ed95decb993/rs/sns/swap/src/swap.rs#L407
+      const openStateError = error.message?.includes("OPEN state") === true;
       // If it's the last commitment, it means that one more e8 is not a valid participation.
       const lastCommitment =
         project?.summary !== undefined &&

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -93,7 +93,7 @@ describe("sns-services", () => {
         .mockImplementation(() =>
           Promise.reject(
             new Error(
-              "Sorry, There was an unexpected error while participating. Call was rejected: Request ID: a26e17bac91489a89f8b1aef858efeebe9993654ee1ace64efc46a60f3a219c8 Reject code: 5 Reject text: Canister tcvdh-niaaa-aaaaa-aaaoa-cai trapped explicitly: Panicked at 'The token amount can only be refreshed when the canister is in the 'open' state', sns/swap/canister/canister.rs:165:21"
+              "Sorry, There was an unexpected error while participating. Call was rejected: Request ID: a26e17bac91489a89f8b1aef858efeebe9993654ee1ace64efc46a60f3a219c8 Reject code: 5 Reject text: Canister tcvdh-niaaa-aaaaa-aaaoa-cai trapped explicitly: Panicked at 'The token amount can only be refreshed when the canister is in the OPEN state', sns/swap/canister/canister.rs:165:21"
             )
           )
         );


### PR DESCRIPTION
# Motivation

Last user to participate in an SNS sale got an error that can be safely ignored.

# Changes

* Change text to match when ignoring error when participating.
* Use the currentUserMax amount as maximum for the participation transfer.

# Tests

* Fix test.
