### PR TITLE
fix: init auth worker race condition

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.1.tgz",
-      "integrity": "sha512-qilRO8sAuWMFOSgBguq97+hPhnyy6QDhmjJxhivJCZmPnGARsTxtDgv9COVk7u1ej4PYxgP4p2OX72ck40VCRA==",
+      "version": "2.0.0-next-2022-11-09.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.2.tgz",
+      "integrity": "sha512-uUs+dusRba5K5RWphb5HRioGj8bGvhTpkWYt/7tBICQTqG4pYmPmlDFvbf6GWSHxRKRnuOz8VLYjLO0hOFwb1g==",
       "dependencies": {
         "dompurify": "^2.4.0"
       }
@@ -10987,9 +10987,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.1.tgz",
-      "integrity": "sha512-qilRO8sAuWMFOSgBguq97+hPhnyy6QDhmjJxhivJCZmPnGARsTxtDgv9COVk7u1ej4PYxgP4p2OX72ck40VCRA==",
+      "version": "2.0.0-next-2022-11-09.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-09.2.tgz",
+      "integrity": "sha512-uUs+dusRba5K5RWphb5HRioGj8bGvhTpkWYt/7tBICQTqG4pYmPmlDFvbf6GWSHxRKRnuOz8VLYjLO0hOFwb1g==",
       "requires": {
         "dompurify": "^2.4.0"
       }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
 
       ready = true;
 
+      // Load app global stores data
       await initAppProxy();
   }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -10,28 +10,28 @@
   let worker: { syncAuthIdle: (auth: AuthStore) => void } | undefined;
 
   const syncAuth = async (auth: AuthStore) => {
-      worker?.syncAuthIdle(auth);
+    worker?.syncAuthIdle(auth);
 
-      if (!auth.identity) {
-          ready = false;
-          return;
-      }
+    if (!auth.identity) {
+      ready = false;
+      return;
+    }
 
-      // syncAuth is triggered each time the auth changes but also when the worker is initialized to avoid race condition.
-      // As the function can be called twice with a valid identity, we use a flag to only init the data once.
-      if (ready) {
-          return;
-      }
+    // syncAuth is triggered each time the auth changes but also when the worker is initialized to avoid race condition.
+    // As the function can be called twice with a valid identity, we use a flag to only init the data once.
+    if (ready) {
+      return;
+    }
 
-      ready = true;
+    ready = true;
 
-      // Load app global stores data
-      await initAppProxy();
-  }
+    // Load app global stores data
+    await initAppProxy();
+  };
 
   onMount(async () => {
-      worker = await initWorker();
-      await syncAuth($authStore);
+    worker = await initWorker();
+    await syncAuth($authStore);
   });
 
   const unsubscribeAuth = authStore.subscribe(syncAuth);


### PR DESCRIPTION
# Motivation

When deployed on the IC, it is possible that fetching the worker takes more time than fetching the code to sync the identity. This can lead to a race condition in the case the user proceed as following:

- user access nns-dapp
- user sign-in
- user refresh the browser

# Changes

- synchronize the auth worker not only when the auth changes but also right after the worker has been loaded

# Tests

This has been debuged locally by setting a delegation that least only 20s and tested manually in various scenario.
