### PR TITLE
GIX-1093: Get Transactions uses sns wrapper

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-27.1.tgz",
-      "integrity": "sha512-gZ8HUyOirbTh703SRFOw0iAeNQtZ/nC9Hh+QazqllScgJGJbjVa2CUKjcPu+7OVZMytZBbxuzAhSO662J+zM+A==",
+      "version": "0.0.2-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-28.1.tgz",
+      "integrity": "sha512-A2kj39An1ZmCIXHRBnG/CrEUB35cVB3J9CRwFUwdEg6E4yEk3CM/IzfGCEQrIfjCXvJekN1wm6sAAdMIwe6t+g==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-27.1.tgz",
-      "integrity": "sha512-cn45P3xm/aQM+0FtlBukeBRKRgL0HMaD6Zwj4RdS2ywB6a2hYfTLDqbRn0vce4OHpjWFOm2D15uyo6qR7pnIdg==",
+      "version": "0.9.0-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-28.1.tgz",
+      "integrity": "sha512-xPjDueffcPZlykUHENIv2zntrMWBVrfyx96ttP9RvnzEEnKoKBd25VSG5jHoLWUF3J6pTHrij+g8NyGZnnQ/uw==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1709,17 +1709,17 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-27.1.tgz",
-      "integrity": "sha512-rIz3SDc0rYfOggor0AwOYw3XaNFmbNVkaSiBdLKdY8Zu79ve3FMIGVdumEt882ss1zwXLa+fJQ2vuFvUYQxqqQ==",
+      "version": "0.0.6-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-28.1.tgz",
+      "integrity": "sha512-E9AscExGHS4m4OJbJB8Zj+M9s8eFrTebsXyES5b7eaHSnet7pAf12od2qthz4d6ZY4vX1IEj+/f2jfP4AvnpwA==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.5-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-27.1.tgz",
-      "integrity": "sha512-qbJMjudeyOlvx4XcmWJaLw/zpibBrCPhu+D06q0l/y1rAlv1GU8YpHtSiAv+JegoP4Ul4EbtQK6dAL4YPV3QXQ=="
+      "version": "0.0.5-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-28.1.tgz",
+      "integrity": "sha512-5DP3ezL1ZP6LvpttCrWLR8jY14sqVv2CJXvFlgfsXqQOtKRvtkJ4DpmQWuFXhz2mX00KjQO3TzCivvXrW/MATQ=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10991,9 +10991,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.2-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-27.1.tgz",
-      "integrity": "sha512-gZ8HUyOirbTh703SRFOw0iAeNQtZ/nC9Hh+QazqllScgJGJbjVa2CUKjcPu+7OVZMytZBbxuzAhSO662J+zM+A==",
+      "version": "0.0.2-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.2-next-2022-10-28.1.tgz",
+      "integrity": "sha512-A2kj39An1ZmCIXHRBnG/CrEUB35cVB3J9CRwFUwdEg6E4yEk3CM/IzfGCEQrIfjCXvJekN1wm6sAAdMIwe6t+g==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11016,9 +11016,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.9.0-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-27.1.tgz",
-      "integrity": "sha512-cn45P3xm/aQM+0FtlBukeBRKRgL0HMaD6Zwj4RdS2ywB6a2hYfTLDqbRn0vce4OHpjWFOm2D15uyo6qR7pnIdg==",
+      "version": "0.9.0-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.9.0-next-2022-10-28.1.tgz",
+      "integrity": "sha512-xPjDueffcPZlykUHENIv2zntrMWBVrfyx96ttP9RvnzEEnKoKBd25VSG5jHoLWUF3J6pTHrij+g8NyGZnnQ/uw==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11036,15 +11036,15 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.6-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-27.1.tgz",
-      "integrity": "sha512-rIz3SDc0rYfOggor0AwOYw3XaNFmbNVkaSiBdLKdY8Zu79ve3FMIGVdumEt882ss1zwXLa+fJQ2vuFvUYQxqqQ==",
+      "version": "0.0.6-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.6-next-2022-10-28.1.tgz",
+      "integrity": "sha512-E9AscExGHS4m4OJbJB8Zj+M9s8eFrTebsXyES5b7eaHSnet7pAf12od2qthz4d6ZY4vX1IEj+/f2jfP4AvnpwA==",
       "requires": {}
     },
     "@dfinity/utils": {
-      "version": "0.0.5-next-2022-10-27.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-27.1.tgz",
-      "integrity": "sha512-qbJMjudeyOlvx4XcmWJaLw/zpibBrCPhu+D06q0l/y1rAlv1GU8YpHtSiAv+JegoP4Ul4EbtQK6dAL4YPV3QXQ=="
+      "version": "0.0.5-next-2022-10-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.5-next-2022-10-28.1.tgz",
+      "integrity": "sha512-5DP3ezL1ZP6LvpttCrWLR8jY14sqVv2CJXvFlgfsXqQOtKRvtkJ4DpmQWuFXhz2mX00KjQO3TzCivvXrW/MATQ=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/sns-index.api.ts
+++ b/frontend/src/lib/api/sns-index.api.ts
@@ -1,22 +1,16 @@
-import { HOST } from "$lib/constants/environment.constants";
-import { createAgent } from "$lib/utils/agent.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
-import {
-  SnsIndexCanister,
-  type SnsAccount,
-  type SnsTransactionWithId,
-} from "@dfinity/sns";
-import { fromNullable, toNullable } from "@dfinity/utils";
+import type { Principal } from "@dfinity/principal";
+import type { SnsAccount, SnsTransactionWithId } from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
+import { wrapper } from "./sns-wrapper.api";
 
 interface GetTransactionsParams {
   identity: Identity;
   account: SnsAccount;
   start?: bigint;
   maxResults: bigint;
-  // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
-  // rootCanisterId: Principal;
+  rootCanisterId: Principal;
 }
 
 interface GetTransactionsResponse {
@@ -24,28 +18,23 @@ interface GetTransactionsResponse {
   transactions: SnsTransactionWithId[];
 }
 
-// TODO: Add test when we use the wrapper https://dfinity.atlassian.net/browse/GIX-1093
 export const getTransactions = async ({
   identity,
-  account: { owner, subaccount },
+  account,
   start,
   maxResults,
+  rootCanisterId,
 }: GetTransactionsParams): Promise<GetTransactionsResponse> => {
   logWithTimestamp("Getting sns accounts transactions: call...");
-  const agent = await createAgent({ identity, host: HOST });
-  // TODO: Use wrapper https://dfinity.atlassian.net/browse/GIX-1093
-  const { getTransactions: getTransactionsApi } = SnsIndexCanister.create({
-    canisterId: Principal.fromText("wzp7w-lyaaa-aaaaa-aaara-cai"),
-    agent,
+  const { getTransactions: getTransactionsApi } = await wrapper({
+    identity,
+    certified: true,
+    rootCanisterId: rootCanisterId.toText(),
   });
-  // TODO: Change the type of `account` to be `SnsAccount`
   const { oldest_tx_id, transactions } = await getTransactionsApi({
     max_results: maxResults,
     start,
-    account: {
-      owner,
-      subaccount: toNullable(subaccount),
-    },
+    account,
   });
 
   logWithTimestamp("Getting sns account transactions: done");

--- a/frontend/src/lib/services/sns-transactions.services.ts
+++ b/frontend/src/lib/services/sns-transactions.services.ts
@@ -13,17 +13,13 @@ export const loadAccountNextTransactions = async ({
   account: Account;
   rootCanisterId: Principal;
 }) => {
-  // Only load transactions for one SNS project which we know the index canister id
-  // TODO: Remove https://dfinity.atlassian.net/browse/GIX-1093
-  if (rootCanisterId.toText() !== "tmxop-wyaaa-aaaaa-aaapa-cai") {
-    return;
-  }
   const identity = await getSnsAccountIdentity(account);
   const snsAccount = decodeSnsAccount(account.identifier);
   const { transactions, oldestTxId } = await getTransactions({
     identity,
     account: snsAccount,
     maxResults: BigInt(DEFAULT_TRANSACTION_PAGE_LIMIT),
+    rootCanisterId,
   });
   snsTransactionsStore.addTransactions({
     accountIdentifier: account.identifier,

--- a/frontend/src/tests/lib/api/sns-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-index.api.spec.ts
@@ -1,0 +1,34 @@
+import { getTransactions } from "$lib/api/sns-index.api";
+import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
+import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
+
+jest.mock("$lib/proxy/api.import.proxy");
+const getTransactionsSpy = jest.fn().mockResolvedValue({
+  transactions: [],
+  oldest_tx_id: BigInt(2),
+});
+jest.mock("$lib/api/sns-wrapper.api", () => {
+  return {
+    wrapper: () => ({
+      getTransactions: getTransactionsSpy,
+    }),
+  };
+});
+
+describe("sns-index api", () => {
+  describe("getTransactions", () => {
+    it("returns the transactions from the api", async () => {
+      const result = await getTransactions({
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+        account: {
+          owner: mockPrincipal,
+        },
+        maxResults: BigInt(10),
+      });
+
+      expect(result.transactions).toBeDefined();
+      expect(getTransactionsSpy).toBeCalled();
+    });
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -18,6 +18,11 @@ import {
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
     syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/sns-transactions.services", () => {
+  return {
     loadAccountNextTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -37,6 +37,7 @@ describe("sns-transactions-services", () => {
           identity: mockIdentity,
           account: snsAccount,
           maxResults: BigInt(DEFAULT_LIST_PAGINATION_LIMIT),
+          rootCanisterId,
         })
       );
 


### PR DESCRIPTION
# Motivation

Use sns-wrapper to interact with Index canister instead of the canister directly.

# Changes

* Remove rootCanisterId temporary checks in transactions services and api.
* Use wrapper to call getTransactions in sns-index api.

# Tests

* Add test for getTransactions api function.
