### PR TITLE
chore: SNS index canister

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -305,7 +305,7 @@ if test -n "${DEPLOY_SNS_WASM_CANISTER:-}"; then
     SNS_WASM_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-sns-wasm)"
     echo "SNS wasm/management canister installed at: $SNS_WASM_CANISTER_ID"
     echo "Uploading wasms to the wasm canister"
-    for canister in root governance ledger swap archive; do
+    for canister in root governance ledger swap archive index; do
       ./target/ic/sns add-sns-wasm-for-tests \
         --network "$DFX_NETWORK" \
         --override-sns-wasm-canister-id-for-tests "${SNS_WASM_CANISTER_ID}" \

--- a/dfx.json
+++ b/dfx.json
@@ -68,6 +68,14 @@
       "wasm": "target/ic/ic-icrc1-archive.wasm",
       "type": "custom"
     },
+    "sns_index": {
+      "build": [
+        "true"
+      ],
+      "candid": "target/ic/ic-icrc1-index.did",
+      "wasm": "target/ic/ic-icrc1-index.wasm",
+      "type": "custom"
+    },
     "sns_swap": {
       "build": [
         "true"

--- a/dfx.json
+++ b/dfx.json
@@ -230,7 +230,7 @@
       "config": {
         "RUSTC_VERSION": "1.63.0",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
-        "IC_COMMIT": "18dc31ca64a4ead42c5d4222e647dce7124eb90e"
+        "IC_COMMIT": "10c0341032ac00c9728ecefa1e82e919f0f09022"
       },
       "packtool": ""
     }

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -120,6 +120,7 @@ get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
 get_wasm ledger-canister_notify-method.wasm
 get_wasm ic-icrc1-archive.wasm
+get_wasm ic-icrc1-index.wasm
 get_wasm ic-icrc1-ledger.wasm
 get_wasm ic-ckbtc-minter.wasm
 get_wasm root-canister.wasm

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -51,6 +51,7 @@ COPY --from=builder /ic/rs/nns/governance/canister/governance.did /governance.di
 COPY --from=builder /ic/rs/rosetta-api/ledger.did /ledger.private.did
 COPY --from=builder /ic/rs/rosetta-api/ledger_canister/ledger.did /ledger.did
 COPY --from=builder /ic/rs/rosetta-api/icrc1/ledger/icrc1.did /ic-icrc1-ledger.did
+COPY --from=builder /ic/rs/rosetta-api/icrc1/index/index.did /ic-icrc1-ledger-index.did
 COPY --from=builder /ic/rs/nns/gtc/canister/gtc.did /genesis_token.did
 COPY --from=builder /ic/rs/nns/cmc/cmc.did /cmc.did
 COPY --from=builder /ic/rs/nns/sns-wasm/canister/sns-wasm.did /sns_wasm.did


### PR DESCRIPTION
# Motivation
The latest SNS has an index canister.

# Changes
- Bump IC_COMMIT to get the latest SNS canister versions.
- Add the index canister to the set of SNS cansters listed in dfx.json
- Download the index canister wasm and did files
- Upload the index canister in deploy.sh

# Tests
None added.

I have confirmed that the wasm and did files are downloaded.