### PR TITLE
GIX-996: Render SNS transactions

### DIFF
--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -7,6 +7,7 @@
   } from "$lib/utils/transactions.utils";
   import { toastsError } from "$lib/stores/toasts.store";
   import TransactionCard from "./TransactionCard.svelte";
+  import { ICPToken } from "@dfinity/nns";
 
   export let account: Account;
   export let transaction: NnsTransaction;
@@ -35,5 +36,9 @@
 </script>
 
 {#if transactionData !== undefined}
-  <TransactionCard transaction={transactionData} {toSelfTransaction} />
+  <TransactionCard
+    transaction={transactionData}
+    {toSelfTransaction}
+    token={ICPToken}
+  />
 {/if}

--- a/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { Account } from "$lib/types/account";
+  import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
+  import type { Transaction } from "$lib/utils/transactions.utils";
+  import type { TokenAmount } from "@dfinity/nns";
+  import type { SnsTransactionWithId } from "@dfinity/sns";
+  import TransactionCard from "./TransactionCard.svelte";
+
+  export let transactionWithId: SnsTransactionWithId;
+  export let account: Account;
+  export let toSelfTransaction: boolean;
+  export let fee: TokenAmount | undefined = undefined;
+
+  let transactionData: Transaction | undefined;
+  $: transactionData = mapSnsTransaction({
+    transaction: transactionWithId,
+    account,
+    toSelfTransaction,
+    fee,
+  });
+</script>
+
+{#if transactionData !== undefined}
+  <TransactionCard
+    {toSelfTransaction}
+    transaction={transactionData}
+    token={account.balance.token}
+  />
+{/if}

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,20 +1,79 @@
 <script lang="ts">
   import { loadAccountNextTransactions } from "$lib/services/sns-transactions.services";
+  import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
+  import {
+    getSortedTransactionsFromStore,
+    isTransactionsCompleted,
+    type SnsTransactionData,
+  } from "$lib/utils/sns-transactions.utils";
+  import { InfiniteScroll, Spinner } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import SnsTransactionCard from "./SnsTransactionCard.svelte";
+  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
+  import SkeletonCard from "../ui/SkeletonCard.svelte";
 
   export let account: Account;
   export let rootCanisterId: Principal;
 
-  onMount(() => {
-    loadAccountNextTransactions({
+  let loading = true;
+
+  onMount(async () => {
+    loading = true;
+    await loadAccountNextTransactions({
       account,
       rootCanisterId,
     });
+    loading = false;
   });
 
-  // TODO: GIX-996 Render transactions.
+  // `loadMore` depends on props account and rootCanisterId
+  let loadMore: () => Promise<void>;
+  $: loadMore = async () => {
+    loading = true;
+    await loadAccountNextTransactions({
+      account,
+      rootCanisterId,
+    });
+    loading = false;
+  };
+
+  let transactions: SnsTransactionData[];
+  $: transactions = getSortedTransactionsFromStore({
+    store: $snsTransactionsStore,
+    rootCanisterId,
+    account,
+  });
+
+  let completed: boolean;
+  $: completed = isTransactionsCompleted({
+    store: $snsTransactionsStore,
+    rootCanisterId,
+    account,
+  });
 </script>
 
-<div data-tid="sns-transactions-list" />
+<div data-tid="sns-transactions-list">
+  {#if transactions.length === 0 && !loading}
+    {$i18n.wallet.no_transactions}
+  {:else if transactions.length === 0 && loading}
+    <SkeletonCard />
+    <SkeletonCard />
+  {:else}
+    <InfiniteScroll on:nnsIntersect={loadMore} disabled={loading || completed}>
+      {#each transactions as { transaction, toSelfTransaction } (`${transaction.id}-${toSelfTransaction ? "0" : "1"}`)}
+        <SnsTransactionCard
+          transactionWithId={transaction}
+          {toSelfTransaction}
+          {account}
+          fee={$snsSelectedTransactionFeeStore}
+        />
+      {/each}
+    </InfiniteScroll>
+    {#if loading}
+      <Spinner inline />
+    {/if}
+  {/if}
+</div>

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -3,7 +3,7 @@
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";
-  import type { TokenAmount } from "@dfinity/nns";
+  import type { Token, TokenAmount } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import {
     AccountTransactionType,
@@ -13,6 +13,7 @@
 
   export let transaction: Transaction;
   export let toSelfTransaction = false;
+  export let token: Token;
 
   let type: AccountTransactionType;
   let isReceive: boolean;
@@ -28,6 +29,7 @@
     type,
     isReceive: isReceive || toSelfTransaction,
     labels: $i18n.transaction_names,
+    tokenSymbol: token.symbol,
   });
 
   let label: string | undefined;

--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -9,7 +9,7 @@
     SELECTED_ACCOUNT_CONTEXT_KEY,
     type SelectedAccountContext,
   } from "$lib/types/selected-account.context";
-  import { mapToSelfNnsTransaction } from "$lib/utils/transactions.utils";
+  import { mapToSelfTransaction } from "$lib/utils/transactions.utils";
 
   export let transactions: NnsTransaction[] | undefined;
 
@@ -24,7 +24,7 @@
     transaction: NnsTransaction;
     toSelfTransaction: boolean;
   }[];
-  $: extendedTransactions = mapToSelfNnsTransaction(transactions ?? []);
+  $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
 {#if account === undefined || transactions === undefined}
@@ -32,7 +32,7 @@
 {:else if transactions.length === 0}
   {$i18n.wallet.no_transactions}
 {:else}
-  {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}${toSelfTransaction}`)}
+  {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}-${toSelfTransaction}`)}
     <NnsTransactionCard {account} {transaction} {toSelfTransaction} />
   {/each}
 {/if}

--- a/frontend/src/lib/constants/constants.ts
+++ b/frontend/src/lib/constants/constants.ts
@@ -1,5 +1,8 @@
 export const DEFAULT_LIST_PAGINATION_LIMIT = 100;
 export const DEFAULT_TRANSACTION_PAGE_LIMIT = 100;
+// Use a different limit for SNS transactions
+// the Index canister needs to query the SNS Ledger canister for each transaction.
+export const DEFAULT_SNS_TRANSACTION_PAGE_LIMIT = 20;
 
 /**
  * The infinite scroll observe an element that finds place after x % of last page.
@@ -16,3 +19,5 @@ export const SECONDS_IN_YEAR = ((4 * 365 + 1) * SECONDS_IN_DAY) / 4;
 export const SECONDS_IN_HALF_YEAR = SECONDS_IN_YEAR / 2;
 export const SECONDS_IN_FOUR_YEARS = SECONDS_IN_YEAR * 4;
 export const SECONDS_IN_EIGHT_YEARS = SECONDS_IN_YEAR * 8;
+
+export const NANO_SECONDS_IN_MILLISECOND = 1_000_000;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -103,6 +103,7 @@
     "swap_not_loaded": "Sorry, there was an error loading the sale information.",
     "transaction_fee_not_found": "Sorry, there was an error loading the transaction fee.",
     "fetch_transactions": "Sorry, there was an error loading the transactions for this account.",
+    "transaction_data": "Sorry, there was an error with the transaction $txId.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {
@@ -368,10 +369,10 @@
     "add_controller": "Add Controller"
   },
   "transaction_names": {
-    "receive": "Received ICP",
-    "send": "Sent ICP",
-    "mint": "Received ICP",
-    "burn": "Sent ICP",
+    "receive": "Received $tokenSymbol",
+    "send": "Sent $tokenSymbol",
+    "mint": "Received $tokenSymbol",
+    "burn": "Sent $tokenSymbol",
     "stakeNeuron": "Stake Neuron",
     "stakeNeuronNotification": "Stake Neuron (Part 2 of 2)",
     "topUpNeuron": "Top-up Neuron",

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -15,6 +15,7 @@
   import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
 
   export let selectedAccount: Account | undefined = undefined;
+  export let loadTransactions = false;
 
   let currentStep: WizardStep;
 
@@ -36,6 +37,7 @@
       destinationAddress,
       e8s: numberToE8s(amount),
       rootCanisterId: $snsProjectSelectedStore,
+      loadTransactions,
     });
 
     stopBusy("accounts");

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -107,5 +107,6 @@
   <SnsTransactionModal
     on:nnsClose={() => (showNewTransactionModal = false)}
     selectedAccount={$selectedAccountStore.account}
+    loadTransactions
   />
 {/if}

--- a/frontend/src/lib/services/sns-transactions.services.ts
+++ b/frontend/src/lib/services/sns-transactions.services.ts
@@ -1,12 +1,50 @@
 import { getTransactions } from "$lib/api/sns-index.api";
-import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_SNS_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
+import { getOldestTxIdFromStore } from "$lib/utils/sns-transactions.utils";
 import type { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
+import { get } from "svelte/store";
 import { getSnsAccountIdentity } from "./sns-accounts.services";
+
+export const loadAccountTransactions = async ({
+  account,
+  rootCanisterId,
+  start,
+}: {
+  account: Account;
+  rootCanisterId: Principal;
+  start?: bigint;
+}) => {
+  try {
+    const identity = await getSnsAccountIdentity(account);
+    const snsAccount = decodeSnsAccount(account.identifier);
+    const maxResults = DEFAULT_SNS_TRANSACTION_PAGE_LIMIT;
+    const { transactions, oldestTxId } = await getTransactions({
+      identity,
+      account: snsAccount,
+      maxResults: BigInt(maxResults),
+      rootCanisterId,
+      start,
+    });
+    // If API returns less than the maxResults, we reached the end of the list.
+    const completed = transactions.length < maxResults;
+    snsTransactionsStore.addTransactions({
+      accountIdentifier: account.identifier,
+      rootCanisterId,
+      transactions,
+      oldestTxId,
+      completed,
+    });
+  } catch (err) {
+    toastsError(
+      toToastError({ fallbackErrorLabelKey: "error.fetch_transactions", err })
+    );
+  }
+};
 
 export const loadAccountNextTransactions = async ({
   account,
@@ -15,24 +53,15 @@ export const loadAccountNextTransactions = async ({
   account: Account;
   rootCanisterId: Principal;
 }) => {
-  try {
-    const identity = await getSnsAccountIdentity(account);
-    const snsAccount = decodeSnsAccount(account.identifier);
-    const { transactions, oldestTxId } = await getTransactions({
-      identity,
-      account: snsAccount,
-      maxResults: BigInt(DEFAULT_TRANSACTION_PAGE_LIMIT),
-      rootCanisterId,
-    });
-    snsTransactionsStore.addTransactions({
-      accountIdentifier: account.identifier,
-      rootCanisterId,
-      transactions,
-      oldestTxId,
-    });
-  } catch (err) {
-    toastsError(
-      toToastError({ fallbackErrorLabelKey: "error.fetch_transactions", err })
-    );
-  }
+  const store = get(snsTransactionsStore);
+  const currentOldestTxId = getOldestTxIdFromStore({
+    account,
+    rootCanisterId,
+    store,
+  });
+  return loadAccountTransactions({
+    account,
+    rootCanisterId,
+    start: currentOldestTxId,
+  });
 };

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -9,6 +9,7 @@ interface SnsTransactions {
   [accountIdentifier: string]: {
     transactions: SnsTransactionWithId[];
     oldestTxId?: bigint;
+    completed: boolean;
   };
 }
 
@@ -25,7 +26,7 @@ export interface SnsTransactionsStore {
  * - reset: reset the store to an empty state.
  * - resetProject: removed the transactions for a specific project.
  */
-const initSnsAccountsStore = () => {
+const initSnsTransactionsStore = () => {
   const { subscribe, update, set } = writable<SnsTransactionsStore>({});
 
   return {
@@ -36,11 +37,13 @@ const initSnsAccountsStore = () => {
       rootCanisterId,
       transactions,
       oldestTxId,
+      completed,
     }: {
       accountIdentifier: string;
       rootCanisterId: Principal;
       transactions: SnsTransactionWithId[];
       oldestTxId?: bigint;
+      completed: boolean;
     }) {
       update((currentState: SnsTransactionsStore) => {
         const projectState = currentState[rootCanisterId.toText()];
@@ -58,6 +61,7 @@ const initSnsAccountsStore = () => {
             [accountIdentifier]: {
               transactions: [...uniquePreviousTransactions, ...transactions],
               oldestTxId,
+              completed,
             },
           },
         };
@@ -80,4 +84,4 @@ const initSnsAccountsStore = () => {
   };
 };
 
-export const snsTransactionsStore = initSnsAccountsStore();
+export const snsTransactionsStore = initSnsTransactionsStore();

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -54,13 +54,20 @@ const initSnsTransactionsStore = () => {
           ({ id: oldTxId }) =>
             !transactions.some(({ id: newTxId }) => newTxId === oldTxId)
         );
+        // Ids are in increasing order. We want to keep the oldest id.
+        const newOldestTxId =
+          oldestTxId === undefined
+            ? accountState?.oldestTxId
+            : oldestTxId <= (accountState?.oldestTxId ?? oldestTxId)
+            ? oldestTxId
+            : accountState?.oldestTxId;
         return {
           ...currentState,
           [rootCanisterId.toText()]: {
             ...projectState,
             [accountIdentifier]: {
               transactions: [...uniquePreviousTransactions, ...transactions],
-              oldestTxId,
+              oldestTxId: newOldestTxId,
               completed,
             },
           },

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -107,6 +107,7 @@ interface I18nError {
   swap_not_loaded: string;
   transaction_fee_not_found: string;
   fetch_transactions: string;
+  transaction_data: string;
   canister_invalid_transaction: string;
 }
 

--- a/frontend/src/lib/utils/sns-transactions.utils.ts
+++ b/frontend/src/lib/utils/sns-transactions.utils.ts
@@ -1,0 +1,207 @@
+import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
+import { toastsError } from "$lib/stores/toasts.store";
+import type { Account } from "$lib/types/account";
+import { TokenAmount } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import {
+  encodeSnsAccount,
+  type SnsTransaction,
+  type SnsTransactionWithId,
+} from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
+import type { SnsTransactionsStore } from "../stores/sns-transactions.store";
+import {
+  AccountTransactionType,
+  mapToSelfTransaction,
+  showTransactionFee,
+  type Transaction,
+} from "./transactions.utils";
+
+export interface SnsTransactionData {
+  toSelfTransaction: boolean;
+  transaction: SnsTransactionWithId;
+}
+
+/**
+ * Returns transactions of an SNS account sorted by date (newest first).
+ * Filters out duplicated transactions.
+ * A duplicated transaction is normally one made to itself.
+ * The data of the duplicated transaction is the same in both transactions. No need to show it twice.
+ *
+ * @param params
+ * @param {Account} params.account
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsTransactionsStore} params.store
+ * @returns {SnsTransactionWithId[]}
+ */
+export const getSortedTransactionsFromStore = ({
+  store,
+  rootCanisterId,
+  account,
+}: {
+  store: SnsTransactionsStore;
+  rootCanisterId: Principal;
+  account: Account;
+}): SnsTransactionData[] =>
+  mapToSelfTransaction(
+    store[rootCanisterId.toText()]?.[account.identifier].transactions ?? []
+  ).sort(({ transaction: txA }, { transaction: txB }) =>
+    Number(txB.transaction.timestamp - txA.transaction.timestamp)
+  );
+
+/**
+ * Returns whether all transactions of an SNS account have been loaded.
+ *
+ * @param params
+ * @param {Account} params.account
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsTransactionsStore} params.store
+ * @returns {boolean}
+ */
+export const isTransactionsCompleted = ({
+  store,
+  rootCanisterId,
+  account,
+}: {
+  store: SnsTransactionsStore;
+  rootCanisterId: Principal;
+  account: Account;
+}): boolean =>
+  Boolean(store[rootCanisterId.toText()]?.[account.identifier].completed);
+
+// TODO: use `oldestTxId` instead of sorting and getting the oldest element's id.
+// It seems that the `Index` canister has a bug.
+/**
+ * Returns the oldest transaction id of an SNS account.
+ *
+ * @param params
+ * @param {Account} params.account
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsTransactionsStore} params.store
+ * @returns {bigint}
+ */
+export const getOldestTxIdFromStore = ({
+  store,
+  rootCanisterId,
+  account,
+}: {
+  store: SnsTransactionsStore;
+  rootCanisterId: Principal;
+  account: Account;
+}): bigint | undefined => {
+  const accountData = store[rootCanisterId.toText()]?.[account.identifier];
+  if (accountData === undefined) {
+    return;
+  }
+  return accountData.transactions.sort((a, b) =>
+    Number(a.transaction.timestamp - b.transaction.timestamp)
+  )[0].id;
+};
+
+const getSnsTransactionType = (
+  transaction: SnsTransaction
+): AccountTransactionType => {
+  if (fromNullable(transaction.burn) !== undefined) {
+    return AccountTransactionType.Burn;
+  }
+  if (fromNullable(transaction.mint) !== undefined) {
+    return AccountTransactionType.Mint;
+  }
+  if (fromNullable(transaction.transfer) !== undefined) {
+    return AccountTransactionType.Send;
+  }
+  // Just for type safety. This should never happen.
+  throw new Error(`Unknown transaction type ${transaction.kind}`);
+};
+
+interface TransactionInfo {
+  to?: string;
+  from?: string;
+  memo?: Uint8Array;
+  created_at_time?: bigint;
+  amount: bigint;
+}
+
+const getTransactionInformation = (
+  transaction: SnsTransaction
+): TransactionInfo | undefined => {
+  const data =
+    fromNullable(transaction.burn) ??
+    fromNullable(transaction.mint) ??
+    fromNullable(transaction.transfer);
+  // Edge case, a transaction will have either "burn", "mint" or "transfer" data.
+  if (data === undefined) {
+    throw new Error(`Unknown transaction type ${JSON.stringify(transaction)}`);
+  }
+  return {
+    from:
+      "from" in data
+        ? encodeSnsAccount({
+            owner: data.from.owner,
+            subaccount: fromNullable(data.from.subaccount),
+          })
+        : undefined,
+    to:
+      "to" in data
+        ? encodeSnsAccount({
+            owner: data.to.owner,
+            subaccount: fromNullable(data.to.subaccount),
+          })
+        : undefined,
+    memo: fromNullable(data?.memo),
+    created_at_time: fromNullable(data?.created_at_time),
+    amount: data?.amount,
+  };
+};
+
+export const mapSnsTransaction = ({
+  transaction,
+  account,
+  toSelfTransaction,
+  fee,
+}: {
+  transaction: SnsTransactionWithId;
+  account: Account;
+  toSelfTransaction: boolean;
+  fee?: TokenAmount;
+}): Transaction | undefined => {
+  try {
+    const type = getSnsTransactionType(transaction.transaction);
+    const txInfo = getTransactionInformation(transaction.transaction);
+    if (txInfo === undefined) {
+      throw new Error(
+        `Unknown transaction type ${transaction.transaction.kind}`
+      );
+    }
+    const isReceive =
+      toSelfTransaction === true || txInfo.from !== account.identifier;
+    const isSend = txInfo.to !== account.identifier;
+    const useFee =
+      toSelfTransaction === true
+        ? false
+        : showTransactionFee({ type, isReceive });
+    const feeApplied = useFee && fee !== undefined ? fee.toE8s() : BigInt(0);
+
+    // Timestamp is in nano seconds
+    const timestampMilliseconds =
+      Number(transaction.transaction.timestamp) / NANO_SECONDS_IN_MILLISECOND;
+    return {
+      type,
+      isReceive,
+      isSend,
+      from: txInfo.from,
+      to: txInfo.to,
+      displayAmount: TokenAmount.fromE8s({
+        amount: txInfo.amount + feeApplied,
+        token: account.balance.token,
+      }),
+      date: new Date(timestampMilliseconds),
+    };
+  } catch (err) {
+    toastsError({
+      labelKey: "error.transaction_data",
+      substitutions: { $txId: String(transaction.id) },
+      err,
+    });
+  }
+};

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -3,8 +3,10 @@
  */
 
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
+import { ICPToken } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import {
   mockMainAccount,
@@ -29,25 +31,27 @@ describe("NnsTransactionCard", () => {
     });
 
   it("renders received headline", () => {
-    const { container } = renderTransactionCard(
+    const { getByText } = renderTransactionCard(
       mockSubAccount,
       mockReceivedFromMainAccountTransaction
     );
 
-    expect(container.querySelector(".title")?.textContent).toBe(
-      en.transaction_names.receive
-    );
+    const expectedText = replacePlaceholders(en.transaction_names.receive, {
+      $tokenSymbol: ICPToken.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
   });
 
   it("renders sent headline", () => {
-    const { container } = renderTransactionCard(
+    const { getByText } = renderTransactionCard(
       mockMainAccount,
       mockSentToSubAccountTransaction
     );
 
-    expect(container.querySelector(".title")?.textContent).toBe(
-      en.transaction_names.send
-    );
+    const expectedText = replacePlaceholders(en.transaction_names.send, {
+      $tokenSymbol: ICPToken.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
   });
 
   it("renders transaction ICPs with - sign", () => {

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsTransactionCard from "$lib/components/accounts/SnsTransactionCard.svelte";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
+import { formatToken } from "$lib/utils/token.utils";
+import { TokenAmount } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import en from "../../../mocks/i18n.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+} from "../../../mocks/sns-accounts.mock";
+import { createSnstransactionWithId } from "../../../mocks/sns-transactions.mock";
+
+describe("SnsTransactionCard", () => {
+  const transactoinFee = TokenAmount.fromE8s({
+    amount: BigInt(10_000),
+    token: { name: "Test", symbol: "TST" },
+  });
+  const renderTransactionCard = (account, transactionWithId) =>
+    render(SnsTransactionCard, {
+      props: {
+        account,
+        transactionWithId,
+        toSelfTransaction: false,
+        fee: transactoinFee,
+      },
+    });
+
+  const to = {
+    owner: mockPrincipal,
+    subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+  };
+  const from = {
+    owner: mockPrincipal,
+    subaccount: [] as [],
+  };
+  const transactionFromMainToSubaccount = createSnstransactionWithId(to, from);
+
+  it("renders received headline", () => {
+    const { getByText } = renderTransactionCard(
+      mockSnsSubAccount,
+      transactionFromMainToSubaccount
+    );
+
+    const expectedText = replacePlaceholders(en.transaction_names.receive, {
+      $tokenSymbol: mockSnsSubAccount.balance.token.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
+  });
+
+  it("renders sent headline", () => {
+    const { getByText } = renderTransactionCard(
+      mockSnsMainAccount,
+      transactionFromMainToSubaccount
+    );
+
+    const expectedText = replacePlaceholders(en.transaction_names.send, {
+      $tokenSymbol: mockSnsSubAccount.balance.token.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
+  });
+
+  it("renders transaction Token symbol with - sign", () => {
+    const account = mockSnsMainAccount;
+    const transaction = transactionFromMainToSubaccount;
+    const { getByTestId } = renderTransactionCard(account, transaction);
+    const { displayAmount } = mapSnsTransaction({
+      account,
+      toSelfTransaction: false,
+      transaction,
+    });
+
+    expect(getByTestId("token-value")?.textContent).toBe(
+      `-${formatToken({
+        value: displayAmount.toE8s() + transactoinFee.toE8s(),
+        detailed: true,
+      })}`
+    );
+  });
+
+  it("renders transaction Tokens with + sign", () => {
+    const account = mockSnsSubAccount;
+    const transaction = transactionFromMainToSubaccount;
+    const { getByTestId } = renderTransactionCard(
+      mockSnsSubAccount,
+      transactionFromMainToSubaccount
+    );
+    const { displayAmount } = mapSnsTransaction({
+      account,
+      transaction,
+      toSelfTransaction: false,
+    });
+
+    expect(getByTestId("token-value")?.textContent).toBe(
+      `+${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
+    );
+  });
+
+  it("displays transaction date and time", () => {
+    const { container } = renderTransactionCard(
+      mockSnsMainAccount,
+      transactionFromMainToSubaccount
+    );
+
+    expect(container.querySelector("p")?.textContent).toContain(
+      "January 1, 1970"
+    );
+    expect(container.querySelector("p")?.textContent).toContain("12:00 AM");
+  });
+
+  it("displays identifier for received", () => {
+    const { getByTestId } = renderTransactionCard(
+      mockSnsSubAccount,
+      transactionFromMainToSubaccount
+    );
+    const identifier = getByTestId("identifier")?.textContent;
+
+    expect(identifier).toContain(mockSnsMainAccount.identifier);
+    expect(identifier).toContain(en.wallet.direction_from);
+  });
+
+  it("displays identifier for sent", () => {
+    const { getByTestId } = renderTransactionCard(
+      mockSnsMainAccount,
+      transactionFromMainToSubaccount
+    );
+    const identifier = getByTestId("identifier")?.textContent;
+
+    expect(identifier).toContain(mockSnsSubAccount.identifier);
+    expect(identifier).toContain(en.wallet.direction_to);
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsTransactionList from "$lib/components/accounts/SnsTransactionsList.svelte";
+import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
+import { render, waitFor } from "@testing-library/svelte";
+import { mockMainAccount } from "../../../mocks/accounts.store.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import en from "../../../mocks/i18n.mock";
+import { mockSnsMainAccount } from "../../../mocks/sns-accounts.mock";
+import {
+  mockSnsTransactionsStoreSubscribe,
+  mockSnsTransactionWithId,
+} from "../../../mocks/sns-transactions.mock";
+
+jest.mock("$lib/services/sns-transactions.services", () => {
+  // To test loading state as well
+  return {
+    loadAccountNextTransactions: jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(undefined);
+          }, 1000);
+        })
+    ),
+  };
+});
+
+describe("SnsTransactionList", () => {
+  const renderSnsTransactionList = (account, rootCanisterId) =>
+    render(SnsTransactionList, {
+      props: {
+        account,
+        rootCanisterId,
+      },
+    });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("renders skeleton when loading transactions", async () => {
+    jest
+      .spyOn(snsTransactionsStore, "subscribe")
+      .mockImplementation(mockSnsTransactionsStoreSubscribe({}));
+    const { queryAllByTestId } = renderSnsTransactionList(
+      mockSnsMainAccount,
+      mockPrincipal
+    );
+
+    expect(queryAllByTestId("skeleton-card").length).toBeGreaterThan(0);
+  });
+
+  it("should display no-transactions message", async () => {
+    jest
+      .spyOn(snsTransactionsStore, "subscribe")
+      .mockImplementation(mockSnsTransactionsStoreSubscribe({}));
+    const { getByText } = renderSnsTransactionList(
+      mockSnsMainAccount,
+      mockPrincipal
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(en.wallet.no_transactions, { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should render transactions", () => {
+    const store = {
+      [mockPrincipal.toText()]: {
+        [mockMainAccount.identifier]: {
+          transactions: [mockSnsTransactionWithId],
+          completed: false,
+          oldestTxId: BigInt(0),
+        },
+      },
+    };
+    jest
+      .spyOn(snsTransactionsStore, "subscribe")
+      .mockImplementation(mockSnsTransactionsStoreSubscribe(store));
+    const { queryAllByTestId } = renderSnsTransactionList(
+      mockMainAccount,
+      mockPrincipal
+    );
+
+    expect(queryAllByTestId("transaction-card").length).toBe(1);
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -3,7 +3,9 @@
  */
 
 import TransactionCard from "$lib/components/accounts/TransactionCard.svelte";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { ICPToken } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 import {
@@ -18,27 +20,30 @@ describe("TransactionCard", () => {
     render(TransactionCard, {
       props: {
         transaction,
+        token: ICPToken,
       },
     });
 
   it("renders received headline", () => {
-    const { container } = renderTransactionCard(
+    const { getByText } = renderTransactionCard(
       mockTransactionReceiveDataFromMain
     );
 
-    expect(container.querySelector(".title")?.textContent).toBe(
-      en.transaction_names.receive
-    );
+    const expectedText = replacePlaceholders(en.transaction_names.receive, {
+      $tokenSymbol: ICPToken.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
   });
 
   it("renders sent headline", () => {
-    const { container } = renderTransactionCard(
+    const { getByText } = renderTransactionCard(
       mockTransactionSendDataFromMain
     );
 
-    expect(container.querySelector(".title")?.textContent).toBe(
-      en.transaction_names.send
-    );
+    const expectedText = replacePlaceholders(en.transaction_names.send, {
+      $tokenSymbol: ICPToken.symbol,
+    });
+    expect(getByText(expectedText)).toBeInTheDocument();
   });
 
   it("renders transaction ICPs with - sign", () => {

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import * as indexApi from "$lib/api/sns-index.api";
-import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_SNS_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import * as services from "$lib/services/sns-transactions.services";
 import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { Principal } from "@dfinity/principal";
@@ -14,7 +14,54 @@ import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 import { mockSnsTransactionWithId } from "../../mocks/sns-transactions.mock";
 
 describe("sns-transactions-services", () => {
+  describe("loadAccountTransactions", () => {
+    beforeEach(() => {
+      snsTransactionsStore.reset();
+    });
+    afterEach(() => jest.clearAllMocks());
+    it("loads transactions in the store", async () => {
+      const spyGetTransactions = jest
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: BigInt(1234),
+          transactions: [mockSnsTransactionWithId],
+        });
+      const start = BigInt(1234);
+      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
+      await services.loadAccountTransactions({
+        rootCanisterId,
+        account: mockSnsMainAccount,
+        start,
+      });
+
+      const snsAccount = {
+        owner: mockSnsMainAccount.principal,
+      };
+
+      await waitFor(() =>
+        expect(spyGetTransactions).toBeCalledWith({
+          identity: mockIdentity,
+          account: snsAccount,
+          maxResults: BigInt(DEFAULT_SNS_TRANSACTION_PAGE_LIMIT),
+          rootCanisterId,
+          start,
+        })
+      );
+
+      const storeData = get(snsTransactionsStore);
+      expect(
+        storeData[rootCanisterId.toText()]?.[
+          mockSnsMainAccount.principal.toText()
+        ].transactions[0]
+      ).toEqual(mockSnsTransactionWithId);
+    });
+  });
+
   describe("loadAccountNextTransactions", () => {
+    beforeEach(() => {
+      snsTransactionsStore.reset();
+    });
+    afterEach(() => jest.clearAllMocks());
     it("loads transactions in the store", async () => {
       const spyGetTransactions = jest
         .spyOn(indexApi, "getTransactions")
@@ -36,7 +83,7 @@ describe("sns-transactions-services", () => {
         expect(spyGetTransactions).toBeCalledWith({
           identity: mockIdentity,
           account: snsAccount,
-          maxResults: BigInt(DEFAULT_LIST_PAGINATION_LIMIT),
+          maxResults: BigInt(DEFAULT_SNS_TRANSACTION_PAGE_LIMIT),
           rootCanisterId,
         })
       );
@@ -47,6 +94,42 @@ describe("sns-transactions-services", () => {
           mockSnsMainAccount.principal.toText()
         ].transactions[0]
       ).toEqual(mockSnsTransactionWithId);
+    });
+
+    it("uses store oldest transaction to set the start", async () => {
+      const spyGetTransactions = jest
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: BigInt(1234),
+          transactions: [mockSnsTransactionWithId],
+        });
+      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
+      const oldestTxId = BigInt(1234);
+      snsTransactionsStore.addTransactions({
+        rootCanisterId,
+        accountIdentifier: mockSnsMainAccount.identifier,
+        transactions: [mockSnsTransactionWithId],
+        oldestTxId,
+        completed: false,
+      });
+      await services.loadAccountNextTransactions({
+        rootCanisterId,
+        account: mockSnsMainAccount,
+      });
+
+      await waitFor(() => {
+        expect(spyGetTransactions).toBeCalledWith({
+          identity: mockIdentity,
+          account: {
+            owner: mockSnsMainAccount.principal,
+          },
+          maxResults: BigInt(DEFAULT_SNS_TRANSACTION_PAGE_LIMIT),
+          rootCanisterId,
+          // TODO: It should be oldestTxId but there is a bug in the Index canister that doesn't return proper oldestTxId
+          // Instead, we need to calculate the oldest by checking the transactions.
+          start: mockSnsTransactionWithId.id,
+        });
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -17,6 +17,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
 
       const accountsInStore = get(snsTransactionsStore);
@@ -32,6 +33,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
 
       snsTransactionsStore.addTransactions({
@@ -39,6 +41,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsSubAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
 
       const accountsInStore = get(snsTransactionsStore);
@@ -70,12 +73,14 @@ describe("SNS Transactions store", () => {
         transactions: [tx1, tx2],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
       snsTransactionsStore.addTransactions({
         rootCanisterId: mockPrincipal,
         transactions: [tx1, tx3],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
 
       const accountsInStore = get(snsTransactionsStore);
@@ -91,6 +96,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
 
       const accountsInStore = get(snsTransactionsStore);
@@ -112,6 +118,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
       const accountsInStore = get(snsTransactionsStore);
       expect(
@@ -124,6 +131,7 @@ describe("SNS Transactions store", () => {
         transactions: [mockSnsTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
         oldestTxId: BigInt(10),
+        completed: false,
       });
       const accountsInStore2 = get(snsTransactionsStore);
       expect(

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -90,6 +90,42 @@ describe("SNS Transactions store", () => {
       ).toBe(3);
     });
 
+    it("should not change txOldestId if not oldest", () => {
+      const tx1 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(1),
+      };
+      const tx2 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(2),
+      };
+      const tx3 = {
+        ...mockSnsTransactionWithId,
+        id: BigInt(3),
+      };
+      const oldestTxId = BigInt(1);
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [tx1, tx2],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId,
+        completed: false,
+      });
+      snsTransactionsStore.addTransactions({
+        rootCanisterId: mockPrincipal,
+        transactions: [tx1, tx3],
+        accountIdentifier: mockSnsMainAccount.identifier,
+        oldestTxId: BigInt(3),
+        completed: false,
+      });
+
+      const accountsInStore = get(snsTransactionsStore);
+      expect(
+        accountsInStore[mockPrincipal.toText()]?.[mockSnsMainAccount.identifier]
+          ?.oldestTxId
+      ).toBe(oldestTxId);
+    });
+
     it("should reset accounts for a project", () => {
       snsTransactionsStore.addTransactions({
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -1,0 +1,235 @@
+import type { SnsTransactionsStore } from "$lib/stores/sns-transactions.store";
+import {
+  getOldestTxIdFromStore,
+  getSortedTransactionsFromStore,
+  isTransactionsCompleted,
+  mapSnsTransaction,
+} from "$lib/utils/sns-transactions.utils";
+import { TokenAmount } from "@dfinity/nns";
+import { mockPrincipal } from "../..//mocks/auth.store.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+} from "../..//mocks/sns-accounts.mock";
+import { createSnstransactionWithId } from "../..//mocks/sns-transactions.mock";
+
+describe("sns-transaction utils", () => {
+  const to = {
+    owner: mockPrincipal,
+    subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+  };
+  const from = {
+    owner: mockPrincipal,
+    subaccount: [] as [],
+  };
+  const transactionFromMainToSubaccount = createSnstransactionWithId(to, from);
+  const recentTx = {
+    id: BigInt(1234),
+    transaction: {
+      ...transactionFromMainToSubaccount.transaction,
+      timestamp: BigInt(3000),
+    },
+  };
+  const secondTx = {
+    id: BigInt(1235),
+    transaction: {
+      ...transactionFromMainToSubaccount.transaction,
+      timestamp: BigInt(2000),
+    },
+  };
+  const oldestTx = {
+    id: BigInt(1236),
+    transaction: {
+      ...transactionFromMainToSubaccount.transaction,
+      timestamp: BigInt(1000),
+    },
+  };
+  const selfTransaction = createSnstransactionWithId(to, to);
+
+  describe("getSortedTransactionsFromStore", () => {
+    it("should return transactions sorted by date", () => {
+      const transactions = [secondTx, oldestTx, recentTx];
+      const store: SnsTransactionsStore = {
+        [mockPrincipal.toText()]: {
+          [mockSnsMainAccount.identifier]: {
+            transactions,
+            completed: false,
+            oldestTxId: BigInt(1234),
+          },
+        },
+      };
+      const data = getSortedTransactionsFromStore({
+        store,
+        rootCanisterId: mockPrincipal,
+        account: mockSnsMainAccount,
+      });
+      expect(data[0]).toEqual({
+        toSelfTransaction: false,
+        transaction: recentTx,
+      });
+      expect(data[1]).toEqual({
+        toSelfTransaction: false,
+        transaction: secondTx,
+      });
+      expect(data[2]).toEqual({
+        toSelfTransaction: false,
+        transaction: oldestTx,
+      });
+    });
+
+    it("should set selfTransaction to true", () => {
+      const store: SnsTransactionsStore = {
+        [mockSnsMainAccount.principal.toText()]: {
+          [mockSnsMainAccount.identifier]: {
+            transactions: [selfTransaction, selfTransaction],
+            completed: false,
+            oldestTxId: BigInt(1234),
+          },
+        },
+      };
+      const data = getSortedTransactionsFromStore({
+        store,
+        rootCanisterId: mockPrincipal,
+        account: mockSnsMainAccount,
+      });
+      expect(data[0]).toEqual({
+        toSelfTransaction: true,
+        transaction: selfTransaction,
+      });
+      // Only the first one should be set to true
+      expect(data[1]).toEqual({
+        toSelfTransaction: false,
+        transaction: selfTransaction,
+      });
+    });
+  });
+
+  describe("isTransactionsCompleted", () => {
+    it("returns the value in store", () => {
+      const rootCanisterId = mockSnsMainAccount.principal;
+      const store: SnsTransactionsStore = {
+        [rootCanisterId.toText()]: {
+          [mockSnsMainAccount.identifier]: {
+            transactions: [transactionFromMainToSubaccount],
+            completed: false,
+            oldestTxId: BigInt(1234),
+          },
+          [mockSnsSubAccount.identifier]: {
+            transactions: [transactionFromMainToSubaccount],
+            completed: true,
+            oldestTxId: BigInt(1234),
+          },
+        },
+      };
+      expect(
+        isTransactionsCompleted({
+          store,
+          rootCanisterId,
+          account: mockSnsMainAccount,
+        })
+      ).toBe(false);
+      expect(
+        isTransactionsCompleted({
+          store,
+          rootCanisterId,
+          account: mockSnsSubAccount,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("getOldestTransactionId", () => {
+    it("returns the id of the oldest tx", () => {
+      const rootCanisterId = mockSnsMainAccount.principal;
+      const transactions = [secondTx, oldestTx, recentTx];
+      const store: SnsTransactionsStore = {
+        [rootCanisterId.toText()]: {
+          [mockSnsMainAccount.identifier]: {
+            transactions,
+            completed: false,
+            oldestTxId: BigInt(1234),
+          },
+        },
+      };
+      expect(
+        getOldestTxIdFromStore({
+          store,
+          rootCanisterId,
+          account: mockSnsMainAccount,
+        })
+      ).toBe(oldestTx.id);
+    });
+
+    it("returns undefined if no data is found", () => {
+      expect(
+        getOldestTxIdFromStore({
+          store: {},
+          rootCanisterId: mockSnsMainAccount.principal,
+          account: mockSnsMainAccount,
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe("mapSnsTransaction", () => {
+    it("maps sent transaction", () => {
+      const data = mapSnsTransaction({
+        transaction: transactionFromMainToSubaccount,
+        account: mockSnsMainAccount,
+        fee: TokenAmount.fromE8s({
+          amount: BigInt(100),
+          token: mockSnsMainAccount.balance.token,
+        }),
+        toSelfTransaction: false,
+      });
+      expect(data.isSend).toBe(true);
+      expect(data.isReceive).toBe(false);
+    });
+
+    it("maps received transaction", () => {
+      const data = mapSnsTransaction({
+        transaction: transactionFromMainToSubaccount,
+        account: mockSnsSubAccount,
+        fee: TokenAmount.fromE8s({
+          amount: BigInt(100),
+          token: mockSnsSubAccount.balance.token,
+        }),
+        toSelfTransaction: false,
+      });
+      expect(data.isSend).toBe(false);
+      expect(data.isReceive).toBe(true);
+    });
+
+    it("maps self transaction", () => {
+      const data = mapSnsTransaction({
+        transaction: selfTransaction,
+        account: mockSnsSubAccount,
+        fee: TokenAmount.fromE8s({
+          amount: BigInt(100),
+          token: mockSnsSubAccount.balance.token,
+        }),
+        toSelfTransaction: true,
+      });
+      expect(data.isSend).toBe(false);
+      expect(data.isReceive).toBe(true);
+    });
+
+    it("adds fee to sent transactions", () => {
+      const fee = TokenAmount.fromE8s({
+        amount: BigInt(100),
+        token: mockSnsMainAccount.balance.token,
+      });
+      const data = mapSnsTransaction({
+        transaction: transactionFromMainToSubaccount,
+        account: mockSnsMainAccount,
+        fee,
+        toSelfTransaction: false,
+      });
+      expect(data.isSend).toBe(true);
+      expect(data.displayAmount.toE8s()).toBe(
+        transactionFromMainToSubaccount.transaction.transfer[0].amount +
+          fee.toE8s()
+      );
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,9 +1,10 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { enumKeys } from "$lib/utils/enum.utils";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
   AccountTransactionType,
   mapNnsTransaction,
-  mapToSelfNnsTransaction,
+  mapToSelfTransaction,
   showTransactionFee,
   transactionDisplayAmount,
   transactionName,
@@ -156,9 +157,9 @@ describe("transactions-utils", () => {
     });
   });
 
-  describe("mapToSelfNnsTransaction", () => {
+  describe("mapToSelfTransaction", () => {
     it("should map to self transactions", () => {
-      const transactions = mapToSelfNnsTransaction([
+      const transactions = mapToSelfTransaction([
         {
           ...mockSentToSubAccountTransaction,
           timestamp: { timestamp_nanos: BigInt("111") },
@@ -327,8 +328,14 @@ describe("transactions-utils", () => {
             type: key as AccountTransactionType,
             isReceive: false,
             labels: en.transaction_names,
+            tokenSymbol: ICPToken.symbol,
           })
-        ).toBe(en.transaction_names[key as AccountTransactionType]);
+        ).toBe(
+          replacePlaceholders(
+            en.transaction_names[key as AccountTransactionType],
+            { $tokenSymbol: ICPToken.symbol }
+          )
+        );
       }
     });
 
@@ -338,8 +345,13 @@ describe("transactions-utils", () => {
           type: AccountTransactionType.Send,
           isReceive: true,
           labels: en.transaction_names,
+          tokenSymbol: ICPToken.symbol,
         })
-      ).toBe(en.transaction_names.receive);
+      ).toBe(
+        replacePlaceholders(en.transaction_names.receive, {
+          $tokenSymbol: ICPToken.symbol,
+        })
+      );
     });
 
     it("returns raw type if not label", () => {
@@ -348,6 +360,7 @@ describe("transactions-utils", () => {
           type: "test" as AccountTransactionType,
           isReceive: true,
           labels: en.transaction_names,
+          tokenSymbol: ICPToken.symbol,
         })
       ).toBe("test");
     });

--- a/frontend/src/tests/mocks/sns-transactions.mock.ts
+++ b/frontend/src/tests/mocks/sns-transactions.mock.ts
@@ -1,5 +1,7 @@
+import type { SnsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { Principal } from "@dfinity/principal";
 import type { SnsTransaction, SnsTransactionWithId } from "@dfinity/sns";
+import type { Subscriber } from "svelte/store";
 
 const fakeAccount = {
   owner: Principal.fromText("aaaaa-aa"),
@@ -26,3 +28,38 @@ export const mockSnsTransactionWithId: SnsTransactionWithId = {
   id: BigInt(123),
   transaction: mockSnsTransaction,
 };
+
+interface SnsCandidAccount {
+  owner: Principal;
+  subaccount: [] | [Uint8Array];
+}
+
+export const createSnstransactionWithId = (
+  to: SnsCandidAccount,
+  from: SnsCandidAccount
+): SnsTransactionWithId => ({
+  id: BigInt(123),
+  transaction: {
+    kind: "transfer",
+    timestamp: BigInt(12354),
+    burn: [],
+    mint: [],
+    transfer: [
+      {
+        to,
+        from,
+        memo: [],
+        created_at_time: [BigInt(123)],
+        amount: BigInt(33),
+      },
+    ],
+  },
+});
+
+export const mockSnsTransactionsStoreSubscribe =
+  (store: SnsTransactionsStore) =>
+  (run: Subscriber<SnsTransactionsStore>): (() => void) => {
+    run(store);
+
+    return () => undefined;
+  };


### PR DESCRIPTION
# Motivation

Render the sns account transactions in the SNS wallet page.

# Changes

* New SnsTransactionCard component to render a TransactionCard from and SnsTransaction.
* Use SnsTransactionCard in SnsTransactionList.
* Use InfiniteScroll in SnsTransactionList to lead more.
* Add token prop to TransactionCard.
* Use a different page size for SNS transactions: DEFAULT_SNS_TRANSACTION_PAGE_LIMIT
* Two sns transaction services: loadAccountNextTransactions and loadAccountTransactions.
* Load new transactions after performing an sns transaction from SnsWallet page.
* New sns transactions utils: "getSortedTransactionsFromStore", "getOldestTxIdFromStore", "isTransactionsCompleted" and "mapSnsTransaction".

# Tests

* New SnsTransactionCard test
* New SnsTransactionList test
* Test for new sns transaction utils.
* Fix broken changes.
* Test sns transaction services.