### PR TITLE
Fix: Decode II proposal payload's arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idl2json"
+version = "0.8.1"
+source = "git+https://github.com/dfinity/idl2json?rev=3f81d545dc2c798495945fd50e96585e74968adf#3f81d545dc2c798495945fd50e96585e74968adf"
+dependencies = [
+ "candid",
+ "serde_json",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3373,7 @@ dependencies = [
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=a3608ed7cf64a01dcdb82486deb7aaa25d768787)",
  "ic-sns-swap",
  "ic-sns-wasm",
+ "idl2json",
  "itertools",
  "lazy_static",
  "ledger-canister",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
  "pretty",
  "serde",
  "serde_bytes",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1548,7 +1548,7 @@ checksum = "c301b1d4fc0b8ec0ee9bc558f702a2480c821e1fe647bf0d75fda46b3efa5602"
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2 0.10.5",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3033,10 +3033,11 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "idl2json"
 version = "0.8.1"
-source = "git+https://github.com/dfinity/idl2json?rev=3f81d545dc2c798495945fd50e96585e74968adf#3f81d545dc2c798495945fd50e96585e74968adf"
+source = "git+https://github.com/dfinity/idl2json?rev=c983dea6fc5666912218e7babf2b6b2f8b5648a4#c983dea6fc5666912218e7babf2b6b2f8b5648a4"
 dependencies = [
  "candid",
  "serde_json",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3385,7 +3386,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "tar",
 ]
 
@@ -4296,13 +4297,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]

--- a/frontend/src/lib/components/common/Json.svelte
+++ b/frontend/src/lib/components/common/Json.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { bytesToHexString, isHash } from "$lib/utils/utils";
+  import { isHash, stringifyJson } from "$lib/utils/utils";
   import { isPrincipal } from "$lib/utils/utils";
 
   export let json: unknown | undefined = undefined;
@@ -27,38 +27,6 @@
     if (Array.isArray(json) && isHash(json)) return "hash";
     return typeof value;
   };
-  const stringify = (value: unknown): string | object => {
-    switch (typeof value) {
-      case "object": {
-        if (value === null) {
-          return "null";
-        }
-        // Represent Principals as strings rather than as byte arrays when serializing to JSON strings
-        if (isPrincipal(value)) {
-          const asText = value.toString();
-          if (asText !== "[object Object]") {
-            // To not stringify NOT-Principal object that contains _isPrincipal field
-            return `"${asText}"`;
-          }
-        }
-        // optimistic hash stringifying
-        if (Array.isArray(value) && isHash(value)) {
-          return bytesToHexString(value);
-        }
-        return value;
-      }
-      case "string":
-        return `"${value}"`;
-      case "bigint":
-        return value.toString();
-      case "function":
-        return "f () { ... }";
-      case "symbol":
-        return value.toString();
-      default:
-        return `${value}`;
-    }
-  };
 
   let valueType: ValueType;
   let value: unknown;
@@ -74,7 +42,7 @@
   $: {
     valueType = getValueType(json);
     isExpandable = valueType === "object";
-    value = isExpandable ? json : stringify(json);
+    value = isExpandable ? json : stringifyJson(json);
     keyLabel = `${_key}${_key.length > 0 ? ": " : ""}`;
     children = isExpandable ? Object.entries(json as object) : [];
     hasChildren = children.length > 0;

--- a/frontend/src/lib/components/common/Json.svelte
+++ b/frontend/src/lib/components/common/Json.svelte
@@ -170,16 +170,22 @@
     margin: 0;
     padding: 0 0 0 var(--padding-1_5x);
     list-style: none;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
   }
   .key {
     display: inline-block;
     position: relative;
 
     color: var(--label-color);
+
+    margin-right: var(--padding-0_5x);
   }
-  .key-value {
-    // word-wrap long values in it's column
-    display: inline-flex;
+  .value {
+    // Values can be strings of JSON and long. We want to break the value, so that the keys stay on the same line.
+    word-break: break-all;
   }
   .arrow {
     @include interaction.tappable;
@@ -209,9 +215,11 @@
       position: absolute;
       left: 0;
       top: 0;
+      // Move left to compensate for the padding of the ul
+      // Move down to componsate for the gap between li
       transform: translate(
         calc(-1 * var(--padding-1_5x)),
-        calc(0.3 * var(--padding))
+        calc(0.8 * var(--padding))
       );
       font-size: var(--padding);
     }
@@ -243,7 +251,6 @@
     color: var(--json-principal-color);
   }
   .value.hash {
-    word-break: break-all;
     color: var(--json-hash-color);
   }
   .value.bigint {

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -28,8 +28,6 @@
       <span class="value" slot="value">
         {#if typeof value === "object"}
           <Json json={value} />
-        {:else if typeof value === "undefined"}
-          <Json json={null} />
         {:else}
           {value}
         {/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -6,7 +6,6 @@
   import type { Proposal } from "@dfinity/nns";
   import Json from "../common/Json.svelte";
   import { KeyValuePair } from "@dfinity/gix-components";
-  import { i18n } from "$lib/stores/i18n";
 
   export let proposal: Proposal | undefined;
 
@@ -30,7 +29,7 @@
         {#if typeof value === "object"}
           <Json json={value} />
         {:else if typeof value === "undefined"}
-          {$i18n.core.null}
+          <Json json={null} />
         {:else}
           {value}
         {/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -7,17 +7,16 @@
   import { SkeletonText } from "@dfinity/gix-components";
   import type { Proposal } from "@dfinity/nns";
   import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
-  import { expandObject } from "$lib/utils/utils";
+  import { expandObject, isNullish } from "$lib/utils/utils";
 
   export let proposalId: ProposalId | undefined;
   export let proposal: Proposal | undefined;
 
   let payload: object | undefined | null;
   let expandedPayload: object | undefined | null;
-  $: expandedPayload =
-    payload === undefined || payload === null
-      ? payload
-      : expandObject(payload as Record<string, unknown>);
+  $: expandedPayload = isNullish(payload)
+    ? payload
+    : expandObject(payload as Record<string, unknown>);
 
   $: $proposalPayloadsStore,
     (payload =

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -7,11 +7,17 @@
   import { SkeletonText } from "@dfinity/gix-components";
   import type { Proposal } from "@dfinity/nns";
   import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
+  import { expandObject } from "$lib/utils/utils";
 
   export let proposalId: ProposalId | undefined;
   export let proposal: Proposal | undefined;
 
   let payload: object | undefined | null;
+  let expandedPayload: object | undefined | null;
+  $: expandedPayload =
+    payload === undefined || payload === null
+      ? payload
+      : expandObject(payload as Record<string, unknown>);
 
   $: $proposalPayloadsStore,
     (payload =
@@ -41,9 +47,9 @@
   </h2>
 
   <div class="content-cell-details">
-    {#if payload !== undefined}
-      <div class="json">
-        <Json json={payload} />
+    {#if expandedPayload !== undefined}
+      <div class="json" data-tid="json-wrapper">
+        <Json json={expandedPayload} />
       </div>
     {:else}
       <SkeletonText />

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -27,7 +27,6 @@
     "ic": "Internet Computer",
     "previous": "Previous",
     "next": "Next",
-    "null": "NULL",
     "principal_is": "Your principal is"
   },
   "error": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -30,7 +30,6 @@ interface I18nCore {
   ic: string;
   previous: string;
   next: string;
-  null: string;
   principal_is: string;
 }
 

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -50,6 +50,11 @@ export const stringifyJson = (
             return asText === "[object Object]" ? value : asText;
           }
 
+          // optimistic hash stringifying
+          if (Array.isArray(value) && isHash(value)) {
+            return bytesToHexString(value);
+          }
+
           if (value instanceof Promise) {
             return "Promise(...)";
           }
@@ -312,3 +317,32 @@ export const isPngAsset = (
   asset: string | undefined | PngDataUrl
 ): asset is PngDataUrl =>
   nonNullish(asset) && asset.startsWith("data:image/png;base64,");
+
+/**
+ * Takes an object and tries to parse inner string as JSON.
+ * If it fails, it returns the original string value.
+ *
+ * For example: {b: '{"c":"d"}'} becomes {b: {c: 'd'}}
+ *
+ * @param obj
+ * @returns parsed object
+ */
+export const expandObject = (
+  obj: Record<string, unknown>
+): Record<string, unknown> =>
+  Object.keys(obj).reduce((acc, key) => {
+    const value = obj[key];
+    if (typeof value === "string") {
+      try {
+        acc[key] = JSON.parse(value);
+      } catch (e) {
+        acc[key] = value;
+      }
+    } else if (typeof value === "object") {
+      acc[key] =
+        value !== null ? expandObject(value as Record<string, unknown>) : value;
+    } else {
+      acc[key] = value;
+    }
+    return acc;
+  }, {} as Record<string, unknown>);

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
@@ -80,14 +80,14 @@ describe("ProposalProposerActionsEntry", () => {
     expect(motionActions.queryAllByTestId("json").length).toBe(0);
   });
 
-  it("should render undefined fields as 'null'", () => {
+  it("should render undefined fields as 'undefined'", () => {
     const { getByText } = render(ProposalProposerActionsEntry, {
       props: {
         proposal: proposalWithActionWithUndefined,
       },
     });
 
-    expect(getByText("null")).toBeInTheDocument();
+    expect(getByText("undefined")).toBeInTheDocument();
   });
 
   it("should render nnsFunction id", () => {

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
@@ -6,7 +6,6 @@ import ProposalProposerActionsEntry from "$lib/components/proposal-detail/Propos
 import { proposalFirstActionKey } from "$lib/utils/proposals.utils";
 import type { Action, Proposal } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import en from "../../../mocks/i18n.mock";
 import {
   mockProposalInfo,
   proposalActionMotion,
@@ -81,14 +80,14 @@ describe("ProposalProposerActionsEntry", () => {
     expect(motionActions.queryAllByTestId("json").length).toBe(0);
   });
 
-  it("should render undefined fields as NULL", () => {
+  it("should render undefined fields as 'null'", () => {
     const { getByText } = render(ProposalProposerActionsEntry, {
       props: {
         proposal: proposalWithActionWithUndefined,
       },
     });
 
-    expect(getByText(en.core.null)).toBeInTheDocument();
+    expect(getByText("null")).toBeInTheDocument();
   });
 
   it("should render nnsFunction id", () => {

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -2,6 +2,7 @@ import {
   bytesToHexString,
   createChunks,
   debounce,
+  expandObject,
   hexStringToBytes,
   isDefined,
   isHash,
@@ -449,6 +450,18 @@ describe("utils", () => {
       expect(isPngAsset(svg1)).toBe(false);
       expect(isPngAsset(jpg1)).toBe(false);
       expect(isPngAsset(pngFake)).toBe(false);
+    });
+  });
+
+  describe("expandObject", () => {
+    it("should not do anything in strings that are not JSON", () => {
+      const obj = { a: "a string" };
+      expect(expandObject(obj)).toEqual(obj);
+    });
+
+    it("should parse JSON strings", () => {
+      const obj = { a: JSON.stringify({ b: "c" }) };
+      expect(expandObject(obj)).toEqual({ a: { b: "c" } });
     });
   });
 });

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -49,6 +49,7 @@ ledger-canister = { git = "https://github.com/dfinity/ic", rev = "a3608ed7cf64a0
 on_wire = { git = "https://github.com/dfinity/ic", rev = "a3608ed7cf64a01dcdb82486deb7aaa25d768787" }
 # Registry canister deploy as of 2022-11-23, ahead of Blessed Replica Version
 registry-canister = { git = "https://github.com/dfinity/ic", rev = "0a729806f2fbc717f2183b07efac19f24f32e717" }
+idl2json = { git = "https://github.com/dfinity/idl2json", rev="3f81d545dc2c798495945fd50e96585e74968adf" }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0.136"
 serde_bytes = "0.11.5"
 serde_cbor = "0.11.2"
 serde_json = "1.0.81"
-sha2 = "0.9.1"
+sha2 = "0.10.6"
 lzma-rs = "0.2.0"
 tar = "0.4.37"
 hex = "0.4.3"
@@ -49,7 +49,7 @@ ledger-canister = { git = "https://github.com/dfinity/ic", rev = "a3608ed7cf64a0
 on_wire = { git = "https://github.com/dfinity/ic", rev = "a3608ed7cf64a01dcdb82486deb7aaa25d768787" }
 # Registry canister deploy as of 2022-11-23, ahead of Blessed Replica Version
 registry-canister = { git = "https://github.com/dfinity/ic", rev = "0a729806f2fbc717f2183b07efac19f24f32e717" }
-idl2json = { git = "https://github.com/dfinity/idl2json", rev="3f81d545dc2c798495945fd50e96585e74968adf" }
+idl2json = { git = "https://github.com/dfinity/idl2json", rev="c983dea6fc5666912218e7babf2b6b2f8b5648a4" }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -20,7 +20,7 @@ use ic_nns_constants::IDENTITY_CANISTER_ID;
 use ic_nns_governance::pb::v1::proposal::Action;
 use ic_nns_governance::pb::v1::ProposalInfo;
 use idl2json::candid_types::internal_candid_type_to_idl_type;
-use idl2json::{BytesFormat, idl2json_with_weak_names, Idl2JsonOptions};
+use idl2json::{idl2json_with_weak_names, BytesFormat, Idl2JsonOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::cell::RefCell;
@@ -90,7 +90,10 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
     };
 
     let idl_value = Decode!(arg, IDLValue).expect("Binary is not valid candid");
-    let options = Idl2JsonOptions{ bytes_as: Some(BytesFormat::Hex), long_bytes_as: None };
+    let options = Idl2JsonOptions {
+        bytes_as: Some(BytesFormat::Hex),
+        long_bytes_as: None,
+    };
     let json_value = idl2json_with_weak_names(&idl_value, &idl_type, &options);
     serde_json::to_string(&json_value).expect("Failed to serialize JSON")
 }

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -239,8 +239,7 @@ mod def {
         pub mode: CanisterInstallMode,
         pub canister_id: CanisterId,
         pub wasm_module_hash: String,
-        #[serde(with = "serde_bytes")]
-        pub arg: Vec<u8>,
+        pub arg: String,
         pub candid_arg: Json,
         #[serde(serialize_with = "serialize_optional_nat")]
         pub compute_allocation: Option<candid::Nat>,
@@ -261,7 +260,7 @@ mod def {
                 mode: payload.mode,
                 canister_id: payload.canister_id,
                 wasm_module_hash,
-                arg: payload.arg,
+                arg: hex::encode(&payload.arg),
                 candid_arg,
                 compute_allocation: payload.compute_allocation,
                 memory_allocation: payload.memory_allocation,


### PR DESCRIPTION
# Motivation

The payload of the proposal when upgrading a canister has an arg property. This property is a candid blob that in the case of Internet Identity is important to deserialize to be able to properly validate the proposal.

# Changes

* Create a helper that given the value of "arg" and the canister id returns a json representation of it.
* In ProposalProposerPayloadEntry.svelte expand the object to parse any string value that is JSON.
* Util "expandObject" that parses JSON strings of an object.
* Render "null" instead of "NULL" for undefined properties in payloads. For consistency with "null" in JSON stringify.
* Json component uses "stringifyJson" util instead of it's own "stringify".
* CSS Style changes in Json component.

# Tests

* Test new use cases for ProposalProposerPayloadEntry.
* Test new util expandObject.
* Fix broken tests after some changes.
