### PR TITLE
Fix: Proposals not shown

### DIFF
--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -87,7 +87,7 @@ export const uiProposals: Readable<UIProposalsStore> = derived(
     filters,
     neurons,
     { registrations },
-    $authStore,
+    { identity },
   ]) => ({
     proposals: proposals.map((proposalInfo) => ({
       ...proposalInfo,
@@ -96,7 +96,7 @@ export const uiProposals: Readable<UIProposalsStore> = derived(
         filters,
         neurons,
         registrations,
-        identity: $authStore.identity,
+        identity,
       }),
     })),
     certified,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -267,7 +267,8 @@
   },
   "new_followee": {
     "title": "Enter New Followee",
-    "address_placeholder": "Followee Id",
+    "placeholder": "Neuron Id",
+    "label": "Followee's Neuron Id",
     "follow_neuron": "Follow Neuron",
     "options_title": "Options for Following",
     "follow": "Follow",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -267,7 +267,7 @@
   },
   "new_followee": {
     "title": "Enter New Followee",
-    "address_placeholder": "Followee Address",
+    "address_placeholder": "Followee Id",
     "follow_neuron": "Follow Neuron",
     "options_title": "Options for Following",
     "follow": "Follow",

--- a/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -93,13 +93,11 @@
     <Input
       inputType="text"
       autocomplete="off"
-      placeholderLabelKey="new_followee.address_placeholder"
+      placeholderLabelKey="new_followee.placeholder"
       name="new-followee-address"
       bind:value={followeeAddress}
     >
-      <svelte:fragment slot="label"
-        >{$i18n.new_followee.address_placeholder}</svelte:fragment
-      >
+      <svelte:fragment slot="label">{$i18n.new_followee.label}</svelte:fragment>
     </Input>
     <button
       class="primary"

--- a/frontend/src/lib/pages/Proposals.svelte
+++ b/frontend/src/lib/pages/Proposals.svelte
@@ -23,6 +23,7 @@
     sortedProposals,
     filteredProposals,
   } from "$lib/derived/proposals.derived";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let referrerPath: AppPath | undefined = undefined;
 
@@ -137,6 +138,7 @@
         proposals: $filteredProposals.proposals,
         filters: $proposalsFiltersStore,
         neurons: $definedNeuronsStore,
+        identity: $authStore.identity,
       });
   };
 

--- a/frontend/src/lib/pages/Proposals.svelte
+++ b/frontend/src/lib/pages/Proposals.svelte
@@ -122,7 +122,7 @@
     }
   );
 
-  $: $authStore.identity, (() => proposalsFiltersStore.refresh())();
+  $: $authStore.identity, (() => proposalsFiltersStore.reload())();
 
   onDestroy(unsubscribe);
 

--- a/frontend/src/lib/pages/Proposals.svelte
+++ b/frontend/src/lib/pages/Proposals.svelte
@@ -90,14 +90,11 @@
       return;
     }
 
+    await findProposals();
+
     initDebounceFindProposals();
 
     initialized = true;
-  });
-
-  // Fetch the proposals when the user logges in or out
-  const unsubscribeAuth = authStore.subscribe(async () => {
-    await findProposals();
   });
 
   const unsubscribe: Unsubscriber = proposalsFiltersStore.subscribe(
@@ -125,10 +122,9 @@
     }
   );
 
-  onDestroy(() => {
-    unsubscribe();
-    unsubscribeAuth();
-  });
+  $: $authStore.identity, (() => proposalsFiltersStore.refresh())();
+
+  onDestroy(unsubscribe);
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches

--- a/frontend/src/lib/pages/Proposals.svelte
+++ b/frontend/src/lib/pages/Proposals.svelte
@@ -90,11 +90,14 @@
       return;
     }
 
-    await findProposals();
-
     initDebounceFindProposals();
 
     initialized = true;
+  });
+
+  // Fetch the proposals when the user logges in or out
+  const unsubscribeAuth = authStore.subscribe(async () => {
+    await findProposals();
   });
 
   const unsubscribe: Unsubscriber = proposalsFiltersStore.subscribe(
@@ -122,7 +125,10 @@
     }
   );
 
-  onDestroy(unsubscribe);
+  onDestroy(() => {
+    unsubscribe();
+    unsubscribeAuth();
+  });
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -170,7 +170,8 @@ const initProposalsFiltersStore = () => {
       set(DEFAULT_PROPOSALS_FILTERS);
     },
 
-    refresh: () => update((state) => ({ ...state })),
+    reload: () =>
+      update((state) => ({ ...state, lastAppliedFilter: undefined })),
   };
 };
 

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -169,6 +169,8 @@ const initProposalsFiltersStore = () => {
     reset() {
       set(DEFAULT_PROPOSALS_FILTERS);
     },
+
+    refresh: () => update((state) => ({ ...state })),
   };
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -278,7 +278,8 @@ interface I18nNeurons {
 
 interface I18nNew_followee {
   title: string;
-  address_placeholder: string;
+  placeholder: string;
+  label: string;
   follow_neuron: string;
   options_title: string;
   follow: string;

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -101,6 +101,7 @@ export const hideProposal = ({
 }): boolean =>
   !matchFilters({ proposalInfo, filters }) ||
   (nonNullish(identity) &&
+    !identity.getPrincipal().isAnonymous() &&
     isExcludedVotedProposal({ proposalInfo, filters, neurons }));
 
 /**

--- a/frontend/src/tests/lib/pages/Proposals.spec.ts
+++ b/frontend/src/tests/lib/pages/Proposals.spec.ts
@@ -4,7 +4,7 @@
 
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import Proposals from "$lib/pages/Proposals.svelte";
-import { authStore } from "$lib/stores/auth.store";
+import { authStore, type AuthStore } from "$lib/stores/auth.store";
 import { neuronsStore, type NeuronsStore } from "$lib/stores/neurons.store";
 import {
   proposalsFiltersStore,
@@ -38,133 +38,195 @@ describe("Proposals", () => {
       (p) => p.textContent === en.voting.nothing_found
     )[0];
 
-  beforeEach(() => {
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-
-    const mockNeuronsStoreSubscribe = (
-      run: Subscriber<NeuronsStore>
-    ): (() => void) => {
-      run({ neurons: [], certified: true });
-
-      return () => undefined;
-    };
-    jest
-      .spyOn(neuronsStore, "subscribe")
-      .mockImplementation(mockNeuronsStoreSubscribe);
-  });
-
-  describe("Matching results", () => {
-    const mockGovernanceCanister: MockGovernanceCanister =
-      new MockGovernanceCanister(mockProposals);
-
-    const mockLoadProposals = () =>
+  describe("logged in user", () => {
+    beforeEach(() => {
       jest
-        .spyOn(proposalsStore, "subscribe")
-        .mockImplementation(mockProposalsStoreSubscribe);
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreSubscribe);
 
-    beforeEach(() =>
-      jest
-        .spyOn(GovernanceCanister, "create")
-        .mockImplementation((): GovernanceCanister => mockGovernanceCanister)
-    );
+      const mockNeuronsStoreSubscribe = (
+        run: Subscriber<NeuronsStore>
+      ): (() => void) => {
+        run({ neurons: [], certified: true });
 
-    it("should render filters", () => {
-      const { getByText } = render(Proposals);
-
-      expect(getByText("Topics")).toBeInTheDocument();
-      expect(getByText("Reward Status")).toBeInTheDocument();
-      expect(getByText("Proposal Status")).toBeInTheDocument();
-      expect(
-        getByText("Show only proposals", {
-          exact: false,
-        })
-      ).toBeInTheDocument();
-    });
-
-    it("should render a spinner while searching proposals", async () => {
-      const { getByTestId } = render(Proposals);
-
-      proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
-
-      await waitFor(() =>
-        expect(getByTestId("proposals-spinner")).not.toBeNull()
-      );
-    });
-
-    it("should render proposals", () => {
-      mockLoadProposals();
-
-      const { getByText } = render(Proposals);
-
-      const firstProposal = mockProposals[0] as ProposalInfo;
-      const secondProposal = mockProposals[1] as ProposalInfo;
-      expect(
-        getByText((firstProposal.proposal as Proposal).title as string)
-      ).toBeInTheDocument();
-      expect(
-        getByText((secondProposal.proposal as Proposal).title as string)
-      ).toBeInTheDocument();
-    });
-
-    it("should hide proposal card if already voted", async () => {
-      mockLoadProposals();
-
+        return () => undefined;
+      };
       jest
         .spyOn(neuronsStore, "subscribe")
-        .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
-
-      const { container } = render(Proposals);
-
-      proposalsFiltersStore.toggleExcludeVotedProposals();
-
-      await waitFor(() =>
-        expect(container.querySelectorAll("article").length).toBe(
-          mockProposals.length - 1
-        )
-      );
+        .mockImplementation(mockNeuronsStoreSubscribe);
     });
 
-    it("should disable infinite scroll when all proposals loaded", async () => {
-      mockLoadProposals();
+    describe("Matching results", () => {
+      const mockGovernanceCanister: MockGovernanceCanister =
+        new MockGovernanceCanister(mockProposals);
 
-      const { getByTestId } = render(Proposals);
+      const mockLoadProposals = () =>
+        jest
+          .spyOn(proposalsStore, "subscribe")
+          .mockImplementation(mockProposalsStoreSubscribe);
 
-      await waitFor(() =>
-        expect(getByTestId("proposals-scroll-off")).not.toBeNull()
+      beforeEach(() =>
+        jest
+          .spyOn(GovernanceCanister, "create")
+          .mockImplementation((): GovernanceCanister => mockGovernanceCanister)
       );
+
+      it("should render filters", () => {
+        const { getByText } = render(Proposals);
+
+        expect(getByText("Topics")).toBeInTheDocument();
+        expect(getByText("Reward Status")).toBeInTheDocument();
+        expect(getByText("Proposal Status")).toBeInTheDocument();
+        expect(
+          getByText("Show only proposals", {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+      });
+
+      it("should render a spinner while searching proposals", async () => {
+        const { getByTestId } = render(Proposals);
+
+        proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
+
+        await waitFor(() =>
+          expect(getByTestId("proposals-spinner")).not.toBeNull()
+        );
+      });
+
+      it("should render proposals", () => {
+        mockLoadProposals();
+
+        const { getByText } = render(Proposals);
+
+        const firstProposal = mockProposals[0] as ProposalInfo;
+        const secondProposal = mockProposals[1] as ProposalInfo;
+        expect(
+          getByText((firstProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+        expect(
+          getByText((secondProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+      });
+
+      it("should hide proposal card if already voted", async () => {
+        mockLoadProposals();
+
+        jest
+          .spyOn(neuronsStore, "subscribe")
+          .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
+
+        const { container } = render(Proposals);
+
+        proposalsFiltersStore.toggleExcludeVotedProposals();
+
+        await waitFor(() =>
+          expect(container.querySelectorAll("article").length).toBe(
+            mockProposals.length - 1
+          )
+        );
+      });
+
+      it("should disable infinite scroll when all proposals loaded", async () => {
+        mockLoadProposals();
+
+        const { getByTestId } = render(Proposals);
+
+        await waitFor(() =>
+          expect(getByTestId("proposals-scroll-off")).not.toBeNull()
+        );
+      });
+
+      it("should not render not found text on init", () => {
+        const { container } = render(Proposals);
+
+        const p: HTMLParagraphElement | undefined = nothingFound(container);
+
+        expect(p).toBeUndefined();
+      });
     });
 
-    it("should not render not found text on init", () => {
-      const { container } = render(Proposals);
+    describe("No results", () => {
+      const mockGovernanceCanister: MockGovernanceCanister =
+        new MockGovernanceCanister([]);
 
-      const p: HTMLParagraphElement | undefined = nothingFound(container);
+      beforeEach(() =>
+        jest
+          .spyOn(GovernanceCanister, "create")
+          .mockImplementation((): GovernanceCanister => mockGovernanceCanister)
+      );
 
-      expect(p).toBeUndefined();
+      it("should render not found text", async () => {
+        jest
+          .spyOn(proposalsStore, "subscribe")
+          .mockImplementation(mockEmptyProposalsStoreSubscribe);
+
+        const { container } = render(Proposals);
+
+        await waitFor(() => {
+          const p: HTMLParagraphElement | undefined = nothingFound(container);
+          expect(p).not.toBeUndefined();
+        });
+      });
     });
   });
 
-  describe("No results", () => {
-    const mockGovernanceCanister: MockGovernanceCanister =
-      new MockGovernanceCanister([]);
-
-    beforeEach(() =>
+  describe("when not logged in", () => {
+    beforeEach(() => {
       jest
-        .spyOn(GovernanceCanister, "create")
-        .mockImplementation((): GovernanceCanister => mockGovernanceCanister)
-    );
+        .spyOn(authStore, "subscribe")
+        .mockImplementation((run: Subscriber<AuthStore>): (() => void) => {
+          run({ identity: undefined });
 
-    it("should render not found text", async () => {
-      jest
-        .spyOn(proposalsStore, "subscribe")
-        .mockImplementation(mockEmptyProposalsStoreSubscribe);
+          return () => undefined;
+        });
+    });
 
-      const { container } = render(Proposals);
+    describe("Matching results", () => {
+      const mockGovernanceCanister: MockGovernanceCanister =
+        new MockGovernanceCanister(mockProposals);
 
-      await waitFor(() => {
-        const p: HTMLParagraphElement | undefined = nothingFound(container);
-        expect(p).not.toBeUndefined();
+      const mockLoadProposals = () =>
+        jest
+          .spyOn(proposalsStore, "subscribe")
+          .mockImplementation(mockProposalsStoreSubscribe);
+
+      beforeEach(() =>
+        jest
+          .spyOn(GovernanceCanister, "create")
+          .mockImplementation((): GovernanceCanister => mockGovernanceCanister)
+      );
+
+      it("should render proposals", () => {
+        mockLoadProposals();
+
+        const { getByText } = render(Proposals);
+
+        const firstProposal = mockProposals[0] as ProposalInfo;
+        const secondProposal = mockProposals[1] as ProposalInfo;
+        expect(
+          getByText((firstProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+        expect(
+          getByText((secondProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+      });
+
+      it("should render proposals also when ", () => {
+        mockLoadProposals();
+
+        const { getByText } = render(Proposals);
+
+        const firstProposal = mockProposals[0] as ProposalInfo;
+        const secondProposal = mockProposals[1] as ProposalInfo;
+        expect(
+          getByText((firstProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+        expect(
+          getByText((secondProposal.proposal as Proposal).title as string)
+        ).toBeInTheDocument();
+
+        proposalsFiltersStore.toggleExcludeVotedProposals();
       });
     });
   });

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -38,6 +38,7 @@ import {
   Vote,
 } from "@dfinity/nns";
 import type { KnownNeuron } from "@dfinity/nns/dist/types/types/governance_converters";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockNeuron } from "../../mocks/neurons.mock";
 import {
@@ -98,6 +99,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -109,6 +111,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -120,6 +123,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -131,6 +135,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -150,6 +155,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -169,6 +175,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -180,6 +187,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -191,6 +199,22 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
+        })
+      ).toBeFalsy();
+
+      expect(
+        hideProposal({
+          proposalInfo: proposalWithBallot({
+            proposal: mockProposals[0],
+            vote: Vote.Yes,
+          }),
+          filters: {
+            ...DEFAULT_PROPOSALS_FILTERS,
+            excludeVotedProposals: true,
+          },
+          neurons,
+          identity: undefined,
         })
       ).toBeFalsy();
     });
@@ -207,6 +231,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -221,6 +246,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
     });
@@ -237,6 +263,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -251,6 +278,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -265,6 +293,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
     });
@@ -281,6 +310,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -295,6 +325,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -309,6 +340,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
     });
@@ -325,6 +357,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -344,6 +377,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
     });
@@ -369,6 +403,7 @@ describe("proposals-utils", () => {
               neuronId: BigInt(666),
             } as NeuronInfo,
           ],
+          identity: mockIdentity,
         })
       ).toBeTruthy();
     });
@@ -390,6 +425,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -409,6 +445,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -431,6 +468,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -453,6 +491,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -475,6 +514,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -497,6 +537,29 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
+        })
+      ).toBeTruthy();
+
+      expect(
+        hasMatchingProposals({
+          proposals: [
+            {
+              ...mockProposals[0],
+              ballots: [
+                {
+                  neuronId: BigInt(0),
+                  vote: Vote.Yes,
+                } as Ballot,
+              ],
+            },
+          ],
+          filters: {
+            ...DEFAULT_PROPOSALS_FILTERS,
+            excludeVotedProposals: true,
+          },
+          neurons,
+          identity: null,
         })
       ).toBeTruthy();
     });
@@ -510,6 +573,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: false,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -531,6 +595,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
 
@@ -552,6 +617,7 @@ describe("proposals-utils", () => {
             excludeVotedProposals: true,
           },
           neurons,
+          identity: mockIdentity,
         })
       ).toBeFalsy();
     });


### PR DESCRIPTION
# Motivation

The filter to show only the ones you can vote on was being used even though the user was not logged in.

Therefore, logged out users that had that turned on had an empty list of proposals.

# Changes

* Pass the identity to the proposals utils to check whether it's present or not before hiding proposals.
* Load proposals when auth store changes.

# Tests

* Add test cases for new scenario.
* Fix broken tests because of new API.
