### PR TITLE
Fix: Shadow below sns neuron button

### DIFF
--- a/frontend/src/lib/components/neurons/SnsNeuronsFooter.svelte
+++ b/frontend/src/lib/components/neurons/SnsNeuronsFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Footer from "$lib/components/common/Footer.svelte";
-  import { Modal, Spinner, Toolbar } from "@dfinity/gix-components";
+  import { Modal, Spinner } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import StakeSnsNeuronModal from "$lib/modals/sns/StakeSnsNeuronModal.svelte";
   import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
@@ -12,15 +12,13 @@
   const closeModal = () => (showModal = undefined);
 </script>
 
-<Footer>
-  <Toolbar>
-    <button
-      data-tid="stake-sns-neuron-button"
-      class="primary full-width"
-      on:click={() => openModal("stake-neuron")}
-      >{$i18n.neurons.stake_neurons}</button
-    >
-  </Toolbar>
+<Footer columns={1}>
+  <button
+    data-tid="stake-sns-neuron-button"
+    class="primary full-width"
+    on:click={() => openModal("stake-neuron")}
+    >{$i18n.neurons.stake_neurons}</button
+  >
 </Footer>
 
 {#if showModal === "stake-neuron"}


### PR DESCRIPTION
# Motivation

Remove a shadow below the Stake Neuron button in SNS Neurons page.

# Changes

* Remove `Toolbar` from `SnsNeuronsFooter`. It's already included in the `Footer`.

# Tests

Only UI changes, no test required.
