### PR TITLE
fix: preserve login page mobile view in landscape mode

### DIFF
--- a/frontend/src/lib/components/common/AuthLayout.svelte
+++ b/frontend/src/lib/components/common/AuthLayout.svelte
@@ -30,10 +30,11 @@
     flex-direction: column;
     height: 100%;
     background: transparent;
+    overflow-y: auto;
 
     padding: var(--padding-6x) var(--padding-4x);
 
-    @include media.min-width(medium) {
+    @media (min-width: 768px) and (min-height: 620px) {
       justify-content: center;
       align-items: center;
       max-width: 540px;

--- a/frontend/src/routes/Auth.svelte
+++ b/frontend/src/routes/Auth.svelte
@@ -72,9 +72,18 @@
 <h1>{$i18n.auth.title}&nbsp;<span>{$i18n.auth.on_chain}</span></h1>
 
 <ul>
-  <li><IconWallet /> {$i18n.auth.secure}</li>
-  <li><IconPsychology /> {$i18n.auth.stake}</li>
-  <li><IconHowToVote /> {$i18n.auth.earn}</li>
+  <li>
+    <IconWallet />
+    {$i18n.auth.secure}
+  </li>
+  <li>
+    <IconPsychology />
+    {$i18n.auth.stake}
+  </li>
+  <li>
+    <IconHowToVote />
+    {$i18n.auth.earn}
+  </li>
 </ul>
 
 <button
@@ -85,7 +94,9 @@
 >
   {$i18n.auth.login}
   {#if signedIn}
-    <div class="spinner"><Spinner size="small" inline /></div>
+    <div class="spinner">
+      <Spinner size="small" inline />
+    </div>
   {/if}
 </button>
 
@@ -113,7 +124,7 @@
       letter-spacing: 0.1rem;
     }
 
-    @include media.min-width(medium) {
+    @media (min-width: 768px) and (min-height: 620px) {
       justify-content: center;
       flex-direction: column;
 
@@ -140,7 +151,7 @@
     width: 100%;
     max-width: 475px;
 
-    @include media.min-width(medium) {
+    @media (min-width: 768px) and (min-height: 620px) {
       margin: var(--padding-6x) 0 calc(14 * var(--padding));
       width: auto;
     }
@@ -164,7 +175,7 @@
       font-size: var(--font-size-h1);
     }
 
-    @include media.min-width(medium) {
+    @media (min-width: 768px) and (min-height: 620px) {
       max-width: 550px;
       font-size: 2.441rem;
     }
@@ -178,7 +189,7 @@
     font-weight: var(--font-weight-bold);
     letter-spacing: 0.05rem;
 
-    @include media.min-width(medium) {
+    @media (min-width: 768px) and (min-height: 620px) {
       flex-grow: inherit;
 
       position: absolute;


### PR DESCRIPTION
# Motivation

There is some overflows or hidden content on the login page in the landscape mode. A problem affects some mobile devices like iphone 11+ and pixels. 

<img width="854" alt="image" src="https://user-images.githubusercontent.com/98811342/194373837-872efdc4-a7e8-4470-8b93-ff28d4334292.png">

# Changes

- lock the mobile view till there is not enough vertical space
- make the login main content scrollable on mobile

# Screenshots

<img width="858" alt="image" src="https://user-images.githubusercontent.com/98811342/194375004-fd901209-fe71-40d6-843a-a16e4e080480.png">



