### PR TITLE
fix: votingNeuronSelectStore reset race condition

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -72,10 +72,7 @@
         })),
     });
 
-  onDestroy(() => {
-    unsubscribe();
-    votingNeuronSelectStore.reset();
-  });
+  onDestroy(() => unsubscribe());
 </script>
 
 {#if $definedNeuronsStore.length > 0}

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -204,6 +204,7 @@ const initNeuronSelectStore = () => {
       });
     },
 
+    // Used for testing purpose
     reset() {
       this.set([]);
     },


### PR DESCRIPTION
# Motivation

When navigating between proposals, it's possible that the next proposal gets mounted while the previous still destroy some components therefore it's possible that component `<VotingCard />` has its function `onDestroy` called after the next proposal is mounted. Because this function reset the scoped `votingNeuronSelectStore`, it's possible that as a side effect, these neurons gets resetted and the voting option per extension becomes disabled.

User -> proposal 1 -> voting neurons = 1,2,3
User -> proposal 2 -> voting neurons = 1,2,3
Destroy -> voting neurons = _
User -> still on proposal 2 -> ui re-rendered -> no voting neurons

# Changes

- remove `reset` from `onDestroy`. it can be ignored because on mount the `VotingCard` component first `set` the voting neurons and since we navigate between pages, it will be called.

# Screenshot

Side effect issue

<img width="1536" alt="Capture d’écran 2022-11-17 à 07 18 29" src="https://user-images.githubusercontent.com/16886711/202373375-6138873c-4df9-4c9a-ac44-19601f92f89d.png">

