### PR TITLE
GIX-994: User transfers SNS tokens

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { accountsStore } from "$lib/stores/accounts.store";
   import { accountsListStore } from "$lib/derived/accounts-list.derived";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
@@ -16,7 +15,7 @@
     selectedAccount?.identifier;
   $: selectedAccount = getAccountFromStore({
     identifier: selectedAccountIdentifier,
-    accountsStore: $accountsStore,
+    accounts: $accountsListStore,
   });
 
   $: selectableAccounts = $accountsListStore.filter(filterAccounts);

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { accountsListStore } from "$lib/derived/accounts-list.derived";
+  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import { getAccountFromStore } from "$lib/utils/accounts.utils";
@@ -15,10 +15,10 @@
     selectedAccount?.identifier;
   $: selectedAccount = getAccountFromStore({
     identifier: selectedAccountIdentifier,
-    accounts: $accountsListStore,
+    accounts: $accountsSelectedProjectStore,
   });
 
-  $: selectableAccounts = $accountsListStore.filter(filterAccounts);
+  $: selectableAccounts = $accountsSelectedProjectStore.filter(filterAccounts);
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { accountsListStore } from "$lib/derived/accounts-list.derived";
+  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import {
@@ -17,7 +17,7 @@
   // If the component is already initialized with a selectedDestinationAddress
   let selectedAccount: Account | undefined = getAccountFromStore({
     identifier: selectedDestinationAddress,
-    accounts: $accountsListStore,
+    accounts: $accountsSelectedProjectStore,
   });
   let address: string;
   $: {
@@ -32,7 +32,8 @@
 
   // Show the toggle if there are more than one account to select from.
   let showToggle = true;
-  $: showToggle = $accountsListStore.filter(filterAccounts).length > 0;
+  $: showToggle =
+    $accountsSelectedProjectStore.filter(filterAccounts).length > 0;
 
   const onToggleManualInput = () => {
     showManualAddress = !showManualAddress;

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { accountsListStore } from "$lib/derived/accounts-list.derived";
-  import { accountsStore } from "$lib/stores/accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import {
@@ -18,7 +17,7 @@
   // If the component is already initialized with a selectedDestinationAddress
   let selectedAccount: Account | undefined = getAccountFromStore({
     identifier: selectedDestinationAddress,
-    accountsStore: $accountsStore,
+    accounts: $accountsListStore,
   });
   let address: string;
   $: {

--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -2,8 +2,8 @@
   import { i18n } from "../../stores/i18n";
   import { Toolbar } from "@dfinity/gix-components";
   import Footer from "../common/Footer.svelte";
-  import IcpTransactionModal from "../../modals/accounts/IcpTransactionModal.svelte";
   import { snsProjectAccountsStore } from "../../derived/sns/sns-project-accounts.derived";
+  import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 
   // TODO: Support adding subaccounts
   let modal: "NewTransaction" | undefined = undefined;
@@ -12,7 +12,7 @@
 </script>
 
 {#if modal === "NewTransaction"}
-  <IcpTransactionModal on:nnsClose={closeModal} />
+  <SnsTransactionModal on:nnsClose={closeModal} />
 {/if}
 
 {#if $snsProjectAccountsStore !== undefined}

--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { i18n } from "../../stores/i18n";
+  import { Toolbar } from "@dfinity/gix-components";
+  import Footer from "../common/Footer.svelte";
+  import IcpTransactionModal from "../../modals/accounts/IcpTransactionModal.svelte";
+  import { snsProjectAccountsStore } from "../../derived/sns/sns-project-accounts.derived";
+
+  // TODO: Support adding subaccounts
+  let modal: "NewTransaction" | undefined = undefined;
+  const openNewTransaction = () => (modal = "NewTransaction");
+  const closeModal = () => (modal = undefined);
+</script>
+
+{#if modal === "NewTransaction"}
+  <IcpTransactionModal on:nnsClose={closeModal} />
+{/if}
+
+{#if $snsProjectAccountsStore !== undefined}
+  <Footer>
+    <Toolbar>
+      <button
+        class="primary full-width"
+        on:click={openNewTransaction}
+        data-tid="open-new-sns-transaction"
+        >{$i18n.accounts.new_transaction}</button
+      >
+    </Toolbar>
+  </Footer>
+{/if}

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -2,8 +2,8 @@
  * A derived store that returns the accounts as an array of accounts.
  */
 
-import { isNnsProjectStore } from "$lib/selected-project.derived";
-import { snsProjectAccountsStore } from "$lib/sns/sns-project-accounts.derived";
+import { isNnsProjectStore } from "$lib/derived/selected-project.derived";
+import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { derived } from "svelte/store";
 

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -2,19 +2,19 @@
  * A derived store that returns the accounts as an array of accounts.
  */
 
-import { isNnsProjectStore } from "$lib/derived/selected-project.derived";
-import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { derived } from "svelte/store";
+import { isNnsProjectStore } from "./selected-project.derived";
+import { snsProjectAccountsStore } from "./sns/sns-project-accounts.derived";
 
 export const accountsListStore = derived(
   [accountsStore, isNnsProjectStore, snsProjectAccountsStore],
-  ([{ main, subAccounts, hardwareWallets }, isNns, projectAccounts]) => {
+  ([{ main, subAccounts, hardwareWallets }, isNns, snsAccounts]) => {
     if (isNns) {
       return main === undefined
         ? []
         : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])];
     }
-    return projectAccounts ?? [];
+    return snsAccounts ?? [];
   }
 );

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -3,11 +3,15 @@
  */
 
 import { accountsStore } from "$lib/stores/accounts.store";
-import { derived } from "svelte/store";
+import type { Account } from "$lib/types/account";
+import { derived, type Readable } from "svelte/store";
 import { isNnsProjectStore } from "./selected-project.derived";
 import { snsProjectAccountsStore } from "./sns/sns-project-accounts.derived";
 
-export const accountsListStore = derived(
+/**
+ * Returns the accounts of the project matching the context.
+ */
+export const accountsSelectedProjectStore: Readable<Account[]> = derived(
   [accountsStore, isNnsProjectStore, snsProjectAccountsStore],
   ([{ main, subAccounts, hardwareWallets }, isNns, snsAccounts]) => {
     if (isNns) {

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -2,13 +2,19 @@
  * A derived store that returns the accounts as an array of accounts.
  */
 
+import { isNnsProjectStore } from "$lib/selected-project.derived";
+import { snsProjectAccountsStore } from "$lib/sns/sns-project-accounts.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { derived } from "svelte/store";
 
 export const accountsListStore = derived(
-  accountsStore,
-  ({ main, subAccounts, hardwareWallets }) =>
-    main === undefined
-      ? []
-      : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])]
+  [accountsStore, isNnsProjectStore, snsProjectAccountsStore],
+  ([{ main, subAccounts, hardwareWallets }, isNns, projectAccounts]) => {
+    if (isNns) {
+      return main === undefined
+        ? []
+        : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])];
+    }
+    return projectAccounts ?? [];
+  }
 );

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -8,17 +8,19 @@ import { derived, type Readable } from "svelte/store";
 import { isNnsProjectStore } from "./selected-project.derived";
 import { snsProjectAccountsStore } from "./sns/sns-project-accounts.derived";
 
+export const nnsAccountsListStore: Readable<Account[]> = derived(
+  accountsStore,
+  ({ main, subAccounts, hardwareWallets }) =>
+    main === undefined
+      ? []
+      : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])]
+);
+
 /**
  * Returns the accounts of the project matching the context.
  */
 export const accountsSelectedProjectStore: Readable<Account[]> = derived(
-  [accountsStore, isNnsProjectStore, snsProjectAccountsStore],
-  ([{ main, subAccounts, hardwareWallets }, isNns, snsAccounts]) => {
-    if (isNns) {
-      return main === undefined
-        ? []
-        : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])];
-    }
-    return snsAccounts ?? [];
-  }
+  [nnsAccountsListStore, isNnsProjectStore, snsProjectAccountsStore],
+  ([nnsAccounts, isNns, snsAccounts]) =>
+    isNns ? nnsAccounts : snsAccounts ?? []
 );

--- a/frontend/src/lib/derived/selected-project.derived.ts
+++ b/frontend/src/lib/derived/selected-project.derived.ts
@@ -11,7 +11,7 @@ import { derived, type Readable } from "svelte/store";
  * The store reads the routeStore and returns the context.
  * It defaults to NNS (OWN_CANISTER_ID) if the path is not a context path.
  */
-export const snsProjectSelectedStore = derived([routeStore], ([{ path }]) => {
+export const snsProjectSelectedStore = derived(routeStore, ({ path }) => {
   const maybeContextId = getContextFromPath(path);
   if (maybeContextId !== undefined) {
     try {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -135,6 +135,7 @@
     "balance": "Balance",
     "new_transaction": "New Transaction",
     "icp_transaction_description": "ICP Transaction",
+    "sns_transaction_description": "$token Transaction",
     "review_action": "Review",
     "add_account": "Add Account",
     "new_linked_title": "New Linked Account",

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionReview.svelte
@@ -25,7 +25,7 @@
   $: tokenAmount = TokenAmount.fromNumber({
     amount,
     token,
-  }) as TokenAmount;
+  });
 
   const dispatcher = createEventDispatcher();
   const submit = () => {

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { createEventDispatcher } from "svelte";
+  import { startBusy, stopBusy } from "../../stores/busy.store";
+  import { i18n } from "../../stores/i18n";
+  import type { Step } from "../../stores/steps.state";
+  import { toastsSuccess } from "../../stores/toasts.store";
+  import type { NewTransaction } from "../../types/transaction.context";
+  import TransactionModal from "./NewTransaction/TransactionModal.svelte";
+
+  let currentStep: Step;
+
+  $: title =
+    currentStep?.name === "Form"
+      ? $i18n.accounts.new_transaction
+      : $i18n.accounts.review_transaction;
+
+  const dispatcher = createEventDispatcher();
+  const transfer = async ({
+    detail: { sourceAccount, amount, destinationAddress },
+  }: CustomEvent<NewTransaction>) => {
+    startBusy({
+      initiator: "accounts",
+    });
+
+    // Errors in amount already handled by TransactionModal
+    const tokenAmount = TokenAmount.fromNumber({
+      amount,
+      token: ICPToken,
+    });
+
+    console.log("transfer", sourceAccount, destinationAddress, tokenAmount);
+
+    // if (success) {
+    //   toastsSuccess({ labelKey: "accounts.transaction_success" });
+    // }
+
+    stopBusy("accounts");
+
+    // // We close the modal in case of success or error if the selected source is not a hardware wallet.
+    // // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
+    // if (success || !isAccountHardwareWallet(sourceAccount)) {
+    //   dispatcher("nnsClose");
+    // }
+  };
+</script>
+
+<TransactionModal on:nnsSubmit={transfer} on:nnsClose bind:currentStep>
+  <svelte:fragment slot="title"
+    >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+  >
+  <p slot="description">
+    {$i18n.accounts.icp_transaction_description}
+  </p>
+</TransactionModal>

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -12,6 +12,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
   import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { numberToE8s } from "$lib/utils/icp.utils";
 
   let currentStep: Step;
 
@@ -28,16 +29,10 @@
       initiator: "accounts",
     });
 
-    // Errors in amount already handled by TransactionModal
-    const tokenAmount = TokenAmount.fromNumber({
-      amount,
-      token: ICPToken,
-    });
-
     const { success } = await snsTransferTokens({
       source: sourceAccount,
       destinationAddress,
-      amount: tokenAmount,
+      e8s: numberToE8s(amount),
       rootCanisterId: $snsProjectSelectedStore,
     });
 

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -7,6 +7,9 @@
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import type { NewTransaction } from "$lib/types/transaction.context";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
+  import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
+  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   let currentStep: Step;
 
@@ -45,11 +48,19 @@
   };
 </script>
 
-<TransactionModal on:nnsSubmit={transfer} on:nnsClose bind:currentStep>
+<TransactionModal
+  on:nnsSubmit={transfer}
+  on:nnsClose
+  bind:currentStep
+  token={$snsTokenSymbolSelectedStore}
+  transactionFee={$snsSelectedTransactionFeeStore}
+>
   <svelte:fragment slot="title"
     >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
   >
   <p slot="description">
-    {$i18n.accounts.icp_transaction_description}
+    {replacePlaceholders($i18n.accounts.sns_transaction_description, {
+      $token: $snsTokenSymbolSelectedStore?.symbol ?? "",
+    })}
   </p>
 </TransactionModal>

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -10,6 +10,8 @@
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { snsTransferTokens } from "$lib/services/sns-accounts.services";
+  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
 
   let currentStep: Step;
 
@@ -32,19 +34,19 @@
       token: ICPToken,
     });
 
-    console.log("transfer", sourceAccount, destinationAddress, tokenAmount);
-
-    // if (success) {
-    //   toastsSuccess({ labelKey: "accounts.transaction_success" });
-    // }
+    const { success } = await snsTransferTokens({
+      source: sourceAccount,
+      destinationAddress,
+      amount: tokenAmount,
+      rootCanisterId: $snsProjectSelectedStore,
+    });
 
     stopBusy("accounts");
 
-    // // We close the modal in case of success or error if the selected source is not a hardware wallet.
-    // // In case of hardware wallet, the error messages might contain interesting information for the user such as "your device is idle"
-    // if (success || !isAccountHardwareWallet(sourceAccount)) {
-    //   dispatcher("nnsClose");
-    // }
+    if (success) {
+      toastsSuccess({ labelKey: "accounts.transaction_success" });
+      dispatcher("nnsClose");
+    }
   };
 </script>
 

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { ICPToken, TokenAmount } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
-  import { startBusy, stopBusy } from "../../stores/busy.store";
-  import { i18n } from "../../stores/i18n";
-  import type { Step } from "../../stores/steps.state";
-  import { toastsSuccess } from "../../stores/toasts.store";
-  import type { NewTransaction } from "../../types/transaction.context";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Step } from "$lib/stores/steps.state";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
+  import type { NewTransaction } from "$lib/types/transaction.context";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
 
   let currentStep: Step;

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { ICPToken, TokenAmount } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import type { Step } from "$lib/stores/steps.state";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import type { NewTransaction } from "$lib/types/transaction.context";
+  import type { NewTransaction } from "$lib/types/transaction";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import { onDestroy } from "svelte";
-  import {
-    routePathNeuronId,
-    loadNeuron,
-  } from "$lib/services/neurons.services";
+  import { loadNeuron } from "$lib/services/neurons.services";
   import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
   import NeuronHotkeysCard from "$lib/components/neuron-detail/NeuronHotkeysCard.svelte";
   import NeuronMaturityCard from "$lib/components/neuron-detail/NeuronMaturityCard.svelte";
@@ -21,6 +18,7 @@
     getNeuronById,
     isSpawning,
     neuronVoting,
+    routePathNeuronId,
   } from "$lib/utils/neuron.utils";
   import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
   import NeuronJoinFundCard from "$lib/components/neuron-detail/NeuronJoinFundCard.svelte";

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -4,10 +4,7 @@
   import { Toolbar } from "@dfinity/gix-components";
   import Footer from "$lib/components/common/Footer.svelte";
   import { routeStore } from "$lib/stores/route.store";
-  import {
-    getAccountTransactions,
-    routePathAccountIdentifier,
-  } from "$lib/services/accounts.services";
+  import { getAccountTransactions } from "$lib/services/accounts.services";
   import { accountsStore } from "$lib/stores/accounts.store";
   import { Spinner } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
@@ -23,7 +20,10 @@
     type SelectedAccountContext,
     type SelectedAccountStore,
   } from "$lib/types/selected-account.context";
-  import { getAccountFromStore } from "$lib/utils/accounts.utils";
+  import {
+    getAccountFromStore,
+    routePathAccountIdentifier,
+  } from "$lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "$lib/stores/debug.store";
   import { layoutBackStore } from "$lib/stores/layout.store";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -32,7 +32,7 @@
     AccountIdentifierString,
     Transaction,
   } from "$lib/canisters/nns-dapp/nns-dapp.types";
-  import { accountsListStore } from "$lib/derived/accounts-list.derived";
+  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
 
   const goBack = () =>
     routeStore.navigate({
@@ -77,7 +77,7 @@
   let selectedAccount: Account | undefined;
   $: selectedAccount = getAccountFromStore({
     identifier: routeAccountIdentifier?.accountIdentifier,
-    accounts: $accountsListStore,
+    accounts: $accountsSelectedProjectStore,
   });
 
   $: routeAccountIdentifier,

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -32,6 +32,7 @@
     AccountIdentifierString,
     Transaction,
   } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import { accountsListStore } from "$lib/derived/accounts-list.derived";
 
   const goBack = () =>
     routeStore.navigate({
@@ -76,7 +77,7 @@
   let selectedAccount: Account | undefined;
   $: selectedAccount = getAccountFromStore({
     identifier: routeAccountIdentifier?.accountIdentifier,
-    accountsStore: $accountsStore,
+    accounts: $accountsListStore,
   });
 
   $: routeAccountIdentifier,

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -8,7 +8,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { snsOnlyProjectStore } from "$lib/derived/selected-project.derived";
   import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
-  import { routePathAccountIdentifier } from "$lib/services/accounts.services";
+  import { routePathAccountIdentifier } from "$lib/utils/accounts.utils";
   import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
   import { debugSelectedAccountStore } from "$lib/stores/debug.store";
   import { routeStore } from "$lib/stores/route.store";

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -13,6 +13,7 @@
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
   import SelectProjectDropdownHeader from "$lib/components/ic/SelectProjectDropdownHeader.svelte";
+  import SnsAccountsFooter from "$lib/components/accounts/SnsAccountsFooter.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -42,4 +43,6 @@
 
 {#if $isNnsProjectStore}
   <NnsAccountsFooter />
+{:else}
+  <SnsAccountsFooter />
 {/if}

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -10,7 +10,6 @@ import type {
   Transaction,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
-import { AppPath } from "$lib/constants/routes.constants";
 import { accountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
@@ -23,7 +22,6 @@ import {
   getAccountByPrincipal,
   getAccountFromStore,
 } from "$lib/utils/accounts.utils";
-import { getLastPathDetail, isRoutePath } from "$lib/utils/app-path.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
@@ -122,32 +120,6 @@ const transferError = ({
   );
 
   return { success: false, err: labelKey };
-};
-
-/**
- * @param path current route path
- * @return an object containing either a valid account identifier or undefined if not provided for the wallet route or undefined if another route is currently accessed
- */
-export const routePathAccountIdentifier = (
-  path: string | undefined
-): { accountIdentifier: string | undefined } | undefined => {
-  if (
-    !isRoutePath({
-      paths: [AppPath.LegacyWallet, AppPath.Wallet],
-      routePath: path,
-    })
-  ) {
-    return undefined;
-  }
-
-  const accountIdentifier: string | undefined = getLastPathDetail(path);
-
-  return {
-    accountIdentifier:
-      accountIdentifier !== undefined && accountIdentifier !== ""
-        ? accountIdentifier
-        : undefined,
-  };
 };
 
 export const getAccountTransactions = async ({

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -10,7 +10,7 @@ import type {
   Transaction,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
-import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
+import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import type { AccountsStore } from "$lib/stores/accounts.store";
@@ -166,7 +166,7 @@ export const getAccountIdentity = async (
 ): Promise<Identity | LedgerIdentity> => {
   const account: Account | undefined = getAccountFromStore({
     identifier,
-    accounts: get(accountsSelectedProjectStore),
+    accounts: get(nnsAccountsListStore),
   });
 
   if (account?.type === "hardwareWallet") {

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -11,6 +11,7 @@ import type {
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { accountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import type { AccountsStore } from "$lib/stores/accounts.store";
@@ -193,7 +194,7 @@ export const getAccountIdentity = async (
 ): Promise<Identity | LedgerIdentity> => {
   const account: Account | undefined = getAccountFromStore({
     identifier,
-    accountsStore: get(accountsStore),
+    accounts: get(accountsListStore),
   });
 
   if (account?.type === "hardwareWallet") {

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -10,7 +10,7 @@ import type {
   Transaction,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
-import { accountsListStore } from "$lib/derived/accounts-list.derived";
+import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import type { AccountsStore } from "$lib/stores/accounts.store";
@@ -166,7 +166,7 @@ export const getAccountIdentity = async (
 ): Promise<Identity | LedgerIdentity> => {
   const account: Account | undefined = getAccountFromStore({
     identifier,
-    accounts: get(accountsListStore),
+    accounts: get(accountsSelectedProjectStore),
   });
 
   if (account?.type === "hardwareWallet") {

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -24,7 +24,6 @@ import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { MIN_VERSION_MERGE_MATURITY } from "$lib/constants/neurons.constants";
-import { AppPath } from "$lib/constants/routes.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -46,7 +45,6 @@ import {
   assertEnoughAccountFunds,
   isAccountHardwareWallet,
 } from "$lib/utils/accounts.utils";
-import { getLastPathDetailId, isRoutePath } from "$lib/utils/app-path.utils";
 import {
   errorToString,
   mapNeuronErrorToToastMessage,
@@ -986,16 +984,4 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     console.error(error);
     toastsShow(mapNeuronErrorToToastMessage(error));
   }
-};
-
-export const routePathNeuronId = (path: string): NeuronId | undefined => {
-  if (
-    !isRoutePath({
-      paths: [AppPath.LegacyNeuronDetail, AppPath.NeuronDetail],
-      routePath: path,
-    })
-  ) {
-    return undefined;
-  }
-  return getLastPathDetailId(path);
 };

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -4,7 +4,6 @@ import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
 import type { Identity } from "@dfinity/agent";
-import type { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
 import { getIdentity } from "./auth.services";
@@ -62,12 +61,12 @@ export const snsTransferTokens = async ({
   rootCanisterId,
   source,
   destinationAddress,
-  amount,
+  e8s,
 }: {
   rootCanisterId: Principal;
   source: Account;
   destinationAddress: string;
-  amount: TokenAmount;
+  e8s: bigint;
 }): Promise<{ success: boolean }> => {
   try {
     const identity: Identity = await getAccountIdentity(source);
@@ -77,7 +76,7 @@ export const snsTransferTokens = async ({
       identity,
       to,
       fromSubAccount: source.subAccount,
-      e8s: amount.toE8s(),
+      e8s,
       rootCanisterId,
     });
 

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -85,7 +85,9 @@ export const snsTransferTokens = async ({
 
     return { success: true };
   } catch (err) {
-    toToastError({ fallbackErrorLabelKey: "error.transaction_error", err });
+    toastsError(
+      toToastError({ fallbackErrorLabelKey: "error.transaction_error", err })
+    );
     return { success: false };
   }
 };

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -1,9 +1,13 @@
-import { getSnsAccounts } from "$lib/api/sns-ledger.api";
+import { getSnsAccounts, transfer } from "$lib/api/sns-ledger.api";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
+import type { Identity } from "@dfinity/agent";
+import type { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
+import { decodeSnsAccount } from "@dfinity/sns";
+import { getIdentity } from "./auth.services";
 import { loadSnsTransactionFee } from "./transaction-fees.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -45,4 +49,43 @@ export const syncSnsAccounts = async (rootCanisterId: Principal) => {
     loadSnsAccounts(rootCanisterId),
     loadSnsTransactionFee(rootCanisterId),
   ]);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getAccountIdentity = async (_: Account): Promise<Identity> => {
+  // TODO: Support Hardware Wallets
+  const identity = await getIdentity();
+  return identity;
+};
+
+export const snsTransferTokens = async ({
+  rootCanisterId,
+  source,
+  destinationAddress,
+  amount,
+}: {
+  rootCanisterId: Principal;
+  source: Account;
+  destinationAddress: string;
+  amount: TokenAmount;
+}): Promise<{ success: boolean }> => {
+  try {
+    const identity: Identity = await getAccountIdentity(source);
+    const to = decodeSnsAccount(destinationAddress);
+
+    await transfer({
+      identity,
+      to,
+      fromSubAccount: source.subAccount,
+      e8s: amount.toE8s(),
+      rootCanisterId,
+    });
+
+    await loadSnsAccounts(rootCanisterId);
+
+    return { success: true };
+  } catch (err) {
+    toToastError({ fallbackErrorLabelKey: "error.transaction_error", err });
+    return { success: false };
+  }
 };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -144,6 +144,7 @@ interface I18nAccounts {
   balance: string;
   new_transaction: string;
   icp_transaction_description: string;
+  sns_transaction_description: string;
   review_action: string;
   add_account: string;
   new_linked_title: string;

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -4,6 +4,7 @@ import type { Account } from "$lib/types/account";
 import { InsufficientAmountError } from "$lib/types/common.errors";
 import { checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { decodeSnsAccount } from "@dfinity/sns";
 import { getLastPathDetail, isRoutePath } from "./app-path.utils";
 
 /*
@@ -38,7 +39,16 @@ export const invalidAddress = (address: string | undefined): boolean => {
     checkAccountId(address);
     return false;
   } catch (_) {
-    return true;
+    try {
+      // It might also be an SNS address
+      decodeSnsAccount(address);
+      return false;
+    } catch {
+      _;
+    }
+    {
+      return true;
+    }
   }
 };
 

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -1,8 +1,10 @@
+import { AppPath } from "$lib/constants/routes.constants";
 import type { AccountsStore } from "$lib/stores/accounts.store";
 import type { Account } from "$lib/types/account";
 import { InsufficientAmountError } from "$lib/types/common.errors";
 import { checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { getLastPathDetail, isRoutePath } from "./app-path.utils";
 
 /*
  * Returns the principal's main or hardware account
@@ -101,4 +103,30 @@ export const assertEnoughAccountFunds = ({
  */
 export const mainAccount = (accounts: Account[]): Account | undefined => {
   return accounts.find((account) => account.type === "main");
+};
+
+/*
+ * @param path current route path
+ * @return an object containing either a valid account identifier or undefined if not provided for the wallet route or undefined if another route is currently accessed
+ */
+export const routePathAccountIdentifier = (
+  path: string | undefined
+): { accountIdentifier: string | undefined } | undefined => {
+  if (
+    !isRoutePath({
+      paths: [AppPath.LegacyWallet, AppPath.Wallet],
+      routePath: path,
+    })
+  ) {
+    return undefined;
+  }
+
+  const accountIdentifier: string | undefined = getLastPathDetail(path);
+
+  return {
+    accountIdentifier:
+      accountIdentifier !== undefined && accountIdentifier !== ""
+        ? accountIdentifier
+        : undefined,
+  };
 };

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -40,6 +40,7 @@ export const invalidAddress = (address: string | undefined): boolean => {
     return false;
   } catch (_) {
     try {
+      // TODO: Find a better solution to check if the address is valid for SNS as well.
       // It might also be an SNS address
       decodeSnsAccount(address);
       return false;

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -67,30 +67,16 @@ export const isAccountHardwareWallet = (
 
 export const getAccountFromStore = ({
   identifier,
-  accountsStore: { main, subAccounts, hardwareWallets },
+  accounts,
 }: {
   identifier: string | undefined;
-  accountsStore: AccountsStore;
+  accounts: Account[];
 }): Account | undefined => {
   if (identifier === undefined) {
     return undefined;
   }
 
-  if (main?.identifier === identifier) {
-    return main;
-  }
-
-  const subAccount: Account | undefined = subAccounts?.find(
-    (account: Account) => account.identifier === identifier
-  );
-
-  if (subAccount !== undefined) {
-    return subAccount;
-  }
-
-  return hardwareWallets?.find(
-    (account: Account) => account.identifier === identifier
-  );
+  return accounts.find(({ identifier: id }) => id === identifier);
 };
 
 /**

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -1,7 +1,7 @@
 import { ENABLE_SNS, ENABLE_SNS_2 } from "$lib/constants/environment.constants";
 import { AppPath, CONTEXT_PATH } from "$lib/constants/routes.constants";
-import { routePathAccountIdentifier } from "$lib/services/accounts.services";
-import { routePathNeuronId } from "$lib/services/neurons.services";
+import { routePathAccountIdentifier } from "$lib/utils/accounts.utils";
+import { routePathNeuronId } from "$lib/utils/neuron.utils";
 
 const IDENTIFIER_REGEX = "[a-zA-Z0-9-]+";
 

--- a/frontend/src/lib/utils/icp.utils.ts
+++ b/frontend/src/lib/utils/icp.utils.ts
@@ -121,3 +121,6 @@ export const convertTCyclesToIcpNumber = ({
   tCycles: number;
   exchangeRate: bigint;
 }): number => tCycles / (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);
+
+export const numberToE8s = (amount: number): bigint =>
+  BigInt(Math.floor(amount * E8S_PER_ICP));

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -12,6 +12,7 @@ import {
   MIN_NEURON_STAKE,
   SPAWN_VARIANCE_PERCENTAGE,
 } from "$lib/constants/neurons.constants";
+import { AppPath } from "$lib/constants/routes.constants";
 import type { AccountsStore } from "$lib/stores/accounts.store";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { Step } from "$lib/stores/steps.state";
@@ -42,6 +43,7 @@ import {
   getAccountByPrincipal,
   isAccountHardwareWallet,
 } from "./accounts.utils";
+import { getLastPathDetailId, isRoutePath } from "./app-path.utils";
 import { nowInSeconds } from "./date.utils";
 import { enumValues } from "./enum.utils";
 import { formatNumber } from "./format.utils";
@@ -734,4 +736,16 @@ export const validTopUpAmount = ({
   const amountE8s = BigInt(Math.floor(amount * E8S_PER_ICP));
   const neuronStakeE8s = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
   return amountE8s + neuronStakeE8s > MIN_NEURON_STAKE;
+};
+
+export const routePathNeuronId = (path: string): NeuronId | undefined => {
+  if (
+    !isRoutePath({
+      paths: [AppPath.LegacyNeuronDetail, AppPath.NeuronDetail],
+      routePath: path,
+    })
+  ) {
+    return undefined;
+  }
+  return getLastPathDetailId(path);
 };

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -1,4 +1,8 @@
-import { getSnsAccounts, transactionFee } from "$lib/api/sns-ledger.api";
+import {
+  getSnsAccounts,
+  transactionFee,
+  transfer,
+} from "$lib/api/sns-ledger.api";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import { mockQueryTokenResponse } from "../../mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
@@ -8,6 +12,7 @@ const mainBalance = BigInt(10_000_000);
 const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
 const fee = BigInt(10_000);
 const transactionFeeSpy = jest.fn().mockResolvedValue(fee);
+const transferSpy = jest.fn().mockResolvedValue(BigInt(10));
 
 let metadataReturn = mockQueryTokenResponse;
 const setMetadataError = () => (metadataReturn = []);
@@ -21,6 +26,7 @@ jest.mock("$lib/api/sns-wrapper.api", () => {
       balance: balanceSpy,
       ledgerMetadata: metadataSpy,
       transactionFee: transactionFeeSpy,
+      transfer: transferSpy,
     }),
   };
 });
@@ -71,6 +77,19 @@ describe("sns-ledger api", () => {
 
       expect(actualFee).toBe(fee);
       expect(transactionFeeSpy).toBeCalled();
+    });
+  });
+
+  describe("transfer", () => {
+    it("successfully calls transfer api", async () => {
+      await transfer({
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+        to: { owner: mockIdentity.getPrincipal() },
+        e8s: BigInt(10_000_000),
+      });
+
+      expect(transferSpy).toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -2,7 +2,10 @@
  * @jest-environment jsdom
  */
 import { AppPath, CONTEXT_PATH } from "$lib/constants/routes.constants";
-import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
+import {
+  accountsSelectedProjectStore,
+  nnsAccountsListStore,
+} from "$lib/derived/accounts-list.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { routeStore } from "$lib/stores/route.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
@@ -12,32 +15,47 @@ import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 
 describe("accounts", () => {
-  it("should return empty array if main is not set", () => {
-    accountsStore.reset();
-    const value = get(accountsSelectedProjectStore);
-    expect(value.length).toBe(0);
+  describe("nnsAccountsListStore", () => {
+    it("returns nns accounts in an array", () => {
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSnsMainAccount],
+        hardwareWallets: [],
+      });
+
+      const accounts = get(nnsAccountsListStore);
+      expect(accounts).toEqual([mockMainAccount, mockSnsMainAccount]);
+    });
   });
 
-  it("should return the accounts of the nns", () => {
-    routeStore.update({ path: AppPath.LegacyAccounts });
-    accountsStore.set({ main: mockMainAccount });
-
-    const value = get(accountsSelectedProjectStore);
-    expect(value[0]).toEqual(mockMainAccount);
-  });
-
-  it("should return the accounts of the selected sns", () => {
-    const principalString = "aaaaa-aa";
-    routeStore.update({
-      path: `${CONTEXT_PATH}/${principalString}/neuron/12344`,
+  describe("accountsSelectedProjectStore", () => {
+    it("should return empty array if main is not set", () => {
+      accountsStore.reset();
+      const value = get(accountsSelectedProjectStore);
+      expect(value.length).toBe(0);
     });
-    accountsStore.set({ main: mockMainAccount });
-    snsAccountsStore.setAccounts({
-      rootCanisterId: Principal.fromText(principalString),
-      certified: true,
-      accounts: [mockSnsMainAccount],
+
+    it("should return the accounts of the nns", () => {
+      routeStore.update({ path: AppPath.LegacyAccounts });
+      accountsStore.set({ main: mockMainAccount });
+
+      const value = get(accountsSelectedProjectStore);
+      expect(value[0]).toEqual(mockMainAccount);
     });
-    const value = get(accountsSelectedProjectStore);
-    expect(value[0]).toEqual(mockSnsMainAccount);
+
+    it("should return the accounts of the selected sns", () => {
+      const principalString = "aaaaa-aa";
+      routeStore.update({
+        path: `${CONTEXT_PATH}/${principalString}/neuron/12344`,
+      });
+      accountsStore.set({ main: mockMainAccount });
+      snsAccountsStore.setAccounts({
+        rootCanisterId: Principal.fromText(principalString),
+        certified: true,
+        accounts: [mockSnsMainAccount],
+      });
+      const value = get(accountsSelectedProjectStore);
+      expect(value[0]).toEqual(mockSnsMainAccount);
+    });
   });
 });

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { AppPath, CONTEXT_PATH } from "$lib/constants/routes.constants";
-import { accountsListStore } from "$lib/derived/accounts-list.derived";
+import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { routeStore } from "$lib/stores/route.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
@@ -14,7 +14,7 @@ import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 describe("accounts", () => {
   it("should return empty array if main is not set", () => {
     accountsStore.reset();
-    const value = get(accountsListStore);
+    const value = get(accountsSelectedProjectStore);
     expect(value.length).toBe(0);
   });
 
@@ -22,7 +22,7 @@ describe("accounts", () => {
     routeStore.update({ path: AppPath.LegacyAccounts });
     accountsStore.set({ main: mockMainAccount });
 
-    const value = get(accountsListStore);
+    const value = get(accountsSelectedProjectStore);
     expect(value[0]).toEqual(mockMainAccount);
   });
 
@@ -37,7 +37,7 @@ describe("accounts", () => {
       certified: true,
       accounts: [mockSnsMainAccount],
     });
-    const value = get(accountsListStore);
+    const value = get(accountsSelectedProjectStore);
     expect(value[0]).toEqual(mockSnsMainAccount);
   });
 });

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -1,11 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { AppPath, CONTEXT_PATH } from "$lib/constants/routes.constants";
 import { accountsListStore } from "$lib/derived/accounts-list.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
+import { routeStore } from "$lib/stores/route.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
+import { mockMainAccount } from "../../mocks/accounts.store.mock";
+import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 
 describe("accounts", () => {
   it("should return empty array if main is not set", () => {
     accountsStore.reset();
     const value = get(accountsListStore);
     expect(value.length).toBe(0);
+  });
+
+  it("should return the accounts of the nns", () => {
+    routeStore.update({ path: AppPath.LegacyAccounts });
+    accountsStore.set({ main: mockMainAccount });
+
+    const value = get(accountsListStore);
+    expect(value[0]).toEqual(mockMainAccount);
+  });
+
+  it("should return the accounts of the selected sns", () => {
+    const principalString = "aaaaa-aa";
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${principalString}/neuron/12344`,
+    });
+    accountsStore.set({ main: mockMainAccount });
+    snsAccountsStore.setAccounts({
+      rootCanisterId: Principal.fromText(principalString),
+      certified: true,
+      accounts: [mockSnsMainAccount],
+    });
+    const value = get(accountsListStore);
+    expect(value[0]).toEqual(mockSnsMainAccount);
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
+import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
+import { snsTransferTokens } from "$lib/services/sns-accounts.services";
+import { routeStore } from "$lib/stores/route.store";
+import { paths } from "$lib/utils/app-path.utils";
+import { fireEvent, waitFor } from "@testing-library/svelte";
+import { renderModal } from "../../../mocks/modal.mock";
+import {
+  mockSnsAccountsStoreSubscribe,
+  mockSnsMainAccount,
+} from "../../../mocks/sns-accounts.mock";
+
+jest.mock("$lib/services/sns-accounts.services", () => {
+  return {
+    snsTransferTokens: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+describe("SnsTransactionModal", () => {
+  const renderTransactionModal = () =>
+    renderModal({
+      component: SnsTransactionModal,
+      props: {},
+    });
+
+  beforeEach(() => {
+    jest
+      .spyOn(snsProjectAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe([mockSnsMainAccount]));
+
+    routeStore.update({ path: paths.accounts("aaaaa-aa") });
+  });
+
+  it("should transfer tokens", async () => {
+    const { queryAllByText, getByTestId, container } =
+      await renderTransactionModal();
+
+    await waitFor(() =>
+      expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+    const participateButton = getByTestId("transaction-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    // Enter amount
+    const icpAmount = "10";
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: icpAmount } });
+
+    // Enter valid destination address
+    const addressInput = container.querySelector(
+      "input[name='accounts-address']"
+    );
+    addressInput &&
+      fireEvent.input(addressInput, { target: { value: "aaaaa-aa" } });
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+
+    fireEvent.click(participateButton);
+
+    await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());
+    expect(queryAllByText(icpAmount, { exact: false }).length).toBeGreaterThan(
+      0
+    );
+
+    const confirmButton = getByTestId("transaction-button-execute");
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(snsTransferTokens).toBeCalled());
+  });
+});

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -7,7 +7,6 @@ import {
   getAccountIdentityByPrincipal,
   getAccountTransactions,
   renameSubAccount,
-  routePathAccountIdentifier,
   syncAccounts,
   transferICP,
 } from "$lib/services/accounts.services";
@@ -201,27 +200,6 @@ describe("accounts-services", () => {
       });
 
       spyToastError.mockClear();
-    });
-  });
-
-  describe("details", () => {
-    beforeAll(() => {
-      // Avoid to print errors during test
-      jest.spyOn(console, "error").mockImplementation(() => undefined);
-    });
-    afterAll(() => jest.clearAllMocks());
-
-    it("should get account identifier from valid path", () => {
-      expect(
-        routePathAccountIdentifier(`/#/wallet/${mockMainAccount.identifier}`)
-      ).toEqual({
-        accountIdentifier: mockMainAccount.identifier,
-      });
-    });
-
-    it("should not get account identifier from invalid path", () => {
-      expect(routePathAccountIdentifier("/#/wallet/")).toEqual(undefined);
-      expect(routePathAccountIdentifier(undefined)).toBeUndefined();
     });
   });
 

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import * as accountsApi from "$lib/api/accounts.api";
 import * as ledgerApi from "$lib/api/ledger.api";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initApp } from "$lib/services/app.services";
 import {

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { startBusyNeuron } from "$lib/services/busy.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import * as busyStore from "$lib/stores/busy.store";

--- a/frontend/src/tests/lib/services/dev.services.spec.ts
+++ b/frontend/src/tests/lib/services/dev.services.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { getICPs } from "$lib/services/dev.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { mockAccountsStoreSubscribe } from "../../mocks/accounts.store.mock";

--- a/frontend/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/ledger.services.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import * as api from "$lib/api/governance.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { LedgerConnectionState } from "$lib/constants/ledger.constants";
@@ -44,13 +47,13 @@ describe("ledger-services", () => {
     describe("success", () => {
       const mockLedgerIdentity: MockLedgerIdentity = new MockLedgerIdentity();
 
-      beforeAll(() =>
+      beforeAll(() => {
         jest
           .spyOn(LedgerIdentity, "create")
           .mockImplementation(
             async (): Promise<LedgerIdentity> => mockLedgerIdentity
-          )
-      );
+          );
+      });
 
       afterAll(() => {
         jest.clearAllMocks();
@@ -84,14 +87,14 @@ describe("ledger-services", () => {
         });
       });
 
-      it("should display a toast for the error assuming the user has cancelled the process", async () => {
+      it("should display a toast for the error assuming the browser is not supported", async () => {
         const spyToastError = jest.spyOn(toastsStore, "toastsError");
 
         await connectToHardwareWallet(callback);
 
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
-          labelKey: "error__ledger.access_denied",
+          labelKey: "error__ledger.browser_not_supported",
         });
 
         spyToastError.mockRestore();

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -37,7 +37,6 @@ const {
   addHotkey,
   addHotkeyForHardwareWalletNeuron,
   addFollowee,
-  routePathNeuronId,
   getIdentityOfControllerByNeuronId,
   toggleCommunityFund,
   listNeurons,
@@ -1329,26 +1328,6 @@ describe("neurons-services", () => {
         followee,
       });
       expect(spySetFollowees).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("details", () => {
-    beforeAll(() => {
-      // Avoid to print errors during test
-      jest.spyOn(console, "error").mockImplementation(() => undefined);
-    });
-    afterAll(() => jest.clearAllMocks());
-    it("should get neuronId from valid path", async () => {
-      expect(routePathNeuronId("/#/neuron/123")).toBe(BigInt(123));
-      expect(routePathNeuronId("/#/neuron/0")).toBe(BigInt(0));
-    });
-
-    it("should not get neuronId from invalid path", async () => {
-      expect(routePathNeuronId("/#/neuron/")).toBeUndefined();
-      expect(routePathNeuronId("/#/neuron/1.5")).toBeUndefined();
-      expect(routePathNeuronId("/#/neuron/123n")).toBeUndefined();
-      expect(routePathNeuronId("/#/neurons/")).toBeUndefined();
-      expect(routePathNeuronId("/#/accounts/")).toBeUndefined();
     });
   });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -96,6 +96,7 @@ jest.mock("$lib/proxy/ledger.services.proxy", () => {
 });
 
 describe("neurons-services", () => {
+  jest.spyOn(console, "error").mockImplementation(jest.fn);
   const notControlledNeuron = {
     ...mockNeuron,
     neuronId: BigInt(123),

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -3,7 +3,6 @@ import * as services from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { TokenAmount } from "@dfinity/nns";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
@@ -95,10 +94,7 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
-        amount: TokenAmount.fromE8s({
-          amount: BigInt(10_000_000),
-          token: { name: "test", symbol: "TST" },
-        }),
+        e8s: BigInt(10_000_000),
       });
 
       expect(success).toBe(true);
@@ -116,10 +112,7 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
-        amount: TokenAmount.fromE8s({
-          amount: BigInt(10_000_000),
-          token: { name: "test", symbol: "TST" },
-        }),
+        e8s: BigInt(10_000_000),
       });
 
       expect(success).toBe(false);

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/utils/accounts.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { encodeSnsAccount } from "@dfinity/sns";
 import {
   mockAddressInputInvalid,
   mockAddressInputValid,
@@ -62,6 +63,17 @@ describe("accounts-utils", () => {
     it("should be a valid address", () => {
       expect(invalidAddress(mockAddressInputValid)).toBeFalsy();
     });
+
+    it("should return false for sns accounts", () => {
+      const subaccount = new Uint8Array(32).fill(0);
+      subaccount[31] = 1;
+      const account = {
+        owner: Principal.fromText("2vxsx-fae"),
+        subaccount: subaccount,
+      };
+      const subaccountString = encodeSnsAccount(account);
+      expect(invalidAddress(subaccountString)).toBeFalsy();
+    });
   });
 
   describe("emptyAddress", () => {
@@ -107,20 +119,17 @@ describe("accounts-utils", () => {
   });
 
   describe("getAccountFromStore", () => {
-    const accountsStore = {
-      main: mockMainAccount,
-      subAccounts: [mockSubAccount],
-    };
+    const accounts = [mockMainAccount, mockSubAccount];
 
     it("should not return an account if no identifier is provided", () => {
       expect(
-        getAccountFromStore({ identifier: undefined, accountsStore })
+        getAccountFromStore({ identifier: undefined, accounts })
       ).toBeUndefined();
     });
 
     it("should find no account if not matches", () => {
       expect(
-        getAccountFromStore({ identifier: "aaa", accountsStore })
+        getAccountFromStore({ identifier: "aaa", accounts })
       ).toBeUndefined();
     });
 
@@ -128,13 +137,13 @@ describe("accounts-utils", () => {
       expect(
         getAccountFromStore({
           identifier: mockMainAccount.identifier,
-          accountsStore,
+          accounts,
         })
       ).toEqual(mockMainAccount);
       expect(
         getAccountFromStore({
           identifier: mockSubAccount.identifier,
-          accountsStore,
+          accounts,
         })
       ).toEqual(mockSubAccount);
     });

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   invalidAddress,
   isAccountHardwareWallet,
   mainAccount,
+  routePathAccountIdentifier,
 } from "$lib/utils/accounts.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -186,6 +187,27 @@ describe("accounts-utils", () => {
         mockSnsSubAccount,
       ];
       expect(mainAccount(accounts)).toEqual(mockSnsMainAccount);
+    });
+  });
+
+  describe("routePathAccountIdentifier", () => {
+    beforeAll(() => {
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterAll(() => jest.clearAllMocks());
+
+    it("should get account identifier from valid path", () => {
+      expect(
+        routePathAccountIdentifier(`/#/wallet/${mockMainAccount.identifier}`)
+      ).toEqual({
+        accountIdentifier: mockMainAccount.identifier,
+      });
+    });
+
+    it("should not get account identifier from invalid path", () => {
+      expect(routePathAccountIdentifier("/#/wallet/")).toEqual(undefined);
+      expect(routePathAccountIdentifier(undefined)).toBeUndefined();
     });
   });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -50,6 +50,7 @@ import {
   minNeuronSplittable,
   neuronCanBeSplit,
   neuronStake,
+  routePathNeuronId,
   sortNeuronsByCreatedTimestamp,
   topicsToFollow,
   userAuthorizedNeuron,
@@ -1741,6 +1742,26 @@ describe("neuron-utils", () => {
           amount: MIN_NEURON_STAKE / 2 / E8S_PER_ICP - 10,
         })
       ).toBe(false);
+    });
+  });
+
+  describe("routePathNeuronId", () => {
+    beforeAll(() => {
+      // Avoid to print errors during test
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterAll(() => jest.clearAllMocks());
+    it("should get neuronId from valid path", async () => {
+      expect(routePathNeuronId("/#/neuron/123")).toBe(BigInt(123));
+      expect(routePathNeuronId("/#/neuron/0")).toBe(BigInt(0));
+    });
+
+    it("should not get neuronId from invalid path", async () => {
+      expect(routePathNeuronId("/#/neuron/")).toBeUndefined();
+      expect(routePathNeuronId("/#/neuron/1.5")).toBeUndefined();
+      expect(routePathNeuronId("/#/neuron/123n")).toBeUndefined();
+      expect(routePathNeuronId("/#/neurons/")).toBeUndefined();
+      expect(routePathNeuronId("/#/accounts/")).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User can transfer SNS tokens.

# Changes

* New modal SnsTransactionModal.
* New sns accounts service to transfer tokens.
* New sns ledger api function to transfer tokens.
* Add support for SNS accounts in helper "invalidAddress".
* accountsListStore returns the list of accounts of the context account.
* getAccountFromStore expect an array of acconts instead of the type of NNS Accounts Store.
* New SnsAccountsFooter that renders SnsTransactionModal in Accounts route.
* Moved routePathNeuronId from services to utils to avoid cycle dependency.
* Moved routePathAccountIdentifier from services to utils to avoid cycle dependency.

# Tests

* Test new modal.
* Test new sns account service.
* Test new sns ledger api function.
* Test new functionality in Accounts route to open SnsTransactionModal.
* Add test cases to invalidAddress.
* Moved according tests from services to utils.
* Fix broken tests.
* Add test cases to accountsListStore.
