### PR TITLE
feat: redirect user to login screen if offline

### DIFF
--- a/frontend/src/lib/services/auth.services.ts
+++ b/frontend/src/lib/services/auth.services.ts
@@ -21,6 +21,14 @@ export const logout = async ({
 
   await authStore.signOut();
 
+  // TODO(GIX-1152): improve the user experience
+  // Automatic sign-out might happen while user device is idle and therefore the network might be off.
+  // That's why, to prevent the app to try to fetch public data, we redirect the user to the login page.
+  if (!navigator.onLine) {
+    const { origin }: URL = new URL(window.location.href);
+    replaceHistory(new URL(origin));
+  }
+
   if (msg) {
     appendMsgToUrl(msg);
   }

--- a/frontend/src/lib/workers/auth.worker.ts
+++ b/frontend/src/lib/workers/auth.worker.ts
@@ -27,7 +27,7 @@ let timer: NodeJS.Timeout | undefined = undefined;
  * The timer is executed only if user has signed in
  */
 export const startIdleTimer = () =>
-  (timer = setInterval(async () => await onIdleSignOut(), 1000));
+  (timer = setInterval(async () => await onIdleSignOut(), 10000));
 
 export const stopIdleTimer = () => {
   if (!timer) {
@@ -59,7 +59,7 @@ const onIdleSignOut = async () => {
  */
 const checkAuthentication = async (): Promise<boolean> => {
   const authClient: AuthClient = await createAuthClient();
-  return authClient.isAuthenticated();
+  return false;
 };
 
 /**

--- a/frontend/src/lib/workers/auth.worker.ts
+++ b/frontend/src/lib/workers/auth.worker.ts
@@ -27,7 +27,7 @@ let timer: NodeJS.Timeout | undefined = undefined;
  * The timer is executed only if user has signed in
  */
 export const startIdleTimer = () =>
-  (timer = setInterval(async () => await onIdleSignOut(), 10000));
+  (timer = setInterval(async () => await onIdleSignOut(), 1000));
 
 export const stopIdleTimer = () => {
   if (!timer) {
@@ -59,7 +59,7 @@ const onIdleSignOut = async () => {
  */
 const checkAuthentication = async (): Promise<boolean> => {
   const authClient: AuthClient = await createAuthClient();
-  return false;
+  return authClient.isAuthenticated();
 };
 
 /**

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -3,7 +3,7 @@
   import { syncBeforeUnload } from "$lib/utils/before-unload.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { onDestroy, onMount } from "svelte";
-  import { Toasts, BusyScreen } from "@dfinity/gix-components";
+  import { BusyScreen } from "@dfinity/gix-components";
   import {
     initAppPublicData,
     initAppAuth,
@@ -21,5 +21,4 @@
 
 <slot />
 
-<Toasts />
 <BusyScreen />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import { initWorker } from "$lib/services/worker.services";
   import { initAppDataProxy } from "$lib/proxy/app.services.proxy";
   import { toastsReset } from "$lib/stores/toasts.store";
+  import { Toasts } from "@dfinity/gix-components";
 
   let ready = false;
 
@@ -46,6 +47,8 @@
 </script>
 
 <slot />
+
+<Toasts />
 
 <style lang="scss" global>
   @import "@dfinity/gix-components/styles/global.scss";


### PR DESCRIPTION
# Motivation

Automatic sign-out might happen while user device is idle and therefore - according the error message we noticed - the network might be off.

That's why, to prevent the app to try to fetch public data and display errors, we can redirect the user to the login page which is static and will not perform.

# Changes

- if `!navigator.onLine` on automatic signout, redirect to origin
- move `Toast` to main layout so that toats can be displayed on login page too

# Screenshot

The issue we noticed.

![image](https://user-images.githubusercontent.com/16886711/203514935-eaede942-afca-4387-a739-6c1016fccdbf.png)

<img width="1536" alt="Capture d’écran 2022-11-23 à 11 09 59" src="https://user-images.githubusercontent.com/16886711/203520600-6c78323b-fb1c-4670-808f-d90b07281866.png">

<img width="1536" alt="Capture d’écran 2022-11-23 à 11 10 33" src="https://user-images.githubusercontent.com/16886711/203520726-0e00b0e8-6fb7-418e-8564-9e4fe86676f7.png">
<img width="1536" alt="Capture d’écran 2022-11-23 à 11 10 43" src="https://user-images.githubusercontent.com/16886711/203520743-7ca31708-52a3-4bd1-9faa-49c50aca8b6c.png">

