### PR TITLE
Fix: GH Actions Upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get cached nns canisters
         id: create_nns_canister_cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             target/ic
@@ -72,7 +72,7 @@ jobs:
       # "restore-keys"-style matching). Because (in case of an exact match)
       # GitHub actions won't (re-)upload the cache after the build, it means that
       # our cache won't just grow forever.
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -81,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
 
       # Cache the ic-cdk-optimizer
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/ic-cdk-optimizer
@@ -109,7 +109,7 @@ jobs:
 
       - name: Get cached nns canisters
         id: create_nns_canister_cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             target/ic

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -103,6 +103,7 @@ jobs:
         run : |
           touch assets.tar.xz
 
+      # Does not support Node 16 yet
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Motivation

Fix GH warnings in actions regarding usage of Node 12.

# Changes

* Upgrade `actions/cache`