### PR TITLE
test: reload filters

### DIFF
--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -173,6 +173,20 @@ describe("proposals-store", () => {
         excludeVotedProposals: false,
       });
     });
+
+    it("should reload filters", () => {
+      const filter = [Topic.NetworkEconomics, Topic.SubnetManagement];
+      proposalsFiltersStore.filterTopics(filter);
+
+      proposalsFiltersStore.reload();
+
+      const filters = get(proposalsFiltersStore);
+      expect(filters).toEqual({
+        ...DEFAULT_PROPOSALS_FILTERS,
+        topics: filter
+      });
+      expect(filters.lastAppliedFilter).toBeUndefined();
+    });
   });
 
   describe("votingNeuronSelectStore", () => {

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -183,7 +183,7 @@ describe("proposals-store", () => {
       const filters = get(proposalsFiltersStore);
       expect(filters).toEqual({
         ...DEFAULT_PROPOSALS_FILTERS,
-        topics: filter
+        topics: filter,
       });
       expect(filters.lastAppliedFilter).toBeUndefined();
     });


### PR DESCRIPTION
# Motivation

I literally dreamed of that missing test this night (😅) so let's add a test for the new proposal filter `reload()` function.

# Changes

- test `reload` store and call
