### PR TITLE
Adding back Manage Neuron Topic

### DIFF
--- a/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
+++ b/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
@@ -23,9 +23,9 @@
     {/each}
   </div>
  
-  <div>
+  <h3>
     {$i18n.topics_description.Advanced}
-  </div>
+  </h3>
   <div>
      <FollowTopicSection {neuron} topic={1} />
   </div>

--- a/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
+++ b/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
@@ -22,6 +22,13 @@
       <FollowTopicSection {neuron} {topic} />
     {/each}
   </div>
+ 
+  <div>
+    {$i18n.topics_description.Advanced}
+  </div>
+  <div>
+     <FollowTopicSection {neuron} topic={1} />
+  </div>
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -64,6 +64,9 @@
       <div>
         <h3>{title}</h3>
         <p class="subtitle description">{subtitle}</p>
+        {#if topic == 1}
+          <p class="subtitle description">{$i18n.ManageNeuronWarning.topics_description}</p>
+        {/if}
       </div>
       <div class="toolbar">
         <h3 class="badge" data-tid={`topic-${topic}-followees-badge`}>

--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -26,6 +26,8 @@
   "topics_description": {
     "Unspecified": "",
     "ManageNeuron": "A special topic by means of which a neuron can be managed by the followees for this topic (in this case, there is no fallback to default). Votes on this topic are not included in the voting history of the neuron. For proposals on this topic, only the neuron’s followees on the topic that the proposals pertain to are allowed to vote. Because the set of eligible voters of proposals on this topic is restricted, proposals on this topic have a shorter than normal voting period.",
+    "ManageNeuronWarning": "Warning: The neurons you follow on this topic will be able to control your neruon including harvesting the maturity.",
+    "Advanced": "Advanced",
     "ExchangeRate": "All proposals provide information in “real time” about the market value of ICP, as measured by an International Monetary Fund (IMF) Special Drawing Right (SDR) , which allows the NNS to convert ICP to cycles (which power computation) at a rate that keeps their real-world cost constant. Because proposals on this topic are very frequent, they have a shorter voting period, and votes on this topic are not included in the voting history of the neuron.",
     "NetworkEconomics": "Proposals that administer network economics — for example, determining what rewards should be paid to node providers.",
     "Governance": "All proposals that administer governance — for example, motions and the configuration of certain parameters.",


### PR DESCRIPTION
# Motivation

Users should be able to use the manage neuron topic from the NNS

# Changes

I added Manage neuron under an "Advanced" section and added a warning that any neuron added would have control of their neuron including harvesting maturity.

# Tests

I do not have the ability to test. If someone can provide instructions on how I can run this on the local replica, I'll be happy to test.  All I changed was the display code.
