### PR TITLE
feat: use back property instead of store

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-16.tgz",
-      "integrity": "sha512-yAl9aoex8EZ0CKxPuuShsb6do9H5IkmIjPhpsncpwuV2t3bnubeddHN+eyhPGP9rih/q90LTB+NU2uK1xrA//Q==",
+      "version": "2.0.0-next-2022-11-16.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-16.1.tgz",
+      "integrity": "sha512-11sBRfWDmbmOnd7qcYjOH1MwVPOFvpnYtGOZ/WAgpPs/jQ6z7WILeH3/qRSSCqRdIwsWrKXnVBCjTpFCcnvsIA==",
       "dependencies": {
         "dompurify": "^2.4.0"
       }
@@ -10990,9 +10990,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-16.tgz",
-      "integrity": "sha512-yAl9aoex8EZ0CKxPuuShsb6do9H5IkmIjPhpsncpwuV2t3bnubeddHN+eyhPGP9rih/q90LTB+NU2uK1xrA//Q==",
+      "version": "2.0.0-next-2022-11-16.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-16.1.tgz",
+      "integrity": "sha512-11sBRfWDmbmOnd7qcYjOH1MwVPOFvpnYtGOZ/WAgpPs/jQ6z7WILeH3/qRSSCqRdIwsWrKXnVBCjTpFCcnvsIA==",
       "requires": {
         "dompurify": "^2.4.0"
       }

--- a/frontend/src/lib/components/common/Layout.svelte
+++ b/frontend/src/lib/components/common/Layout.svelte
@@ -16,11 +16,7 @@
 <Layout>
   <MenuItems slot="menu-items" />
 
-  <Content
-    {back}
-    {contrast}
-    on:nnsBack={async () => await back?.()}
-  >
+  <Content {back} {contrast} on:nnsBack={async () => await back?.()}>
     <div use:triggerDebugReport slot="title">
       <HeaderTitle>{$layoutTitleStore}</HeaderTitle>
     </div>

--- a/frontend/src/lib/components/common/Layout.svelte
+++ b/frontend/src/lib/components/common/Layout.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import Banner from "../header/Banner.svelte";
   import MenuItems from "./MenuItems.svelte";
-  import { layoutTitleStore, layoutBackStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { Layout, HeaderTitle, Content } from "@dfinity/gix-components";
   import AccountMenu from "$lib/components/header/AccountMenu.svelte";
   import { triggerDebugReport } from "$lib/services/debug.services";
 
-  let back = false;
-  $: back = $layoutBackStore !== undefined;
+  export let back: () => Promise<void> | undefined = undefined;
 
   export let contrast = false;
 </script>
@@ -20,7 +19,7 @@
   <Content
     {back}
     {contrast}
-    on:nnsBack={async () => await $layoutBackStore?.()}
+    on:nnsBack={async () => await back?.()}
   >
     <div use:triggerDebugReport slot="title">
       <HeaderTitle>{$layoutTitleStore}</HeaderTitle>

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -30,7 +30,6 @@
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import CanisterCardTitle from "$lib/components/canisters/CanisterCardTitle.svelte";
   import CanisterCardSubTitle from "$lib/components/canisters/CanisterCardSubTitle.svelte";
-  import { layoutBackStore } from "$lib/stores/layout.store";
   import Footer from "$lib/components/common/Footer.svelte";
   import { goto } from "$app/navigation";
 
@@ -61,8 +60,6 @@
   });
 
   const goBack = (): Promise<void> => goto(AppPath.Canisters);
-
-  layoutBackStore.set(goBack);
 
   const selectedCanisterStore = writable<SelectCanisterDetailsStore>({
     info: undefined,

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -15,7 +15,7 @@
     isSpawning,
     neuronVoting,
   } from "$lib/utils/neuron.utils";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import NeuronJoinFundCard from "$lib/components/neuron-detail/NeuronJoinFundCard.svelte";
   import { toastsError } from "$lib/stores/toasts.store";
   import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
@@ -39,10 +39,7 @@
 
   // BEGIN: loading and navigation
 
-  const goBack = (replaceState: boolean): Promise<void> =>
-    goto(AppPath.Neurons, { replaceState });
-
-  layoutBackStore.set(async () => goBack(false));
+  const goBack = (): Promise<void> => goto(AppPath.Neurons, { replaceState: true });
 
   type NeuronFromStore = { neuron: NeuronInfo | undefined };
 

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -39,7 +39,8 @@
 
   // BEGIN: loading and navigation
 
-  const goBack = (): Promise<void> => goto(AppPath.Neurons, { replaceState: true });
+  const goBack = (): Promise<void> =>
+    goto(AppPath.Neurons, { replaceState: true });
 
   type NeuronFromStore = { neuron: NeuronInfo | undefined };
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -18,7 +18,6 @@
   } from "$lib/types/selected-account.context";
   import { getAccountFromStore } from "$lib/utils/accounts.utils";
   import { debugSelectedAccountStore } from "$lib/stores/debug.store";
-  import { layoutBackStore } from "$lib/stores/layout.store";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
   import type {
     AccountIdentifierString,
@@ -29,8 +28,6 @@
   import { AppPath } from "$lib/constants/routes.constants";
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);
-
-  layoutBackStore.set(goBack);
 
   let transactions: Transaction[] | undefined;
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -3,7 +3,7 @@
   import ProjectInfoSection from "$lib/components/project-detail/ProjectInfoSection.svelte";
   import ProjectStatusSection from "$lib/components/project-detail/ProjectStatusSection.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import {
     loadSnsSummary,
     loadSnsSwapCommitment,
@@ -28,7 +28,7 @@
       onError: () => {
         // Set to not found
         $projectDetailStore.summary = undefined;
-        goBack(true);
+        goBack();
       },
     });
 
@@ -38,7 +38,7 @@
       onError: () => {
         // Set to not found
         $projectDetailStore.swapCommitment = undefined;
-        goBack(true);
+        goBack();
       },
     });
 
@@ -66,8 +66,8 @@
     reload,
   });
 
-  const goBack = (replaceState: boolean): Promise<void> =>
-    goto(AppPath.Launchpad, { replaceState });
+  const goBack = (): Promise<void> =>
+    goto(AppPath.Launchpad, { replaceState: true });
 
   const mapProjectDetail = (rootCanisterId: string) => {
     // Check project summaries are loaded in store
@@ -114,13 +114,11 @@
     $snsSwapCommitmentsStore,
     (async () => {
       if (rootCanisterId === undefined || rootCanisterId === null) {
-        await goBack(true);
+        await goBack();
         return;
       }
       mapProjectDetail(rootCanisterId);
     })();
-
-  layoutBackStore.set(async () => goBack(false));
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
 
@@ -133,7 +131,7 @@
         labelKey: "error__sns.project_not_found",
       });
 
-      await goBack(true);
+      await goBack();
     }
   })();
 </script>

--- a/frontend/src/lib/pages/ProposalDetail.svelte
+++ b/frontend/src/lib/pages/ProposalDetail.svelte
@@ -4,7 +4,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import type { ProposalId, ProposalInfo } from "@dfinity/nns";
   import { neuronsStore } from "$lib/stores/neurons.store";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { writable } from "svelte/store";
   import type {
     SelectedProposalContext,
@@ -49,8 +49,6 @@
     goto(
       referrerPath === AppPath.Launchpad ? AppPath.Launchpad : AppPath.Proposals
     );
-
-  layoutBackStore.set(goBack);
 
   const findProposal = async () => {
     const onError = (certified: boolean) => {

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -5,7 +5,6 @@
   import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { getSnsNeuron } from "$lib/services/sns-neurons.services";
-  import { layoutBackStore } from "$lib/stores/layout.store";
   import {
     type SelectedSnsNeuronContext,
     type SelectedSnsNeuronStore,
@@ -35,8 +34,6 @@
 
   const goBack = (replaceState: boolean): Promise<void> =>
     goto(AppPath.Neurons, { replaceState });
-
-  layoutBackStore.set(async () => goBack(false));
 
   const loadNeuron = async (
     { forceFetch }: { forceFetch: boolean } = { forceFetch: false }

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -18,10 +18,7 @@
   import Footer from "$lib/components/common/Footer.svelte";
   import { i18n } from "$lib/stores/i18n";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
-  import { pageStore } from "$lib/derived/page.derived";
   import { goto } from "$app/navigation";
-  import { layoutBackStore } from "$lib/stores/layout.store";
-  import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import SnsTransactionsList from "$lib/components/accounts/SnsTransactionsList.svelte";
 
   // TODO: Clean after enabling sns https://dfinity.atlassian.net/browse/GIX-1013
@@ -31,11 +28,6 @@
       return;
     }
   });
-
-  const goBack = (): Promise<void> =>
-    goto(buildAccountsUrl({ universe: $pageStore.universe }));
-
-  layoutBackStore.set(goBack);
 
   let showNewTransactionModal = false;
 

--- a/frontend/src/lib/stores/layout.store.ts
+++ b/frontend/src/lib/stores/layout.store.ts
@@ -2,12 +2,6 @@ import { writable } from "svelte/store";
 
 export const layoutTitleStore = writable<string>("");
 
-// TODO(GIX-1071): can be inlined in each +layout.svelte
-// @deprecated
-export const layoutBackStore = writable<(() => Promise<void>) | undefined>(
-  undefined
-);
-
 // A store used to enable all sign-in buttons displayed on pages as enabled only once the app has been loaded
 // Once JS is loaded, auth has been synced and message listener are ready
 export const layoutAuthReady = writable<boolean>(false);

--- a/frontend/src/routes/(app)/accounts/+page.svelte
+++ b/frontend/src/routes/(app)/accounts/+page.svelte
@@ -3,7 +3,7 @@
   import { isSignedIn } from "$lib/utils/auth.utils";
   import SignInAccounts from "$lib/pages/SignInAccounts.svelte";
   import { onMount } from "svelte";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import RouteModule from "$lib/components/common/RouteModule.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -11,12 +11,7 @@
   let signedIn = false;
   $: signedIn = isSignedIn($authStore.identity);
 
-  onMount(() => {
-    layoutTitleStore.set($i18n.navigation.tokens);
-
-    // Reset back action because only detail routes have such feature other views use the menu
-    layoutBackStore.set(undefined);
-  });
+  onMount(() => layoutTitleStore.set($i18n.navigation.tokens));
 </script>
 
 {#if signedIn}

--- a/frontend/src/routes/(app)/canister/+layout.svelte
+++ b/frontend/src/routes/(app)/canister/+layout.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
+  import {goto} from "$app/navigation";
+  import {AppPath} from "$lib/constants/routes.constants";
+
+  const back = (): Promise<void> => goto(AppPath.Canisters);
 </script>
 
-<Layout contrast>
+<Layout contrast {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/canister/+layout.svelte
+++ b/frontend/src/routes/(app)/canister/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import {goto} from "$app/navigation";
-  import {AppPath} from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   const back = (): Promise<void> => goto(AppPath.Canisters);
 </script>

--- a/frontend/src/routes/(app)/canisters/+page.svelte
+++ b/frontend/src/routes/(app)/canisters/+page.svelte
@@ -3,7 +3,7 @@
   import { isSignedIn } from "$lib/utils/auth.utils";
   import SignInCanisters from "$lib/pages/SignInCanisters.svelte";
   import { onMount } from "svelte";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import RouteModule from "$lib/components/common/RouteModule.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -17,12 +17,7 @@
   let referrerPath: AppPath | undefined = undefined;
   afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
 
-  onMount(() => {
-    layoutTitleStore.set($i18n.navigation.canisters);
-
-    // Reset back action because only detail routes have such feature other views use the menu
-    layoutBackStore.set(undefined);
-  });
+  onMount(() => layoutTitleStore.set($i18n.navigation.canisters));
 </script>
 
 {#if signedIn}

--- a/frontend/src/routes/(app)/launchpad/+page.svelte
+++ b/frontend/src/routes/(app)/launchpad/+page.svelte
@@ -3,7 +3,7 @@
   import { isSignedIn } from "$lib/utils/auth.utils";
   import SignInSns from "$lib/pages/SignInSns.svelte";
   import { onMount } from "svelte";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
   import RouteModule from "$lib/components/common/RouteModule.svelte";
@@ -20,9 +20,6 @@
     }
 
     layoutTitleStore.set($i18n.sns_launchpad.header);
-
-    // Reset back action because only detail routes have such feature other views use the menu
-    layoutBackStore.set(undefined);
   });
 </script>
 

--- a/frontend/src/routes/(app)/neuron/+layout.svelte
+++ b/frontend/src/routes/(app)/neuron/+layout.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import {goto} from "$app/navigation";
-  import {AppPath} from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
-  const back = (): Promise<void> =>
-          goto(AppPath.Neurons);
+  const back = (): Promise<void> => goto(AppPath.Neurons);
 </script>
 
 <Layout contrast {back}>

--- a/frontend/src/routes/(app)/neuron/+layout.svelte
+++ b/frontend/src/routes/(app)/neuron/+layout.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
+  import {goto} from "$app/navigation";
+  import {AppPath} from "$lib/constants/routes.constants";
+
+  const back = (): Promise<void> =>
+          goto(AppPath.Neurons);
 </script>
 
-<Layout contrast>
+<Layout contrast {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/neurons/+page.svelte
+++ b/frontend/src/routes/(app)/neurons/+page.svelte
@@ -3,7 +3,7 @@
   import { isSignedIn } from "$lib/utils/auth.utils";
   import SignInNeurons from "$lib/pages/SignInNeurons.svelte";
   import { onMount } from "svelte";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import RouteModule from "$lib/components/common/RouteModule.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -11,12 +11,7 @@
   let signedIn = false;
   $: signedIn = isSignedIn($authStore.identity);
 
-  onMount(() => {
-    layoutTitleStore.set($i18n.navigation.neurons);
-
-    // Reset back action because only detail routes have such feature other views use the menu
-    layoutBackStore.set(undefined);
-  });
+  onMount(() => layoutTitleStore.set($i18n.navigation.neurons));
 </script>
 
 {#if signedIn}

--- a/frontend/src/routes/(app)/project/+layout.svelte
+++ b/frontend/src/routes/(app)/project/+layout.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import {goto} from "$app/navigation";
-  import {AppPath} from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
-  const back = (): Promise<void> =>
-          goto(AppPath.Launchpad, { replaceState: true });
+  const back = (): Promise<void> => goto(AppPath.Launchpad);
 </script>
 
 <Layout contrast {back}>

--- a/frontend/src/routes/(app)/project/+layout.svelte
+++ b/frontend/src/routes/(app)/project/+layout.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
+  import {goto} from "$app/navigation";
+  import {AppPath} from "$lib/constants/routes.constants";
+
+  const back = (): Promise<void> =>
+          goto(AppPath.Launchpad, { replaceState: true });
 </script>
 
-<Layout contrast>
+<Layout contrast {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/proposal/+layout.svelte
@@ -1,7 +1,19 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
+  import {afterNavigate, goto} from "$app/navigation";
+  import {AppPath} from "$lib/constants/routes.constants";
+  import type { Navigation } from "@sveltejs/kit";
+  import {referrerPathForNav} from "$lib/utils/page.utils";
+
+  let referrerPath: AppPath | undefined = undefined;
+  afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
+
+  const back = (): Promise<void> =>
+          goto(
+                  referrerPath === AppPath.Launchpad ? AppPath.Launchpad : AppPath.Proposals
+          );
 </script>
 
-<Layout contrast>
+<Layout contrast {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/proposal/+layout.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import {afterNavigate, goto} from "$app/navigation";
-  import {AppPath} from "$lib/constants/routes.constants";
+  import { afterNavigate, goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
   import type { Navigation } from "@sveltejs/kit";
-  import {referrerPathForNav} from "$lib/utils/page.utils";
+  import { referrerPathForNav } from "$lib/utils/page.utils";
 
   let referrerPath: AppPath | undefined = undefined;
   afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
 
   const back = (): Promise<void> =>
-          goto(
-                  referrerPath === AppPath.Launchpad ? AppPath.Launchpad : AppPath.Proposals
-          );
+    goto(
+      referrerPath === AppPath.Launchpad ? AppPath.Launchpad : AppPath.Proposals
+    );
 </script>
 
 <Layout contrast {back}>

--- a/frontend/src/routes/(app)/proposals/+page.svelte
+++ b/frontend/src/routes/(app)/proposals/+page.svelte
@@ -3,7 +3,7 @@
   import { isSignedIn } from "$lib/utils/auth.utils";
   import SignInProposals from "$lib/pages/SignInProposals.svelte";
   import { onMount } from "svelte";
-  import { layoutBackStore, layoutTitleStore } from "$lib/stores/layout.store";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import RouteModule from "$lib/components/common/RouteModule.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -17,12 +17,7 @@
   let referrerPath: AppPath | undefined = undefined;
   afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
 
-  onMount(() => {
-    layoutTitleStore.set($i18n.navigation.voting);
-
-    // Reset back action because only detail routes have such feature other views use the menu
-    layoutBackStore.set(undefined);
-  });
+  onMount(() => layoutTitleStore.set($i18n.navigation.voting));
 </script>
 
 {#if signedIn}

--- a/frontend/src/routes/(app)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/wallet/+layout.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
+  import {goto} from "$app/navigation";
+  import {AppPath} from "$lib/constants/routes.constants";
+
+  const back = (): Promise<void> => goto(AppPath.Accounts);
 </script>
 
-<Layout contrast>
+<Layout contrast {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/wallet/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import {goto} from "$app/navigation";
-  import {AppPath} from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   const back = (): Promise<void> => goto(AppPath.Accounts);
 </script>

--- a/frontend/src/tests/lib/components/common/LayoutTest.svelte
+++ b/frontend/src/tests/lib/components/common/LayoutTest.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
-  import { layoutBackStore } from "$lib/stores/layout.store";
 
   export let content: string;
   export let spy: () => void;
 
-  const goBack = () => spy();
-
-  layoutBackStore.set(goBack);
+  const back = () => spy();
 </script>
 
-<Layout>
+<Layout {back}>
   <p>{content}</p>
 </Layout>


### PR DESCRIPTION
# Motivation

The `layoutBackStore` was deprecated. In addition, updating the store after all components are mounted might lead to some glitch refreshing the navigation header - updating menu and back buttons - on route changes.

# PRs

- [x] linked with PR https://github.com/dfinity/gix-components/pull/115

# Changes

- deprecate `$layoutBackStore` and replace with property defined on `+layout`
