### PR TITLE
feat: proposal and project detail new design

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.1.tgz",
-      "integrity": "sha512-tsVHeRvZ/ToLgdr6y+WZWN9OqLFcgiCW+tPnE6nldUPVsqmUGlbga6NtlDO/f3FSuWYzIM4LjmvuRX1MZIqOdA==",
+      "version": "2.0.0-next-2022-11-29.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.2.tgz",
+      "integrity": "sha512-jUDdN1mbfuP1QLfCg89B9/tn2AZnhFUkb4bl1pjZ+7HhhDDFX9nSFuqMtH0xBOiYitEaZe4rP2Xc4hdn56LdkA==",
       "dependencies": {
         "dompurify": "^2.4.1"
       }
@@ -11077,9 +11077,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.1.tgz",
-      "integrity": "sha512-tsVHeRvZ/ToLgdr6y+WZWN9OqLFcgiCW+tPnE6nldUPVsqmUGlbga6NtlDO/f3FSuWYzIM4LjmvuRX1MZIqOdA==",
+      "version": "2.0.0-next-2022-11-29.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.2.tgz",
+      "integrity": "sha512-jUDdN1mbfuP1QLfCg89B9/tn2AZnhFUkb4bl1pjZ+7HhhDDFX9nSFuqMtH0xBOiYitEaZe4rP2Xc4hdn56LdkA==",
       "requires": {
         "dompurify": "^2.4.1"
       }

--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -43,7 +43,7 @@
     {/each}
   </div>
   {#if projects.length === 0}
-    <p data-tid="no-projects-message" class="no-projects">
+    <p data-tid="no-projects-message" class="no-projects description">
       <Html text={noProjectsMessageLabel} />
     </p>
   {/if}
@@ -56,7 +56,6 @@
   }
 
   .no-projects {
-    text-align: center;
-    margin: var(--padding-2x) 0;
+    margin: 0 0 var(--padding-2x);
   }
 </style>

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -28,7 +28,7 @@
     <SkeletonProposalCard />
   </div>
 {:else if $openSnsProposalsStore.length === 0}
-  <p class="no-proposals">{$i18n.sns_launchpad.no_proposals}</p>
+  <p class="no-proposals description">{$i18n.sns_launchpad.no_proposals}</p>
 {:else}
   <ul class="card-grid">
     {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}
@@ -39,8 +39,7 @@
 
 <style lang="scss">
   .no-proposals {
-    text-align: center;
-    margin: var(--padding-2x) 0;
+    margin: 0 0 var(--padding-2x);
   }
 
   ul {

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -2,6 +2,7 @@
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import type { SnsSummary } from "$lib/types/sns";
   import { getContext } from "svelte";
+  import { BottomSheet } from "@dfinity/gix-components";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
@@ -45,32 +46,59 @@
 </script>
 
 {#if lifecycle === SnsSwapLifecycle.Open}
-  <SignInGuard>
-    {#if userCanParticipateToSwap}
-      <button
-        on:click={openModal}
-        class="primary"
-        data-tid="sns-project-participate-button"
-        >{userHasParticipatedToSwap
-          ? $i18n.sns_project_detail.increase_participation
-          : $i18n.sns_project_detail.participate}</button
-      >
-    {:else}
-      <Tooltip
-        id="sns-project-participate-button-tooltip"
-        text={$i18n.sns_project_detail.max_user_commitment_reached}
-      >
-        <button
-          class="primary"
-          data-tid="sns-project-participate-button"
-          disabled>{$i18n.sns_project_detail.participate}</button
-        >
-      </Tooltip>
-    {/if}
-    <span slot="signin-cta">{$i18n.sns_project_detail.sign_in}</span>
-  </SignInGuard>
+  <BottomSheet>
+    <div role="toolbar">
+      <SignInGuard>
+        {#if userCanParticipateToSwap}
+          <button
+            on:click={openModal}
+            class="primary"
+            data-tid="sns-project-participate-button"
+            >{userHasParticipatedToSwap
+              ? $i18n.sns_project_detail.increase_participation
+              : $i18n.sns_project_detail.participate}</button
+          >
+        {:else}
+          <Tooltip
+            id="sns-project-participate-button-tooltip"
+            text={$i18n.sns_project_detail.max_user_commitment_reached}
+          >
+            <button
+              class="primary"
+              data-tid="sns-project-participate-button"
+              disabled>{$i18n.sns_project_detail.participate}</button
+            >
+          </Tooltip>
+        {/if}
+        <span slot="signin-cta">{$i18n.sns_project_detail.sign_in}</span>
+      </SignInGuard>
+    </div>
+  </BottomSheet>
 {/if}
 
 {#if showModal}
   <ParticipateSwapModal on:nnsClose={closeModal} />
 {/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/media";
+
+  [role="toolbar"] {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    padding: var(--padding-2x);
+
+    @include media.min-width(medium) {
+      align-items: center;
+      justify-content: center;
+    }
+
+    @include media.min-width(large) {
+      align-items: flex-start;
+      justify-content: flex-start;
+      padding: 0;
+    }
+  }
+  </style>

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -101,4 +101,4 @@
       padding: 0;
     }
   }
-  </style>
+</style>

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -31,7 +31,10 @@
 </script>
 
 {#if !isNullish(metadata) && !isNullish(token)}
-  <div data-tid="sns-project-detail-info" class="content-cell-details content-cell-island">
+  <div
+    data-tid="sns-project-detail-info"
+    class="content-cell-details content-cell-island"
+  >
     <KeyValuePair>
       <svelte:fragment slot="key"
         >{$i18n.sns_project_detail.token_name}</svelte:fragment

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -31,7 +31,7 @@
 </script>
 
 {#if !isNullish(metadata) && !isNullish(token)}
-  <div data-tid="sns-project-detail-info" class="content-cell-details beach">
+  <div data-tid="sns-project-detail-info" class="content-cell-details content-cell-island">
     <KeyValuePair>
       <svelte:fragment slot="key"
         >{$i18n.sns_project_detail.token_name}</svelte:fragment

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -34,22 +34,22 @@
   <div data-tid="sns-project-detail-info" class="content-cell-details beach">
     <KeyValuePair>
       <svelte:fragment slot="key"
-      >{$i18n.sns_project_detail.token_name}</svelte:fragment
+        >{$i18n.sns_project_detail.token_name}</svelte:fragment
       >
       <span
-              class="value"
-              slot="value"
-              data-tid="sns-project-detail-info-token-name">{token.name}</span
+        class="value"
+        slot="value"
+        data-tid="sns-project-detail-info-token-name">{token.name}</span
       >
     </KeyValuePair>
     <KeyValuePair>
       <svelte:fragment slot="key"
-      >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
+        >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
       >
       <span
-              class="value"
-              slot="value"
-              data-tid="sns-project-detail-info-token-symbol">{token.symbol}</span
+        class="value"
+        slot="value"
+        data-tid="sns-project-detail-info-token-symbol">{token.symbol}</span
       >
     </KeyValuePair>
 

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -31,13 +31,9 @@
 </script>
 
 {#if isNullish(metadata) || isNullish(token)}
-  <div class="content-grid">
-    <div class="content-a">
-      <SkeletonDetails />
-    </div>
-  </div>
+  <SkeletonDetails />
 {:else}
-  <div data-tid="sns-project-detail-metadata" class="container">
+  <div data-tid="sns-project-detail-metadata">
     <div class="title">
       <Logo src={metadata.logo} alt={$i18n.sns_launchpad.project_logo} />
       <h1 class="content-cell-title">{metadata.name}</h1>
@@ -52,10 +48,6 @@
 {/if}
 
 <style lang="scss">
-  .container {
-    margin-bottom: var(--padding-3x);
-  }
-
   .title {
     display: flex;
     gap: var(--padding-1_5x);

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -60,5 +60,10 @@
     display: flex;
     gap: var(--padding-1_5x);
     align-items: center;
+    margin-bottom: var(--padding-2x);
+  }
+
+  p {
+    margin-top: var(--padding);
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -30,36 +30,35 @@
   $: token = summary?.token;
 </script>
 
-{#if !isNullish(metadata) && !isNullish(token)}
-  <div data-tid="sns-project-detail-info" class="content-cell-details beach">
-    <KeyValuePair>
-      <svelte:fragment slot="key"
-      >{$i18n.sns_project_detail.token_name}</svelte:fragment
-      >
-      <span
-              class="value"
-              slot="value"
-              data-tid="sns-project-detail-info-token-name">{token.name}</span
-      >
-    </KeyValuePair>
-    <KeyValuePair>
-      <svelte:fragment slot="key"
-      >{$i18n.sns_project_detail.token_symbol}</svelte:fragment
-      >
-      <span
-              class="value"
-              slot="value"
-              data-tid="sns-project-detail-info-token-symbol">{token.symbol}</span
-      >
-    </KeyValuePair>
-
-    <ProjectSwapDetails />
+{#if isNullish(metadata) || isNullish(token)}
+  <div class="content-grid">
+    <div class="content-a">
+      <SkeletonDetails />
+    </div>
+  </div>
+{:else}
+  <div data-tid="sns-project-detail-info" class="container">
+    <div class="title">
+      <Logo src={metadata.logo} alt={$i18n.sns_launchpad.project_logo} />
+      <h1 class="content-cell-title">{metadata.name}</h1>
+    </div>
+    <a href={metadata.url} target="_blank" rel="noopener noreferrer"
+    >{metadata.url}</a
+    >
+    <p class="description content-cell-details">
+      {metadata.description}
+    </p>
   </div>
 {/if}
 
 <style lang="scss">
-  .content-cell-details {
-    margin-top: 0;
-    gap: var(--padding-2x);
+  .container {
+    margin-bottom: var(--padding-3x);
+  }
+
+  .title {
+    display: flex;
+    gap: var(--padding-1_5x);
+    align-items: center;
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -37,13 +37,13 @@
     </div>
   </div>
 {:else}
-  <div data-tid="sns-project-detail-info" class="container">
+  <div data-tid="sns-project-detail-metadata" class="container">
     <div class="title">
       <Logo src={metadata.logo} alt={$i18n.sns_launchpad.project_logo} />
       <h1 class="content-cell-title">{metadata.name}</h1>
     </div>
     <a href={metadata.url} target="_blank" rel="noopener noreferrer"
-    >{metadata.url}</a
+      >{metadata.url}</a
     >
     <p class="description content-cell-details">
       {metadata.description}

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -2,7 +2,7 @@
   import { ICPToken, TokenAmount } from "@dfinity/nns";
   import type { SnsSwapCommitment, SnsSummary } from "$lib/types/sns";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import { BottomSheet, KeyValuePair } from "@dfinity/gix-components";
+  import { KeyValuePair } from "@dfinity/gix-components";
   import ProjectStatus from "./ProjectStatus.svelte";
   import ProjectCommitment from "./ProjectCommitment.svelte";
   import ProjectUserCommitmentLabel from "./ProjectUserCommitmentLabel.svelte";
@@ -77,11 +77,7 @@
         </div>
       {/if}
 
-      <BottomSheet>
-        <div role="toolbar">
-          <ParticipateButton />
-        </div>
-      </BottomSheet>
+      <ParticipateButton />
     </div>
   </div>
 {/if}
@@ -102,24 +98,6 @@
 
     @include media.min-width(medium) {
       align-items: flex-start;
-    }
-  }
-  [role="toolbar"] {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: center;
-    padding: var(--padding-2x);
-
-    @include media.min-width(medium) {
-      align-items: center;
-      justify-content: center;
-    }
-
-    @include media.min-width(large) {
-      align-items: flex-start;
-      justify-content: flex-start;
-      padding: 0;
     }
   }
 </style>

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -54,7 +54,7 @@
 <!-- Because information might not be displayed once loaded - according the state - we do no display a spinner or skeleton -->
 
 {#if displayStatusSection}
-  <div data-tid="sns-project-detail-status" class="beach">
+  <div data-tid="sns-project-detail-status" class="content-cell-island">
     <ProjectStatus />
 
     <div class="content content-cell-details">

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -54,7 +54,7 @@
 <!-- Because information might not be displayed once loaded - according the state - we do no display a spinner or skeleton -->
 
 {#if displayStatusSection}
-  <div data-tid="sns-project-detail-status">
+  <div data-tid="sns-project-detail-status" class="beach">
     <ProjectStatus />
 
     <div class="content content-cell-details">

--- a/frontend/src/lib/components/proposal-detail/Proposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/Proposal.svelte
@@ -20,7 +20,7 @@
 
 {#if $store?.proposal !== undefined}
   <div class="content-grid" data-tid="proposal-details-grid">
-    <div class="content-a">
+    <div class="content-a beach">
       <ProposalSystemInfoSection proposalInfo={$store.proposal} />
     </div>
     <div class="content-b expand-content-b">

--- a/frontend/src/lib/components/proposal-detail/Proposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/Proposal.svelte
@@ -20,7 +20,7 @@
 
 {#if $store?.proposal !== undefined}
   <div class="content-grid" data-tid="proposal-details-grid">
-    <div class="content-a beach">
+    <div class="content-a content-cell-island">
       <ProposalSystemInfoSection proposalInfo={$store.proposal} />
     </div>
     <div class="content-b expand-content-b">

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -17,27 +17,29 @@
     proposal !== undefined ? proposalActionFields(proposal) : [];
 </script>
 
-<h2 class="content-cell-title" data-tid="proposal-proposer-actions-entry-title">
-  {actionKey ?? ""}
-</h2>
+<div class="beach">
+  <h2 class="content-cell-title" data-tid="proposal-proposer-actions-entry-title">
+    {actionKey ?? ""}
+  </h2>
 
-<div class="content-cell-details">
-  {#each actionFields as [key, value]}
-    <KeyValuePair>
-      <span slot="key">{key}</span>
-      <span class="value" slot="value">
+  <div class="content-cell-details">
+    {#each actionFields as [key, value]}
+      <KeyValuePair>
+        <span slot="key">{key}</span>
+        <span class="value" slot="value">
         {#if typeof value === "object"}
           <Json json={value} />
         {:else}
           {value}
         {/if}
       </span>
-    </KeyValuePair>
-  {/each}
+      </KeyValuePair>
+    {/each}
+  </div>
 </div>
 
 <style lang="scss">
-  .content-cell-title {
-    margin-top: var(--padding-8x);
+  .beach {
+    margin-top: var(--row-gap);
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -17,7 +17,7 @@
     proposal !== undefined ? proposalActionFields(proposal) : [];
 </script>
 
-<div class="beach">
+<div class="content-cell-island">
   <h2
     class="content-cell-title"
     data-tid="proposal-proposer-actions-entry-title"
@@ -42,7 +42,7 @@
 </div>
 
 <style lang="scss">
-  .beach {
+  .content-cell-island {
     margin-top: var(--row-gap);
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -18,7 +18,10 @@
 </script>
 
 <div class="beach">
-  <h2 class="content-cell-title" data-tid="proposal-proposer-actions-entry-title">
+  <h2
+    class="content-cell-title"
+    data-tid="proposal-proposer-actions-entry-title"
+  >
     {actionKey ?? ""}
   </h2>
 
@@ -27,12 +30,12 @@
       <KeyValuePair>
         <span slot="key">{key}</span>
         <span class="value" slot="value">
-        {#if typeof value === "object"}
-          <Json json={value} />
-        {:else}
-          {value}
-        {/if}
-      </span>
+          {#if typeof value === "object"}
+            <Json json={value} />
+          {:else}
+            {value}
+          {/if}
+        </span>
       </KeyValuePair>
     {/each}
   </div>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
@@ -14,30 +14,25 @@
   $: ({ title, proposal, url } = mapProposalInfo(proposalInfo));
 </script>
 
-<h2 class="content-cell-title" data-tid="proposal-proposer-info-title">
-  {$i18n.proposal_detail.summary}
-</h2>
+<div class="beach">
+  <h2 class="content-cell-title" data-tid="proposal-proposer-info-title">
+    {$i18n.proposal_detail.summary}
+  </h2>
 
-<div class="content-cell-details">
-  <ProposalSummary {proposal}>
-    <svelte:fragment slot="title">
-      <h1>{title ?? ""}</h1>
+  <div class="content-cell-details">
+    <ProposalSummary {proposal}>
+      <svelte:fragment slot="title">
+        <h1>{title ?? ""}</h1>
 
-      {#if url}
-        <a target="_blank" href={url} rel="noopener noreferrer">{url}</a>
-      {/if}
-    </svelte:fragment>
-  </ProposalSummary>
+        {#if url}
+          <a target="_blank" href={url} rel="noopener noreferrer">{url}</a>
+        {/if}
+      </svelte:fragment>
+    </ProposalSummary>
+  </div>
 </div>
 
 <style lang="scss">
-  .content-cell-details {
-    background: var(--secondary);
-    color: var(--secondary-contrast);
-    padding: var(--padding-2x);
-    border-radius: var(--border-radius);
-  }
-
   a {
     overflow-wrap: break-word;
   }

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
@@ -14,7 +14,7 @@
   $: ({ title, proposal, url } = mapProposalInfo(proposalInfo));
 </script>
 
-<div class="beach">
+<div class="content-cell-island">
   <h2 class="content-cell-title" data-tid="proposal-proposer-info-title">
     {$i18n.proposal_detail.summary}
   </h2>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -38,29 +38,31 @@
 </script>
 
 {#if nnsFunctionKey !== undefined && proposalId !== undefined}
-  <h2
-    class="content-cell-title"
-    data-tid="proposal-proposer-payload-entry-title"
-  >
-    {$i18n.proposal_detail.payload}
-  </h2>
+  <div class="beach">
+    <h2
+            class="content-cell-title"
+            data-tid="proposal-proposer-payload-entry-title"
+    >
+      {$i18n.proposal_detail.payload}
+    </h2>
 
-  <div class="content-cell-details">
-    {#if expandedPayload !== undefined}
-      <div class="json" data-tid="json-wrapper">
-        <Json json={expandedPayload} />
-      </div>
-    {:else}
-      <SkeletonText />
-      <SkeletonText />
-      <SkeletonText />
-    {/if}
+    <div class="content-cell-details">
+      {#if expandedPayload !== undefined}
+        <div class="json" data-tid="json-wrapper">
+          <Json json={expandedPayload} />
+        </div>
+      {:else}
+        <SkeletonText />
+        <SkeletonText />
+        <SkeletonText />
+      {/if}
+    </div>
   </div>
 {/if}
 
 <style lang="scss">
-  .content-cell-title {
-    margin-top: var(--padding-8x);
+  .beach {
+    margin-top: var(--row-gap);
   }
 
   .json {

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -40,8 +40,8 @@
 {#if nnsFunctionKey !== undefined && proposalId !== undefined}
   <div class="beach">
     <h2
-            class="content-cell-title"
-            data-tid="proposal-proposer-payload-entry-title"
+      class="content-cell-title"
+      data-tid="proposal-proposer-payload-entry-title"
     >
       {$i18n.proposal_detail.payload}
     </h2>

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -38,7 +38,7 @@
 </script>
 
 {#if nnsFunctionKey !== undefined && proposalId !== undefined}
-  <div class="beach">
+  <div class="content-cell-island">
     <h2
       class="content-cell-title"
       data-tid="proposal-proposer-payload-entry-title"
@@ -61,7 +61,7 @@
 {/if}
 
 <style lang="scss">
-  .beach {
+  .content-cell-island {
     margin-top: var(--row-gap);
   }
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -22,12 +22,12 @@
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
 
+  .title {
+    margin-bottom: var(--padding-4x);
+  }
+
   .markdown {
     overflow-wrap: break-word;
-
-    :global(> *:nth-child(2)) {
-      margin-bottom: var(--padding-4x);
-    }
 
     :global(a) {
       font-size: inherit;

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -22,12 +22,12 @@
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
 
-  .title {
-    margin-bottom: var(--padding-4x);
-  }
-
   .markdown {
     overflow-wrap: break-word;
+
+    :global(> *:nth-child(2)) {
+      margin-bottom: var(--padding-4x);
+    }
 
     :global(a) {
       font-size: inherit;

--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -6,5 +6,7 @@
   export let proposalInfo: ProposalInfo;
 </script>
 
-<VotesResults {proposalInfo} />
-<VotingCard {proposalInfo} />
+<div class="beach">
+    <VotesResults {proposalInfo} />
+    <VotingCard {proposalInfo} />
+</div>

--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -7,6 +7,6 @@
 </script>
 
 <div class="beach">
-    <VotesResults {proposalInfo} />
-    <VotingCard {proposalInfo} />
+  <VotesResults {proposalInfo} />
+  <VotingCard {proposalInfo} />
 </div>

--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -6,7 +6,7 @@
   export let proposalInfo: ProposalInfo;
 </script>
 
-<div class="beach">
+<div class="content-cell-island">
   <VotesResults {proposalInfo} />
   <VotingCard {proposalInfo} />
 </div>

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -112,7 +112,7 @@
       justify-content: flex-end;
 
       :global(.value) {
-        color: var(--primary);
+        color: var(--tertiary);
       }
     }
   }

--- a/frontend/src/lib/components/ui/Logo.svelte
+++ b/frontend/src/lib/components/ui/Logo.svelte
@@ -25,8 +25,9 @@
   }
 
   .framed {
-    border-radius: var(--border-radius);
-    border: 2px solid var(--background-contrast);
+    border-radius: 50%;
+    background: var(--background);
+    padding: var(--padding);
   }
 
   .big {

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -134,14 +134,16 @@
 </script>
 
 <main>
-  <ProjectMetadataSection />
-
   <div class="stretch-mobile">
     <div class="content-grid">
       <div class="content-a">
+        <ProjectMetadataSection />
+      </div>
+
+      <div class="content-c">
         <ProjectInfoSection />
       </div>
-      <div class="content-b">
+      <div class="content-d">
         <ProjectStatusSection />
       </div>
     </div>

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { setContext } from "svelte";
   import ProjectInfoSection from "$lib/components/project-detail/ProjectInfoSection.svelte";
+  import ProjectMetadataSection from "$lib/components/project-detail/ProjectMetadataSection.svelte";
   import ProjectStatusSection from "$lib/components/project-detail/ProjectStatusSection.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { layoutTitleStore } from "$lib/stores/layout.store";
@@ -133,6 +134,8 @@
 </script>
 
 <main>
+  <ProjectMetadataSection />
+
   <div class="stretch-mobile">
     <div class="content-grid">
       <div class="content-a">

--- a/frontend/src/routes/(app)/project/+layout.svelte
+++ b/frontend/src/routes/(app)/project/+layout.svelte
@@ -6,6 +6,6 @@
   const back = (): Promise<void> => goto(AppPath.Launchpad);
 </script>
 
-<Layout contrast {back}>
+<Layout {back}>
   <slot />
 </Layout>

--- a/frontend/src/routes/(app)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/proposal/+layout.svelte
@@ -14,6 +14,6 @@
     );
 </script>
 
-<Layout contrast {back}>
+<Layout {back}>
   <slot />
 </Layout>

--- a/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
@@ -29,50 +29,10 @@ describe("ProjectInfoSection", () => {
       },
     });
 
-  it("should render title", async () => {
-    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
-
-    const element = container.querySelector("h1") as HTMLElement;
-    expect(element).toBeInTheDocument();
-    expect(element.textContent).toEqual(
-      mockSnsFullProject.summary.metadata.name
-    );
-  });
-
-  it("should render project link", async () => {
-    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
-
-    const element = container.querySelector("a") as HTMLElement;
-    expect(element).toBeInTheDocument();
-    expect(element.getAttribute("href")).toEqual(
-      mockSnsFullProject.summary.metadata.url
-    );
-  });
-
   it("should not render content if the summary is not yet defined", async () => {
     const { getByTestId } = renderProjectInfoSection(undefined);
     const call = () => getByTestId("sns-project-detail-info");
     expect(call).toThrow();
-  });
-
-  it("should render project description", async () => {
-    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
-
-    const element = container.querySelector("p:first-of-type") as HTMLElement;
-    expect(element).toBeInTheDocument();
-    expect(element.textContent).toEqual(
-      mockSnsFullProject.summary.metadata.description
-    );
-  });
-
-  it("should render project logo", async () => {
-    const { container } = renderProjectInfoSection(mockSnsFullProject.summary);
-
-    const element = container.querySelector("img") as HTMLElement;
-    expect(element).toBeInTheDocument();
-    expect(element.getAttribute("src")).toEqual(
-      mockSnsFullProject.summary.metadata.logo
-    );
   });
 
   it("should render token name", async () => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectMetadataSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectMetadataSection.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import ProjectMetadataSection from "$lib/components/project-detail/ProjectMetadataSection.svelte";
+import {
+  PROJECT_DETAIL_CONTEXT_KEY,
+  type ProjectDetailContext,
+  type ProjectDetailStore,
+} from "$lib/types/project-detail.context";
+import type { SnsSummary } from "$lib/types/sns";
+import { render } from "@testing-library/svelte";
+import { writable } from "svelte/store";
+import { mockSnsFullProject } from "../../../mocks/sns-projects.mock";
+import ContextWrapperTest from "../ContextWrapperTest.svelte";
+
+describe("ProjectMetadataSection", () => {
+  const renderProjectMetadataSection = (summary: SnsSummary | undefined) =>
+    render(ContextWrapperTest, {
+      props: {
+        contextKey: PROJECT_DETAIL_CONTEXT_KEY,
+        contextValue: {
+          store: writable<ProjectDetailStore>({
+            summary,
+            swapCommitment: mockSnsFullProject.swapCommitment,
+          }),
+        } as ProjectDetailContext,
+        Component: ProjectMetadataSection,
+      },
+    });
+
+  it("should render title", async () => {
+    const { container } = renderProjectMetadataSection(
+      mockSnsFullProject.summary
+    );
+
+    const element = container.querySelector("h1") as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element.textContent).toEqual(
+      mockSnsFullProject.summary.metadata.name
+    );
+  });
+
+  it("should render project link", async () => {
+    const { container } = renderProjectMetadataSection(
+      mockSnsFullProject.summary
+    );
+
+    const element = container.querySelector("a") as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element.getAttribute("href")).toEqual(
+      mockSnsFullProject.summary.metadata.url
+    );
+  });
+
+  it("should not render content if the summary is not yet defined", async () => {
+    const { getByTestId } = renderProjectMetadataSection(undefined);
+    const call = () => getByTestId("sns-project-detail-metadata");
+    expect(call).toThrow();
+  });
+
+  it("should render project description", async () => {
+    const { container } = renderProjectMetadataSection(
+      mockSnsFullProject.summary
+    );
+
+    const element = container.querySelector("p:first-of-type") as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element.textContent).toEqual(
+      mockSnsFullProject.summary.metadata.description
+    );
+  });
+
+  it("should render project logo", async () => {
+    const { container } = renderProjectMetadataSection(
+      mockSnsFullProject.summary
+    );
+
+    const element = container.querySelector("img") as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element.getAttribute("src")).toEqual(
+      mockSnsFullProject.summary.metadata.logo
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

Review the design of the "Proposal" and "Project" detail views as defined by the designer.

# PRs

- [x] need https://github.com/dfinity/gix-components/pull/137

# Changes

- set few text as `.description`
- use `.content-cell-island` and adapt spacing when needed
- fix `BottomSheet` usage in "Project" view to present a bottom sheet only when needed - i.e. to not present an empty bottom sheet
- extract title, logo, url, description of project to a new `ProjectMetadataSection` to present these information in a separate spot
- adapt skeleton loader accordingly

# Notes

- I pinged designers about the fact that there is not much accessibility difference between cards that are clickable and cards that are static - contain information only. This is currently discussed.

- There is also an on going discussion on the description of the Project that can becomes quite long

- I also asked if we should update the default logo of Sns projects now that the style has changed

This PR does not contain any feature changes.

# Screenshots

<img width="1536" alt="Capture d’écran 2022-11-29 à 10 50 40" src="https://user-images.githubusercontent.com/16886711/204497343-6f225f0e-47af-4512-833b-0c1e7ec0885d.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 50 44" src="https://user-images.githubusercontent.com/16886711/204497358-e2db6670-d050-4e5c-8ace-b08cf33171c8.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 50 49" src="https://user-images.githubusercontent.com/16886711/204497374-99cac843-bde5-4ce6-a796-1bb48d2689f1.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 50 52" src="https://user-images.githubusercontent.com/16886711/204497384-62364094-df9b-41fa-8166-70b55a50d142.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 50 59" src="https://user-images.githubusercontent.com/16886711/204497390-8a795718-6ad1-4c12-b495-4b1b1517af8c.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 51 02" src="https://user-images.githubusercontent.com/16886711/204497395-2b20b258-0fa5-48af-a195-4c85718c4bd4.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 51 07" src="https://user-images.githubusercontent.com/16886711/204497399-e2fa0c42-3a27-491e-b33f-c1fdb3b6749d.png">
<img width="1536" alt="Capture d’écran 2022-11-29 à 10 51 10" src="https://user-images.githubusercontent.com/16886711/204497401-cfac905e-4a03-4742-ba3a-31837f8051d2.png">

