### PR TITLE
chore: bump `EndBug/add-and-commit` GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
 # Disable screenshot saving until screenshots are stable.
 #      - name: Commit screenshots
 #        if: ${{ github.ref != 'refs/heads/main' }}
-#        uses: EndBug/add-and-commit@v7.4.0
+#        uses: EndBug/add-and-commit@v9.1.1
 #        with:
 #          add: e2e-tests/screenshots
 #          author_name: Screenshot Committer

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,7 @@ jobs:
         run: cat <<<$(jq . dfx.json) > dfx.json
 
       - name: Commit Formatting changes - will not trigger rebuild
-        uses: EndBug/add-and-commit@v7.2.0
+        uses: EndBug/add-and-commit@v9.1.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           add: .

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,7 +48,7 @@ jobs:
           git diff package-lock.json
         working-directory: e2e-tests
       - name: Commit updated chromedriver
-        uses: EndBug/add-and-commit@v7.2.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           add: .
           author_name: Nightly GitHub Action

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Update II
         run: ./scripts/update-ii
       - name: Commit updated Internet Identity
-        uses: EndBug/add-and-commit@v7.2.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           add: .
           author_name: Nightly GitHub Action


### PR DESCRIPTION
This avoids the CI warning about deprecated `node12` (for this action..., though others still trigger it).