### PR TITLE
Fix: Voting power calculation nns

### DIFF
--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -66,6 +66,7 @@
         votingPower({
           stake: neuronICP,
           dissolveDelayInSeconds: delayInSeconds,
+          ageSeconds: 0,
         })
       )}
     </p>

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -95,6 +95,7 @@
               votingPower({
                 stake: neuronICP,
                 dissolveDelayInSeconds: delayInSeconds,
+                ageSeconds: Number(neuron.ageSeconds),
               })
             )}
           </p>

--- a/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
@@ -55,6 +55,7 @@
         votingPower({
           stake: neuronStake,
           dissolveDelayInSeconds: delayInSeconds,
+          ageSeconds: Number(neuron.aging_since_timestamp_seconds),
         })
       )}
     </p>

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -106,6 +106,7 @@
               votingPower({
                 stake: neuronStake,
                 dissolveDelayInSeconds: delayInSeconds,
+                ageSeconds: Number(neuron.aging_since_timestamp_seconds),
               })
             )}
           </p>

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -95,7 +95,7 @@ export const votingPower = ({
 }: {
   stake: bigint;
   dissolveDelayInSeconds: number;
-  ageSeconds?: number;
+  ageSeconds: number;
 }): bigint =>
   dissolveDelayInSeconds > SECONDS_IN_HALF_YEAR
     ? BigInt(

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -75,6 +75,7 @@ describe("ConfirmSnsDissolveDelay", () => {
       votingPower({
         stake: getSnsNeuronStake(mockSnsNeuron),
         dissolveDelayInSeconds: delayInSeconds,
+        ageSeconds: Number(mockSnsNeuron.aging_since_timestamp_seconds),
       })
     );
 

--- a/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
@@ -75,6 +75,7 @@ describe("ConfirmSnsDissolveDelay", () => {
       votingPower({
         stake: getSnsNeuronStake(mockSnsNeuron),
         dissolveDelayInSeconds: delayInSeconds,
+        ageSeconds: Number(mockSnsNeuron.aging_since_timestamp_seconds),
       })
     );
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -96,7 +96,11 @@ describe("neuron-utils", () => {
     }) as TokenAmount;
     it("should return zero for delays less than six months", () => {
       expect(
-        votingPower({ stake: BigInt(2), dissolveDelayInSeconds: 100 })
+        votingPower({
+          stake: BigInt(2),
+          dissolveDelayInSeconds: 100,
+          ageSeconds: 0,
+        })
       ).toBe(BigInt(0));
     });
 
@@ -105,6 +109,7 @@ describe("neuron-utils", () => {
         votingPower({
           stake: tokenStake.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
+          ageSeconds: 0,
         })
       ).toBeGreaterThan(tokenStake.toE8s());
     });
@@ -114,6 +119,7 @@ describe("neuron-utils", () => {
         votingPower({
           stake: tokenStake.toE8s(),
           dissolveDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+          ageSeconds: 0,
         })
       ).toBe(tokenStake.toE8s() * BigInt(2));
     });
@@ -127,6 +133,7 @@ describe("neuron-utils", () => {
       const powerWithoutAge = votingPower({
         stake: tokenStake.toE8s(),
         dissolveDelayInSeconds: SECONDS_IN_HALF_YEAR + SECONDS_IN_HOUR,
+        ageSeconds: 0,
       });
       expect(powerWithAge).toBeGreaterThan(powerWithoutAge);
     });


### PR DESCRIPTION
# Motivation

Calculation of the dissolve delay modal didn't consider the neuron's age.

# Changes

* Make ageSeconds mandatory when calculating voting power.

# Tests

* Fix broken tests after change.
* The rest of the tests were ok, the problem was that it was not used.
