### PR TITLE
style: fix skeleton card display on canister detail

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,11 +1661,11 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-25.1.tgz",
-      "integrity": "sha512-9nUfEEsyTSiF/OxcNeQtwT6GhdYwiHMipjCXPLZBqHeva7MLxlG5Vlbj3iPYXGmZ11UM4hBEaB/4OrNRIV+oeQ==",
+      "version": "2.0.0-next-2022-11-29.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.1.tgz",
+      "integrity": "sha512-tsVHeRvZ/ToLgdr6y+WZWN9OqLFcgiCW+tPnE6nldUPVsqmUGlbga6NtlDO/f3FSuWYzIM4LjmvuRX1MZIqOdA==",
       "dependencies": {
-        "dompurify": "^2.4.0"
+        "dompurify": "^2.4.1"
       }
     },
     "node_modules/@dfinity/identity": {
@@ -11077,11 +11077,11 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-25.1.tgz",
-      "integrity": "sha512-9nUfEEsyTSiF/OxcNeQtwT6GhdYwiHMipjCXPLZBqHeva7MLxlG5Vlbj3iPYXGmZ11UM4hBEaB/4OrNRIV+oeQ==",
+      "version": "2.0.0-next-2022-11-29.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.1.tgz",
+      "integrity": "sha512-tsVHeRvZ/ToLgdr6y+WZWN9OqLFcgiCW+tPnE6nldUPVsqmUGlbga6NtlDO/f3FSuWYzIM4LjmvuRX1MZIqOdA==",
       "requires": {
-        "dompurify": "^2.4.0"
+        "dompurify": "^2.4.1"
       }
     },
     "@dfinity/identity": {

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -211,8 +211,8 @@
           <p class="error-message">{translate({ labelKey: errorKey })}</p>
         </CardInfo>
       {:else}
-        <SkeletonCard />
-        <SkeletonCard />
+        <SkeletonCard cardType="info" />
+        <SkeletonCard cardType="info" />
       {/if}
     </section>
   </main>


### PR DESCRIPTION
# Motivation

Looks ugly too now, flatten the skeleton card on caniste detail island.

I also use this PR to bump the gix cmp to update the button colors as in the reviewed design.

# Screenshot

Afterwards

<img width="1536" alt="Capture d’écran 2022-11-28 à 18 09 05" src="https://user-images.githubusercontent.com/16886711/204339033-faa24d80-bbc8-4575-8bcd-518b48eefef5.png">
