### PR TITLE
feat: sns neuron title

### DIFF
--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -7,6 +7,7 @@
   } from "$lib/utils/sns-neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
+  import { onIntersection } from "$lib/directives/intersection.directives";
 
   export let neuron: SnsNeuron;
   export let tagName: "h3" | "p" = "h3";
@@ -22,7 +23,9 @@
 </script>
 
 <div class="identifier" data-tid="sns-neuron-card-title">
-  <Hash id="neuron-id" {tagName} testId="neuron-id" text={neuronId} />
+  <div use:onIntersection on:nnsIntersecting>
+    <Hash id="neuron-id" {tagName} testId="neuron-id" text={neuronId} />
+  </div>
   {#if isHotkey}
     <span>{$i18n.neurons.hotkey_control}</span>
   {/if}

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <div class="identifier" data-tid="sns-neuron-card-title">
-  <div use:onIntersection on:nnsIntersecting>
+  <div use:onIntersection on:nnsIntersecting data-tid="neuron-id-container">
     <Hash id="neuron-id" {tagName} testId="neuron-id" text={neuronId} />
   </div>
   {#if isHotkey}

--- a/frontend/src/lib/routes/NeuronDetail.svelte
+++ b/frontend/src/lib/routes/NeuronDetail.svelte
@@ -2,8 +2,12 @@
   import { isNnsProjectStore } from "$lib/derived/selected-project.derived";
   import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
   import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { i18n } from "$lib/stores/i18n";
 
   export let neuronId: string | null | undefined;
+
+  layoutTitleStore.set($i18n.neuron_detail.title);
 </script>
 
 {#if $isNnsProjectStore}


### PR DESCRIPTION
# Motivation

Implement (dynamic) title for Sns neuron.

# Changes

- render either "Neuron" or the hashed neuron id on scroll

# Screenshot

![2222Enregistrement de l’écran 2022-11-29 à 12 49 52](https://user-images.githubusercontent.com/16886711/204521563-964ef3bd-4f26-4d06-9684-3f4dfae1b34e.gif)

