### PR TITLE
feat: canister detail modals with custom event

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1661,11 +1661,14 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-29.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.2.tgz",
-      "integrity": "sha512-jUDdN1mbfuP1QLfCg89B9/tn2AZnhFUkb4bl1pjZ+7HhhDDFX9nSFuqMtH0xBOiYitEaZe4rP2Xc4hdn56LdkA==",
+      "version": "2.1.0-next-2022-11-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-11-29.tgz",
+      "integrity": "sha512-Imi1WQZ1WLP0WQFrKgVKPeB5oKLDbF1aPb14vX425Ug5AA3N0lqQTg16HT6CoHi6rqKcYTmY7lm3BXJOv9ypDQ==",
       "dependencies": {
         "dompurify": "^2.4.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0"
       }
     },
     "node_modules/@dfinity/identity": {
@@ -8883,7 +8886,6 @@
       "version": "3.53.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
       "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11077,9 +11079,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.0.0-next-2022-11-29.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.0.0-next-2022-11-29.2.tgz",
-      "integrity": "sha512-jUDdN1mbfuP1QLfCg89B9/tn2AZnhFUkb4bl1pjZ+7HhhDDFX9nSFuqMtH0xBOiYitEaZe4rP2Xc4hdn56LdkA==",
+      "version": "2.1.0-next-2022-11-29",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-11-29.tgz",
+      "integrity": "sha512-Imi1WQZ1WLP0WQFrKgVKPeB5oKLDbF1aPb14vX425Ug5AA3N0lqQTg16HT6CoHi6rqKcYTmY7lm3BXJOv9ypDQ==",
       "requires": {
         "dompurify": "^2.4.1"
       }
@@ -16343,8 +16345,7 @@
     "svelte": {
       "version": "3.53.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
-      "dev": true
+      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw=="
     },
     "svelte-check": {
       "version": "2.9.2",

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -16,7 +16,7 @@ interface IntersectingDetail {
 declare namespace svelte.JSX {
   interface HTMLAttributes<T> {
     onnnsIntersecting?: (event: CustomEvent<IntersectingDetail>) => void;
-    nnsCanisterDetailModal?: (event: CustomEvent<any>) => void;
+    onnnsCanisterDetailModal?: (event: CustomEvent<any>) => void;
   }
 }
 

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -8,14 +8,13 @@ declare namespace App {
   // interface Platform {}
 }
 
-interface IntersectingDetail {
-  intersecting: boolean;
-}
-
 // eslint window checks for custom events
 declare namespace svelte.JSX {
+  // Svelte needs help to support typing of custom events.
+  // Source: https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-using-an-attributeevent-on-a-dom-element-and-it-throws-a-type-error
+  // We use `<any>` because we cannot import the types we use in the dapps that needs to be explicitely imported in the components - i.e. we cannot use .d.ts for these types.
   interface HTMLAttributes<T> {
-    onnnsIntersecting?: (event: CustomEvent<IntersectingDetail>) => void;
+    onnnsIntersecting?: (event: CustomEvent<any>) => void;
     onnnsCanisterDetailModal?: (event: CustomEvent<any>) => void;
   }
 }

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -16,6 +16,7 @@ interface IntersectingDetail {
 declare namespace svelte.JSX {
   interface HTMLAttributes<T> {
     onnnsIntersecting?: (event: CustomEvent<IntersectingDetail>) => void;
+    nnsCanisterDetailModal?: (event: CustomEvent<any>) => void;
   }
 }
 

--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -16,6 +16,7 @@
   import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
   import { onIntersection } from "$lib/directives/intersection.directives";
   import { layoutTitleStore } from "$lib/stores/layout.store";
+  import type { IntersectingDetail } from "$lib/types/intersection.types";
 
   const { store } = getContext<WalletContext>(WALLET_CONTEXT_KEY);
 

--- a/frontend/src/lib/components/canister-detail/AddCanisterControllerButton.svelte
+++ b/frontend/src/lib/components/canister-detail/AddCanisterControllerButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { emit } from "$lib/utils/events.utils";
-  import type { CanisterDetailsModal } from "$lib/types/canister-detail.modal";
+  import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
 
   const openModal = () =>
-    emit<CanisterDetailsModal>({
+    emit<CanisterDetailModal>({
       message: "nnsCanisterDetailModal",
       detail: { type: "add-controller" },
     });

--- a/frontend/src/lib/components/canister-detail/AddCanisterControllerButton.svelte
+++ b/frontend/src/lib/components/canister-detail/AddCanisterControllerButton.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import {
-    CANISTER_DETAILS_CONTEXT_KEY,
-    type CanisterDetailsContext,
-  } from "$lib/types/canister-detail.context";
-  import { getContext } from "svelte";
+  import { emit } from "$lib/utils/events.utils";
+  import type { CanisterDetailsModal } from "$lib/types/canister-detail.modal";
 
-  const context: CanisterDetailsContext = getContext<CanisterDetailsContext>(
-    CANISTER_DETAILS_CONTEXT_KEY
-  );
-  const { toggleModal }: CanisterDetailsContext = context;
+  const openModal = () =>
+    emit<CanisterDetailsModal>({
+      message: "nnsCanisterDetailModal",
+      detail: { type: "add-controller" },
+    });
 </script>
 
 <button
   data-tid="add-canister-controller-button"
-  on:click={() => toggleModal("add-controller")}
+  on:click={openModal}
   class="primary">{$i18n.canister_detail.add_controller}</button
 >

--- a/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
@@ -10,7 +10,7 @@
   const openModal = () =>
     emit<CanisterDetailsModalDetach>({
       message: "nnsCanisterDetailModal",
-      detail: { type: "detach", detail: { canisterId } },
+      detail: { type: "detach", data: { canisterId } },
     });
 </script>
 

--- a/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-  import type { Principal } from "@dfinity/principal";
   import { busy } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    CANISTER_DETAILS_CONTEXT_KEY,
-    type CanisterDetailsContext,
-  } from "$lib/types/canister-detail.context";
-  import { getContext } from "svelte";
+  import { emit } from "$lib/utils/events.utils";
+  import type { CanisterDetailsModalDetach } from "$lib/types/canister-detail.modal";
+  import type { Principal } from "@dfinity/principal";
 
-  const context: CanisterDetailsContext = getContext<CanisterDetailsContext>(
-    CANISTER_DETAILS_CONTEXT_KEY
-  );
-  const { toggleModal }: CanisterDetailsContext = context;
+  export let canisterId: Principal;
+
+  const openModal = () =>
+    emit<CanisterDetailsModalDetach>({
+      message: "nnsCanisterDetailModal",
+      detail: { type: "detach", detail: { canisterId } },
+    });
 </script>
 
 <button
   class="primary"
   type="button"
-  on:click={() => toggleModal("detach")}
+  on:click={openModal}
   disabled={$busy}
   data-tid="detach-canister-button"
 >

--- a/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/DetachCanisterButton.svelte
@@ -2,13 +2,13 @@
   import { busy } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { emit } from "$lib/utils/events.utils";
-  import type { CanisterDetailsModalDetach } from "$lib/types/canister-detail.modal";
+  import type { CanisterDetailModalDetach } from "$lib/types/canister-detail.modal";
   import type { Principal } from "@dfinity/principal";
 
   export let canisterId: Principal;
 
   const openModal = () =>
-    emit<CanisterDetailsModalDetach>({
+    emit<CanisterDetailModalDetach>({
       message: "nnsCanisterDetailModal",
       detail: { type: "detach", data: { canisterId } },
     });

--- a/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
@@ -9,7 +9,7 @@
   const openModal = () =>
     emit<CanisterDetailsModalRemoveController>({
       message: "nnsCanisterDetailModal",
-      detail: { type: "remove-controller", detail: { controller } },
+      detail: { type: "remove-controller", data: { controller } },
     });
 </script>
 

--- a/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
@@ -1,28 +1,21 @@
 <script lang="ts">
-  import { getContext } from "svelte";
   import { IconClose } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    CANISTER_DETAILS_CONTEXT_KEY,
-    type CanisterDetailsContext,
-  } from "$lib/types/canister-detail.context";
+  import { emit } from "$lib/utils/events.utils";
+  import type { CanisterDetailsModalRemoveController } from "$lib/types/canister-detail.modal";
 
   export let controller: string;
 
-  const context: CanisterDetailsContext = getContext<CanisterDetailsContext>(
-    CANISTER_DETAILS_CONTEXT_KEY
-  );
-  const { toggleModal, store }: CanisterDetailsContext = context;
-
-  const removeController = () => {
-    store.update((data) => ({ ...data, selectedController: controller }));
-    toggleModal("remove-controller");
-  };
+  const openModal = () =>
+    emit<CanisterDetailsModalRemoveController>({
+      message: "nnsCanisterDetailModal",
+      detail: { type: "remove-controller", detail: { controller } },
+    });
 </script>
 
 <button
   aria-label={$i18n.core.remove}
-  on:click={() => removeController()}
+  on:click={openModal}
   data-tid="remove-canister-controller-button"
 >
   <IconClose size="18px" />

--- a/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RemoveCanisterControllerButton.svelte
@@ -2,12 +2,12 @@
   import { IconClose } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { emit } from "$lib/utils/events.utils";
-  import type { CanisterDetailsModalRemoveController } from "$lib/types/canister-detail.modal";
+  import type { CanisterDetailModalRemoveController } from "$lib/types/canister-detail.modal";
 
   export let controller: string;
 
   const openModal = () =>
-    emit<CanisterDetailsModalRemoveController>({
+    emit<CanisterDetailModalRemoveController>({
       message: "nnsCanisterDetailModal",
       detail: { type: "remove-controller", data: { controller } },
     });

--- a/frontend/src/lib/components/common/Footer.svelte
+++ b/frontend/src/lib/components/common/Footer.svelte
@@ -21,6 +21,7 @@
     pointer-events: none;
 
     background: var(--footer-background);
+    --button-secondary-background: var(--focus-background);
 
     :global(.toolbar) {
       align-items: end;

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
@@ -23,6 +23,7 @@
   import NnsNeuronAge from "$lib/components/neurons/NnsNeuronAge.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { layoutTitleStore } from "$lib/stores/layout.store";
+  import type { IntersectingDetail } from "$lib/types/intersection.types";
 
   export let neuron: NeuronInfo;
 
@@ -33,8 +34,6 @@
   });
 
   const updateLayoutTitle = ($event: Event) => {
-    // TODO: svelte-check ignores https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-using-an-attributeevent-on-a-dom-element-and-it-throws-a-type-error
-    // even though we have set the types in app.d.ts as displayed by the documentation
     const {
       detail: { intersecting },
     } = $event as unknown as CustomEvent<IntersectingDetail>;

--- a/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectInfoSection.svelte
@@ -7,14 +7,12 @@
   import { i18n } from "$lib/stores/i18n";
   import { KeyValuePair } from "@dfinity/gix-components";
   import ProjectSwapDetails from "./ProjectSwapDetails.svelte";
-  import Logo from "$lib/components/ui/Logo.svelte";
   import { getContext } from "svelte";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
   import { isNullish } from "$lib/utils/utils";
-  import SkeletonDetails from "$lib/components/ui/SkeletonDetails.svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -5,8 +5,6 @@
     SnsTokenMetadata,
   } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
-  import { KeyValuePair } from "@dfinity/gix-components";
-  import ProjectSwapDetails from "./ProjectSwapDetails.svelte";
   import Logo from "$lib/components/ui/Logo.svelte";
   import { getContext } from "svelte";
   import {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -20,6 +20,7 @@
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+  import type { IntersectingDetail } from "$lib/types/intersection.types";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);

--- a/frontend/src/lib/directives/intersection.directives.ts
+++ b/frontend/src/lib/directives/intersection.directives.ts
@@ -1,4 +1,5 @@
 import { INTERSECTION_THRESHOLD } from "$lib/constants/layout.constants";
+import type { IntersectingDetail } from "$lib/types/intersection.types";
 
 // Exposed for test purpose only
 export const dispatchIntersecting = ({

--- a/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
+++ b/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
@@ -19,10 +19,10 @@
 
   let controller: string | undefined;
   $: controller = (modal as CanisterDetailsModalRemoveController | undefined)
-    ?.detail?.controller;
+    ?.data?.controller;
 
   let canisterId: Principal | undefined;
-  $: canisterId = (modal as CanisterDetailsModalDetach | undefined)?.detail
+  $: canisterId = (modal as CanisterDetailsModalDetach | undefined)?.data
     ?.canisterId;
 </script>
 

--- a/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
+++ b/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
@@ -4,25 +4,25 @@
   import AddCanisterControllerModal from "$lib/modals/canisters/AddCanisterControllerModal.svelte";
   import RemoveCanisterControllerModal from "$lib/modals/canisters/RemoveCanisterControllerModal.svelte";
   import type {
-    CanisterDetailsModal,
-    CanisterDetailsModalDetach,
-    CanisterDetailsModalRemoveController,
-    CanisterDetailsModalType,
+    CanisterDetailModal,
+    CanisterDetailModalDetach,
+    CanisterDetailModalRemoveController,
+    CanisterDetailModalType,
   } from "$lib/types/canister-detail.modal";
   import type { Principal } from "@dfinity/principal";
 
-  let modal: CanisterDetailsModal | undefined = undefined;
+  let modal: CanisterDetailModal | undefined = undefined;
   const close = () => (modal = undefined);
 
-  let type: CanisterDetailsModalType | undefined;
+  let type: CanisterDetailModalType | undefined;
   $: type = modal?.type;
 
   let controller: string | undefined;
-  $: controller = (modal as CanisterDetailsModalRemoveController | undefined)
+  $: controller = (modal as CanisterDetailModalRemoveController | undefined)
     ?.data?.controller;
 
   let canisterId: Principal | undefined;
-  $: canisterId = (modal as CanisterDetailsModalDetach | undefined)?.data
+  $: canisterId = (modal as CanisterDetailModalDetach | undefined)?.data
     ?.canisterId;
 </script>
 

--- a/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
+++ b/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
@@ -1,51 +1,45 @@
 <script lang="ts">
   import AddCyclesModal from "$lib/modals/canisters/AddCyclesModal.svelte";
-  import type {
-    CanisterDetailsContext,
-    CanisterDetailsModal,
-  } from "$lib/types/canister-detail.context";
-  import { CANISTER_DETAILS_CONTEXT_KEY } from "$lib/types/canister-detail.context";
-  import { getContext } from "svelte";
-  import type { CanisterId } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import DetachCanisterModal from "$lib/modals/canisters/DetachCanisterModal.svelte";
   import AddCanisterControllerModal from "$lib/modals/canisters/AddCanisterControllerModal.svelte";
   import RemoveCanisterControllerModal from "$lib/modals/canisters/RemoveCanisterControllerModal.svelte";
+  import type {
+    CanisterDetailsModal,
+    CanisterDetailsModalDetach,
+    CanisterDetailsModalRemoveController,
+    CanisterDetailsModalType,
+  } from "$lib/types/canister-detail.modal";
+  import type { Principal } from "@dfinity/principal";
 
-  const context: CanisterDetailsContext = getContext<CanisterDetailsContext>(
-    CANISTER_DETAILS_CONTEXT_KEY
-  );
-  const { store }: CanisterDetailsContext = context;
+  let modal: CanisterDetailsModal | undefined = undefined;
+  const close = () => (modal = undefined);
 
-  let modal: CanisterDetailsModal | undefined;
-  let selectedController: string | undefined;
-  $: ({ modal, selectedController } = $store);
+  let type: CanisterDetailsModalType | undefined;
+  $: type = modal?.type;
 
-  let canisterId: CanisterId | undefined;
-  $: canisterId = $store.info?.canister_id;
+  let controller: string | undefined;
+  $: controller = (modal as CanisterDetailsModalRemoveController | undefined)
+    ?.detail?.controller;
 
-  // We also reset the selected controller here to avoid visual glitch - e.g. the controller being refreshed in the UI before the remove controller modal being closed
-  const close = () =>
-    store.update((data) => ({
-      ...data,
-      modal: undefined,
-      selectedController: undefined,
-    }));
+  let canisterId: Principal | undefined;
+  $: canisterId = (modal as CanisterDetailsModalDetach | undefined)?.detail
+    ?.canisterId;
 </script>
 
-{#if canisterId !== undefined}
-  {#if modal === "add-cycles"}
-    <AddCyclesModal on:nnsClose={close} />
-  {/if}
+<svelte:window on:nnsCanisterDetailModal={({ detail }) => (modal = detail)} />
 
-  {#if modal === "detach"}
-    <DetachCanisterModal {canisterId} on:nnsClose={close} />
-  {/if}
+{#if type === "add-cycles"}
+  <AddCyclesModal on:nnsClose={close} />
+{/if}
 
-  {#if modal === "add-controller"}
-    <AddCanisterControllerModal on:nnsClose={close} />
-  {/if}
+{#if type === "detach" && canisterId !== undefined}
+  <DetachCanisterModal {canisterId} on:nnsClose={close} />
+{/if}
 
-  {#if modal === "remove-controller" && selectedController !== undefined}
-    <RemoveCanisterControllerModal on:nnsClose={close} />
-  {/if}
+{#if type === "add-controller"}
+  <AddCanisterControllerModal on:nnsClose={close} />
+{/if}
+
+{#if type === "remove-controller" && controller !== undefined}
+  <RemoveCanisterControllerModal {controller} on:nnsClose={close} />
 {/if}

--- a/frontend/src/lib/modals/canisters/RemoveCanisterControllerModal.svelte
+++ b/frontend/src/lib/modals/canisters/RemoveCanisterControllerModal.svelte
@@ -13,20 +13,17 @@
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
 
+  export let controller: string;
+
+  let userController: boolean;
+  $: userController = isUserController({
+    controller,
+    authStore: $authStore,
+  });
+
   const { store, reloadDetails }: CanisterDetailsContext =
     getContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY);
 
-  let controller: string | undefined;
-  $: controller = $store.selectedController;
-
-  let userController: boolean;
-  $: userController =
-    controller !== undefined
-      ? isUserController({
-          controller,
-          authStore: $authStore,
-        })
-      : false;
   let lastController: boolean;
   $: lastController = $store.details?.settings.controllers.length === 1;
 

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -34,7 +34,7 @@
   import { goto } from "$app/navigation";
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
   import { emit } from "$lib/utils/events.utils";
-  import type { CanisterDetailsModal } from "$lib/types/canister-detail.modal";
+  import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
 
   // BEGIN: loading and navigation
 
@@ -179,7 +179,7 @@
   // END: loading and navigation
 
   const openModal = () =>
-    emit<CanisterDetailsModal>({
+    emit<CanisterDetailModal>({
       message: "nnsCanisterDetailModal",
       detail: { type: "add-cycles" },
     });

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -18,7 +18,6 @@
   import {
     CANISTER_DETAILS_CONTEXT_KEY,
     type CanisterDetailsContext,
-    type CanisterDetailsModal,
     type SelectCanisterDetailsStore,
   } from "$lib/types/canister-detail.context";
   import { debugSelectedCanisterStore } from "$lib/stores/debug.store";
@@ -34,6 +33,8 @@
   import Footer from "$lib/components/common/Footer.svelte";
   import { goto } from "$app/navigation";
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
+  import { emit } from "$lib/utils/events.utils";
+  import type { CanisterDetailsModal } from "$lib/types/canister-detail.modal";
 
   // BEGIN: loading and navigation
 
@@ -67,8 +68,6 @@
     info: undefined,
     details: undefined,
     controller: undefined,
-    modal: undefined,
-    selectedController: undefined,
   });
 
   debugSelectedCanisterStore(selectedCanisterStore);
@@ -112,13 +111,9 @@
     }
   };
 
-  const toggleModal = (modal: CanisterDetailsModal | undefined) =>
-    selectedCanisterStore.update((data) => ({ ...data, modal }));
-
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
     store: selectedCanisterStore,
     reloadDetails,
-    toggleModal,
   });
 
   export let canisterId: string | undefined | null;
@@ -155,8 +150,6 @@
           info: selectedCanister,
           details: sameCanister ? details : undefined,
           controller: sameCanister ? controller : undefined,
-          modal: undefined,
-          selectedController: undefined,
         }));
 
         if (selectedCanister !== undefined) {
@@ -184,6 +177,12 @@
     $selectedCanisterStore);
 
   // END: loading and navigation
+
+  const openModal = () =>
+    emit<CanisterDetailsModal>({
+      message: "nnsCanisterDetailModal",
+      detail: { type: "add-cycles" },
+    });
 </script>
 
 <Island>
@@ -193,7 +192,7 @@
         <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
         <CanisterCardSubTitle canister={canisterInfo} />
         <div class="actions">
-          <DetachCanisterButton />
+          <DetachCanisterButton canisterId={canisterInfo.canister_id} />
         </div>
       {:else}
         <div class="loader-title">
@@ -221,7 +220,7 @@
 <Footer columns={1}>
   <button
     class="primary"
-    on:click={() => toggleModal("add-cycles")}
+    on:click={openModal}
     disabled={canisterInfo === undefined || $busy}
     >{$i18n.canister_detail.add_cycles}</button
   >

--- a/frontend/src/lib/types/canister-detail.context.ts
+++ b/frontend/src/lib/types/canister-detail.context.ts
@@ -3,12 +3,6 @@ import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nn
 import type { Principal } from "@dfinity/principal";
 import type { Writable } from "svelte/store";
 
-export type CanisterDetailsModal =
-  | "add-cycles"
-  | "detach"
-  | "add-controller"
-  | "remove-controller";
-
 /**
  * A store that contains canister info and detail.
  */
@@ -16,15 +10,11 @@ export interface SelectCanisterDetailsStore {
   info: CanisterInfo | undefined;
   details: CanisterDetails | undefined;
   controller: boolean | undefined;
-  modal: CanisterDetailsModal | undefined;
-  // TODO: find a better pattern than including the selected controller within the canister context and thus just to open the related modal
-  selectedController: string | undefined;
 }
 
 export interface CanisterDetailsContext {
   store: Writable<SelectCanisterDetailsStore>;
   reloadDetails: (canisterId: Principal) => Promise<void>;
-  toggleModal: (modal: CanisterDetailsModal | undefined) => void;
 }
 
 export const CANISTER_DETAILS_CONTEXT_KEY = Symbol("canister-details");

--- a/frontend/src/lib/types/canister-detail.modal.ts
+++ b/frontend/src/lib/types/canister-detail.modal.ts
@@ -8,15 +8,15 @@ export type CanisterDetailsModalType =
 
 export interface CanisterDetailsModal<D = void> {
   type: CanisterDetailsModalType;
-  detail?: D;
+  data?: D;
 }
 
 export type CanisterDetailsModalRemoveController = Required<
-  Pick<CanisterDetailsModal<{ controller: string }>, "detail">
+  Pick<CanisterDetailsModal<{ controller: string }>, "data">
 > &
   Pick<CanisterDetailsModal, "type">;
 
 export type CanisterDetailsModalDetach = Required<
-  Pick<CanisterDetailsModal<{ canisterId: Principal }>, "detail">
+  Pick<CanisterDetailsModal<{ canisterId: Principal }>, "data">
 > &
   Pick<CanisterDetailsModal, "type">;

--- a/frontend/src/lib/types/canister-detail.modal.ts
+++ b/frontend/src/lib/types/canister-detail.modal.ts
@@ -1,0 +1,22 @@
+import type { Principal } from "@dfinity/principal";
+
+export type CanisterDetailsModalType =
+  | "add-cycles"
+  | "detach"
+  | "add-controller"
+  | "remove-controller";
+
+export interface CanisterDetailsModal<D = void> {
+  type: CanisterDetailsModalType;
+  detail?: D;
+}
+
+export type CanisterDetailsModalRemoveController = Required<
+  Pick<CanisterDetailsModal<{ controller: string }>, "detail">
+> &
+  Pick<CanisterDetailsModal, "type">;
+
+export type CanisterDetailsModalDetach = Required<
+  Pick<CanisterDetailsModal<{ canisterId: Principal }>, "detail">
+> &
+  Pick<CanisterDetailsModal, "type">;

--- a/frontend/src/lib/types/canister-detail.modal.ts
+++ b/frontend/src/lib/types/canister-detail.modal.ts
@@ -1,22 +1,22 @@
 import type { Principal } from "@dfinity/principal";
 
-export type CanisterDetailsModalType =
+export type CanisterDetailModalType =
   | "add-cycles"
   | "detach"
   | "add-controller"
   | "remove-controller";
 
-export interface CanisterDetailsModal<D = void> {
-  type: CanisterDetailsModalType;
+export interface CanisterDetailModal<D = void> {
+  type: CanisterDetailModalType;
   data?: D;
 }
 
-export type CanisterDetailsModalRemoveController = Required<
-  Pick<CanisterDetailsModal<{ controller: string }>, "data">
+export type CanisterDetailModalRemoveController = Required<
+  Pick<CanisterDetailModal<{ controller: string }>, "data">
 > &
-  Pick<CanisterDetailsModal, "type">;
+  Pick<CanisterDetailModal, "type">;
 
-export type CanisterDetailsModalDetach = Required<
-  Pick<CanisterDetailsModal<{ canisterId: Principal }>, "data">
+export type CanisterDetailModalDetach = Required<
+  Pick<CanisterDetailModal<{ canisterId: Principal }>, "data">
 > &
-  Pick<CanisterDetailsModal, "type">;
+  Pick<CanisterDetailModal, "type">;

--- a/frontend/src/lib/types/canister-detail.modal.ts
+++ b/frontend/src/lib/types/canister-detail.modal.ts
@@ -6,17 +6,18 @@ export type CanisterDetailModalType =
   | "add-controller"
   | "remove-controller";
 
-export interface CanisterDetailModal<D = void> {
+export interface CanisterDetailModal {
   type: CanisterDetailModalType;
-  data?: D;
 }
 
-export type CanisterDetailModalRemoveController = Required<
-  Pick<CanisterDetailModal<{ controller: string }>, "data">
-> &
-  Pick<CanisterDetailModal, "type">;
+export interface CanisterDetailModalWithData<D> extends CanisterDetailModal {
+  data: D;
+}
 
-export type CanisterDetailModalDetach = Required<
-  Pick<CanisterDetailModal<{ canisterId: Principal }>, "data">
-> &
-  Pick<CanisterDetailModal, "type">;
+export type CanisterDetailModalRemoveController = CanisterDetailModalWithData<{
+  controller: string;
+}>;
+
+export type CanisterDetailModalDetach = CanisterDetailModalWithData<{
+  canisterId: Principal;
+}>;

--- a/frontend/src/lib/types/intersection.types.ts
+++ b/frontend/src/lib/types/intersection.types.ts
@@ -1,0 +1,3 @@
+export interface IntersectingDetail {
+  intersecting: boolean;
+}

--- a/frontend/src/lib/utils/events.utils.ts
+++ b/frontend/src/lib/utils/events.utils.ts
@@ -1,0 +1,13 @@
+export const emit = <T>({
+  message,
+  detail,
+}: {
+  message: string;
+  detail?: T | undefined;
+}) => {
+  const $event: CustomEvent<T> = new CustomEvent<T>(message, {
+    detail,
+    bubbles: true,
+  });
+  document.dispatchEvent($event);
+};

--- a/frontend/src/tests/lib/components/canister-detail/ControllersCardTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/ControllersCardTest.svelte
@@ -5,10 +5,7 @@
     CANISTER_DETAILS_CONTEXT_KEY,
     type CanisterDetailsContext,
   } from "$lib/types/canister-detail.context";
-  import {
-    mockCanisterDetailsStore,
-    mockToggleCanisterModal,
-  } from "../../../mocks/canisters.mock";
+  import { mockCanisterDetailsStore } from "../../../mocks/canisters.mock";
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
 
   export let controllers: string[];
@@ -16,7 +13,6 @@
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
     store: mockCanisterDetailsStore,
     reloadDetails: () => Promise.resolve(undefined),
-    toggleModal: mockToggleCanisterModal,
   });
 
   onMount(() => {

--- a/frontend/src/tests/lib/components/canister-detail/DetachActionButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/DetachActionButtonTest.svelte
@@ -5,22 +5,11 @@
     CANISTER_DETAILS_CONTEXT_KEY,
     type CanisterDetailsContext,
   } from "$lib/types/canister-detail.context";
-  import {
-    mockCanisterDetailsStore,
-    mockToggleCanisterModal,
-  } from "../../../mocks/canisters.mock";
+  import { mockCanister } from "../../../mocks/canisters.mock";
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
   import DetachActionButton from "$lib/components/canister-detail/DetachCanisterButton.svelte";
-
-  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
-    store: mockCanisterDetailsStore,
-    reloadDetails: async () => {
-      // Do nnothing
-    },
-    toggleModal: mockToggleCanisterModal,
-  });
 </script>
 
-<DetachActionButton />
+<DetachActionButton canisterId={mockCanister.canister_id} />
 
 <CanisterDetailModals />

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -87,32 +87,4 @@ describe("RemoveCanisterControllerButton", () => {
     expect(removeController).toBeCalled();
     expect(reloadDetailsMock).toBeCalled();
   });
-
-  it("clear selected controller after remove", async () => {
-    let selectedController = "value";
-    const spy = (c) => (selectedController = c);
-
-    const { queryByTestId } = render(RemoveCanisterControllerButton, {
-      props: {
-        ...props,
-        spy,
-      },
-    });
-
-    await clickByTestId(queryByTestId, "remove-canister-controller-button");
-
-    expect(
-      queryByTestId("remove-canister-controller-confirmation-modal")
-    ).toBeInTheDocument();
-
-    await clickByTestId(queryByTestId, "confirm-yes");
-
-    await waitFor(() =>
-      expect(
-        queryByTestId("remove-canister-controller-confirmation-modal")
-      ).not.toBeInTheDocument()
-    );
-
-    expect(selectedController).toBeUndefined();
-  });
 });

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte
@@ -6,10 +6,7 @@
     CANISTER_DETAILS_CONTEXT_KEY,
     type CanisterDetailsContext,
   } from "$lib/types/canister-detail.context";
-  import {
-    mockCanisterDetailsStore,
-    mockToggleCanisterModal,
-  } from "../../../mocks/canisters.mock";
+  import { mockCanisterDetailsStore } from "../../../mocks/canisters.mock";
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
 
   export let reloadDetails: (canisterId: Principal) => Promise<void>;
@@ -19,11 +16,7 @@
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
     store: mockCanisterDetailsStore,
     reloadDetails,
-    toggleModal: mockToggleCanisterModal,
   });
-
-  $: $mockCanisterDetailsStore,
-    (() => spy?.($mockCanisterDetailsStore.selectedController))();
 </script>
 
 <RemoveCanisterControllerButton {controller} />

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButtonTest.svelte
@@ -11,7 +11,6 @@
 
   export let reloadDetails: (canisterId: Principal) => Promise<void>;
   export let controller: string;
-  export let spy: ((value: string | undefined) => void) | undefined = undefined;
 
   setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
     store: mockCanisterDetailsStore,

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -4,10 +4,7 @@ import {
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { CanistersStore } from "$lib/stores/canisters.store";
-import type {
-  CanisterDetailsModal,
-  SelectCanisterDetailsStore,
-} from "$lib/types/canister-detail.context";
+import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
 import { Principal } from "@dfinity/principal";
 import { writable, type Subscriber } from "svelte/store";
 import { mockIdentity } from "./auth.store.mock";
@@ -59,10 +56,4 @@ export const mockCanisterDetailsStore = writable<SelectCanisterDetailsStore>({
   info: mockCanister,
   details: mockCanisterDetails,
   controller: true,
-  modal: undefined,
-  selectedController: undefined,
 });
-
-export const mockToggleCanisterModal = (
-  modal: CanisterDetailsModal | undefined
-) => mockCanisterDetailsStore.update((data) => ({ ...data, modal }));


### PR DESCRIPTION
# Motivation

Replace usage of context store to trigger the canister details modal opening, closing and passing extra data.

# Changes

- use `CustomEvent` to trigger opening of modals used in "Canister" detail page
- adapt `Intersection` types to pattern use in this PR
- remove few unused imports
