### PR TITLE
FIx: Import module not found in VS Code

### DIFF
--- a/frontend/src/tests/tsconfig.json
+++ b/frontend/src/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.spec.json"
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true
   },
   "exclude": [
+    "**/*.spec.ts",
     "jest.setup.ts",
     "**/*.mock.ts",
     "**/*Test.svelte",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,9 +11,10 @@
     "strict": true
   },
   "exclude": [
-    "**/*.spec.ts",
     "jest.setup.ts",
     "**/*.mock.ts",
-    "**/*Test.svelte"
+    "**/*Test.svelte",
+    "svelte/**/*",
+    "public/**/*"
   ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,8 +14,6 @@
     "**/*.spec.ts",
     "jest.setup.ts",
     "**/*.mock.ts",
-    "**/*Test.svelte",
-    "svelte/**/*",
-    "public/**/*"
+    "**/*Test.svelte"
   ]
 }


### PR DESCRIPTION
# Motivation

There was an error in VS Code with test files that the module was not found.

# Changes

* Add tsconfig in `tests` folder.

# Tests

Not applicable.
