### PR TITLE
feat: reset toast on signin

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import type { AuthStore } from "$lib/stores/auth.store";
   import { initWorker } from "$lib/services/worker.services";
   import { initAppDataProxy } from "$lib/proxy/app.services.proxy";
-  import {toastsReset} from "$lib/stores/toasts.store";
+  import { toastsReset } from "$lib/stores/toasts.store";
 
   let ready = false;
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import type { AuthStore } from "$lib/stores/auth.store";
   import { initWorker } from "$lib/services/worker.services";
   import { initAppDataProxy } from "$lib/proxy/app.services.proxy";
+  import {toastsReset} from "$lib/stores/toasts.store";
 
   let ready = false;
 
@@ -24,6 +25,11 @@
     }
 
     ready = true;
+
+    // We reset the toast to clear any previous messages.
+    // This is notably user-friendly in case of the user would have been sign-out automatically - session duration expired.
+    // That way user does not have to manually close previous message.
+    toastsReset();
 
     // Load app global stores data
     await initAppDataProxy();

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -12,6 +12,7 @@ import {
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "../mocks/auth.store.mock";
+import {toastsStore} from "@dfinity/gix-components";
 
 jest.mock("$lib/services/worker.services", () => ({
   initWorker: jest.fn(() =>
@@ -61,5 +62,17 @@ describe("Layout", () => {
     });
 
     expect(initWorker).toHaveBeenCalled();
+  });
+
+  it("should reset toasts on sign in",  () => {
+    const spy = jest.spyOn(toastsStore, "reset");
+
+    render(App);
+
+    authStoreMock.next({
+      identity: mockIdentity,
+    });
+
+    expect(spy).toBeCalled();
   });
 });

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -6,13 +6,13 @@ import { initAppDataProxy } from "$lib/proxy/app.services.proxy";
 import { initWorker } from "$lib/services/worker.services";
 import { authStore } from "$lib/stores/auth.store";
 import App from "$routes/+layout.svelte";
+import { toastsStore } from "@dfinity/gix-components";
 import { render, waitFor } from "@testing-library/svelte";
 import {
   authStoreMock,
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "../mocks/auth.store.mock";
-import {toastsStore} from "@dfinity/gix-components";
 
 jest.mock("$lib/services/worker.services", () => ({
   initWorker: jest.fn(() =>
@@ -64,7 +64,7 @@ describe("Layout", () => {
     expect(initWorker).toHaveBeenCalled();
   });
 
-  it("should reset toasts on sign in",  () => {
+  it("should reset toasts on sign in", () => {
     const spy = jest.spyOn(toastsStore, "reset");
 
     render(App);


### PR DESCRIPTION
# Motivation

When user are signed out automatically, they have to manully close the toast. It makes sense that it does not fade away - because you never know when the user comeback - but it can be more user friendly to automatically close the toast on sign-in.

# Changes

- `toastReset` on sign-in


