### PR TITLE
GIX-1092: Refresh SNS sale before participation

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -138,7 +138,7 @@ export const querySnsSwapState = async ({
   rootCanisterId: QueryRootCanisterId;
   identity: Identity;
   certified: boolean;
-}): Promise<QuerySnsSwapState | undefined> => {
+}): Promise<QuerySnsSwapState> => {
   logWithTimestamp(
     `Getting Sns ${rootCanisterId} swap state certified:${certified} call...`
   );

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -236,13 +236,10 @@ const reloadSnsState = async (rootCanisterId: Principal): Promise<void> => {
       identity,
       certified: true,
     });
-    // Ignore if swap data is undefined
-    if (swapData !== undefined) {
-      snsQueryStore.updateSwapState({
-        swapData,
-        rootCanisterId: rootCanisterId.toText(),
-      });
-    }
+    snsQueryStore.updateSwapState({
+      swapData,
+      rootCanisterId: rootCanisterId.toText(),
+    });
   } catch (err) {
     // Ignore error
     console.error("Error reloading swap state", err);

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -223,7 +223,8 @@ export const listSnsProposals = async (): Promise<void> => {
 /**
  * Requests swap state and loads it in the store.
  * Ignores possible undefined. This is used only to recheck the data with up-to-date information.
- * If an error happens, we want to rely on the data that it's already in the store.
+ * This should be used only when the data is already in the store.
+ * That's why if an error happens, we want to rely on the data that it's already in the store.
  *
  * @param {Principal} rootCanisterId Root canister id of the project.
  */
@@ -288,6 +289,10 @@ export const participateInSwap = async ({
       account,
       amountE8s: amount.toE8s() + transactionFee,
     });
+    // TODO: Move the logic to the `catch` for a faster participation.
+    // At the moment we can't move it to the `catch`
+    // because it's hard for us to differentiate when the error comes from stale data or the second notify for the last participation.
+    //
     // Reload the sale state before validating the participation.
     // The current state might have change since it was loaded.
     // This might prevent transferring funds that will not be accepted as participation and avoid refunds.

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -133,6 +133,28 @@ const initSnsQueryStore = () => {
               ),
       }));
     },
+
+    /**
+     * Updates only the swap state of a sale.
+     *
+     * @param {Object} params
+     * @param {QuerySnsSwapState} params.swapData new swap data.
+     * @param {string} params.rootCanisterId canister id in text format.
+     */
+    updateSwapState({
+      swapData,
+      rootCanisterId,
+    }: {
+      swapData: QuerySnsSwapState;
+      rootCanisterId: string;
+    }) {
+      update((store: SnsQueryStore) => ({
+        metadata: store?.metadata ?? [],
+        swaps: (store?.swaps ?? []).map((swap) =>
+          swap.rootCanisterId === rootCanisterId ? swapData : swap
+        ),
+      }));
+    },
   };
 };
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -60,7 +60,7 @@ describe("sns-services", () => {
         .mockImplementation(() => Promise.resolve(undefined));
       const spyQueryState = jest
         .spyOn(api, "querySnsSwapState")
-        .mockImplementation(() => Promise.resolve(undefined));
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const { success } = await participateInSwap({
         amount: TokenAmount.fromString({
           amount: "3",
@@ -92,6 +92,9 @@ describe("sns-services", () => {
       querySnsSwapStates[0].swap[0]!.params[0]!.max_icp_e8s = maxE8s;
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() =>
@@ -117,6 +120,9 @@ describe("sns-services", () => {
     it("should return success false if api call fails", async () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.reject(new Error("test")));
@@ -147,6 +153,9 @@ describe("sns-services", () => {
         BigInt(200_000_000_000);
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
@@ -177,6 +186,9 @@ describe("sns-services", () => {
         BigInt(200_000_000_000);
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
@@ -202,6 +214,9 @@ describe("sns-services", () => {
           token: ICPToken,
         }),
       };
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));
@@ -224,6 +239,9 @@ describe("sns-services", () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
       setNoAccountIdentity();
+      jest
+        .spyOn(api, "querySnsSwapState")
+        .mockImplementation(() => Promise.resolve(querySnsSwapStates[0]));
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
         .mockImplementation(() => Promise.resolve(undefined));

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -52,11 +52,14 @@ describe("sns-services", () => {
       snsQueryStore.reset();
     });
 
-    it("should call api.participateInSnsSwap, sync accounts and return success true", async () => {
+    it("should fetch swap state call api.participateInSnsSwap, sync accounts and return success true", async () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest
         .spyOn(api, "participateInSnsSwap")
+        .mockImplementation(() => Promise.resolve(undefined));
+      const spyQueryState = jest
+        .spyOn(api, "querySnsSwapState")
         .mockImplementation(() => Promise.resolve(undefined));
       const { success } = await participateInSwap({
         amount: TokenAmount.fromString({
@@ -67,6 +70,7 @@ describe("sns-services", () => {
         account: mockMainAccount,
       });
       expect(success).toBe(true);
+      expect(spyQueryState).toBeCalled();
       expect(spyParticipate).toBeCalled();
       expect(syncAccounts).toBeCalled();
     });

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -52,7 +52,7 @@ describe("sns-services", () => {
       snsQueryStore.reset();
     });
 
-    it("should fetch swap state call api.participateInSnsSwap, sync accounts and return success true", async () => {
+    it("should fetch swap state, call api.participateInSnsSwap, sync accounts and return success true", async () => {
       const rootCanisterId = Principal.fromText(metadatas[0].rootCanisterId);
       snsQueryStore.setData([metadatas, querySnsSwapStates]);
       const spyParticipate = jest

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -227,8 +227,8 @@ describe("sns.store", () => {
       expect(
         updatedStore?.swaps.find(
           (swap) => swap.rootCanisterId === rootCanisterId
-        )?.swap[0]?.lifecycle
-      ).toBe(SnsSwapLifecycle.Open);
+        )
+      ).toEqual(updatedSwapData);
     });
   });
 });


### PR DESCRIPTION
# Motivation

User might try to participate in a decentralization sale and fail because the information is stale. We only load it once at the initialization.

To avoid edge cases and bad UX where refunds need to happen, we refresh the swap state before validating the user participation.

# Changes

* New sns service "reloadSnsState" used only internally in "participateInSwap".
* New method in sns store "updateSwapState" that loads in store only the swap state.

# Tests

* A test case that participateInSwap fetches new data.
* A test case in sns store for updateSwapState.
