### PR TITLE
Chore: Validate amount participation inline

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -100,6 +100,7 @@
     "limit_exceeded_topping_up_canister": "Error topping up canister. ICP might have been transferred, refresh the page. Try again if not.",
     "limit_exceeded_creating_canister": "Error creating canister. Canister might be created, refresh the page. Try again if not.",
     "sns_loading_commited_projects": "Sorry, there was an error loading the projects.",
+    "swap_not_loaded": "Sorry, there was an error loading the sale information.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {
@@ -649,7 +650,7 @@
     "project_not_found": "Sorry, the project was not found. Please refresh and try again",
     "project_not_open": "Sorry, the project does not accept participations yet.",
     "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
-    "commitment_too_large": "Sorry, your commitment of $commitment ICP is too high. The maximum is $maxCommitment ICP.",
+    "commitment_too_large": "Sorry, your new commitment of $newCommitment ICP is too high. You have already committed $currentCommitment ICP and the maximum is $maxCommitment ICP.",
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
     "cannot_participate": "Sorry, There was an unexpected error while participating.",
     "invalid_root_canister_id": "Sorry, the project ID $canisterId is invalid.",

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -30,6 +30,9 @@
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
   export let showManualAddress = true;
+  export let validateAmount: (
+    amount: number | undefined
+  ) => string | undefined = () => undefined;
 
   let filterDestinationAccounts: (account: Account) => boolean;
   $: filterDestinationAccounts = (account: Account) => {
@@ -68,7 +71,7 @@
         account: selectedAccount,
         amountE8s: tokens.toE8s() + transactionFee.toE8s(),
       });
-      errorMessage = undefined;
+      errorMessage = validateAmount(amount);
     } catch (error: unknown) {
       if (error instanceof InvalidAmountError) {
         errorMessage = $i18n.error.amount_not_valid;

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -18,6 +18,9 @@
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
+  export let validateAmount: (
+    amount: number | undefined
+  ) => string | undefined = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
   const steps: WizardSteps = [
@@ -59,6 +62,7 @@
       {canSelectDestination}
       {canSelectSource}
       {transactionFee}
+      {validateAmount}
       bind:selectedDestinationAddress
       bind:selectedAccount
       bind:amount

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -104,6 +104,7 @@ interface I18nError {
   limit_exceeded_topping_up_canister: string;
   limit_exceeded_creating_canister: string;
   sns_loading_commited_projects: string;
+  swap_not_loaded: string;
   canister_invalid_transaction: string;
 }
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -189,7 +189,10 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.commitment_too_large",
       substitutions: {
-        $commitment: formatToken({ value: totalCommitment }),
+        $newCommitment: formatToken({ value: amount.toE8s() }),
+        $currentCommitment: formatToken({
+          value: getCommitmentE8s(project.swapCommitment) ?? BigInt(0),
+        }),
         $maxCommitment: formatToken({
           value: project.summary.swap.params.max_participant_icp_e8s,
         }),

--- a/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
@@ -28,6 +28,7 @@ describe("TransactionModal", () => {
     sourceAccount?: Account;
     transactionFee?: TokenAmount;
     rootCanisterId?: Principal;
+    validateAmount?: (amount: number | undefined) => string | undefined;
   }) =>
     renderModal({
       component: TransactionModal,
@@ -148,6 +149,28 @@ describe("TransactionModal", () => {
 
       await waitFor(() =>
         expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      );
+    });
+
+    it("should not enable button when input value is not validated with the prop `validateAmount`", async () => {
+      const { getByTestId, container } = await renderTransactionModal({
+        rootCanisterId: OWN_CANISTER_ID,
+        validateAmount: () => "error__sns.not_enough_amount",
+      });
+
+      const participateButton = getByTestId("transaction-button-next");
+      expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+      const input = container.querySelector("input[name='amount']");
+      input && fireEvent.input(input, { target: { value: "10" } });
+
+      // Choose select account
+      // It will choose the fist subaccount as default
+      const toggle = container.querySelector("input[id='toggle']");
+      toggle && fireEvent.click(toggle);
+
+      await waitFor(() =>
+        expect(participateButton?.hasAttribute("disabled")).toBeTruthy()
       );
     });
 


### PR DESCRIPTION
# Motivation

Improve the UX by inlining the error message in sale participation.

# Changes

* New prop in TransactionModal "validateAmount".
* Use new prop validateAmount in "ParticipateSwapModal" with helper validParticipation.
* Improve error message when commitment is too large.

# Tests

* Test new prop in TransactionModal specs.
