### PR TITLE
GIX-998: Get SNS tokens from test account

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -292,6 +292,14 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
+      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
@@ -969,702 +977,94 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
       "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dependencies": {
-        "expect": "^28.0.0",
-        "pretty-format": "^28.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/babel-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
-      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
-      "dependencies": {
-        "@jest/transform": "^28.1.3",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/babel-plugin-jest-hoist": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
-      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/babel-preset-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
-      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^28.1.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/expect": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
-      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
-      "dependencies": {
-        "@jest/expect-utils": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-matcher-utils": "^28.1.3",
         "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
-      "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
-      "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^28.1.3"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-changed-files": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
-      "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
         "jest-util": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-cli": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
-      "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
-      "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "import-local": "^3.0.2",
-        "jest-config": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "prompts": "^2.0.1",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-config": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
-      "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "babel-jest": "^28.1.3",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^28.1.3",
-        "jest-environment-node": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-diff": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
-      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-docblock": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
-      "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-each": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
-      "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-environment-node": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
-      "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-haste-map": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
-      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-leak-detector": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
-      "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
-      "dependencies": {
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-matcher-utils": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
-      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-message-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
-      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^28.1.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-mock": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz",
-      "integrity": "sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-regex-util": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-resolve": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
-      "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/@dfinity/auth-client/node_modules/jest-resolve-dependencies": {
+    "node_modules/@dfinity/auth-client/node_modules/@jest/core": {
       "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
-      "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
-      "dependencies": {
-        "jest-regex-util": "^28.0.2",
-        "jest-snapshot": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-runner": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
-      "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
+      "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
       "dependencies": {
         "@jest/console": "^28.1.3",
-        "@jest/environment": "^28.1.3",
+        "@jest/reporters": "^28.1.3",
         "@jest/test-result": "^28.1.3",
         "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^28.1.1",
-        "jest-environment-node": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-leak-detector": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-resolve": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "jest-worker": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-runtime": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
-      "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/globals": "^28.1.3",
-        "@jest/source-map": "^28.1.2",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-snapshot": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
-      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/babel__traverse": "^7.0.6",
-        "@types/prettier": "^2.1.5",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^28.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-haste-map": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^28.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
-      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-validate": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
-      "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "leven": "^3.1.0",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-watcher": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
-      "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
-      "dependencies": {
-        "@jest/test-result": "^28.1.3",
         "@jest/types": "^28.1.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^28.1.3",
+        "jest-config": "^28.1.3",
+        "jest-haste-map": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-resolve-dependencies": "^28.1.3",
+        "jest-runner": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
         "jest-util": "^28.1.3",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-worker": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
-      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/pretty-format": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
-      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
-      "dependencies": {
-        "@jest/schemas": "^28.1.3",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/@dfinity/auth-client/node_modules/ts-jest": {
-      "version": "28.0.8",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
-      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^28.0.0",
-        "json5": "^2.2.1",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
+        "jest-validate": "^28.1.3",
+        "jest-watcher": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.1.3",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       },
       "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^28.0.0",
-        "babel-jest": "^28.0.0",
-        "jest": "^28.0.0",
-        "typescript": ">=4.3"
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
       },
       "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
+        "node-notifier": {
           "optional": true
         }
       }
     },
-    "node_modules/@dfinity/authentication": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-1.0.0-beta.0.tgz",
-      "integrity": "sha512-UOgBvvPDMBlnwec4XuB/5Vs9aI37J+NWeJlBRn4JxaE7i41XFyQZ5N9CF6/pKuFnjO31NEYmqq1FuZcYieH5kA==",
-      "peerDependencies": {
-        "@dfinity/agent": "^1.0.0-beta.0",
-        "@dfinity/identity": "^1.0.0-beta.0",
-        "@dfinity/principal": "^1.0.0-beta.0"
-      }
-    },
-    "node_modules/@dfinity/candid": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.0.0-beta.0.tgz",
-      "integrity": "sha512-1ryK79nTtA2I0OQzHwyVPUa+JYwinje6ALATkypvNLUhSIfaGCFO7TixiJGg+AAD326/zPXumo9SRmP9Z2e+vQ==",
+    "node_modules/@dfinity/auth-client/node_modules/@jest/environment": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
+      "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
       "dependencies": {
+<<<<<<< HEAD
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "jest-mock": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+=======
         "ts-node": "^10.8.2"
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
-      "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
+      "version": "0.0.2-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
+      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
+      "peerDependencies": {
+        "@dfinity/utils": "^0.0.5-next"
+>>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
+      }
+    },
+    "node_modules/@dfinity/cmc": {
+      "version": "0.0.2-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
+      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1679,69 +1079,65 @@
       "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-1.0.0-beta.0.tgz",
       "integrity": "sha512-A4gv0EvJD6aMxwygklZFiissC0EadY/tQhJmf2FCKSaytTIzpI/oWoFeRQ+l2J/61ZEMNj8dkub2D4z6ebignw==",
       "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "borc": "^2.1.1",
-        "js-sha256": "^0.9.0",
-        "secp256k1": "^4.0.2",
-        "ts-node": "^10.8.2",
-        "tweetnacl": "^1.0.1",
-        "vitest": "^0.18.0"
+        "expect": "^28.1.3",
+        "jest-snapshot": "^28.1.3"
       },
-      "peerDependencies": {
-        "@dfinity/agent": "^1.0.0-beta.0",
-        "@dfinity/principal": "^1.0.0-beta.0"
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
-      "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
+      "version": "0.9.0-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
+      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
       "dependencies": {
-        "crc": "^4.1.1",
-        "crc-32": "^1.2.2",
-        "google-protobuf": "^3.21.0",
-        "js-sha256": "^0.9.0",
-        "randombytes": "^2.1.0"
+        "jest-get-type": "^28.0.2"
       },
-      "peerDependencies": {
-        "@dfinity/utils": "^0.0.5-next"
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/@dfinity/principal": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.0-beta.0.tgz",
-      "integrity": "sha512-PqooLq0/fZ3gPR0vZ0Z4yDoK0j/xGh/XcdGUciME1SBTjCwIEjojZRJMFLbAc2G8lmFbEsB7ntsg3eKk7MPM/Q==",
+    "node_modules/@dfinity/auth-client/node_modules/@jest/fake-timers": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
+      "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
       "dependencies": {
-        "ts-node": "^10.8.2"
+        "@jest/types": "^28.1.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@types/node": "*",
+        "jest-message-util": "^28.1.3",
+        "jest-mock": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/@jest/globals": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
+      "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/types": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
-      "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
+      "version": "0.0.6-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
+      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-03.tgz",
-      "integrity": "sha512-AnFubC6sm4cSy+8E3Cj+QYcJi0IAp+gYWOo4TySqHSU6WKwIohsiLRqMjJhL6E6kbyQ1u6OKDQpOjw9qVQYmaw=="
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
-      "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "0.0.5-next-2022-09-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-09-29.tgz",
+      "integrity": "sha512-b98PIzQ1RnsAVIxOPsz/ORobEsj2aGeIlycDU7kA70aZyAsoTo6x+moubE4f6eCbyYL4gbhFR3EgidqOIxQRTQ=="
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.15.10",
@@ -11799,9 +11195,15 @@
       }
     },
     "@dfinity/cmc": {
+<<<<<<< HEAD
       "version": "0.0.2-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
       "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
+=======
+      "version": "0.0.2-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
+      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
+>>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11824,9 +11226,15 @@
       }
     },
     "@dfinity/nns": {
+<<<<<<< HEAD
       "version": "0.9.0-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
       "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
+=======
+      "version": "0.9.0-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
+      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
+>>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11844,6 +11252,7 @@
       }
     },
     "@dfinity/sns": {
+<<<<<<< HEAD
       "version": "0.0.6-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
       "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
@@ -11859,6 +11268,17 @@
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
       "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
       "optional": true
+=======
+      "version": "0.0.6-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
+      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
+      "requires": {}
+    },
+    "@dfinity/utils": {
+      "version": "0.0.5-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
+      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
+>>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
     },
     "@esbuild/linux-loong64": {
       "version": "0.15.10",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
-      "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
+      "version": "0.0.2-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
+      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1693,9 +1693,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
-      "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
+      "version": "0.9.0-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
+      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1716,17 +1716,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
-      "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
+      "version": "0.0.6-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
+      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-03.tgz",
-      "integrity": "sha512-AnFubC6sm4cSy+8E3Cj+QYcJi0IAp+gYWOo4TySqHSU6WKwIohsiLRqMjJhL6E6kbyQ1u6OKDQpOjw9qVQYmaw=="
+      "version": "0.0.5-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
+      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -11799,9 +11799,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
-      "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
+      "version": "0.0.2-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
+      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11824,9 +11824,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
-      "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
+      "version": "0.9.0-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
+      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11844,15 +11844,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
-      "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
+      "version": "0.0.6-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
+      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-03.tgz",
-      "integrity": "sha512-AnFubC6sm4cSy+8E3Cj+QYcJi0IAp+gYWOo4TySqHSU6WKwIohsiLRqMjJhL6E6kbyQ1u6OKDQpOjw9qVQYmaw=="
+      "version": "0.0.5-next-2022-10-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
+      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -292,14 +292,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
@@ -977,51 +969,120 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
       "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
+        "expect": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/babel-jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
+      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
+      "dependencies": {
+        "@jest/transform": "^28.1.3",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^28.1.3",
         "chalk": "^4.0.0",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/babel-plugin-jest-hoist": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
+      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/@dfinity/auth-client/node_modules/@jest/core": {
+    "node_modules/@dfinity/auth-client/node_modules/babel-preset-jest": {
       "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
-      "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
+      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
       "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/reporters": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^28.1.3",
-        "jest-config": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
+        "babel-plugin-jest-hoist": "^28.1.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/expect": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
+      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "dependencies": {
+        "@jest/expect-utils": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-matcher-utils": "^28.1.3",
         "jest-message-util": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-resolve-dependencies": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "rimraf": "^3.0.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
+      "dependencies": {
+        "@jest/core": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^28.1.3"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
@@ -1035,36 +1096,575 @@
         }
       }
     },
-    "node_modules/@dfinity/auth-client/node_modules/@jest/environment": {
+    "node_modules/@dfinity/auth-client/node_modules/jest-changed-files": {
       "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
-      "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
+      "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
       "dependencies": {
-<<<<<<< HEAD
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "jest-mock": "^28.1.3"
+        "execa": "^5.0.0",
+        "p-limit": "^3.1.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-=======
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-circus": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-cli": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
+      "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
+      "dependencies": {
+        "@jest/core": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "import-local": "^3.0.2",
+        "jest-config": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "prompts": "^2.0.1",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-config": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
+      "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "babel-jest": "^28.1.3",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^28.1.3",
+        "jest-environment-node": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-runner": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-docblock": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
+      "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-each": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
+      "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-environment-node": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
+      "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "jest-mock": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-haste-map": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
+      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-leak-detector": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
+      "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
+      "dependencies": {
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-message-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^28.1.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-mock": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz",
+      "integrity": "sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==",
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-resolve": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
+      "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^1.1.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-resolve-dependencies": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
+      "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
+      "dependencies": {
+        "jest-regex-util": "^28.0.2",
+        "jest-snapshot": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-runner": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
+      "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+      "dependencies": {
+        "@jest/console": "^28.1.3",
+        "@jest/environment": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^28.1.1",
+        "jest-environment-node": "^28.1.3",
+        "jest-haste-map": "^28.1.3",
+        "jest-leak-detector": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-resolve": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-watcher": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-runtime": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
+      "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/globals": "^28.1.3",
+        "@jest/source-map": "^28.1.2",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-mock": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-snapshot": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
+      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^28.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-haste-map": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^28.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
+      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-validate": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
+      "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "leven": "^3.1.0",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-watcher": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
+      "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
+      "dependencies": {
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "jest-util": "^28.1.3",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-worker": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@dfinity/auth-client/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@dfinity/auth-client/node_modules/ts-jest": {
+      "version": "28.0.8",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
+      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^28.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^28.0.0",
+        "babel-jest": "^28.0.0",
+        "jest": "^28.0.0",
+        "typescript": ">=4.3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dfinity/authentication": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-1.0.0-beta.0.tgz",
+      "integrity": "sha512-UOgBvvPDMBlnwec4XuB/5Vs9aI37J+NWeJlBRn4JxaE7i41XFyQZ5N9CF6/pKuFnjO31NEYmqq1FuZcYieH5kA==",
+      "peerDependencies": {
+        "@dfinity/agent": "^1.0.0-beta.0",
+        "@dfinity/identity": "^1.0.0-beta.0",
+        "@dfinity/principal": "^1.0.0-beta.0"
+      }
+    },
+    "node_modules/@dfinity/candid": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.0.0-beta.0.tgz",
+      "integrity": "sha512-1ryK79nTtA2I0OQzHwyVPUa+JYwinje6ALATkypvNLUhSIfaGCFO7TixiJGg+AAD326/zPXumo9SRmP9Z2e+vQ==",
+      "dependencies": {
         "ts-node": "^10.8.2"
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
-      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
-      "peerDependencies": {
-        "@dfinity/utils": "^0.0.5-next"
->>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
-      }
-    },
-    "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
-      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
+      "version": "0.0.2-next-2022-10-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
+      "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1079,65 +1679,69 @@
       "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-1.0.0-beta.0.tgz",
       "integrity": "sha512-A4gv0EvJD6aMxwygklZFiissC0EadY/tQhJmf2FCKSaytTIzpI/oWoFeRQ+l2J/61ZEMNj8dkub2D4z6ebignw==",
       "dependencies": {
-        "expect": "^28.1.3",
-        "jest-snapshot": "^28.1.3"
+        "@peculiar/webcrypto": "^1.4.0",
+        "borc": "^2.1.1",
+        "js-sha256": "^0.9.0",
+        "secp256k1": "^4.0.2",
+        "ts-node": "^10.8.2",
+        "tweetnacl": "^1.0.1",
+        "vitest": "^0.18.0"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      "peerDependencies": {
+        "@dfinity/agent": "^1.0.0-beta.0",
+        "@dfinity/principal": "^1.0.0-beta.0"
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
-      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
+      "version": "0.9.0-next-2022-10-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
+      "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
       "dependencies": {
-        "jest-get-type": "^28.0.2"
+        "crc": "^4.1.1",
+        "crc-32": "^1.2.2",
+        "google-protobuf": "^3.21.0",
+        "js-sha256": "^0.9.0",
+        "randombytes": "^2.1.0"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      "peerDependencies": {
+        "@dfinity/utils": "^0.0.5-next"
       }
     },
-    "node_modules/@dfinity/auth-client/node_modules/@jest/fake-timers": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
-      "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
+    "node_modules/@dfinity/principal": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.0-beta.0.tgz",
+      "integrity": "sha512-PqooLq0/fZ3gPR0vZ0Z4yDoK0j/xGh/XcdGUciME1SBTjCwIEjojZRJMFLbAc2G8lmFbEsB7ntsg3eKk7MPM/Q==",
       "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@types/node": "*",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@dfinity/auth-client/node_modules/@jest/globals": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
-      "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/types": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "ts-node": "^10.8.2"
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
-      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
+      "version": "0.0.6-next-2022-10-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
+      "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-09-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-09-29.tgz",
-      "integrity": "sha512-b98PIzQ1RnsAVIxOPsz/ORobEsj2aGeIlycDU7kA70aZyAsoTo6x+moubE4f6eCbyYL4gbhFR3EgidqOIxQRTQ=="
+      "version": "0.0.5-next-2022-10-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-03.tgz",
+      "integrity": "sha512-AnFubC6sm4cSy+8E3Cj+QYcJi0IAp+gYWOo4TySqHSU6WKwIohsiLRqMjJhL6E6kbyQ1u6OKDQpOjw9qVQYmaw=="
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
+      "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.15.10",
@@ -11195,15 +11799,9 @@
       }
     },
     "@dfinity/cmc": {
-<<<<<<< HEAD
       "version": "0.0.2-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-03.tgz",
       "integrity": "sha512-l+hI/qaloJk83Rxf0L8xY5bUNwsEaL3NhqjUVSlnKWBsGHh53Sao40TXcB7Toh9JcKlOwtLzJdvvtBPO3GFhmw==",
-=======
-      "version": "0.0.2-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
-      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
->>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11226,15 +11824,9 @@
       }
     },
     "@dfinity/nns": {
-<<<<<<< HEAD
       "version": "0.9.0-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-03.tgz",
       "integrity": "sha512-Mk7W1X42IAHHiijxXI/DtOP41m74JiNAdt8/Hpae4etyHwH/AL5hFmEXagOt4Pb6HP4PdkaIQ+XkdybS1AuMig==",
-=======
-      "version": "0.9.0-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
-      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
->>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11252,7 +11844,6 @@
       }
     },
     "@dfinity/sns": {
-<<<<<<< HEAD
       "version": "0.0.6-next-2022-10-03",
       "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-03.tgz",
       "integrity": "sha512-2PxmkDCWnabdOxiZ8kHTma9dTXlNAEd28LFYjUCFrp7D51nYuykjv7IXhmbUVf7jPH3zXrlRT85I3r7eyJe6Dg==",
@@ -11268,17 +11859,6 @@
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
       "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
       "optional": true
-=======
-      "version": "0.0.6-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
-      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
-      "requires": {}
-    },
-    "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
-      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
->>>>>>> f8b9aa2b1 (GIX-998: Update next libraries)
     },
     "@esbuild/linux-loong64": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -83,10 +83,6 @@ export const acquireSnsTokens = async ({
           ? []
           : toNullable(arrayOfNumberToUint8Array(account.subAccount)),
     },
-    fee: [],
-    memo: [],
-    from_subaccount: [],
-    created_at_time: [],
   });
 };
 

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -3,22 +3,14 @@ import { HttpAgent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import { HOST, IS_TESTNET } from "../constants/environment.constants";
+import type { Account } from "../types/account";
 import { governanceCanister } from "./governance.api";
+import { initSns } from "./sns-wrapper.api";
 
-/*
- * Gives the caller the specified amount of (fake) ICPs.
- * Should/can only be used on testnets.
- */
-export const acquireICPTs = async ({
-  accountIdentifier,
-  e8s,
-}: {
-  accountIdentifier: string;
-  e8s: E8s;
-}): Promise<BlockHeight> => {
-  assertTestnet();
-
+const getTestAccountAgent = async (): Promise<HttpAgent> => {
   // Create an identity who's default ledger account is initialised with 10k ICP on the testnet, then use that
   // identity to send the current user some ICP to test things with.
   // The identity's principal is jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe
@@ -37,11 +29,64 @@ export const acquireICPTs = async ({
   });
   await agent.fetchRootKey();
 
+  return agent;
+};
+
+/*
+ * Gives the caller the specified amount of (fake) ICPs.
+ * Should/can only be used on testnets.
+ */
+export const acquireICPTs = async ({
+  accountIdentifier,
+  e8s,
+}: {
+  accountIdentifier: string;
+  e8s: E8s;
+}): Promise<BlockHeight> => {
+  assertTestnet();
+
+  const agent = await getTestAccountAgent();
+
   const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
 
   return ledgerCanister.transfer({
     amount: e8s,
     to: AccountIdentifier.fromHex(accountIdentifier),
+  });
+};
+
+export const acquireSnsTokens = async ({
+  account,
+  e8s,
+  rootCanisterId,
+}: {
+  account: Account;
+  e8s: bigint;
+  rootCanisterId: Principal;
+}): Promise<void> => {
+  assertTestnet();
+
+  const agent = await getTestAccountAgent();
+
+  const { transfer } = await initSns({
+    agent,
+    rootCanisterId,
+    certified: true,
+  });
+
+  await transfer({
+    amount: e8s,
+    to: {
+      owner: account.principal as Principal,
+      subaccount:
+        account.subAccount === undefined
+          ? []
+          : toNullable(arrayOfNumberToUint8Array(account.subAccount)),
+    },
+    fee: [],
+    memo: [],
+    from_subaccount: [],
+    created_at_time: [],
   });
 };
 

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -56,7 +56,7 @@ const listSnses = async ({
   );
 };
 
-const initSns = async ({
+export const initSns = async ({
   agent,
   rootCanisterId,
   certified,

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -18,7 +18,7 @@
     IS_TESTNET,
   } from "../../constants/environment.constants";
   import BadgeNew from "../ui/BadgeNew.svelte";
-  import GetICPs from "../ic/GetICPs.svelte";
+  import GetTokens from "../ic/GetTokens.svelte";
   import {
     accountsPathStore,
     neuronsPathStore,
@@ -104,5 +104,5 @@
 {/each}
 
 {#if IS_TESTNET}
-  <GetICPs />
+  <GetTokens />
 {/if}

--- a/frontend/src/lib/components/ic/GetICPs.svelte
+++ b/frontend/src/lib/components/ic/GetICPs.svelte
@@ -4,9 +4,12 @@
    */
   import { Modal } from "@dfinity/gix-components";
   import Input from "../ui/Input.svelte";
-  import { getICPs } from "../../services/dev.services";
+  import { getICPs, getTokens } from "../../services/dev.services";
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
   import { toastsError } from "../../stores/toasts.store";
+  import { get } from "svelte/store";
+  import { snsProjectSelectedStore } from "../../derived/selected-project.derived";
+  import { OWN_CANISTER_ID } from "../../constants/canister-ids.constants";
 
   let visible: boolean = false;
   let transferring: boolean = false;
@@ -22,12 +25,21 @@
     }
 
     const formData: FormData = new FormData(target);
-    const icps: number = formData.get("icp") as unknown as number;
+    const tokensNumber: number = formData.get("icp") as unknown as number;
 
     transferring = true;
 
+    const selectedProjectId = get(snsProjectSelectedStore);
+
     try {
-      await getICPs(icps);
+      if (selectedProjectId.toText() === OWN_CANISTER_ID.toText()) {
+        await getICPs(tokensNumber);
+      } else {
+        await getTokens({
+          tokens: tokensNumber,
+          rootCanisterId: selectedProjectId,
+        });
+      }
 
       reset();
     } catch (err: unknown) {

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -151,4 +151,8 @@
 
     padding: var(--padding-2x) var(--padding);
   }
+
+  button.primary {
+    min-width: var(--padding-8x);
+  }
 </style>

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -18,16 +18,13 @@
 
   let inputValue: number | undefined = undefined;
 
-  const onSubmit = async ({ target }) => {
-    if (invalidForm) {
+  const onSubmit = async () => {
+    if (invalidForm || inputValue === undefined) {
       toastsError({
         labelKey: "Invalid ICPs input.",
       });
       return;
     }
-
-    const formData: FormData = new FormData(target);
-    const tokensNumber: number = formData.get("icp") as unknown as number;
 
     transferring = true;
 
@@ -35,10 +32,10 @@
 
     try {
       if (selectedProjectId.toText() === OWN_CANISTER_ID.toText()) {
-        await getICPs(tokensNumber);
+        await getICPs(inputValue);
       } else {
         await getTokens({
-          tokens: tokensNumber,
+          tokens: inputValue,
           rootCanisterId: selectedProjectId,
         });
       }
@@ -72,7 +69,7 @@
 <button
   role="menuitem"
   data-tid="get-icp-button"
-  on:click|stopPropagation={() => (visible = true)}
+  on:click|preventDefault|stopPropagation={() => (visible = true)}
   class="open"
 >
   <IconAccountBalance />

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -10,6 +10,8 @@
   import { get } from "svelte/store";
   import { snsProjectSelectedStore } from "../../derived/selected-project.derived";
   import { OWN_CANISTER_ID } from "../../constants/canister-ids.constants";
+  import { ICPToken, type Token } from "@dfinity/nns";
+  import { snsTokenSymbolSelectedStore } from "../../derived/sns/sns-token-symbol-selected.store";
 
   let visible: boolean = false;
   let transferring: boolean = false;
@@ -62,6 +64,9 @@
   let invalidForm: boolean;
 
   $: invalidForm = inputValue === undefined || inputValue <= 0;
+
+  let token: Token;
+  $: token = $snsTokenSymbolSelectedStore || ICPToken;
 </script>
 
 <button
@@ -71,11 +76,11 @@
   class="open"
 >
   <IconAccountBalance />
-  <span>Get ICPs</span>
+  <span>{`Get ${token.symbol}`}</span>
 </button>
 
 <Modal {visible} role="alert" on:nnsClose={onClose}>
-  <span slot="title">Get ICPs</span>
+  <span slot="title">{`Get ${token.symbol}`}</span>
 
   <form
     id="get-icp-form"
@@ -85,8 +90,8 @@
     <span class="label">How much?</span>
 
     <Input
-      placeholderLabelKey="core.icp"
-      name="icp"
+      placeholderLabelKey="core.amount"
+      name="tokens"
       inputType="icp"
       bind:value={inputValue}
       disabled={transferring}
@@ -104,7 +109,7 @@
     {#if transferring}
       <Spinner />
     {:else}
-      Get
+      Get tokens
     {/if}
   </button>
 </Modal>

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -46,5 +46,5 @@ export const getTokens = async ({
     rootCanisterId,
   });
 
-  await syncAccounts();
+  // TODO: Sync SNS accounts
 };

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -1,8 +1,13 @@
+import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
-import { acquireICPTs } from "../api/dev.api";
+import { acquireICPTs, acquireSnsTokens } from "../api/dev.api";
 import { E8S_PER_ICP } from "../constants/icp.constants";
 import type { AccountsStore } from "../stores/accounts.store";
 import { accountsStore } from "../stores/accounts.store";
+import {
+  snsAccountsStore,
+  type SnsAccountsStore,
+} from "../stores/sns-accounts.store";
 import { syncAccounts } from "./accounts.services";
 
 export const getICPs = async (icps: number) => {
@@ -15,6 +20,30 @@ export const getICPs = async (icps: number) => {
   await acquireICPTs({
     e8s: BigInt(icps * E8S_PER_ICP),
     accountIdentifier: main.identifier,
+  });
+
+  await syncAccounts();
+};
+
+export const getTokens = async ({
+  tokens,
+  rootCanisterId,
+}: {
+  tokens: number;
+  rootCanisterId: Principal;
+}) => {
+  const store: SnsAccountsStore = get(snsAccountsStore);
+  const { accounts } = store[rootCanisterId.toText()];
+  const main = accounts.find((account) => account.type === "main");
+
+  if (!main) {
+    throw new Error("No account found to send tokens");
+  }
+
+  await acquireSnsTokens({
+    e8s: BigInt(tokens * E8S_PER_ICP),
+    account: main,
+    rootCanisterId,
   });
 
   await syncAccounts();

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -9,6 +9,7 @@ import {
   type SnsAccountsStore,
 } from "../stores/sns-accounts.store";
 import { syncAccounts } from "./accounts.services";
+import { loadSnsAccounts } from "./sns-accounts.services";
 
 export const getICPs = async (icps: number) => {
   const { main }: AccountsStore = get(accountsStore);
@@ -46,5 +47,5 @@ export const getTokens = async ({
     rootCanisterId,
   });
 
-  // TODO: Sync SNS accounts
+  await loadSnsAccounts(rootCanisterId);
 };

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -33,6 +33,8 @@ export const getTokens = async ({
   tokens: number;
   rootCanisterId: Principal;
 }) => {
+  // Accounts are loaded when user visits the Accounts page, so we need to load them here.
+  await loadSnsAccounts(rootCanisterId);
   const store: SnsAccountsStore = get(snsAccountsStore);
   const { accounts } = store[rootCanisterId.toText()];
   const main = accounts.find((account) => account.type === "main");

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -1,8 +1,6 @@
-import { wrappers } from "../../../lib/api/sns-wrapper.api";
-import {
-  importInitSnsWrapper,
-  importSnsWasmCanister,
-} from "../../../lib/proxy/api.import.proxy";
+import type { HttpAgent } from "@dfinity/agent";
+import mock from "jest-mock-extended/lib/Mock";
+import { initSns, wrappers } from "../../../lib/api/sns-wrapper.api";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   deployedSnsMock,
@@ -12,33 +10,48 @@ import {
   swapCanisterIdMock,
 } from "../../mocks/sns.api.mock";
 
-jest.mock("../../../lib/proxy/api.import.proxy");
+const listSnsesSpy = jest.fn().mockResolvedValue(deployedSnsMock);
+const initSnsWrapperSpy = jest.fn().mockResolvedValue(
+  Promise.resolve({
+    canisterIds: {
+      rootCanisterId: rootCanisterIdMock,
+      ledgerCanisterId: ledgerCanisterIdMock,
+      governanceCanisterId: governanceCanisterIdMock,
+      swapCanisterId: swapCanisterIdMock,
+    },
+  })
+);
+
+jest.mock("../../../lib/proxy/api.import.proxy", () => {
+  return {
+    importSnsWasmCanister: jest.fn().mockImplementation(() => ({
+      create: () => ({
+        listSnses: listSnsesSpy,
+      }),
+    })),
+    importInitSnsWrapper: jest.fn().mockImplementation(() => initSnsWrapperSpy),
+  };
+});
 
 describe("sns-wrapper api", () => {
   describe("wrappers", () => {
-    const listSnsesSpy = jest.fn().mockResolvedValue(deployedSnsMock);
-    beforeEach(() => {
-      (importSnsWasmCanister as jest.Mock).mockResolvedValue({
-        create: () => ({
-          listSnses: listSnsesSpy,
-        }),
-      });
-
-      (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
-        Promise.resolve({
-          canisterIds: {
-            rootCanisterId: rootCanisterIdMock,
-            ledgerCanisterId: ledgerCanisterIdMock,
-            governanceCanisterId: governanceCanisterIdMock,
-            swapCanisterId: swapCanisterIdMock,
-          },
-        })
-      );
-    });
     it("calls list to all Snses", async () => {
       await wrappers({ identity: mockIdentity, certified: false });
 
       expect(listSnsesSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("initSns", () => {
+    it("inits sns wrapper", async () => {
+      const mockAgent = mock<HttpAgent>();
+      await initSns({
+        agent: mockAgent,
+        rootCanisterId: rootCanisterIdMock,
+        certified: false,
+      });
+
+      expect(initSnsWrapperSpy).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Motivation

Testnet users can get any kind of tokens.

# Changes

* Use the context to differentiate between transferring from NNS or from SNS.
* Change modal text to use token of the SNS project.

# Tests

Not applicable, this is just a feature for testnets.
