### PR TITLE
FIX: Cache sns wrapper by identity

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -678,6 +678,12 @@
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
     "cannot_participate": "Sorry, There was an unexpected error while participating.",
     "invalid_root_canister_id": "Sorry, the project ID $canisterId is invalid.",
+    "ledger_temporarily_unavailable": "Sorry, the ledger is not available at the moment. Please try again later.",
+    "ledger_duplicate": "Sorry, the transaction is duplicated. Please try again.",
+    "ledger_bad_fee": "Sorry, wrong transaction fee applied. Please try again.",
+    "ledger_created_future": "Sorry, the transaction can't be created in the future. Please try again.",
+    "ledger_too_old": "Sorry, the transaction is too old. Please try again.",
+    "ledger_unsufficient_funds": "Sorry, the account doesn't have enough funds for this transaction.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   },
   "auth_accounts": {

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -4,6 +4,7 @@ import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
+import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
@@ -95,7 +96,10 @@ export const snsTransferTokens = async ({
     return { success: true };
   } catch (err) {
     toastsError(
-      toToastError({ fallbackErrorLabelKey: "error.transaction_error", err })
+      ledgerErrorToToastError({
+        fallbackErrorLabelKey: "error.transaction_error",
+        err,
+      })
     );
     return { success: false };
   }

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -22,6 +22,7 @@ import {
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
+import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
 import {
   getSnsDissolveDelaySeconds,
   getSnsNeuronByHexId,
@@ -416,7 +417,10 @@ export const stakeNeuron = async ({
     return { success: true };
   } catch (err) {
     toastsError(
-      toToastError({ err, fallbackErrorLabelKey: "error__sns.sns_stake" })
+      ledgerErrorToToastError({
+        err,
+        fallbackErrorLabelKey: "error__sns.sns_stake",
+      })
     );
     return { success: false };
   }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -712,6 +712,12 @@ interface I18nError__sns {
   commitment_exceeds_current_allowed: string;
   cannot_participate: string;
   invalid_root_canister_id: string;
+  ledger_temporarily_unavailable: string;
+  ledger_duplicate: string;
+  ledger_bad_fee: string;
+  ledger_created_future: string;
+  ledger_too_old: string;
+  ledger_unsufficient_funds: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/lib/utils/sns-ledger.utils.ts
+++ b/frontend/src/lib/utils/sns-ledger.utils.ts
@@ -1,0 +1,60 @@
+import { SnsTransferError } from "@dfinity/sns";
+import { toToastError } from "./error.utils";
+import type { I18nSubstitutions } from "./i18n.utils";
+
+export const ledgerErrorToToastError = ({
+  err,
+  fallbackErrorLabelKey,
+}: {
+  err: unknown;
+  fallbackErrorLabelKey: string;
+}): {
+  labelKey: string;
+  err?: unknown;
+  substitutions?: I18nSubstitutions;
+} => {
+  if (err instanceof SnsTransferError) {
+    const error: SnsTransferError = err;
+    if ("GenericError" in error.errorType) {
+      return {
+        labelKey: "error.transaction_error",
+        err: new Error(error.errorType.GenericError.message),
+      };
+    }
+    if ("TemporarilyUnavailable" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_temporarily_unavailable",
+      };
+    }
+    if ("Duplicate" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_duplicate",
+      };
+    }
+    if ("BadFee" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_bad_fee",
+      };
+    }
+    if ("CreatedInFuture" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_created_future",
+      };
+    }
+    if ("TooOld" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_too_old",
+      };
+    }
+    if ("InsufficientFunds" in error.errorType) {
+      return {
+        labelKey: "error__sns.ledger_unsufficient_funds",
+      };
+    }
+  }
+
+  return toToastError({
+    fallbackErrorLabelKey,
+    err,
+  });
+};


### PR DESCRIPTION
# Motivation

We are using different identities to interact with SNSes. For now logged in and anonymous.

Therefore, we need to cache the sns wrapper by identity so that we don't use the wrong wrapper. For example, using the anonymous identity wrapper to get the balance.

# Changes

* Change implementation of "wrappers" to cache by identity principal instead of only by certified or not.
* Map transfer errors and show a proper message according to each error.

# Tests

* No changes. Same functionality.
