### PR TITLE
GIX-1063: Fix Spinner Dropdown

### DIFF
--- a/frontend/src/lib/components/neurons/SelectProjectDropdown.svelte
+++ b/frontend/src/lib/components/neurons/SelectProjectDropdown.svelte
@@ -78,5 +78,8 @@
     {/each}
   </Dropdown>
 {:else}
-  <Spinner inline />
+  <!-- Extra div needed to make sure the Spinner is centered in the same place as the Dropdown -->
+  <div>
+    <Spinner inline />
+  </div>
 {/if}


### PR DESCRIPTION
# Motivation

The Spinner of the ProjectDropdown was aligned to the right, not in the middle like the dropdown.

# Changes

* Wrap Spinner inside ProjectDropdown with a `div` to center it.

# Tests

Not applicable. Only UI changes.
