### PR TITLE
build: remove https: from CSP script-src

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -75,7 +75,7 @@ const extractStartScript = () => {
  *
  * - script-src and 'strict-dynamic':
  * Chrome 40+ / Firefox 31+ / Safari 15.4+ / Edge 15+ supports 'strict-dynamic'.
- * Safari 15.4 has been released recently - March 15, 2022 - that's why we add 'unsafe-inline' and https: to the rules for backwards compatibility.
+ * Safari 15.4 has been released recently - March 15, 2022 - that's why we add 'unsafe-inline' to the rules for backwards compatibility.
  * Browsers that supports the 'strict-dynamic' rule will ignore these backwards directives (CSP 3).
  *
  * - style-src 'unsafe-inline' is required because:
@@ -103,7 +103,7 @@ const updateCSP = (indexHtml) => {
         img-src 'self' data: https://nns.raw.ic0.app/;
         child-src 'self';
         manifest-src 'self';
-        script-src 'unsafe-eval' 'unsafe-inline' https: 'strict-dynamic' ${indexHashes.join(
+        script-src 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(
           " "
         )};
         base-uri 'self';


### PR DESCRIPTION
# Motivation

We use the `https:` in the `script-src` rules of the CSP for backwards compatibility as displayed by [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src). However we have a report from a user who cannot access NNS-dapp on his Android v10 device. We are not sure what his issue is but, using Android Simulator, we can reproduce a blank screen on OS <= Android v12. That's why, in accordance with Security team, we remove the `https:` rule that solves the issue in the simulator and which is in any case not used in modern browsers that support `strict-dynamic`.

# Changes

- remove `https:` rules from CSP `script-src`
