### PR TITLE
GIX-1115: Stake SNS Neuron UI

### DIFF
--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -8,7 +8,7 @@
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { get } from "svelte/store";
-  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { ICPToken, type Token } from "@dfinity/nns";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
@@ -30,7 +30,7 @@
 
     transferring = true;
 
-    const selectedProjectId = get(snsProjectSelectedStore);
+    const selectedProjectId = get(snsProjectIdSelectedStore);
 
     try {
       if (selectedProjectId.toText() === OWN_CANISTER_ID.toText()) {

--- a/frontend/src/lib/components/neurons/SelectProjectDropdown.svelte
+++ b/frontend/src/lib/components/neurons/SelectProjectDropdown.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
   import { i18n } from "$lib/stores/i18n";
   import { committedProjectsStore } from "$lib/stores/projects.store";
   import { Dropdown, DropdownItem } from "@dfinity/gix-components";
@@ -20,10 +20,10 @@
   const updateSelectedCanisterId = () => {
     if (
       selectableProjects.find(
-        ({ canisterId }) => $snsProjectSelectedStore.toText() === canisterId
+        ({ canisterId }) => $snsProjectIdSelectedStore.toText() === canisterId
       ) !== undefined
     ) {
-      selectedCanisterId = $snsProjectSelectedStore.toText();
+      selectedCanisterId = $snsProjectIdSelectedStore.toText();
     }
   };
 

--- a/frontend/src/lib/components/neurons/SnsNeuronsFooter.svelte
+++ b/frontend/src/lib/components/neurons/SnsNeuronsFooter.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import Footer from "$lib/components/common/Footer.svelte";
+  import { Modal, Spinner, Toolbar } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import StakeSnsNeuronModal from "$lib/modals/sns/StakeSnsNeuronModal.svelte";
+  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+  import { decodeSnsAccount } from "@dfinity/sns";
+
+  type ModalKey = "stake-neuron";
+  let showModal: ModalKey | undefined = undefined;
+  const openModal = (key: ModalKey) => (showModal = key);
+  const closeModal = () => (showModal = undefined);
+</script>
+
+<Footer>
+  <Toolbar>
+    <button
+      data-tid="stake-sns-neuron-button"
+      class="primary full-width"
+      on:click={() => openModal("stake-neuron")}
+      >{$i18n.neurons.stake_neurons}</button
+    >
+  </Toolbar>
+</Footer>
+
+{#if showModal === "stake-neuron"}
+  <!-- TODO: Use governance canister id as destination or the subaccount slot for this neuron -->
+  {#if $snsSelectedProjectNewTxData !== undefined && $snsProjectSelectedStore !== undefined}
+    <StakeSnsNeuronModal
+      token={$snsSelectedProjectNewTxData.token}
+      on:nnsClose={closeModal}
+      rootCanisterId={$snsSelectedProjectNewTxData.rootCanisterId}
+      transactionFee={$snsSelectedProjectNewTxData.transactionFee}
+      destination={decodeSnsAccount(
+        $snsProjectSelectedStore.summary.rootCanisterId.toText()
+      )}
+    />
+  {:else}
+    <!-- A toast error is shown if there is an error fetching any of the needed data -->
+    <Modal on:nnsClose>
+      <svelte:fragment slot="title"
+        >{$i18n.neurons.stake_neuron}</svelte:fragment
+      ><Spinner /></Modal
+    >
+  {/if}
+{/if}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -13,7 +13,7 @@
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
   import {
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
@@ -61,7 +61,7 @@
     const { success } = await removeHotkey({
       neuronId,
       hotkey,
-      rootCanisterId: $snsProjectSelectedStore,
+      rootCanisterId: $snsProjectIdSelectedStore,
     });
     if (success) {
       await reload();

--- a/frontend/src/lib/derived/selected-project-new-tx-data.derived.ts
+++ b/frontend/src/lib/derived/selected-project-new-tx-data.derived.ts
@@ -1,0 +1,38 @@
+import type { Token, TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { derived, type Readable } from "svelte/store";
+import { snsProjectIdSelectedStore } from "./selected-project.derived";
+import { snsSelectedTransactionFeeStore } from "./sns/sns-selected-transaction-fee.store";
+import { snsTokenSymbolSelectedStore } from "./sns/sns-token-symbol-selected.store";
+
+interface SnsNewTxData {
+  token: Token;
+  rootCanisterId: Principal;
+  transactionFee: TokenAmount;
+}
+
+export const snsSelectedProjectNewTxData: Readable<SnsNewTxData | undefined> =
+  derived(
+    [
+      snsTokenSymbolSelectedStore,
+      snsProjectIdSelectedStore,
+      snsSelectedTransactionFeeStore,
+    ],
+    ([
+      $snsTokenSymbolSelectedStore,
+      $snsProjectIdSelectedStore,
+      $snsSelectedTransactionFeeStore,
+    ]) => {
+      if (
+        $snsTokenSymbolSelectedStore !== undefined &&
+        $snsProjectIdSelectedStore !== undefined &&
+        $snsSelectedTransactionFeeStore !== undefined
+      ) {
+        return {
+          token: $snsTokenSymbolSelectedStore,
+          rootCanisterId: $snsProjectIdSelectedStore,
+          transactionFee: $snsSelectedTransactionFeeStore,
+        };
+      }
+    }
+  );

--- a/frontend/src/lib/derived/selected-project.derived.ts
+++ b/frontend/src/lib/derived/selected-project.derived.ts
@@ -3,7 +3,7 @@ import {
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
 import { pageStore } from "$lib/derived/page.derived";
-import type { SnsFullProject } from "$lib/stores/projects.store";
+import { projectsStore, type SnsFullProject } from "$lib/stores/projects.store";
 import { isNnsProject } from "$lib/utils/projects.utils";
 import { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
@@ -14,12 +14,15 @@ import { derived, type Readable } from "svelte/store";
  * The store reads the routeStore and returns the context.
  * It defaults to NNS (OWN_CANISTER_ID) if the path is not a context path.
  */
-export const snsProjectIdSelectedStore = derived(pageStore, ({ universe }) => {
-  if (![null, undefined, OWN_CANISTER_ID_TEXT].includes(universe)) {
-    try {
-      return Principal.fromText(universe);
-    } catch (error: unknown) {
-      // Add exceptions, maybe bitcoin wallet?
+export const snsProjectIdSelectedStore: Readable<Principal> = derived(
+  pageStore,
+  ({ universe }) => {
+    if (![null, undefined, OWN_CANISTER_ID_TEXT].includes(universe)) {
+      try {
+        return Principal.fromText(universe);
+      } catch (error: unknown) {
+        // Add exceptions, maybe bitcoin wallet?
+      }
     }
     // Consider NNS as default project
     return OWN_CANISTER_ID;

--- a/frontend/src/lib/derived/selected-project.derived.ts
+++ b/frontend/src/lib/derived/selected-project.derived.ts
@@ -53,10 +53,9 @@ export const snsOnlyProjectStore = derived<
 export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =
   derived(
     [snsProjectIdSelectedStore, projectsStore],
-    ([$snsProjectIdSelectedStore, $projectsStore]) => {
-      return $projectsStore?.find(
+    ([$snsProjectIdSelectedStore, $projectsStore]) =>
+      $projectsStore?.find(
         ({ rootCanisterId }) =>
           rootCanisterId.toText() === $snsProjectIdSelectedStore.toText()
-      );
-    }
+      )
   );

--- a/frontend/src/lib/derived/sns/sns-project-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-project-accounts.derived.ts
@@ -1,4 +1,4 @@
-import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { mainAccount } from "$lib/utils/accounts.utils";
@@ -19,7 +19,7 @@ const sortAccounts = (accounts: Account[]): Account[] => {
 };
 
 export const snsProjectAccountsStore: Readable<Account[] | undefined> = derived(
-  [snsAccountsStore, snsProjectSelectedStore],
+  [snsAccountsStore, snsProjectIdSelectedStore],
   ([store, selectedSnsRootCanisterId]) => {
     const projectStore = store[selectedSnsRootCanisterId.toText()];
     return projectStore === undefined
@@ -30,7 +30,7 @@ export const snsProjectAccountsStore: Readable<Account[] | undefined> = derived(
 
 export const snsProjectMainAccountStore: Readable<Account | undefined> =
   derived(
-    [snsAccountsStore, snsProjectSelectedStore],
+    [snsAccountsStore, snsProjectIdSelectedStore],
     ([store, selectedSnsRootCanisterId]) => {
       const projectStore = store[selectedSnsRootCanisterId.toText()];
       return projectStore === undefined

--- a/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
@@ -1,14 +1,14 @@
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { TokenAmount } from "@dfinity/nns";
 import { derived, type Readable } from "svelte/store";
-import { snsProjectSelectedStore } from "../selected-project.derived";
+import { snsProjectIdSelectedStore } from "../selected-project.derived";
 import { snsTokenSymbolSelectedStore } from "./sns-token-symbol-selected.store";
 
 // TS was not smart enough to infer the type of the stores, so we need to specify them
 export const snsSelectedTransactionFeeStore: Readable<TokenAmount | undefined> =
   derived(
     [
-      snsProjectSelectedStore,
+      snsProjectIdSelectedStore,
       transactionsFeesStore,
       snsTokenSymbolSelectedStore,
     ],

--- a/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
+++ b/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
@@ -1,10 +1,10 @@
-import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
 import { snsSummariesStore } from "$lib/stores/sns.store";
 import type { Token } from "@dfinity/nns";
 import { derived, type Readable } from "svelte/store";
 
 export const snsTokenSymbolSelectedStore: Readable<Token | undefined> = derived(
-  [snsProjectSelectedStore, snsSummariesStore],
+  [snsProjectIdSelectedStore, snsSummariesStore],
   ([selectedRootCanisterId, summaries]) => {
     const selectedTokenMetadata = summaries.find(
       ({ rootCanisterId }) =>

--- a/frontend/src/lib/derived/sorted-sns-neurons.derived.ts
+++ b/frontend/src/lib/derived/sorted-sns-neurons.derived.ts
@@ -6,10 +6,10 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { derived, type Readable } from "svelte/store";
-import { snsProjectSelectedStore } from "./selected-project.derived";
+import { snsProjectIdSelectedStore } from "./selected-project.derived";
 
 export const sortedSnsNeuronStore: Readable<SnsNeuron[]> = derived(
-  [snsNeuronsStore, snsProjectSelectedStore],
+  [snsNeuronsStore, snsProjectIdSelectedStore],
   ([store, selectedSnsRootCanisterId]) => {
     const projectStore = store[selectedSnsRootCanisterId.toText()];
     return projectStore === undefined

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -586,6 +586,10 @@
     "add_hotkey_info": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp.",
     "add_hotkey_tooltip": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp."
   },
+  "sns_neurons": {
+    "stake_sns_neuron": "Stake $tokenName Neuron",
+    "stake_sns_neuron_success": "$tokenName Neuron created successfully."
+  },
   "time": {
     "year": "year",
     "year_plural": "years",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -587,8 +587,8 @@
     "add_hotkey_tooltip": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp."
   },
   "sns_neurons": {
-    "stake_sns_neuron": "Stake $tokenName Neuron",
-    "stake_sns_neuron_success": "$tokenName Neuron created successfully."
+    "stake_sns_neuron": "Stake $tokenSymbol Neuron",
+    "stake_sns_neuron_success": "$tokenSymbol Neuron created successfully."
   },
   "time": {
     "year": "year",

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -9,11 +9,13 @@
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
-  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
   import { numberToE8s } from "$lib/utils/token.utils";
   import type { Account } from "$lib/types/account";
   import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
 
+  // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
+  // This way we can reuse this component in a dashboard page.
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
 
@@ -36,8 +38,8 @@
       source: sourceAccount,
       destinationAddress,
       e8s: numberToE8s(amount),
-      rootCanisterId: $snsProjectSelectedStore,
       loadTransactions,
+      rootCanisterId: $snsProjectIdSelectedStore,
     });
 
     stopBusy("accounts");
@@ -51,7 +53,7 @@
 
 {#if $snsSelectedTransactionFeeStore !== undefined}
   <TransactionModal
-    rootCanisterId={$snsProjectSelectedStore}
+    rootCanisterId={$snsProjectIdSelectedStore}
     on:nnsSubmit={transfer}
     on:nnsClose
     bind:currentStep

--- a/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
+++ b/frontend/src/lib/modals/sns/AddSnsHotkeyModal.svelte
@@ -7,7 +7,7 @@
   import { createEventDispatcher, getContext } from "svelte";
   import { toastsError } from "$lib/stores/toasts.store";
   import AddPrincipal from "$lib/components/common/AddPrincipal.svelte";
-  import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
   import {
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
@@ -36,7 +36,7 @@
     const { success } = await addHotkey({
       neuronId,
       hotkey: principal,
-      rootCanisterId: $snsProjectSelectedStore,
+      rootCanisterId: $snsProjectIdSelectedStore,
     });
     if (success) {
       await reload();

--- a/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
+  import type { NewTransaction } from "$lib/types/transaction";
+  import TransactionModal from "../accounts/NewTransaction/TransactionModal.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { numberToE8s } from "$lib/utils/token.utils";
+  import type { WizardStep } from "@dfinity/gix-components";
+  import type { Token, TokenAmount } from "@dfinity/nns";
+  import type { Principal } from "@dfinity/principal";
+  import { encodeSnsAccount, type SnsAccount } from "@dfinity/sns";
+  import { stakeNeuron } from "$lib/services/sns-neurons.services";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
+
+  export let token: Token;
+  export let rootCanisterId: Principal;
+  export let transactionFee: TokenAmount;
+  export let destination: SnsAccount;
+
+  let currentStep: WizardStep;
+
+  let stakeNeuronText = replacePlaceholders(
+    $i18n.sns_neurons.stake_sns_neuron,
+    {
+      $tokenName: token.symbol,
+    }
+  );
+  $: title =
+    currentStep?.name === "Form"
+      ? stakeNeuronText
+      : $i18n.accounts.review_transaction;
+
+  const dispatcher = createEventDispatcher();
+  const stake = async ({ detail }: CustomEvent<NewTransaction>) => {
+    startBusy({
+      initiator: "stake-sns-neuron",
+    });
+
+    const { success } = await stakeNeuron({
+      rootCanisterId,
+      amount: numberToE8s(detail.amount),
+      account: detail.sourceAccount,
+    });
+
+    stopBusy("stake-sns-neuron");
+
+    if (success) {
+      toastsSuccess({
+        labelKey: "sns_neurons.stake_sns_neuron_success",
+        substitutions: {
+          $$tokenName: token.symbol,
+        },
+      });
+      dispatcher("nnsClose");
+    }
+  };
+</script>
+
+<!-- TODO: Use minimum token to stake from data -->
+<TransactionModal
+  {rootCanisterId}
+  on:nnsSubmit={stake}
+  on:nnsClose
+  bind:currentStep
+  {token}
+  {transactionFee}
+  destinationAddress={encodeSnsAccount(destination)}
+>
+  <svelte:fragment slot="title"
+    >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
+  >
+  <p slot="description" class="value">
+    {stakeNeuronText}
+  </p>
+</TransactionModal>

--- a/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
@@ -23,7 +23,7 @@
   let stakeNeuronText = replacePlaceholders(
     $i18n.sns_neurons.stake_sns_neuron,
     {
-      $tokenName: token.symbol,
+      $tokenSymbol: token.symbol,
     }
   );
   $: title =
@@ -49,7 +49,7 @@
       toastsSuccess({
         labelKey: "sns_neurons.stake_sns_neuron_success",
         substitutions: {
-          $$tokenName: token.symbol,
+          $$tokenSymbol: token.symbol,
         },
       });
       dispatcher("nnsClose");

--- a/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/StakeSnsNeuronModal.svelte
@@ -57,7 +57,7 @@
   };
 </script>
 
-<!-- TODO: Use minimum token to stake from data -->
+<!-- TODO: Fetch SNS params and use minimum neuron stake for validation -->
 <TransactionModal
   {rootCanisterId}
   on:nnsSubmit={stake}

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -17,6 +17,7 @@
   import { goto } from "$app/navigation";
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
+  import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 
   let loading = true;
 
@@ -24,7 +25,10 @@
     async (selectedProjectCanisterId) => {
       if (selectedProjectCanisterId !== undefined) {
         loading = true;
-        await loadSnsNeurons(selectedProjectCanisterId);
+        await Promise.all([
+          loadSnsNeurons(selectedProjectCanisterId),
+          syncSnsAccounts(selectedProjectCanisterId),
+        ]);
         loading = false;
       }
     }

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -4,7 +4,7 @@
   import NnsAccountsFooter from "$lib/components/accounts/NnsAccountsFooter.svelte";
   import {
     isNnsProjectStore,
-    snsProjectSelectedStore,
+    snsProjectIdSelectedStore,
   } from "$lib/derived/selected-project.derived";
   import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
   import SelectProjectDropdownHeader from "$lib/components/ic/SelectProjectDropdownHeader.svelte";
@@ -18,7 +18,7 @@
 
   {#if $isNnsProjectStore}
     <NnsAccounts />
-  {:else if $snsProjectSelectedStore !== undefined}
+  {:else if $snsProjectIdSelectedStore !== undefined}
     <SnsAccounts />
   {/if}
 </main>

--- a/frontend/src/lib/routes/Neurons.svelte
+++ b/frontend/src/lib/routes/Neurons.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { ENABLE_SNS } from "$lib/constants/environment.constants";
+  import { ENABLE_SNS, IS_TESTNET } from "$lib/constants/environment.constants";
   import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
   import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
   import NnsNeuronsFooter from "$lib/components/neurons/NnsNeuronsFooter.svelte";
+  import SnsNeuronsFooter from "$lib/components/neurons/SnsNeuronsFooter.svelte";
   import {
     isNnsProjectStore,
-    snsProjectSelectedStore,
+    snsProjectIdSelectedStore,
   } from "$lib/derived/selected-project.derived";
   import SelectProjectDropdownHeader from "$lib/components/ic/SelectProjectDropdownHeader.svelte";
 </script>
@@ -17,11 +18,13 @@
 
   {#if $isNnsProjectStore}
     <NnsNeurons />
-  {:else if $snsProjectSelectedStore !== undefined}
+  {:else if $snsProjectIdSelectedStore !== undefined}
     <SnsNeurons />
   {/if}
 </main>
 
 {#if $isNnsProjectStore}
   <NnsNeuronsFooter />
+{:else if $snsProjectIdSelectedStore !== undefined && IS_TESTNET}
+  <SnsNeuronsFooter />
 {/if}

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -11,6 +11,7 @@ import {
   type ProjectNeuronStore,
 } from "$lib/stores/sns-neurons.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
 import { getSnsNeuronByHexId } from "$lib/utils/sns-neuron.utils";
 import { hexStringToBytes } from "$lib/utils/utils";
@@ -289,4 +290,23 @@ export const stopDissolving = async ({
     });
     return { success: false };
   }
+};
+
+// TODO: Implement in sns-js, create an api function and use it here
+export const stakeNeuron = async ({
+  rootCanisterId,
+  amount,
+  account,
+}: {
+  rootCanisterId: Principal;
+  amount: bigint;
+  account: Account;
+}): Promise<{ success: boolean }> => {
+  console.log(
+    "Staking neuron",
+    rootCanisterId.toText(),
+    amount,
+    account.identifier
+  );
+  return { success: true };
 };

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -33,6 +33,7 @@ export type BusyStateInitiatorType =
   | "remove-sns-hotkey-neuron"
   | "disburse-neuron"
   | "top-up-neuron"
+  | "stake-sns-neuron"
   | "disburse-sns-neuron";
 
 export interface BusyState {

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -59,6 +59,11 @@ const initTransactionFeesStore = () => {
         },
       }));
     },
+
+    // Used for testing
+    reset() {
+      update(() => defaultTransactionFees);
+    },
   };
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -613,6 +613,11 @@ interface I18nSns_neuron_detail {
   add_hotkey_tooltip: string;
 }
 
+interface I18nSns_neurons {
+  stake_sns_neuron: string;
+  stake_sns_neuron_success: string;
+}
+
 interface I18nTime {
   year: string;
   year_plural: string;
@@ -941,6 +946,7 @@ interface I18n {
   sns_project: I18nSns_project;
   sns_project_detail: I18nSns_project_detail;
   sns_neuron_detail: I18nSns_neuron_detail;
+  sns_neurons: I18nSns_neurons;
   time: I18nTime;
   error__ledger: I18nError__ledger;
   error__attach_wallet: I18nError__attach_wallet;

--- a/frontend/src/tests/lib/components/neurons/SelectProjectDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SelectProjectDropdown.spec.ts
@@ -6,7 +6,7 @@ import {
   OWN_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
 import { committedProjectsStore } from "$lib/stores/projects.store";
 import { page } from "$mocks/$app/stores";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -80,10 +80,10 @@ describe("SelectProjectDropdown", () => {
     selectElement && expect(selectElement.value).toBe(projectCanisterId);
   });
 
-  it("changes in dropdown are propagated to the snsProjectSelectedStore", async () => {
+  it("changes in dropdown are propagated to the snsProjectIdSelectedStore", async () => {
     const { container } = render(SelectProjectDropdown);
 
-    const $store1 = get(snsProjectSelectedStore);
+    const $store1 = get(snsProjectIdSelectedStore);
     expect($store1.toText()).toEqual(OWN_CANISTER_ID.toText());
 
     const selectElement = container.querySelector("select");
@@ -94,7 +94,7 @@ describe("SelectProjectDropdown", () => {
       });
 
     await waitFor(() => {
-      const $store2 = get(snsProjectSelectedStore);
+      const $store2 = get(snsProjectIdSelectedStore);
       return expect($store2.toText()).toEqual(projectCanisterId);
     });
   });

--- a/frontend/src/tests/lib/components/neurons/SnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SnsNeuronsFooter.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronsFooter from "$lib/components/neurons/SnsNeuronsFooter.svelte";
+import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { neuronsStore } from "$lib/stores/neurons.store";
+import { NeuronState, TokenAmount } from "@dfinity/nns";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { mockStoreSubscribe } from "../../../mocks/commont.mock";
+import {
+  buildMockNeuronsStoreSubscribe,
+  mockFullNeuron,
+  mockNeuron,
+} from "../../../mocks/neurons.mock";
+import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
+
+describe("SnsNeuron footer", () => {
+  beforeEach(() => {
+    const mockNeuron2 = {
+      ...mockNeuron,
+      neuronId: BigInt(223),
+    };
+    const spawningNeuron = {
+      ...mockNeuron,
+      state: NeuronState.Spawning,
+      neuronId: BigInt(223),
+      fullNeuron: {
+        ...mockFullNeuron,
+        spawnAtTimesSeconds: BigInt(12312313),
+      },
+    };
+    jest
+      .spyOn(neuronsStore, "subscribe")
+      .mockImplementation(
+        buildMockNeuronsStoreSubscribe([
+          mockNeuron,
+          mockNeuron2,
+          spawningNeuron,
+        ])
+      );
+  });
+
+  it("should open the StakeSnsNeuronModal on click to stake SNS Neurons", async () => {
+    jest.spyOn(snsSelectedProjectNewTxData, "subscribe").mockImplementation(
+      mockStoreSubscribe({
+        token: mockSnsFullProject.summary.token,
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        transactionFee: TokenAmount.fromE8s({
+          amount: BigInt(10_000),
+          token: mockSnsFullProject.summary.token,
+        }),
+      })
+    );
+    jest
+      .spyOn(snsProjectSelectedStore, "subscribe")
+      .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
+    const { queryByTestId } = render(SnsNeuronsFooter);
+
+    const toolbarButton = queryByTestId("stake-sns-neuron-button");
+    expect(toolbarButton).not.toBeNull();
+
+    toolbarButton !== null && (await fireEvent.click(toolbarButton));
+
+    await waitFor(() =>
+      expect(queryByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/derived/selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-project-new-tx-data.derived.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { mapOptionalToken } from "$lib/utils/sns.utils";
+import { page } from "$mocks/$app/stores";
+import { Principal } from "@dfinity/principal";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { get } from "svelte/store";
+import { mockSnsSwapCommitment } from "../../mocks/sns-projects.mock";
+import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
+
+describe("selected-project-new-transaction-data derived store", () => {
+  describe("snsSelectedProjectNewTxData", () => {
+    beforeEach(() => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      snsQueryStore.reset();
+      snsSwapCommitmentsStore.reset();
+      transactionsFeesStore.reset();
+    });
+    it("returns undefined when nns", () => {
+      const $store = get(snsSelectedProjectNewTxData);
+      expect($store).toBeUndefined();
+    });
+    it("returns the data for the a new Tx from the current universe", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+      const tokenData = projectData[0][0].token;
+      const rootCanisterId = Principal.fromText(rootCanisterIdText);
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(rootCanisterId),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: rootCanisterIdText } });
+
+      const fee = BigInt(40_000);
+      transactionsFeesStore.setFee({
+        rootCanisterId,
+        fee,
+        certified: true,
+      });
+
+      const token = mapOptionalToken(tokenData);
+      const storeData = get(snsSelectedProjectNewTxData);
+      expect(storeData.rootCanisterId.toText()).toEqual(rootCanisterIdText);
+      expect(storeData.token).toEqual(token);
+      expect(storeData.transactionFee.toE8s()).toEqual(fee);
+    });
+
+    it("returns undefined if no transaction fee", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+      const rootCanisterId = Principal.fromText(rootCanisterIdText);
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(rootCanisterId),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: rootCanisterIdText } });
+
+      expect(get(snsSelectedProjectNewTxData)).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/tests/lib/derived/selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-project.derived.spec.ts
@@ -8,7 +8,7 @@ import {
 import {
   isNnsProjectStore,
   snsOnlyProjectStore,
-  snsProjectSelectedStore,
+  snsProjectIdSelectedStore,
 } from "$lib/derived/selected-project.derived";
 import { page } from "$mocks/$app/stores";
 import { get } from "svelte/store";
@@ -65,19 +65,19 @@ describe("selected project derived stores", () => {
     });
   });
 
-  describe("snsProjectSelectedStore", () => {
+  describe("snsProjectIdSelectedStore", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
     });
 
     it("should be set by default to own canister id", () => {
-      const $store = get(snsProjectSelectedStore);
+      const $store = get(snsProjectIdSelectedStore);
 
       expect($store).toEqual(OWN_CANISTER_ID);
     });
 
     it("should able to set it to another project id", () => {
-      const $store1 = get(snsProjectSelectedStore);
+      const $store1 = get(snsProjectIdSelectedStore);
 
       expect($store1).toEqual(OWN_CANISTER_ID);
 
@@ -88,13 +88,13 @@ describe("selected project derived stores", () => {
     });
 
     it("returns OWN_CANISTER_ID if context is not a valid principal id", () => {
-      const $store1 = get(snsProjectSelectedStore);
+      const $store1 = get(snsProjectIdSelectedStore);
 
       expect($store1).toEqual(OWN_CANISTER_ID);
 
       page.mock({ data: { universe: "invalid-principal" } });
 
-      const $store2 = get(snsProjectSelectedStore);
+      const $store2 = get(snsProjectIdSelectedStore);
       expect($store2.toText()).toEqual(OWN_CANISTER_ID.toText());
     });
   });

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { snsProjectSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 import { snsTransferTokens } from "$lib/services/sns-accounts.services";
@@ -43,7 +43,7 @@ describe("SnsTransactionModal", () => {
       .spyOn(snsSelectedTransactionFeeStore, "subscribe")
       .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe());
     jest
-      .spyOn(snsProjectSelectedStore, "subscribe")
+      .spyOn(snsProjectIdSelectedStore, "subscribe")
       .mockImplementation((run: Subscriber<Principal>): (() => void) => {
         run(mockPrincipal);
         return () => undefined;

--- a/frontend/src/tests/lib/modals/sns/StakeSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/StakeSnsNeuronModal.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
+import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
+import StakeSnsNeuronModal from "$lib/modals/sns/StakeSnsNeuronModal.svelte";
+import { stakeNeuron } from "$lib/services/sns-neurons.services";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { page } from "$mocks/$app/stores";
+import { TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import { fireEvent, waitFor } from "@testing-library/svelte";
+import type { Subscriber } from "svelte/store";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { renderModal } from "../../../mocks/modal.mock";
+import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
+import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../../mocks/transaction-fee.mock";
+
+jest.mock("$lib/services/sns-neurons.services", () => {
+  return {
+    stakeNeuron: jest.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+describe("StakeSnsNeuronModal", () => {
+  const token = { name: "SNS", symbol: "SNS" };
+  const renderTransactionModal = () =>
+    renderModal({
+      component: StakeSnsNeuronModal,
+      props: {
+        destination: {
+          owner: mockPrincipal,
+        },
+        token,
+        transactionFee: TokenAmount.fromE8s({
+          amount: BigInt(10_000),
+          token,
+        }),
+        rootCanisterId: mockPrincipal,
+      },
+    });
+
+  beforeEach(() => {
+    jest
+      .spyOn(snsAccountsStore, "subscribe")
+      .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
+    jest
+      .spyOn(snsSelectedTransactionFeeStore, "subscribe")
+      .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe());
+    jest
+      .spyOn(snsProjectIdSelectedStore, "subscribe")
+      .mockImplementation((run: Subscriber<Principal>): (() => void) => {
+        run(mockPrincipal);
+        return () => undefined;
+      });
+
+    page.mock({ data: { universe: mockPrincipal.toText() } });
+  });
+
+  it("should stake a new sns neuron", async () => {
+    const { queryAllByText, getByTestId, container } =
+      await renderTransactionModal();
+
+    await waitFor(() =>
+      expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+    const participateButton = getByTestId("transaction-button-next");
+    expect(participateButton?.hasAttribute("disabled")).toBeTruthy();
+
+    // Enter amount
+    const icpAmount = "10";
+    const input = container.querySelector("input[name='amount']");
+    input && fireEvent.input(input, { target: { value: icpAmount } });
+    await waitFor(() =>
+      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    );
+
+    fireEvent.click(participateButton);
+
+    await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());
+    expect(queryAllByText(icpAmount, { exact: false }).length).toBeGreaterThan(
+      0
+    );
+
+    const confirmButton = getByTestId("transaction-button-execute");
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(stakeNeuron).toBeCalled());
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -7,6 +7,8 @@ import {
   sortedSnsUserNeuronsStore,
 } from "$lib/derived/sorted-sns-neurons.derived";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
+import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
+import { loadSnsNeurons } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -24,6 +26,12 @@ import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
     loadSnsNeurons: jest.fn().mockReturnValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/sns-accounts.services", () => {
+  return {
+    syncSnsAccounts: jest.fn().mockReturnValue(undefined),
   };
 });
 
@@ -60,9 +68,11 @@ describe("SnsNeurons", () => {
 
     afterEach(() => jest.clearAllMocks());
 
-    it("should subscribe to store", () => {
+    it("should subscribe to store and call services to set up data", async () => {
       render(SnsNeurons);
       expect(authStoreMock).toHaveBeenCalled();
+      await waitFor(() => expect(syncSnsAccounts).toBeCalled());
+      await waitFor(() => expect(loadSnsNeurons).toBeCalled());
     });
 
     it("should render a principal as text", () => {

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -30,6 +30,12 @@ jest.mock("$lib/services/sns-neurons.services", () => {
   };
 });
 
+jest.mock("$lib/services/sns-accounts.services", () => {
+  return {
+    syncSnsAccounts: jest.fn().mockReturnValue(undefined),
+  };
+});
+
 describe("Neurons", () => {
   beforeAll(() =>
     jest

--- a/frontend/src/tests/mocks/commont.mock.ts
+++ b/frontend/src/tests/mocks/commont.mock.ts
@@ -1,0 +1,9 @@
+import type { Subscriber } from "svelte/store";
+
+export const mockStoreSubscribe =
+  <T>(arg: T) =>
+  (run: Subscriber<T>): (() => void) => {
+    run(arg);
+
+    return () => undefined;
+  };


### PR DESCRIPTION
# Motivation

User can stake SNS Neurons. First step, UI modal.

# Changes

* New SnsNeuronsFooter.
* New StakeSnsNeuronModal.
* Rename snsProjectSelectedStore to snsProjectIdSelectedStore.
* New derived store snsProjectSelectedStore that returns the project of the current universe.
* New derived store snsSelectedProjectNewTxData that checks and returns all data needed for a new SNS transaction.
* Load sync sns accounts when visiting SnsNeurons page.

# Tests

* Test SnsNeuronsFooter
* Test StakeSnsNeuronModal
* Test new derived stores snsProjectSelectedStore and snsSelectedProjectNewTxData
* Fix broken tests.
