### PR TITLE
GIX-1116: Syns SNS Neuron Balances

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-11.1.tgz",
-      "integrity": "sha512-/1aJJ22hzZAT/Wo2p2aTU2KKtYP6Uiw53aky4Im9QhdbW5F1tqeOR4lAhbnuD4QYxTkvx62TWRllLUKiBHKz+g==",
+      "version": "0.0.3-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-16.2.tgz",
+      "integrity": "sha512-Wzmjc+4olSEhZ15wSV3Ua6o1w0V9Y886+zyhEIzPT70xTNgtawWfh0okfCx7FH3O1fQBu5GmKeYRvUlgVJBpsw==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.6-next"
       }
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-11.1.tgz",
-      "integrity": "sha512-t3t4NR+jLPkb6n0x0k1ToCES4xAe53M6DLoNkOaJ0J4pgnwhodZE+EwwYDzaz/8fDdMEYASDjkU8KSKc6Yq1+g==",
+      "version": "0.10.0-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-16.2.tgz",
+      "integrity": "sha512-myyTJdmLiE9K2KGr8nZe9DZUoDLyMBOnGbBJaFN6OiIwEipPBd7GBVps30YdKxdrQG/dR2g6tbpZGWw92BhB2Q==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-11.1.tgz",
-      "integrity": "sha512-d/bJLOV5ZWkkYC57i+79C9CPTQLAUi49AscT7apTYUTTUS/rJdZY45+QqTTE3/yu+w9DuLfULyTOD6nKe6ejBg==",
+      "version": "0.0.7-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-16.2.tgz",
+      "integrity": "sha512-NRhUAkLib1VLpZakg20VQz/ZDHijanNH6WHrFGLrO+94JvjQ9VJte0XwK/0P4O7AfXlSUqxwOqL+EUTBlqkPUQ==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-11.1.tgz",
-      "integrity": "sha512-bGWX05f1wZDhWDPRta1/ck5JxelObnUmGhF5yZGjTOXEBMH7A7oMs2di+T+NYuidvbmhV+9BGrIIy1AaTKE1aw=="
+      "version": "0.0.6-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-16.2.tgz",
+      "integrity": "sha512-A/4CARv4uAccdzX5BFk13Ljc6kio+hiOGh/6oKVxG1FzutBYhxGSI2aoCX+YrIv+kDxUjbfW+1c4Axps5I324g=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10984,9 +10984,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-11.1.tgz",
-      "integrity": "sha512-/1aJJ22hzZAT/Wo2p2aTU2KKtYP6Uiw53aky4Im9QhdbW5F1tqeOR4lAhbnuD4QYxTkvx62TWRllLUKiBHKz+g==",
+      "version": "0.0.3-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-16.2.tgz",
+      "integrity": "sha512-Wzmjc+4olSEhZ15wSV3Ua6o1w0V9Y886+zyhEIzPT70xTNgtawWfh0okfCx7FH3O1fQBu5GmKeYRvUlgVJBpsw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11012,9 +11012,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-11.1.tgz",
-      "integrity": "sha512-t3t4NR+jLPkb6n0x0k1ToCES4xAe53M6DLoNkOaJ0J4pgnwhodZE+EwwYDzaz/8fDdMEYASDjkU8KSKc6Yq1+g==",
+      "version": "0.10.0-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-16.2.tgz",
+      "integrity": "sha512-myyTJdmLiE9K2KGr8nZe9DZUoDLyMBOnGbBJaFN6OiIwEipPBd7GBVps30YdKxdrQG/dR2g6tbpZGWw92BhB2Q==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11032,17 +11032,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-11.1.tgz",
-      "integrity": "sha512-d/bJLOV5ZWkkYC57i+79C9CPTQLAUi49AscT7apTYUTTUS/rJdZY45+QqTTE3/yu+w9DuLfULyTOD6nKe6ejBg==",
+      "version": "0.0.7-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-16.2.tgz",
+      "integrity": "sha512-NRhUAkLib1VLpZakg20VQz/ZDHijanNH6WHrFGLrO+94JvjQ9VJte0XwK/0P4O7AfXlSUqxwOqL+EUTBlqkPUQ==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-11.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-11.1.tgz",
-      "integrity": "sha512-bGWX05f1wZDhWDPRta1/ck5JxelObnUmGhF5yZGjTOXEBMH7A7oMs2di+T+NYuidvbmhV+9BGrIIy1AaTKE1aw=="
+      "version": "0.0.6-next-2022-11-16.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-16.2.tgz",
+      "integrity": "sha512-A/4CARv4uAccdzX5BFk13Ljc6kio+hiOGh/6oKVxG1FzutBYhxGSI2aoCX+YrIv+kDxUjbfW+1c4Axps5I324g=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -1,4 +1,5 @@
 import { logWithTimestamp } from "$lib/utils/dev.utils";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type { SnsNeuronId, SnsNeuronPermissionType } from "@dfinity/sns";
@@ -146,8 +147,95 @@ export const increaseDissolveDelay = async ({
     rootCanisterId: rootCanisterId.toText(),
     certified: true,
   });
-
   await increaseDissolveDelay({ neuronId, additionalDissolveDelaySeconds });
 
   logWithTimestamp(`Increase sns dissolve delay complete.`);
+};
+
+export const getNeuronBalance = async ({
+  neuronId,
+  rootCanisterId,
+  certified,
+  identity,
+}: {
+  neuronId: SnsNeuronId;
+  rootCanisterId: Principal;
+  certified: boolean;
+  identity: Identity;
+}): Promise<bigint> => {
+  logWithTimestamp(
+    `Getting neuron ${subaccountToHexString(neuronId.id)} balance call...`
+  );
+
+  const { getNeuronBalance: getNeuronBalanceApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+
+  const balance = await getNeuronBalanceApi(neuronId);
+
+  logWithTimestamp(
+    `Getting neuron ${subaccountToHexString(
+      neuronId.id
+    )} balance call complete.`
+  );
+  return balance;
+};
+
+export const refreshNeuron = async ({
+  rootCanisterId,
+  identity,
+  neuronId,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  neuronId: SnsNeuronId;
+}): Promise<void> => {
+  logWithTimestamp(
+    `Refreshing neuron ${subaccountToHexString(neuronId.id)} call...`
+  );
+
+  const { refreshNeuron: refreshNeuronApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  await refreshNeuronApi(neuronId);
+
+  logWithTimestamp(
+    `Refreshing neuron ${subaccountToHexString(neuronId.id)} call complete.`
+  );
+};
+
+export const claimNeuron = async ({
+  rootCanisterId,
+  identity,
+  memo,
+  controller,
+  subaccount,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  memo: bigint;
+  controller: Principal;
+  subaccount: Uint8Array;
+}): Promise<SnsNeuronId> => {
+  logWithTimestamp(`Claiming neuron call...`);
+
+  const { claimNeuron: claimNeuronApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  const neuronId = await claimNeuronApi({
+    subaccount,
+    memo,
+    controller,
+  });
+
+  logWithTimestamp(`Claiming neuron call complete.`);
+  return neuronId;
 };

--- a/frontend/src/lib/constants/sns-neurons.constants.ts
+++ b/frontend/src/lib/constants/sns-neurons.constants.ts
@@ -1,0 +1,2 @@
+// Limit coming from the limit of subaccounts
+export const MAX_NEURONS_SUBACCOUNTS = 2 ** 16;

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -7,7 +7,7 @@
     sortedSnsUserNeuronsStore,
   } from "$lib/derived/sorted-sns-neurons.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { loadSnsNeurons } from "$lib/services/sns-neurons.services";
+  import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import SnsNeuronCard from "$lib/components/sns-neurons/SnsNeuronCard.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { snsOnlyProjectStore } from "$lib/derived/selected-project.derived";
@@ -26,7 +26,7 @@
       if (selectedProjectCanisterId !== undefined) {
         loading = true;
         await Promise.all([
-          loadSnsNeurons(selectedProjectCanisterId),
+          syncSnsNeurons(selectedProjectCanisterId),
           syncSnsAccounts(selectedProjectCanisterId),
         ]);
         loading = false;

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -1,0 +1,297 @@
+import {
+  claimNeuron,
+  getNeuronBalance,
+  refreshNeuron,
+} from "$lib/api/sns-governance.api";
+import { querySnsNeuron } from "$lib/api/sns.api";
+import { MAX_NEURONS_SUBACCOUNTS } from "$lib/constants/sns-neurons.constants";
+import { getIdentity } from "$lib/services/auth.services";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import {
+  getSnsNeuronIdAsHexString,
+  needsRefresh,
+  subaccountToHexString,
+} from "$lib/utils/sns-neuron.utils";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import {
+  neuronSubaccount,
+  type SnsNeuron,
+  type SnsNeuronId,
+} from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
+
+const loadNeuron = async ({
+  rootCanisterId,
+  neuronId,
+  certified,
+  identity,
+}: {
+  rootCanisterId: Principal;
+  neuronId: SnsNeuronId;
+  certified: boolean;
+  identity: Identity;
+}): Promise<void> => {
+  const neuron = await querySnsNeuron({
+    identity,
+    rootCanisterId,
+    neuronId,
+    certified,
+  });
+  snsNeuronsStore.addNeurons({
+    rootCanisterId,
+    certified,
+    neurons: [neuron],
+  });
+};
+
+/**
+ * Returns true if the neuron's stake doesn't match the balance of the subaccount.
+ *
+ * @param params
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsNeuron} params.neuron
+ * @param {Identity} params.identity
+ * @param {bigint} params.balanceE8s
+ * @returns {Promise<boolean>}
+ */
+export const neuronNeedsRefresh = async ({
+  rootCanisterId,
+  neuron,
+  identity,
+}: {
+  rootCanisterId: Principal;
+  neuron: SnsNeuron;
+  identity: Identity;
+}): Promise<boolean> => {
+  const neuronId = fromNullable(neuron.id);
+  // Edge case, a valid neuron should have a neuron id
+  if (neuronId === undefined) {
+    return false;
+  }
+  // We use certified: false for performance reasons.
+  // A bad actor will only get that we call refresh on a neuron.
+  const balanceE8s = await getNeuronBalance({
+    rootCanisterId,
+    neuronId,
+    certified: false,
+    identity,
+  });
+  return needsRefresh({ neuron, balanceE8s });
+};
+
+const claimAndLoadNeuron = async ({
+  rootCanisterId,
+  identity,
+  controller,
+  memo,
+  subaccount,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  controller: Principal;
+  memo: bigint;
+  subaccount: Uint8Array;
+}): Promise<void> => {
+  // There is a subaccount with balance and no neuron. Claim it.
+  const neuronId = await claimNeuron({
+    rootCanisterId,
+    identity,
+    memo,
+    controller,
+    subaccount,
+  });
+  // No need to wait for this to continue with the checks.
+  loadNeuron({
+    neuronId,
+    rootCanisterId,
+    certified: true,
+    identity,
+  });
+};
+
+const findNeuronBySubaccount =
+  (subaccount: Uint8Array) => (neuron: SnsNeuron) =>
+    getSnsNeuronIdAsHexString(neuron) === subaccountToHexString(subaccount);
+
+/**
+ * Checks subaccounts of identity in order to find neurons that need to be refreshed or claimed.
+ *
+ * Neuron subaccount is { sha256(0x0c . “neuron-stake” . P . i) | i ∈ ℕ }
+ *
+ * The main property of this is that it is always possible to recompute all the neurons subaccounts of a principal.
+ * This can be used to make the SNS UI stateless, which then means that the SNS UI can fail at any time
+ * without losing any important information needed to derive accounts.
+ *
+ * Neurons subaccounts of a principal must be used in order of i.
+ * The first account of P is sha256(0x0c . “neuron-staking” . P . 0), the second one is sha256(0x0c . “neuron-staking” . P . 1) …
+ * This allows any client to verify the state of neurons subaccounts that have received a transfer without checking all the ns subaccounts.
+ *
+ * A stateless SNS UI will perform the following operations every time it starts:
+ * - It gets the list of neurons from the SNS Governance using list_neurons. This is done via an update call to confirm the correctness of the data.
+ * - It calculates all its ns subaccounts and then checks their balances via query calls. This is where the ordering of ns subaccounts comes into play: the client just needs to check the ns subaccounts that are either already neuron accounts returned in 1. or have a balance different from 0.
+ * - The SNS UI notifies the SNS Governance of all the neuron subaccounts that
+ *   - Have a balance different from 0 but the list of neurons doesn’t list them as neurons.
+ *     - In this case, the client need to claim the neuron.
+ *   - Have a balance different from the cached_neuron_stake_e8s returned by the SNS Governance
+ *     - In this case, the client needs to refresh the neuron.
+ *
+ * SUMMARY:
+ *
+ * -------------------------------------------------
+ * |              |  Balance 0     | Balance > 0   |
+ * | found neuron |  check neuron stake vs balance |
+ * | no neuron    |  stop checking | claim neuron  |
+ * -------------------------------------------------
+ *
+ * @param {Object}
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsNeuron[]} params.neurons neurons to check
+ * @param {Identity} params.identity
+ * @returns
+ */
+const checkNeuronsSubaccounts = async ({
+  identity,
+  rootCanisterId,
+  neurons,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  neurons: SnsNeuron[];
+}): Promise<SnsNeuron[]> => {
+  const visitedSubaccounts = new Set<string>();
+  const controller = identity.getPrincipal();
+  // Visit subaccounts by order until we find a balance of 0.
+  // Therefore, we set the initial balance to some non-zero value.
+  let currentBalance = BigInt(Number.MAX_SAFE_INTEGER);
+  for (let index = 0; index < MAX_NEURONS_SUBACCOUNTS; index++) {
+    try {
+      // In case there is an error getting the balance, the loop stops.
+      currentBalance = BigInt(0);
+      const subaccount = neuronSubaccount({
+        controller,
+        index,
+      });
+      // Id of an sns neuron is the subaccount of the sns governance canister where the stake is
+      const currentNeuronId: SnsNeuronId = { id: subaccount };
+      visitedSubaccounts.add(subaccountToHexString(subaccount));
+      // We use certified: false for performance reasons.
+      // A bad actor will only get that we call refresh or claim on a neuron.
+      currentBalance = await getNeuronBalance({
+        rootCanisterId,
+        neuronId: currentNeuronId,
+        certified: false,
+        identity,
+      });
+      const neuron = neurons.find(findNeuronBySubaccount(subaccount));
+      const neuronNotFound = neuron === undefined;
+      const positiveBalance = currentBalance > BigInt(0);
+      // Subaccount balance > 0 but no neuron found, claim it.
+      if (positiveBalance && neuronNotFound) {
+        await claimAndLoadNeuron({
+          rootCanisterId,
+          identity,
+          controller,
+          memo: BigInt(index),
+          subaccount,
+        });
+      }
+      // Neuron found, check if it needs to be refreshed.
+      if (
+        neuron !== undefined &&
+        needsRefresh({ neuron, balanceE8s: currentBalance })
+      ) {
+        // Edge case, a valid neuron should have a neuron id
+        const neuronId = fromNullable(neuron.id);
+        if (neuronId !== undefined) {
+          await refreshNeuron({ rootCanisterId, identity, neuronId });
+          loadNeuron({
+            rootCanisterId,
+            neuronId: neuronId,
+            certified: true,
+            identity,
+          });
+        }
+      }
+      // If the balance is 0 and there is no neuron in that subaccount, stop checking.
+      if (currentBalance === BigInt(0) && neuronNotFound) {
+        break;
+      }
+    } catch (error) {
+      // Ignore the error, we do this in the background.
+      // If this fails the data might be stale but it should refreshed on the next sync.
+      console.error(error);
+    }
+  }
+  const unvisitedNeurons = neurons.filter(
+    ({ id }) =>
+      !visitedSubaccounts.has(
+        subaccountToHexString(fromNullable(id)?.id ?? new Uint8Array())
+      )
+  );
+  return unvisitedNeurons;
+};
+
+/**
+ * Checks neurons subaccounts and refreshes neurons that need it.
+ *
+ * @param {Object}
+ * @param {Principal} params.rootCanisterId
+ * @param {SnsNeuron[]} params.neurons neurons to check
+ * @param {Identity} params.identity
+ * @returns
+ */
+const checkNeurons = async ({
+  identity,
+  rootCanisterId,
+  neurons,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  neurons: SnsNeuron[];
+}) => {
+  for (const neuron of neurons) {
+    const neuronId = fromNullable(neuron.id);
+    if (neuronId !== undefined) {
+      if (await neuronNeedsRefresh({ rootCanisterId, neuron, identity })) {
+        await refreshNeuron({ rootCanisterId, identity, neuronId });
+        loadNeuron({
+          rootCanisterId,
+          neuronId: neuronId,
+          certified: true,
+          identity,
+        });
+      }
+    }
+  }
+};
+
+/**
+ * Checks a couple of things:
+ * - Neurons subaccounts balances and refreshes or claims neurons that need it.
+ *   - This follows a new staking neuron algorithm explained in the helper `checkNeuronsSubaccounts`
+ * - Check the rest of the neurons and refreshes them if needed.
+ *
+ * It refetches the neurons that are not in sync with the subaccounts and adds them to the store.
+ *
+ * @param param0
+ * @returns {boolean}
+ */
+export const checkSnsNeuronBalances = async ({
+  rootCanisterId,
+  neurons,
+}: {
+  rootCanisterId: Principal;
+  neurons: SnsNeuron[];
+}): Promise<void> => {
+  // TODO: Check neurons controlled by linked HW?
+  const identity = await getIdentity();
+
+  const unvisitedNeurons = await checkNeuronsSubaccounts({
+    identity,
+    rootCanisterId,
+    neurons,
+  });
+
+  await checkNeurons({ identity, rootCanisterId, neurons: unvisitedNeurons });
+};

--- a/frontend/src/lib/stores/sns-neurons.store.ts
+++ b/frontend/src/lib/stores/sns-neurons.store.ts
@@ -1,3 +1,4 @@
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { removeKeys } from "$lib/utils/utils";
 import type { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -41,6 +42,34 @@ const initSnsNeuronsStore = () => {
           certified,
         },
       }));
+    },
+
+    addNeurons({
+      rootCanisterId,
+      neurons,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      neurons: SnsNeuron[];
+      certified: boolean | undefined;
+    }) {
+      update((currentState: NeuronsStore) => {
+        const newIds = new Set(
+          neurons.map((neuron) => getSnsNeuronIdAsHexString(neuron))
+        );
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            neurons: [
+              ...neurons,
+              ...(currentState[rootCanisterId.toText()]?.neurons.filter(
+                (neuron) => !newIds.has(getSnsNeuronIdAsHexString(neuron))
+              ) ?? []),
+            ],
+            certified,
+          },
+        };
+      });
     },
 
     // Used in tests

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -97,7 +97,17 @@ export const getSnsNeuronByHexId = ({
 export const getSnsNeuronIdAsHexString = ({
   id: neuronId,
 }: SnsNeuron): string =>
-  bytesToHexString(Array.from(fromNullable(neuronId)?.id ?? []));
+  subaccountToHexString(fromNullable(neuronId)?.id ?? new Uint8Array());
+
+/**
+ * Convert a subaccount to a hex string.
+ * SnsNeuron id is a subaccount.
+ *
+ * @param {Uint8Array} subaccount
+ * @returns {string} hex string
+ */
+export const subaccountToHexString = (subaccount: Uint8Array): string =>
+  bytesToHexString(Array.from(subaccount));
 
 export const canIdentityManageHotkeys = ({
   neuron,
@@ -249,3 +259,21 @@ export const formattedSnsMaturity = (
  */
 export const isCommunityFund = ({ source_nns_neuron_id }: SnsNeuron): boolean =>
   nonNullish(fromNullable(source_nns_neuron_id));
+
+/**
+ * Returns true if the neuron needs to be refreshed.
+ * Refresh means to make a call to the backend to get the latest data.
+ * A neuron needs to be refreshed if the balance of the subaccount doesn't match the stake.
+ *
+ * @param {Object}
+ * @param {SnsNeuron} param.neuron neuron to check
+ * @param {bigint} param.balanceE8s  subaccount balance
+ * @returns
+ */
+export const needsRefresh = ({
+  neuron,
+  balanceE8s,
+}: {
+  neuron: SnsNeuron;
+  balanceE8s: bigint;
+}): boolean => balanceE8s !== neuron.cached_neuron_stake_e8s;

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -4,8 +4,11 @@
 
 import {
   addNeuronPermissions,
+  claimNeuron,
   disburse,
+  getNeuronBalance,
   increaseDissolveDelay,
+  refreshNeuron,
   removeNeuronPermissions,
   startDissolving,
   stopDissolving,
@@ -48,6 +51,9 @@ describe("sns-api", () => {
   const startDissolvingSpy = jest.fn().mockResolvedValue(undefined);
   const stopDissolvingSpy = jest.fn().mockResolvedValue(undefined);
   const increaseDissolveDelaySpy = jest.fn().mockResolvedValue(undefined);
+  const getNeuronBalanceSpy = jest.fn().mockResolvedValue(undefined);
+  const refreshNeuronSpy = jest.fn().mockResolvedValue(undefined);
+  const claimNeuronSpy = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     jest
@@ -77,6 +83,9 @@ describe("sns-api", () => {
         startDissolving: startDissolvingSpy,
         stopDissolving: stopDissolvingSpy,
         increaseDissolveDelay: increaseDissolveDelaySpy,
+        getNeuronBalance: getNeuronBalanceSpy,
+        refreshNeuron: refreshNeuronSpy,
+        claimNeuron: claimNeuronSpy,
       })
     );
   });
@@ -149,5 +158,38 @@ describe("sns-api", () => {
     });
 
     expect(increaseDissolveDelaySpy).toBeCalled();
+  });
+
+  it("should getNeuronBalance", async () => {
+    await getNeuronBalance({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      neuronId: { id: arrayOfNumberToUint8Array([1, 2, 3]) },
+      certified: true,
+    });
+
+    expect(getNeuronBalanceSpy).toBeCalled();
+  });
+
+  it("should refreshNeuron", async () => {
+    await refreshNeuron({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      neuronId: { id: arrayOfNumberToUint8Array([1, 2, 3]) },
+    });
+
+    expect(refreshNeuronSpy).toBeCalled();
+  });
+
+  it("should claimNeuron", async () => {
+    await claimNeuron({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      memo: BigInt(2),
+      controller: Principal.fromText("aaaaa-aa"),
+      subaccount: arrayOfNumberToUint8Array([1, 2, 3]),
+    });
+
+    expect(claimNeuronSpy).toBeCalled();
   });
 });

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "$lib/derived/sorted-sns-neurons.derived";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
-import { loadSnsNeurons } from "$lib/services/sns-neurons.services";
+import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -25,7 +25,7 @@ import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
-    loadSnsNeurons: jest.fn().mockReturnValue(undefined),
+    syncSnsNeurons: jest.fn().mockReturnValue(undefined),
   };
 });
 
@@ -72,7 +72,7 @@ describe("SnsNeurons", () => {
       render(SnsNeurons);
       expect(authStoreMock).toHaveBeenCalled();
       await waitFor(() => expect(syncSnsAccounts).toBeCalled());
-      await waitFor(() => expect(loadSnsNeurons).toBeCalled());
+      await waitFor(() => expect(syncSnsNeurons).toBeCalled());
     });
 
     it("should render a principal as text", () => {

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -26,7 +26,7 @@ jest.mock("$lib/services/sns.services", () => {
 
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
-    loadSnsNeurons: jest.fn().mockResolvedValue(undefined),
+    syncSnsNeurons: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as governanceApi from "$lib/api/sns-governance.api";
+import * as api from "$lib/api/sns.api";
+import {
+  checkSnsNeuronBalances,
+  neuronNeedsRefresh,
+} from "$lib/services/sns-neurons-check-balances.services";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { neuronSubaccount, type SnsNeuronId } from "@dfinity/sns";
+import { waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
+
+describe("sns-neurons-check-balances-services", () => {
+  describe("checkSnsNeuronBalances", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      snsNeuronsStore.reset();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    it("should check balance and not refresh when balance matches stake", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(neuron));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        )
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [neuron],
+      });
+
+      await waitFor(() => expect(spyNeuronBalance).toBeCalled());
+      expect(spyQuery).not.toBeCalled();
+    });
+
+    it("should check balance and refresh when balance does not match stake and load the updated neuron in the store", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const stake = neuron.cached_neuron_stake_e8s + BigInt(10_000);
+      const updatedNeuron = {
+        ...neuron,
+        cached_neuron_stake_e8s: stake,
+      };
+      const spyNeuronQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(updatedNeuron));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(
+            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
+          )
+        )
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      const spyRefreshNeuron = jest
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [neuron],
+      });
+
+      await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
+      expect(spyNeuronQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()].neurons).toEqual([updatedNeuron]);
+    });
+
+    it("should check balance and refresh when balance is 0 and does not match stake and load the updated neuron in the store", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const updatedNeuron = {
+        ...neuron,
+        cached_neuron_stake_e8s: BigInt(0),
+      };
+      const spyNeuronQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(updatedNeuron));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      const spyRefreshNeuron = jest
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [neuron],
+      });
+
+      await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
+      expect(spyNeuronQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()].neurons).toEqual([updatedNeuron]);
+    });
+  });
+
+  describe("neuronNeedsRefresh", () => {
+    it("should query the balance and return true when balance does not match stake", async () => {
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(() =>
+          Promise.resolve(
+            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
+          )
+        );
+      const res = await neuronNeedsRefresh({
+        rootCanisterId: mockPrincipal,
+        neuron: mockSnsNeuron,
+        identity: mockIdentity,
+      });
+      await waitFor(() => expect(spyNeuronBalance).toBeCalled());
+      expect(res).toBe(true);
+    });
+
+    it("should query the balance and return false when balance matches stake", async () => {
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        );
+      const res = await neuronNeedsRefresh({
+        rootCanisterId: mockPrincipal,
+        neuron: mockSnsNeuron,
+        identity: mockIdentity,
+      });
+      await waitFor(() => expect(spyNeuronBalance).toBeCalled());
+      expect(res).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import * as governanceApi from "$lib/api/sns-governance.api";
 import * as api from "$lib/api/sns.api";
 import * as services from "$lib/services/sns-neurons.services";
@@ -10,35 +14,133 @@ import {
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { bytesToHexString } from "$lib/utils/utils";
 import { Principal } from "@dfinity/principal";
-import type { SnsNeuron } from "@dfinity/sns";
-import { SnsNeuronPermissionType, type SnsNeuronId } from "@dfinity/sns";
+import {
+  neuronSubaccount,
+  SnsNeuronPermissionType,
+  type SnsNeuron,
+  type SnsNeuronId,
+} from "@dfinity/sns";
 import { fromDefinedNullable } from "@dfinity/utils";
+import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
 
-const { loadSnsNeurons, getSnsNeuron, addHotkey, removeHotkey, stakeNeuron } =
+const { syncSnsNeurons, getSnsNeuron, addHotkey, removeHotkey, stakeNeuron } =
   services;
 
 describe("sns-neurons-services", () => {
-  describe("loadSnsNeurons", () => {
+  describe("syncSnsNeurons", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       snsNeuronsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
+
     it("should call api.querySnsNeurons and load neurons in store", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
       const spyQuery = jest
         .spyOn(api, "querySnsNeurons")
-        .mockImplementation(() => Promise.resolve([mockSnsNeuron]));
-      await loadSnsNeurons(mockPrincipal);
+        .mockImplementation(() => Promise.resolve([neuron]));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        )
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      await syncSnsNeurons(mockPrincipal);
 
       await tick();
       const store = get(snsNeuronsStore);
       expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
       expect(spyQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+    });
+
+    it("should refresh and refetch the neuron if balance doesn't match", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([neuron]));
+      const spyNeuronQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(neuron));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(
+            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
+          )
+        )
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      const spyRefreshNeuron = jest
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      await syncSnsNeurons(mockPrincipal);
+
+      await tick();
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      expect(spyQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+      expect(spyRefreshNeuron).toBeCalled();
+      expect(spyNeuronQuery).toBeCalled();
+    });
+
+    it("should claim neuron if find a subaccount without neuron", async () => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 1,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([neuron]));
+      const spyNeuronQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        .mockImplementation(() => Promise.resolve(neuron));
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        )
+        .mockImplementationOnce(() => Promise.resolve(BigInt(200_000_000)))
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      const spyClaimNeuron = jest
+        .spyOn(governanceApi, "claimNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      await syncSnsNeurons(mockPrincipal);
+
+      await tick();
+      await tick();
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      expect(spyQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+      expect(spyClaimNeuron).toBeCalled();
+      expect(spyNeuronQuery).toBeCalled();
     });
 
     it("should empty store if update call fails", async () => {
@@ -51,7 +153,7 @@ describe("sns-neurons-services", () => {
         .spyOn(api, "querySnsNeurons")
         .mockImplementation(() => Promise.reject(undefined));
 
-      await loadSnsNeurons(mockPrincipal);
+      await syncSnsNeurons(mockPrincipal);
 
       await tick();
       const store = get(snsNeuronsStore);
@@ -67,19 +169,89 @@ describe("sns-neurons-services", () => {
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
     it("should call api.querySnsNeuron and call load neuron when neuron not in store", (done) => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        )
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
       const spyQuery = jest
         .spyOn(api, "querySnsNeuron")
-        .mockImplementation(() => Promise.resolve(mockSnsNeuron));
-      const onLoad = ({
-        neuron,
+        .mockImplementation(() => Promise.resolve(neuron));
+      const onLoad = async ({
+        neuron: neuronToLoad,
         certified,
       }: {
         neuron: SnsNeuron;
         certified: boolean;
       }) => {
         expect(spyQuery).toBeCalled();
-        expect(neuron).toEqual(mockSnsNeuron);
+        expect(neuronToLoad).toEqual(neuron);
         if (certified) {
+          await waitFor(() => expect(spyNeuronBalance).toBeCalled());
+          done();
+        }
+      };
+      getSnsNeuron({
+        neuronIdHex: bytesToHexString(
+          Array.from(mockSnsNeuron.id[0]?.id as Uint8Array)
+        ),
+        rootCanisterId: mockPrincipal,
+        onLoad,
+      });
+    });
+
+    it("should refresh neuron if balance does not match and load again", (done) => {
+      const subaccount: Uint8Array = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const stake = neuron.cached_neuron_stake_e8s + BigInt(10_000);
+      const updatedNeuron = {
+        ...neuron,
+        cached_neuron_stake_e8s: stake,
+      };
+      const spyNeuronBalance = jest
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() => Promise.resolve(stake))
+        .mockImplementation(() => Promise.resolve(BigInt(0)));
+      const spyQuery = jest
+        .spyOn(api, "querySnsNeuron")
+        // First is the query call and returns old neuron
+        .mockImplementationOnce(() => Promise.resolve(neuron))
+        // Second is the update call and returns old neuron. It will be checked.
+        .mockImplementationOnce(() => Promise.resolve(neuron))
+        // After refreshing we get the updated neuron.
+        .mockImplementation(() => Promise.resolve(updatedNeuron));
+      const spyRefreshNeuron = jest
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      const onLoad = ({
+        neuron: neuronToLoad,
+      }: {
+        neuron: SnsNeuron;
+        certified: boolean;
+      }) => {
+        // Wait until we get the updated neuron to finish the test.
+        if (neuronToLoad.cached_neuron_stake_e8s === stake) {
+          expect(spyQuery).toBeCalledTimes(3);
+          expect(spyNeuronBalance).toBeCalledTimes(1);
+          expect(spyRefreshNeuron).toBeCalledTimes(1);
+          expect(neuronToLoad).toEqual(updatedNeuron);
           done();
         }
       };

--- a/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
@@ -87,5 +87,35 @@ describe("SNS Neurons stores", () => {
       expect(neuronsInStore[mockPrincipal.toText()].neurons).toEqual(neurons1);
       expect(neuronsInStore[principal2.toText()].neurons).toEqual(neurons2);
     });
+
+    it("should add neurons to a project with neurons", () => {
+      const neuron1 = createMockSnsNeuron({
+        stake: BigInt(1_000_000_000),
+        id: [1, 5, 3, 9, 1, 1, 1],
+      });
+      const neuron2 = createMockSnsNeuron({
+        stake: BigInt(2_000_000_000),
+        id: [1, 5, 3, 9, 9, 3, 2],
+      });
+      const neuron3 = createMockSnsNeuron({
+        stake: BigInt(2_000_000_000),
+        id: [1, 5, 2, 9, 9, 3, 2],
+      });
+      const neurons1: SnsNeuron[] = [neuron1, neuron2];
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: mockPrincipal,
+        neurons: neurons1,
+        certified: true,
+      });
+      const neurons2: SnsNeuron[] = [neuron1, neuron3];
+      snsNeuronsStore.addNeurons({
+        rootCanisterId: mockPrincipal,
+        neurons: neurons2,
+        certified: true,
+      });
+
+      const neuronsInStore = get(snsNeuronsStore);
+      expect(neuronsInStore[mockPrincipal.toText()].neurons.length).toEqual(3);
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -16,13 +16,16 @@ import {
   isCommunityFund,
   isSnsNeuron,
   isUserHotkey,
+  needsRefresh,
   sortSnsNeuronsByCreatedTimestamp,
+  subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
 import { bytesToHexString } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
+import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockNeuron } from "../../mocks/neurons.mock";
 import {
@@ -183,6 +186,18 @@ describe("sns-neuron utils", () => {
         id,
       });
       expect(getSnsNeuronIdAsHexString(neuron)).toBe(
+        "9aaefb31ec11d6bdc38c3a593d1d8a714f308825603dd732b641c6610813ee24"
+      );
+    });
+  });
+
+  describe("subaccountToHexString", () => {
+    it("returns id numbers concatenated", () => {
+      const subaccount = arrayOfNumberToUint8Array([
+        154, 174, 251, 49, 236, 17, 214, 189, 195, 140, 58, 89, 61, 29, 138,
+        113, 79, 48, 136, 37, 96, 61, 215, 50, 182, 65, 198, 97, 8, 19, 238, 36,
+      ]);
+      expect(subaccountToHexString(subaccount)).toBe(
         "9aaefb31ec11d6bdc38c3a593d1d8a714f308825603dd732b641c6610813ee24"
       );
     });
@@ -701,6 +716,33 @@ describe("sns-neuron utils", () => {
         source_nns_neuron_id: [],
       };
       expect(isCommunityFund(neuron)).toBeFalsy();
+    });
+  });
+
+  describe("needsRefresh", () => {
+    it("returns true when neuron stake does not match the balance", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(2),
+      };
+      expect(
+        needsRefresh({
+          neuron,
+          balanceE8s: BigInt(1),
+        })
+      ).toBeTruthy();
+    });
+    it("returns false when the neuron stake matches the balance", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: BigInt(2),
+      };
+      expect(
+        needsRefresh({
+          neuron,
+          balanceE8s: BigInt(2),
+        })
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

Check sns neuron balances with the stake and claim or refresh accordingly if they don't match

# Changes

* New sns-governance api: "getNeuronBalance", "refreshNeuron", "claimNeuron".
* Rename sns neuron service "loadSnsNeurons" to "syncSnsNeurons". Add balance check there.
* Add balance check in getSnsNeuron service.
* Balance check and refreshing is done in "checkSnsNeuronBalances". No recursion, each neuron refreshed is loaded independently.
* New method in sns neurons store "addNeurons".

# Tests

* Test new cases in syncSnsNeurons and getSnsNeuron services.
* Test new sns neurons method.
* Test new sns governance apis.
