### PR TITLE
GIX-996: TransactionCard refactor

### DIFF
--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { Account } from "$lib/types/account";
+  import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import {
+    mapNnsTransaction,
+    type Transaction,
+  } from "$lib/utils/transactions.utils";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import TransactionCard from "./TransactionCard.svelte";
+
+  export let account: Account;
+  export let transaction: NnsTransaction;
+  export let toSelfTransaction = false;
+
+  let transactionData: Transaction | undefined;
+
+  $: account,
+    transaction,
+    (() => {
+      try {
+        transactionData = mapNnsTransaction({
+          transaction,
+          toSelfTransaction,
+          account,
+        });
+      } catch (err: unknown) {
+        transactionData = undefined;
+        toastsError(
+          err instanceof Error
+            ? { labelKey: err.message }
+            : { labelKey: "error.unknown", err }
+        );
+      }
+    })();
+</script>
+
+{#if transactionData !== undefined}
+  <TransactionCard transaction={transactionData} {toSelfTransaction} />
+{/if}

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -1,52 +1,27 @@
 <script lang="ts">
-  import type { Account } from "$lib/types/account";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";
   import type { TokenAmount } from "@dfinity/nns";
-  import type {
-    AccountIdentifierString,
-    Transaction,
-  } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { i18n } from "$lib/stores/i18n";
   import {
     AccountTransactionType,
-    mapTransaction,
+    type Transaction,
     transactionName,
   } from "$lib/utils/transactions.utils";
-  import { toastsError } from "$lib/stores/toasts.store";
 
-  export let account: Account;
   export let transaction: Transaction;
   export let toSelfTransaction = false;
 
   let type: AccountTransactionType;
   let isReceive: boolean;
   let isSend: boolean;
-  let from: AccountIdentifierString | undefined;
-  let to: AccountIdentifierString | undefined;
+  let from: string | undefined;
+  let to: string | undefined;
   let displayAmount: TokenAmount;
   let date: Date;
-
-  $: account,
-    transaction,
-    (() => {
-      try {
-        ({ type, isReceive, isSend, from, to, displayAmount, date } =
-          mapTransaction({
-            transaction,
-            toSelfTransaction,
-            account,
-          }));
-      } catch (err: unknown) {
-        toastsError(
-          err instanceof Error
-            ? { labelKey: err.message }
-            : { labelKey: "error.unknown", err }
-        );
-      }
-    })();
+  $: ({ type, isReceive, isSend, from, to, displayAmount, date } = transaction);
 
   let headline: string;
   $: headline = transactionName({
@@ -67,8 +42,6 @@
   let seconds: number;
   $: seconds = date.getTime() / 1000;
 </script>
-
-<hr />
 
 <CardInfo testId="transaction-card">
   <div slot="start" class="title">

--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import type { Account } from "$lib/types/account";
   import { i18n } from "$lib/stores/i18n";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import TransactionCard from "./TransactionCard.svelte";
+  import NnsTransactionCard from "./NnsTransactionCard.svelte";
   import { getContext } from "svelte";
   import {
     SELECTED_ACCOUNT_CONTEXT_KEY,
     type SelectedAccountContext,
   } from "$lib/types/selected-account.context";
-  import { mapToSelfTransaction } from "$lib/utils/transactions.utils";
+  import { mapToSelfNnsTransaction } from "$lib/utils/transactions.utils";
 
-  export let transactions: Transaction[] | undefined;
+  export let transactions: NnsTransaction[] | undefined;
 
   const { store } = getContext<SelectedAccountContext>(
     SELECTED_ACCOUNT_CONTEXT_KEY
@@ -21,10 +21,10 @@
   $: ({ account } = $store);
 
   let extendedTransactions: {
-    transaction: Transaction;
+    transaction: NnsTransaction;
     toSelfTransaction: boolean;
   }[];
-  $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
+  $: extendedTransactions = mapToSelfNnsTransaction(transactions ?? []);
 </script>
 
 {#if account === undefined || transactions === undefined}
@@ -33,6 +33,6 @@
   {$i18n.wallet.no_transactions}
 {:else}
   {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}
-    <TransactionCard {account} {transaction} {toSelfTransaction} />
+    <NnsTransactionCard {account} {transaction} {toSelfTransaction} />
   {/each}
 {/if}

--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ICPToken, TokenAmount } from "@dfinity/nns";
-  import { accountName as getAccountName } from "$lib/utils/transactions.utils";
+  import { accountName as getAccountName } from "$lib/utils/accounts.utils";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -187,3 +187,12 @@ export const routePathAccountIdentifier = (
         : undefined,
   };
 };
+
+export const accountName = ({
+  account,
+  mainName,
+}: {
+  account: Account | undefined;
+  mainName: string;
+}): string =>
+  account?.name ?? (account?.type === "main" ? mainName : account?.name ?? "");

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -25,7 +25,7 @@ import type {
   SnsTransferableAmount,
 } from "@dfinity/sns";
 import { digestText } from "./dev.utils";
-import { mapTransaction } from "./transactions.utils";
+import { mapNnsTransaction } from "./transactions.utils";
 import { isNullish, mapPromises, nonNullish } from "./utils";
 
 const anonymiseAvailability = (value: unknown): "yes" | "no" =>
@@ -260,7 +260,7 @@ export const anonymizeTransaction = async ({
   const { transaction_type, memo, timestamp, block_height } = transaction;
 
   const { isReceive, isSend, type, from, to, displayAmount, date } =
-    mapTransaction({
+    mapNnsTransaction({
       transaction,
       account,
     });

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -1,6 +1,6 @@
 import type {
   AccountIdentifierString,
-  Transaction,
+  Transaction as NnsTransaction,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Account } from "$lib/types/account";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
@@ -19,29 +19,8 @@ export enum AccountTransactionType {
   ParticipateSwap = "participateSwap",
 }
 
-export const accountName = ({
-  account,
-  mainName,
-}: {
-  account: Account | undefined;
-  mainName: string;
-}): string =>
-  account?.name ?? (account?.type === "main" ? mainName : account?.name ?? "");
-
-export interface AccountTransaction {
-  from: AccountIdentifierString;
-  to: AccountIdentifierString;
-  amount: TokenAmount;
-  date: Date;
-  fee: TokenAmount;
-  type: AccountTransactionType;
-  memo: bigint;
-  incomplete: boolean;
-  blockHeight: bigint;
-}
-
 export const transactionType = (
-  transaction: Transaction
+  transaction: NnsTransaction
 ): AccountTransactionType => {
   const { transaction_type } = transaction;
   if (transaction_type.length === 0) {
@@ -120,23 +99,27 @@ export const transactionDisplayAmount = ({
   return amount;
 };
 
-export const mapTransaction = ({
+export interface Transaction {
+  type: AccountTransactionType;
+  isReceive: boolean;
+  isSend: boolean;
+  // Account string representation
+  from: string | undefined;
+  // Account string representation
+  to: string | undefined;
+  displayAmount: TokenAmount;
+  date: Date;
+}
+
+export const mapNnsTransaction = ({
   transaction,
   account,
   toSelfTransaction,
 }: {
-  transaction: Transaction;
+  transaction: NnsTransaction;
   account: Account;
   toSelfTransaction?: boolean;
-}): {
-  type: AccountTransactionType;
-  isReceive: boolean;
-  isSend: boolean;
-  from: AccountIdentifierString | undefined;
-  to: AccountIdentifierString | undefined;
-  displayAmount: TokenAmount;
-  date: Date;
-} => {
+}): Transaction => {
   const { transfer, timestamp } = transaction;
   let from: AccountIdentifierString | undefined;
   let to: AccountIdentifierString | undefined;
@@ -216,10 +199,10 @@ export const transactionName = ({
       : labels.send
     : labels[type] ?? type;
 
-/** (from==to workaround) Set `mapToSelfTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
-export const mapToSelfTransaction = (
-  transactions: Transaction[]
-): { transaction: Transaction; toSelfTransaction: boolean }[] => {
+/** (from==to workaround) Set `mapToSelfNnsTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
+export const mapToSelfNnsTransaction = (
+  transactions: NnsTransaction[]
+): { transaction: NnsTransaction; toSelfTransaction: boolean }[] => {
   const resultTransactions = transactions.map((transaction) => ({
     transaction: { ...transaction },
     toSelfTransaction: false,

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -2,28 +2,36 @@
  * @jest-environment jsdom
  */
 
-import TransactionCard from "$lib/components/accounts/TransactionCard.svelte";
+import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
 import { formatToken } from "$lib/utils/token.utils";
+import { mapNnsTransaction } from "$lib/utils/transactions.utils";
 import { render } from "@testing-library/svelte";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import {
-  mockTransactionReceiveDataFromMain,
-  mockTransactionSendDataFromMain,
+  mockReceivedFromMainAccountTransaction,
+  mockSentToSubAccountTransaction,
 } from "../../../mocks/transaction.mock";
 
-describe("TransactionCard", () => {
+describe("NnsTransactionCard", () => {
   const renderTransactionCard = (
-    transaction = mockTransactionSendDataFromMain
+    account = mockMainAccount,
+    transaction = mockReceivedFromMainAccountTransaction
   ) =>
-    render(TransactionCard, {
+    render(NnsTransactionCard, {
       props: {
+        account,
         transaction,
       },
     });
 
   it("renders received headline", () => {
     const { container } = renderTransactionCard(
-      mockTransactionReceiveDataFromMain
+      mockSubAccount,
+      mockReceivedFromMainAccountTransaction
     );
 
     expect(container.querySelector(".title")?.textContent).toBe(
@@ -33,7 +41,8 @@ describe("TransactionCard", () => {
 
   it("renders sent headline", () => {
     const { container } = renderTransactionCard(
-      mockTransactionSendDataFromMain
+      mockMainAccount,
+      mockSentToSubAccountTransaction
     );
 
     expect(container.querySelector(".title")?.textContent).toBe(
@@ -42,59 +51,58 @@ describe("TransactionCard", () => {
   });
 
   it("renders transaction ICPs with - sign", () => {
-    const { getByTestId } = renderTransactionCard(
-      mockTransactionSendDataFromMain
-    );
+    const account = mockMainAccount;
+    const transaction = mockSentToSubAccountTransaction;
+    const { getByTestId } = renderTransactionCard(account, transaction);
+    const { displayAmount } = mapNnsTransaction({ account, transaction });
 
     expect(getByTestId("token-value")?.textContent).toBe(
-      `-${formatToken({
-        value: mockTransactionSendDataFromMain.displayAmount.toE8s(),
-        detailed: true,
-      })}`
+      `-${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
     );
   });
 
   it("renders transaction ICPs with + sign", () => {
-    const { getByTestId } = renderTransactionCard(
-      mockTransactionReceiveDataFromMain
-    );
+    const account = mockSubAccount;
+    const transaction = mockReceivedFromMainAccountTransaction;
+    const { getByTestId } = renderTransactionCard(account, transaction);
+    const { displayAmount } = mapNnsTransaction({ account, transaction });
 
     expect(getByTestId("token-value")?.textContent).toBe(
-      `+${formatToken({
-        value: mockTransactionReceiveDataFromMain.displayAmount.toE8s(),
-        detailed: true,
-      })}`
+      `+${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
     );
   });
 
   it("displays transaction date and time", () => {
     const { container } = renderTransactionCard(
-      mockTransactionSendDataFromMain
+      mockMainAccount,
+      mockSentToSubAccountTransaction
     );
 
     expect(container.querySelector("p")?.textContent).toContain(
-      "March 14, 2021 12:00 AM"
+      "January 1, 1970"
     );
     expect(container.querySelector("p")?.textContent).toContain("12:00 AM");
   });
 
-  it("displays identifier for received", () => {
+  it("displays identifier for reseived", () => {
     const { getByTestId } = renderTransactionCard(
-      mockTransactionReceiveDataFromMain
+      mockSubAccount,
+      mockReceivedFromMainAccountTransaction
     );
     const identifier = getByTestId("identifier")?.textContent;
 
-    expect(identifier).toContain(mockTransactionReceiveDataFromMain.from);
+    expect(identifier).toContain(mockMainAccount.identifier);
     expect(identifier).toContain(en.wallet.direction_from);
   });
 
   it("displays identifier for sent", () => {
     const { getByTestId } = renderTransactionCard(
-      mockTransactionSendDataFromMain
+      mockMainAccount,
+      mockSentToSubAccountTransaction
     );
     const identifier = getByTestId("identifier")?.textContent;
 
-    expect(identifier).toContain(mockTransactionSendDataFromMain.to);
+    expect(identifier).toContain(mockSubAccount.identifier);
     expect(identifier).toContain(en.wallet.direction_to);
   });
 });

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -1,5 +1,6 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
+  accountName,
   assertEnoughAccountFunds,
   emptyAddress,
   getAccountByPrincipal,
@@ -315,6 +316,35 @@ describe("accounts-utils", () => {
     it("should not get account identifier from invalid path", () => {
       expect(routePathAccountIdentifier("/#/wallet/")).toEqual(undefined);
       expect(routePathAccountIdentifier(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("accountName", () => {
+    it("returns subAccount name", () => {
+      expect(
+        accountName({
+          account: mockSubAccount,
+          mainName: "main",
+        })
+      ).toBe(mockSubAccount.name);
+    });
+
+    it("returns main account name", () => {
+      expect(
+        accountName({
+          account: mockMainAccount,
+          mainName: "main",
+        })
+      ).toBe("main");
+    });
+
+    it('returns "" if no account', () => {
+      expect(
+        accountName({
+          account: undefined,
+          mainName: "main",
+        })
+      ).toBe("");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,10 +1,9 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { enumKeys } from "$lib/utils/enum.utils";
 import {
-  accountName,
   AccountTransactionType,
-  mapToSelfTransaction,
-  mapTransaction,
+  mapNnsTransaction,
+  mapToSelfNnsTransaction,
   showTransactionFee,
   transactionDisplayAmount,
   transactionName,
@@ -157,9 +156,9 @@ describe("transactions-utils", () => {
     });
   });
 
-  describe("mapToSelfTransaction", () => {
+  describe("mapToSelfNnsTransaction", () => {
     it("should map to self transactions", () => {
-      const transactions = mapToSelfTransaction([
+      const transactions = mapToSelfNnsTransaction([
         {
           ...mockSentToSubAccountTransaction,
           timestamp: { timestamp_nanos: BigInt("111") },
@@ -194,10 +193,10 @@ describe("transactions-utils", () => {
     });
   });
 
-  describe("mapTransaction", () => {
+  describe("mapNnsTransaction", () => {
     it("should map Send transaction", () => {
       const { type, isReceive, isSend, from, to, displayAmount, date } =
-        mapTransaction({
+        mapNnsTransaction({
           transaction: mockSentToSubAccountTransaction,
           account: mockMainAccount,
         });
@@ -230,7 +229,7 @@ describe("transactions-utils", () => {
 
     it("should map Receive transaction", () => {
       const { type, isReceive, isSend, from, to, displayAmount, date } =
-        mapTransaction({
+        mapNnsTransaction({
           transaction: mockReceivedFromMainAccountTransaction,
           account: mockSubAccount,
         });
@@ -264,7 +263,7 @@ describe("transactions-utils", () => {
     });
 
     it("should support toSelfTransaction", () => {
-      const { isReceive, isSend, displayAmount } = mapTransaction({
+      const { isReceive, isSend, displayAmount } = mapNnsTransaction({
         transaction: mockSentToSubAccountTransaction,
         account: mockSubAccount,
         toSelfTransaction: true,
@@ -285,35 +284,6 @@ describe("transactions-utils", () => {
       );
       expect(isSend).toBeFalsy();
       expect(isReceive).toBeTruthy();
-    });
-  });
-
-  describe("accountName", () => {
-    it("returns subAccount name", () => {
-      expect(
-        accountName({
-          account: mockSubAccount,
-          mainName: "main",
-        })
-      ).toBe(mockSubAccount.name);
-    });
-
-    it("returns main account name", () => {
-      expect(
-        accountName({
-          account: mockMainAccount,
-          mainName: "main",
-        })
-      ).toBe("main");
-    });
-
-    it('returns "" if no account', () => {
-      expect(
-        accountName({
-          account: undefined,
-          mainName: "main",
-        })
-      ).toBe("");
     });
   });
 

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,4 +1,9 @@
-import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import {
+  AccountTransactionType,
+  type Transaction,
+} from "$lib/utils/transactions.utils";
+import { ICPToken, TokenAmount } from "@dfinity/nns";
 import { mockMainAccount, mockSubAccount } from "./accounts.store.mock";
 
 export const mockSentToSubAccountTransaction = {
@@ -13,7 +18,7 @@ export const mockSentToSubAccountTransaction = {
       amount: { e8s: BigInt(110000023) },
     },
   },
-} as Transaction;
+} as NnsTransaction;
 
 export const mockReceivedFromMainAccountTransaction = {
   transaction_type: [{ Transfer: null }],
@@ -27,4 +32,24 @@ export const mockReceivedFromMainAccountTransaction = {
       amount: { e8s: BigInt(110000000) },
     },
   },
-} as Transaction;
+} as NnsTransaction;
+
+export const mockTransactionReceiveDataFromMain: Transaction = {
+  type: AccountTransactionType.Send,
+  isReceive: true,
+  isSend: false,
+  from: "aaaaa-aa",
+  to: "bbbbb-bb",
+  displayAmount: TokenAmount.fromNumber({ amount: 110000000, token: ICPToken }),
+  date: new Date("03-14-2021"),
+};
+
+export const mockTransactionSendDataFromMain: Transaction = {
+  type: AccountTransactionType.Send,
+  isReceive: false,
+  isSend: true,
+  from: "aaaaa-aa",
+  to: "bbbbb-bb",
+  displayAmount: TokenAmount.fromNumber({ amount: 110000000, token: ICPToken }),
+  date: new Date("03-14-2021"),
+};


### PR DESCRIPTION
# Motivation

Refactor needed to render the list of Sns Transactions.

# Changes

* New component NnsTransaction used in NnsTransactionList.
* TransactionCard is now agnostic to nns-dapp transaction type.
* New transaction card: `Transaction` to be used with both types of transactions.
* Move `accountName` helper to accounts utils.

# Tests

* New test for TransactionCard.
* Move accountName util test.
