### PR TITLE
GIX-1044: Extend transaction fee store

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
-      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
+      "version": "0.0.2-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-06.tgz",
+      "integrity": "sha512-/MgKHfbAWMdg1kFDoqJb/5mGZbkg+gubUsfpVzw2EjEwkVzo4zyIUtazuZnTCB4lcy/n4lF0qNGkjhF3OaQzKg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1693,9 +1693,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
-      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
+      "version": "0.9.0-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-06.tgz",
+      "integrity": "sha512-1qYFlkVByRfPSsDSfjYERiDxT+NtgG7Qlt+XqL7zjSAYyjR5IzB8cbW6DwQ75/A+OZlf+A7G9XqHjKp5Ayzsxw==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1716,17 +1716,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
-      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
+      "version": "0.0.6-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-06.tgz",
+      "integrity": "sha512-hz1R83orvFuIsYuArHtIOZzKYuaemBUUpVIPBz7UcvhScNisycHZ+RJZCbWHJVSbjyN0WJdOgEshm6xjAdvqfw==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
-      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
+      "version": "0.0.5-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-06.tgz",
+      "integrity": "sha512-THE0nMp/xtVAxxvaBUJLFf8KK/EZehVCP6zZRGhnM2ug6j3BTY8njf0rzCRBEpb6Xc+D1sUKM/GSrD/vnLQ1TA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -11799,9 +11799,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-04.tgz",
-      "integrity": "sha512-FYMMqsRpMvB+4QI/cb2ThNdZOk0pZQB0Mv/gUmMoxfye3XLSD636Zw7G01+Zzotz6GZqn9o9RN5cJ170+msujA==",
+      "version": "0.0.2-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-06.tgz",
+      "integrity": "sha512-/MgKHfbAWMdg1kFDoqJb/5mGZbkg+gubUsfpVzw2EjEwkVzo4zyIUtazuZnTCB4lcy/n4lF0qNGkjhF3OaQzKg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11824,9 +11824,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-04.tgz",
-      "integrity": "sha512-71m6zJpEunyFInBDMH3EtjrqujgM0b+HusAzmIwmtVymH/U9gMr8F+n4/EG15iY/vlVFHdhEJzP8atDM+joPKw==",
+      "version": "0.9.0-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-06.tgz",
+      "integrity": "sha512-1qYFlkVByRfPSsDSfjYERiDxT+NtgG7Qlt+XqL7zjSAYyjR5IzB8cbW6DwQ75/A+OZlf+A7G9XqHjKp5Ayzsxw==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11844,15 +11844,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-04.tgz",
-      "integrity": "sha512-H+OcTeUsZfyinWM0RqiStwS/uu2PQJEQwijx+nRj4uuqB80Fz926pN+Y36akTAqrf5eTNm6HrWPY/Y6hdQH/Pg==",
+      "version": "0.0.6-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-06.tgz",
+      "integrity": "sha512-hz1R83orvFuIsYuArHtIOZzKYuaemBUUpVIPBz7UcvhScNisycHZ+RJZCbWHJVSbjyN0WJdOgEshm6xjAdvqfw==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-04",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-04.tgz",
-      "integrity": "sha512-IVdOTmdGtnyIcsQaK1qMypUpHhdSyqSpel6CERxJChQmJLahSUFmsHt+JiF2XsGbLC+sCHfO3EsUryadbWQs9A=="
+      "version": "0.0.5-next-2022-10-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-06.tgz",
+      "integrity": "sha512-THE0nMp/xtVAxxvaBUJLFf8KK/EZehVCP6zZRGhnM2ug6j3BTY8njf0rzCRBEpb6Xc+D1sUKM/GSrD/vnLQ1TA=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -44,3 +44,25 @@ export const getSnsAccounts = async ({
   logWithTimestamp("Getting sns neuron: done");
   return [mainAccount];
 };
+
+export const transactionFee = async ({
+  rootCanisterId,
+  identity,
+  certified,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+}): Promise<bigint> => {
+  logWithTimestamp("Getting sns transaction fee: call...");
+  const { transactionFee: transactionFeeApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+
+  const fee = await transactionFeeApi({ certified });
+
+  logWithTimestamp("Getting sns transaction fee: done");
+  return fee;
+};

--- a/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
@@ -1,0 +1,25 @@
+import { TokenAmount } from "@dfinity/nns";
+import { derived, type Readable } from "svelte/store";
+import { transactionsFeesStore } from "../../stores/transaction-fees.store";
+import { snsProjectSelectedStore } from "../selected-project.derived";
+import { snsTokenSymbolSelectedStore } from "./sns-token-symbol-selected.store";
+
+// TS was not smart enough to infer the type of the stores, so we need to specify them
+export const snsSelectedTransactionFeeStore: Readable<TokenAmount | undefined> =
+  derived(
+    [
+      snsProjectSelectedStore,
+      transactionsFeesStore,
+      snsTokenSymbolSelectedStore,
+    ],
+    ([selectedRootCanisterId, feesStore, selectedToken]) => {
+      const selectedFee =
+        feesStore.projects[selectedRootCanisterId.toText()]?.fee;
+      if (selectedFee !== undefined && selectedToken !== undefined) {
+        return TokenAmount.fromE8s({
+          amount: selectedFee,
+          token: selectedToken,
+        });
+      }
+    }
+  );

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -13,6 +13,7 @@
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import { routeStore } from "../stores/route.store";
   import { walletPathStore } from "../derived/paths.derived";
+  import { loadSnsTransactionFee } from "../services/transaction-fees.services";
 
   let loading: boolean = false;
   const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
@@ -21,6 +22,8 @@
         // TODO: improve loading and use in memory sns neurons or load from backend
         loading = true;
         await loadSnsAccounts(selectedProjectCanisterId);
+        // No need to wait for the transaction fee
+        loadSnsTransactionFee(selectedProjectCanisterId);
         loading = false;
       }
     }

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -4,7 +4,7 @@
   import type { Unsubscriber } from "svelte/store";
   import AccountsTitle from "../components/accounts/AccountsTitle.svelte";
   import { snsOnlyProjectStore } from "../derived/selected-project.derived";
-  import { loadSnsAccounts } from "../services/sns-accounts.services";
+  import { syncSnsAccounts } from "../services/sns-accounts.services";
   import { snsProjectAccountsStore } from "../derived/sns/sns-project-accounts.derived";
   import AccountCard from "../components/accounts/AccountCard.svelte";
   import { i18n } from "../stores/i18n";
@@ -13,7 +13,6 @@
   import SkeletonCard from "../components/ui/SkeletonCard.svelte";
   import { routeStore } from "../stores/route.store";
   import { walletPathStore } from "../derived/paths.derived";
-  import { loadSnsTransactionFee } from "../services/transaction-fees.services";
 
   let loading: boolean = false;
   const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
@@ -21,9 +20,7 @@
       if (selectedProjectCanisterId !== undefined) {
         // TODO: improve loading and use in memory sns neurons or load from backend
         loading = true;
-        await loadSnsAccounts(selectedProjectCanisterId);
-        // No need to wait for the transaction fee
-        loadSnsTransactionFee(selectedProjectCanisterId);
+        await syncSnsAccounts(selectedProjectCanisterId);
         loading = false;
       }
     }

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -10,6 +10,7 @@
   import { snsProjectAccountsStore } from "../derived/sns/sns-project-accounts.derived";
   import { routePathAccountIdentifier } from "../services/accounts.services";
   import { loadSnsAccounts } from "../services/sns-accounts.services";
+  import { loadSnsTransactionFee } from "../services/transaction-fees.services";
   import { debugSelectedAccountStore } from "../stores/debug.store";
   import { routeStore } from "../stores/route.store";
   import {
@@ -30,7 +31,10 @@
       if (selectedProjectCanisterId !== undefined) {
         // Reload accounts always.
         // Do not set to loading because we might use the account in the store.
-        await loadSnsAccounts(selectedProjectCanisterId);
+        await Promise.all([
+          loadSnsAccounts(selectedProjectCanisterId),
+          loadSnsTransactionFee(selectedProjectCanisterId),
+        ]);
       }
     }
   );

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -9,8 +9,7 @@
   import { snsOnlyProjectStore } from "../derived/selected-project.derived";
   import { snsProjectAccountsStore } from "../derived/sns/sns-project-accounts.derived";
   import { routePathAccountIdentifier } from "../services/accounts.services";
-  import { loadSnsAccounts } from "../services/sns-accounts.services";
-  import { loadSnsTransactionFee } from "../services/transaction-fees.services";
+  import { syncSnsAccounts } from "../services/sns-accounts.services";
   import { debugSelectedAccountStore } from "../stores/debug.store";
   import { routeStore } from "../stores/route.store";
   import {
@@ -31,10 +30,7 @@
       if (selectedProjectCanisterId !== undefined) {
         // Reload accounts always.
         // Do not set to loading because we might use the account in the store.
-        await Promise.all([
-          loadSnsAccounts(selectedProjectCanisterId),
-          loadSnsTransactionFee(selectedProjectCanisterId),
-        ]);
+        await syncSnsAccounts(selectedProjectCanisterId);
       }
     }
   );

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -4,6 +4,7 @@ import { snsAccountsStore } from "../stores/sns-accounts.store";
 import { toastsError } from "../stores/toasts.store";
 import type { Account } from "../types/account";
 import { toToastError } from "../utils/error.utils";
+import { loadSnsTransactionFee } from "./transaction-fees.services";
 import { queryAndUpdate } from "./utils.services";
 
 export const loadSnsAccounts = async (
@@ -37,4 +38,11 @@ export const loadSnsAccounts = async (
     },
     logMessage: "Syncing Sns Accounts",
   });
+};
+
+export const syncSnsAccounts = async (rootCanisterId: Principal) => {
+  await Promise.all([
+    loadSnsAccounts(rootCanisterId),
+    loadSnsTransactionFee(rootCanisterId),
+  ]);
 };

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -1,15 +1,44 @@
-import { transactionFee } from "../api/ledger.api";
+import type { Principal } from "@dfinity/principal/lib/cjs";
+import { transactionFee as nnsTransactionFee } from "../api/ledger.api";
+import { transactionFee as snsTransactionFee } from "../api/sns-ledger.api";
 import { transactionsFeesStore } from "../stores/transaction-fees.store";
 import { getIdentity } from "./auth.services";
+import { queryAndUpdate } from "./utils.services";
 
 export const loadMainTransactionFee = async () => {
   try {
     const identity = await getIdentity();
-    const fee = await transactionFee({ identity });
+    const fee = await nnsTransactionFee({ identity });
     transactionsFeesStore.setMain(fee);
   } catch (error) {
     // Swallow error and continue with the DEFAULT_TRANSACTION_FEE value
     console.error("Error getting the transaction fee from the ledger");
     console.error(error);
   }
+};
+
+export const loadSnsTransactionFee = async (rootCanisterId: Principal) => {
+  return queryAndUpdate<bigint, unknown>({
+    request: ({ certified, identity }) =>
+      snsTransactionFee({
+        identity,
+        rootCanisterId,
+        certified,
+      }),
+    onLoad: async ({ response: fee, certified }) => {
+      transactionsFeesStore.setFee({ certified, rootCanisterId, fee });
+    },
+    onError: ({ error, certified }) => {
+      if (certified !== true) {
+        return;
+      }
+
+      // Explicitly handle only UPDATE errors
+      // TODO: Manage errors gracefully https://dfinity.atlassian.net/browse/GIX-1026
+      console.error(
+        `Error loading sns transaction fee for ${rootCanisterId.toText()}`
+      );
+      console.error(error);
+    },
+  });
 };

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -1,13 +1,22 @@
+import type { Principal } from "@dfinity/principal";
 import { derived, writable } from "svelte/store";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../constants/icp.constants";
 
 export type TransactionFeesStore = {
   // Main Ledger of IC
   main: bigint;
+  // SNS ledgers
+  projects: {
+    [rootCanisterId: string]: {
+      fee: bigint;
+      certified: boolean;
+    };
+  };
 };
 
-const defaultTransactionFees = {
+const defaultTransactionFees: TransactionFeesStore = {
   main: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+  projects: {},
 };
 
 /**
@@ -27,6 +36,27 @@ const initTransactionFeesStore = () => {
       update((data) => ({
         ...data,
         main: fee,
+      }));
+    },
+
+    setFee({
+      rootCanisterId,
+      fee,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      fee: bigint;
+      certified: boolean;
+    }) {
+      update((data) => ({
+        ...data,
+        projects: {
+          ...data.projects,
+          [rootCanisterId.toText()]: {
+            fee,
+            certified,
+          },
+        },
       }));
     },
   };

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -1,4 +1,7 @@
-import { getSnsAccounts } from "../../../lib/api/sns-ledger.api";
+import {
+  getSnsAccounts,
+  transactionFee,
+} from "../../../lib/api/sns-ledger.api";
 import {
   importInitSnsWrapper,
   importSnsWasmCanister,
@@ -19,6 +22,8 @@ describe("sns-ledger api", () => {
   const mainBalance = BigInt(10_000_000);
   const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
   const metadataSpy = jest.fn().mockResolvedValue(mockQueryTokenResponse);
+  const fee = BigInt(10_000);
+  const transactionFeeSpy = jest.fn().mockResolvedValue(fee);
 
   beforeEach(() => {
     (importSnsWasmCanister as jest.Mock).mockResolvedValue({
@@ -37,6 +42,7 @@ describe("sns-ledger api", () => {
         },
         balance: balanceSpy,
         ledgerMetadata: metadataSpy,
+        transactionFee: transactionFeeSpy,
       })
     );
   });
@@ -57,6 +63,19 @@ describe("sns-ledger api", () => {
 
       expect(balanceSpy).toBeCalled();
       expect(metadataSpy).toBeCalled();
+    });
+  });
+
+  describe("transactionFee", () => {
+    it("returns transaction fee for an sns project", async () => {
+      const actualFee = await transactionFee({
+        certified: true,
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+      });
+
+      expect(actualFee).toBe(fee);
+      expect(transactionFeeSpy).toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Principal } from "@dfinity/principal";
+import { SnsMetadataResponseEntries, SnsSwapLifecycle } from "@dfinity/sns";
+import { get } from "svelte/store";
+import { AppPath } from "../../../../lib/constants/routes.constants";
+import { snsSelectedTransactionFeeStore } from "../../../../lib/derived/sns/sns-selected-transaction-fee.store";
+import { routeStore } from "../../../../lib/stores/route.store";
+import { snsQueryStore } from "../../../../lib/stores/sns.store";
+import { transactionsFeesStore } from "../../../../lib/stores/transaction-fees.store";
+import { paths } from "../../../../lib/utils/app-path.utils";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
+
+describe("snsSelectedTransactionFeeStore", () => {
+  const data = snsResponsesForLifecycle({
+    lifecycles: [SnsSwapLifecycle.Open],
+    certified: true,
+  });
+  afterEach(() => {
+    snsQueryStore.reset();
+    routeStore.update({
+      path: paths.neurons(mockPrincipal.toText()),
+    });
+  });
+  it("returns transaction fee of current selected sns project", () => {
+    snsQueryStore.setData(data);
+    const [metadatas] = data;
+    routeStore.update({
+      // path: `${CONTEXT_PATH}/${metadatas[0].rootCanisterId}/neurons`,
+      path: paths.neurons(metadatas[0].rootCanisterId),
+    });
+    const ledgerMetadata = metadatas[0].token;
+    const symbolResponse = ledgerMetadata.find(
+      (metadata) => metadata[0] === SnsMetadataResponseEntries.SYMBOL
+    );
+    const symbol =
+      symbolResponse !== undefined && "Text" in symbolResponse[1]
+        ? symbolResponse[1].Text
+        : undefined;
+
+    const fee = BigInt(10_000);
+    transactionsFeesStore.setFee({
+      rootCanisterId: Principal.fromText(metadatas[0].rootCanisterId),
+      fee,
+      certified: true,
+    });
+
+    const actualFeeTokens = get(snsSelectedTransactionFeeStore);
+
+    expect(actualFeeTokens?.toE8s()).toBe(fee);
+    expect(actualFeeTokens?.token.symbol).toBe(symbol);
+  });
+
+  it("returns undefined if selected project is NNS", () => {
+    snsQueryStore.setData(data);
+    routeStore.update({
+      path: AppPath.LegacyNeurons,
+    });
+    const actualFeeTokens = get(snsSelectedTransactionFeeStore);
+
+    expect(actualFeeTokens).toBeUndefined();
+  });
+
+  it("returns undefined if current selected project has no data", () => {
+    const [metadatas] = data;
+    routeStore.update({
+      path: paths.neurons(metadatas[0].rootCanisterId),
+    });
+    const actualFeeTokens = get(snsSelectedTransactionFeeStore);
+
+    expect(actualFeeTokens).toBeUndefined();
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -7,8 +7,7 @@ import type { Subscriber } from "svelte/store";
 import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsAccounts from "../../../lib/pages/SnsAccounts.svelte";
-import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
-import { loadSnsTransactionFee } from "../../../lib/services/transaction-fees.services";
+import { syncSnsAccounts } from "../../../lib/services/sns-accounts.services";
 import { routeStore } from "../../../lib/stores/route.store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
@@ -16,13 +15,7 @@ import { mockSnsAccountsStoreSubscribe } from "../../mocks/sns-accounts.mock";
 
 jest.mock("../../../lib/services/sns-accounts.services", () => {
   return {
-    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("../../../lib/services/transaction-fees.services", () => {
-  return {
-    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+    syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -47,8 +40,7 @@ describe("SnsAccounts", () => {
     it("should load accounts and transaction fee", () => {
       render(SnsAccounts);
 
-      expect(loadSnsAccounts).toHaveBeenCalled();
-      expect(loadSnsTransactionFee).toHaveBeenCalled();
+      expect(syncSnsAccounts).toHaveBeenCalled();
     });
 
     it("should contain a tooltip", () => {
@@ -76,7 +68,7 @@ describe("SnsAccounts", () => {
     it("should load sns accounts of the project", () => {
       render(SnsAccounts);
 
-      expect(loadSnsAccounts).toHaveBeenCalledWith(mockPrincipal);
+      expect(syncSnsAccounts).toHaveBeenCalledWith(mockPrincipal);
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -8,6 +8,7 @@ import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsAccounts from "../../../lib/pages/SnsAccounts.svelte";
 import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
+import { loadSnsTransactionFee } from "../../../lib/services/transaction-fees.services";
 import { routeStore } from "../../../lib/stores/route.store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
@@ -16,6 +17,12 @@ import { mockSnsAccountsStoreSubscribe } from "../../mocks/sns-accounts.mock";
 jest.mock("../../../lib/services/sns-accounts.services", () => {
   return {
     loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("../../../lib/services/transaction-fees.services", () => {
+  return {
+    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -35,6 +42,13 @@ describe("SnsAccounts", () => {
       const { getByTestId } = render(SnsAccounts);
 
       expect(getByTestId("accounts-title")).toBeInTheDocument();
+    });
+
+    it("should load accounts and transaction fee", () => {
+      render(SnsAccounts);
+
+      expect(loadSnsAccounts).toHaveBeenCalled();
+      expect(loadSnsTransactionFee).toHaveBeenCalled();
     });
 
     it("should contain a tooltip", () => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -6,8 +6,7 @@ import { render, waitFor } from "@testing-library/svelte";
 import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsWallet from "../../../lib/pages/SnsWallet.svelte";
-import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
-import { loadSnsTransactionFee } from "../../../lib/services/transaction-fees.services";
+import { syncSnsAccounts } from "../../../lib/services/sns-accounts.services";
 import { routeStore } from "../../../lib/stores/route.store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
@@ -17,13 +16,7 @@ import {
 
 jest.mock("../../../lib/services/sns-accounts.services", () => {
   return {
-    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("../../../lib/services/transaction-fees.services", () => {
-  return {
-    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+    syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -47,8 +40,7 @@ describe("SnsWallet", () => {
     it("should call to load sns accounts and transaction fee", async () => {
       render(SnsWallet);
 
-      await waitFor(() => expect(loadSnsAccounts).toBeCalled());
-      expect(loadSnsTransactionFee).toBeCalled();
+      await waitFor(() => expect(syncSnsAccounts).toBeCalled());
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -7,6 +7,7 @@ import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
 import { snsProjectAccountsStore } from "../../../lib/derived/sns/sns-project-accounts.derived";
 import SnsWallet from "../../../lib/pages/SnsWallet.svelte";
 import { loadSnsAccounts } from "../../../lib/services/sns-accounts.services";
+import { loadSnsTransactionFee } from "../../../lib/services/transaction-fees.services";
 import { routeStore } from "../../../lib/stores/route.store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
@@ -17,6 +18,12 @@ import {
 jest.mock("../../../lib/services/sns-accounts.services", () => {
   return {
     loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("../../../lib/services/transaction-fees.services", () => {
+  return {
+    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -37,10 +44,11 @@ describe("SnsWallet", () => {
       expect(getByTestId("spinner")).not.toBeNull();
     });
 
-    it("should call to load sns accounts", async () => {
+    it("should call to load sns accounts and transaction fee", async () => {
       render(SnsWallet);
 
       await waitFor(() => expect(loadSnsAccounts).toBeCalled());
+      expect(loadSnsTransactionFee).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -1,46 +1,82 @@
 import { get } from "svelte/store";
 import * as api from "../../../lib/api/ledger.api";
+import * as snsApi from "../../../lib/api/sns-ledger.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "../../../lib/constants/icp.constants";
-import { loadMainTransactionFee } from "../../../lib/services/transaction-fees.services";
+import {
+  loadMainTransactionFee,
+  loadSnsTransactionFee,
+} from "../../../lib/services/transaction-fees.services";
 import {
   mainTransactionFeeStore,
   transactionsFeesStore,
 } from "../../../lib/stores/transaction-fees.store";
-import { resetIdentity, setNoIdentity } from "../../mocks/auth.store.mock";
+import {
+  mockPrincipal,
+  resetIdentity,
+  setNoIdentity,
+} from "../../mocks/auth.store.mock";
 
 describe("transactionFee-services", () => {
   const fee = BigInt(30_000);
 
-  let spyTranactionFeeApi;
-  beforeEach(() => {
-    spyTranactionFeeApi = jest
-      .spyOn(api, "transactionFee")
-      .mockResolvedValue(fee);
-    // Avoid to print errors during test
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  describe("loadMainTransactionFee", () => {
+    let spyTranactionFeeApi;
+    beforeEach(() => {
+      spyTranactionFeeApi = jest
+        .spyOn(api, "transactionFee")
+        .mockResolvedValue(fee);
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    afterEach(() =>
+      transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
+    );
+
+    it("set transaction fee to the ledger canister value", async () => {
+      await loadMainTransactionFee();
+
+      expect(spyTranactionFeeApi).toHaveBeenCalled();
+
+      const storeFee = get(mainTransactionFeeStore);
+      expect(storeFee).toEqual(Number(fee));
+    });
+
+    it("should not set new fee if no identity", async () => {
+      setNoIdentity();
+
+      await loadMainTransactionFee();
+
+      const storeFee = get(mainTransactionFeeStore);
+      expect(storeFee).toEqual(DEFAULT_TRANSACTION_FEE_E8S);
+
+      resetIdentity();
+    });
   });
 
-  afterEach(() =>
-    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
-  );
+  describe("loadSnsTransactionFee", () => {
+    let spyTranactionFeeApi;
+    beforeEach(() => {
+      spyTranactionFeeApi = jest
+        .spyOn(snsApi, "transactionFee")
+        .mockResolvedValue(fee);
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
 
-  it("set transaction fee to the ledger canister value", async () => {
-    await loadMainTransactionFee();
+    afterEach(() =>
+      transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
+    );
 
-    expect(spyTranactionFeeApi).toHaveBeenCalled();
+    it("set transaction fee of the sns project to the ledger canister value", async () => {
+      await loadSnsTransactionFee(mockPrincipal);
 
-    const storeFee = get(mainTransactionFeeStore);
-    expect(storeFee).toEqual(Number(fee));
-  });
+      expect(spyTranactionFeeApi).toHaveBeenCalled();
 
-  it("should not set new fee if no identity", async () => {
-    setNoIdentity();
-
-    await loadMainTransactionFee();
-
-    const storeFee = get(mainTransactionFeeStore);
-    expect(storeFee).toEqual(DEFAULT_TRANSACTION_FEE_E8S);
-
-    resetIdentity();
+      const feesStore = get(transactionsFeesStore);
+      const { fee: actualFee } = feesStore.projects[mockPrincipal.toText()];
+      expect(actualFee).toEqual(fee);
+      expect(spyTranactionFeeApi).toBeCalled();
+    });
   });
 });

--- a/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -4,6 +4,7 @@ import {
   mainTransactionFeeStore,
   transactionsFeesStore,
 } from "../../../lib/stores/transaction-fees.store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
 
 describe("transactionsFeesStore", () => {
   beforeEach(() =>
@@ -27,5 +28,27 @@ describe("transactionsFeesStore", () => {
     transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
     const fee2 = get(transactionsFeesStore);
     expect(fee1.main).not.toEqual(fee2);
+  });
+
+  it("should set fee of an sns project", () => {
+    transactionsFeesStore.setFee({
+      rootCanisterId: mockPrincipal,
+      fee: BigInt(40_000),
+      certified: true,
+    });
+    const store1 = get(transactionsFeesStore);
+    const { fee: fee1 } = store1.projects[mockPrincipal.toText()];
+
+    const expectedFee = BigInt(50_000);
+    transactionsFeesStore.setFee({
+      rootCanisterId: mockPrincipal,
+      fee: expectedFee,
+      certified: true,
+    });
+    const store2 = get(transactionsFeesStore);
+    const { fee: fee2 } = store2.projects[mockPrincipal.toText()];
+
+    expect(fee1).not.toEqual(fee2);
+    expect(fee2).toEqual(expectedFee);
   });
 });

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -17,13 +17,7 @@ import {
 
 jest.mock("../../lib/services/sns-accounts.services", () => {
   return {
-    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("../../lib/services/transaction-fees.services", () => {
-  return {
-    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+    syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/routes/Accounts.spec.ts
+++ b/frontend/src/tests/routes/Accounts.spec.ts
@@ -21,6 +21,12 @@ jest.mock("../../lib/services/sns-accounts.services", () => {
   };
 });
 
+jest.mock("../../lib/services/transaction-fees.services", () => {
+  return {
+    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe("Accounts", () => {
   jest
     .spyOn(committedProjectsStore, "subscribe")

--- a/frontend/src/tests/routes/Wallet.spec.ts
+++ b/frontend/src/tests/routes/Wallet.spec.ts
@@ -10,13 +10,7 @@ import { principal } from "../mocks/sns-projects.mock";
 
 jest.mock("../../lib/services/sns-accounts.services", () => {
   return {
-    loadSnsAccounts: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("../../lib/services/transaction-fees.services", () => {
-  return {
-    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+    syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/routes/Wallet.spec.ts
+++ b/frontend/src/tests/routes/Wallet.spec.ts
@@ -14,6 +14,12 @@ jest.mock("../../lib/services/sns-accounts.services", () => {
   };
 });
 
+jest.mock("../../lib/services/transaction-fees.services", () => {
+  return {
+    loadSnsTransactionFee: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe("Wallet", () => {
   describe("nns context", () => {
     it("should render NnsWallet", () => {


### PR DESCRIPTION
# Motivation

Each SNS project might have a different transaction fee. Extend the current functionality to accommodate that.

# Changes

* Add "transactionFee" function to sns-ledger api.
* Extend the transactionFeeStore with a "projects" property to store different transaction fees.
* New transaction fee service to load sns transaction fee to the store.
* Load SNS transaction fees in SnsAccounts and SnsWallet.
* New derived store that returns the fee of the current project context in a TokenAmount type.

# Tests

* New test new api function.
* New test for extended transactionFeeStore functionality.
* New test for transaction fee service.
* Add calls check on SnsAccounts and SnsWallet.
* New test for new derived store.
