### PR TITLE
Fix: Navigation and SNS Neuron Detail issues

### DIFF
--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -14,6 +14,7 @@ const initPageStoreMock = () => {
     subscribe,
 
     mock: ({
+      // routeId is the path
       routeId = undefined,
       data = { universe: OWN_CANISTER_ID_TEXT },
     }: {

--- a/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -11,6 +11,7 @@
   export let source: string;
   export let destinationAddress: string;
   export let loading = false;
+  export let secondaryButtonText: string = $i18n.core.back;
 
   const dispatcher = createEventDispatcher();
 </script>
@@ -29,7 +30,7 @@
     <button
       type="button"
       class="secondary"
-      on:click={() => dispatcher("nnsBack")}>{$i18n.core.back}</button
+      on:click={() => dispatcher("nnsBack")}>{secondaryButtonText}</button
     >
     <button class="primary" type="submit" data-tid="disburse-neuron-button">
       {#if loading}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -15,7 +15,7 @@
     hasPermissionToDissolve,
   } from "$lib/utils/sns-neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { isDefined, isNullish, nonNullish } from "$lib/utils/utils";
+  import { isNullish, nonNullish } from "$lib/utils/utils";
   import { NeuronState, type Token } from "@dfinity/nns";
   import DissolveSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte";
   import { fromDefinedNullable } from "@dfinity/utils";

--- a/frontend/src/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte
@@ -48,7 +48,7 @@
   };
 </script>
 
-<button on:click={showModal} class="secondary"
+<button on:click={showModal} class="secondary" data-tid="sns-dissolve-button"
   >{keyOf({ obj: $i18n.neuron_detail, key: buttonKey })}</button
 >
 {#if isOpen}

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -118,7 +118,11 @@
   {#if currentStep.name === "ConfirmDisburse" && destinationAddress !== undefined}
     <ConfirmDisburseNeuron
       on:nnsClose
+      on:nnsBack={() => {
+        dispatcher("nnsClose");
+      }}
       on:nnsConfirm={executeTransaction}
+      secondaryButtonText={$i18n.core.cancel}
       {amount}
       {source}
       {loading}

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -21,6 +21,7 @@
   import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
+  import { pageStore } from "$lib/derived/page.derived";
 
   export let neuronIdText: string | undefined | null;
 
@@ -46,7 +47,11 @@
 
   const neuronDidUpdate = async ({ neuron }: NeuronFromStore) => {
     // handle unknown neuronId from URL
-    if (neuron === undefined && $neuronsStore.neurons !== undefined) {
+    if (
+      neuron === undefined &&
+      $neuronsStore.neurons !== undefined &&
+      $pageStore.path === AppPath.Neuron
+    ) {
       toastsError({
         labelKey: $i18n.error.neuron_not_found,
       });

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -26,6 +26,7 @@
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { goto } from "$app/navigation";
   import { AppPath } from "$lib/constants/routes.constants";
+  import { pageStore } from "$lib/derived/page.derived";
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);
 
@@ -66,7 +67,11 @@
     }
 
     // handle unknown accountIdentifier from URL
-    if (account === undefined && $accountsStore.main !== undefined) {
+    if (
+      account === undefined &&
+      $accountsStore.main !== undefined &&
+      $pageStore.path === AppPath.Wallet
+    ) {
       toastsError({
         labelKey: replacePlaceholders($i18n.error.account_not_found, {
           $account_identifier: accountIdentifier ?? "",

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -3,7 +3,6 @@
   import type { SnsNeuron } from "@dfinity/sns";
   import SnsNeuronHotkeysCard from "$lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte";
   import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
   import { getSnsNeuron } from "$lib/services/sns-neurons.services";
   import {
     type SelectedSnsNeuronContext,
@@ -17,6 +16,8 @@
   import { goto } from "$app/navigation";
   import { pageStore } from "$lib/derived/page.derived";
   import SnsNeuronMaturityCard from "$lib/components/neuron-detail/SnsNeuronMaturityCard.svelte";
+  import { neuronsPathStore } from "$lib/derived/paths.derived";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   export let neuronId: string | null | undefined;
 
@@ -33,13 +34,13 @@
   // BEGIN: loading and navigation
 
   const goBack = (replaceState: boolean): Promise<void> =>
-    goto(AppPath.Neurons, { replaceState });
+    goto($neuronsPathStore, { replaceState });
 
   const loadNeuron = async (
     { forceFetch }: { forceFetch: boolean } = { forceFetch: false }
   ) => {
     const { selected } = $selectedSnsNeuronStore;
-    if (selected !== undefined) {
+    if (selected !== undefined && $pageStore.path === AppPath.Neuron) {
       await getSnsNeuron({
         forceFetch,
         rootCanisterId: selected.rootCanisterId,

--- a/frontend/src/routes/(app)/neuron/+layout.svelte
+++ b/frontend/src/routes/(app)/neuron/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
   import { goto } from "$app/navigation";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { neuronsPathStore } from "$lib/derived/paths.derived";
 
-  const back = (): Promise<void> => goto(AppPath.Neurons);
+  const back = (): Promise<void> => goto($neuronsPathStore);
 </script>
 
 <Layout contrast {back}>

--- a/frontend/src/routes/(app)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/wallet/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Layout from "$lib/components/common/Layout.svelte";
   import { goto } from "$app/navigation";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { accountsPathStore } from "$lib/derived/paths.derived";
 
-  const back = (): Promise<void> => goto(AppPath.Accounts);
+  const back = (): Promise<void> => goto($accountsPathStore);
 </script>
 
 <Layout contrast {back}>

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -42,7 +42,10 @@ describe("SnsNeuronDetail", () => {
 
   describe("when neuron and projects are valid and present", () => {
     beforeEach(() =>
-      page.mock({ data: { universe: rootCanisterIdMock.toText() } })
+      page.mock({
+        data: { universe: rootCanisterIdMock.toText() },
+        routeId: AppPath.Neuron,
+      })
     );
 
     const props = {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getSnsNeuronState,
   hasPermissions,
   hasPermissionToDisburse,
+  hasPermissionToDissolve,
   hasValidStake,
   isCommunityFund,
   isSnsNeuron,
@@ -538,6 +539,46 @@ describe("sns-neuron utils", () => {
 
       expect(
         hasPermissionToDisburse({
+          neuron,
+          identity: mockIdentity,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("hasPermissionToDissolve", () => {
+    it("returns true when user has disburse rights", () => {
+      const neuron: SnsNeuron = { ...mockSnsNeuron, permissions: [] };
+      appendPermissions({
+        neuron,
+        identity: mockIdentity,
+        permissions: [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE,
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE,
+        ],
+      });
+
+      expect(
+        hasPermissionToDissolve({
+          neuron,
+          identity: mockIdentity,
+        })
+      ).toBe(true);
+    });
+
+    it("returns false when user has no disburse rights", () => {
+      const neuron: SnsNeuron = { ...mockSnsNeuron, permissions: [] };
+      appendPermissions({
+        neuron,
+        identity: mockIdentity,
+        permissions: [
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE_MATURITY,
+          SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+        ],
+      });
+
+      expect(
+        hasPermissionToDissolve({
           neuron,
           identity: mockIdentity,
         })


### PR DESCRIPTION
# Motivation

Fix some navigation issues and hides dissolve buttons depending on permissions.

# Changes

* Change the button of the SNS Disburse modal. It was "back" but that was the first screen. Switched to "Cancel".
* New sns neuron util "hasPermissionToDissolve" used in SnsNeuronMetaInfoCard to hide Dissolve button.
* Check the path from the store before raising an error if neuron or wallet not found.
* Use `accountsPathStore` and `neuronsPathStore` to maintain the universe when going back from Wallet and Neuron detail.

# Tests

* Test the new util hasPermissionToDissolve
* Add test to SnsNeuronMetaInfoCard for new cases and also disburse cases.
* Fix test SnsNeuronDetail after new check.
