### PR TITLE
GIX-1121: Use fee from transaction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "nns-dapp"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "base64 0.13.0",
  "candid",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns-dapp",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@dfinity/agent": "^0.14.0",
         "@dfinity/auth-client": "^0.14.0",
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-10.1.tgz",
-      "integrity": "sha512-x5urhxw9kXlG8v0o0Qh87mNzDU9z0btesFzWnCEJS0ZEguM0zV6KPQetiyqKKk5c0XCOCPkEzXE6H2RpBuaL7Q==",
+      "version": "0.0.3-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-11.1.tgz",
+      "integrity": "sha512-/1aJJ22hzZAT/Wo2p2aTU2KKtYP6Uiw53aky4Im9QhdbW5F1tqeOR4lAhbnuD4QYxTkvx62TWRllLUKiBHKz+g==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.6-next"
       }
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-10.1.tgz",
-      "integrity": "sha512-euwQFSAgLpZp7JPMt3UqE7+tcDaMy14nbfkqu3sgfa2C5FJJMwWVlFmcJrorv31SDyIVEoyAq+5VW5jI3U/quw==",
+      "version": "0.10.0-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-11.1.tgz",
+      "integrity": "sha512-t3t4NR+jLPkb6n0x0k1ToCES4xAe53M6DLoNkOaJ0J4pgnwhodZE+EwwYDzaz/8fDdMEYASDjkU8KSKc6Yq1+g==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-10.1.tgz",
-      "integrity": "sha512-Sxm3vLKxnwlfwDiyG525vOAiPf6s7AHHU4QMXDO9ckxjZUnHZhPM5LzSt5fN5w424s9fXkcu3ORTDIWZDNAJ0Q==",
+      "version": "0.0.7-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-11.1.tgz",
+      "integrity": "sha512-d/bJLOV5ZWkkYC57i+79C9CPTQLAUi49AscT7apTYUTTUS/rJdZY45+QqTTE3/yu+w9DuLfULyTOD6nKe6ejBg==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-10.1.tgz",
-      "integrity": "sha512-F/4rYuNHNfq1g7UC6lzl4yZwsTGpR8XkKcu2MFeUBljoAx8zYJGFUBJpWh6i3WwZvcGK5qWgS8ju/QDE/mHnVg=="
+      "version": "0.0.6-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-11.1.tgz",
+      "integrity": "sha512-bGWX05f1wZDhWDPRta1/ck5JxelObnUmGhF5yZGjTOXEBMH7A7oMs2di+T+NYuidvbmhV+9BGrIIy1AaTKE1aw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10984,9 +10984,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-10.1.tgz",
-      "integrity": "sha512-x5urhxw9kXlG8v0o0Qh87mNzDU9z0btesFzWnCEJS0ZEguM0zV6KPQetiyqKKk5c0XCOCPkEzXE6H2RpBuaL7Q==",
+      "version": "0.0.3-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-11.1.tgz",
+      "integrity": "sha512-/1aJJ22hzZAT/Wo2p2aTU2KKtYP6Uiw53aky4Im9QhdbW5F1tqeOR4lAhbnuD4QYxTkvx62TWRllLUKiBHKz+g==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11012,9 +11012,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-10.1.tgz",
-      "integrity": "sha512-euwQFSAgLpZp7JPMt3UqE7+tcDaMy14nbfkqu3sgfa2C5FJJMwWVlFmcJrorv31SDyIVEoyAq+5VW5jI3U/quw==",
+      "version": "0.10.0-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-11.1.tgz",
+      "integrity": "sha512-t3t4NR+jLPkb6n0x0k1ToCES4xAe53M6DLoNkOaJ0J4pgnwhodZE+EwwYDzaz/8fDdMEYASDjkU8KSKc6Yq1+g==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11032,17 +11032,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-10.1.tgz",
-      "integrity": "sha512-Sxm3vLKxnwlfwDiyG525vOAiPf6s7AHHU4QMXDO9ckxjZUnHZhPM5LzSt5fN5w424s9fXkcu3ORTDIWZDNAJ0Q==",
+      "version": "0.0.7-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-11.1.tgz",
+      "integrity": "sha512-d/bJLOV5ZWkkYC57i+79C9CPTQLAUi49AscT7apTYUTTUS/rJdZY45+QqTTE3/yu+w9DuLfULyTOD6nKe6ejBg==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-10.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-10.1.tgz",
-      "integrity": "sha512-F/4rYuNHNfq1g7UC6lzl4yZwsTGpR8XkKcu2MFeUBljoAx8zYJGFUBJpWh6i3WwZvcGK5qWgS8ju/QDE/mHnVg=="
+      "version": "0.0.6-next-2022-11-11.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-11.1.tgz",
+      "integrity": "sha512-bGWX05f1wZDhWDPRta1/ck5JxelObnUmGhF5yZGjTOXEBMH7A7oMs2di+T+NYuidvbmhV+9BGrIIy1AaTKE1aw=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
@@ -2,21 +2,18 @@
   import type { Account } from "$lib/types/account";
   import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
   import type { Transaction } from "$lib/utils/transactions.utils";
-  import type { TokenAmount } from "@dfinity/nns";
   import type { SnsTransactionWithId } from "@dfinity/sns";
   import TransactionCard from "./TransactionCard.svelte";
 
   export let transactionWithId: SnsTransactionWithId;
   export let account: Account;
   export let toSelfTransaction: boolean;
-  export let fee: TokenAmount | undefined = undefined;
 
   let transactionData: Transaction | undefined;
   $: transactionData = mapSnsTransaction({
     transaction: transactionWithId,
     account,
     toSelfTransaction,
-    fee,
   });
 </script>
 

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -12,7 +12,6 @@
   import { InfiniteScroll, Spinner } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import SnsTransactionCard from "./SnsTransactionCard.svelte";
-  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import SkeletonCard from "../ui/SkeletonCard.svelte";
 
   export let account: Account;
@@ -68,7 +67,6 @@
           transactionWithId={transaction}
           {toSelfTransaction}
           {account}
-          fee={$snsSelectedTransactionFeeStore}
         />
       {/each}
     </InfiniteScroll>

--- a/frontend/src/lib/utils/sns-transactions.utils.ts
+++ b/frontend/src/lib/utils/sns-transactions.utils.ts
@@ -120,6 +120,7 @@ interface TransactionInfo {
   memo?: Uint8Array;
   created_at_time?: bigint;
   amount: bigint;
+  fee?: bigint;
 }
 
 const getTransactionInformation = (
@@ -151,6 +152,7 @@ const getTransactionInformation = (
     memo: fromNullable(data?.memo),
     created_at_time: fromNullable(data?.created_at_time),
     amount: data?.amount,
+    fee: "fee" in data ? fromNullable(data.fee) : undefined,
   };
 };
 
@@ -158,12 +160,10 @@ export const mapSnsTransaction = ({
   transaction,
   account,
   toSelfTransaction,
-  fee,
 }: {
   transaction: SnsTransactionWithId;
   account: Account;
   toSelfTransaction: boolean;
-  fee?: TokenAmount;
 }): Transaction | undefined => {
   try {
     const type = getSnsTransactionType(transaction.transaction);
@@ -180,7 +180,8 @@ export const mapSnsTransaction = ({
       toSelfTransaction === true
         ? false
         : showTransactionFee({ type, isReceive });
-    const feeApplied = useFee && fee !== undefined ? fee.toE8s() : BigInt(0);
+    const feeApplied =
+      useFee && txInfo.fee !== undefined ? txInfo.fee : BigInt(0);
 
     // Timestamp is in nano seconds
     const timestampMilliseconds =

--- a/frontend/src/lib/utils/sns-transactions.utils.ts
+++ b/frontend/src/lib/utils/sns-transactions.utils.ts
@@ -134,6 +134,8 @@ const getTransactionInformation = (
   if (data === undefined) {
     throw new Error(`Unknown transaction type ${JSON.stringify(transaction)}`);
   }
+  // Fee is only present in "transfer" transactions.
+  const fee = fromNullable(transaction.transfer[0]?.fee ?? []);
   return {
     from:
       "from" in data
@@ -152,7 +154,7 @@ const getTransactionInformation = (
     memo: fromNullable(data?.memo),
     created_at_time: fromNullable(data?.created_at_time),
     amount: data?.amount,
-    fee: "fee" in data ? fromNullable(data.fee) : undefined,
+    fee,
   };
 };
 

--- a/frontend/src/lib/utils/sns-transactions.utils.ts
+++ b/frontend/src/lib/utils/sns-transactions.utils.ts
@@ -135,7 +135,7 @@ const getTransactionInformation = (
     throw new Error(`Unknown transaction type ${JSON.stringify(transaction)}`);
   }
   // Fee is only present in "transfer" transactions.
-  const fee = fromNullable(transaction.transfer[0]?.fee ?? []);
+  const fee = fromNullable(fromNullable(transaction.transfer)?.fee ?? []);
   return {
     from:
       "from" in data

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -6,7 +6,6 @@ import SnsTransactionCard from "$lib/components/accounts/SnsTransactionCard.svel
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { TokenAmount } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
@@ -17,17 +16,12 @@ import {
 import { createSnstransactionWithId } from "../../../mocks/sns-transactions.mock";
 
 describe("SnsTransactionCard", () => {
-  const transactoinFee = TokenAmount.fromE8s({
-    amount: BigInt(10_000),
-    token: { name: "Test", symbol: "TST" },
-  });
   const renderTransactionCard = (account, transactionWithId) =>
     render(SnsTransactionCard, {
       props: {
         account,
         transactionWithId,
         toSelfTransaction: false,
-        fee: transactoinFee,
       },
     });
 

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -4,7 +4,6 @@
 
 import SnsTransactionCard from "$lib/components/accounts/SnsTransactionCard.svelte";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
@@ -63,15 +62,12 @@ describe("SnsTransactionCard", () => {
     const account = mockSnsMainAccount;
     const transaction = transactionFromMainToSubaccount;
     const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapSnsTransaction({
-      account,
-      toSelfTransaction: false,
-      transaction,
-    });
 
+    const fee = transaction.transaction.transfer[0]?.fee[0];
+    const amount = transaction.transaction.transfer[0]?.amount;
     expect(getByTestId("token-value")?.textContent).toBe(
       `-${formatToken({
-        value: displayAmount.toE8s() + transactoinFee.toE8s(),
+        value: amount + fee,
         detailed: true,
       })}`
     );
@@ -80,18 +76,11 @@ describe("SnsTransactionCard", () => {
   it("renders transaction Tokens with + sign", () => {
     const account = mockSnsSubAccount;
     const transaction = transactionFromMainToSubaccount;
-    const { getByTestId } = renderTransactionCard(
-      mockSnsSubAccount,
-      transactionFromMainToSubaccount
-    );
-    const { displayAmount } = mapSnsTransaction({
-      account,
-      transaction,
-      toSelfTransaction: false,
-    });
+    const { getByTestId } = renderTransactionCard(account, transaction);
 
+    const amount = transaction.transaction.transfer[0]?.amount;
     expect(getByTestId("token-value")?.textContent).toBe(
-      `+${formatToken({ value: displayAmount.toE8s(), detailed: true })}`
+      `+${formatToken({ value: amount, detailed: true })}`
     );
   });
 

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -5,7 +5,6 @@ import {
   isTransactionsCompleted,
   mapSnsTransaction,
 } from "$lib/utils/sns-transactions.utils";
-import { TokenAmount } from "@dfinity/nns";
 import { mockPrincipal } from "../..//mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
@@ -176,10 +175,6 @@ describe("sns-transaction utils", () => {
       const data = mapSnsTransaction({
         transaction: transactionFromMainToSubaccount,
         account: mockSnsMainAccount,
-        fee: TokenAmount.fromE8s({
-          amount: BigInt(100),
-          token: mockSnsMainAccount.balance.token,
-        }),
         toSelfTransaction: false,
       });
       expect(data.isSend).toBe(true);
@@ -190,10 +185,6 @@ describe("sns-transaction utils", () => {
       const data = mapSnsTransaction({
         transaction: transactionFromMainToSubaccount,
         account: mockSnsSubAccount,
-        fee: TokenAmount.fromE8s({
-          amount: BigInt(100),
-          token: mockSnsSubAccount.balance.token,
-        }),
         toSelfTransaction: false,
       });
       expect(data.isSend).toBe(false);
@@ -204,10 +195,6 @@ describe("sns-transaction utils", () => {
       const data = mapSnsTransaction({
         transaction: selfTransaction,
         account: mockSnsSubAccount,
-        fee: TokenAmount.fromE8s({
-          amount: BigInt(100),
-          token: mockSnsSubAccount.balance.token,
-        }),
         toSelfTransaction: true,
       });
       expect(data.isSend).toBe(false);
@@ -215,21 +202,14 @@ describe("sns-transaction utils", () => {
     });
 
     it("adds fee to sent transactions", () => {
-      const fee = TokenAmount.fromE8s({
-        amount: BigInt(100),
-        token: mockSnsMainAccount.balance.token,
-      });
       const data = mapSnsTransaction({
         transaction: transactionFromMainToSubaccount,
         account: mockSnsMainAccount,
-        fee,
         toSelfTransaction: false,
       });
       expect(data.isSend).toBe(true);
-      expect(data.displayAmount.toE8s()).toBe(
-        transactionFromMainToSubaccount.transaction.transfer[0].amount +
-          fee.toE8s()
-      );
+      const txData = transactionFromMainToSubaccount.transaction.transfer[0];
+      expect(data.displayAmount.toE8s()).toBe(txData.amount + txData.fee[0]);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -20,6 +20,8 @@ export const createMockSnsNeuron = ({
   created_timestamp_seconds: BigInt(
     Math.floor(Date.now() / 1000 - 3600 * 24 * 6)
   ),
+  staked_maturity_e8s_equivalent: [],
+  auto_stake_maturity: [],
   aging_since_timestamp_seconds: BigInt(100),
   voting_power_percentage_multiplier: BigInt(1),
   dissolve_state:

--- a/frontend/src/tests/mocks/sns-transactions.mock.ts
+++ b/frontend/src/tests/mocks/sns-transactions.mock.ts
@@ -20,6 +20,7 @@ const mockSnsTransaction: SnsTransaction = {
       memo: [],
       created_at_time: [BigInt(123)],
       amount: BigInt(33),
+      fee: [BigInt(1)],
     },
   ],
 };
@@ -51,6 +52,7 @@ export const createSnstransactionWithId = (
         memo: [],
         created_at_time: [BigInt(123)],
         amount: BigInt(33),
+        fee: [BigInt(1)],
       },
     ],
   },


### PR DESCRIPTION
# Motivation

In SNS transactions, use the fee from the transactions instead of the fee from the project.

# Changes

* Remove fee prop from `SnsTransactionCard`.
* Remove fee parameter from `mapSnsTransaction` and use instead the `fee` from the transaction if present.

# Tests

* Adapt tests accordingly.
