### PR TITLE
style: revert to base font 16px

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.1.tgz",
-      "integrity": "sha512-qilRO8sAuWMFOSgBguq97+hPhnyy6QDhmjJxhivJCZmPnGARsTxtDgv9COVk7u1ej4PYxgP4p2OX72ck40VCRA==",
+      "version": "2.0.0-next-2022-11-09.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.2.tgz",
+      "integrity": "sha512-uUs+dusRba5K5RWphb5HRioGj8bGvhTpkWYt/7tBICQTqG4pYmPmlDFvbf6GWSHxRKRnuOz8VLYjLO0hOFwb1g==",
       "dependencies": {
         "dompurify": "^2.4.0"
       }
@@ -10987,9 +10987,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.1.tgz",
-      "integrity": "sha512-qilRO8sAuWMFOSgBguq97+hPhnyy6QDhmjJxhivJCZmPnGARsTxtDgv9COVk7u1ej4PYxgP4p2OX72ck40VCRA==",
+      "version": "2.0.0-next-2022-11-09.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.2.tgz",
+      "integrity": "sha512-uUs+dusRba5K5RWphb5HRioGj8bGvhTpkWYt/7tBICQTqG4pYmPmlDFvbf6GWSHxRKRnuOz8VLYjLO0hOFwb1g==",
       "requires": {
         "dompurify": "^2.4.0"
       }


### PR DESCRIPTION
# Motivation

Font size < 16px in inputs makes iOS automatically ping zoom for a11y reason. We do not want such issue.

https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/

Therefore we revert to a base font size of 16px.

# PRs

- [x] https://github.com/dfinity/gix-components/pull/111
