### PR TITLE
GIX-1045: Manage when sns token not defined

### DIFF
--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,8 +1,9 @@
 import type { Identity } from "@dfinity/agent";
-import { ICPToken, TokenAmount } from "@dfinity/nns";
+import { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { encodeSnsAccount } from "@dfinity/sns";
 import type { Account } from "../types/account";
+import { LedgerErrorKey } from "../types/ledger.errors";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { mapOptionalToken } from "../utils/sns.utils";
 import { wrapper } from "./sns-wrapper.api";
@@ -30,13 +31,18 @@ export const getSnsAccounts = async ({
     ledgerMetadata({}),
   ]);
 
+  const projectToken = mapOptionalToken(metadata);
+
+  if (projectToken === undefined) {
+    throw new LedgerErrorKey("error.sns_token_load");
+  }
+
   const mainAccount: Account = {
     identifier: encodeSnsAccount(snsMainAccount),
     principal: identity.getPrincipal(),
     balance: TokenAmount.fromE8s({
       amount: mainBalanceE8s,
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1045
-      token: mapOptionalToken(metadata) ?? ICPToken,
+      token: projectToken,
     }),
     type: "main",
   };

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ICPToken, NeuronState, TokenAmount } from "@dfinity/nns";
+  import { type Token, NeuronState, TokenAmount } from "@dfinity/nns";
   import type { SnsNeuron } from "@dfinity/sns";
   import { authStore } from "../../stores/auth.store";
   import { i18n } from "../../stores/i18n";
@@ -36,8 +36,9 @@
   let neuronStake: TokenAmount;
   $: neuronStake = TokenAmount.fromE8s({
     amount: getSnsNeuronStake(neuron),
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1045
-    token: $snsTokenSymbolSelectedStore ?? ICPToken,
+    // If we got here is because the token symbol is present.
+    // The projects without token are discarded filtered out.
+    token: $snsTokenSymbolSelectedStore as Token,
   });
 
   let neuronState: NeuronState;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -38,6 +38,7 @@
     "neuron_load": "An error occurred while loading the neuron.",
     "sns_neurons_load": "An error occurred while loading the neurons.",
     "sns_accounts_load": "An error occurred while loading the accounts.",
+    "sns_token_load": "An error occurred while loading the project token.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",
     "missing_identity": "The operation cannot be executed without any identity.",

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -15,7 +15,7 @@
     getSnsNeuronStake,
   } from "../../utils/sns-neuron.utils";
   import type { Principal } from "@dfinity/principal";
-  import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { type Token, TokenAmount } from "@dfinity/nns";
   import ConfirmDisburseNeuron from "../../components/neuron-detail/ConfirmDisburseNeuron.svelte";
   import { snsTokenSymbolSelectedStore } from "../../derived/sns/sns-token-symbol-selected.store";
   import { transactionsFeesStore } from "../../stores/transaction-fees.store";
@@ -35,14 +35,14 @@
   let amount: TokenAmount;
   $: amount = TokenAmount.fromE8s({
     amount: getSnsNeuronStake(neuron),
-    token: $snsTokenSymbolSelectedStore ?? ICPToken,
+    token: $snsTokenSymbolSelectedStore as Token,
   });
 
   let fee: TokenAmount;
   $: fee = TokenAmount.fromE8s({
     // TODO(GIX-1044): update FeesStore with the current sns project value
     amount: $transactionsFeesStore.main,
-    token: $snsTokenSymbolSelectedStore ?? ICPToken,
+    token: $snsTokenSymbolSelectedStore as Token,
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -32,7 +32,7 @@ export const loadSnsAccounts = async (
       toastsError(
         toToastError({
           err,
-          fallbackErrorLabelKey: "error.sns_neurons_load",
+          fallbackErrorLabelKey: "error.sns_accounts_load",
         })
       );
     },

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -42,6 +42,7 @@ interface I18nError {
   neuron_load: string;
   sns_neurons_load: string;
   sns_accounts_load: string;
+  sns_token_load: string;
   list_proposals: string;
   list_canisters: string;
   missing_identity: string;

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -2,51 +2,37 @@ import {
   getSnsAccounts,
   transactionFee,
 } from "../../../lib/api/sns-ledger.api";
-import {
-  importInitSnsWrapper,
-  importSnsWasmCanister,
-} from "../../../lib/proxy/api.import.proxy";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import { mockQueryTokenResponse } from "../../mocks/sns-projects.mock";
-import {
-  deployedSnsMock,
-  governanceCanisterIdMock,
-  ledgerCanisterIdMock,
-  rootCanisterIdMock,
-  swapCanisterIdMock,
-} from "../../mocks/sns.api.mock";
+import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 
 jest.mock("../../../lib/proxy/api.import.proxy");
+const mainBalance = BigInt(10_000_000);
+const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
+const fee = BigInt(10_000);
+const transactionFeeSpy = jest.fn().mockResolvedValue(fee);
+
+let metadataReturn = mockQueryTokenResponse;
+const setMetadataError = () => (metadataReturn = []);
+const setMetadataSuccess = () => (metadataReturn = mockQueryTokenResponse);
+const metadataSpy = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve(metadataReturn));
+jest.mock("../../../lib/api/sns-wrapper.api", () => {
+  return {
+    wrapper: () => ({
+      balance: balanceSpy,
+      ledgerMetadata: metadataSpy,
+      transactionFee: transactionFeeSpy,
+    }),
+  };
+});
 
 describe("sns-ledger api", () => {
-  const mainBalance = BigInt(10_000_000);
-  const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
-  const metadataSpy = jest.fn().mockResolvedValue(mockQueryTokenResponse);
-  const fee = BigInt(10_000);
-  const transactionFeeSpy = jest.fn().mockResolvedValue(fee);
-
-  beforeEach(() => {
-    (importSnsWasmCanister as jest.Mock).mockResolvedValue({
-      create: () => ({
-        listSnses: () => Promise.resolve(deployedSnsMock),
-      }),
-    });
-
-    (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
-      Promise.resolve({
-        canisterIds: {
-          rootCanisterId: rootCanisterIdMock,
-          ledgerCanisterId: ledgerCanisterIdMock,
-          governanceCanisterId: governanceCanisterIdMock,
-          swapCanisterId: swapCanisterIdMock,
-        },
-        balance: balanceSpy,
-        ledgerMetadata: metadataSpy,
-        transactionFee: transactionFeeSpy,
-      })
-    );
-  });
   describe("getSnsAccounts", () => {
+    beforeEach(() => {
+      setMetadataSuccess();
+    });
     it("returns main account with balance and project token metadata", async () => {
       const accounts = await getSnsAccounts({
         certified: true,
@@ -63,6 +49,18 @@ describe("sns-ledger api", () => {
 
       expect(balanceSpy).toBeCalled();
       expect(metadataSpy).toBeCalled();
+    });
+
+    it("throws an error if no token", () => {
+      setMetadataError();
+      const call = () =>
+        getSnsAccounts({
+          certified: true,
+          identity: mockIdentity,
+          rootCanisterId: rootCanisterIdMock,
+        });
+
+      expect(call).rejects.toThrowError();
     });
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -3,10 +3,17 @@
  */
 
 import SnsNeuronMetaInfoCard from "../../../../lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
+import { snsTokenSymbolSelectedStore } from "../../../../lib/derived/sns/sns-token-symbol-selected.store";
 import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { mockTokenStore } from "../../../mocks/sns-projects.mock";
 
 describe("SnsNeuronMetaInfoCard", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(snsTokenSymbolSelectedStore, "subscribe")
+      .mockImplementation(mockTokenStore);
+  });
   it("renders a SnsNeuronCard", () => {
     // We can skip many edge cases tested in the NeuronCard
     const { queryByTestId } = renderSelectedSnsNeuronContext({

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { mockTokenStore } from "../../../mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
 describe("SnsNeuronCard", () => {
@@ -35,6 +36,9 @@ describe("SnsNeuronCard", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest
+      .spyOn(snsTokenSymbolSelectedStore, "subscribe")
+      .mockImplementation(mockTokenStore);
   });
 
   const defaultProps = {

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -7,6 +7,7 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import * as accountsApi from "../../../../lib/api/accounts.api";
 import { CONTEXT_PATH } from "../../../../lib/constants/routes.constants";
+import { snsTokenSymbolSelectedStore } from "../../../../lib/derived/sns/sns-token-symbol-selected.store";
 import DisburseSnsNeuronModal from "../../../../lib/modals/neurons/DisburseSnsNeuronModal.svelte";
 import { disburse } from "../../../../lib/services/sns-neurons.services";
 import { accountsStore } from "../../../../lib/stores/accounts.store";
@@ -18,6 +19,7 @@ import {
 } from "../../../mocks/accounts.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { mockTokenStore } from "../../../mocks/sns-projects.mock";
 
 jest.mock("../../../../lib/services/sns-neurons.services", () => {
   return {
@@ -54,6 +56,10 @@ describe("DisburseSnsNeuronModal", () => {
       .mockImplementation(() =>
         Promise.resolve({ main: mockMainAccount, subAccounts: [] })
       );
+
+    jest
+      .spyOn(snsTokenSymbolSelectedStore, "subscribe")
+      .mockImplementation(mockTokenStore);
   });
 
   afterAll(() => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -4,12 +4,14 @@
 
 import { render, waitFor } from "@testing-library/svelte";
 import { CONTEXT_PATH } from "../../../lib/constants/routes.constants";
+import { snsTokenSymbolSelectedStore } from "../../../lib/derived/sns/sns-token-symbol-selected.store";
 import SnsNeuronDetail from "../../../lib/pages/SnsNeuronDetail.svelte";
 import { getSnsNeuron } from "../../../lib/services/sns-neurons.services";
 import { routeStore } from "../../../lib/stores/route.store";
 import { getSnsNeuronIdAsHexString } from "../../../lib/utils/sns-neuron.utils";
 import { mockRouteStoreSubscribe } from "../../mocks/route.store.mock";
 import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
+import { mockTokenStore } from "../../mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 
 let validNeuron = true;
@@ -26,6 +28,11 @@ jest.mock("../../../lib/services/sns-neurons.services", () => {
 });
 
 describe("SnsNeuronDetail", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(snsTokenSymbolSelectedStore, "subscribe")
+      .mockImplementation(mockTokenStore);
+  });
   afterEach(() => {
     jest.clearAllMocks();
     validNeuron = true;

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -1,3 +1,4 @@
+import type { Token } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
   SnsMetadataResponseEntries,
@@ -231,4 +232,9 @@ export const mockQueryMetadata: QuerySnsMetadata = {
   certified: true,
   metadata: mockQueryMetadataResponse,
   token: mockQueryTokenResponse,
+};
+
+export const mockTokenStore = (run: Subscriber<Token>) => {
+  run({ symbol: "TST", name: "test" });
+  return () => undefined;
 };


### PR DESCRIPTION
# Motivation

Manage the possible situations where sns token might not be present.

# Changes

* Throw an error when loading sns accounts and token is not present.
* Cast the token in components when we know the token is present otherwise the component would not be rendered.

# Tests

* Add test to check an error is thrown when token is not present.
