### PR TITLE
GIX-996: Setup getting SNS transactions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.1.tgz",
-      "integrity": "sha512-4hYhNUsaJPwJBAjqNNJzFIQMlx4UW/b0UTuNSoON1XB8wOi4Ts454HoIRU9c10kwkuNQaz8kwsGDoNm3+2sCqQ==",
+      "version": "0.0.2-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.2.tgz",
+      "integrity": "sha512-LSqeT3CmS8b3XSPlr1mdAphVhWwB4x1eI78b7bL1GddPG259CaY58/52y2x7rIFB5hp7NcEIEz30jiCXLQR15A==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.1.tgz",
-      "integrity": "sha512-7ULIGQWN61XVESgxjxktC2GvvrkOqyba48JJjyvf3beC70KWD5zUkF03KkCyGLKf54A45GAgAAeNNDaaAYZEUw==",
+      "version": "0.9.0-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.2.tgz",
+      "integrity": "sha512-qVQbctKXdPzoVZllQtTOGbdkDOTUP0oJ207ya38vR9IirUhbR1FBWCPnVV+XZ270CJsnJDQsMh11qttZROi3Wg==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1709,17 +1709,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.1.tgz",
-      "integrity": "sha512-FxzyeMezDXphKzllgNeLlISgB94uABRfi0CZtiIpKzv8rZDT5elq4aGTg9IVjSyoq08kLmHEP8mVQE11DQT+Jw==",
+      "version": "0.0.6-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.2.tgz",
+      "integrity": "sha512-8GL7XQZTk5QXc/1n0kp/5ujBjxXRZ5jcU2MprSZoxhw7me2HQBqKtKJc4Bh5KCwARP78XOLa7l4bsNvyvwAcZg==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.1.tgz",
-      "integrity": "sha512-S3TSUN0kov5RhFKTBKvIOgt3jRxwJj/nTPsWg/0s5NcnUW8eirZhbjSQ41SzYgCjxN1AHEQbapvC81T77HFRaw=="
+      "version": "0.0.5-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.2.tgz",
+      "integrity": "sha512-UHFtXEKEx2v7GAo4ZvtkHVFRvqQoRLjh1p43IKYCGI+RX1aFkZXoPCLaIyhuKK1bCZ9/YQE1s4oAwxPs8AVsrQ=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10991,9 +10991,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.1.tgz",
-      "integrity": "sha512-4hYhNUsaJPwJBAjqNNJzFIQMlx4UW/b0UTuNSoON1XB8wOi4Ts454HoIRU9c10kwkuNQaz8kwsGDoNm3+2sCqQ==",
+      "version": "0.0.2-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.2.tgz",
+      "integrity": "sha512-LSqeT3CmS8b3XSPlr1mdAphVhWwB4x1eI78b7bL1GddPG259CaY58/52y2x7rIFB5hp7NcEIEz30jiCXLQR15A==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11016,9 +11016,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.1.tgz",
-      "integrity": "sha512-7ULIGQWN61XVESgxjxktC2GvvrkOqyba48JJjyvf3beC70KWD5zUkF03KkCyGLKf54A45GAgAAeNNDaaAYZEUw==",
+      "version": "0.9.0-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.2.tgz",
+      "integrity": "sha512-qVQbctKXdPzoVZllQtTOGbdkDOTUP0oJ207ya38vR9IirUhbR1FBWCPnVV+XZ270CJsnJDQsMh11qttZROi3Wg==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11036,15 +11036,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.1.tgz",
-      "integrity": "sha512-FxzyeMezDXphKzllgNeLlISgB94uABRfi0CZtiIpKzv8rZDT5elq4aGTg9IVjSyoq08kLmHEP8mVQE11DQT+Jw==",
+      "version": "0.0.6-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.2.tgz",
+      "integrity": "sha512-8GL7XQZTk5QXc/1n0kp/5ujBjxXRZ5jcU2MprSZoxhw7me2HQBqKtKJc4Bh5KCwARP78XOLa7l4bsNvyvwAcZg==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.1.tgz",
-      "integrity": "sha512-S3TSUN0kov5RhFKTBKvIOgt3jRxwJj/nTPsWg/0s5NcnUW8eirZhbjSQ41SzYgCjxN1AHEQbapvC81T77HFRaw=="
+      "version": "0.0.5-next-2022-10-25.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.2.tgz",
+      "integrity": "sha512-UHFtXEKEx2v7GAo4ZvtkHVFRvqQoRLjh1p43IKYCGI+RX1aFkZXoPCLaIyhuKK1bCZ9/YQE1s4oAwxPs8AVsrQ=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-10.1.tgz",
-      "integrity": "sha512-btLwQBdAGRzMs6A6WLSFkh9fOmxntVICznrMrzPfdj7iFbPd5WbCvcZjF7oUeNxxDys8/DR3JFoYhzzlHPrA8g==",
+      "version": "0.0.2-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.1.tgz",
+      "integrity": "sha512-4hYhNUsaJPwJBAjqNNJzFIQMlx4UW/b0UTuNSoON1XB8wOi4Ts454HoIRU9c10kwkuNQaz8kwsGDoNm3+2sCqQ==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-10.1.tgz",
-      "integrity": "sha512-dQP71RR19lGWnTxGclfJmbEos8ExVDgxlOGKw9Sz5JMBh9NYQ/bbnb7Bx4oNmhNXszGMtMGC1ZAWp8j/h2LhZg==",
+      "version": "0.9.0-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.1.tgz",
+      "integrity": "sha512-7ULIGQWN61XVESgxjxktC2GvvrkOqyba48JJjyvf3beC70KWD5zUkF03KkCyGLKf54A45GAgAAeNNDaaAYZEUw==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1709,17 +1709,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-10.1.tgz",
-      "integrity": "sha512-gd1X6U9CMjyASENH4+8uEM83UNElb6FkRH3g/9ffRsnbgkGqCGht7gwEvaLU1L6sgQpSW8E12PjcK280KjD2Zw==",
+      "version": "0.0.6-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.1.tgz",
+      "integrity": "sha512-FxzyeMezDXphKzllgNeLlISgB94uABRfi0CZtiIpKzv8rZDT5elq4aGTg9IVjSyoq08kLmHEP8mVQE11DQT+Jw==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-10.1.tgz",
-      "integrity": "sha512-A0RIBuTsD+Kb8tTg6gls0hTy2ltR+UsYARyaLfb1CbY/hgcbNqbGyBLtoKNVDzR/sjsb2XSXV1sWWr38jmeSzg=="
+      "version": "0.0.5-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.1.tgz",
+      "integrity": "sha512-S3TSUN0kov5RhFKTBKvIOgt3jRxwJj/nTPsWg/0s5NcnUW8eirZhbjSQ41SzYgCjxN1AHEQbapvC81T77HFRaw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10991,9 +10991,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-10.1.tgz",
-      "integrity": "sha512-btLwQBdAGRzMs6A6WLSFkh9fOmxntVICznrMrzPfdj7iFbPd5WbCvcZjF7oUeNxxDys8/DR3JFoYhzzlHPrA8g==",
+      "version": "0.0.2-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-25.1.tgz",
+      "integrity": "sha512-4hYhNUsaJPwJBAjqNNJzFIQMlx4UW/b0UTuNSoON1XB8wOi4Ts454HoIRU9c10kwkuNQaz8kwsGDoNm3+2sCqQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11016,9 +11016,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-10.1.tgz",
-      "integrity": "sha512-dQP71RR19lGWnTxGclfJmbEos8ExVDgxlOGKw9Sz5JMBh9NYQ/bbnb7Bx4oNmhNXszGMtMGC1ZAWp8j/h2LhZg==",
+      "version": "0.9.0-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-25.1.tgz",
+      "integrity": "sha512-7ULIGQWN61XVESgxjxktC2GvvrkOqyba48JJjyvf3beC70KWD5zUkF03KkCyGLKf54A45GAgAAeNNDaaAYZEUw==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11036,15 +11036,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-10.1.tgz",
-      "integrity": "sha512-gd1X6U9CMjyASENH4+8uEM83UNElb6FkRH3g/9ffRsnbgkGqCGht7gwEvaLU1L6sgQpSW8E12PjcK280KjD2Zw==",
+      "version": "0.0.6-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-25.1.tgz",
+      "integrity": "sha512-FxzyeMezDXphKzllgNeLlISgB94uABRfi0CZtiIpKzv8rZDT5elq4aGTg9IVjSyoq08kLmHEP8mVQE11DQT+Jw==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-10.1.tgz",
-      "integrity": "sha512-A0RIBuTsD+Kb8tTg6gls0hTy2ltR+UsYARyaLfb1CbY/hgcbNqbGyBLtoKNVDzR/sjsb2XSXV1sWWr38jmeSzg=="
+      "version": "0.0.5-next-2022-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-25.1.tgz",
+      "integrity": "sha512-S3TSUN0kov5RhFKTBKvIOgt3jRxwJj/nTPsWg/0s5NcnUW8eirZhbjSQ41SzYgCjxN1AHEQbapvC81T77HFRaw=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -8,6 +8,7 @@ import {
   type SnsAccount,
   type SnsTransactionWithId,
 } from "@dfinity/sns";
+import { fromNullable, toNullable } from "@dfinity/utils";
 
 interface GetTransactionsParams {
   identity: Identity;
@@ -19,8 +20,8 @@ interface GetTransactionsParams {
 }
 
 interface GetTransactionsResponse {
-  oldestTxId: bigint;
-  transactions: SnsTransactionWithId;
+  oldestTxId?: bigint;
+  transactions: SnsTransactionWithId[];
 }
 
 export const getTransactions = async ({
@@ -33,18 +34,22 @@ export const getTransactions = async ({
   const agent = await createAgent({ identity, host: HOST });
   // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
   const { getTransactions: getTransactionsApi } = SnsIndexCanister.create({
-    canisterId: Principal.fromText("tqtu6-byaaa-aaaaa-aaana-cai"),
+    canisterId: Principal.fromText("wzp7w-lyaaa-aaaaa-aaara-cai"),
     agent,
   });
+  // TODO: Change the type of `account` to be `SnsAccount`
   const { oldest_tx_id, transactions } = await getTransactionsApi({
     max_results: maxResults,
     start,
-    account,
+    account: {
+      owner: account.owner,
+      subaccount: toNullable(account.subaccount),
+    },
   });
 
   logWithTimestamp("");
   return {
-    oldestTxId: oldest_tx_id,
+    oldestTxId: fromNullable(oldest_tx_id),
     transactions,
   };
 };

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -27,7 +27,7 @@ interface GetTransactionsResponse {
 // TODO: Add test when we use the wrapper https://dfinity.atlassian.net/browse/GIX-1093
 export const getTransactions = async ({
   identity,
-  account,
+  account: { owner, subaccount },
   start,
   maxResults,
 }: GetTransactionsParams): Promise<GetTransactionsResponse> => {
@@ -43,8 +43,8 @@ export const getTransactions = async ({
     max_results: maxResults,
     start,
     account: {
-      owner: account.owner,
-      subaccount: toNullable(account.subaccount),
+      owner,
+      subaccount: toNullable(subaccount),
     },
   });
 

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -24,6 +24,7 @@ interface GetTransactionsResponse {
   transactions: SnsTransactionWithId[];
 }
 
+// TODO: Add test when we use the wrapper https://dfinity.atlassian.net/browse/GIX-1093
 export const getTransactions = async ({
   identity,
   account,

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -31,7 +31,7 @@ export const getTransactions = async ({
   start,
   maxResults,
 }: GetTransactionsParams): Promise<GetTransactionsResponse> => {
-  logWithTimestamp("Getting sns accounts: call...");
+  logWithTimestamp("Getting sns accounts transactions: call...");
   const agent = await createAgent({ identity, host: HOST });
   // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
   const { getTransactions: getTransactionsApi } = SnsIndexCanister.create({
@@ -48,7 +48,7 @@ export const getTransactions = async ({
     },
   });
 
-  logWithTimestamp("");
+  logWithTimestamp("Getting sns account transactions: done");
   return {
     oldestTxId: fromNullable(oldest_tx_id),
     transactions,

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -1,0 +1,50 @@
+import { HOST } from "$lib/constants/environment.constants";
+import { createAgent } from "$lib/utils/agent.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
+import type { Identity } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import {
+  SnsIndexCanister,
+  type SnsAccount,
+  type SnsTransactionWithId,
+} from "@dfinity/sns";
+
+interface GetTransactionsParams {
+  identity: Identity;
+  account: SnsAccount;
+  start?: bigint;
+  maxResults: bigint;
+  // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
+  // rootCanisterId: Principal;
+}
+
+interface GetTransactionsResponse {
+  oldestTxId: bigint;
+  transactions: SnsTransactionWithId;
+}
+
+export const getTransactions = async ({
+  identity,
+  account,
+  start,
+  maxResults,
+}: GetTransactionsParams): Promise<GetTransactionsResponse> => {
+  logWithTimestamp("Getting sns accounts: call...");
+  const agent = await createAgent({ identity, host: HOST });
+  // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
+  const { getTransactions: getTransactionsApi } = SnsIndexCanister.create({
+    canisterId: Principal.fromText("tqtu6-byaaa-aaaaa-aaana-cai"),
+    agent,
+  });
+  const { oldest_tx_id, transactions } = await getTransactionsApi({
+    max_results: maxResults,
+    start,
+    account,
+  });
+
+  logWithTimestamp("");
+  return {
+    oldestTxId: oldest_tx_id,
+    transactions,
+  };
+};

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { loadAccountTransactions } from "$lib/services/sns-accounts.services";
+  import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
@@ -13,6 +14,8 @@
       rootCanisterId,
     });
   });
+
+  $: transactions = $snsTransactionsStore[rootCanisterId.toText()];
 </script>
 
-<div>{`TODO render transactions`}</div>
+<div />

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { loadAccountTransactions } from "$lib/services/sns-accounts.services";
-  import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
@@ -14,8 +13,6 @@
       rootCanisterId,
     });
   });
-
-  $: transactions = $snsTransactionsStore[rootCanisterId.toText()];
 </script>
 
 <div />

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { loadAccountTransactions } from "$lib/services/sns-accounts.services";
+  import { loadAccountTransactions } from "$lib/services/sns-transactions.services";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { loadAccountTransactions } from "$lib/services/sns-transactions.services";
+  import { loadAccountNextTransactions } from "$lib/services/sns-transactions.services";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
@@ -8,7 +8,7 @@
   export let rootCanisterId: Principal;
 
   onMount(() => {
-    loadAccountTransactions({
+    loadAccountNextTransactions({
       account,
       rootCanisterId,
     });

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -13,6 +13,8 @@
       rootCanisterId,
     });
   });
+
+  // TODO: GIX-996 Render transactions.
 </script>
 
-<div />
+<div data-tid="sns-transactions-list" />

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { loadAccountTransactions } from "$lib/services/sns-accounts.services";
+  import type { Account } from "$lib/types/account";
+  import type { Principal } from "@dfinity/principal";
+  import { onMount } from "svelte";
+
+  export let account: Account;
+  export let rootCanisterId: Principal;
+
+  onMount(() => {
+    loadAccountTransactions({
+      account,
+      rootCanisterId,
+    });
+  });
+</script>
+
+<div>{`TODO render transactions`}</div>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -21,6 +21,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { busy } from "$lib/stores/busy.store";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
+  import SnsTransactionsList from "$lib/components/accounts/SnsTransactionsList.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
   onMount(() => {
@@ -75,8 +76,12 @@
 
 <main class="legacy" data-tid="sns-wallet">
   <section>
-    {#if $selectedAccountStore.account !== undefined}
+    {#if $selectedAccountStore.account !== undefined && $snsOnlyProjectStore !== undefined}
       <WalletSummary />
+      <SnsTransactionsList
+        rootCanisterId={$snsOnlyProjectStore}
+        account={$selectedAccountStore.account}
+      />
     {:else}
       <Spinner />
     {/if}

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -101,17 +101,14 @@ export const loadAccountTransactions = async ({
   rootCanisterId: Principal;
 }) => {
   // Only load transactions for one SNS project which we know the index canister id
-  if (rootCanisterId.toText() !== "su63m-yyaaa-aaaaa-aaala-cai") {
+  if (rootCanisterId.toText() !== "tmxop-wyaaa-aaaaa-aaapa-cai") {
     return;
   }
   const identity = await getAccountIdentity(account);
   const snsAccount = decodeSnsAccount(account.identifier);
   const transactions = await getTransactions({
     identity,
-    account: {
-      ...snsAccount,
-      subaccount: [],
-    },
+    account: snsAccount,
     maxResults: BigInt(50),
   });
   console.log(transactions);

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -1,3 +1,4 @@
+import { getTransactions } from "$lib/api/sns-index.api";
 import { getSnsAccounts, transfer } from "$lib/api/sns-ledger.api";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -89,4 +90,29 @@ export const snsTransferTokens = async ({
     );
     return { success: false };
   }
+};
+
+// TODO: Pass rootcanister id and use wrapper https://dfinity.atlassian.net/browse/GIX-1093
+export const loadAccountTransactions = async ({
+  account,
+  rootCanisterId,
+}: {
+  account: Account;
+  rootCanisterId: Principal;
+}) => {
+  // Only load transactions for one SNS project which we know the index canister id
+  if (rootCanisterId.toText() !== "su63m-yyaaa-aaaaa-aaala-cai") {
+    return;
+  }
+  const identity = await getAccountIdentity(account);
+  const snsAccount = decodeSnsAccount(account.identifier);
+  const transactions = await getTransactions({
+    identity,
+    account: {
+      ...snsAccount,
+      subaccount: [],
+    },
+    maxResults: BigInt(50),
+  });
+  console.log(transactions);
 };

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -12,6 +12,8 @@ import { getIdentity } from "./auth.services";
 import { loadSnsTransactionFee } from "./transaction-fees.services";
 import { queryAndUpdate } from "./utils.services";
 
+export const TRANSACTION_PAGE_SIZE = BigInt(50);
+
 export const loadSnsAccounts = async (
   rootCanisterId: Principal
 ): Promise<void> => {
@@ -102,6 +104,7 @@ export const loadAccountTransactions = async ({
   rootCanisterId: Principal;
 }) => {
   // Only load transactions for one SNS project which we know the index canister id
+  // TODO: Remove https://dfinity.atlassian.net/browse/GIX-1093
   if (rootCanisterId.toText() !== "tmxop-wyaaa-aaaaa-aaapa-cai") {
     return;
   }
@@ -110,7 +113,7 @@ export const loadAccountTransactions = async ({
   const { transactions, oldestTxId } = await getTransactions({
     identity,
     account: snsAccount,
-    maxResults: BigInt(50),
+    maxResults: TRANSACTION_PAGE_SIZE,
   });
   snsTransactionsStore.addTransactions({
     accountIdentifier: account.identifier,

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -11,8 +11,6 @@ import { getIdentity } from "./auth.services";
 import { loadSnsTransactionFee } from "./transaction-fees.services";
 import { queryAndUpdate } from "./utils.services";
 
-export const TRANSACTION_PAGE_SIZE = BigInt(50);
-
 export const loadSnsAccounts = async (
   rootCanisterId: Principal
 ): Promise<void> => {

--- a/frontend/src/lib/services/sns-transactions.services.ts
+++ b/frontend/src/lib/services/sns-transactions.services.ts
@@ -1,0 +1,35 @@
+import { getTransactions } from "$lib/api/sns-index.api";
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
+import type { Account } from "$lib/types/account";
+import type { Principal } from "@dfinity/principal";
+import { decodeSnsAccount } from "@dfinity/sns";
+import { getSnsAccountIdentity } from "./sns-accounts.services";
+
+export const TRANSACTION_PAGE_SIZE = BigInt(50);
+
+export const loadAccountTransactions = async ({
+  account,
+  rootCanisterId,
+}: {
+  account: Account;
+  rootCanisterId: Principal;
+}) => {
+  // Only load transactions for one SNS project which we know the index canister id
+  // TODO: Remove https://dfinity.atlassian.net/browse/GIX-1093
+  if (rootCanisterId.toText() !== "tmxop-wyaaa-aaaaa-aaapa-cai") {
+    return;
+  }
+  const identity = await getSnsAccountIdentity(account);
+  const snsAccount = decodeSnsAccount(account.identifier);
+  const { transactions, oldestTxId } = await getTransactions({
+    identity,
+    account: snsAccount,
+    maxResults: TRANSACTION_PAGE_SIZE,
+  });
+  snsTransactionsStore.addTransactions({
+    accountIdentifier: account.identifier,
+    rootCanisterId,
+    transactions,
+    oldestTxId: oldestTxId ?? transactions[transactions.length - 1].id,
+  });
+};

--- a/frontend/src/lib/services/sns-transactions.services.ts
+++ b/frontend/src/lib/services/sns-transactions.services.ts
@@ -1,13 +1,12 @@
 import { getTransactions } from "$lib/api/sns-index.api";
+import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import type { Account } from "$lib/types/account";
 import type { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
 import { getSnsAccountIdentity } from "./sns-accounts.services";
 
-export const TRANSACTION_PAGE_SIZE = BigInt(50);
-
-export const loadAccountTransactions = async ({
+export const loadAccountNextTransactions = async ({
   account,
   rootCanisterId,
 }: {
@@ -24,12 +23,12 @@ export const loadAccountTransactions = async ({
   const { transactions, oldestTxId } = await getTransactions({
     identity,
     account: snsAccount,
-    maxResults: TRANSACTION_PAGE_SIZE,
+    maxResults: BigInt(DEFAULT_TRANSACTION_PAGE_LIMIT),
   });
   snsTransactionsStore.addTransactions({
     accountIdentifier: account.identifier,
     rootCanisterId,
     transactions,
-    oldestTxId: oldestTxId ?? transactions[transactions.length - 1].id,
+    oldestTxId,
   });
 };

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -1,0 +1,82 @@
+import { removeKeys } from "$lib/utils/utils";
+import type { Principal } from "@dfinity/principal";
+import type { SnsTransactionWithId } from "@dfinity/sns";
+import { writable } from "svelte/store";
+
+interface SnsTransactions {
+  // Each SNS Account is an entry in this Store.
+  // We use the account string representation as the key to identify the transactions.
+  [accountIdentifier: string]: {
+    transactions: SnsTransactionWithId[];
+    oldestTxId: bigint;
+  };
+}
+
+export interface SnsTransactionsStore {
+  // Each SNS Project is an entry in this Store.
+  // We use the root canister id and then the account identifier as the key to identify the transactions.
+  [rootCanisterId: string]: SnsTransactions;
+}
+
+/**
+ * A store that contains the sns accounts for each project.
+ *
+ * - setAccounts: replace the current list of accounts for a specific sns project with a new list.
+ * - reset: reset the store to an empty state.
+ * - resetProject: removed the accounts for a specific project.
+ */
+const initSnsAccountsStore = () => {
+  const { subscribe, update, set } = writable<SnsTransactionsStore>({});
+
+  return {
+    subscribe,
+
+    setAccounts({
+      accountIdentifier,
+      rootCanisterId,
+      transactions,
+      oldestTxId,
+    }: {
+      accountIdentifier: string;
+      rootCanisterId: Principal;
+      transactions: SnsTransactionWithId[];
+      oldestTxId: bigint;
+    }) {
+      update((currentState: SnsTransactionsStore) => {
+        const projectState = currentState[rootCanisterId.toText()];
+        const accountState = projectState?.[accountIdentifier];
+        const uniquePreviousTransactions = (
+          accountState?.transactions ?? []
+        ).filter(({ id: oldTxId }) =>
+          transactions.some(({ id: newTxId }) => newTxId !== oldTxId)
+        );
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            ...projectState,
+            [accountIdentifier]: {
+              transactions: [...uniquePreviousTransactions, ...transactions],
+              oldestTxId,
+            },
+          },
+        };
+      });
+    },
+
+    // Used in tests
+    reset() {
+      set({});
+    },
+
+    resetProject(rootCanisterId: Principal) {
+      update((currentState: SnsTransactionsStore) =>
+        removeKeys({
+          obj: currentState,
+          keysToRemove: [rootCanisterId.toText()],
+        })
+      );
+    },
+  };
+};
+
+export const snsTransactionsStore = initSnsAccountsStore();

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -8,7 +8,7 @@ interface SnsTransactions {
   // We use the account string representation as the key to identify the transactions.
   [accountIdentifier: string]: {
     transactions: SnsTransactionWithId[];
-    oldestTxId: bigint;
+    oldestTxId?: bigint;
   };
 }
 
@@ -40,7 +40,7 @@ const initSnsAccountsStore = () => {
       accountIdentifier: string;
       rootCanisterId: Principal;
       transactions: SnsTransactionWithId[];
-      oldestTxId: bigint;
+      oldestTxId?: bigint;
     }) {
       update((currentState: SnsTransactionsStore) => {
         const projectState = currentState[rootCanisterId.toText()];

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -47,8 +47,9 @@ const initSnsAccountsStore = () => {
         const accountState = projectState?.[accountIdentifier];
         const uniquePreviousTransactions = (
           accountState?.transactions ?? []
-        ).filter(({ id: oldTxId }) =>
-          transactions.some(({ id: newTxId }) => newTxId !== oldTxId)
+        ).filter(
+          ({ id: oldTxId }) =>
+            !transactions.some(({ id: newTxId }) => newTxId === oldTxId)
         );
         return {
           ...currentState,

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -19,11 +19,11 @@ export interface SnsTransactionsStore {
 }
 
 /**
- * A store that contains the sns accounts for each project.
+ * A store that contains the transactions for each account in sns projects.
  *
- * - setAccounts: replace the current list of accounts for a specific sns project with a new list.
+ * - addTransactions: adds new transactions for a specific account in a specific sns project. If the state does not exist, it will be created.
  * - reset: reset the store to an empty state.
- * - resetProject: removed the accounts for a specific project.
+ * - resetProject: removed the transactions for a specific project.
  */
 const initSnsAccountsStore = () => {
   const { subscribe, update, set } = writable<SnsTransactionsStore>({});
@@ -31,7 +31,7 @@ const initSnsAccountsStore = () => {
   return {
     subscribe,
 
-    setAccounts({
+    addTransactions({
       accountIdentifier,
       rootCanisterId,
       transactions,

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -15,7 +15,10 @@ import {
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
-import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
+import {
+  mockSnsAccountsStoreSubscribe,
+  mockSnsMainAccount,
+} from "../../../mocks/sns-accounts.mock";
 
 describe("SelectAccountDropdown", () => {
   describe("nns accounts", () => {
@@ -94,7 +97,7 @@ describe("SelectAccountDropdown", () => {
       });
 
       expect(container.querySelector("select")?.value).toBe(
-        mockMainAccount.identifier
+        mockSnsMainAccount.identifier
       );
     });
   });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -70,11 +70,14 @@ describe("SnsWallet", () => {
       await waitFor(() => expect(queryByTestId("spinner")).toBeNull());
     });
 
-    it("should render wallet summary", async () => {
+    it("should render wallet summary and transactions", async () => {
       const { queryByTestId } = render(SnsWallet);
 
       await waitFor(() =>
         expect(queryByTestId("wallet-summary")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(queryByTestId("sns-transactions-list")).toBeInTheDocument()
       );
     });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -18,7 +18,7 @@ import {
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
     syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
-    loadAccountTransactions: jest.fn().mockResolvedValue(undefined),
+    loadAccountNextTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -18,6 +18,7 @@ import {
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
     syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
+    loadAccountTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -1,12 +1,23 @@
-import * as api from "$lib/api/sns-ledger.api";
+/**
+ * @jest-environment jsdom
+ */
+
+import * as indexApi from "$lib/api/sns-index.api";
+import * as ledgerApi from "$lib/api/sns-ledger.api";
 import * as services from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { Principal } from "@dfinity/principal";
+import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import { mockPrincipal } from "../../mocks/auth.store.mock";
-import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
+import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsTransactionWithId,
+} from "../../mocks/sns-accounts.mock";
 
 describe("sns-accounts-services", () => {
   describe("loadSnsAccounts", () => {
@@ -17,7 +28,7 @@ describe("sns-accounts-services", () => {
     });
     it("should call api.getSnsAccounts and load neurons in store", async () => {
       const spyQuery = jest
-        .spyOn(api, "getSnsAccounts")
+        .spyOn(ledgerApi, "getSnsAccounts")
         .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
 
       await services.loadSnsAccounts(mockPrincipal);
@@ -35,7 +46,7 @@ describe("sns-accounts-services", () => {
         certified: true,
       });
       const spyQuery = jest
-        .spyOn(api, "getSnsAccounts")
+        .spyOn(ledgerApi, "getSnsAccounts")
         .mockImplementation(() => Promise.reject(undefined));
 
       await services.loadSnsAccounts(mockPrincipal);
@@ -54,11 +65,11 @@ describe("sns-accounts-services", () => {
     });
     it("should call sns accounts and transaction fee and load them in store", async () => {
       const spyAccountsQuery = jest
-        .spyOn(api, "getSnsAccounts")
+        .spyOn(ledgerApi, "getSnsAccounts")
         .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
       const fee = BigInt(10_000);
       const spyFeeQuery = jest
-        .spyOn(api, "transactionFee")
+        .spyOn(ledgerApi, "transactionFee")
         .mockImplementation(() => Promise.resolve(fee));
 
       await services.syncSnsAccounts(mockPrincipal);
@@ -77,7 +88,7 @@ describe("sns-accounts-services", () => {
 
   describe("snsTransferTokens", () => {
     const spyAccounts = jest
-      .spyOn(api, "getSnsAccounts")
+      .spyOn(ledgerApi, "getSnsAccounts")
       .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
 
     beforeEach(() => {
@@ -87,7 +98,7 @@ describe("sns-accounts-services", () => {
     });
     it("should call sns transfer tokens", async () => {
       const spyTransfer = jest
-        .spyOn(api, "transfer")
+        .spyOn(ledgerApi, "transfer")
         .mockResolvedValue(undefined);
 
       const { success } = await services.snsTransferTokens({
@@ -104,7 +115,7 @@ describe("sns-accounts-services", () => {
 
     it("should show toast and return success false if transfer fails", async () => {
       const spyTransfer = jest
-        .spyOn(api, "transfer")
+        .spyOn(ledgerApi, "transfer")
         .mockRejectedValue(new Error("test error"));
       const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
 
@@ -119,6 +130,41 @@ describe("sns-accounts-services", () => {
       expect(spyTransfer).toBeCalled();
       expect(spyAccounts).not.toBeCalled();
       expect(spyOnToastsError).toBeCalled();
+    });
+  });
+
+  describe("loadAccountTransactions", () => {
+    it("loads transactions in the store", async () => {
+      const spyGetTransactions = jest
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: BigInt(1234),
+          transactions: [mockSnsTransactionWithId],
+        });
+      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
+      await services.loadAccountTransactions({
+        rootCanisterId,
+        account: mockSnsMainAccount,
+      });
+
+      const snsAccount = {
+        owner: mockSnsMainAccount.principal,
+      };
+      // await tick();
+      await waitFor(() =>
+        expect(spyGetTransactions).toBeCalledWith({
+          identity: mockIdentity,
+          account: snsAccount,
+          maxResults: services.TRANSACTION_PAGE_SIZE,
+        })
+      );
+
+      const storeData = get(snsTransactionsStore);
+      expect(
+        storeData[rootCanisterId.toText()]?.[
+          mockSnsMainAccount.principal.toText()
+        ].transactions[0]
+      ).toEqual(mockSnsTransactionWithId);
     });
   });
 });

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -5,8 +5,10 @@
 import * as ledgerApi from "$lib/api/sns-ledger.api";
 import * as services from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
@@ -44,9 +46,12 @@ describe("sns-accounts-services", () => {
 
       await services.loadSnsAccounts(mockPrincipal);
 
-      await tick();
-      const store = get(snsAccountsStore);
-      expect(store[mockPrincipal.toText()]).toBeUndefined();
+      await waitFor(() => {
+        const store = get(snsAccountsStore);
+        return expect(store[mockPrincipal.toText()]).toBeUndefined();
+      });
+      const transactionsStore = get(snsTransactionsStore);
+      return expect(transactionsStore[mockPrincipal.toText()]).toBeUndefined();
       expect(spyQuery).toBeCalled();
     });
   });

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -2,22 +2,15 @@
  * @jest-environment jsdom
  */
 
-import * as indexApi from "$lib/api/sns-index.api";
 import * as ledgerApi from "$lib/api/sns-ledger.api";
 import * as services from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { Principal } from "@dfinity/principal";
-import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
-import {
-  mockSnsMainAccount,
-  mockSnsTransactionWithId,
-} from "../../mocks/sns-accounts.mock";
+import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 
 describe("sns-accounts-services", () => {
   describe("loadSnsAccounts", () => {
@@ -133,38 +126,10 @@ describe("sns-accounts-services", () => {
     });
   });
 
-  describe("loadAccountTransactions", () => {
-    it("loads transactions in the store", async () => {
-      const spyGetTransactions = jest
-        .spyOn(indexApi, "getTransactions")
-        .mockResolvedValue({
-          oldestTxId: BigInt(1234),
-          transactions: [mockSnsTransactionWithId],
-        });
-      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
-      await services.loadAccountTransactions({
-        rootCanisterId,
-        account: mockSnsMainAccount,
-      });
-
-      const snsAccount = {
-        owner: mockSnsMainAccount.principal,
-      };
-      // await tick();
-      await waitFor(() =>
-        expect(spyGetTransactions).toBeCalledWith({
-          identity: mockIdentity,
-          account: snsAccount,
-          maxResults: services.TRANSACTION_PAGE_SIZE,
-        })
-      );
-
-      const storeData = get(snsTransactionsStore);
-      expect(
-        storeData[rootCanisterId.toText()]?.[
-          mockSnsMainAccount.principal.toText()
-        ].transactions[0]
-      ).toEqual(mockSnsTransactionWithId);
+  describe("getSnsAccountIdentity", () => {
+    it("returns identity", async () => {
+      const identity = await services.getSnsAccountIdentity(mockSnsMainAccount);
+      expect(identity).toEqual(mockIdentity);
     });
   });
 });

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import * as indexApi from "$lib/api/sns-index.api";
+import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
 import * as services from "$lib/services/sns-transactions.services";
 import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { Principal } from "@dfinity/principal";
@@ -13,7 +14,7 @@ import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 import { mockSnsTransactionWithId } from "../../mocks/sns-transactions.mock";
 
 describe("sns-transactions-services", () => {
-  describe("loadAccountTransactions", () => {
+  describe("loadAccountNextTransactions", () => {
     it("loads transactions in the store", async () => {
       const spyGetTransactions = jest
         .spyOn(indexApi, "getTransactions")
@@ -22,7 +23,7 @@ describe("sns-transactions-services", () => {
           transactions: [mockSnsTransactionWithId],
         });
       const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
-      await services.loadAccountTransactions({
+      await services.loadAccountNextTransactions({
         rootCanisterId,
         account: mockSnsMainAccount,
       });
@@ -30,12 +31,12 @@ describe("sns-transactions-services", () => {
       const snsAccount = {
         owner: mockSnsMainAccount.principal,
       };
-      // await tick();
+
       await waitFor(() =>
         expect(spyGetTransactions).toBeCalledWith({
           identity: mockIdentity,
           account: snsAccount,
-          maxResults: services.TRANSACTION_PAGE_SIZE,
+          maxResults: BigInt(DEFAULT_LIST_PAGINATION_LIMIT),
         })
       );
 

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as indexApi from "$lib/api/sns-index.api";
+import * as services from "$lib/services/sns-transactions.services";
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
+import { Principal } from "@dfinity/principal";
+import { waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { mockIdentity } from "../../mocks/auth.store.mock";
+import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
+import { mockSnsTransactionWithId } from "../../mocks/sns-transactions.mock";
+
+describe("sns-transactions-services", () => {
+  describe("loadAccountTransactions", () => {
+    it("loads transactions in the store", async () => {
+      const spyGetTransactions = jest
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: BigInt(1234),
+          transactions: [mockSnsTransactionWithId],
+        });
+      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
+      await services.loadAccountTransactions({
+        rootCanisterId,
+        account: mockSnsMainAccount,
+      });
+
+      const snsAccount = {
+        owner: mockSnsMainAccount.principal,
+      };
+      // await tick();
+      await waitFor(() =>
+        expect(spyGetTransactions).toBeCalledWith({
+          identity: mockIdentity,
+          account: snsAccount,
+          maxResults: services.TRANSACTION_PAGE_SIZE,
+        })
+      );
+
+      const storeData = get(snsTransactionsStore);
+      expect(
+        storeData[rootCanisterId.toText()]?.[
+          mockSnsMainAccount.principal.toText()
+        ].transactions[0]
+      ).toEqual(mockSnsTransactionWithId);
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -1,0 +1,140 @@
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
+import { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+  mockSnsTransactionWithId,
+} from "../../mocks/sns-accounts.mock";
+
+describe("SNS Transactions store", () => {
+  describe("snsTransactionsStore", () => {
+    afterEach(() => snsTransactionsStore.reset());
+    it("should set transactions for a project and account when it doesn't exist", () => {
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+    });
+
+    it("should add transactions for a project and a different account", () => {
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsSubAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsSubAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+    });
+
+    it("should not add duplicated transactions", () => {
+      const tx1 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(1),
+      };
+      const tx2 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(2),
+      };
+      const tx3 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(3),
+      };
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [tx1, tx2],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [tx1, tx3],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions.length
+      ).toBe(3);
+    });
+
+    it("should reset accounts for a project", () => {
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+
+      snsTransactionsStore.resetProject(mockPrincipal);
+      const accountsInStore2 = get(snsTransactionsStore);
+      expect(accountsInStore2[mockPrincipal.toText()]).toBeUndefined();
+    });
+
+    it("should add transactions for another project", () => {
+      const principal2 = Principal.fromText("aaaaa-aa");
+
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: principal2,
+        transactions: [mockSnsTransactionWithId],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(10),
+      });
+      const accountsInStore2 = get(snsTransactionsStore);
+      expect(
+        accountsInStore2[mockPrincipal.toText()]?.[
+          mockSnsMainAccount.identifier
+        ]?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+      expect(
+        accountsInStore2[principal2.toText()]?.[mockSnsMainAccount.identifier]
+          ?.transactions
+      ).toEqual([mockSnsTransactionWithId]);
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -5,8 +5,8 @@ import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
-  mockSnsTransactionWithId,
 } from "../../mocks/sns-accounts.mock";
+import { mockSnsTransactionWithId } from "../../mocks/sns-transactions.mock";
 
 describe("SNS Transactions store", () => {
   describe("snsTransactionsStore", () => {

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,12 +1,8 @@
 import type { SnsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TokenAmount } from "@dfinity/nns";
-import { Principal } from "@dfinity/principal";
-import {
-  encodeSnsAccount,
-  type SnsTransaction,
-  type SnsTransactionWithId,
-} from "@dfinity/sns";
+import type { Principal } from "@dfinity/principal";
+import { encodeSnsAccount } from "@dfinity/sns";
 import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "./auth.store.mock";
 
@@ -59,29 +55,3 @@ export const mockSnsAccountsStoreSubscribe =
     run(mockSnsAccountsStore(principal));
     return () => undefined;
   };
-
-const fakeAccount = {
-  owner: Principal.fromText("aaaaa-aa"),
-  subaccount: [] as [],
-};
-
-const mockSnsTransaction: SnsTransaction = {
-  kind: "transfer",
-  timestamp: BigInt(12354),
-  burn: [],
-  mint: [],
-  transfer: [
-    {
-      to: fakeAccount,
-      from: fakeAccount,
-      memo: [],
-      created_at_time: [BigInt(123)],
-      amount: BigInt(33),
-    },
-  ],
-};
-
-export const mockSnsTransactionWithId: SnsTransactionWithId = {
-  id: BigInt(123),
-  transaction: mockSnsTransaction,
-};

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,14 +1,19 @@
 import type { SnsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TokenAmount } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
+import {
+  encodeSnsAccount,
+  type SnsTransaction,
+  type SnsTransactionWithId,
+} from "@dfinity/sns";
 import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "./auth.store.mock";
 
 export const mockSnsMainAccount: Account = {
-  // TODO: String representation https://dfinity.atlassian.net/browse/GIX-1025
-  identifier:
-    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+  identifier: encodeSnsAccount({
+    owner: mockPrincipal,
+  }),
   balance: TokenAmount.fromString({
     amount: "1234567.8901",
     token: {
@@ -20,10 +25,15 @@ export const mockSnsMainAccount: Account = {
   type: "main",
 };
 
+const subAccount = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 1,
+];
 export const mockSnsSubAccount: Account = {
-  // TODO: String representation https://dfinity.atlassian.net/browse/GIX-1025
-  identifier:
-    "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
+  identifier: encodeSnsAccount({
+    owner: mockPrincipal,
+    subaccount: Uint8Array.from(subAccount),
+  }),
   balance: TokenAmount.fromString({
     amount: "1234567.8901",
     token: {
@@ -31,10 +41,7 @@ export const mockSnsSubAccount: Account = {
       symbol: "TST",
     },
   }) as TokenAmount,
-  subAccount: [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 1,
-  ],
+  subAccount,
   name: "test subaccount",
   type: "subAccount",
 };
@@ -52,3 +59,29 @@ export const mockSnsAccountsStoreSubscribe =
     run(mockSnsAccountsStore(principal));
     return () => undefined;
   };
+
+const fakeAccount = {
+  owner: Principal.fromText("aaaaa-aa"),
+  subaccount: [] as [],
+};
+
+const mockSnsTransaction: SnsTransaction = {
+  kind: "transfer",
+  timestamp: BigInt(12354),
+  burn: [],
+  mint: [],
+  transfer: [
+    {
+      to: fakeAccount,
+      from: fakeAccount,
+      memo: [],
+      created_at_time: [BigInt(123)],
+      amount: BigInt(33),
+    },
+  ],
+};
+
+export const mockSnsTransactionWithId: SnsTransactionWithId = {
+  id: BigInt(123),
+  transaction: mockSnsTransaction,
+};

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -13,6 +13,7 @@ import {
   SnsMetadataResponseEntries,
   SnsSwapLifecycle,
   type SnsGetMetadataResponse,
+  type SnsParams,
   type SnsSwap,
   type SnsSwapBuyerState,
   type SnsSwapDerivedState,
@@ -81,9 +82,10 @@ export const mockSnsSwapCommitment = (
 const SECONDS_IN_DAY = 60 * 60 * 24;
 const SECONDS_TODAY = +new Date(new Date().toJSON().split("T")[0]) / 1000;
 
-export const mockSnsParams = {
+export const mockSnsParams: SnsParams = {
   min_participant_icp_e8s: BigInt(150000000),
   max_icp_e8s: BigInt(3000 * 100000000),
+  neuron_basket_construction_parameters: [],
   swap_due_timestamp_seconds: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 5),
   min_participants: 1,
   sns_token_e8s: BigInt(150000000),

--- a/frontend/src/tests/mocks/sns-transactions.mock.ts
+++ b/frontend/src/tests/mocks/sns-transactions.mock.ts
@@ -1,0 +1,28 @@
+import { Principal } from "@dfinity/principal";
+import type { SnsTransaction, SnsTransactionWithId } from "@dfinity/sns";
+
+const fakeAccount = {
+  owner: Principal.fromText("aaaaa-aa"),
+  subaccount: [] as [],
+};
+
+const mockSnsTransaction: SnsTransaction = {
+  kind: "transfer",
+  timestamp: BigInt(12354),
+  burn: [],
+  mint: [],
+  transfer: [
+    {
+      to: fakeAccount,
+      from: fakeAccount,
+      memo: [],
+      created_at_time: [BigInt(123)],
+      amount: BigInt(33),
+    },
+  ],
+};
+
+export const mockSnsTransactionWithId: SnsTransactionWithId = {
+  id: BigInt(123),
+  transaction: mockSnsTransaction,
+};


### PR DESCRIPTION
# Motivation

Setup getting the SNS transactions for an account.

Rendering the transactions will come in another PR.

# Changes

* New sns api function "getTransactions".
* Setup of the new component SnsTransactionList.
* New sns transactions service "loadAccountTransactions".
* New snsTransactionsStore
* Fix mock issue after upgrading sns-js
* Add new SnsTransactionList in SnsWallet

# Tests

* Test new snsTransactionsStore
* Test new sns transaction service loadAccountTransactions
* Use correct string representation in sns mock accounts. Fix broken test.
* New test case in SnsWallet
