### PR TITLE
style: few minor improvements

### DIFF
--- a/frontend/src/lib/components/common/Footer.svelte
+++ b/frontend/src/lib/components/common/Footer.svelte
@@ -12,6 +12,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/styles/mixins/text";
 
   footer {
     height: var(--footer-height);
@@ -30,7 +31,7 @@
       display: grid;
       --footer-main-inner-width: calc(100% - (2 * var(--padding-0_5x)));
       grid-template-columns: repeat(
-        auto-fit,
+        var(--footer-columns),
         calc(var(--footer-main-inner-width) / var(--footer-columns))
       );
 
@@ -53,6 +54,15 @@
 
       :global(div.tooltip-wrapper) {
         width: 100%;
+      }
+
+      :global(button) {
+        @include text.truncate;
+
+        @media (min-width: 300px) {
+          overflow: inherit;
+          white-space: initial;
+        }
       }
     }
   }

--- a/frontend/src/lib/components/neurons/NeuronStateRemainingTime.svelte
+++ b/frontend/src/lib/components/neurons/NeuronStateRemainingTime.svelte
@@ -13,7 +13,7 @@
 {#if timeInSeconds !== undefined}
   {#if state === NeuronState.Dissolving || state === NeuronState.Spawning}
     {#if inline}
-      <p class="duration description">
+      <p class="duration label">
         <Html
           text={replacePlaceholders($i18n.neurons.inline_remaining, {
             $duration: secondsToDuration(timeInSeconds),
@@ -30,7 +30,7 @@
     {/if}
   {:else if state === NeuronState.Locked}
     {#if inline}
-      <p class="duration description">
+      <p class="duration label">
         {secondsToDuration(timeInSeconds)} – {$i18n.neurons
           .dissolve_delay_title}
       </p>

--- a/frontend/src/lib/components/universe/SelectProjectDropdownWrapper.svelte
+++ b/frontend/src/lib/components/universe/SelectProjectDropdownWrapper.svelte
@@ -21,7 +21,9 @@
       align-items: center;
 
       --logo-display: none;
-      --select-offset-start: var(--padding-2x);
+
+      --select-padding-top-bottom: var(--padding);
+      --select-padding-start: var(--padding-2x);
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

- Footer buttons width have overflow on small Firefox
- Contrast in neurcard card for dissolve text is a-ok
- Dropdown size in modal

# PRs

- need https://github.com/dfinity/gix-components/pull/131

# Changes

- tweak style

# Screenshots

Issues:

<img width="1536" alt="Capture d’écran 2022-11-23 à 18 46 41" src="https://user-images.githubusercontent.com/16886711/203615077-5b4074c8-82bf-4d39-85ee-789192951703.png">
<img width="1536" alt="Capture d’écran 2022-11-23 à 18 48 49" src="https://user-images.githubusercontent.com/16886711/203615091-dd00a251-2310-45e6-9152-1e3cd13a736c.png">
<img width="562" alt="Capture d’écran 2022-11-23 à 18 49 06" src="https://user-images.githubusercontent.com/16886711/203615100-75991128-cb78-4256-8127-c10b427a0700.png">

