### PR TITLE
feat: show input info and modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-10-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-10-11.1.tgz",
-      "integrity": "sha512-JUJZermXoggB9fhlxMV0UdMYfIZZLJubOhviBO2Z6ZBsZg5184oVV4CcGAgLBjAq8dXoLqMJ/FCXoy8tVbbhpQ=="
+      "version": "0.0.1-next-2022-10-13.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-10-13.1.tgz",
+      "integrity": "sha512-Wzf/jOt1iIUZIN3mXgGjyoj9yRXGPb3fpVFwn5sJeUTxYXO3eoOrUt787+QnNKTzJbQcLL/K++uk1Af1wQ2wtA=="
     },
     "node_modules/@dfinity/identity": {
       "version": "0.14.0",
@@ -10974,9 +10974,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "0.0.1-next-2022-10-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-10-11.1.tgz",
-      "integrity": "sha512-JUJZermXoggB9fhlxMV0UdMYfIZZLJubOhviBO2Z6ZBsZg5184oVV4CcGAgLBjAq8dXoLqMJ/FCXoy8tVbbhpQ=="
+      "version": "0.0.1-next-2022-10-13.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-0.0.1-next-2022-10-13.1.tgz",
+      "integrity": "sha512-Wzf/jOt1iIUZIN3mXgGjyoj9yRXGPb3fpVFwn5sJeUTxYXO3eoOrUt787+QnNKTzJbQcLL/K++uk1Af1wQ2wtA=="
     },
     "@dfinity/identity": {
       "version": "0.14.0",

--- a/frontend/src/lib/components/accounts/AddressInput.svelte
+++ b/frontend/src/lib/components/accounts/AddressInput.svelte
@@ -23,5 +23,6 @@
   name="accounts-address"
   bind:value={address}
   errorMessage={showError ? $i18n.error.address_not_valid : undefined}
+  showInfo={$$slots.label !== undefined}
   on:blur={showErrorIfAny}><slot name="label" slot="label" /></InputWithError
 >

--- a/frontend/src/lib/components/accounts/HardwareWalletName.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletName.svelte
@@ -48,6 +48,7 @@
       name="walletName"
       bind:value={hardwareWalletName}
       on:blur={showInvalidInputLength}
+      showInfo={false}
       errorMessage={invalidInputMessage
         ? replacePlaceholders($i18n.error.input_length, {
             $length: `${HARDWARE_WALLET_NAME_MIN_LENGTH}`,

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -18,6 +18,7 @@
   export let autocomplete: "off" | "on" | undefined = undefined;
   export let value: string | number | undefined = undefined;
   export let placeholderLabelKey: string;
+  export let showInfo = true;
 </script>
 
 <div class="wrapper" class:error>
@@ -32,7 +33,7 @@
     {placeholderLabelKey}
     {max}
     {autocomplete}
-    showInfo={$$slots.label !== undefined || $$slots.additional !== undefined}
+    {showInfo}
     bind:value
     on:blur
     on:input

--- a/frontend/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/src/lib/components/ui/PrincipalInput.svelte
@@ -26,6 +26,7 @@
   bind:value={address}
   errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
   on:blur={showErrorIfAny}
+  showInfo={$$slots.label !== undefined}
 >
   <slot name="label" slot="label" />
 </InputWithError>


### PR DESCRIPTION
# Changes

- Show info in input a level higher because `PrincipaInput` always pass a `slot`
- Fix style modal height on Safari and in landascape

# PR

- [x] need https://github.com/dfinity/gix-components/pulls

# Screenshot

<img width="1536" alt="Capture d’écran 2022-10-13 à 06 58 13" src="https://user-images.githubusercontent.com/16886711/195505488-4f3a4002-c231-4272-a938-470527d4b47b.png">

