### PR TITLE
GIX-1026: Manage errors in SNS Accounts pages gracefully

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -101,6 +101,7 @@
     "limit_exceeded_creating_canister": "Error creating canister. Canister might be created, refresh the page. Try again if not.",
     "sns_loading_commited_projects": "Sorry, there was an error loading the projects.",
     "swap_not_loaded": "Sorry, there was an error loading the sale information.",
+    "transaction_fee_not_found": "Sorry, there was an error loading the transaction fee.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -102,6 +102,7 @@
     "sns_loading_commited_projects": "Sorry, there was an error loading the projects.",
     "swap_not_loaded": "Sorry, there was an error loading the sale information.",
     "transaction_fee_not_found": "Sorry, there was an error loading the transaction fee.",
+    "fetch_transactions": "Sorry, there was an error loading the transactions for this account.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -10,6 +10,7 @@
   import TransactionModal from "./NewTransaction/TransactionModal.svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { WizardStep } from "@dfinity/gix-components";
+  import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -57,6 +58,7 @@
   on:nnsClose
   bind:currentStep
   sourceAccount={selectedAccount}
+  transactionFee={$mainTransactionFeeStoreAsToken}
 >
   <svelte:fragment slot="title"
     >{title ?? $i18n.accounts.new_transaction}</svelte:fragment

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -5,7 +5,6 @@
   import TransactionForm from "./TransactionForm.svelte";
   import TransactionReview from "./TransactionReview.svelte";
   import { ICPToken, TokenAmount, type Token } from "@dfinity/nns";
-  import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import type { Principal } from "@dfinity/principal";
 
   export let rootCanisterId: Principal;
@@ -13,7 +12,7 @@
   export let destinationAddress: string | undefined = undefined;
   export let sourceAccount: Account | undefined = undefined;
   export let token: Token = ICPToken;
-  export let transactionFee: TokenAmount = $mainTransactionFeeStoreAsToken;
+  export let transactionFee: TokenAmount;
   export let disableSubmit = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -12,7 +12,7 @@
   import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
   import { numberToE8s } from "$lib/utils/token.utils";
   import type { Account } from "$lib/types/account";
-  import type { WizardStep } from "@dfinity/gix-components";
+  import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -47,21 +47,26 @@
   };
 </script>
 
-<TransactionModal
-  rootCanisterId={$snsProjectSelectedStore}
-  on:nnsSubmit={transfer}
-  on:nnsClose
-  bind:currentStep
-  token={$snsTokenSymbolSelectedStore}
-  transactionFee={$snsSelectedTransactionFeeStore}
-  sourceAccount={selectedAccount}
->
-  <svelte:fragment slot="title"
-    >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+{#if $snsSelectedTransactionFeeStore !== undefined}
+  <TransactionModal
+    rootCanisterId={$snsProjectSelectedStore}
+    on:nnsSubmit={transfer}
+    on:nnsClose
+    bind:currentStep
+    token={$snsTokenSymbolSelectedStore}
+    transactionFee={$snsSelectedTransactionFeeStore}
+    sourceAccount={selectedAccount}
   >
-  <p slot="description" class="value">
-    {replacePlaceholders($i18n.accounts.sns_transaction_description, {
-      $token: $snsTokenSymbolSelectedStore?.symbol ?? "",
-    })}
-  </p>
-</TransactionModal>
+    <svelte:fragment slot="title"
+      >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+    >
+    <p slot="description" class="value">
+      {replacePlaceholders($i18n.accounts.sns_transaction_description, {
+        $token: $snsTokenSymbolSelectedStore?.symbol ?? "",
+      })}
+    </p>
+  </TransactionModal>
+{:else}
+  <!-- A toast error is shown if there is an error fetching the transaction fee -->
+  <Modal on:nnsClose><Spinner /></Modal>
+{/if}

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -68,5 +68,9 @@
   </TransactionModal>
 {:else}
   <!-- A toast error is shown if there is an error fetching the transaction fee -->
-  <Modal on:nnsClose><Spinner /></Modal>
+  <Modal on:nnsClose>
+    <svelte:fragment slot="title"
+      >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+    ><Spinner /></Modal
+  >
 {/if}

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -11,6 +11,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { WizardStep } from "@dfinity/gix-components";
+  import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
 
   export let neuron: NeuronInfo;
 
@@ -61,6 +62,7 @@
     on:nnsClose
     bind:currentStep
     destinationAddress={neuron.fullNeuron?.accountIdentifier}
+    transactionFee={$mainTransactionFeeStoreAsToken}
   >
     <svelte:fragment slot="title"
       >{title ?? $i18n.neurons.top_up_neuron}</svelte:fragment

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -27,6 +27,7 @@
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { WizardStep } from "@dfinity/gix-components";
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
+  import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
 
   const { store: projectDetailStore, reload } =
     getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
@@ -147,6 +148,7 @@
     {destinationAddress}
     disableSubmit={!accepted}
     skipHardwareWallets
+    transactionFee={$mainTransactionFeeStoreAsToken}
     maxAmount={currentUserMaxCommitment({ summary, swapCommitment })}
   >
     <svelte:fragment slot="title"

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -39,7 +39,6 @@ export const loadSnsTransactionFee = async (rootCanisterId: Principal) => {
         labelKey: "error.transaction_fee_not_found",
         err,
       });
-      console.error(err);
     },
   });
 };

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -1,5 +1,6 @@
 import { transactionFee as nnsTransactionFee } from "$lib/api/ledger.api";
 import { transactionFee as snsTransactionFee } from "$lib/api/sns-ledger.api";
+import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Principal } from "@dfinity/principal/lib/cjs";
 import { getIdentity } from "./auth.services";
@@ -28,17 +29,17 @@ export const loadSnsTransactionFee = async (rootCanisterId: Principal) => {
     onLoad: async ({ response: fee, certified }) => {
       transactionsFeesStore.setFee({ certified, rootCanisterId, fee });
     },
-    onError: ({ error, certified }) => {
+    onError: ({ error: err, certified }) => {
       if (certified !== true) {
         return;
       }
 
       // Explicitly handle only UPDATE errors
-      // TODO: Manage errors gracefully https://dfinity.atlassian.net/browse/GIX-1026
-      console.error(
-        `Error loading sns transaction fee for ${rootCanisterId.toText()}`
-      );
-      console.error(error);
+      toastsError({
+        labelKey: "error.transaction_fee_not_found",
+        err,
+      });
+      console.error(err);
     },
   });
 };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -106,6 +106,7 @@ interface I18nError {
   sns_loading_commited_projects: string;
   swap_not_loaded: string;
   transaction_fee_not_found: string;
+  fetch_transactions: string;
   canister_invalid_transaction: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -105,6 +105,7 @@ interface I18nError {
   limit_exceeded_creating_canister: string;
   sns_loading_commited_projects: string;
   swap_not_loaded: string;
+  transaction_fee_not_found: string;
   canister_invalid_transaction: string;
 }
 

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 import { snsTransferTokens } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
@@ -18,6 +19,7 @@ import {
   mockSnsAccountsStoreSubscribe,
   mockSnsMainAccount,
 } from "../../../mocks/sns-accounts.mock";
+import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../../mocks/transaction-fee.mock";
 
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -38,6 +40,9 @@ describe("SnsTransactionModal", () => {
     jest
       .spyOn(snsAccountsStore, "subscribe")
       .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
+    jest
+      .spyOn(snsSelectedTransactionFeeStore, "subscribe")
+      .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe());
     jest
       .spyOn(snsProjectSelectedStore, "subscribe")
       .mockImplementation((run: Subscriber<Principal>): (() => void) => {

--- a/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
@@ -9,7 +9,7 @@ import { accountsStore } from "$lib/stores/accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
-import { TokenAmount } from "@dfinity/nns";
+import { ICPToken, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import {
@@ -23,7 +23,16 @@ import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock"
 import { clickByTestId } from "../../../utils/utils.test-utils";
 
 describe("TransactionModal", () => {
-  const renderTransactionModal = (props?: {
+  const renderTransactionModal = ({
+    destinationAddress,
+    sourceAccount,
+    transactionFee = TokenAmount.fromE8s({
+      amount: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+      token: ICPToken,
+    }),
+    rootCanisterId,
+    validateAmount,
+  }: {
     destinationAddress?: string;
     sourceAccount?: Account;
     transactionFee?: TokenAmount;
@@ -32,7 +41,13 @@ describe("TransactionModal", () => {
   }) =>
     renderModal({
       component: TransactionModal,
-      props: props ?? {},
+      props: {
+        destinationAddress,
+        sourceAccount,
+        transactionFee,
+        rootCanisterId,
+        validateAmount,
+      },
     });
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { CONTEXT_PATH } from "$lib/constants/routes.constants";
+import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { routeStore } from "$lib/stores/route.store";
@@ -14,6 +15,7 @@ import {
   mockSnsAccountsStoreSubscribe,
   mockSnsMainAccount,
 } from "../../mocks/sns-accounts.mock";
+import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../mocks/transaction-fee.mock";
 
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -36,6 +38,10 @@ describe("SnsWallet", () => {
         .mockImplementation(
           mockSnsAccountsStoreSubscribe(Principal.fromText("aaaaa-aa"))
         );
+
+      jest
+        .spyOn(snsSelectedTransactionFeeStore, "subscribe")
+        .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe());
       // Context needs to match the mocked sns accounts
       routeStore.update({
         path: `${CONTEXT_PATH}/${mockPrincipal.toText()}/accounts`,

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -4,10 +4,12 @@
 
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import Accounts from "$lib/routes/Accounts.svelte";
 import { committedProjectsStore } from "$lib/stores/projects.store";
 import { routeStore } from "$lib/stores/route.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import en from "../../mocks/i18n.mock";
@@ -16,6 +18,7 @@ import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "../../mocks/sns-projects.mock";
+import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../mocks/transaction-fee.mock";
 
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -29,6 +32,10 @@ describe("Accounts", () => {
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {
+    jest
+      .spyOn(snsSelectedTransactionFeeStore, "subscribe")
+      .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe());
+
     // Reset to default value
     routeStore.update({ path: AppPath.LegacyAccounts });
 
@@ -124,6 +131,11 @@ describe("Accounts", () => {
   });
 
   it("should open sns transaction modal", async () => {
+    transactionsFeesStore.setFee({
+      rootCanisterId: mockSnsFullProject.rootCanisterId,
+      fee: BigInt(10_000),
+      certified: true,
+    });
     const { queryByTestId, getByTestId } = render(Accounts);
 
     expect(queryByTestId("accounts-body")).toBeInTheDocument();

--- a/frontend/src/tests/mocks/transaction-fee.mock.ts
+++ b/frontend/src/tests/mocks/transaction-fee.mock.ts
@@ -1,0 +1,14 @@
+import { TokenAmount } from "@dfinity/nns";
+import type { Subscriber } from "svelte/store";
+
+export const mockSnsSelectedTransactionFeeStoreSubscribe =
+  () =>
+  (run: Subscriber<TokenAmount>): (() => void) => {
+    run(
+      TokenAmount.fromE8s({
+        amount: BigInt(10_000),
+        token: { name: "Test", symbol: "TST" },
+      })
+    );
+    return () => undefined;
+  };


### PR DESCRIPTION
# Motivation

User should get feedback when something doesn't work well.
User should not get a blank page when something goes bad.

# Changes

* Try/catch when loading transactions and show a toast error in the catch.
* Make transactionFee prop as mandatory in TransactionModal.
* Show Modal with Spinner in SnsTransactionModal while transaction fee is not loaded. The fee is loaded along the accounts; therefore, it should be there by the time the user clicks to make a transaction.
* Show a toast error when there is an error loading the sns transaction fee.

# Tests

* Fix broken tests.
