### PR TITLE
GIX-1073: SNS Hotkey more permissions

### DIFF
--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -157,7 +157,10 @@ export const addHotkey = async ({
   rootCanisterId: Principal;
 }): Promise<{ success: boolean }> => {
   try {
-    const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+    const permissions = [
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+    ];
     const identity = await getNeuronIdentity();
     await addNeuronPermissions({
       permissions,
@@ -186,7 +189,10 @@ export const removeHotkey = async ({
   rootCanisterId: Principal;
 }): Promise<{ success: boolean }> => {
   try {
-    const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+    const permissions = [
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+    ];
     const identity = await getNeuronIdentity();
     const principal = Principal.fromText(hotkey);
     await removeNeuronPermissions({

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -179,6 +179,7 @@ export const hasPermissions = ({
   return !permissions.some(notFound);
 };
 
+// TODO: Confirm that a hotkey is only a neuron with NEURON_PERMISSION_TYPE_VOTE
 export const getSnsNeuronHotkeys = ({ permissions }: SnsNeuron): string[] =>
   permissions
     // Filter the controller. The controller is the neuron with all permissions

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -179,15 +179,18 @@ export const hasPermissions = ({
   return !permissions.some(notFound);
 };
 
-// TODO: Confirm that a hotkey is only a neuron with NEURON_PERMISSION_TYPE_VOTE
 export const getSnsNeuronHotkeys = ({ permissions }: SnsNeuron): string[] =>
   permissions
     // Filter the controller. The controller is the neuron with all permissions
     .filter(({ permission_type }) => !hasAllPermissions(permission_type))
-    .filter(({ permission_type }) =>
-      permission_type.includes(
-        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE
-      )
+    .filter(
+      ({ permission_type }) =>
+        permission_type.includes(
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE
+        ) &&
+        permission_type.includes(
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL
+        )
     )
     .map(({ principal }) => fromNullable(principal)?.toText())
     .filter(nonNullish);

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -185,12 +185,11 @@ export const getSnsNeuronHotkeys = ({ permissions }: SnsNeuron): string[] =>
     .filter(({ permission_type }) => !hasAllPermissions(permission_type))
     .filter(
       ({ permission_type }) =>
-        permission_type.includes(
-          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE
-        ) &&
-        permission_type.includes(
-          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL
-        )
+        [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+        ].find((permission) => !permission_type.includes(permission)) ===
+        undefined
     )
     .map(({ principal }) => fromNullable(principal)?.toText())
     .filter(nonNullish);

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -23,10 +23,11 @@ jest.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("SnsNeuronHotkeysCard", () => {
-  const addVotePermission = (key) => ({
+  const addHotkeiPermissions = (key) => ({
     principal: [Principal.fromText(key)] as [Principal],
     permission_type: Int32Array.from([
       SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
     ]),
   });
   const hotkeys = [
@@ -36,13 +37,13 @@ describe("SnsNeuronHotkeysCard", () => {
   const controlledNeuron: SnsNeuron = {
     ...mockSnsNeuron,
     permissions: [...hotkeys, mockIdentity.getPrincipal().toText()].map(
-      addVotePermission
+      addHotkeiPermissions
     ),
   };
 
   const unControlledNeuron: SnsNeuron = {
     ...mockSnsNeuron,
-    permissions: hotkeys.map(addVotePermission),
+    permissions: hotkeys.map(addHotkeiPermissions),
   };
 
   const reload = jest.fn();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -23,7 +23,7 @@ jest.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("SnsNeuronHotkeysCard", () => {
-  const addHotkeiPermissions = (key) => ({
+  const addHotkeyPermissions = (key) => ({
     principal: [Principal.fromText(key)] as [Principal],
     permission_type: Int32Array.from([
       SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
@@ -37,13 +37,13 @@ describe("SnsNeuronHotkeysCard", () => {
   const controlledNeuron: SnsNeuron = {
     ...mockSnsNeuron,
     permissions: [...hotkeys, mockIdentity.getPrincipal().toText()].map(
-      addHotkeiPermissions
+      addHotkeyPermissions
     ),
   };
 
   const unControlledNeuron: SnsNeuron = {
     ...mockSnsNeuron,
-    permissions: hotkeys.map(addHotkeiPermissions),
+    permissions: hotkeys.map(addHotkeyPermissions),
   };
 
   const reload = jest.fn();

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -181,7 +181,7 @@ describe("SnsNeuronCard", () => {
     expect(getByText(en.time.year, { exact: false })).toBeInTheDocument();
   });
 
-  it("renders the hotkey_control label when user has only voting permissions", async () => {
+  it("renders the hotkey_control label when user has only voting and proposal permissions", async () => {
     const hotkeyneuron: SnsNeuron = {
       ...mockSnsNeuron,
       permissions: [
@@ -189,6 +189,7 @@ describe("SnsNeuronCard", () => {
           principal: [mockIdentity.getPrincipal()],
           permission_type: Int32Array.from([
             SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
           ]),
         },
       ],

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -186,7 +186,10 @@ describe("sns-neurons-services", () => {
         identity: mockIdentity,
         principal: hotkey,
         rootCanisterId: mockPrincipal,
-        permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
+        permissions: [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+        ],
       });
     });
   });
@@ -208,7 +211,10 @@ describe("sns-neurons-services", () => {
         identity: mockIdentity,
         principal: Principal.fromText(hotkey),
         rootCanisterId: mockPrincipal,
-        permissions: [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE],
+        permissions: [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
+        ],
       });
     });
   });

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -404,7 +404,7 @@ describe("sns-neuron utils", () => {
   });
 
   describe("isUserHotkey", () => {
-    it("returns true if user only has voting and proporal permissions but not all permissions", () => {
+    it("returns true if user only has voting and proposal permissions but not all permissions", () => {
       const hotkeyneuron: SnsNeuron = {
         ...mockSnsNeuron,
         permissions: [


### PR DESCRIPTION
# Motivation

A SNS Hotkey is not just NEURON_PERMISSION_TYPE_VOTE permission but also NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL.

# Changes

* Add and remove NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL permission when adding or removing hotkeys.

# Tests

* Fix tests.
