### PR TITLE
chore(networks): Add small09

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -12,6 +12,7 @@
           "mainnet": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "testnet": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "small06": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+          "small09": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "small11": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "small12": "rrkah-fqaaa-aaaaa-aaaaq-cai",
           "small13": "rrkah-fqaaa-aaaaa-aaaaq-cai",
@@ -181,6 +182,20 @@
       ],
       "type": "persistent"
     },
+    "small09": {
+      "config": {
+        "FETCH_ROOT_KEY": true,
+        "HOST": "https://small09.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_SNS": true,
+          "ENABLE_SNS_2": true
+        }
+      },
+      "providers": [
+        "http://[2a00:fb01:400:42:5000:d0ff:fe7c:bd3f]:8080"
+      ],
+      "type": "persistent"
+    },
     "small06": {
       "config": {
         "FETCH_ROOT_KEY": true,
@@ -222,7 +237,7 @@
       "config": {
         "RUSTC_VERSION": "1.63.0",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
-        "IC_COMMIT": "10c0341032ac00c9728ecefa1e82e919f0f09022"
+        "IC_COMMIT": "2de9321857b3a713144932d8fd08f791f37e228f"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
We wish to deploy to small09.  We are not yet using dfx v 0.12.0 that allows us to define networks in an external file.


# Changes
- Add small09 to the list of networks

# Tests
- I have deployed  atestnet to small09 using this.  See: https://qvhpv-4qaaa-aaaaa-aaagq-cai.small09.dfinity.network/#/u/qvhpv-4qaaa-aaaaa-aaagq-cai/neuron/2603623906375990293