### PR TITLE
Chore: Reduce token amount usage

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -11,7 +11,6 @@ import type {
   KnownNeuron,
   NeuronId,
   NeuronInfo,
-  TokenAmount,
   Topic,
 } from "@dfinity/nns";
 import { GovernanceCanister } from "@dfinity/nns";
@@ -243,7 +242,7 @@ export const splitNeuron = async ({
   identity,
 }: {
   neuronId: NeuronId;
-  amount: TokenAmount;
+  amount: bigint;
   identity: Identity;
 }): Promise<NeuronId> => {
   logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) call...`);
@@ -251,7 +250,7 @@ export const splitNeuron = async ({
 
   const response = await canister.splitNeuron({
     neuronId,
-    amount: amount.toE8s(),
+    amount,
   });
   logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) complete.`);
   return response;
@@ -361,7 +360,7 @@ export const stakeNeuron = async ({
   identity,
   fromSubAccount,
 }: {
-  stake: TokenAmount;
+  stake: bigint;
   controller: Principal;
   ledgerCanisterIdentity: Identity;
   identity: Identity;
@@ -376,7 +375,7 @@ export const stakeNeuron = async ({
   });
 
   const response = await canister.stakeNeuron({
-    stake: stake.toE8s(),
+    stake: stake,
     principal: controller,
     fromSubAccount,
     ledgerCanister,

--- a/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ICPToken, TokenAmount, type NeuronInfo } from "@dfinity/nns";
+  import type { NeuronInfo } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -18,10 +18,7 @@
 
   let disabled: boolean;
   $: disabled = !isEnoughToStakeNeuron({
-    stake: TokenAmount.fromE8s({
-      amount: neuron.fullNeuron?.maturityE8sEquivalent ?? BigInt(0),
-      token: ICPToken,
-    }),
+    stakeE8s: neuron.fullNeuron?.maturityE8sEquivalent ?? BigInt(0),
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -22,7 +22,6 @@ import {
 } from "$lib/api/governance.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { MIN_VERSION_MERGE_MATURITY } from "$lib/constants/neurons.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
@@ -33,7 +32,7 @@ import {
   toastsShow,
   toastsSuccess,
 } from "$lib/stores/toasts.store";
-import { mainTransactionFeeStore } from "$lib/stores/transaction-fees.store";
+import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
 import { InsufficientAmountError } from "$lib/types/common.errors";
 import {
@@ -61,14 +60,9 @@ import {
   userAuthorizedNeuron,
   validTopUpAmount,
 } from "$lib/utils/neuron.utils";
+import { numberToE8s } from "$lib/utils/token.utils";
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
-import {
-  ICPToken,
-  TokenAmount,
-  Topic,
-  type NeuronId,
-  type NeuronInfo,
-} from "@dfinity/nns";
+import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import {
@@ -206,16 +200,13 @@ export const stakeNeuron = async ({
   loadNeuron?: boolean;
 }): Promise<NeuronId | undefined> => {
   try {
-    const stake = TokenAmount.fromNumber({
-      amount,
-      token: ICPToken,
-    });
+    const stake = numberToE8s(amount);
     assertEnoughAccountFunds({
       account,
-      amountE8s: stake.toE8s(),
+      amountE8s: stake,
     });
 
-    if (!isEnoughToStakeNeuron({ stake })) {
+    if (!isEnoughToStakeNeuron({ stakeE8s: stake })) {
       toastsError({
         labelKey: "error.amount_not_enough_stake_neuron",
       });
@@ -562,18 +553,14 @@ export const splitNeuron = async ({
       neuronId
     );
 
-    const fee = get(mainTransactionFeeStore);
-    const transactionFeeAmount = fee / E8S_PER_ICP;
-    const stake = TokenAmount.fromNumber({
-      amount: amount + transactionFeeAmount,
-      token: ICPToken,
-    });
+    const feeE8s = get(mainTransactionFeeE8sStore);
+    const amountE8s = numberToE8s(amount);
 
-    if (!isEnoughToStakeNeuron({ stake, fee })) {
+    if (!isEnoughToStakeNeuron({ stakeE8s: amountE8s, feeE8s })) {
       throw new InsufficientAmountError();
     }
 
-    await splitNeuronApi({ neuronId, identity, amount: stake });
+    await splitNeuronApi({ neuronId, identity, amount: amountE8s });
 
     await listNeurons();
 

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -554,7 +554,7 @@ export const splitNeuron = async ({
     );
 
     const feeE8s = get(mainTransactionFeeE8sStore);
-    const amountE8s = numberToE8s(amount);
+    const amountE8s = numberToE8s(amount) + feeE8s;
 
     if (!isEnoughToStakeNeuron({ stakeE8s: amountE8s, feeE8s })) {
       throw new InsufficientAmountError();

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -68,3 +68,8 @@ export const mainTransactionFeeStore = derived(
   transactionsFeesStore,
   ($store) => Number($store.main)
 );
+
+export const mainTransactionFeeE8sStore = derived(
+  transactionsFeesStore,
+  ($store) => $store.main
+);

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -64,6 +64,9 @@ const initTransactionFeesStore = () => {
 
 export const transactionsFeesStore = initTransactionFeesStore();
 
+/**
+ * @deprecated prefer mainTransactionFeeE8sStore to use e8s for amount of tokens instead of Number.
+ */
 export const mainTransactionFeeStore = derived(
   transactionsFeesStore,
   ($store) => Number($store.main)

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -26,7 +26,6 @@ import {
 } from "@dfinity/gix-components";
 import {
   NeuronState,
-  TokenAmount,
   Topic,
   Vote,
   votedNeurons,
@@ -325,12 +324,12 @@ export const isValidInputAmount = ({
 }): boolean => amount !== undefined && amount > 0 && amount <= max;
 
 export const isEnoughToStakeNeuron = ({
-  stake,
-  fee = 0,
+  stakeE8s,
+  feeE8s = BigInt(0),
 }: {
-  stake: TokenAmount;
-  fee?: number;
-}): boolean => stake.toE8s() >= MIN_NEURON_STAKE + fee;
+  stakeE8s: bigint;
+  feeE8s?: bigint;
+}): boolean => stakeE8s >= BigInt(MIN_NEURON_STAKE) + feeE8s;
 
 export const isEnoughMaturityToSpawn = ({
   neuron: { fullNeuron },

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -19,13 +19,7 @@ import {
   startDissolving,
   stopDissolving,
 } from "$lib/api/governance.api";
-import {
-  GovernanceCanister,
-  ICPToken,
-  LedgerCanister,
-  TokenAmount,
-  Topic,
-} from "@dfinity/nns";
+import { GovernanceCanister, LedgerCanister, Topic } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 import { mockMainAccount } from "../../mocks/accounts.store.mock";
@@ -60,10 +54,7 @@ describe("neurons-api", () => {
       .mockImplementation(() => mock<LedgerCanister>());
 
     await stakeNeuron({
-      stake: TokenAmount.fromString({
-        amount: "2",
-        token: ICPToken,
-      }) as TokenAmount,
+      stake: BigInt(20_000_000),
       controller: mockIdentity.getPrincipal(),
       ledgerCanisterIdentity: mockIdentity,
       identity: mockIdentity,
@@ -600,10 +591,7 @@ describe("neurons-api", () => {
   });
 
   describe("splitNeuron", () => {
-    const amount = TokenAmount.fromString({
-      amount: "2.2",
-      token: ICPToken,
-    }) as TokenAmount;
+    const amount = BigInt(220_000_000);
     it("updates neuron successfully", async () => {
       mockGovernanceCanister.splitNeuron.mockImplementation(
         jest.fn().mockResolvedValue(BigInt(11))

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -14,6 +14,7 @@ import * as busyStore from "$lib/stores/busy.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
+import { numberToE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, LedgerCanister, TokenAmount, Topic } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -1018,10 +1019,7 @@ describe("neurons-services", () => {
       expect(spySplitNeuron).toHaveBeenCalledWith({
         identity: mockIdentity,
         neuronId: controlledNeuron.neuronId,
-        amount: TokenAmount.fromE8s({
-          amount: BigInt(Math.round(amountWithFee * E8S_PER_ICP)),
-          token: ICPToken,
-        }),
+        amount: numberToE8s(amountWithFee),
       });
     });
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -861,7 +861,7 @@ describe("neuron-utils", () => {
 
   describe("isEnoughToStakeNeuron", () => {
     it("return true if enough ICP to create a neuron", () => {
-      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(30_000_000) })).toBe(
+      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(300_000_000) })).toBe(
         true
       );
     });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -861,18 +861,26 @@ describe("neuron-utils", () => {
 
   describe("isEnoughToStakeNeuron", () => {
     it("return true if enough ICP to create a neuron", () => {
-      const stake = TokenAmount.fromString({
-        amount: "3",
-        token: ICPToken,
-      }) as TokenAmount;
-      expect(isEnoughToStakeNeuron({ stake })).toBe(true);
+      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(30_000_000) })).toBe(
+        true
+      );
     });
     it("returns false if not enough ICP to create a neuron", () => {
-      const stake = TokenAmount.fromString({
-        amount: "0.000001",
-        token: ICPToken,
-      }) as TokenAmount;
-      expect(isEnoughToStakeNeuron({ stake })).toBe(false);
+      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(10_000) })).toBe(false);
+    });
+
+    it("takes into account fee", () => {
+      expect(
+        isEnoughToStakeNeuron({
+          stakeE8s: BigInt(100_000_000),
+          feeE8s: BigInt(10_000),
+        })
+      ).toBe(false);
+      expect(
+        isEnoughToStakeNeuron({
+          stakeE8s: BigInt(100_000_000),
+        })
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
# Motivation

Reduce usage of TokenAmount for non-UI related functionality and use e8s instead.

# Changes

* Remove dependency of TokenAmount in "neuron.utils", "governance.api" and "neuron.services".

# Tests

* Fix tests after refactor.
