### PR TITLE
feat: account title

### DIFF
--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -14,6 +14,8 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { KeyValuePair } from "@dfinity/gix-components";
   import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
+  import { onIntersection } from "$lib/directives/intersection.directives";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
 
   const { store } = getContext<WalletContext>(WALLET_CONTEXT_KEY);
 
@@ -33,11 +35,32 @@
     value: accountBalance.toE8s(),
     detailed: true,
   });
+
+  const updateLayoutTitle = ($event: Event) => {
+    const {
+      detail: { intersecting },
+    } = $event as unknown as CustomEvent<IntersectingDetail>;
+
+    layoutTitleStore.set(
+      intersecting
+        ? $i18n.wallet.title
+        : `${accountName} – ${formatToken({ value: accountBalance.toE8s() })} ${
+            accountBalance.token.symbol
+          }`
+    );
+  };
 </script>
 
 <div class="content-cell-details">
   <KeyValuePair>
-    <h3 slot="key" data-tid="wallet-summary">{accountName}</h3>
+    <h3
+      slot="key"
+      data-tid="wallet-summary"
+      use:onIntersection
+      on:nnsIntersecting={updateLayoutTitle}
+    >
+      {accountName}
+    </h3>
     <Tooltip
       slot="value"
       id="wallet-detailed-icp"

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -2,8 +2,12 @@
   import { isNnsProjectStore } from "$lib/derived/selected-project.derived";
   import NnsWallet from "$lib/pages/NnsWallet.svelte";
   import SnsWallet from "$lib/pages/SnsWallet.svelte";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { i18n } from "$lib/stores/i18n";
 
   export let accountIdentifier: string | undefined | null = undefined;
+
+  layoutTitleStore.set($i18n.wallet.title);
 </script>
 
 {#if $isNnsProjectStore}

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -98,14 +98,14 @@ describe("WalletSummary", () => {
     await waitFor(() => expect(title).toEqual(text));
   };
 
-  it("should render a title with neuron ID if title is not intersecting viewport", () =>
-    testTitle({
+  it("should render a title with neuron ID if title is not intersecting viewport", async () =>
+    await testTitle({
       intersecting: false,
       text: `${en.accounts.main} – ${formatToken({
         value: mockMainAccount.balance.toE8s(),
       })} ${mockMainAccount.balance.token.symbol}`,
     }));
 
-  it("should render a static title if title is intersecting viewport", () =>
-    testTitle({ intersecting: true, text: en.wallet.title }));
+  it("should render a static title if title is intersecting viewport", async () =>
+    await testTitle({ intersecting: true, text: en.wallet.title }));
 });

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -98,7 +98,7 @@ describe("WalletSummary", () => {
     await waitFor(() => expect(title).toEqual(text));
   };
 
-  it("should render a title with neuron ID if title is not intersecting viewport", async () =>
+  it("should render account name and balance if title not intersecting viewport", async () =>
     await testTitle({
       intersecting: false,
       text: `${en.accounts.main} – ${formatToken({

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -3,6 +3,8 @@
  */
 
 import WalletSummary from "$lib/components/accounts/WalletSummary.svelte";
+import { dispatchIntersecting } from "$lib/directives/intersection.directives";
+import { layoutTitleStore } from "$lib/stores/layout.store";
 import {
   WALLET_CONTEXT_KEY,
   type WalletContext,
@@ -10,8 +12,8 @@ import {
 } from "$lib/types/wallet.context";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { render } from "@testing-library/svelte";
-import { writable } from "svelte/store";
+import { render, waitFor } from "@testing-library/svelte";
+import { get, writable } from "svelte/store";
 import { mockMainAccount } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import ContextWrapperTest from "../ContextWrapperTest.svelte";
@@ -79,4 +81,31 @@ describe("WalletSummary", () => {
       })
     );
   });
+
+  const testTitle = async ({
+    intersecting,
+    text,
+  }: {
+    intersecting: boolean;
+    text: string;
+  }) => {
+    const { getByTestId } = renderWalletSummary();
+
+    const element = getByTestId("wallet-summary") as HTMLElement;
+    dispatchIntersecting({ element, intersecting });
+
+    const title = get(layoutTitleStore);
+    await waitFor(() => expect(title).toEqual(text));
+  };
+
+  it("should render a title with neuron ID if title is not intersecting viewport", () =>
+    testTitle({
+      intersecting: false,
+      text: `${en.accounts.main} – ${formatToken({
+        value: mockMainAccount.balance.toE8s(),
+      })} ${mockMainAccount.balance.token.symbol}`,
+    }));
+
+  it("should render a static title if title is intersecting viewport", () =>
+    testTitle({ intersecting: true, text: en.wallet.title }));
 });

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -71,10 +71,10 @@ describe("NeuronDetail", () => {
     await waitFor(() => expect(title).toEqual(text));
   };
 
-  it("should render a title with neuron ID if title is not intersecting viewport", async () =>
+  it("should render a title with neuron ID if title is not intersecting viewport", () =>
     testTitle({ intersecting: false, text: `${en.core.icp} – ${neuronId}` }));
 
-  it.only("should render a static title if title is intersecting viewport", async () =>
+  it("should render a static title if title is intersecting viewport", () =>
     testTitle({ intersecting: true, text: en.neuron_detail.title }));
 
   it("should hide skeletons after neuron data are available", async () => {

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -71,11 +71,14 @@ describe("NeuronDetail", () => {
     await waitFor(() => expect(title).toEqual(text));
   };
 
-  it("should render a title with neuron ID if title is not intersecting viewport", () =>
-    testTitle({ intersecting: false, text: `${en.core.icp} – ${neuronId}` }));
+  it("should render a title with neuron ID if title is not intersecting viewport", async () =>
+    await testTitle({
+      intersecting: false,
+      text: `${en.core.icp} – ${neuronId}`,
+    }));
 
-  it("should render a static title if title is intersecting viewport", () =>
-    testTitle({ intersecting: true, text: en.neuron_detail.title }));
+  it("should render a static title if title is intersecting viewport", async () =>
+    await testTitle({ intersecting: true, text: en.neuron_detail.title }));
 
   it("should hide skeletons after neuron data are available", async () => {
     const { container } = render(NnsNeuronDetail, props);


### PR DESCRIPTION
# Motivation

Make account title dynamic when user scroll to keep important information visible.

# Changes

- use intersection directive to display either the "Account" title or the name of the account and its balance
- fix account title not set when "Wallet" page accessed directly
- fix neuron detail test skipped

# Screenshot

![Enregistrement de l’écran 2022-11-29 à 12 27 39](https://user-images.githubusercontent.com/16886711/204517487-6f1e58d9-1bbc-4fc1-8021-f4c160a137c9.gif)

