### PR TITLE
build: fix SvelteKit CSP 'stric-dynamic' issue in Firefox

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -32,9 +32,7 @@ const extractStartScript = () => {
     /(<script type=\"module\" data-sveltekit-hydrate[\s\S]*?>)([\s\S]*?)(<\/script>)/gm;
 
   // 1. extract SvelteKit start script to a separate main.js file
-  const m = svelteKitStartScript.exec(indexHtml);
-  const content = m[2];
-
+  const [_script, _scriptStartTag, content] = svelteKitStartScript.exec(indexHtml);
   const inlineScript = content.replace(/^\s*/gm, "");
 
   writeFileSync(

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -32,7 +32,7 @@ const extractStartScript = () => {
     /(<script type=\"module\" data-sveltekit-hydrate[\s\S]*?>)([\s\S]*?)(<\/script>)/gm;
 
   // 1. extract SvelteKit start script to a separate main.js file
-  const [_script, _scriptStartTag, content] = svelteKitStartScript.exec(indexHtml);
+  const [_script, _scriptStartTag, content, _scriptEndTag] = svelteKitStartScript.exec(indexHtml);
   const inlineScript = content.replace(/^\s*/gm, "");
 
   writeFileSync(

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -32,7 +32,8 @@ const extractStartScript = () => {
     /(<script type=\"module\" data-sveltekit-hydrate[\s\S]*?>)([\s\S]*?)(<\/script>)/gm;
 
   // 1. extract SvelteKit start script to a separate main.js file
-  const [_script, _scriptStartTag, content, _scriptEndTag] = svelteKitStartScript.exec(indexHtml);
+  const [_script, _scriptStartTag, content, _scriptEndTag] =
+    svelteKitStartScript.exec(indexHtml);
   const inlineScript = content.replace(/^\s*/gm, "");
 
   writeFileSync(

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -8,8 +8,43 @@ import { join } from "path";
 dotenv.config();
 
 const buildCsp = () => {
-  const updatedIndexHTML = updateCSP();
-  writeFileSync("./public/index.html", updatedIndexHTML);
+  const indexHTMLWithoutStartScript = extractStartScript();
+  const indexHTMLWithCSP = updateCSP(indexHTMLWithoutStartScript);
+  writeFileSync("./public/index.html", indexHTMLWithCSP);
+};
+
+/**
+ * Using a CSP with 'strict-dynamic' with SvelteKit breaks in Firefox.
+ * Issue: https://github.com/sveltejs/kit/issues/3558
+ *
+ * As workaround:
+ * 1. we extract the start script that is injected by SvelteKit in index.html into a separate main.js
+ * 2. we remove the script content from index.html but, let the script tag as anchor
+ * 3. we use our custom script loader to load the main.js script
+ */
+const extractStartScript = () => {
+  const indexHtml = readFileSync(
+    join(process.cwd(), "public", "index.html"),
+    "utf-8"
+  );
+
+  const svelteKitStartScript =
+    /(<script type=\"module\" data-sveltekit-hydrate[\s\S]*?>)([\s\S]*?)(<\/script>)/gm;
+
+  // 1. extract SvelteKit start script to a separate main.js file
+  const m = svelteKitStartScript.exec(indexHtml);
+  const content = m[2];
+
+  const inlineScript = content.replace(/^\s*/gm, "");
+
+  writeFileSync(
+    join(process.cwd(), "public", "main.js"),
+    inlineScript,
+    "utf-8"
+  );
+
+  // 2. replace SvelteKit script tag content with empty
+  return indexHtml.replace(svelteKitStartScript, "$1$3");
 };
 
 /**
@@ -37,11 +72,7 @@ const buildCsp = () => {
  * 1. svelte uses inline style for animation (scale, fly, fade, etc.)
  *    source: https://github.com/sveltejs/svelte/issues/6662
  */
-const updateCSP = () => {
-  const indexHtml = readFileSync(
-    join(process.cwd(), "public", "index.html"),
-    "utf-8"
-  );
+const updateCSP = (indexHtml) => {
   const sw = /<script[\s\S]*?>([\s\S]*?)<\/script>/gm;
 
   const indexHashes = [];

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -107,6 +107,13 @@
       }
     </script>
 
+    <script>
+      const loader = document.createElement("script");
+      loader.type = "module";
+      loader.src = "./main.js";
+      document.head.appendChild(loader);
+    </script>
+
     %sveltekit.head%
   </head>
   <body>


### PR DESCRIPTION
# Motivation

Using a CSP `'strict-dynamic'` with SvelteKit breaks in Firefox.

# Solution

Extracting the script content that gets injected by SvelteKit in `index.html` into a separate JS script that gets appended with a script loader.

Exact same "script loader" as the one we use to use for Rollup.

# Issue

- SvelteKit https://github.com/sveltejs/kit/issues/3558 

# Changes

- update `build.csp.mjs` to extract script
- add script loader to `app.html`

# Screenshot

<img width="1536" alt="Capture d’écran 2022-10-13 à 17 50 46" src="https://user-images.githubusercontent.com/16886711/195645187-cb2d857b-76e3-49d3-962c-aed7b059da4a.png">

