### PR TITLE
GIX-995: SNS Wallet details

### DIFF
--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,6 +1,7 @@
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
+import { encodeSnsAccount } from "@dfinity/sns";
 import type { Account } from "../types/account";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { mapOptionalToken } from "../utils/sns.utils";
@@ -23,14 +24,14 @@ export const getSnsAccounts = async ({
     certified,
   });
 
+  const snsMainAccount = { owner: identity.getPrincipal() };
   const [mainBalanceE8s, metadata] = await Promise.all([
-    balance({ owner: identity.getPrincipal() }),
+    balance(snsMainAccount),
     ledgerMetadata({}),
   ]);
 
   const mainAccount: Account = {
-    // TODO: Implement string representation https://dfinity.atlassian.net/browse/GIX-1025
-    identifier: "sns-main-account-identifier",
+    identifier: encodeSnsAccount(snsMainAccount),
     principal: identity.getPrincipal(),
     balance: TokenAmount.fromE8s({
       amount: mainBalanceE8s,

--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -36,7 +36,7 @@
   });
 </script>
 
-<div class="title">
+<div class="title" data-tid="wallet-summary">
   <h1>{accountName}</h1>
   <Tooltip
     id="wallet-detailed-icp"

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Spinner } from "@dfinity/gix-components";
-  import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
   import { onDestroy, setContext } from "svelte/internal";
   import { writable, type Unsubscriber } from "svelte/store";

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,8 +1,23 @@
 <script lang="ts">
+  import { Spinner } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
+  import { onDestroy, setContext } from "svelte/internal";
+  import { writable, type Unsubscriber } from "svelte/store";
+  import WalletSummary from "../components/accounts/WalletSummary.svelte";
   import { ENABLE_SNS } from "../constants/environment.constants";
   import { AppPath } from "../constants/routes.constants";
+  import { snsOnlyProjectStore } from "../derived/selected-project.derived";
+  import { snsProjectAccountsStore } from "../derived/sns/sns-project-accounts.derived";
+  import { routePathAccountIdentifier } from "../services/accounts.services";
+  import { loadSnsAccounts } from "../services/sns-accounts.services";
+  import { debugSelectedAccountStore } from "../stores/debug.store";
   import { routeStore } from "../stores/route.store";
+  import {
+    SELECTED_ACCOUNT_CONTEXT_KEY,
+    type SelectedAccountContext,
+    type SelectedAccountStore,
+  } from "../types/selected-account.context";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -10,7 +25,55 @@
       routeStore.update({ path: AppPath.LegacyAccounts });
     }
   });
+
+  const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
+    async (selectedProjectCanisterId) => {
+      if (selectedProjectCanisterId !== undefined) {
+        // Reload accounts always.
+        // Do not set to loading because we might use the account in the store.
+        await loadSnsAccounts(selectedProjectCanisterId);
+      }
+    }
+  );
+
+  onDestroy(unsubscribe);
+
+  const selectedAccountStore = writable<SelectedAccountStore>({
+    account: undefined,
+  });
+
+  // TODO: Add transactions to debug store https://dfinity.atlassian.net/browse/GIX-1043
+  debugSelectedAccountStore(selectedAccountStore);
+
+  setContext<SelectedAccountContext>(SELECTED_ACCOUNT_CONTEXT_KEY, {
+    store: selectedAccountStore,
+  });
+
+  let routeAccountIdentifier:
+    | { accountIdentifier: string | undefined }
+    | undefined;
+  $: routeAccountIdentifier = routePathAccountIdentifier($routeStore.path);
+
+  $: {
+    if (routeAccountIdentifier?.accountIdentifier !== undefined) {
+      const selectedAccount = $snsProjectAccountsStore?.find(
+        ({ identifier }) =>
+          identifier === routeAccountIdentifier?.accountIdentifier
+      );
+
+      selectedAccountStore.update(() => ({
+        account: selectedAccount,
+      }));
+    }
+  }
 </script>
 
-<!-- TODO: GIX-995 Implement SNS Wallet details -->
-<div data-tid="sns-wallet">TO BE IMPLEMENTED</div>
+<main class="legacy" data-tid="sns-wallet">
+  <section>
+    {#if $selectedAccountStore.account !== undefined}
+      <WalletSummary />
+    {:else}
+      <Spinner />
+    {/if}
+  </section>
+</main>

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/svelte";
+import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
+import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
+import SnsWallet from "../../../lib/pages/SnsWallet.svelte";
+import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
+import { routeStore } from "../../../lib/stores/route.store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import {
+  mockSnsAccountsStoreSubscribe,
+  mockSnsMainAccount,
+} from "../../mocks/sns-accounts.mock";
+
+jest.mock("../../../lib/services/sns-accounts.services", () => {
+  return {
+    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("SnsWallet", () => {
+  describe("accounts not loaded", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(snsProjectAccountsStore, "subscribe")
+        .mockImplementation(mockSnsAccountsStoreSubscribe([]));
+      // Context needs to match the mocked sns accounts
+      routeStore.update({
+        path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
+      });
+    });
+    it("should render a spinner while loading", () => {
+      const { getByTestId } = render(SnsWallet);
+
+      expect(getByTestId("spinner")).not.toBeNull();
+    });
+
+    it("should call to load sns accounts", async () => {
+      render(SnsWallet);
+
+      await waitFor(() => expect(loadSnsAccounts).toBeCalled());
+    });
+  });
+
+  describe("accounts loaded", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(snsProjectAccountsStore, "subscribe")
+        .mockImplementation(
+          mockSnsAccountsStoreSubscribe([mockSnsMainAccount])
+        );
+      // Context and identifier needs to match the mocked sns accounts
+      routeStore.update({
+        path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/wallet/${
+          mockSnsMainAccount.identifier
+        }`,
+      });
+    });
+
+    afterAll(() => jest.clearAllMocks());
+
+    it("should hide spinner when selected account is loaded", async () => {
+      const { queryByTestId } = render(SnsWallet);
+
+      await waitFor(() => expect(queryByTestId("spinner")).toBeNull());
+    });
+
+    it("should render wallet summary", async () => {
+      const { queryByTestId } = render(SnsWallet);
+
+      await waitFor(() =>
+        expect(queryByTestId("wallet-summary")).toBeInTheDocument()
+      );
+    });
+  });
+});

--- a/frontend/src/tests/routes/Wallet.spec.ts
+++ b/frontend/src/tests/routes/Wallet.spec.ts
@@ -8,6 +8,12 @@ import { routeStore } from "../../lib/stores/route.store";
 import Wallet from "../../routes/Wallet.svelte";
 import { principal } from "../mocks/sns-projects.mock";
 
+jest.mock("../../lib/services/sns-accounts.services", () => {
+  return {
+    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe("Wallet", () => {
   describe("nns context", () => {
     it("should render NnsWallet", () => {


### PR DESCRIPTION
# Motivation

User has access to the details page with main data of SNS account.

# Changes

* Implement SnsWallet to set up the context to be able to render WalletSummary.
* Encode the Sns Account in the "identifier" property.

# Tests

* Test SnsWallet page.
* Fix ugly comment in Wallet page test.
