### PR TITLE
feat: nns neuron age

### DIFF
--- a/frontend/src/lib/components/neurons/NnsNeuronAge.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronAge.svelte
@@ -11,7 +11,7 @@
 {#if neuron.ageSeconds > 0}
   <KeyValuePair>
     <span class="label" slot="key">{$i18n.neurons.age}</span>
-    <span class="value" slot="value">
+    <span class="value" slot="value" data-tid="nns-neuron-age">
       {secondsToDuration(neuronAge(neuron))}
     </span>
   </KeyValuePair>

--- a/frontend/src/lib/components/neurons/NnsNeuronAge.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronAge.svelte
@@ -2,25 +2,17 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import { KeyValuePair } from "@dfinity/gix-components";
-  import { secondsToDate } from "$lib/utils/date.utils";
+  import { secondsToDuration } from "$lib/utils/date.utils";
+  import { neuronAge } from "$lib/utils/neuron.utils";
 
   export let neuron: NeuronInfo;
-
-  // TODO: uncomment to activate display of neuron "Age"
 </script>
 
-<!--{#if neuron.ageSeconds > 0}-->
-<!--  <KeyValuePair>-->
-<!--    <span class="label" slot="key">{$i18n.neurons.age}</span>-->
-<!--    <span class="value" slot="value">-->
-<!--      {secondsToDuration(neuronAge(neuron))}-->
-<!--    </span>-->
-<!--  </KeyValuePair>-->
-<!--{/if}-->
-
-<KeyValuePair>
-  <span class="label" slot="key">{$i18n.neurons.staked}</span>
-  <span class="value" slot="value">
-    {secondsToDate(Number(neuron.createdTimestampSeconds))}
-  </span>
-</KeyValuePair>
+{#if neuron.ageSeconds > 0}
+  <KeyValuePair>
+    <span class="label" slot="key">{$i18n.neurons.age}</span>
+    <span class="value" slot="value">
+      {secondsToDuration(neuronAge(neuron))}
+    </span>
+  </KeyValuePair>
+{/if}

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronAge.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronAge.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { SnsNeuron } from "@dfinity/sns";
 
+  // TODO: remove svelte ignore for svelte-check once implemented
+  // svelte-ignore unused-export-let
   export let neuron: SnsNeuron;
 
   // TODO: implement Sns neuron Age

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -750,6 +750,5 @@ export const validTopUpAmount = ({
   return amountE8s + neuronStakeE8s > MIN_NEURON_STAKE;
 };
 
-// TODO: uncomment to activate display of neuron "Age"
-// export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
-//   BigInt(Math.min(Number(ageSeconds), SECONDS_IN_FOUR_YEARS));
+export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
+  BigInt(Math.min(Number(ageSeconds), SECONDS_IN_FOUR_YEARS));

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
@@ -5,7 +5,8 @@
 import NnsNeuronMetaInfoCard from "$lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
-import { formatVotingPower } from "$lib/utils/neuron.utils";
+import { secondsToDuration } from "$lib/utils/date.utils";
+import { formatVotingPower, neuronAge } from "$lib/utils/neuron.utils";
 import { render } from "@testing-library/svelte";
 import {
   mockAccountsStoreSubscribe,
@@ -116,5 +117,15 @@ describe("NnsNeuronMetaInfoCard", () => {
       queryByText(en.neuron_detail.increase_stake)
     ).not.toBeInTheDocument();
     expect(queryByText(en.neuron_detail.split_neuron)).not.toBeInTheDocument();
+  });
+
+  it("should render neuron age", () => {
+    const { getByTestId } = render(NnsNeuronMetaInfoCard, {
+      props,
+    });
+
+    expect(getByTestId("nns-neuron-age")?.textContent.trim()).toEqual(
+      secondsToDuration(neuronAge(mockNeuron))
+    );
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -5,12 +5,16 @@
 import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { authStore } from "$lib/stores/auth.store";
+import { secondsToDuration } from "$lib/utils/date.utils";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
-import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import {
+  mockSnsNeuron,
+  mockSnsNeuronTimestampSeconds,
+} from "../../../mocks/sns-neurons.mock";
 import { mockTokenStore } from "../../../mocks/sns-projects.mock";
 
 describe("SnsNeuronMetaInfoCard", () => {
@@ -49,16 +53,15 @@ describe("SnsNeuronMetaInfoCard", () => {
     );
   });
 
-  // TODO: uncomment for display neuron age
-  // it("should render neuron age", () => {
-  //   const { getByTestId } = renderSelectedSnsNeuronContext({
-  //     Component: SnsNeuronMetaInfoCard,
-  //     neuron: mockSnsNeuron,
-  //     reload: jest.fn(),
-  //   });
-  //
-  //   expect(getByTestId("sns-neuron-age")?.textContent.trim()).toEqual(
-  //     secondsToDuration(BigInt(mockSnsNeuronTimestampSeconds))
-  //   );
-  // });
+  it("should render neuron age", () => {
+    const { getByTestId } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronMetaInfoCard,
+      neuron: mockSnsNeuron,
+      reload: jest.fn(),
+    });
+
+    expect(getByTestId("sns-neuron-age")?.textContent.trim()).toEqual(
+      secondsToDuration(BigInt(mockSnsNeuronTimestampSeconds))
+    );
+  });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -5,16 +5,12 @@
 import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { authStore } from "$lib/stores/auth.store";
-import { secondsToDuration } from "$lib/utils/date.utils";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
-import {
-  mockSnsNeuron,
-  mockSnsNeuronTimestampSeconds,
-} from "../../../mocks/sns-neurons.mock";
+import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 import { mockTokenStore } from "../../../mocks/sns-projects.mock";
 
 describe("SnsNeuronMetaInfoCard", () => {
@@ -53,15 +49,16 @@ describe("SnsNeuronMetaInfoCard", () => {
     );
   });
 
-  it("should render neuron age", () => {
-    const { getByTestId } = renderSelectedSnsNeuronContext({
-      Component: SnsNeuronMetaInfoCard,
-      neuron: mockSnsNeuron,
-      reload: jest.fn(),
-    });
-
-    expect(getByTestId("sns-neuron-age")?.textContent.trim()).toEqual(
-      secondsToDuration(BigInt(mockSnsNeuronTimestampSeconds))
-    );
-  });
+  // TODO: uncomment for display neuron age
+  // it("should render neuron age", () => {
+  //   const { getByTestId } = renderSelectedSnsNeuronContext({
+  //     Component: SnsNeuronMetaInfoCard,
+  //     neuron: mockSnsNeuron,
+  //     reload: jest.fn(),
+  //   });
+  //
+  //   expect(getByTestId("sns-neuron-age")?.textContent.trim()).toEqual(
+  //     secondsToDuration(BigInt(mockSnsNeuronTimestampSeconds))
+  //   );
+  // });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -50,6 +50,7 @@ import {
   mapNeuronIds,
   minMaturityMerge,
   minNeuronSplittable,
+  neuronAge,
   neuronCanBeSplit,
   neuronStake,
   sortNeuronsByCreatedTimestamp,
@@ -1867,18 +1868,17 @@ describe("neuron-utils", () => {
     });
   });
 
-  // TODO: uncomment for display neuron age
-  // describe("neuronAge", () => {
-  //   it("should return ageSeconds property", () => {
-  //     expect(neuronAge(mockNeuron)).toEqual(mockNeuron.ageSeconds);
-  //   });
-  //
-  //   it("should return max age value", () => {
-  //     const neuron = {
-  //       ...mockNeuron,
-  //       ageSeconds: mockNeuron.ageSeconds + BigInt(SECONDS_IN_FOUR_YEARS),
-  //     };
-  //     expect(neuronAge(neuron)).toEqual(BigInt(SECONDS_IN_FOUR_YEARS));
-  //   });
-  // });
+  describe("neuronAge", () => {
+    it("should return ageSeconds property", () => {
+      expect(neuronAge(mockNeuron)).toEqual(mockNeuron.ageSeconds);
+    });
+
+    it("should return max age value", () => {
+      const neuron = {
+        ...mockNeuron,
+        ageSeconds: mockNeuron.ageSeconds + BigInt(SECONDS_IN_FOUR_YEARS),
+      };
+      expect(neuronAge(neuron)).toEqual(BigInt(SECONDS_IN_FOUR_YEARS));
+    });
+  });
 });

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -26,7 +26,7 @@ export const renderContextWrapper = <T>({
   Component: typeof SvelteComponent;
   contextKey: symbol;
   contextValue: T;
-  props?: any;
+  props?: never;
 }): RenderResult =>
   render(ContextWrapperTest, {
     props: {
@@ -63,7 +63,7 @@ export const renderSelectedSnsNeuronContext = ({
   Component: typeof SvelteComponent;
   neuron: SnsNeuron;
   reload: () => Promise<void>;
-  props?: any;
+  props?: never;
 }) =>
   renderContextWrapper({
     Component,


### PR DESCRIPTION
# Motivation

Instead of the stake created date, display the "Age" of a neuron. Information is more user friendly.

# Changes

- adds utils to calculate `neuronAge`
- display "Age" on NNS neuron detail page

# Note

How to display the age of Sns neuron is currently discussed therefore this PR focus only Nns.
