### PR TITLE
Fix: i18n script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build:csp": "node scripts/build.csp.mjs",
-    "i18n": "node scripts/i18n.types.js",
+    "i18n": "node --experimental-json-modules scripts/i18n.types.js",
     "dev": "vite dev",
     "build": "vite build && npm run build:csp",
     "preview": "vite preview",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build:csp": "node scripts/build.csp.mjs",
     "i18n": "node --experimental-json-modules scripts/i18n.types.js",
-    "dev": "vite dev",
-    "build": "vite build && npm run build:csp",
+    "dev": "npm run i18n && vite dev",
+    "build": "npm run i18n && vite build && npm run build:csp",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/frontend/scripts/i18n.types.js
+++ b/frontend/scripts/i18n.types.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-const { writeFileSync } = require("fs");
-const prettier = require("prettier");
-
-const en = require("../src/lib/i18n/en.json");
-const en_governance = require("../src/lib/i18n/en.governance.json");
+import { writeFileSync } from "fs";
+import prettier from "prettier";
+import en_governance from "../src/lib/i18n/en.governance.json" assert { type: "json" };
+import en from "../src/lib/i18n/en.json" assert { type: "json" };
 
 const mapKeys = (entries) =>
   Object.keys(entries).map((key) => {

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -101,6 +101,7 @@ export const makeDummyProposals = async ({
 
   const dummyProposalsScriptPath = "/assets/libs/dummy-proposals.utils.js";
   const { makeDummyProposals: makeProposals } = await import(
+    /* @vite-ignore */
     dummyProposalsScriptPath
   );
 


### PR DESCRIPTION
# Motivation

Script that creates i18n key types was not working.

There was a warning from Vite.

# Changes

* Add a comment for Vite to ignore a dynamic import.
* Fix i18n script.

# Tests

Not applicable
