### PR TITLE
FIx: Rename action OpenSnsTokenSwap

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -6,6 +6,7 @@
   import type { Proposal } from "@dfinity/nns";
   import Json from "../common/Json.svelte";
   import { KeyValuePair } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
 
   export let proposal: Proposal | undefined;
 
@@ -13,12 +14,17 @@
   let actionFields: [string, unknown][] = [];
   $: actionKey =
     proposal !== undefined ? proposalFirstActionKey(proposal) : undefined;
+  let title: string;
+  $: title =
+    actionKey === "OpenSnsTokenSwap"
+      ? $i18n.actions.OpenSnsTokenSwap
+      : actionKey ?? "";
   $: actionFields =
     proposal !== undefined ? proposalActionFields(proposal) : [];
 </script>
 
 <h2 class="content-cell-title" data-tid="proposal-proposer-actions-entry-title">
-  {actionKey ?? ""}
+  {title}
 </h2>
 
 <div class="content-cell-details">
@@ -28,6 +34,8 @@
       <span class="value" slot="value">
         {#if typeof value === "object"}
           <Json json={value} />
+        {:else if typeof value === "undefined"}
+          {$i18n.core.null}
         {:else}
           {value}
         {/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -14,6 +14,7 @@
   let actionFields: [string, unknown][] = [];
   $: actionKey =
     proposal !== undefined ? proposalFirstActionKey(proposal) : undefined;
+  // TODO: Remove hack https://dfinity.atlassian.net/browse/GIX-1155
   let title: string;
   $: title =
     actionKey === "OpenSnsTokenSwap"

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -27,6 +27,7 @@
     "ic": "Internet Computer",
     "previous": "Previous",
     "next": "Next",
+    "null": "NULL",
     "principal_is": "Your principal is"
   },
   "error": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -30,6 +30,7 @@ interface I18nCore {
   ic: string;
   previous: string;
   next: string;
+  null: string;
   principal_is: string;
 }
 

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -53,6 +53,7 @@ export const proposalActionFields = (
     switch (typeof value) {
       case "object":
         return value && Object.keys(value).length > 0;
+      case "undefined":
       case "string":
       case "bigint":
       case "boolean":

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
@@ -4,8 +4,9 @@
 
 import ProposalProposerActionsEntry from "$lib/components/proposal-detail/ProposalProposerActionsEntry.svelte";
 import { proposalFirstActionKey } from "$lib/utils/proposals.utils";
-import type { Proposal } from "@dfinity/nns";
+import type { Action, Proposal } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import en from "../../../mocks/i18n.mock";
 import {
   mockProposalInfo,
   proposalActionMotion,
@@ -21,6 +22,17 @@ const proposalWithMotionAction = {
 const proposalWithRewardNodeProviderAction = {
   ...mockProposalInfo.proposal,
   action: proposalActionRewardNodeProvider,
+} as Proposal;
+
+const actionWithUndefined = {
+  Motion: {
+    motionText: undefined,
+  },
+} as Action;
+
+const proposalWithActionWithUndefined = {
+  ...mockProposalInfo.proposal,
+  action: actionWithUndefined,
 } as Proposal;
 
 describe("ProposalProposerActionsEntry", () => {
@@ -67,6 +79,16 @@ describe("ProposalProposerActionsEntry", () => {
     });
 
     expect(motionActions.queryAllByTestId("json").length).toBe(0);
+  });
+
+  it("should render undefined fields as NULL", () => {
+    const { getByText } = render(ProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithActionWithUndefined,
+      },
+    });
+
+    expect(getByText(en.core.null)).toBeInTheDocument();
   });
 
   it("should render nnsFunction id", () => {

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -24,6 +24,7 @@ import {
   selectedNeuronsVotingPower,
 } from "$lib/utils/proposals.utils";
 import type {
+  Action,
   Ballot,
   ExecuteNnsFunction,
   NeuronInfo,
@@ -57,6 +58,25 @@ const proposalWithNnsFunctionAction = {
 const proposalWithRewardNodeProviderAction = {
   ...mockProposalInfo.proposal,
   action: proposalActionRewardNodeProvider,
+} as Proposal;
+
+const actionWithEmpty = {
+  RewardNodeProvider: {
+    nodeProvider: {
+      id: "aaaaa-aa",
+    },
+    amountE8s: undefined,
+    rewardMode: {
+      RewardToNeuron: {
+        dissolveDelaySeconds: BigInt(1000),
+      },
+    },
+  },
+} as Action;
+
+const proposalWithActionWithUndefined = {
+  ...mockProposalInfo.proposal,
+  action: actionWithEmpty,
 } as Proposal;
 
 describe("proposals-utils", () => {
@@ -626,6 +646,14 @@ describe("proposals-utils", () => {
   describe("proposalActionFields", () => {
     it("should filter action fields", () => {
       const fields = proposalActionFields(proposalWithRewardNodeProviderAction);
+
+      expect(fields.map(([key]) => key).join()).toEqual(
+        "nodeProvider,amountE8s,rewardMode"
+      );
+    });
+
+    it("should include undefined action fields", () => {
+      const fields = proposalActionFields(proposalWithActionWithUndefined);
 
       expect(fields.map(([key]) => key).join()).toEqual(
         "nodeProvider,amountE8s,rewardMode"


### PR DESCRIPTION
# Motivation

Users should not see the word Swap in the nns-dapp.

We want to show also the properties of the actions that are undefined. We show them as `NULL`.

# Changes

* Include `undefined` as the type of action field value that we support.
* Check when the action is OpenSnsTokenSwap and show a different title.

# Tests

* Add test for new support for `undefined` properties in action fields.
* Add test to check that ProposalProposerActionsEntry renders `NULL` for undefined properties.
