### PR TITLE
GIX-1668: Check SNS logo is Png

### DIFF
--- a/frontend/src/lib/types/assets.ts
+++ b/frontend/src/lib/types/assets.ts
@@ -1,0 +1,1 @@
+export type Png = string;

--- a/frontend/src/lib/types/assets.ts
+++ b/frontend/src/lib/types/assets.ts
@@ -1,1 +1,1 @@
-export type Png = string;
+export type PngDataUrl = string;

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -7,13 +7,13 @@ import type {
   SnsSwapDerivedState,
   SnsSwapInit,
 } from "@dfinity/sns";
-import type { Png } from "./assets";
+import type { PngDataUrl } from "./assets";
 
 /**
  * Metadata are full optional in Candid files but mandatory currently in NNS-dapp
  */
 export interface SnsSummaryMetadata {
-  url: Png;
+  url: PngDataUrl;
   logo: string;
   name: string;
   description: string;

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -7,12 +7,13 @@ import type {
   SnsSwapDerivedState,
   SnsSwapInit,
 } from "@dfinity/sns";
+import type { Png } from "./assets";
 
 /**
  * Metadata are full optional in Candid files but mandatory currently in NNS-dapp
  */
 export interface SnsSummaryMetadata {
-  url: string;
+  url: Png;
   logo: string;
   name: string;
   description: string;

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SNS_LOGO } from "$lib/constants/sns.constants";
-import type { Png } from "$lib/types/assets";
+import type { PngDataUrl } from "$lib/types/assets";
 import type {
   SnsSummary,
   SnsSummaryMetadata,
@@ -86,7 +86,9 @@ const mapOptionalMetadata = ({
   // We have to check if the logo is a png asset for security reasons.
   // Default logo can be svg.
   return {
-    logo: isPngAsset(nullishLogo) ? nullishLogo : (DEFAULT_SNS_LOGO as Png),
+    logo: isPngAsset(nullishLogo)
+      ? nullishLogo
+      : (DEFAULT_SNS_LOGO as PngDataUrl),
     url: nullishUrl,
     name: nullishName,
     description: nullishDescription,

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SNS_LOGO } from "$lib/constants/sns.constants";
+import type { Png } from "$lib/types/assets";
 import type {
   SnsSummary,
   SnsSummaryMetadata,
@@ -22,6 +23,7 @@ import {
   type SnsTokenMetadataResponse,
 } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
+import { isPngAsset } from "./utils";
 
 type OptionalSnsSummarySwap = Omit<SnsSummarySwap, "params"> & {
   params?: SnsParams;
@@ -81,8 +83,10 @@ const mapOptionalMetadata = ({
     return undefined;
   }
 
+  // We have to check if the logo is a png asset for security reasons.
+  // Default logo can be svg.
   return {
-    logo: nullishLogo ?? DEFAULT_SNS_LOGO,
+    logo: isPngAsset(nullishLogo) ? nullishLogo : (DEFAULT_SNS_LOGO as Png),
     url: nullishUrl,
     name: nullishName,
     description: nullishDescription,

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -1,4 +1,4 @@
-import type { Png } from "$lib/types/assets";
+import type { PngDataUrl } from "$lib/types/assets";
 import type { Principal } from "@dfinity/principal";
 import { errorToString } from "./error.utils";
 
@@ -308,5 +308,8 @@ export const keyOfOptional = <T>({
  * @param {string} src
  * @returns boolean
  */
-export const isPngAsset = (asset: string | undefined | Png): asset is Png =>
-  asset?.startsWith("data:image/png;base64,") ?? false;
+export const isPngAsset = (
+  asset: string | undefined | PngDataUrl
+): asset is PngDataUrl =>
+  nonNullish(asset) &&
+  /data:image\/png;(charset=[-a-z0-9]+;|)base64,/i.test(asset);

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -1,3 +1,4 @@
+import type { Png } from "$lib/types/assets";
 import type { Principal } from "@dfinity/principal";
 import { errorToString } from "./error.utils";
 
@@ -300,3 +301,12 @@ export const keyOfOptional = <T>({
   obj: T | undefined;
   key: string | keyof T;
 }): T[keyof T] | undefined => obj?.[key as keyof T];
+
+/**
+ * Returns whether an asset is PNG or not.
+ *
+ * @param {string} src
+ * @returns boolean
+ */
+export const isPngAsset = (asset: string | undefined | Png): asset is Png =>
+  asset?.startsWith("data:image/png;base64,") ?? false;

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -311,5 +311,4 @@ export const keyOfOptional = <T>({
 export const isPngAsset = (
   asset: string | undefined | PngDataUrl
 ): asset is PngDataUrl =>
-  nonNullish(asset) &&
-  /data:image\/png;(charset=[-a-z0-9]+;|)base64,/i.test(asset);
+  nonNullish(asset) && asset.startsWith("data:image/png;base64,");

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   isDefined,
   isHash,
   isNullish,
+  isPngAsset,
   nonNullish,
   poll,
   PollingLimitExceededError,
@@ -425,6 +426,26 @@ describe("utils", () => {
         c: 3,
       };
       expect(removeKeys({ obj, keysToRemove: ["b", "d"] })).toEqual(expected);
+    });
+  });
+
+  describe("isPngAsset", () => {
+    it("returns true for png assets", () => {
+      const png1 =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
+      const png2 =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcasdfafdaCklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
+      expect(isPngAsset(png1)).toBe(true);
+      expect(isPngAsset(png2)).toBe(true);
+    });
+
+    it("returns false for non png assets", () => {
+      const svg1 =
+        "data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
+      const jpg1 =
+        "data:image/jpg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
+      expect(isPngAsset(svg1)).toBe(false);
+      expect(isPngAsset(jpg1)).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -444,8 +444,11 @@ describe("utils", () => {
         "data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
       const jpg1 =
         "data:image/jpg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
+      const pngFake =
+        "data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcasdfafdaCklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5Edata:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcasdfafdaCklEQVR42mP8z8BQDwAEhQGAhKmMIwAAAABJRU5ErkJggg==";
       expect(isPngAsset(svg1)).toBe(false);
       expect(isPngAsset(jpg1)).toBe(false);
+      expect(isPngAsset(pngFake)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

For security reasons, we need to check that the SNS logo from the canister is PNG.

# Changes

* Changed type of logo to `Png` instead of `string`.
* Add util to assert that an assert is of type `Png`: "isPngAsset"
* Use new util in "mapOptionalMetadata".
* Cast default logo as Png.

# Tests

* Add test for the new util "isPngAsset"
