### PR TITLE
Chore: Fix e2e running locally

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -86,7 +86,7 @@ DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
 
 By default, tests will be executed (or tried to) in Firefox and Chrome.
 
-*Firefox tests are still shaky at the moment.*
+_Firefox tests are still shaky at the moment._
 
 Recommendation: Use only chrome:
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -3,31 +3,154 @@
 See `e2e.test.ts` for the actual tests. Follow `test` from `package.json` for
 more info.
 
-## Run the tests
+## Run the tests locally
 
-First, deploy to a local replica the required canisters:
+**NOTE: Most commands are executed from the root folder**
+
+### Start replica
+
+Start a dfx replica:
 
 ```bash
 # in root folder
-./deploy.sh --network local
+dfx start --clean
+
+# run replica in the background with
+dfx start --clean --background
 ```
 
-This will build NNS Dapp and deploy all the necessary canister to your local machine.
+### Download and install NNS canisters
 
-Install all the dependencies for the test suite, and run the tests:
+**TODO: Use new dfx version to install NNS projects.**
+
+#### NEW WAY
+
+Install dfx version `0.12.0-snsdemo.4` and set it in `dfx.json`.
 
 ```bash
-# in e2e-tests/
+dfx nns install
+```
+
+**NOTE: Not fully working yet.**
+
+#### OLD WAY
+
+This step downloads and installs the NNS canisters in the local replica.
+
+For example the governance and ledger canisters.
+
+```bash
+# from this file
+./scripts/nns-canister-download
+./scripts/nns-canister-install
+
+# from root
+./e2e-tests/scripts/nns-canister-download
+./e2e-tests/scripts/nns-canister-install
+```
+
+**IMPORTANT:**
+
+This step does not install sns-wasm. Therefore, there is always a notification error that prevents the tests to pass without manual interaction.
+
+We could add the step to remove the notifications. But the new way to install the nns canisters (including sns) is already working, but not yet officially released.
+
+### II and NNS Dapp
+
+Install Internet Identity and NNS Dapp in the local replica.
+
+```bash
+# in root folder
+dfx canister create internet_identity --no-wallet
+dfx canister create nns-dapp --no-wallet
+./deploy.sh --ii --nns-dapp local
+```
+
+### Setup e2e tests
+
+Install dependencies.
+
+```bash
+# In this folder
 npm ci
+```
+
+Create environment variables in e2e folder
+
+```bash
+# in root folder
+DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
+```
+
+**Choose browser:**
+
+By default, tests will be executed (or tried to) in Firefox and Chrome.
+
+*Firefox tests are still shaky at the moment.*
+
+Recommendation: Use only chrome:
+
+```bash
+# It doesn't matter the folder
+export WDIO_BROWSER=chrome
+```
+
+### Populate
+
+First e2e is also used to populate the nns dapp:
+
+```bash
+# in root folder
+./deploy.sh --populate local
+```
+
+This command sets the cycles exchange rate and the list of subnets CMC is authorized to create canisters in.
+
+Both through proposals which are needed for the e2e tests.
+
+Then it executes the e2e test in "user-N01-neuron-created.e2e.ts".
+
+Therefore, if this works your setup is ready.
+
+### Execute e2e tests
+
+All the e2e tests can be run with:
+
+```bash
+# In this folder
 npm run test
 ```
 
-Finally, shut down the replica by killing the `dfx start` process.
+You can specify which test you want to run:
+
+```bash
+# In this folder
+npm run test -- --spec "./specs/user-N01-neuron-created.e2e.ts"
+```
+
+### Stop Local Replica
+
+```bash
+# In root folder
+dfx stop
+```
+
+Or close the execution with "command + C"
 
 ## Run the tests against a testnet
 
-Use the environment variables `NNS_DAPP_URL` and direct wdio command:
+Build the environment file for that testnet:
 
+```bash
+# In root folder
+DFX_NETWORK=staging ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
 ```
-NNS_DAPP_URL=... npm run test
+
+Run the test:
+
+```bash
+# In this folder
+npm run test
+# or
+npm run test -- --spec "./specs/user-N01-neuron-created.e2e.ts"
 ```

--- a/e2e-tests/components/accounts-tab.ts
+++ b/e2e-tests/components/accounts-tab.ts
@@ -132,7 +132,7 @@ export class AccountsTab extends MyNavigator {
       AccountsTab.DESTINATION_TOGGLE_SELECTOR,
       "Click destination toggle"
     );
-    
+
     // TODO: Select recipient with xpath by recipient name
     // At the moment it will select the first subaccount available
 

--- a/e2e-tests/components/neurons-tab.ts
+++ b/e2e-tests/components/neurons-tab.ts
@@ -48,7 +48,7 @@ export class NeuronsTab extends MyNavigator {
       neuronId,
       `Get neuron ${neuronId} to check balance`
     );
-    const icpField = await neuron.$(`[data-tid="icp-value"]`);
+    const icpField = await neuron.$(`[data-tid="token-value"]`);
     const icpValue = Number(await icpField.getText());
     if (Number.isFinite(icpValue)) {
       return icpValue;

--- a/e2e-tests/components/proposals-tab.ts
+++ b/e2e-tests/components/proposals-tab.ts
@@ -8,8 +8,12 @@ export class ProposalsTab extends MyNavigator {
   static readonly PROPOSAL_FILTER_APPLY_SELECTOR: string = `[data-tid="apply-proposals-filter"]`;
   static readonly HEADER_BACK_SELECTOR: string = '[data-tid="back"]';
 
-  public static proposalIdSelector(proposalId: number): string {
-    return `[data-tid="proposal-id"][data-proposal-id="${proposalId}"]`;
+  public static proposalCardSelector(proposalId: number): string {
+    return `[data-tid="proposal-card"] [data-proposal-id="${proposalId}"]`;
+  }
+
+  public static proposalDetailsSelector(proposalId: number): string {
+    return `[data-tid="proposal-system-info-details"][data-proposal-id="${proposalId}"]`;
   }
 
   /**

--- a/e2e-tests/specs/home.e2e.ts
+++ b/e2e-tests/specs/home.e2e.ts
@@ -33,7 +33,9 @@ describe("landing page", () => {
     // We wait for the header of the dashboard
     await browser.$("header").waitForExist({ timeout: 20_000 });
 
-    await browser.$('[data-tid="accounts-title"]').waitForExist({ timeout: 30_000 });
+    await browser
+      .$('[data-tid="accounts-title"]')
+      .waitForExist({ timeout: 30_000 });
 
     await waitForImages(browser);
     await browser["screenshot"]("home-page");

--- a/e2e-tests/specs/home.e2e.ts
+++ b/e2e-tests/specs/home.e2e.ts
@@ -32,15 +32,10 @@ describe("landing page", () => {
     // At this point it's still the login page
     // We wait for the header of the dashboard
     await browser.$("header").waitForExist({ timeout: 20_000 });
-    const title = await browser.$("h1");
-    const titleText = await title.getText();
 
-    expect(titleText).toBe("Accounts");
+    await browser.$('[data-tid="accounts-title"]').waitForExist({ timeout: 30_000 });
 
     await waitForImages(browser);
     await browser["screenshot"]("home-page");
-    // TODO: Deploy Ledger and Governance canisters and proxy them
-    // How do we do this when they are in another repo? Do we have a repository of docker images?
-    // TODO: Create docker image of NNS Dapp with IDENTITY_SERVICE_URL pointing to these proxies
   });
 });

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -40,7 +40,8 @@ describe("multi-tab-auth", () => {
     await Promise.all(
       nnsTabs.map(async (tabId, index) => {
         await browser.switchToWindow(tabId);
-        await navigator.getElement(Header.ACCOUNT_MENU_BUTTON_SELECTOR);
+        await browser.refresh();
+        await navigator.getElement(Header.ACCOUNT_MENU_BUTTON_SELECTOR, "Account menu button");
         await browser["screenshot"](`register-logged-in-tab-${index}`);
       })
     );
@@ -48,14 +49,16 @@ describe("multi-tab-auth", () => {
 
   it("oneTabLogsOut", async () => {
     await browser.switchToWindow(nnsTabs[0]);
-    await navigator.click(Header.ACCOUNT_MENU_BUTTON_SELECTOR, "account-menu");
+    await navigator.click(Header.ACCOUNT_MENU_BUTTON_SELECTOR, "Account menu button");
 
     // Small delay for menu animation
     await browser.pause(500);
 
     await navigator.click(Header.LOGOUT_BUTTON_SELECTOR, "logout");
 
-    await navigator.getElement(AuthPage.SELECTOR);
+    // Wait for the logout to complete
+    await browser.pause(2_000);
+    await navigator.getElement(AuthPage.SELECTOR, "Login page");
   });
 
   it("allTabsLogOut", async () => {

--- a/e2e-tests/specs/multi-tab-auth.e2e.ts
+++ b/e2e-tests/specs/multi-tab-auth.e2e.ts
@@ -41,7 +41,10 @@ describe("multi-tab-auth", () => {
       nnsTabs.map(async (tabId, index) => {
         await browser.switchToWindow(tabId);
         await browser.refresh();
-        await navigator.getElement(Header.ACCOUNT_MENU_BUTTON_SELECTOR, "Account menu button");
+        await navigator.getElement(
+          Header.ACCOUNT_MENU_BUTTON_SELECTOR,
+          "Account menu button"
+        );
         await browser["screenshot"](`register-logged-in-tab-${index}`);
       })
     );
@@ -49,7 +52,10 @@ describe("multi-tab-auth", () => {
 
   it("oneTabLogsOut", async () => {
     await browser.switchToWindow(nnsTabs[0]);
-    await navigator.click(Header.ACCOUNT_MENU_BUTTON_SELECTOR, "Account menu button");
+    await navigator.click(
+      Header.ACCOUNT_MENU_BUTTON_SELECTOR,
+      "Account menu button"
+    );
 
     // Small delay for menu animation
     await browser.pause(500);

--- a/e2e-tests/specs/user-A02-create-linked-account.e2e.ts
+++ b/e2e-tests/specs/user-A02-create-linked-account.e2e.ts
@@ -56,7 +56,8 @@ describe("Users get a main account", () => {
     // fail the test.
     await new AccountsTab(browser).getAccountByName(
       linkedAccountName,
-      "Checking that the linked account exists after refresh"
+      "Checking that the linked account exists after refresh",
+      {timeout: 30_000}
     );
   });
 });

--- a/e2e-tests/specs/user-A02-create-linked-account.e2e.ts
+++ b/e2e-tests/specs/user-A02-create-linked-account.e2e.ts
@@ -57,7 +57,7 @@ describe("Users get a main account", () => {
     await new AccountsTab(browser).getAccountByName(
       linkedAccountName,
       "Checking that the linked account exists after refresh",
-      {timeout: 30_000}
+      { timeout: 30_000 }
     );
   });
 });

--- a/e2e-tests/specs/user-N03-neurons-merged.e2e.ts
+++ b/e2e-tests/specs/user-N03-neurons-merged.e2e.ts
@@ -77,8 +77,7 @@ describe("Verifies that neurons can be merged", () => {
     } catch (_) {
       expect(true).toBe(true);
     }
-    const fees =
-      neuron1IcpBefore + neuron2IcpBefore - neuron1IcpAfter;
+    const fees = neuron1IcpBefore + neuron2IcpBefore - neuron1IcpAfter;
     const expectedMaxFees = 0.000101;
     if (fees < 0 || fees > expectedMaxFees) {
       throw new Error(

--- a/e2e-tests/specs/user-N03-neurons-merged.e2e.ts
+++ b/e2e-tests/specs/user-N03-neurons-merged.e2e.ts
@@ -70,18 +70,22 @@ describe("Verifies that neurons can be merged", () => {
   it("Merged balances are correct", async () => {
     const neuronsTab = new NeuronsTab(browser);
     const neuron1IcpAfter = await neuronsTab.getNeuronBalance(neuronId1);
-    const neuron2IcpAfter = await neuronsTab.getNeuronBalance(neuronId2);
-    expect(neuron2IcpAfter).toBe(0);
+    // Second neuron is not displayed because the stake is 0.
+    try {
+      await neuronsTab.getNeuronBalance(neuronId2);
+      expect(true).toBe(false);
+    } catch (_) {
+      expect(true).toBe(true);
+    }
     const fees =
-      neuron1IcpBefore + neuron2IcpBefore - neuron1IcpAfter - neuron2IcpAfter;
+      neuron1IcpBefore + neuron2IcpBefore - neuron1IcpAfter;
     const expectedMaxFees = 0.000101;
-    if (fees < 0 || fees > expectedMaxFees || neuron2IcpAfter !== 0) {
+    if (fees < 0 || fees > expectedMaxFees) {
       throw new Error(
         `Incorrect neuron values: ${JSON.stringify({
           neuron1IcpBefore,
           neuron2IcpBefore,
           neuron1IcpAfter,
-          neuron2IcpAfter,
           fees,
           expectedMaxFees,
         })}`

--- a/e2e-tests/specs/user-V01-open-proposals-are-shown.e2e.ts
+++ b/e2e-tests/specs/user-V01-open-proposals-are-shown.e2e.ts
@@ -43,10 +43,7 @@ describe("Makes a proposal and verifies that it is shown", () => {
     const proposalCardSelector = ProposalsTab.proposalCardSelector(
       proposalId as number
     );
-    await navigator.click(
-      proposalCardSelector,
-      "Navigate to proposal detail"
-    );
+    await navigator.click(proposalCardSelector, "Navigate to proposal detail");
     await navigator.getElement(
       ProposalsTab.PROPOSAL_TALLY_SELECTOR,
       "Waiting for proposal detail"

--- a/e2e-tests/specs/user-V01-open-proposals-are-shown.e2e.ts
+++ b/e2e-tests/specs/user-V01-open-proposals-are-shown.e2e.ts
@@ -35,19 +35,27 @@ describe("Makes a proposal and verifies that it is shown", () => {
   it("Can see the new proposal", async () => {
     const navigator = new MyNavigator(browser);
     console.warn({ proposalId });
-    const proposalMetadataSelector = ProposalsTab.proposalIdSelector(
+    // The proposal is Fails immediately in local tests.
+    const proposalsTab = new ProposalsTab(browser);
+    await proposalsTab.filter("filters-by-status", ["Open", "Failed"]);
+    // Set to the filter of the proposal type.
+    await proposalsTab.filter("filters-by-topics", ["Subnet Management"]);
+    const proposalCardSelector = ProposalsTab.proposalCardSelector(
       proposalId as number
     );
     await navigator.click(
-      proposalMetadataSelector,
+      proposalCardSelector,
       "Navigate to proposal detail"
     );
     await navigator.getElement(
       ProposalsTab.PROPOSAL_TALLY_SELECTOR,
       "Waiting for proposal detail"
     );
+    const proposalDetailsSelector = ProposalsTab.proposalDetailsSelector(
+      proposalId as number
+    );
     await navigator.getElement(
-      proposalMetadataSelector,
+      proposalDetailsSelector,
       "Verifying that the proposal detail is for the correct proposal"
     );
     await navigator.click(

--- a/e2e-tests/specs/user-V02-proposal-filters-work.e2e.ts
+++ b/e2e-tests/specs/user-V02-proposal-filters-work.e2e.ts
@@ -46,8 +46,12 @@ describe("Makes a proposal and verifies that the filters work", () => {
     )} proposals are selected`, async () => {
       await browser.refresh();
       const proposalsTab = new ProposalsTab(browser);
+      // Default status is only "Open".
+      // Yet, the proposal Fails immediately in local tests.
+      await proposalsTab.filter("filters-by-status", ["Open", "Failed"]);
+    
       await proposalsTab.filter(filterSelector, selection);
-      const proposalMetadataSelector = ProposalsTab.proposalIdSelector(
+      const proposalMetadataSelector = ProposalsTab.proposalCardSelector(
         proposalId as number
       );
       await proposalsTab.getElement(
@@ -67,8 +71,12 @@ describe("Makes a proposal and verifies that the filters work", () => {
     )} proposals are deselected`, async () => {
       await browser.refresh();
       const proposalsTab = new ProposalsTab(browser);
+      // Default status is only "Open".
+      // Yet, the proposal Fails immediately in local tests.
+      await proposalsTab.filter("filters-by-status", ["Open", "Failed"]);
+
       await proposalsTab.filter(filterSelector, selection, false);
-      const proposalMetadataSelector = ProposalsTab.proposalIdSelector(
+      const proposalMetadataSelector = ProposalsTab.proposalCardSelector(
         proposalId as number
       );
       await proposalsTab.waitForGone(
@@ -87,6 +95,6 @@ describe("Makes a proposal and verifies that the filters work", () => {
   };
 
   testFilter("filters-by-topics", ["Subnet Management"]);
-  testFilter("filters-by-rewards", ["Accepting Votes"]);
-  testFilter("filters-by-status", ["Open", "Failed"]);
+  // We can't test "Accepting Votes" because the proposal Fails immediately in local tests.
+  // testFilter("filters-by-rewards", ["Accepting Votes"]);
 });

--- a/e2e-tests/specs/user-V02-proposal-filters-work.e2e.ts
+++ b/e2e-tests/specs/user-V02-proposal-filters-work.e2e.ts
@@ -49,7 +49,7 @@ describe("Makes a proposal and verifies that the filters work", () => {
       // Default status is only "Open".
       // Yet, the proposal Fails immediately in local tests.
       await proposalsTab.filter("filters-by-status", ["Open", "Failed"]);
-    
+
       await proposalsTab.filter(filterSelector, selection);
       const proposalMetadataSelector = ProposalsTab.proposalCardSelector(
         proposalId as number

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -20,7 +20,8 @@ function capabilitiesFromEnv(): Capabilities.RemoteCapabilities {
     const chrome = {
       browserName: "chrome",
       "goog:chromeOptions": {
-        args: ["headless", "disable-gpu"],
+        // args: ["headless", "disable-gpu"],
+        args: ["disable-gpu"],
       },
       acceptInsecureCerts: true,
     };

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -20,8 +20,7 @@ function capabilitiesFromEnv(): Capabilities.RemoteCapabilities {
     const chrome = {
       browserName: "chrome",
       "goog:chromeOptions": {
-        // args: ["headless", "disable-gpu"],
-        args: ["disable-gpu"],
+        args: ["headless", "disable-gpu"],
       },
       acceptInsecureCerts: true,
     };

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -6,9 +6,11 @@
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import { i18n } from "$lib/stores/i18n";
   import type { NeuronId } from "@dfinity/nns";
+  import type { ProposalId } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
 
+  let id: ProposalId | undefined;
   let type: string | undefined;
   let typeDescription: string | undefined;
   let topic: string | undefined;
@@ -39,12 +41,17 @@
     executed,
     failed,
     proposer,
+    id,
   } = mapProposalInfo(proposalInfo));
 </script>
 
 <h1 class="content-cell-title">{type ?? ""}</h1>
 
-<div class="content-cell-details" data-tid="proposal-system-info-details">
+<div
+  class="content-cell-details"
+  data-tid="proposal-system-info-details"
+  data-proposal-id={id}
+>
   {#if type !== undefined}
     <ProposalSystemInfoEntry
       labelKey="type_prefix"

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -44,7 +44,7 @@
     testId="proposal-card"
     withArrow={true}
   >
-    <div class="card-meta id">
+    <div class="card-meta id" data-proposal-id={id}>
       <Value ariaLabel={$i18n.proposal_detail.id_prefix}>{id}</Value>
     </div>
 


### PR DESCRIPTION
# Motivation

Improve documentation of how to execute e2e tests.

Fix selectors and other minor broken e2e tests.

# Important

This does NOT fix all the e2e yet. But it's one step towards adding them to our CI.

What is still pending:

* Deploy the SNS-W canister locally. Better to wait until the next dfx release which will include an easy way to do so: `dfx nns install`.
* When making a new proposal to be tested, it should be Open and not fail immediately.
* I also added a couple more of TODOs in the code that would add nice functionality, but are not necessary for the current e2e tests.

# Changes

* Improve Readme in e2e-tests directory.
* Fix some broken e2e tests.
* Add some data-tid in nns-dapp frontend.

# Tests

All changes are in tests.
