### PR TITLE
feat: show busy screen on logout

### DIFF
--- a/frontend/src/lib/services/auth.services.ts
+++ b/frontend/src/lib/services/auth.services.ts
@@ -1,4 +1,5 @@
 import { authStore } from "$lib/stores/auth.store";
+import { startBusy } from "$lib/stores/busy.store";
 import { toastsShow } from "$lib/stores/toasts.store";
 import type { ToastMsg } from "$lib/types/toast";
 import { replaceHistory } from "$lib/utils/route.utils";
@@ -14,6 +15,9 @@ export const logout = async ({
 }: {
   msg?: Pick<ToastMsg, "labelKey" | "level">;
 }) => {
+  // To mask not operational UI (a side effect of sometimes slow JS loading after window.reload because of service worker and no cache).
+  startBusy({ initiator: "logout" });
+
   await authStore.signOut();
 
   if (msg) {

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -5,6 +5,7 @@ import {
 } from "@dfinity/gix-components";
 
 export type BusyStateInitiatorType =
+  | "logout"
   | "stake-neuron"
   | "update-delay"
   | "attach-canister"

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -5,7 +5,7 @@
 import { displayAndCleanLogoutMsg, logout } from "$lib/services/auth.services";
 import * as routeUtils from "$lib/utils/route.utils";
 import { AuthClient, IdbStorage } from "@dfinity/auth-client";
-import { toastsStore } from "@dfinity/gix-components";
+import { busyStore, toastsStore } from "@dfinity/gix-components";
 import { waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 
@@ -129,6 +129,16 @@ describe("auth-services", () => {
         writable: true,
         value: { ...location },
       });
+
+      spy.mockClear();
+    });
+
+    it("should display a busy screen", async () => {
+      const spy = jest.spyOn(busyStore, "startBusy");
+
+      await logout({});
+
+      expect(spy).not.toHaveBeenCalled();
 
       spy.mockClear();
     });

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -3,9 +3,10 @@
  */
 
 import { displayAndCleanLogoutMsg, logout } from "$lib/services/auth.services";
+import * as busyStore from "$lib/stores/busy.store";
 import * as routeUtils from "$lib/utils/route.utils";
 import { AuthClient, IdbStorage } from "@dfinity/auth-client";
-import { busyStore, toastsStore } from "@dfinity/gix-components";
+import { toastsStore } from "@dfinity/gix-components";
 import { waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
 
@@ -138,7 +139,7 @@ describe("auth-services", () => {
 
       await logout({});
 
-      expect(spy).not.toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
 
       spy.mockClear();
     });


### PR DESCRIPTION
# Motivation

Display the busy screen on logout to hide not working UI on reload.

# Changes

- show the screen

# Tests

- added the test that the busy store should be called on logout.
