### PR TITLE
GIX-1113: Add SNS Neuron Followee

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-18.2.tgz",
-      "integrity": "sha512-dZrGQLIo82cVR7PfkoM4ELOUpTMYocInLD+w2xDWaLpYc/2E1JgtHugZRzY3dviakc7kf9gVW9vA5xI19/ShVQ==",
+      "version": "0.0.3-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-23.tgz",
+      "integrity": "sha512-gv46WmjvjwVKDLmHzKECitLweNkSsYKcBdazSQHipE2KWQe2Dv52mdZenBE9DK96VJhnHLuGd8odTnvSsOPYwQ==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.6-next"
       }
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-18.2.tgz",
-      "integrity": "sha512-aCRiLUmVIZhF1Zxv1fRFWUxf5SyJHm6sC7gzcNjcpFpnZmEDVc/FANQRD4UYJ6CGIscIO3JjR7zK+o9R0qhpRg==",
+      "version": "0.10.0-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-23.tgz",
+      "integrity": "sha512-B/YySGf71q2KqvNYhjwx37wSgc0/mpHYo+khol0iEUvByOp4i+lfrTOz8hGLe3qbmAQUynsbvIYUhq7yeW77AA==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-18.2.tgz",
-      "integrity": "sha512-ZbT+5y8etgNS+pR7rWx/LVUP1JW9kWGvmGrwcGto3pmV0u3we77acUftoFQ5hrFtqz7HKD/C7WV4HEZ0mrmtZQ==",
+      "version": "0.0.7-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-23.tgz",
+      "integrity": "sha512-o/2rdOBS34akX6yh+RYG0Oc3XztVwThNS4G9pmniCq0owjT119HZQ5C+RfFt0kKW9Y8catZ5xEjyz/tLm9a04g==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-18.2.tgz",
-      "integrity": "sha512-v4Kgpt9C8aXapy5Qx+lfvpxB3R5OEYBbOq/fpdFOQQglnHwvYrG45CqoR5yYX5ifWEx1wqaQHe3XWUt+2ZYTmA=="
+      "version": "0.0.6-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-23.tgz",
+      "integrity": "sha512-R0CmVJ7ZRtugF+9YlbZ66dPoP4BCroRzMs3rfgul5cmJt7EHLqt0KKW08qsXHU4RPC/lpfs8oYy+ySzDJCaq+Q=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -10984,9 +10984,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-18.2.tgz",
-      "integrity": "sha512-dZrGQLIo82cVR7PfkoM4ELOUpTMYocInLD+w2xDWaLpYc/2E1JgtHugZRzY3dviakc7kf9gVW9vA5xI19/ShVQ==",
+      "version": "0.0.3-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-23.tgz",
+      "integrity": "sha512-gv46WmjvjwVKDLmHzKECitLweNkSsYKcBdazSQHipE2KWQe2Dv52mdZenBE9DK96VJhnHLuGd8odTnvSsOPYwQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11012,9 +11012,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-18.2.tgz",
-      "integrity": "sha512-aCRiLUmVIZhF1Zxv1fRFWUxf5SyJHm6sC7gzcNjcpFpnZmEDVc/FANQRD4UYJ6CGIscIO3JjR7zK+o9R0qhpRg==",
+      "version": "0.10.0-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-23.tgz",
+      "integrity": "sha512-B/YySGf71q2KqvNYhjwx37wSgc0/mpHYo+khol0iEUvByOp4i+lfrTOz8hGLe3qbmAQUynsbvIYUhq7yeW77AA==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11032,17 +11032,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-18.2.tgz",
-      "integrity": "sha512-ZbT+5y8etgNS+pR7rWx/LVUP1JW9kWGvmGrwcGto3pmV0u3we77acUftoFQ5hrFtqz7HKD/C7WV4HEZ0mrmtZQ==",
+      "version": "0.0.7-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-23.tgz",
+      "integrity": "sha512-o/2rdOBS34akX6yh+RYG0Oc3XztVwThNS4G9pmniCq0owjT119HZQ5C+RfFt0kKW9Y8catZ5xEjyz/tLm9a04g==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-18.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-18.2.tgz",
-      "integrity": "sha512-v4Kgpt9C8aXapy5Qx+lfvpxB3R5OEYBbOq/fpdFOQQglnHwvYrG45CqoR5yYX5ifWEx1wqaQHe3XWUt+2ZYTmA=="
+      "version": "0.0.6-next-2022-11-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-23.tgz",
+      "integrity": "sha512-R0CmVJ7ZRtugF+9YlbZ66dPoP4BCroRzMs3rfgul5cmJt7EHLqt0KKW08qsXHU4RPC/lpfs8oYy+ySzDJCaq+Q=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -266,3 +266,33 @@ export const getNervousSystemFunctions = async ({
   logWithTimestamp(`Getting nervous system functions call complete.`);
   return functions;
 };
+
+export const setFollowees = async ({
+  rootCanisterId,
+  identity,
+  neuronId,
+  functionId,
+  followees,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  neuronId: SnsNeuronId;
+  functionId: bigint;
+  followees: SnsNeuronId[];
+}): Promise<void> => {
+  logWithTimestamp(`Setting sns neuron followee call...`);
+
+  const { setTopicFollowees } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  await setTopicFollowees({
+    neuronId,
+    functionId,
+    followees,
+  });
+
+  logWithTimestamp(`Setting sns neuron followee call complete.`);
+};

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -315,7 +315,7 @@ export const querySnsNeurons = async ({
   return neurons;
 };
 
-export const querySnsNeuron = async ({
+export const getSnsNeuron = async ({
   identity,
   rootCanisterId,
   certified,
@@ -333,6 +333,31 @@ export const querySnsNeuron = async ({
     certified,
   });
   const neuron = await getNeuron({
+    neuronId,
+  });
+
+  logWithTimestamp("Getting sns neuron: done");
+  return neuron;
+};
+
+export const querySnsNeuron = async ({
+  identity,
+  rootCanisterId,
+  certified,
+  neuronId,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+  neuronId: SnsNeuronId;
+}): Promise<SnsNeuron | undefined> => {
+  logWithTimestamp("Querying sns neuron: call...");
+  const { queryNeuron } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+  const neuron = await queryNeuron({
     neuronId,
   });
 

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -315,6 +315,9 @@ export const querySnsNeurons = async ({
   return neurons;
 };
 
+/**
+ * Returns the neuron or raises an error if not found.
+ */
 export const getSnsNeuron = async ({
   identity,
   rootCanisterId,
@@ -340,6 +343,9 @@ export const getSnsNeuron = async ({
   return neuron;
 };
 
+/**
+ * Returns the neuron or undefined.
+ */
 export const querySnsNeuron = async ({
   identity,
   rootCanisterId,

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -88,11 +88,6 @@
     padding: 0;
   }
 
-  h3 {
-    // Titles longer than one line had too much space with the default line-height for h3
-    line-height: normal;
-  }
-
   .subtitle {
     margin: 0 0 var(--padding) 0;
   }

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -37,11 +37,6 @@
 {/if}
 
 <style lang="scss">
-  h3 {
-    // Titles longer than one line had too much space with the default line-height for h3
-    line-height: normal;
-  }
-
   .subtitle {
     margin: 0 0 var(--padding) 0;
   }

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
+  import NewSnsFolloweeModal from "$lib/modals/sns/NewSnsFolloweeModal.svelte";
+  import type { Principal } from "@dfinity/principal";
+  import type { SnsNeuron, SnsNervousSystemFunction } from "@dfinity/sns";
+  import { fromNullable } from "@dfinity/utils";
+
+  export let neuron: SnsNeuron;
+  export let rootCanisterId: Principal;
+  export let nsFunction: SnsNervousSystemFunction;
+
+  let showModal = false;
+  const openModal = () => (showModal = true);
+  const closeModal = () => (showModal = false);
+</script>
+
+<FollowTopicSection
+  on:nnsOpen={openModal}
+  count={0}
+  id={nsFunction.id.toString()}
+>
+  <h3 slot="title">{nsFunction.name}</h3>
+  <p slot="subtitle" class="subtitle description">
+    {fromNullable(nsFunction.description)}
+  </p>
+  <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
+  <div>{`TODO: render followees ${neuron.followees.length}`}</div>
+</FollowTopicSection>
+
+{#if showModal}
+  <NewSnsFolloweeModal
+    {rootCanisterId}
+    {neuron}
+    functionId={nsFunction.id}
+    on:nnsClose={closeModal}
+  />
+{/if}
+
+<style lang="scss">
+  h3 {
+    // Titles longer than one line had too much space with the default line-height for h3
+    line-height: normal;
+  }
+
+  .subtitle {
+    margin: 0 0 var(--padding) 0;
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -688,6 +688,7 @@
     "ledger_created_future": "Sorry, the transaction can't be created in the future. Please try again.",
     "ledger_too_old": "Sorry, the transaction is too old. Please try again.",
     "ledger_unsufficient_funds": "Sorry, the account doesn't have enough funds for this transaction.",
+    "sns_add_followee": "There was an error while adding a followee.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   },
   "auth_accounts": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -274,6 +274,7 @@
     "follow": "Follow",
     "unfollow": "Unfollow",
     "same_neuron": "You can't add the same neuron as followee.",
+    "followee_does_not_exist": "Neuron with id $neuronId does not exist.",
     "already_followed": "You are already following this neuron."
   },
   "follow_neurons": {

--- a/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/FollowSnsNeuronsModal.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-  import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import { functionsToFollow } from "$lib/utils/sns-neuron.utils";
+  import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
   import { Modal, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
-  import { fromNullable } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
@@ -27,15 +26,8 @@
     {#if functions === undefined}
       <Spinner />
     {:else}
-      {#each functions as { name, id, description }}
-        <FollowTopicSection count={0} id={id.toString()}>
-          <h3 slot="title">{name}</h3>
-          <p slot="subtitle" class="subtitle description">
-            {fromNullable(description)}
-          </p>
-          <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
-          <div>{`TODO: render followees ${neuron.followees.length}`}</div>
-        </FollowTopicSection>
+      {#each functions as nsFunction (nsFunction.id.toString())}
+        <FollowSnsTopicSection {nsFunction} {rootCanisterId} {neuron} />
       {/each}
     {/if}
   </div>
@@ -46,14 +38,5 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-1_5x);
-  }
-
-  h3 {
-    // Titles longer than one line had too much space with the default line-height for h3
-    line-height: normal;
-  }
-
-  .subtitle {
-    margin: 0 0 var(--padding) 0;
   }
 </style>

--- a/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import Input from "$lib/components/ui/Input.svelte";
+  import { addFollowee } from "$lib/services/sns-neurons.services";
+  import { i18n } from "$lib/stores/i18n";
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "$lib/types/sns-neuron-detail.context";
+  import { hexStringToBytes } from "$lib/utils/utils";
+  import { busy, Modal, startBusy, stopBusy } from "@dfinity/gix-components";
+  import type { Principal } from "@dfinity/principal";
+  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
+  import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+  import { createEventDispatcher, getContext } from "svelte";
+
+  export let rootCanisterId: Principal;
+  export let neuron: SnsNeuron;
+  export let functionId: bigint;
+
+  // This mean we can't use this modal outside of the neuron detail page.
+  const { reload }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let followeeAddress = "";
+  const dispatcher = createEventDispatcher();
+  const add = async () => {
+    startBusy({
+      initiator: "add-sns-followee",
+    });
+
+    const followee: SnsNeuronId = {
+      id: arrayOfNumberToUint8Array(hexStringToBytes(followeeAddress)),
+    };
+
+    await addFollowee({
+      rootCanisterId,
+      neuron: neuron,
+      followee,
+      functionId,
+    });
+    await reload();
+
+    stopBusy("add-sns-followee");
+    dispatcher("nnsClose");
+  };
+</script>
+
+<Modal on:nnsClose>
+  <svelte:fragment slot="title">{$i18n.new_followee.title}</svelte:fragment>
+
+  <form on:submit|preventDefault={add}>
+    <Input
+      inputType="text"
+      autocomplete="off"
+      placeholderLabelKey="new_followee.address_placeholder"
+      name="new-followee-id"
+      bind:value={followeeAddress}
+    >
+      <svelte:fragment slot="label"
+        >{$i18n.new_followee.address_placeholder}</svelte:fragment
+      >
+    </Input>
+    <button
+      class="primary"
+      type="submit"
+      disabled={followeeAddress.length === 0 || $busy}
+    >
+      {$i18n.new_followee.follow_neuron}
+    </button>
+  </form>
+</Modal>

--- a/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
@@ -6,11 +6,9 @@
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
-  import { hexStringToBytes } from "$lib/utils/utils";
   import { busy, Modal, startBusy, stopBusy } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
-  import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+  import type { SnsNeuron } from "@dfinity/sns";
   import { createEventDispatcher, getContext } from "svelte";
 
   export let rootCanisterId: Principal;
@@ -21,21 +19,17 @@
   const { reload }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
 
-  let followeeAddress = "";
+  let followeeHex = "";
   const dispatcher = createEventDispatcher();
   const add = async () => {
     startBusy({
       initiator: "add-sns-followee",
     });
 
-    const followee: SnsNeuronId = {
-      id: arrayOfNumberToUint8Array(hexStringToBytes(followeeAddress)),
-    };
-
     await addFollowee({
       rootCanisterId,
       neuron: neuron,
-      followee,
+      followeeHex,
       functionId,
     });
     await reload();
@@ -54,7 +48,7 @@
       autocomplete="off"
       placeholderLabelKey="new_followee.address_placeholder"
       name="new-followee-id"
-      bind:value={followeeAddress}
+      bind:value={followeeHex}
     >
       <svelte:fragment slot="label"
         >{$i18n.new_followee.address_placeholder}</svelte:fragment
@@ -63,7 +57,8 @@
     <button
       class="primary"
       type="submit"
-      disabled={followeeAddress.length === 0 || $busy}
+      data-tid="add-followee-button"
+      disabled={followeeHex.length === 0 || $busy}
     >
       {$i18n.new_followee.follow_neuron}
     </button>

--- a/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
@@ -51,13 +51,11 @@
     <Input
       inputType="text"
       autocomplete="off"
-      placeholderLabelKey="new_followee.address_placeholder"
+      placeholderLabelKey="new_followee.placeholder"
       name="new-followee-id"
       bind:value={followeeHex}
     >
-      <svelte:fragment slot="label"
-        >{$i18n.new_followee.address_placeholder}</svelte:fragment
-      >
+      <svelte:fragment slot="label">{$i18n.new_followee.label}</svelte:fragment>
     </Input>
     <button
       class="primary"

--- a/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
@@ -26,16 +26,21 @@
       initiator: "add-sns-followee",
     });
 
-    await addFollowee({
+    const { success } = await addFollowee({
       rootCanisterId,
       neuron: neuron,
       followeeHex,
       functionId,
     });
-    await reload();
+    if (success) {
+      await reload();
+    }
 
     stopBusy("add-sns-followee");
-    dispatcher("nnsClose");
+
+    if (success) {
+      dispatcher("nnsClose");
+    }
   };
 </script>
 

--- a/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
+++ b/frontend/src/lib/modals/sns/NewSnsFolloweeModal.svelte
@@ -21,6 +21,7 @@
 
   let followeeHex = "";
   const dispatcher = createEventDispatcher();
+  const close = () => dispatcher("nnsClose");
   const add = async () => {
     startBusy({
       initiator: "add-sns-followee",
@@ -39,7 +40,7 @@
     stopBusy("add-sns-followee");
 
     if (success) {
-      dispatcher("nnsClose");
+      close();
     }
   };
 </script>
@@ -57,13 +58,18 @@
     >
       <svelte:fragment slot="label">{$i18n.new_followee.label}</svelte:fragment>
     </Input>
-    <button
-      class="primary"
-      type="submit"
-      data-tid="add-followee-button"
-      disabled={followeeHex.length === 0 || $busy}
-    >
-      {$i18n.new_followee.follow_neuron}
-    </button>
+    <div class="toolbar">
+      <button class="secondary" type="button" on:click={close}>
+        {$i18n.core.cancel}
+      </button>
+      <button
+        class="primary"
+        type="submit"
+        data-tid="add-followee-button"
+        disabled={followeeHex.length === 0 || $busy}
+      >
+        {$i18n.new_followee.follow_neuron}
+      </button>
+    </div>
   </form>
 </Modal>

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -3,7 +3,7 @@ import {
   getNeuronBalance,
   refreshNeuron,
 } from "$lib/api/sns-governance.api";
-import { querySnsNeuron } from "$lib/api/sns.api";
+import { getSnsNeuron } from "$lib/api/sns.api";
 import { MAX_NEURONS_SUBACCOUNTS } from "$lib/constants/sns-neurons.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
@@ -32,7 +32,7 @@ const loadNeuron = async ({
   certified: boolean;
   identity: Identity;
 }): Promise<void> => {
-  const neuron = await querySnsNeuron({
+  const neuron = await getSnsNeuron({
     identity,
     rootCanisterId,
     neuronId,

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -493,8 +493,7 @@ export const addFollowee = async ({
   const topicFollowees = followeesByFunction({ neuron, functionId });
   // Do not allow to add a neuron id who is already followed
   if (
-    topicFollowees !== undefined &&
-    topicFollowees.find(
+    topicFollowees?.find(
       ({ id }) => subaccountToHexString(id) === followeeHex
     ) !== undefined
   ) {

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -35,6 +35,7 @@ export type BusyStateInitiatorType =
   | "top-up-neuron"
   | "stake-sns-neuron"
   | "dissolve-sns-action"
+  | "add-sns-followee"
   | "disburse-sns-neuron";
 
 export interface BusyState {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -285,6 +285,7 @@ interface I18nNew_followee {
   follow: string;
   unfollow: string;
   same_neuron: string;
+  followee_does_not_exist: string;
   already_followed: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -722,6 +722,7 @@ interface I18nError__sns {
   ledger_created_future: string;
   ledger_too_old: string;
   ledger_unsufficient_funds: string;
+  sns_add_followee: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -20,6 +20,7 @@ import {
   InvalidSenderError,
   TransferError,
 } from "@dfinity/nns";
+import { SnsGovernanceError } from "@dfinity/sns";
 import { translate, type I18nSubstitutions } from "./i18n.utils";
 
 export const errorToString = (err?: unknown): string | undefined => {
@@ -28,6 +29,8 @@ export const errorToString = (err?: unknown): string | undefined => {
       ? (err as string)
       : err instanceof GovernanceError
       ? (err as GovernanceError)?.detail?.error_message
+      : err instanceof SnsGovernanceError
+      ? (err as SnsGovernanceError).message
       : err instanceof Error
       ? (err as Error).message
       : undefined;

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -5,7 +5,7 @@ import {
 import { formatToken } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
-import type { SnsNervousSystemFunction } from "@dfinity/sns";
+import type { SnsNervousSystemFunction, SnsNeuronId } from "@dfinity/sns";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
 import { nowInSeconds } from "./date.utils";
@@ -305,3 +305,18 @@ export const functionsToFollow = (
   functions: SnsNervousSystemFunction[] | undefined
 ): SnsNervousSystemFunction[] | undefined =>
   functions?.filter(({ id }) => id !== UNSPECIFIED_FUNCTION_ID);
+
+export const followeesByFunction = ({
+  neuron,
+  functionId,
+}: {
+  neuron: SnsNeuron;
+  functionId: bigint;
+}): SnsNeuronId[] =>
+  neuron.followees.reduce<SnsNeuronId[]>(
+    (functionFollowees, [currentFunctionId, followeesData]) =>
+      currentFunctionId === functionId
+        ? followeesData.followees
+        : functionFollowees,
+    []
+  );

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -11,6 +11,7 @@ import {
   increaseDissolveDelay,
   refreshNeuron,
   removeNeuronPermissions,
+  setFollowees,
   startDissolving,
   stopDissolving,
 } from "$lib/api/sns-governance.api";
@@ -24,11 +25,13 @@ import { Principal } from "@dfinity/principal";
 import {
   SnsNeuronPermissionType,
   type SnsListNervousSystemFunctionsResponse,
+  type SnsNeuronId,
 } from "@dfinity/sns";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import mock from "jest-mock-extended/lib/Mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "../../mocks/sns-functions.mock";
+import { mockSnsNeuron } from "../../mocks/sns-neurons.mock";
 import {
   mockQueryMetadataResponse,
   mockQueryTokenResponse,
@@ -59,6 +62,7 @@ describe("sns-api", () => {
   const getNeuronBalanceSpy = jest.fn().mockResolvedValue(undefined);
   const refreshNeuronSpy = jest.fn().mockResolvedValue(undefined);
   const claimNeuronSpy = jest.fn().mockResolvedValue(undefined);
+  const setTopicFolloweesSpy = jest.fn().mockResolvedValue(undefined);
   const nervousSystemFunctionsMock: SnsListNervousSystemFunctionsResponse = {
     reserved_ids: new BigUint64Array(),
     functions: [nervousSystemFunctionMock],
@@ -99,6 +103,7 @@ describe("sns-api", () => {
         refreshNeuron: refreshNeuronSpy,
         claimNeuron: claimNeuronSpy,
         listNervousSystemFunctions: getFunctionsSpy,
+        setTopicFollowees: setTopicFolloweesSpy,
       })
     );
   });
@@ -204,6 +209,20 @@ describe("sns-api", () => {
     });
 
     expect(claimNeuronSpy).toBeCalled();
+  });
+
+  it("should setFollowees for a topic", async () => {
+    const followee1: SnsNeuronId = { id: arrayOfNumberToUint8Array([1, 2, 3]) };
+    const followee2: SnsNeuronId = { id: arrayOfNumberToUint8Array([1, 2, 4]) };
+    await setFollowees({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      neuronId: mockSnsNeuron.id[0],
+      functionId: BigInt(3),
+      followees: [followee1, followee2],
+    });
+
+    expect(setTopicFolloweesSpy).toBeCalled();
   });
 
   it("should get nervous system functions", async () => {

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  getSnsNeuron,
   participateInSnsSwap,
   queryAllSnsMetadata,
   querySnsMetadata,
@@ -69,6 +70,7 @@ describe("sns-api", () => {
   const getUserCommitmentSpy = jest.fn().mockResolvedValue(mockUserCommitment);
   const ledgerCanisterMock = mock<LedgerCanister>();
   const queryNeuronsSpy = jest.fn().mockResolvedValue([mockSnsNeuron]);
+  const getNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron);
   const queryNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron);
   const stakeNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron.id);
 
@@ -98,8 +100,9 @@ describe("sns-api", () => {
         notifyParticipation: notifyParticipationSpy,
         getUserCommitment: getUserCommitmentSpy,
         listNeurons: queryNeuronsSpy,
-        getNeuron: queryNeuronSpy,
+        getNeuron: getNeuronSpy,
         stakeNeuron: stakeNeuronSpy,
+        queryNeuron: queryNeuronSpy,
       })
     );
   });
@@ -222,7 +225,19 @@ describe("sns-api", () => {
     expect(queryNeuronsSpy).toBeCalled();
   });
 
-  it("should query one sns neurons", async () => {
+  it("should get one sns neuron", async () => {
+    const neuron = await getSnsNeuron({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      certified: false,
+      neuronId: { id: arrayOfNumberToUint8Array([1, 2, 3]) },
+    });
+
+    expect(neuron).not.toBeNull();
+    expect(getNeuronSpy).toBeCalled();
+  });
+
+  it("should query one sns neuron", async () => {
     const neuron = await querySnsNeuron({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
+import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
+import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
+import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { principal } from "../../../mocks/sns-projects.mock";
+
+describe("FollowSnsTopicSection", () => {
+  const reload = jest.fn();
+
+  const renderComponent = (): RenderResult =>
+    renderSelectedSnsNeuronContext({
+      Component: FollowSnsTopicSection,
+      reload,
+      neuron: mockSnsNeuron,
+      props: {
+        neuron: mockSnsNeuron,
+        rootCanisterId: principal(2),
+        nsFunction: nervousSystemFunctionMock,
+      },
+    });
+
+  it("renders follow topic section", () => {
+    const { queryByTestId } = renderComponent();
+
+    expect(
+      queryByTestId(`follow-topic-${nervousSystemFunctionMock.id}-section`)
+    ).toBeInTheDocument();
+  });
+
+  it.only("opens new followee modal", async () => {
+    const { getByTestId, queryByTestId } = renderComponent();
+
+    const button = getByTestId("open-new-followee-modal");
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(queryByTestId("add-followee-button")).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NewSnsFolloweeModal from "$lib/modals/sns/NewSnsFolloweeModal.svelte";
+import { addFollowee } from "$lib/services/sns-neurons.services";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
+import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
+import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { principal } from "../../../mocks/sns-projects.mock";
+
+jest.mock("$lib/services/sns-neurons.services", () => {
+  return {
+    addFollowee: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("NewSnsFolloweeModal", () => {
+  const reload = jest.fn();
+  const functionId = BigInt(4);
+
+  const renderNewSnsFolloweeModal = (): RenderResult =>
+    renderSelectedSnsNeuronContext({
+      Component: NewSnsFolloweeModal,
+      reload,
+      neuron: mockSnsNeuron,
+      props: {
+        rootCanisterId: principal(2),
+        neuron: mockSnsNeuron,
+        functionId,
+      },
+    });
+
+  it("should display modal", async () => {
+    const { container } = renderNewSnsFolloweeModal();
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should call addFollowee service, reload and close modal", async () => {
+    const followeeHex = subaccountToHexString(
+      arrayOfNumberToUint8Array([1, 2, 4])
+    );
+    const { container, queryByTestId, component } = renderNewSnsFolloweeModal();
+
+    const inputElement = container.querySelector("input[type='text']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: followeeHex },
+      }));
+
+    const buttonElement = queryByTestId("add-followee-button");
+    expect(buttonElement).not.toBeNull();
+
+    const onClose = jest.fn();
+    component.$on("nnsClose", onClose);
+    buttonElement && (await fireEvent.click(buttonElement));
+    expect(addFollowee).toBeCalled();
+
+    await waitFor(() => expect(onClose).toBeCalled());
+    expect(reload).toBeCalled();
+  });
+});

--- a/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
@@ -13,7 +13,7 @@ import { principal } from "../../../mocks/sns-projects.mock";
 
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
-    addFollowee: jest.fn().mockResolvedValue(undefined),
+    addFollowee: jest.fn().mockResolvedValue({ success: true }),
   };
 });
 

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -34,7 +34,7 @@ describe("sns-neurons-check-balances-services", () => {
         id: [neuronId] as [SnsNeuronId],
       };
       const spyQuery = jest
-        .spyOn(api, "querySnsNeuron")
+        .spyOn(api, "getSnsNeuron")
         .mockImplementation(() => Promise.resolve(neuron));
       const spyNeuronBalance = jest
         .spyOn(governanceApi, "getNeuronBalance")
@@ -67,7 +67,7 @@ describe("sns-neurons-check-balances-services", () => {
         cached_neuron_stake_e8s: stake,
       };
       const spyNeuronQuery = jest
-        .spyOn(api, "querySnsNeuron")
+        .spyOn(api, "getSnsNeuron")
         .mockImplementation(() => Promise.resolve(updatedNeuron));
       const spyNeuronBalance = jest
         .spyOn(governanceApi, "getNeuronBalance")
@@ -108,7 +108,7 @@ describe("sns-neurons-check-balances-services", () => {
         cached_neuron_stake_e8s: BigInt(0),
       };
       const spyNeuronQuery = jest
-        .spyOn(api, "querySnsNeuron")
+        .spyOn(api, "getSnsNeuron")
         .mockImplementation(() => Promise.resolve(updatedNeuron));
       const spyNeuronBalance = jest
         .spyOn(governanceApi, "getNeuronBalance")

--- a/frontend/src/tests/mocks/context-wrapper.mock.ts
+++ b/frontend/src/tests/mocks/context-wrapper.mock.ts
@@ -26,7 +26,8 @@ export const renderContextWrapper = <T>({
   Component: typeof SvelteComponent;
   contextKey: symbol;
   contextValue: T;
-  props?: never;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props?: any;
 }): RenderResult =>
   render(ContextWrapperTest, {
     props: {
@@ -63,7 +64,8 @@ export const renderSelectedSnsNeuronContext = ({
   Component: typeof SvelteComponent;
   neuron: SnsNeuron;
   reload: () => Promise<void>;
-  props?: never;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props?: any;
 }) =>
   renderContextWrapper({
     Component,
@@ -76,7 +78,7 @@ export const renderSelectedSnsNeuronContext = ({
         },
         neuron,
       }),
-      props,
       reload,
     } as SelectedSnsNeuronContext,
+    props,
   });


### PR DESCRIPTION
# Motivation

User can add followees to SNS neurons.

NOTE: Followees are still not rendered.

# Changes

* FollowsSnsNeuronModal uses a new component: FollowSnsTopicSection to render each Topic.
* FollowSnsTopicSection uses a new Component NewSnsFolloweeModal to created the new followee.
* NewSnsFolloweeModal uses a new sns-neuron service addFollowee.
* In sns-neurons.services, addFollowe uses new apis "setFollowees" and "querySndNeuron" and a new sns-neuron utils "followeesByFunction"
* In sns.api.ts, rename "querySnsNeuron" to "getSnsNeuron". This api raises an error if the neuron is not found. The one we use so far.
* In sns.api.ts, new api "querySnsNeuron" that returns `undefined` if neuron does not exist. Useful to check easily whether a followee exists.
* In sns-governance.api.ts, New api "setFollowees".

# Tests

* Test new component FollowSnsTopicSection.
* Test new modal NewSnsFolloweeModal
* Test new service addFollowee with different scenarios.
* Test new apis: "querySnsNeuron" and "setFollowees"
