### PR TITLE
GIX-1104: Enable SNS-1

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -111,7 +111,7 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS": false,
+          "ENABLE_SNS": true,
           "ENABLE_SNS_2": false
         }
       },
@@ -125,7 +125,7 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS": false,
+          "ENABLE_SNS": true,
           "ENABLE_SNS_2": false
         }
       },

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -28,7 +28,7 @@
     <SkeletonProposalCard />
   </div>
 {:else if $openSnsProposalsStore.length === 0}
-  <p class="no-proposals">{$i18n.voting.nothing_found}</p>
+  <p class="no-proposals">{$i18n.sns_launchpad.no_proposals}</p>
 {:else}
   <ul class="card-grid">
     {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -22,6 +22,7 @@
   import { fromDefinedNullable } from "@dfinity/utils";
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
+  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
 
   const { store, reload: reloadContext }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -65,7 +66,8 @@
   </KeyValuePair>
 
   <div class="buttons">
-    {#if allowedToDissolve}
+    {#if allowedToDissolve && ENABLE_SNS_2}
+      <!-- TODO: Enable when voting power calculation is accurate -->
       <IncreaseSnsDissolveDelayButton
         {neuron}
         {token}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -545,12 +545,12 @@
   "sns_launchpad": {
     "header": "Launch Pad",
     "committed_projects": "Launched",
-    "no_committed_projects": "No launched projects at the moment",
+    "no_committed_projects": "No launched projects so far.",
     "open_projects": "Current Launches",
-    "no_open_projects": "Looks like there's no SNSs launching right now. <a href=\"https://internetcomputer.org/sns\" rel=\"noopener noreferrer\" aria-label=\"more info about launching an SNS\" target=\"_blank\">More about creating SNSs</a>.",
+    "no_open_projects": "Looks like there are no SNS decentralisation sales running right now. Hopefully one is coming soon! <a href=\"https://internetcomputer.org/sns\" rel=\"noopener noreferrer\" aria-label=\"more info about launching an SNS\" target=\"_blank\">Read more about how SNSs are created</a>.",
     "proposals": "Proposals",
     "project_logo": "project logo",
-    "no_proposals": "No current proposals at the moment"
+    "no_proposals": "There are no decentralisation sale proposals open at the moment."
   },
   "sns_project": {
     "project": "Project"

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -85,7 +85,7 @@ describe("Proposals", () => {
     const { queryByText } = render(Proposals);
 
     await waitFor(() =>
-      expect(queryByText(en.voting.nothing_found)).toBeInTheDocument()
+      expect(queryByText(en.sns_launchpad.no_proposals)).toBeInTheDocument()
     );
   });
 });


### PR DESCRIPTION
# Motivation

Enable SNS-1 features!

* Launchpad.
* Universes in Tokens and Neurons.

# Changes

* Set ENABLE_SNS to `true` for mainnet and staging.
* Hide Dissolve delay behind ENABLE_SNS_2 because it's not ready.
* Change wording for empty launchpad.

# Tests

Not applicable.
