### PR TITLE
GIX-1111: Render SNS Topics

### DIFF
--- a/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
+++ b/frontend/src/lib/components/neurons/EditFollowNeurons.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import type { Topic } from "@dfinity/nns";
-  import FollowTopicSection from "./FollowTopicSection.svelte";
+  import FollowNnsTopicSection from "./FollowNnsTopicSection.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { onMount } from "svelte";
   import { listKnownNeurons } from "$lib/services/knownNeurons.services";
@@ -9,7 +9,7 @@
 
   export let neuron: NeuronInfo;
 
-  // Load KnownNeurons which are used in the FollowTopicSections
+  // Load KnownNeurons which are used in the FollowNnsTopicSections
   onMount(() => listKnownNeurons());
 
   const topics: Topic[] = topicsToFollow(neuron);
@@ -19,7 +19,7 @@
   <p class="description">{$i18n.follow_neurons.description}</p>
   <div>
     {#each topics as topic}
-      <FollowTopicSection {neuron} {topic} />
+      <FollowNnsTopicSection {neuron} {topic} />
     {/each}
   </div>
 </div>

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -18,8 +18,6 @@
   $: title = $i18n.follow_neurons[`topic_${topic}_title`];
   let subtitle: string;
   $: subtitle = $i18n.follow_neurons[`topic_${topic}_subtitle`];
-  let id: string;
-  $: id = Topic[topic];
 
   let showNewFolloweeModal = false;
   type FolloweeData = {
@@ -67,7 +65,7 @@
   count={followees.length}
 >
   <ul>
-    {#each followees as followee}
+    {#each followees as followee (followee.neuronId)}
       <li data-tid="current-followee-item">
         <KeyValuePair>
           <p slot="key" class="value">{followee.name ?? followee.neuronId}</p>

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -59,11 +59,11 @@
 
 <FollowTopicSection
   on:nnsOpen={openNewFolloweeModal}
-  {title}
-  {subtitle}
   id={String(topic)}
   count={followees.length}
 >
+  <h3 slot="title">{title}</h3>
+  <p slot="subtitle" class="subtitle description">{subtitle}</p>
   <ul>
     {#each followees as followee (followee.neuronId)}
       <li data-tid="current-followee-item">
@@ -86,5 +86,14 @@
   ul {
     list-style-type: none;
     padding: 0;
+  }
+
+  h3 {
+    // Titles longer than one line had too much space with the default line-height for h3
+    line-height: normal;
+  }
+
+  .subtitle {
+    margin: 0 0 var(--padding) 0;
   }
 </style>

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // Tested in EditFollowNeurons.spec.ts
-  import { type NeuronId, Topic, type NeuronInfo } from "@dfinity/nns";
+  import type { NeuronId, Topic, NeuronInfo } from "@dfinity/nns";
   import NewFolloweeModal from "$lib/modals/neurons/NewFolloweeModal.svelte";
   import { removeFollowee } from "$lib/services/neurons.services";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  // Tested in EditFollowNeurons.spec.ts
+  import { type NeuronId, Topic, type NeuronInfo } from "@dfinity/nns";
+  import NewFolloweeModal from "$lib/modals/neurons/NewFolloweeModal.svelte";
+  import { removeFollowee } from "$lib/services/neurons.services";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { knownNeuronsStore } from "$lib/stores/knownNeurons.store";
+  import { followeesByTopic } from "$lib/utils/neuron.utils";
+  import FollowTopicSection from "./FollowTopicSection.svelte";
+  import { KeyValuePair } from "@dfinity/gix-components";
+
+  export let topic: Topic;
+  export let neuron: NeuronInfo;
+
+  // TODO: Align with `en.governance.json` "topics.[topic]"
+  let title: string;
+  $: title = $i18n.follow_neurons[`topic_${topic}_title`];
+  let subtitle: string;
+  $: subtitle = $i18n.follow_neurons[`topic_${topic}_subtitle`];
+  let id: string;
+  $: id = Topic[topic];
+
+  let showNewFolloweeModal = false;
+  type FolloweeData = {
+    neuronId: NeuronId;
+    name?: string;
+  };
+  let followees: FolloweeData[] = [];
+  $: {
+    const followesPerTopic = followeesByTopic({ neuron, topic });
+    const mapToKnownNeuron = (neuronId: NeuronId): FolloweeData => {
+      const knownNeuron = $knownNeuronsStore.find(
+        (currentNeuron) => currentNeuron.id === neuronId
+      );
+      return knownNeuron !== undefined
+        ? {
+            neuronId: knownNeuron.id,
+            name: knownNeuron.name,
+          }
+        : { neuronId };
+    };
+    // If we remove the last followee of that topic, followesPerTopic is undefined.
+    // and we need to reset the followees array
+    followees = followesPerTopic?.map(mapToKnownNeuron) ?? [];
+  }
+
+  const openNewFolloweeModal = () => (showNewFolloweeModal = true);
+  const closeNewFolloweeModal = () => (showNewFolloweeModal = false);
+
+  const removeCurrentFollowee = async (followee: NeuronId) => {
+    startBusy({ initiator: "remove-followee" });
+    await removeFollowee({
+      neuronId: neuron.neuronId,
+      topic,
+      followee,
+    });
+    stopBusy("remove-followee");
+  };
+</script>
+
+<FollowTopicSection
+  on:nnsOpen={openNewFolloweeModal}
+  {title}
+  {subtitle}
+  id={String(topic)}
+  count={followees.length}
+>
+  <ul>
+    {#each followees as followee}
+      <li data-tid="current-followee-item">
+        <KeyValuePair>
+          <p slot="key" class="value">{followee.name ?? followee.neuronId}</p>
+          <button
+            slot="value"
+            on:click={() => removeCurrentFollowee(followee.neuronId)}>x</button
+          >
+        </KeyValuePair>
+      </li>
+    {/each}
+  </ul>
+</FollowTopicSection>
+{#if showNewFolloweeModal}
+  <NewFolloweeModal {neuron} {topic} on:nnsClose={closeNewFolloweeModal} />
+{/if}
+
+<style lang="scss">
+  ul {
+    list-style-type: none;
+    padding: 0;
+  }
+</style>

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -1,64 +1,20 @@
 <script lang="ts">
-  // Tested in EditFollowNeurons.spec.ts
-  import { type NeuronId, Topic, type NeuronInfo } from "@dfinity/nns";
-  import NewFolloweeModal from "$lib/modals/neurons/NewFolloweeModal.svelte";
-  import { removeFollowee } from "$lib/services/neurons.services";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import { knownNeuronsStore } from "$lib/stores/knownNeurons.store";
-  import { followeesByTopic } from "$lib/utils/neuron.utils";
   import { Collapsible } from "@dfinity/gix-components";
+  import { createEventDispatcher } from "svelte";
 
-  export let topic: Topic;
-  export let neuron: NeuronInfo;
+  export let title: string;
+  export let subtitle: string;
+  export let id: string;
+  export let count: number;
 
-  // TODO: Align with `en.governance.json` "topics.[topic]"
-  let title: string;
-  $: title = $i18n.follow_neurons[`topic_${topic}_title`];
-  let subtitle: string;
-  $: subtitle = $i18n.follow_neurons[`topic_${topic}_subtitle`];
-  let id: string | undefined;
-  $: id = Topic[topic];
-
-  let showNewFolloweeModal = false;
-  type FolloweeData = {
-    neuronId: NeuronId;
-    name?: string;
-  };
-  let followees: FolloweeData[] = [];
-  $: {
-    const followesPerTopic = followeesByTopic({ neuron, topic });
-    const mapToKnownNeuron = (neuronId: NeuronId): FolloweeData => {
-      const knownNeuron = $knownNeuronsStore.find(
-        (currentNeuron) => currentNeuron.id === neuronId
-      );
-      return knownNeuron !== undefined
-        ? {
-            neuronId: knownNeuron.id,
-            name: knownNeuron.name,
-          }
-        : { neuronId };
-    };
-    // If we remove the last followee of that topic, followesPerTopic is undefined.
-    // and we need to reset the followees array
-    followees = followesPerTopic?.map(mapToKnownNeuron) ?? [];
-  }
-
-  const openNewFolloweeModal = () => (showNewFolloweeModal = true);
-  const closeNewFolloweeModal = () => (showNewFolloweeModal = false);
-
-  const removeCurrentFollowee = async (followee: NeuronId) => {
-    startBusy({ initiator: "remove-followee" });
-    await removeFollowee({
-      neuronId: neuron.neuronId,
-      topic,
-      followee,
-    });
-    stopBusy("remove-followee");
+  const dispatcher = createEventDispatcher();
+  const open = () => {
+    dispatcher("nnsOpen");
   };
 </script>
 
-<article data-tid={`follow-topic-${topic}-section`}>
+<article data-tid={`follow-topic-${id}-section`}>
   <Collapsible {id} iconSize="medium">
     <div class="wrapper" slot="header">
       <div>
@@ -66,35 +22,25 @@
         <p class="subtitle description">{subtitle}</p>
       </div>
       <div class="toolbar">
-        <h3 class="badge" data-tid={`topic-${topic}-followees-badge`}>
-          {followees.length}
+        <h3 class="badge" data-tid={`topic-${id}-followees-badge`}>
+          {count}
         </h3>
       </div>
     </div>
     <div class="content" data-tid="follow-topic-section-current">
       <p class="label">{$i18n.follow_neurons.current_followees}</p>
-      <ul>
-        {#each followees as followee}
-          <li data-tid="current-followee-item">
-            <p class="value">{followee.name ?? followee.neuronId}</p>
-            <button on:click={() => removeCurrentFollowee(followee.neuronId)}
-              >x</button
-            >
-          </li>
-        {/each}
-      </ul>
+      <div class="followees-wrapper">
+        <slot />
+      </div>
       <div class="button-wrapper">
         <button
           class="primary"
           data-tid="open-new-followee-modal"
-          on:click={openNewFolloweeModal}>{$i18n.follow_neurons.add}</button
+          on:click={open}>{$i18n.follow_neurons.add}</button
         >
       </div>
     </div>
   </Collapsible>
-  {#if showNewFolloweeModal}
-    <NewFolloweeModal {neuron} {topic} on:nnsClose={closeNewFolloweeModal} />
-  {/if}
 </article>
 
 <style lang="scss">
@@ -147,23 +93,15 @@
   }
 
   .content {
+    .followees-wrapper {
+      padding: 0 var(--padding) 0 0;
+      margin-bottom: var(--padding);
+    }
     .button-wrapper {
       display: flex;
       align-items: center;
       justify-content: center;
       padding: var(--padding) 0;
-    }
-
-    ul {
-      list-style-type: none;
-      padding: 0 var(--padding) 0 0;
-      margin-bottom: var(--padding);
-    }
-
-    li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
     }
   }
 </style>

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -3,8 +3,6 @@
   import { Collapsible } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
 
-  export let title: string;
-  export let subtitle: string | undefined;
   export let id: string;
   export let count: number;
 
@@ -18,10 +16,8 @@
   <Collapsible {id} iconSize="medium">
     <div class="wrapper" slot="header">
       <div>
-        <h3>{title}</h3>
-        {#if subtitle !== undefined}
-          <p class="subtitle description">{subtitle}</p>
-        {/if}
+        <slot name="title" />
+        <slot name="subtitle" />
       </div>
       <div class="toolbar">
         <h3 class="badge" data-tid={`topic-${id}-followees-badge`}>
@@ -49,11 +45,6 @@
   @use "@dfinity/gix-components/styles/mixins/interaction";
 
   article {
-    h3 {
-      // Titles longer than one line had too much space with the default line-height for h3
-      line-height: normal;
-    }
-
     :global(.collapsible-expand-icon) {
       align-items: start;
       padding-top: var(--padding-3x);
@@ -66,10 +57,6 @@
     justify-content: space-between;
     gap: var(--padding-2x);
     width: 100%;
-  }
-
-  .subtitle {
-    margin: 0 0 var(--padding) 0;
   }
 
   .toolbar {

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -4,7 +4,7 @@
   import { createEventDispatcher } from "svelte";
 
   export let title: string;
-  export let subtitle: string;
+  export let subtitle: string | undefined;
   export let id: string;
   export let count: number;
 
@@ -19,7 +19,9 @@
     <div class="wrapper" slot="header">
       <div>
         <h3>{title}</h3>
-        <p class="subtitle description">{subtitle}</p>
+        {#if subtitle !== undefined}
+          <p class="subtitle description">{subtitle}</p>
+        {/if}
       </div>
       <div class="toolbar">
         <h3 class="badge" data-tid={`topic-${id}-followees-badge`}>

--- a/frontend/src/lib/constants/sns-neurons.constants.ts
+++ b/frontend/src/lib/constants/sns-neurons.constants.ts
@@ -7,3 +7,5 @@ export const HOTKEY_PERMISSIONS = [
   SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
   SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_SUBMIT_PROPOSAL,
 ];
+
+export const UNSPECIFIED_FUNCTION_ID = BigInt(0);

--- a/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
@@ -1,20 +1,45 @@
 <script lang="ts">
+  import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { Modal } from "@dfinity/gix-components";
+  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+  import { functionsToFollow } from "$lib/utils/sns-neuron.utils";
+  import { Modal, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNervousSystemFunction } from "@dfinity/sns";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
+
+  let functions: SnsNervousSystemFunction[] | undefined;
+  $: functions = functionsToFollow(
+    $snsFunctionsStore[rootCanisterId.toString()]
+  );
 </script>
 
 <Modal on:nnsClose testId="follow-sns-neurons-modal">
   <svelte:fragment slot="title"
     >{$i18n.neurons.follow_neurons_screen}</svelte:fragment
   >
-  <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
-  <p>{rootCanisterId.toText()}</p>
-  {#each neuron.followees as followee}
-    <div>{JSON.stringify(followee)}</div>
-  {/each}
+  <p class="description">{$i18n.follow_neurons.description}</p>
+  <div>
+    {#if functions === undefined}
+      <Spinner />
+    {:else}
+      {#each functions as { name, id, description }}
+        <FollowTopicSection count={0} title={name} subtitle={description} {id}>
+          <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
+          <div>{`TODO: render followees ${neuron.followees.length}`}</div>
+        </FollowTopicSection>
+      {/each}
+    {/if}
+  </div>
 </Modal>
+
+<style lang="scss">
+  div {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-1_5x);
+  }
+</style>

--- a/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
@@ -7,6 +7,7 @@
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
+  import { fromNullable } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
@@ -27,7 +28,12 @@
       <Spinner />
     {:else}
       {#each functions as { name, id, description }}
-        <FollowTopicSection count={0} title={name} subtitle={description} {id}>
+        <FollowTopicSection
+          count={0}
+          title={name}
+          subtitle={fromNullable(description)}
+          id={id.toString()}
+        >
           <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
           <div>{`TODO: render followees ${neuron.followees.length}`}</div>
         </FollowTopicSection>

--- a/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
@@ -22,18 +22,17 @@
   <svelte:fragment slot="title"
     >{$i18n.neurons.follow_neurons_screen}</svelte:fragment
   >
-  <p class="description">{$i18n.follow_neurons.description}</p>
   <div>
+    <p class="description">{$i18n.follow_neurons.description}</p>
     {#if functions === undefined}
       <Spinner />
     {:else}
       {#each functions as { name, id, description }}
-        <FollowTopicSection
-          count={0}
-          title={name}
-          subtitle={fromNullable(description)}
-          id={id.toString()}
-        >
+        <FollowTopicSection count={0} id={id.toString()}>
+          <h3 slot="title">{name}</h3>
+          <p slot="subtitle" class="subtitle description">
+            {fromNullable(description)}
+          </p>
           <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
           <div>{`TODO: render followees ${neuron.followees.length}`}</div>
         </FollowTopicSection>
@@ -47,5 +46,14 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-1_5x);
+  }
+
+  h3 {
+    // Titles longer than one line had too much space with the default line-height for h3
+    line-height: normal;
+  }
+
+  .subtitle {
+    margin: 0 0 var(--padding) 0;
   }
 </style>

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -1,4 +1,7 @@
-import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
+import {
+  HOTKEY_PERMISSIONS,
+  UNSPECIFIED_FUNCTION_ID,
+} from "$lib/constants/sns-neurons.constants";
 import { formatToken } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
@@ -298,7 +301,6 @@ export const needsRefresh = ({
  * https://github.com/dfinity/ic/blob/5248f11c18ca564881bbb82a4eb6915efb7ca62f/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto#L582
  *
  */
-const UNSPECIFIED_FUNCTION_ID = BigInt(0);
 export const functionsToFollow = (
   functions: SnsNervousSystemFunction[] | undefined
 ): SnsNervousSystemFunction[] | undefined =>

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -2,6 +2,7 @@ import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { formatToken } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
+import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
 import { nowInSeconds } from "./date.utils";
@@ -289,3 +290,16 @@ export const needsRefresh = ({
   neuron: SnsNeuron;
   balanceE8s: bigint;
 }): boolean => balanceE8s !== neuron.cached_neuron_stake_e8s;
+
+/**
+ * Returns the functions that are available to follow.
+ *
+ * For now it filters out only the UNSPECIFIED function.
+ * https://github.com/dfinity/ic/blob/5248f11c18ca564881bbb82a4eb6915efb7ca62f/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto#L582
+ *
+ */
+const UNSPECIFIED_FUNCTION_ID = BigInt(0);
+export const functionsToFollow = (
+  functions: SnsNervousSystemFunction[] | undefined
+): SnsNervousSystemFunction[] | undefined =>
+  functions?.filter((f) => f.id !== UNSPECIFIED_FUNCTION_ID);

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -304,4 +304,4 @@ export const needsRefresh = ({
 export const functionsToFollow = (
   functions: SnsNervousSystemFunction[] | undefined
 ): SnsNervousSystemFunction[] | undefined =>
-  functions?.filter((f) => f.id !== UNSPECIFIED_FUNCTION_ID);
+  functions?.filter(({ id }) => id !== UNSPECIFIED_FUNCTION_ID);

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -9,7 +9,7 @@ describe("FollowTopicsSection", () => {
   const title = "title";
   const subtitle = "subtitle";
   it("renders data", () => {
-    const { getByText } = render(FollowTopicsSection, {
+    const { getByText } = render(FollowTopicsSectionTest, {
       props: {
         title,
         subtitle,
@@ -22,15 +22,20 @@ describe("FollowTopicsSection", () => {
   });
 
   it("renders children", () => {
-    const { queryByTestId } = render(FollowTopicsSectionTest);
+    const { queryByTestId } = render(FollowTopicsSectionTest, {
+      props: {
+        title,
+        subtitle,
+        id: "3",
+        count: 4,
+      },
+    });
     expect(queryByTestId("followee-children")).toBeInTheDocument();
   });
 
   it("triggers open event", async () => {
     const { queryByTestId, component } = render(FollowTopicsSection, {
       props: {
-        title,
-        subtitle,
         id: "3",
         count: 4,
       },

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSection.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import FollowTopicsSection from "$lib/components/neurons/FollowTopicSection.svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import FollowTopicsSectionTest from "./FollowTopicSectionTest.svelte";
+
+describe("FollowTopicsSection", () => {
+  const title = "title";
+  const subtitle = "subtitle";
+  it("renders data", () => {
+    const { getByText } = render(FollowTopicsSection, {
+      props: {
+        title,
+        subtitle,
+        id: "3",
+        count: 4,
+      },
+    });
+    expect(getByText(title)).toBeInTheDocument();
+    expect(getByText(subtitle)).toBeInTheDocument();
+  });
+
+  it("renders children", () => {
+    const { queryByTestId } = render(FollowTopicsSectionTest);
+    expect(queryByTestId("followee-children")).toBeInTheDocument();
+  });
+
+  it("triggers open event", async () => {
+    const { queryByTestId, component } = render(FollowTopicsSection, {
+      props: {
+        title,
+        subtitle,
+        id: "3",
+        count: 4,
+      },
+    });
+    const openSpy = jest.fn();
+    component.$on("nnsOpen", openSpy);
+    const button = queryByTestId("open-new-followee-modal");
+    button && fireEvent.click(button);
+
+    await waitFor(() => expect(openSpy).toBeCalled());
+  });
+});

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSectionTest.svelte
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSectionTest.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
+
+  export let title: string;
+  export let subtitle: string;
+  export let count: number;
+  export let id: string;
 </script>
 
-<FollowTopicSection title="title" subtitle="subtitle" count={2} id="2">
+<FollowTopicSection {count} {id}>
+  <h3 slot="title">{title}</h3>
+  <p slot="subtitle">{subtitle}</p>
   <div data-tid="followee-children">
     <p>Followee</p>
   </div>

--- a/frontend/src/tests/lib/components/neurons/FollowTopicSectionTest.svelte
+++ b/frontend/src/tests/lib/components/neurons/FollowTopicSectionTest.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
+</script>
+
+<FollowTopicSection title="title" subtitle="subtitle" count={2} id="2">
+  <div data-tid="followee-children">
+    <p>Followee</p>
+  </div>
+</FollowTopicSection>

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -3,19 +3,76 @@
  */
 
 import FollowSnsNeuronsModal from "$lib/modals/sns/FollowSnsNeuronsModal.svelte";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import en from "../../../mocks/i18n.mock";
+import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
 describe("FollowSnsNeuronsModal", () => {
-  it("should display modal", async () => {
-    const { container } = render(FollowSnsNeuronsModal, {
+  const neuron = {
+    ...mockSnsNeuron,
+  };
+  const rootCanisterId = mockPrincipal;
+
+  afterEach(() => {
+    snsFunctionsStore.reset();
+  });
+  it("renders title", () => {
+    const { queryByText } = render(FollowSnsNeuronsModal, {
       props: {
-        neuron: mockSnsNeuron,
-        rootCanisterId: mockPrincipal,
+        neuron,
+        rootCanisterId,
       },
     });
 
-    expect(container.querySelector("div.modal")).not.toBeNull();
+    expect(queryByText(en.neurons.follow_neurons_screen)).toBeInTheDocument();
+  });
+
+  it("renders spinner if no functions to follow", () => {
+    const { queryByTestId } = render(FollowSnsNeuronsModal, {
+      props: {
+        neuron,
+        rootCanisterId,
+      },
+    });
+    expect(queryByTestId("spinner")).toBeInTheDocument();
+  });
+
+  it("displays the functions to follow", () => {
+    const function0: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(0),
+    };
+    const function1: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(1),
+    };
+    const function2: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(2),
+    };
+    snsFunctionsStore.setFunctions({
+      rootCanisterId,
+      functions: [function0, function1, function2],
+    });
+    const { queryByTestId } = render(FollowSnsNeuronsModal, {
+      props: {
+        neuron,
+        rootCanisterId,
+      },
+    });
+
+    expect(
+      queryByTestId(`follow-topic-${function0.id}-section`)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId(`follow-topic-${function1.id}-section`)
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId(`follow-topic-${function2.id}-section`)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -4,6 +4,7 @@ import { enumValues } from "$lib/utils/enum.utils";
 import {
   canIdentityManageHotkeys,
   formattedSnsMaturity,
+  functionsToFollow,
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
   getSnsNeuronByHexId,
@@ -27,10 +28,15 @@ import { bytesToHexString } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
+import {
+  SnsNeuronPermissionType,
+  type SnsNervousSystemFunction,
+  type SnsNeuron,
+} from "@dfinity/sns";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockNeuron } from "../../mocks/neurons.mock";
+import { nervousSystemFunctionMock } from "../../mocks/sns-functions.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -832,6 +838,26 @@ describe("sns-neuron utils", () => {
           balanceE8s: BigInt(2),
         })
       ).toBeFalsy();
+    });
+  });
+
+  describe("functionsToFollow", () => {
+    it("filters out function with id 0", () => {
+      const function0: SnsNervousSystemFunction = {
+        ...nervousSystemFunctionMock,
+        id: BigInt(0),
+      };
+      const function1: SnsNervousSystemFunction = {
+        ...nervousSystemFunctionMock,
+        id: BigInt(1),
+      };
+      const function2: SnsNervousSystemFunction = {
+        ...nervousSystemFunctionMock,
+        id: BigInt(2),
+      };
+      expect(functionsToFollow([function0, function1, function2]).length).toBe(
+        2
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

List the topics that the user can follow for an SNS project.

# Changes

* Rename FollowTopicSection to FollowNnsTopicSection
* New component FollowTopicSection agnostic to NNS or SNS that renders the UI of a topic.
* Implement FollowSnsNeuronsModal. Access snsFunctions and render a FollowTopicSection for each followable section.
* New sns neuron util "functionsToFollow".

# Tests

* Add test cases for FollowSnsNeuronsModal.
* Test new component FollowTopicSection
