### PR TITLE
Fix: Error message not canister controller

### DIFF
--- a/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
@@ -4,8 +4,6 @@
  * @throws UserNotTheControllerError and Error.
  */
 export function mapError(error: Error | unknown): Error | unknown {
-  let code = 500;
-
   const statusLine =
     error instanceof Error
       ? error.message
@@ -16,22 +14,7 @@ export function mapError(error: Error | unknown): Error | unknown {
             (l) => l.startsWith("code:") || l.startsWith("http status code:")
           );
 
-  if (statusLine !== undefined && statusLine.length > 0) {
-    const parts = statusLine.split(":");
-    if (parts.length > 1) {
-      let valueText = parts[1].trim();
-      const valueParts = valueText.split(" ");
-      if (valueParts.length > 1) {
-        valueText = valueParts[0].trim();
-      }
-      code = parseInt(valueText, 10);
-      if (isNaN(code)) {
-        code = 500;
-      }
-    }
-  }
-
-  if (code === 403) {
+  if (statusLine?.includes("403")) {
     return new UserNotTheControllerError();
   }
   return error;


### PR DESCRIPTION
# Motivation

Users sees a generic error message when he or she is not the controller of the canister.

The new error message is:

```
Server returned an error:
  Code: 403 ()
  Body: Only controllers of canister wxns6-qiaaa-aaaaa-aaaqa-cai can call ic00 method canister_status
  Retrying request.
```

I believe they added the `()` and that messed up with the current parsing method.

# Changes

* Change the way we parse the error message.

# Tests

Updated tests with new error message.