### PR TITLE
Fix: Participation in Swap

### DIFF
--- a/frontend/src/lib/components/accounts/AddressInput.svelte
+++ b/frontend/src/lib/components/accounts/AddressInput.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-
-  import { ACCOUNT_ADDRESS_MIN_LENGTH } from "$lib/constants/accounts.constants";
   import { i18n } from "$lib/stores/i18n";
   import { invalidAddress } from "$lib/utils/accounts.utils";
 
@@ -24,7 +22,6 @@
   placeholderLabelKey="accounts.address"
   name="accounts-address"
   bind:value={address}
-  minLength={ACCOUNT_ADDRESS_MIN_LENGTH}
   errorMessage={showError ? $i18n.error.address_not_valid : undefined}
   on:blur={showErrorIfAny}><slot name="label" slot="label" /></InputWithError
 >

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -3,8 +3,8 @@
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import {
-    getAccountByProject,
-    getAccountsByProject,
+    getAccountByRootCanister,
+    getAccountsByRootCanister,
   } from "$lib/utils/accounts.utils";
   import Dropdown from "$lib/components/ui/Dropdown.svelte";
   import DropdownItem from "$lib/components/ui/DropdownItem.svelte";
@@ -19,18 +19,19 @@
   // To avoid cyclical dependencies, we don't update this if `selectedAccount` changes
   let selectedAccountIdentifier: string | undefined =
     selectedAccount?.identifier;
-  $: selectedAccount = getAccountByProject({
+  $: selectedAccount = getAccountByRootCanister({
     identifier: selectedAccountIdentifier,
     rootCanisterId,
     nnsAccounts: $nnsAccountsListStore,
     snsAccounts: $snsAccountsStore,
   });
 
-  $: selectableAccounts = getAccountsByProject({
-    rootCanisterId,
-    nnsAccounts: $nnsAccountsListStore,
-    snsAccounts: $snsAccountsStore,
-  }).filter(filterAccounts);
+  $: selectableAccounts =
+    getAccountsByRootCanister({
+      rootCanisterId,
+      nnsAccounts: $nnsAccountsListStore,
+      snsAccounts: $snsAccountsStore,
+    })?.filter(filterAccounts) ?? [];
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -1,24 +1,36 @@
 <script lang="ts">
-  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
+  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
-  import { getAccountFromStore } from "$lib/utils/accounts.utils";
+  import {
+    getAccountByProject,
+    getAccountsByProject,
+  } from "$lib/utils/accounts.utils";
   import Dropdown from "$lib/components/ui/Dropdown.svelte";
   import DropdownItem from "$lib/components/ui/DropdownItem.svelte";
+  import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+  import type { Principal } from "@dfinity/principal";
 
   export let selectedAccount: Account | undefined = undefined;
+  export let rootCanisterId: Principal;
   export let filterAccounts: (account: Account) => boolean = () => true;
 
   // In case the component is already initialized with a selectedAccount
   // To avoid cyclical dependencies, we don't update this if `selectedAccount` changes
   let selectedAccountIdentifier: string | undefined =
     selectedAccount?.identifier;
-  $: selectedAccount = getAccountFromStore({
+  $: selectedAccount = getAccountByProject({
     identifier: selectedAccountIdentifier,
-    accounts: $accountsSelectedProjectStore,
+    rootCanisterId,
+    nnsAccounts: $nnsAccountsListStore,
+    snsAccounts: $snsAccountsStore,
   });
 
-  $: selectableAccounts = $accountsSelectedProjectStore.filter(filterAccounts);
+  $: selectableAccounts = getAccountsByProject({
+    rootCanisterId,
+    nnsAccounts: $nnsAccountsListStore,
+    snsAccounts: $snsAccountsStore,
+  }).filter(filterAccounts);
 </script>
 
 {#if selectableAccounts.length === 0}

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -4,8 +4,8 @@
   import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
   import type { Account } from "$lib/types/account";
   import {
-    getAccountByProject,
-    getAccountsByProject,
+    getAccountByRootCanister,
+    getAccountsByRootCanister,
     invalidAddress,
   } from "$lib/utils/accounts.utils";
   import { Toggle } from "@dfinity/gix-components";
@@ -19,7 +19,7 @@
   export let showManualAddress = true;
 
   // If the component is already initialized with a selectedDestinationAddress
-  let selectedAccount: Account | undefined = getAccountByProject({
+  let selectedAccount: Account | undefined = getAccountByRootCanister({
     identifier: selectedDestinationAddress,
     rootCanisterId,
     nnsAccounts: $nnsAccountsListStore,
@@ -39,11 +39,11 @@
   // Show the toggle if there are more than one account to select from.
   let showToggle = true;
   $: showToggle =
-    getAccountsByProject({
+    (getAccountsByRootCanister({
       rootCanisterId,
       nnsAccounts: $nnsAccountsListStore,
       snsAccounts: $snsAccountsStore,
-    }).filter(filterAccounts).length > 0;
+    })?.filter(filterAccounts).length ?? 0) > 0;
 
   const onToggleManualInput = () => {
     showManualAddress = !showManualAddress;

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -1,23 +1,29 @@
 <script lang="ts">
-  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
+  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { i18n } from "$lib/stores/i18n";
+  import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
   import type { Account } from "$lib/types/account";
   import {
-    getAccountFromStore,
+    getAccountByProject,
+    getAccountsByProject,
     invalidAddress,
   } from "$lib/utils/accounts.utils";
   import { Toggle } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
   import AddressInput from "./AddressInput.svelte";
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
 
+  export let rootCanisterId: Principal;
   export let selectedDestinationAddress: string | undefined = undefined;
   export let filterAccounts: (account: Account) => boolean = () => true;
   export let showManualAddress = true;
 
   // If the component is already initialized with a selectedDestinationAddress
-  let selectedAccount: Account | undefined = getAccountFromStore({
+  let selectedAccount: Account | undefined = getAccountByProject({
     identifier: selectedDestinationAddress,
-    accounts: $accountsSelectedProjectStore,
+    rootCanisterId,
+    nnsAccounts: $nnsAccountsListStore,
+    snsAccounts: $snsAccountsStore,
   });
   let address: string;
   $: {
@@ -33,7 +39,11 @@
   // Show the toggle if there are more than one account to select from.
   let showToggle = true;
   $: showToggle =
-    $accountsSelectedProjectStore.filter(filterAccounts).length > 0;
+    getAccountsByProject({
+      rootCanisterId,
+      nnsAccounts: $nnsAccountsListStore,
+      snsAccounts: $snsAccountsStore,
+    }).filter(filterAccounts).length > 0;
 
   const onToggleManualInput = () => {
     showManualAddress = !showManualAddress;
@@ -60,7 +70,11 @@
   {#if showManualAddress}
     <AddressInput bind:address={selectedDestinationAddress} />
   {:else}
-    <SelectAccountDropdown {filterAccounts} bind:selectedAccount />
+    <SelectAccountDropdown
+      {rootCanisterId}
+      {filterAccounts}
+      bind:selectedAccount
+    />
   {/if}
 </div>
 

--- a/frontend/src/lib/constants/accounts.constants.ts
+++ b/frontend/src/lib/constants/accounts.constants.ts
@@ -1,3 +1,1 @@
-export const ACCOUNT_ADDRESS_MIN_LENGTH = 40;
-
 export const HARDWARE_WALLET_NAME_MIN_LENGTH = 2;

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -5,8 +5,6 @@
 import { accountsStore } from "$lib/stores/accounts.store";
 import type { Account } from "$lib/types/account";
 import { derived, type Readable } from "svelte/store";
-import { isNnsProjectStore } from "./selected-project.derived";
-import { snsProjectAccountsStore } from "./sns/sns-project-accounts.derived";
 
 export const nnsAccountsListStore: Readable<Account[]> = derived(
   accountsStore,
@@ -14,13 +12,4 @@ export const nnsAccountsListStore: Readable<Account[]> = derived(
     main === undefined
       ? []
       : [main, ...(subAccounts ?? []), ...(hardwareWallets ?? [])]
-);
-
-/**
- * Returns the accounts of the project matching the context.
- */
-export const accountsSelectedProjectStore: Readable<Account[]> = derived(
-  [nnsAccountsListStore, isNnsProjectStore, snsProjectAccountsStore],
-  ([nnsAccounts, isNns, snsAccounts]) =>
-    isNns ? nnsAccounts : snsAccounts ?? []
 );

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -9,6 +9,7 @@
   import type { NewTransaction } from "$lib/types/transaction";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -51,6 +52,7 @@
 </script>
 
 <TransactionModal
+  rootCanisterId={OWN_CANISTER_ID}
   on:nnsSubmit={transfer}
   on:nnsClose
   bind:currentStep

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -15,8 +15,10 @@
   import KeyValuePair from "$lib/components/ui/KeyValuePair.svelte";
   import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
   import { TokenAmount, type Token } from "@dfinity/nns";
+  import type { Principal } from "@dfinity/principal";
 
   // Tested in the TransactionModal
+  export let rootCanisterId: Principal;
   export let selectedAccount: Account | undefined = undefined;
   export let canSelectDestination: boolean;
   export let canSelectSource: boolean;
@@ -98,7 +100,7 @@
     {/if}
 
     {#if canSelectSource}
-      <SelectAccountDropdown bind:selectedAccount />
+      <SelectAccountDropdown {rootCanisterId} bind:selectedAccount />
     {:else}
       <div class="given-source">
         <p>
@@ -118,6 +120,7 @@
 
   {#if canSelectDestination}
     <SelectDestinationAddress
+      {rootCanisterId}
       filterAccounts={filterDestinationAccounts}
       bind:selectedDestinationAddress
       bind:showManualAddress

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -6,7 +6,9 @@
   import TransactionReview from "./TransactionReview.svelte";
   import { ICPToken, TokenAmount, type Token } from "@dfinity/nns";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
+  import type { Principal } from "@dfinity/principal";
 
+  export let rootCanisterId: Principal;
   export let currentStep: Step | undefined = undefined;
   export let destinationAddress: string | undefined = undefined;
   export let sourceAccount: Account | undefined = undefined;
@@ -55,6 +57,7 @@
   <slot name="title" slot="title" />
   {#if currentStep?.name === "Form"}
     <TransactionForm
+      {rootCanisterId}
       {canSelectDestination}
       {canSelectSource}
       {transactionFee}

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -48,6 +48,7 @@
 </script>
 
 <TransactionModal
+  rootCanisterId={$snsProjectSelectedStore}
   on:nnsSubmit={transfer}
   on:nnsClose
   bind:currentStep

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -10,6 +10,7 @@
   import { i18n } from "$lib/stores/i18n";
   import type { Step } from "$lib/stores/steps.state";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 
   export let neuron: NeuronInfo;
 
@@ -55,6 +56,7 @@
 <!-- That would be an edge case that would not happen becuase then the button won't even be there -->
 {#if neuron.fullNeuron?.accountIdentifier !== undefined}
   <TransactionModal
+    rootCanisterId={OWN_CANISTER_ID}
     on:nnsSubmit={topUp}
     on:nnsClose
     bind:currentStep

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -24,6 +24,7 @@
   import type { NewTransaction } from "$lib/types/transaction";
   import AdditionalInfoForm from "./AdditionalInfoForm.svelte";
   import AdditionalInfoReview from "./AdditionalInfoReview.svelte";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 
   const { store: projectDetailStore, reload } =
     getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
@@ -110,6 +111,7 @@
 <!-- Edge case. If it's not defined, button to open this modal is not shown -->
 {#if destinationAddress !== undefined}
   <TransactionModal
+    rootCanisterId={OWN_CANISTER_ID}
     bind:currentStep
     on:nnsClose
     on:nnsSubmit={participate}

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -32,7 +32,7 @@
     AccountIdentifierString,
     Transaction,
   } from "$lib/canisters/nns-dapp/nns-dapp.types";
-  import { accountsSelectedProjectStore } from "$lib/derived/accounts-list.derived";
+  import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 
   const goBack = () =>
     routeStore.navigate({
@@ -77,7 +77,7 @@
   let selectedAccount: Account | undefined;
   $: selectedAccount = getAccountFromStore({
     identifier: routeAccountIdentifier?.accountIdentifier,
-    accounts: $accountsSelectedProjectStore,
+    accounts: $nnsAccountsListStore,
   });
 
   $: routeAccountIdentifier,

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -1,11 +1,13 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import type { AccountsStore } from "$lib/stores/accounts.store";
+import type { SnsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { InsufficientAmountError } from "$lib/types/common.errors";
 import { checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
 import { getLastPathDetail, isRoutePath } from "./app-path.utils";
+import { isNnsProject } from "./projects.utils";
 
 /*
  * Returns the principal's main or hardware account
@@ -90,6 +92,50 @@ export const getAccountFromStore = ({
   }
 
   return accounts.find(({ identifier: id }) => id === identifier);
+};
+
+export const getAccountByProject = ({
+  identifier,
+  nnsAccounts,
+  snsAccounts,
+  rootCanisterId,
+}: {
+  identifier: string | undefined;
+  nnsAccounts: Account[];
+  snsAccounts: SnsAccountsStore;
+  rootCanisterId: Principal;
+}): Account | undefined => {
+  if (identifier === undefined) {
+    return undefined;
+  }
+
+  if (isNnsProject(rootCanisterId)) {
+    return getAccountFromStore({
+      identifier,
+      accounts: nnsAccounts,
+    });
+  }
+
+  return getAccountFromStore({
+    identifier,
+    accounts: snsAccounts[rootCanisterId.toText()]?.accounts ?? [],
+  });
+};
+
+export const getAccountsByProject = ({
+  nnsAccounts,
+  snsAccounts,
+  rootCanisterId,
+}: {
+  nnsAccounts: Account[];
+  snsAccounts: SnsAccountsStore;
+  rootCanisterId: Principal;
+}): Account[] => {
+  if (isNnsProject(rootCanisterId)) {
+    return nnsAccounts;
+  }
+
+  return snsAccounts[rootCanisterId.toText()]?.accounts ?? [];
 };
 
 /**

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -94,7 +94,7 @@ export const getAccountFromStore = ({
   return accounts.find(({ identifier: id }) => id === identifier);
 };
 
-export const getAccountByProject = ({
+export const getAccountByRootCanister = ({
   identifier,
   nnsAccounts,
   snsAccounts,
@@ -122,7 +122,7 @@ export const getAccountByProject = ({
   });
 };
 
-export const getAccountsByProject = ({
+export const getAccountsByRootCanister = ({
   nnsAccounts,
   snsAccounts,
   rootCanisterId,
@@ -130,12 +130,12 @@ export const getAccountsByProject = ({
   nnsAccounts: Account[];
   snsAccounts: SnsAccountsStore;
   rootCanisterId: Principal;
-}): Account[] => {
+}): Account[] | undefined => {
   if (isNnsProject(rootCanisterId)) {
     return nnsAccounts;
   }
 
-  return snsAccounts[rootCanisterId.toText()]?.accounts ?? [];
+  return snsAccounts[rootCanisterId.toText()]?.accounts;
 };
 
 /**

--- a/frontend/src/tests/lib/components/accounts/Address.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/Address.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import Address from "$lib/components/accounts/Address.svelte";
-import { ACCOUNT_ADDRESS_MIN_LENGTH } from "$lib/constants/accounts.constants";
 import { fireEvent, render } from "@testing-library/svelte";
 import { mockAddressInputValid } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
@@ -20,16 +19,6 @@ describe("Address", () => {
     const button = container.querySelector('button[type="submit"]');
     expect(button).not.toBeNull();
     expect(button?.innerHTML).toEqual(en.core.continue);
-  });
-
-  it("should render an input with a minimal length of 40", () => {
-    const { container } = render(Address, props);
-
-    const input = container.querySelector("input");
-    expect(input).not.toBeNull();
-    expect(input?.getAttribute("minlength")).toEqual(
-      `${ACCOUNT_ADDRESS_MIN_LENGTH}`
-    );
   });
 
   it("should show error message on blur when invalid address", async () => {

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import AddressInput from "$lib/components/accounts/AddressInput.svelte";
-import { ACCOUNT_ADDRESS_MIN_LENGTH } from "$lib/constants/accounts.constants";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("AddressInput", () => {
@@ -14,9 +13,6 @@ describe("AddressInput", () => {
 
     const input = container.querySelector("input");
     expect(input).not.toBeNull();
-    expect(input?.getAttribute("minlength")).toEqual(
-      `${ACCOUNT_ADDRESS_MIN_LENGTH}`
-    );
   });
 
   it("should show error message on blur when invalid address", async () => {

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -3,7 +3,9 @@
  */
 
 import SelectAccountDropdown from "$lib/components/accounts/SelectAccountDropdown.svelte";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { accountsStore } from "$lib/stores/accounts.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
 import { fireEvent, render } from "@testing-library/svelte";
 import {
@@ -12,62 +14,88 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
 
 describe("SelectAccountDropdown", () => {
-  const mockSubAccount2 = {
-    ...mockSubAccount,
-    identifier: "test-identifier",
-  };
-  const subaccounts = [mockSubAccount, mockSubAccount2];
-  const hardwareWallets = [mockHardwareWalletAccount];
+  describe("nns accounts", () => {
+    const mockSubAccount2 = {
+      ...mockSubAccount,
+      identifier: "test-identifier",
+    };
+    const subaccounts = [mockSubAccount, mockSubAccount2];
+    const hardwareWallets = [mockHardwareWalletAccount];
 
-  jest
-    .spyOn(accountsStore, "subscribe")
-    .mockImplementation(
-      mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
-    );
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(
+        mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
+      );
 
-  it("should render accounts as options", () => {
-    const { container } = render(SelectAccountDropdown);
+    const props = { rootCanisterId: OWN_CANISTER_ID };
+    it("should render accounts as options", () => {
+      const { container } = render(SelectAccountDropdown, { props });
 
-    // main + subaccounts + hardware wallets
-    expect(container.querySelectorAll("option").length).toBe(
-      1 + subaccounts.length + hardwareWallets.length
-    );
-  });
-
-  it("should select main as default", () => {
-    const { container } = render(SelectAccountDropdown);
-
-    expect(container.querySelector("select")?.value).toBe(
-      mockMainAccount.identifier
-    );
-  });
-
-  it("should not render accounts hardware wallets", () => {
-    const { container } = render(SelectAccountDropdown, {
-      filterAccounts: (account) => !isAccountHardwareWallet(account),
+      // main + subaccounts + hardware wallets
+      expect(container.querySelectorAll("option").length).toBe(
+        1 + subaccounts.length + hardwareWallets.length
+      );
     });
 
-    // main + subaccounts
-    expect(container.querySelectorAll("option").length).toBe(
-      1 + subaccounts.length
-    );
-  });
+    it("should select main as default", () => {
+      const { container } = render(SelectAccountDropdown, { props });
 
-  it("can select another account", async () => {
-    const { container } = render(SelectAccountDropdown);
+      expect(container.querySelector("select")?.value).toBe(
+        mockMainAccount.identifier
+      );
+    });
 
-    const selectElement = container.querySelector("select");
-    selectElement &&
-      expect(selectElement.value).toBe(mockMainAccount.identifier);
-
-    selectElement &&
-      fireEvent.change(selectElement, {
-        target: { value: subaccounts[0].identifier },
+    it("should not render accounts hardware wallets", () => {
+      const { container } = render(SelectAccountDropdown, {
+        props: {
+          filterAccounts: (account) => !isAccountHardwareWallet(account),
+          rootCanisterId: OWN_CANISTER_ID,
+        },
       });
 
-    selectElement &&
-      expect(selectElement.value).toBe(subaccounts[0].identifier);
+      // main + subaccounts
+      expect(container.querySelectorAll("option").length).toBe(
+        1 + subaccounts.length
+      );
+    });
+
+    it("can select another account", async () => {
+      const { container } = render(SelectAccountDropdown, { props });
+
+      const selectElement = container.querySelector("select");
+      selectElement &&
+        expect(selectElement.value).toBe(mockMainAccount.identifier);
+
+      selectElement &&
+        fireEvent.change(selectElement, {
+          target: { value: subaccounts[0].identifier },
+        });
+
+      selectElement &&
+        expect(selectElement.value).toBe(subaccounts[0].identifier);
+    });
+  });
+
+  describe("sns accounts", () => {
+    jest
+      .spyOn(snsAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
+
+    it("should select main as default", () => {
+      const { container } = render(SelectAccountDropdown, {
+        props: {
+          rootCanisterId: mockPrincipal,
+        },
+      });
+
+      expect(container.querySelector("select")?.value).toBe(
+        mockMainAccount.identifier
+      );
+    });
   });
 });

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -3,66 +3,110 @@
  */
 
 import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { accountsStore } from "$lib/stores/accounts.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
 
 describe("SelectDestinationAddress", () => {
-  const mockSubAccount2 = {
-    ...mockSubAccount,
-    identifier: "test-identifier",
-  };
-  const subaccounts = [mockSubAccount, mockSubAccount2];
-  const hardwareWallets = [mockHardwareWalletAccount];
+  describe("nns accounts", () => {
+    const mockSubAccount2 = {
+      ...mockSubAccount,
+      identifier: "test-identifier",
+    };
+    const subaccounts = [mockSubAccount, mockSubAccount2];
+    const hardwareWallets = [mockHardwareWalletAccount];
 
-  jest
-    .spyOn(accountsStore, "subscribe")
-    .mockImplementation(
-      mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
-    );
+    jest
+      .spyOn(accountsStore, "subscribe")
+      .mockImplementation(
+        mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
+      );
 
-  it("should render address input as default", () => {
-    const { container } = render(SelectDestinationAddress);
+    it("should render address input as default", () => {
+      const { container } = render(SelectDestinationAddress, {
+        props: {
+          rootCanisterId: OWN_CANISTER_ID,
+        },
+      });
 
-    expect(
-      container.querySelector("input[name='accounts-address']")
-    ).toBeInTheDocument();
-  });
-
-  it("should render toggle", () => {
-    const { container } = render(SelectDestinationAddress);
-
-    const toggle = container.querySelector("input[id='toggle']");
-    expect(toggle).toBeInTheDocument();
-  });
-
-  it("should not render toggle if no extra accounts to choose from", () => {
-    const { container } = render(SelectDestinationAddress, {
-      props: {
-        filterAccounts: () => false,
-      },
+      expect(
+        container.querySelector("input[name='accounts-address']")
+      ).toBeInTheDocument();
     });
 
-    const toggle = container.querySelector("input[id='toggle']");
-    expect(toggle).not.toBeInTheDocument();
+    it("should render toggle", () => {
+      const { container } = render(SelectDestinationAddress, {
+        props: {
+          rootCanisterId: OWN_CANISTER_ID,
+        },
+      });
+
+      const toggle = container.querySelector("input[id='toggle']");
+      expect(toggle).toBeInTheDocument();
+    });
+
+    it("should not render toggle if no extra accounts to choose from", () => {
+      const { container } = render(SelectDestinationAddress, {
+        props: {
+          filterAccounts: () => false,
+          rootCanisterId: OWN_CANISTER_ID,
+        },
+      });
+
+      const toggle = container.querySelector("input[id='toggle']");
+      expect(toggle).not.toBeInTheDocument();
+    });
+
+    it("should render select account dropdown when toggle is clicked", async () => {
+      const { container, queryByTestId } = render(SelectDestinationAddress, {
+        props: {
+          rootCanisterId: OWN_CANISTER_ID,
+        },
+      });
+
+      expect(
+        container.querySelector("input[name='accounts-address']")
+      ).toBeInTheDocument();
+
+      const toggle = container.querySelector("input[id='toggle']");
+      toggle && fireEvent.click(toggle);
+
+      await waitFor(() =>
+        expect(queryByTestId("select-account-dropdown")).toBeInTheDocument()
+      );
+    });
   });
 
-  it("should render select account dropdown when toggle is clicked", async () => {
-    const { container, queryByTestId } = render(SelectDestinationAddress);
+  describe("sns accounts", () => {
+    jest
+      .spyOn(snsAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
 
-    expect(
-      container.querySelector("input[name='accounts-address']")
-    ).toBeInTheDocument();
+    it("should render the sns account", async () => {
+      const { container, queryByTestId } = render(SelectDestinationAddress, {
+        props: {
+          rootCanisterId: mockPrincipal,
+        },
+      });
 
-    const toggle = container.querySelector("input[id='toggle']");
-    toggle && fireEvent.click(toggle);
+      expect(
+        container.querySelector("input[name='accounts-address']")
+      ).toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(queryByTestId("select-account-dropdown")).toBeInTheDocument()
-    );
+      const toggle = container.querySelector("input[id='toggle']");
+      toggle && fireEvent.click(toggle);
+
+      await waitFor(() =>
+        expect(queryByTestId("select-account-dropdown")).toBeInTheDocument()
+      );
+    });
   });
 });

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -1,15 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { AppPath, CONTEXT_PATH } from "$lib/constants/routes.constants";
-import {
-  accountsSelectedProjectStore,
-  nnsAccountsListStore,
-} from "$lib/derived/accounts-list.derived";
+import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
-import { routeStore } from "$lib/stores/route.store";
-import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
@@ -25,37 +18,6 @@ describe("accounts", () => {
 
       const accounts = get(nnsAccountsListStore);
       expect(accounts).toEqual([mockMainAccount, mockSnsMainAccount]);
-    });
-  });
-
-  describe("accountsSelectedProjectStore", () => {
-    it("should return empty array if main is not set", () => {
-      accountsStore.reset();
-      const value = get(accountsSelectedProjectStore);
-      expect(value.length).toBe(0);
-    });
-
-    it("should return the accounts of the nns", () => {
-      routeStore.update({ path: AppPath.LegacyAccounts });
-      accountsStore.set({ main: mockMainAccount });
-
-      const value = get(accountsSelectedProjectStore);
-      expect(value[0]).toEqual(mockMainAccount);
-    });
-
-    it("should return the accounts of the selected sns", () => {
-      const principalString = "aaaaa-aa";
-      routeStore.update({
-        path: `${CONTEXT_PATH}/${principalString}/neuron/12344`,
-      });
-      accountsStore.set({ main: mockMainAccount });
-      snsAccountsStore.setAccounts({
-        rootCanisterId: Principal.fromText(principalString),
-        certified: true,
-        accounts: [mockSnsMainAccount],
-      });
-      const value = get(accountsSelectedProjectStore);
-      expect(value[0]).toEqual(mockSnsMainAccount);
     });
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -2,13 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
+import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
 import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 import { snsTransferTokens } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { paths } from "$lib/utils/app-path.utils";
+import type { Principal } from "@dfinity/principal";
 import { fireEvent, waitFor } from "@testing-library/svelte";
+import type { Subscriber } from "svelte/store";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import {
   mockSnsAccountsStoreSubscribe,
@@ -32,10 +36,16 @@ describe("SnsTransactionModal", () => {
 
   beforeEach(() => {
     jest
-      .spyOn(snsProjectAccountsStore, "subscribe")
-      .mockImplementation(mockSnsAccountsStoreSubscribe([mockSnsMainAccount]));
+      .spyOn(snsAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
+    jest
+      .spyOn(snsProjectSelectedStore, "subscribe")
+      .mockImplementation((run: Subscriber<Principal>): (() => void) => {
+        run(mockPrincipal);
+        return () => undefined;
+      });
 
-    routeStore.update({ path: paths.accounts("aaaaa-aa") });
+    routeStore.update({ path: paths.accounts(mockPrincipal.toText()) });
   });
 
   it("should transfer tokens", async () => {

--- a/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
@@ -2,19 +2,24 @@
  * @jest-environment jsdom
  */
 
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import TransactionModal from "$lib/modals/accounts/NewTransaction/TransactionModal.svelte";
 import { accountsStore } from "$lib/stores/accounts.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
 import { TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
+import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
 import { clickByTestId } from "../../testHelpers/clickByTestId";
 
 describe("TransactionModal", () => {
@@ -22,6 +27,7 @@ describe("TransactionModal", () => {
     destinationAddress?: string;
     sourceAccount?: Account;
     transactionFee?: TokenAmount;
+    rootCanisterId?: Principal;
   }) =>
     renderModal({
       component: TransactionModal,
@@ -32,15 +38,28 @@ describe("TransactionModal", () => {
     jest
       .spyOn(accountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+
+    jest
+      .spyOn(snsAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
   });
 
-  const renderEnter10ICPAndNext = async (
-    destination?: string,
-    transactionFee?: TokenAmount
-  ): Promise<RenderResult> => {
+  const renderEnter10ICPAndNext = async ({
+    destinationAddress,
+    transactionFee,
+    rootCanisterId,
+    sourceAccount,
+  }: {
+    destinationAddress?: string;
+    sourceAccount?: Account;
+    transactionFee?: TokenAmount;
+    rootCanisterId?: Principal;
+  }): Promise<RenderResult> => {
     const result = await renderTransactionModal({
-      destinationAddress: destination,
+      destinationAddress,
+      sourceAccount,
       transactionFee,
+      rootCanisterId,
     });
 
     const { queryAllByText, getByTestId, container } = result;
@@ -71,13 +90,17 @@ describe("TransactionModal", () => {
 
   describe("when destination is not provided", () => {
     it("should display modal", async () => {
-      const { container } = await renderTransactionModal();
+      const { container } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       expect(container.querySelector("div.modal")).not.toBeNull();
     });
 
     it("should display dropdown to select account, input to add amount and select destination account", async () => {
-      const { queryByTestId, container } = await renderTransactionModal();
+      const { queryByTestId, container } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
       expect(
@@ -86,7 +109,9 @@ describe("TransactionModal", () => {
     });
 
     it("should trigger close on cancel", async () => {
-      const { getByTestId, component } = await renderTransactionModal();
+      const { getByTestId, component } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       const onClose = jest.fn();
       component.$on("nnsClose", onClose);
@@ -97,14 +122,18 @@ describe("TransactionModal", () => {
     });
 
     it("should have disabled button by default", async () => {
-      const { getByTestId } = await renderTransactionModal();
+      const { getByTestId } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       const participateButton = getByTestId("transaction-button-next");
       expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
     });
 
     it("should enable button when input value and select a destination changes", async () => {
-      const { getByTestId, container } = await renderTransactionModal();
+      const { getByTestId, container } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       const participateButton = getByTestId("transaction-button-next");
       expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
@@ -123,7 +152,9 @@ describe("TransactionModal", () => {
     });
 
     it("should move to the last step and render review info", async () => {
-      const { getByText, getByTestId } = await renderEnter10ICPAndNext();
+      const { getByText, getByTestId } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       expect(
         (
@@ -143,10 +174,10 @@ describe("TransactionModal", () => {
           name: "Test token",
         },
       });
-      const { getByText, getByTestId } = await renderEnter10ICPAndNext(
-        undefined,
-        fee
-      );
+      const { getByText, getByTestId } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+        transactionFee: fee,
+      });
 
       expect(
         (
@@ -159,7 +190,9 @@ describe("TransactionModal", () => {
     });
 
     it("should move to the last step and trigger nnsSubmit event", async () => {
-      const { getByTestId, component } = await renderEnter10ICPAndNext();
+      const { getByTestId, component } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       const onSubmit = jest.fn();
       component.$on("nnsSubmit", onSubmit);
@@ -172,7 +205,9 @@ describe("TransactionModal", () => {
     });
 
     it("should move to the last step and go back", async () => {
-      const { getByTestId, container } = await renderTransactionModal();
+      const { getByTestId, container } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+      });
 
       const participateButton = getByTestId("transaction-button-next");
 
@@ -208,6 +243,7 @@ describe("TransactionModal", () => {
     it("should not show the select destination component", async () => {
       const { queryByTestId, container } = await renderTransactionModal({
         destinationAddress: mockMainAccount.identifier,
+        rootCanisterId: OWN_CANISTER_ID,
       });
 
       expect(queryByTestId("select-account-dropdown")).toBeInTheDocument();
@@ -222,12 +258,56 @@ describe("TransactionModal", () => {
     it("should not show the select account component", async () => {
       const { queryByTestId, container } = await renderTransactionModal({
         sourceAccount: mockMainAccount,
+        rootCanisterId: OWN_CANISTER_ID,
       });
 
       expect(queryByTestId("select-account-dropdown")).not.toBeInTheDocument();
       expect(
         container.querySelector("input[name='amount']")
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("with sns project id", () => {
+    it("should move to the last step and trigger nnsSubmit event", async () => {
+      const { queryByText, getByTestId, container, component } =
+        await renderTransactionModal({
+          rootCanisterId: mockPrincipal,
+        });
+
+      const participateButton = getByTestId("transaction-button-next");
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const icpAmount = "10";
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: icpAmount } });
+
+      // Enter valid destination address
+      const addressInput = container.querySelector(
+        "input[name='accounts-address']"
+      );
+      addressInput &&
+        fireEvent.input(addressInput, { target: { value: "aaaaa-aa" } });
+
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+
+      fireEvent.click(participateButton);
+
+      await waitFor(() =>
+        expect(getByTestId("transaction-step-2")).toBeTruthy()
+      );
+      expect(queryByText(icpAmount, { exact: false })).toBeInTheDocument();
+
+      const onSubmit = jest.fn();
+      component.$on("nnsSubmit", onSubmit);
+
+      const confirmButton = getByTestId("transaction-button-execute");
+
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => expect(onSubmit).toBeCalled());
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -7,6 +7,7 @@ import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.d
 import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
@@ -23,8 +24,8 @@ describe("SnsAccounts", () => {
   describe("when there are accounts in the store", () => {
     beforeEach(() => {
       jest
-        .spyOn(snsProjectAccountsStore, "subscribe")
-        .mockImplementation(mockSnsAccountsStoreSubscribe());
+        .spyOn(snsAccountsStore, "subscribe")
+        .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
       // Context needs to match the mocked sns accounts
       routeStore.update({
         path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -3,10 +3,11 @@
  */
 
 import { CONTEXT_PATH } from "$lib/constants/routes.constants";
-import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { Principal } from "@dfinity/principal";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
@@ -23,9 +24,12 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 describe("SnsWallet", () => {
   describe("accounts not loaded", () => {
     beforeEach(() => {
+      // Load accounts in a different project
       jest
-        .spyOn(snsProjectAccountsStore, "subscribe")
-        .mockImplementation(mockSnsAccountsStoreSubscribe([]));
+        .spyOn(snsAccountsStore, "subscribe")
+        .mockImplementation(
+          mockSnsAccountsStoreSubscribe(Principal.fromText("aaaaa-aa"))
+        );
       // Context needs to match the mocked sns accounts
       routeStore.update({
         path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,
@@ -47,10 +51,8 @@ describe("SnsWallet", () => {
   describe("accounts loaded", () => {
     beforeEach(() => {
       jest
-        .spyOn(snsProjectAccountsStore, "subscribe")
-        .mockImplementation(
-          mockSnsAccountsStoreSubscribe([mockSnsMainAccount])
-        );
+        .spyOn(snsAccountsStore, "subscribe")
+        .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
       // Context and identifier needs to match the mocked sns accounts
       routeStore.update({
         path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/wallet/${

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,8 +1,11 @@
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
   assertEnoughAccountFunds,
   emptyAddress,
   getAccountByPrincipal,
+  getAccountByProject,
   getAccountFromStore,
+  getAccountsByProject,
   getPrincipalFromString,
   invalidAddress,
   isAccountHardwareWallet,
@@ -19,6 +22,7 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
@@ -146,6 +150,90 @@ describe("accounts-utils", () => {
           accounts,
         })
       ).toEqual(mockSubAccount);
+    });
+  });
+
+  describe("getAccountByProject", () => {
+    const accounts = [mockMainAccount, mockSubAccount];
+    const snsAccounts = {
+      [mockPrincipal.toText()]: {
+        accounts: [mockSnsMainAccount, mockSnsSubAccount],
+        certified: true,
+      },
+    };
+
+    it("should not return an account if no identifier is provided", () => {
+      expect(
+        getAccountByProject({
+          identifier: undefined,
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: OWN_CANISTER_ID,
+        })
+      ).toBeUndefined();
+    });
+
+    it("should find no account if not matches", () => {
+      expect(
+        getAccountByProject({
+          identifier: "aaa",
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: OWN_CANISTER_ID,
+        })
+      ).toBeUndefined();
+    });
+
+    it("should return corresponding nns account", () => {
+      expect(
+        getAccountByProject({
+          identifier: mockMainAccount.identifier,
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: OWN_CANISTER_ID,
+        })
+      ).toEqual(mockMainAccount);
+    });
+
+    it("should return corresponding sns account", () => {
+      expect(
+        getAccountByProject({
+          identifier: mockSnsMainAccount.identifier,
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: mockPrincipal,
+        })
+      ).toEqual(mockSnsMainAccount);
+    });
+  });
+
+  describe("getAccountsByProject", () => {
+    const accounts = [mockMainAccount, mockSubAccount];
+    const snsAccounts = {
+      [mockPrincipal.toText()]: {
+        accounts: [mockSnsMainAccount, mockSnsSubAccount],
+        certified: true,
+      },
+    };
+
+    it("should return corresponding nns accounts", () => {
+      expect(
+        getAccountsByProject({
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: OWN_CANISTER_ID,
+        })
+      ).toEqual(accounts);
+    });
+
+    it("should return corresponding sns accounts", () => {
+      expect(
+        getAccountsByProject({
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: mockPrincipal,
+        })
+      ).toEqual(snsAccounts[mockPrincipal.toText()].accounts);
     });
   });
 

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -3,9 +3,9 @@ import {
   assertEnoughAccountFunds,
   emptyAddress,
   getAccountByPrincipal,
-  getAccountByProject,
+  getAccountByRootCanister,
   getAccountFromStore,
-  getAccountsByProject,
+  getAccountsByRootCanister,
   getPrincipalFromString,
   invalidAddress,
   isAccountHardwareWallet,
@@ -153,7 +153,7 @@ describe("accounts-utils", () => {
     });
   });
 
-  describe("getAccountByProject", () => {
+  describe("getAccountByRootCanister", () => {
     const accounts = [mockMainAccount, mockSubAccount];
     const snsAccounts = {
       [mockPrincipal.toText()]: {
@@ -164,7 +164,7 @@ describe("accounts-utils", () => {
 
     it("should not return an account if no identifier is provided", () => {
       expect(
-        getAccountByProject({
+        getAccountByRootCanister({
           identifier: undefined,
           nnsAccounts: accounts,
           snsAccounts,
@@ -175,7 +175,7 @@ describe("accounts-utils", () => {
 
     it("should find no account if not matches", () => {
       expect(
-        getAccountByProject({
+        getAccountByRootCanister({
           identifier: "aaa",
           nnsAccounts: accounts,
           snsAccounts,
@@ -186,7 +186,7 @@ describe("accounts-utils", () => {
 
     it("should return corresponding nns account", () => {
       expect(
-        getAccountByProject({
+        getAccountByRootCanister({
           identifier: mockMainAccount.identifier,
           nnsAccounts: accounts,
           snsAccounts,
@@ -197,7 +197,7 @@ describe("accounts-utils", () => {
 
     it("should return corresponding sns account", () => {
       expect(
-        getAccountByProject({
+        getAccountByRootCanister({
           identifier: mockSnsMainAccount.identifier,
           nnsAccounts: accounts,
           snsAccounts,
@@ -207,7 +207,7 @@ describe("accounts-utils", () => {
     });
   });
 
-  describe("getAccountsByProject", () => {
+  describe("getAccountsByRootCanister", () => {
     const accounts = [mockMainAccount, mockSubAccount];
     const snsAccounts = {
       [mockPrincipal.toText()]: {
@@ -216,9 +216,19 @@ describe("accounts-utils", () => {
       },
     };
 
+    it("should return undefined if no accounts", () => {
+      expect(
+        getAccountsByRootCanister({
+          nnsAccounts: accounts,
+          snsAccounts,
+          rootCanisterId: Principal.fromText("aaaaa-aa"),
+        })
+      ).toBeUndefined();
+    });
+
     it("should return corresponding nns accounts", () => {
       expect(
-        getAccountsByProject({
+        getAccountsByRootCanister({
           nnsAccounts: accounts,
           snsAccounts,
           rootCanisterId: OWN_CANISTER_ID,
@@ -228,7 +238,7 @@ describe("accounts-utils", () => {
 
     it("should return corresponding sns accounts", () => {
       expect(
-        getAccountsByProject({
+        getAccountsByRootCanister({
           nnsAccounts: accounts,
           snsAccounts,
           rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,5 +1,7 @@
+import type { SnsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "./auth.store.mock";
 
@@ -37,9 +39,16 @@ export const mockSnsSubAccount: Account = {
   type: "subAccount",
 };
 
+const mockSnsAccountsStore = (principal: Principal): SnsAccountsStore => ({
+  [principal.toText()]: {
+    accounts: [mockSnsMainAccount],
+    certified: true,
+  },
+});
+
 export const mockSnsAccountsStoreSubscribe =
-  (accounts: Account[] = [mockSnsMainAccount]) =>
-  (run: Subscriber<Account[]>): (() => void) => {
-    run(accounts);
+  (principal: Principal = mockPrincipal) =>
+  (run: Subscriber<SnsAccountsStore>): (() => void) => {
+    run(mockSnsAccountsStore(principal));
     return () => undefined;
   };


### PR DESCRIPTION
# Motivation

The form to participate in the swap was not working.

# Changes

* Add a prop rootCanisterId to: "TransactionModal", "SelectAccountDropdown" and "SelectDestinationAddress".
* Remove minLength in AddressInput.
* New accounts utils: "getAccountByProject" and "getAccountsByProject".
* Remove derived store "accountsSelectedProjectStore".

# Tests

* Fix broken tests because of new prop.
* Add new tests to test new prop.
* New tests for new accounts utils.
* Remove tests for min length.
