### PR TITLE
build: fix buffer polyfill for mainnet

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.6",
         "@ledgerhq/hw-transport-webhid": "^6.27.6",
         "@zondax/ledger-icp": "^0.6.0",
+        "buffer": "^6.0.3",
         "dompurify": "^2.4.0"
       },
       "devDependencies": {
@@ -3722,7 +3723,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -12538,7 +12538,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,10 +22,10 @@
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.6",
         "@ledgerhq/hw-transport-webhid": "^6.27.6",
         "@zondax/ledger-icp": "^0.6.0",
-        "buffer": "^6.0.3",
         "dompurify": "^2.4.0"
       },
       "devDependencies": {
+        "@rollup/plugin-inject": "^5.0.0",
         "@sveltejs/adapter-static": "^1.0.0-next.44",
         "@sveltejs/kit": "next",
         "@testing-library/jest-dom": "^5.16.5",
@@ -2479,6 +2479,28 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.0.tgz",
+      "integrity": "sha512-UfJG/Kz965mnpIWemWzoAKIb2qaApsptDE2jHqdElHQjdbm1TYUiBc7SAOs9xSMUB/spB9G2KUfYzDWCRRO13Q==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.26.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -3700,6 +3722,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -11610,6 +11633,17 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
+    "@rollup/plugin-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.0.tgz",
+      "integrity": "sha512-UfJG/Kz965mnpIWemWzoAKIb2qaApsptDE2jHqdElHQjdbm1TYUiBc7SAOs9xSMUB/spB9G2KUfYzDWCRRO13Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.2.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.26.4"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -12504,6 +12538,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "update:gix": "npm update @dfinity/gix-components"
   },
   "devDependencies": {
+    "@rollup/plugin-inject": "^5.0.0",
     "@sveltejs/adapter-static": "^1.0.0-next.44",
     "@sveltejs/kit": "next",
     "@testing-library/jest-dom": "^5.16.5",
@@ -69,7 +70,6 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.6",
     "@ledgerhq/hw-transport-webhid": "^6.27.6",
     "@zondax/ledger-icp": "^0.6.0",
-    "buffer": "^6.0.3",
     "dompurify": "^2.4.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.6",
     "@ledgerhq/hw-transport-webhid": "^6.27.6",
     "@zondax/ledger-icp": "^0.6.0",
+    "buffer": "^6.0.3",
     "dompurify": "^2.4.0"
   }
 }

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,3 +1,7 @@
 export const prerender = true;
 export const ssr = false;
 
+// Polyfill Buffer for development purpose. The ledger needs buffer.
+// ⚠️ For production build the polyfill needs to be injected with Rollup (see vite.config.ts) because the page might be loaded before the _layout.js which will contains this polyfill
+import { Buffer } from "buffer";
+globalThis.Buffer = Buffer;

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,7 +1,7 @@
 export const prerender = true;
 export const ssr = false;
 
-// Polyfill Buffer for development purpose. The ledger needs buffer.
+// Polyfill Buffer for development purpose. node_modules/@ledgerhq needs buffer.
 // ⚠️ For production build the polyfill needs to be injected with Rollup (see vite.config.ts) because the page might be loaded before the _layout.js which will contains this polyfill
 import { Buffer } from "buffer";
 globalThis.Buffer = Buffer;

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,6 +1,3 @@
 export const prerender = true;
 export const ssr = false;
 
-// Polyfill Buffer for the window object
-import { Buffer } from "buffer";
-globalThis.Buffer = Buffer;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,10 +14,12 @@ const config: UserConfig = {
     target: "es2020",
     rollupOptions: {
       // Polyfill Buffer for production build. The hardware wallet needs Buffer.
-      plugins: [inject({
-        include: ['node_modules/@ledgerhq/**'],
-        modules: { Buffer: ['buffer', 'Buffer'], }
-      })],
+      plugins: [
+        inject({
+          include: ["node_modules/@ledgerhq/**"],
+          modules: { Buffer: ["buffer", "Buffer"] },
+        }),
+      ],
     },
   },
   define: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,10 @@ const config: UserConfig = {
     target: "es2020",
     rollupOptions: {
       // Polyfill Buffer for production build. The hardware wallet needs Buffer.
-      plugins: [inject({ Buffer: ["buffer", "Buffer"] })],
+      plugins: [inject({
+        include: ['node_modules/@ledgerhq/**'],
+        modules: { Buffer: ['buffer', 'Buffer'], }
+      })],
     },
   },
   define: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import inject from "@rollup/plugin-inject";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
@@ -11,12 +12,14 @@ const config: UserConfig = {
   plugins: [sveltekit()],
   build: {
     target: "es2020",
+    rollupOptions: {
+      // Polyfill Buffer for production build. The hardware wallet needs Buffer.
+      plugins: [inject({ Buffer: ["buffer", "Buffer"] })],
+    },
   },
   define: {
     VITE_APP_VERSION: JSON.stringify(version),
   },
-  // Polyfill buffer for development. Thanks solution shared by chovyfu on the Discord channel.
-  // https://stackoverflow.com/questions/71744659/how-do-i-deploy-a-sveltekit-app-to-a-dfinity-container
   optimizeDeps: {
     esbuildOptions: {
       // Node.js global to browser globalThis


### PR DESCRIPTION
# Motivation

Same issue as https://github.com/vitejs/vite/discussions/2785#discussioncomment-1452855

Basicall the ledger needs Buffer which is a NodeJS library which we have to polyfill.

Adding a polyfill (`window.Buffer =...`) works great for local development but does not always work on mainnet.
Indeed, `_layout.js` (which contains the polyfill) might be loaded after a `page.js` therefore, we might hit the issue `start-4e5e2afa.js:1 ReferenceError: Buffer is not defined`.

# Solution

Use rollup plugin as well to inject Buffer (as we used too with rollup bundler) so that the Buffer also gets polyfied within the page

# Potential of improvement

With this PR we polyfill in to places, therefore the bundle will be a bit more heavy. We can probably spare the dev polyfill for prod build.

# Changes

- inject Buffer polyfill with Rollup for prod build