### PR TITLE
feat: link to sub-pages on main login screen

### DIFF
--- a/frontend/src/lib/pages/Auth.svelte
+++ b/frontend/src/lib/pages/Auth.svelte
@@ -17,6 +17,7 @@
     buildProposalUrl,
   } from "$lib/utils/navigation.utils";
   import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   let signedIn = false;
 
@@ -70,16 +71,22 @@
 
 <ul>
   <li>
-    <IconWallet />
-    {$i18n.auth.wallet}
+    <a href={AppPath.Accounts} data-tid="auth-link-accounts"
+      ><IconWallet />
+      {$i18n.auth.wallet}</a
+    >
   </li>
   <li>
-    <IconPsychology />
-    {$i18n.auth.stake}
+    <a href={AppPath.Neurons} data-tid="auth-link-neurons"
+      ><IconPsychology />
+      {$i18n.auth.stake}</a
+    >
   </li>
   <li>
-    <IconHowToVote />
-    {$i18n.auth.earn}
+    <a href={AppPath.Proposals} data-tid="auth-link-proposals"
+      ><IconHowToVote />
+      {$i18n.auth.earn}</a
+    >
   </li>
 </ul>
 
@@ -204,5 +211,9 @@
       margin: var(--padding-6x) 0 calc(14 * var(--padding));
       width: auto;
     }
+  }
+
+  a {
+    color: inherit;
   }
 </style>

--- a/frontend/src/tests/lib/pages/Auth.spec.ts
+++ b/frontend/src/tests/lib/pages/Auth.spec.ts
@@ -78,4 +78,32 @@ describe("Auth", () => {
       window.history.back();
     });
   });
+
+  describe("Links", () => {
+    const shouldRenderLink = ({
+      path,
+      testId,
+    }: {
+      path: AppPath;
+      testId: string;
+    }) => {
+      const { getByTestId } = render(Auth);
+      expect(
+        (getByTestId(testId) as HTMLLinkElement | null)?.getAttribute("href")
+      ).toEqual(path);
+    };
+
+    it("should render a link to accounts", () =>
+      shouldRenderLink({
+        testId: "auth-link-accounts",
+        path: AppPath.Accounts,
+      }));
+    it("should render a link to neurons", () =>
+      shouldRenderLink({ testId: "auth-link-neurons", path: AppPath.Neurons }));
+    it("should render a link to proposals", () =>
+      shouldRenderLink({
+        testId: "auth-link-proposals",
+        path: AppPath.Proposals,
+      }));
+  });
 });


### PR DESCRIPTION
# Motivation

Link sub-pages (Accounts etc.) with their corresponding categories on main login page.

# Changes

- add links
