### PR TITLE
fix: followee modal overflow

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -2,9 +2,13 @@
   import type { Topic } from "@dfinity/nns";
   import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
-  import VotingHistoryModal from "$lib/modals/neurons/VotingHistoryModal.svelte";
   import { knownNeuronsStore } from "$lib/stores/knownNeurons.store";
   import { Tag } from "@dfinity/gix-components";
+  import {
+    NNS_NEURON_CONTEXT_KEY,
+    type NnsNeuronContext,
+  } from "$lib/types/nns-neuron-detail.context";
+  import { getContext } from "svelte";
 
   export let followee: FolloweesNeuron;
 
@@ -12,16 +16,24 @@
   const topicTitle = (topic: Topic) =>
     $i18n.follow_neurons[`topic_${topic}_title`];
 
-  let modalOpen = false;
   let id: string;
   $: id = `followee-${followee.neuronId}`;
   let name: string;
   $: name =
     $knownNeuronsStore.find(({ id }) => id === followee.neuronId)?.name ??
     followee.neuronId.toString();
+
+  const { toggleModal, store }: NnsNeuronContext = getContext<NnsNeuronContext>(
+    NNS_NEURON_CONTEXT_KEY
+  );
+
+  const openVotingHistory = () => {
+    store.update((data) => ({ ...data, selectedFollowee: followee }));
+    toggleModal("voting-history");
+  };
 </script>
 
-<button {id} class="text" on:click|stopPropagation={() => (modalOpen = true)}>
+<button {id} class="text" on:click|stopPropagation={openVotingHistory}>
   {name}
 </button>
 
@@ -30,13 +42,6 @@
     <Tag tagName="li">{topicTitle(topic)}</Tag>
   {/each}
 </ul>
-
-{#if modalOpen}
-  <VotingHistoryModal
-    neuronId={followee.neuronId}
-    on:nnsClose={() => (modalOpen = false)}
-  />
-{/if}
 
 <style lang="scss">
   button {

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -18,6 +18,8 @@
   import JoinCommunityFundModal from "$lib/modals/neurons/JoinCommunityFundModal.svelte";
   import FollowNeuronsModal from "$lib/modals/neurons/FollowNeuronsModal.svelte";
   import AddHotkeyModal from "$lib/modals/neurons/AddHotkeyModal.svelte";
+  import VotingHistoryModal from "$lib/modals/neurons/VotingHistoryModal.svelte";
+  import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
 
   const context: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
@@ -26,9 +28,16 @@
 
   let modal: NnsNeuronModal | undefined;
   let neuron: NeuronInfo | undefined;
-  $: ({ neuron, modal } = $store);
+  let selectedFollowee: FolloweesNeuron | undefined;
+  $: ({ neuron, modal, selectedFollowee } = $store);
 
-  const close = () => store.update((data) => ({ ...data, modal: undefined }));
+  // We reset the selected followee here for convenience reason. See nns-neuron-detail.context.ts.
+  const close = () =>
+    store.update((data) => ({
+      ...data,
+      modal: undefined,
+      selectedFollowee: undefined,
+    }));
 </script>
 
 {#if neuron !== undefined}
@@ -78,5 +87,12 @@
 
   {#if modal === "add-hotkey"}
     <AddHotkeyModal on:nnsClose={close} {neuron} />
+  {/if}
+
+  {#if modal === "voting-history" && selectedFollowee !== undefined}
+    <VotingHistoryModal
+      neuronId={selectedFollowee.neuronId}
+      on:nnsClose={close}
+    />
   {/if}
 {/if}

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -113,6 +113,7 @@
   const selectedNeuronStore = writable<NnsNeuronStore>({
     modal: undefined,
     neuron,
+    selectedFollowee: undefined,
   });
 
   $: neuron,

--- a/frontend/src/lib/types/nns-neuron-detail.context.ts
+++ b/frontend/src/lib/types/nns-neuron-detail.context.ts
@@ -1,3 +1,4 @@
+import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { Writable } from "svelte/store";
 
@@ -13,11 +14,14 @@ export type NnsNeuronModal =
   | "stake-maturity"
   | "merge-maturity"
   | "spawn"
-  | "join-community-fund";
+  | "join-community-fund"
+  | "voting-history";
 
 export interface NnsNeuronStore {
   neuron: NeuronInfo | undefined;
   modal: NnsNeuronModal | undefined;
+  // TODO: find a better pattern than including the selected followee within the neuron context and thus just to open the related modal
+  selectedFollowee: FolloweesNeuron | undefined;
 }
 
 export interface NnsNeuronContext {

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuronTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuronTest.svelte
@@ -19,6 +19,7 @@
   export const neuronStore = writable<NnsNeuronStore>({
     modal: undefined,
     neuron,
+    selectedFollowee: undefined,
   });
 
   const toggleModal = (modal: NnsNeuronModal) =>

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
@@ -18,6 +18,7 @@
   export const neuronStore = writable<NnsNeuronStore>({
     modal: undefined,
     neuron,
+    selectedFollowee: undefined,
   });
 
   const toggleModal = (modal: NnsNeuronModal) =>

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -2,12 +2,12 @@
  * @jest-environment jsdom
  */
 
-import Followee from "$lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte";
 import { knownNeuronsStore } from "$lib/stores/knownNeurons.store";
 import { Topic } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import en from "../../../../mocks/i18n.mock";
+import FolloweeTest from "./FolloweeTest.svelte";
 
 describe("Followee", () => {
   const followee = {
@@ -21,19 +21,34 @@ describe("Followee", () => {
   beforeEach(() => jest.spyOn(console, "error").mockImplementation(jest.fn));
 
   it("should render neuronId", () => {
-    const { getByText } = render(Followee, { props });
+    const { getByText } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
     expect(getByText(followee.neuronId.toString())).toBeInTheDocument();
   });
 
   it("should render topics", () => {
-    const { getByText } = render(Followee, { props });
+    const { getByText } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
     followee.topics.forEach((topic) =>
       expect(getByText(en.topics[Topic[topic]])).toBeInTheDocument()
     );
   });
 
   it("should render ids", () => {
-    const { container } = render(Followee, { props });
+    const { container } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
     expect(container.querySelector("#followee-111")).toBeInTheDocument();
     expect(
       container.querySelector('[aria-labelledby="followee-111"]')
@@ -41,13 +56,23 @@ describe("Followee", () => {
   });
 
   it("should open modal", async () => {
-    const { container, getByTestId } = render(Followee, { props });
+    const { container, getByTestId } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
     await fireEvent.click(container.querySelector("button") as Element);
     expect(getByTestId("voting-history-modal")).toBeInTheDocument();
   });
 
   it("should render known neurons name", async () => {
-    const { getByText } = render(Followee, { props });
+    const { getByText } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
     knownNeuronsStore.setNeurons([
       {
         id: followee.neuronId,

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/FolloweeTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { setContext, SvelteComponent } from "svelte";
+  import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import type {
     NnsNeuronContext,
@@ -9,16 +9,17 @@
     NNS_NEURON_CONTEXT_KEY,
     NnsNeuronModal,
   } from "$lib/types/nns-neuron-detail.context";
-  import type { NeuronInfo } from "@dfinity/nns";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
+  import Followee from "$lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte";
+  import { FolloweesNeuron } from "$lib/utils/neuron.utils";
+  import { mockNeuron } from "../../../../mocks/neurons.mock";
 
-  export let testComponent: typeof SvelteComponent;
-  export let neuron: NeuronInfo | undefined;
+  export let followee: FolloweesNeuron;
 
   export const neuronStore = writable<NnsNeuronStore>({
     modal: undefined,
-    neuron,
-    selectedFollowee: undefined,
+    neuron: mockNeuron,
+    selectedFollowee: followee,
   });
 
   const toggleModal = (modal: NnsNeuronModal) =>
@@ -30,6 +31,6 @@
   });
 </script>
 
-<svelte:component this={testComponent} {neuron} />
+<Followee {followee} />
 
 <NnsNeuronModals />

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButtonTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButtonTest.svelte
@@ -18,6 +18,7 @@
   export const neuronStore = writable<NnsNeuronStore>({
     modal: undefined,
     neuron,
+    selectedFollowee: undefined,
   });
 
   const toggleModal = (modal: NnsNeuronModal) =>


### PR DESCRIPTION
# Motivation

Follow-up of #1585. `Followee` modal needs to be moved outside of the island as well.

# Note

As discussed, pattern is hacky and shall be improved afterwards.

# Changes

- extract modal outside of the island and pass the selected followee with the help of the context

# Screenshot

Afterwards:

<img width="1536" alt="Capture d’écran 2022-11-28 à 17 13 35" src="https://user-images.githubusercontent.com/16886711/204330118-df09d765-47fb-4fc8-8ff8-571014968992.png">

