### PR TITLE
feat: DissolveDelaySeconds=0 neuron state

### DIFF
--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -31,7 +31,10 @@ export const getSnsNeuronState = ({
     return NeuronState.Dissolved;
   }
   if ("DissolveDelaySeconds" in dissolveState) {
-    return NeuronState.Locked;
+    return dissolveState.DissolveDelaySeconds === BigInt(0)
+      ? // 0 = already dissolved (more info: https://gitlab.com/dfinity-lab/public/ic/-/blob/master/rs/nns/governance/src/governance.rs#L827)
+        NeuronState.Dissolved
+      : NeuronState.Locked;
   }
   if ("WhenDissolvedTimestampSeconds" in dissolveState) {
     return NeuronState.Dissolving;

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -94,6 +94,19 @@ describe("sns-neuron utils", () => {
       });
       expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
     });
+
+    it("returns DISSOLVED when DissolveDelaySeconds=0", () => {
+      const neuron = createMockSnsNeuron({
+        id: [1, 2, 3, 4],
+        state: undefined,
+      });
+      neuron.dissolve_state = [
+        {
+          DissolveDelaySeconds: BigInt(0),
+        },
+      ];
+      expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
+    });
   });
 
   describe("getSnsDissolvingTimeInSeconds", () => {


### PR DESCRIPTION
# Motivation

Fix the edge case when the initial sns neuron `dissolve_state` = `{DissolveDelaySeconds: 0}`

# Changes

- `getSnsNeuronState` returns `Dissolved` status when `DissolveDelaySeconds=0`

# Tests

- update getSnsNeuronState specs

# Screenshots

Initial sns neuron state

## Before
<img width="375" alt="Screenshot 2022-10-05 at 09 58 04" src="https://user-images.githubusercontent.com/98811342/194012037-12b83cfd-3602-4d92-b37a-0e22341ea9d1.png">

## After
<img width="379" alt="Screenshot 2022-10-05 at 09 57 33" src="https://user-images.githubusercontent.com/98811342/194012061-76d1940e-e40e-42e5-9e58-34eabb9514f9.png">


