### PR TITLE
GIX-1089: Hide SNS neurons no stake

### DIFF
--- a/frontend/src/lib/derived/sorted-sns-neurons.derived.ts
+++ b/frontend/src/lib/derived/sorted-sns-neurons.derived.ts
@@ -1,5 +1,8 @@
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { sortSnsNeuronsByCreatedTimestamp } from "$lib/utils/sns-neuron.utils";
+import {
+  hasValidStake,
+  sortSnsNeuronsByCreatedTimestamp,
+} from "$lib/utils/sns-neuron.utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { derived, type Readable } from "svelte/store";
 import { snsProjectSelectedStore } from "./selected-project.derived";
@@ -10,6 +13,8 @@ export const sortedSnsNeuronStore: Readable<SnsNeuron[]> = derived(
     const projectStore = store[selectedSnsRootCanisterId.toText()];
     return projectStore === undefined
       ? []
-      : sortSnsNeuronsByCreatedTimestamp(projectStore.neurons);
+      : sortSnsNeuronsByCreatedTimestamp(
+          projectStore.neurons.filter(hasValidStake)
+        );
   }
 );

--- a/frontend/src/lib/stores/neurons.store.ts
+++ b/frontend/src/lib/stores/neurons.store.ts
@@ -28,23 +28,20 @@ const initNeuronsStore = () => {
 
     setNeurons({ neurons, certified }: Required<NeuronsStore>) {
       set({
-        neurons: [...neurons.filter(hasValidStake)],
+        neurons,
         certified,
       });
     },
 
     pushNeurons({ neurons, certified }: Required<NeuronsStore>) {
       update(({ neurons: oldNeurons }: NeuronsStore) => {
-        const filteredNewNeurons = neurons.filter(hasValidStake);
-        const newIds = new Set(
-          filteredNewNeurons.map(({ neuronId }) => neuronId)
-        );
+        const newIds = new Set(neurons.map(({ neuronId }) => neuronId));
         return {
           neurons: [
             ...(oldNeurons || []).filter(
               ({ neuronId }) => !newIds.has(neuronId)
             ),
-            ...filteredNewNeurons,
+            ...neurons,
           ],
           certified,
         };
@@ -91,7 +88,7 @@ export const neuronsStore = initNeuronsStore();
 
 export const definedNeuronsStore: Readable<NeuronInfo[]> = derived(
   neuronsStore,
-  ($neuronsStore) => $neuronsStore.neurons || []
+  ($neuronsStore) => $neuronsStore.neurons?.filter(hasValidStake) || []
 );
 
 export const sortedNeuronStore: Readable<NeuronInfo[]> = derived(

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -214,3 +214,12 @@ export const isSnsNeuron = (
 ): neuron is SnsNeuron =>
   Array.isArray((neuron as SnsNeuron).id) &&
   Array.isArray((neuron as SnsNeuron).permissions);
+
+/**
+ * Checks whether the neuron has either stake or maturity greater than zero.
+ *
+ * @param {SnsNeuron} neuron
+ * @returns {boolean}
+ */
+export const hasValidStake = (neuron: SnsNeuron): boolean =>
+  neuron.cached_neuron_stake_e8s + neuron.maturity_e8s_equivalent > BigInt(0);

--- a/frontend/src/tests/lib/derived/sorted-sns-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sorted-sns-neurons.derived.spec.ts
@@ -59,6 +59,44 @@ describe("sortedSnsNeuronStore", () => {
     ]);
   });
 
+  it("should filter out neurons with no stake nor maturity", async () => {
+    const neurons: SnsNeuron[] = [
+      {
+        ...createMockSnsNeuron({
+          stake: BigInt(0),
+          id: [1, 5, 3, 9, 1, 1, 1],
+        }),
+        created_timestamp_seconds: BigInt(1),
+        maturity_e8s_equivalent: BigInt(0),
+      },
+      {
+        ...createMockSnsNeuron({
+          stake: BigInt(2_000_000_000),
+          id: [1, 5, 3, 9, 9, 3, 2],
+        }),
+        created_timestamp_seconds: BigInt(3),
+      },
+      {
+        ...createMockSnsNeuron({
+          stake: BigInt(10_000_000_000),
+          id: [1, 2, 2, 9, 9, 3, 2],
+        }),
+        created_timestamp_seconds: BigInt(2),
+      },
+    ];
+    snsNeuronsStore.setNeurons({
+      rootCanisterId: mockPrincipal,
+      neurons,
+      certified: true,
+    });
+    routeStore.update({
+      path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/neurons`,
+    });
+
+    await tick();
+    expect(get(sortedSnsNeuronStore)).toEqual([neurons[1], neurons[2]]);
+  });
+
   it("should return the sorted neurons of the selected project", async () => {
     const neurons1: SnsNeuron[] = [
       {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -11,6 +11,7 @@ import {
   getSnsNeuronState,
   hasPermissions,
   hasPermissionToDisburse,
+  hasValidStake,
   isSnsNeuron,
   isUserHotkey,
   routePathSnsNeuronId,
@@ -661,6 +662,44 @@ describe("sns-neuron utils", () => {
     it("returns false for NeuronInfo (nnsNeuron)", () => {
       const neuron: NeuronInfo = { ...mockNeuron };
       expect(isSnsNeuron(neuron)).toBeFalsy();
+    });
+  });
+
+  describe("hasValidStake", () => {
+    it("returns true if neuron has stake greater than 0", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(10_000_000),
+        maturity_e8s_equivalent: BigInt(0),
+      };
+      expect(hasValidStake(neuron)).toBeTruthy();
+    });
+
+    it("returns true if neuron has maturity greater than 0", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(0),
+        maturity_e8s_equivalent: BigInt(10_000_000),
+      };
+      expect(hasValidStake(neuron)).toBeTruthy();
+    });
+
+    it("returns true if neuron has maturity and stake greater than 0", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(10_000_000),
+        maturity_e8s_equivalent: BigInt(10_000_000),
+      };
+      expect(hasValidStake(neuron)).toBeTruthy();
+    });
+
+    it("returns false if neuron has no maturity and no stake", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(0),
+        maturity_e8s_equivalent: BigInt(0),
+      };
+      expect(hasValidStake(neuron)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

The SNS Neurons list showed neurons with 0 stake after they were disbursed.

User should not see the neurons that have already been disbursed.

# Changes

* New sns neuron util `hasValidStake` that returns boolean.
* Use the new sns neuron util in "sortedSnsNeuronStore".
* Do not filter out the NNS neurons without valid stake in the neuronsStore.
* Filter out NNS neurons without valid stake in definedNeuronsStore.

# Tests

* New test for sns neuron util "hasValidStake".
* New test case for sortedSnsNeuronStore
* Tests for definedNeuronsStore.
