### PR TITLE
GIX-1070: Sns Transfer from wallet page

### DIFF
--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -12,6 +12,9 @@
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
   import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
   import { numberToE8s } from "$lib/utils/icp.utils";
+  import type { Account } from "$lib/types/account";
+
+  export let selectedAccount: Account | undefined = undefined;
 
   let currentStep: Step;
 
@@ -50,6 +53,7 @@
   bind:currentStep
   token={$snsTokenSymbolSelectedStore}
   transactionFee={$snsSelectedTransactionFeeStore}
+  sourceAccount={selectedAccount}
 >
   <svelte:fragment slot="title"
     >{title ?? $i18n.accounts.new_transaction}</svelte:fragment

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Spinner } from "@dfinity/gix-components";
+  import { Spinner, Toolbar } from "@dfinity/gix-components";
   import { onMount } from "svelte";
   import { onDestroy, setContext } from "svelte/internal";
   import { writable, type Unsubscriber } from "svelte/store";
@@ -17,6 +17,10 @@
     type SelectedAccountContext,
     type SelectedAccountStore,
   } from "$lib/types/selected-account.context";
+  import Footer from "$lib/components/common/Footer.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { busy } from "$lib/stores/busy.store";
+  import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -24,6 +28,8 @@
       routeStore.update({ path: AppPath.LegacyAccounts });
     }
   });
+
+  let showNewTransactionModal = false;
 
   const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
     async (selectedProjectCanisterId) => {
@@ -76,3 +82,22 @@
     {/if}
   </section>
 </main>
+
+<Footer>
+  <Toolbar>
+    <button
+      class="primary"
+      on:click={() => (showNewTransactionModal = true)}
+      disabled={$selectedAccountStore.account === undefined || $busy}
+      data-tid="open-new-sns-transaction"
+      >{$i18n.accounts.new_transaction}</button
+    >
+  </Toolbar>
+</Footer>
+
+{#if showNewTransactionModal}
+  <SnsTransactionModal
+    on:nnsClose={() => (showNewTransactionModal = false)}
+    selectedAccount={$selectedAccountStore.account}
+  />
+{/if}

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -6,6 +6,7 @@ import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.d
 import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 import { snsTransferTokens } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
+import type { Account } from "$lib/types/account";
 import { paths } from "$lib/utils/app-path.utils";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 import { renderModal } from "../../../mocks/modal.mock";
@@ -21,10 +22,12 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 });
 
 describe("SnsTransactionModal", () => {
-  const renderTransactionModal = () =>
+  const renderTransactionModal = (selectedAccount?: Account) =>
     renderModal({
       component: SnsTransactionModal,
-      props: {},
+      props: {
+        selectedAccount,
+      },
     });
 
   beforeEach(() => {
@@ -71,5 +74,14 @@ describe("SnsTransactionModal", () => {
     fireEvent.click(confirmButton);
 
     await waitFor(() => expect(snsTransferTokens).toBeCalled());
+  });
+
+  it("should not render the select account dropdown if selected account is passed", async () => {
+    const { queryByTestId } = await renderTransactionModal(mockSnsMainAccount);
+
+    await waitFor(() =>
+      expect(queryByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+    expect(queryByTestId("select-account-dropdown")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -7,7 +7,7 @@ import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.d
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
-import { render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   mockSnsAccountsStoreSubscribe,
@@ -73,6 +73,23 @@ describe("SnsWallet", () => {
       await waitFor(() =>
         expect(queryByTestId("wallet-summary")).toBeInTheDocument()
       );
+    });
+
+    it("should open new transaction modal", async () => {
+      const { queryByTestId, getByTestId } = render(SnsWallet);
+
+      await waitFor(() =>
+        expect(queryByTestId("open-new-sns-transaction")).toBeInTheDocument()
+      );
+
+      const button = getByTestId(
+        "open-new-sns-transaction"
+      ) as HTMLButtonElement;
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(getByTestId("transaction-step-1")).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

User can make sns transactions from the wallet page.

# Changes

* Add "New Transaction" button to SnsWallet page.
* Add selectedAccount prop to SnsTransactionModal.

# Tests

* Add test for new functionality in SnsWallet page.
* Add test for new prop in SnsTransactionModal
