### PR TITLE
GIX-1148: SNS Stake Neuron Transaction

### DIFF
--- a/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
@@ -1,19 +1,29 @@
 <script lang="ts">
+  import { projectsStore } from "$lib/stores/projects.store";
   import type { Account } from "$lib/types/account";
   import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
   import type { Transaction } from "$lib/utils/transactions.utils";
+  import type { Principal } from "@dfinity/principal";
   import type { SnsTransactionWithId } from "@dfinity/sns";
   import TransactionCard from "./TransactionCard.svelte";
 
   export let transactionWithId: SnsTransactionWithId;
   export let account: Account;
   export let toSelfTransaction: boolean;
+  export let rootCanisterId: Principal;
+
+  let governanceCanisterId: Principal | undefined;
+  $: governanceCanisterId = $projectsStore?.find(
+    ({ rootCanisterId: currentId }) =>
+      currentId.toText() === rootCanisterId.toText()
+  )?.summary.governanceCanisterId;
 
   let transactionData: Transaction | undefined;
   $: transactionData = mapSnsTransaction({
     transaction: transactionWithId,
     account,
     toSelfTransaction,
+    governanceCanisterId,
   });
 </script>
 

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -67,6 +67,7 @@
           transactionWithId={transaction}
           {toSelfTransaction}
           {account}
+          {rootCanisterId}
         />
       {/each}
     </InfiniteScroll>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -374,9 +374,9 @@
     "send": "Sent $tokenSymbol",
     "mint": "Received $tokenSymbol",
     "burn": "Sent $tokenSymbol",
-    "stakeNeuron": "Stake Neuron",
-    "stakeNeuronNotification": "Stake Neuron (Part 2 of 2)",
-    "topUpNeuron": "Top-up Neuron",
+    "stakeNeuron": "Stake $tokenSymbol Neuron",
+    "stakeNeuronNotification": "Stake $tokenSymbol Neuron (Part 2 of 2)",
+    "topUpNeuron": "Top-up $tokenSymbol Neuron",
     "createCanister": "Create Canister",
     "topUpCanister": "Top-up Canister",
     "participateSwap": "Decentralized Sale"

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -79,10 +79,10 @@ describe("SnsTransactionCard", () => {
       owner: mockSnsFullProject.summary.governanceCanisterId,
       subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
     };
-    const stakeNeuronTransactoin = createSnstransactionWithId(toGov, from);
+    const stakeNeuronTransaction = createSnstransactionWithId(toGov, from);
     const { getByText } = renderTransactionCard(
       mockSnsMainAccount,
-      stakeNeuronTransactoin,
+      stakeNeuronTransaction,
       mockSnsFullProject.rootCanisterId
     );
 

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -6,7 +6,7 @@ import {
   mapSnsTransaction,
 } from "$lib/utils/sns-transactions.utils";
 import { AccountTransactionType } from "$lib/utils/transactions.utils";
-import { Principal } from "@dfinity/principal";
+import { principal } from "src/tests/mocks/sns-projects.mock";
 import { mockPrincipal } from "../..//mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
@@ -184,7 +184,7 @@ describe("sns-transaction utils", () => {
     });
 
     it("maps stake neuron transaction", () => {
-      const governanceCanisterId = Principal.fromText("aaaaa-aa");
+      const governanceCanisterId = principal(2);
       const toGovernance = {
         owner: governanceCanisterId,
         subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -6,12 +6,12 @@ import {
   mapSnsTransaction,
 } from "$lib/utils/sns-transactions.utils";
 import { AccountTransactionType } from "$lib/utils/transactions.utils";
-import { principal } from "src/tests/mocks/sns-projects.mock";
 import { mockPrincipal } from "../..//mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "../..//mocks/sns-accounts.mock";
+import { principal } from "../../mocks/sns-projects.mock";
 import { createSnstransactionWithId } from "../../mocks/sns-transactions.mock";
 
 describe("sns-transaction utils", () => {

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -5,12 +5,14 @@ import {
   isTransactionsCompleted,
   mapSnsTransaction,
 } from "$lib/utils/sns-transactions.utils";
+import { AccountTransactionType } from "$lib/utils/transactions.utils";
+import { Principal } from "@dfinity/principal";
 import { mockPrincipal } from "../..//mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "../..//mocks/sns-accounts.mock";
-import { createSnstransactionWithId } from "../..//mocks/sns-transactions.mock";
+import { createSnstransactionWithId } from "../../mocks/sns-transactions.mock";
 
 describe("sns-transaction utils", () => {
   const to = {
@@ -179,6 +181,27 @@ describe("sns-transaction utils", () => {
       });
       expect(data.isSend).toBe(true);
       expect(data.isReceive).toBe(false);
+    });
+
+    it("maps stake neuron transaction", () => {
+      const governanceCanisterId = Principal.fromText("aaaaa-aa");
+      const toGovernance = {
+        owner: governanceCanisterId,
+        subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+      };
+      const stakeNeuronTransaction = createSnstransactionWithId(
+        toGovernance,
+        from
+      );
+      const data = mapSnsTransaction({
+        transaction: stakeNeuronTransaction,
+        account: mockSnsMainAccount,
+        toSelfTransaction: false,
+        governanceCanisterId,
+      });
+      expect(data.isSend).toBe(true);
+      expect(data.isReceive).toBe(false);
+      expect(data.type).toBe(AccountTransactionType.StakeNeuron);
     });
 
     it("maps received transaction", () => {


### PR DESCRIPTION
# Motivation

User can identify transactions related to neurons in the SNS Wallet page.

# Changes

* Add "rootCanisterId" prop to SnsTransactionCard.
* In SnsTransactionCard get the project related to the "rootCanisterId" prop and pass the governanceCanisterId to "mapSnsTransaction"
* Add new parameter to "mapSnsTransaction": governanceCanisterId. This is used to identify transactions related to neurons.
* Add the token symbol in the headline of transactions related to neurons.

# Tests

* Test new case in mapSnsTransaction.
* Test new case in SnsTransactionCard.
