### PR TITLE
Chore: Change order of nns topics

### DIFF
--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,3 +1,5 @@
+import { enumValues } from "$lib/utils/enum.utils";
+import { Topic } from "@dfinity/nns";
 import { E8S_PER_ICP } from "./icp.constants";
 
 export const MAX_NEURONS_MERGED = 2;
@@ -9,3 +11,22 @@ export const MIN_VERSION_MERGE_MATURITY = "2.0.6";
 
 export const DISSOLVE_DELAY_MULTIPLIER = 1;
 export const AGE_MULTIPLIER = 0.25;
+
+const FIRST_TOPICS = [
+  Topic.Unspecified,
+  Topic.Governance,
+  Topic.SnsAndCommunityFund,
+];
+const LAST_TOPICS = [Topic.ExchangeRate];
+// This list should include ALL topics ordered as we want.
+// Filtering out topics is done in the utils.
+export const TOPICS_TO_FOLLOW_NNS = [
+  Topic.Unspecified,
+  Topic.Governance,
+  Topic.SnsAndCommunityFund,
+  // We add all the topics that are not in the first or last topics
+  ...enumValues(Topic)
+    .filter((topic) => !FIRST_TOPICS.includes(topic))
+    .filter((topic) => !LAST_TOPICS.includes(topic)),
+  Topic.ExchangeRate,
+];

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -13,6 +13,7 @@ import {
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
   SPAWN_VARIANCE_PERCENTAGE,
+  TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
 import type { AccountsStore } from "$lib/stores/accounts.store";
@@ -45,7 +46,6 @@ import {
   isAccountHardwareWallet,
 } from "./accounts.utils";
 import { nowInSeconds } from "./date.utils";
-import { enumValues } from "./enum.utils";
 import { formatNumber } from "./format.utils";
 import { getVotingBallot, getVotingPower } from "./proposals.utils";
 import { formatToken } from "./token.utils";
@@ -679,8 +679,8 @@ export const followeesByTopic = ({
  */
 export const topicsToFollow = (neuron: NeuronInfo): Topic[] =>
   (followeesByTopic({ neuron, topic: Topic.ManageNeuron }) === undefined
-    ? enumValues(Topic).filter((topic) => topic !== Topic.ManageNeuron)
-    : enumValues(Topic)
+    ? TOPICS_TO_FOLLOW_NNS.filter((topic) => topic !== Topic.ManageNeuron)
+    : TOPICS_TO_FOLLOW_NNS
   ).filter((topic) => !DEPRECATED_TOPICS.includes(topic));
 
 // NeuronInfo is public info.

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -12,11 +12,11 @@ import {
 import {
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
+  TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
-import { enumValues } from "$lib/utils/enum.utils";
 import {
   ageMultiplier,
   allHaveSameFollowees,
@@ -1614,25 +1614,29 @@ describe("neuron-utils", () => {
 
     it("should not return deprecated topics", () => {
       expect(topicsToFollow(neuronWithoutManageNeuron)).toEqual(
-        enumValues(Topic).filter(
+        TOPICS_TO_FOLLOW_NNS.filter(
           (topic) =>
             topic !== Topic.ManageNeuron && !DEPRECATED_TOPICS.includes(topic)
         )
       );
       expect(topicsToFollow(neuronWithoutFollowees)).toEqual(
-        enumValues(Topic).filter(
+        TOPICS_TO_FOLLOW_NNS.filter(
           (topic) =>
             topic !== Topic.ManageNeuron && !DEPRECATED_TOPICS.includes(topic)
         )
       );
       expect(topicsToFollow(neuronWithManageNeuron)).toEqual(
-        enumValues(Topic).filter((topic) => !DEPRECATED_TOPICS.includes(topic))
+        TOPICS_TO_FOLLOW_NNS.filter(
+          (topic) => !DEPRECATED_TOPICS.includes(topic)
+        )
       );
     });
 
     it("should return topics with ManageNeuron if neuron follows some neuron on the ManageNeuron topic", () => {
       expect(topicsToFollow(neuronWithManageNeuron)).toEqual(
-        enumValues(Topic).filter((topic) => !DEPRECATED_TOPICS.includes(topic))
+        TOPICS_TO_FOLLOW_NNS.filter(
+          (topic) => !DEPRECATED_TOPICS.includes(topic)
+        )
       );
     });
   });


### PR DESCRIPTION
# Motivation

User should be able to setup followees for all topics easily.

# Changes

* Change the order of the topics shown in the modal to edit followees.
* New constant TOPICS_TO_FOLLOW_NNS with the order desired.
* topicsToFollow neuron util uses new constant TOPICS_TO_FOLLOW_NNS

# Tests

* Fix tests
