### PR TITLE
style: fix auto-fit usage for Firefox

### DIFF
--- a/frontend/src/lib/components/common/Footer.svelte
+++ b/frontend/src/lib/components/common/Footer.svelte
@@ -45,7 +45,7 @@
 
       @include media.min-width(small) {
         grid-template-columns: repeat(
-          auto-fit,
+          var(--footer-columns),
           minmax(calc(var(--footer-main-inner-width) / 2), 180px)
         );
       }


### PR DESCRIPTION
# Motivation

Firefox seems to have issue to interpret `auto-fit` in a `grid-template-columns` which has for effect to stack the footer buttons.

# Changes

- remove `auto-fit` and replace by `var(--footer-columns)` since we now have a value for the number of columns of the footer

# Screenshots

Before

<img width="1536" alt="Capture d’écran 2022-11-16 à 16 30 35" src="https://user-images.githubusercontent.com/16886711/202223156-642bc795-ab7b-4138-adc2-1a74c3907c7f.png">

After

<img width="1536" alt="Capture d’écran 2022-11-16 à 16 30 18" src="https://user-images.githubusercontent.com/16886711/202223193-3ab92783-446f-4cbb-9bee-b306151124f4.png">
