### PR TITLE
build: remove empty unused default csp tag

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -9,8 +9,19 @@ dotenv.config();
 
 const buildCsp = () => {
   const indexHTMLWithoutStartScript = extractStartScript();
-  const indexHTMLWithCSP = updateCSP(indexHTMLWithoutStartScript);
+  const indexHTMLNoCSP = removeDefaultCspTag(indexHTMLWithoutStartScript);
+  const indexHTMLWithCSP = updateCSP(indexHTMLNoCSP);
   writeFileSync("./public/index.html", indexHTMLWithCSP);
+};
+
+/**
+ * Remove the empty content-security-policy tag injected by SvelteKit
+ */
+const removeDefaultCspTag = (indexHtml) => {
+  return indexHtml.replace(
+      '<meta http-equiv="content-security-policy" content="">',
+      ""
+  );
 };
 
 /**

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -19,8 +19,8 @@ const buildCsp = () => {
  */
 const removeDefaultCspTag = (indexHtml) => {
   return indexHtml.replace(
-      '<meta http-equiv="content-security-policy" content="">',
-      ""
+    '<meta http-equiv="content-security-policy" content="">',
+    ""
   );
 };
 


### PR DESCRIPTION
# Motivation

SvelteKit injects an empty (since we do not configure it) CSP tag that is ignored because it finds place after our CSP policy. Still cleaner to remove it.

# Changes

- remove tag before calculting script
