### PR TITLE
GIX-1085: Project does not keep context

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -10,7 +10,7 @@
   import type { SvelteComponent } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import { baseHref } from "$lib/utils/route.utils";
-  import { isRoutePath } from "$lib/utils/app-path.utils";
+  import { isRoutePath, paths } from "$lib/utils/app-path.utils";
   import { AppPath } from "$lib/constants/routes.constants";
   import { routeStore } from "$lib/stores/route.store";
   import { ENABLE_SNS, IS_TESTNET } from "$lib/constants/environment.constants";
@@ -21,11 +21,18 @@
     neuronsPathStore,
   } from "$lib/derived/paths.derived";
   import { keyOf } from "$lib/utils/utils";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 
   const baseUrl = baseHref();
 
   const isSelectedPath = (paths: AppPath[]): boolean =>
     isRoutePath({ paths, routePath: $routeStore.path });
+
+  let isProjectDetailPath: boolean;
+  $: isProjectDetailPath = isRoutePath({
+    paths: [AppPath.ProjectDetail],
+    routePath: $routeStore.path,
+  });
 
   let routes: {
     context: string;
@@ -38,7 +45,9 @@
   $: routes = [
     {
       context: "accounts",
-      href: $accountsPathStore,
+      href: isProjectDetailPath
+        ? paths.accounts(OWN_CANISTER_ID.toText())
+        : $accountsPathStore,
       selected: isSelectedPath([
         AppPath.Accounts,
         AppPath.LegacyAccounts,
@@ -50,7 +59,9 @@
     },
     {
       context: "neurons",
-      href: $neuronsPathStore,
+      href: isProjectDetailPath
+        ? paths.neurons(OWN_CANISTER_ID.toText())
+        : $neuronsPathStore,
       selected: isSelectedPath([
         AppPath.LegacyNeurons,
         AppPath.LegacyNeuronDetail,

--- a/frontend/src/lib/utils/app-path.utils.ts
+++ b/frontend/src/lib/utils/app-path.utils.ts
@@ -39,6 +39,8 @@ export const paths = {
     ENABLE_SNS_2
       ? `${CONTEXT_PATH}/${rootCanisterId}/wallet`
       : AppPath.LegacyWallet,
+  projectDetail: (rootCanisterId: string) =>
+    `${CONTEXT_PATH}/${rootCanisterId}`,
 };
 
 const pathValidation = (path: AppPath): string => mapper[path] ?? path;

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -3,6 +3,9 @@
  */
 
 import MenuItems from "$lib/components/common/MenuItems.svelte";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { routeStore } from "$lib/stores/route.store";
+import { paths } from "$lib/utils/app-path.utils";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 
@@ -36,5 +39,20 @@ describe("MenuItems", () => {
     const { getByTestId } = renderResult;
 
     expect(() => getByTestId("get-icp-button")).toThrow();
+  });
+
+  it("should point Tokens and Neurons to NNS from the project page", () => {
+    routeStore.update({ path: paths.projectDetail("aaaaa-aa") });
+    const { getByTestId } = render(MenuItems);
+
+    const accountsLink = getByTestId("menuitem-accounts");
+    expect(accountsLink.getAttribute("href")).toEqual(
+      paths.accounts(OWN_CANISTER_ID.toText())
+    );
+
+    const neuronsLink = getByTestId("menuitem-neurons");
+    expect(neuronsLink.getAttribute("href")).toEqual(
+      paths.neurons(OWN_CANISTER_ID.toText())
+    );
   });
 });


### PR DESCRIPTION
# Motivation

When the user is in the project details and clicked in Tokens or Neurons menu item was redirected to the Neurons or Tokens of that project.

That was not correct because we don't consider the project details to be part of an SNS universe, rather to be part of the NNS universe

# Changes

* MenuItems in Tokens and Neurons redirect to NNS project if they are in the project details instead of relying in the context.
* Add projectDetail to paths util

# Tests

* Add tests that menu items keep this exception.
