### PR TITLE
fix: partly hidden sign in button on android

### DIFF
--- a/frontend/src/lib/components/common/AuthLayout.svelte
+++ b/frontend/src/lib/components/common/AuthLayout.svelte
@@ -28,7 +28,7 @@
   main {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
     background: transparent;
 
     padding: var(--padding-6x) var(--padding-4x);
@@ -38,11 +38,6 @@
       align-items: center;
       max-width: 540px;
       text-align: center;
-    }
-
-    @supports (-webkit-touch-callout: none) {
-      // webkit-fill-available does not strech to full height
-      height: calc(100vh - (12 * var(--padding)));
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

Fix the partly hidden sign-in button.
<img width="371" alt="image" src="https://user-images.githubusercontent.com/98811342/194350581-7d7ebd53-6eeb-498b-add1-b2de0c639d78.png">

# Changes

The main.height set to be `100%`.

Tested on android pixel (chrome), iphone 11 (safari), desktop: chrome, ff, safari

# Screenshots

## desktop
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/98811342/194349921-6813ce7c-a81d-4ca1-b880-65460686b51a.png">

## mobile
<img width="387" alt="image" src="https://user-images.githubusercontent.com/98811342/194350065-5da960f3-0e8e-4822-987d-0372036642ad.png">

