### PR TITLE
Fix: Node.js 12 actions deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   nns_canisters:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set-env
         run: ./build-config.sh >> $GITHUB_ENV
 
@@ -41,11 +41,11 @@ jobs:
 
       - name: Set up docker buildx
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build nns canisters
         if: steps.create_nns_canister_cache.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: e2e-tests/scripts
           file: e2e-tests/scripts/nns-canister.Dockerfile
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set-env
         run: ./build-config.sh >> $GITHUB_ENV
 
@@ -129,7 +129,7 @@ jobs:
           cp nns-dapp.wasm nns-dapp_local.wasm
 
       - name: 'Upload nns-dapp_local wasm module'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nns-dapp_local
           path: nns-dapp_local.wasm
@@ -176,7 +176,7 @@ jobs:
 
       - name: Archive wdio logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wdio-logs
           path: e2e-tests/wdio.log
@@ -196,7 +196,7 @@ jobs:
 #
       - name: Archive screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-screenshots
           path: screenshots/**/*.png

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt
@@ -82,7 +82,7 @@ jobs:
         os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/cache@v2
         with:
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
@@ -205,7 +205,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,16 +14,16 @@ jobs:
   builder:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # We use buildx and its GitHub Actions caching support `type=gha`. For
       # more information, see
       # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build base Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -42,12 +42,12 @@ jobs:
            DFX_NETWORK: "mainnet"
            OWN_CANISTER_ID: ""
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       # Build and upload testnet assets
       - name: Build ${{ matrix.DFX_NETWORK }} nns-dapp Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -58,12 +58,12 @@ jobs:
           # Exports the artefacts from the final stage
           outputs: ./${{ matrix.BUILD_NAME }}-out
       - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: NNS ${{ matrix.BUILD_NAME }} backend wasm module
           path: ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
       - name: 'Upload ${{ matrix.BUILD_NAME }} frontend assets'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: NNS ${{ matrix.BUILD_NAME }} frontend assets
           path: ${{ matrix.BUILD_NAME }}-out/assets.tar.xz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update II
         run: ./scripts/update-ii
       - name: Commit updated Internet Identity
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           # Note: The node version SHOULD match the dockerfile

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Tag main as tip
         run: |
           git tag -f tip


### PR DESCRIPTION
# Motivation

We have a warning in the Gibhub actions:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

# Changes

- Upgrade some of the node.js github actions.

# Tests

Not applicable
