### PR TITLE
GI-1114: List SNS Followees

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -9,6 +9,7 @@
     type NnsNeuronContext,
   } from "$lib/types/nns-neuron-detail.context";
   import { getContext } from "svelte";
+  import TagsList from "$lib/components/ui/TagsList.svelte";
 
   export let followee: FolloweesNeuron;
 
@@ -33,31 +34,12 @@
   };
 </script>
 
-<button {id} class="text" on:click|stopPropagation={openVotingHistory}>
-  {name}
-</button>
+<TagsList {id} on:nnsTitleClick={openVotingHistory}>
+  <svelte:fragment slot="title">
+    {name}
+  </svelte:fragment>
 
-<ul aria-labelledby={id}>
   {#each followee.topics as topic}
     <Tag tagName="li">{topicTitle(topic)}</Tag>
   {/each}
-</ul>
-
-<style lang="scss">
-  button {
-    margin: 0 0 calc(0.5 * var(--padding));
-    font-size: var(--font-size-h5);
-  }
-
-  ul {
-    display: flex;
-    gap: calc(0.5 * var(--padding));
-    flex-wrap: wrap;
-
-    list-style: none;
-
-    margin-bottom: var(--padding);
-    padding: 0 0 calc(2 * var(--padding));
-    border-bottom: 1px solid currentColor;
-  }
-</style>
+</TagsList>

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -8,7 +8,7 @@
   import { knownNeuronsStore } from "$lib/stores/knownNeurons.store";
   import { followeesByTopic } from "$lib/utils/neuron.utils";
   import FollowTopicSection from "./FollowTopicSection.svelte";
-  import { KeyValuePair } from "@dfinity/gix-components";
+  import { IconClose, Value } from "@dfinity/gix-components";
 
   export let topic: Topic;
   export let neuron: NeuronInfo;
@@ -67,13 +67,12 @@
   <ul>
     {#each followees as followee (followee.neuronId)}
       <li data-tid="current-followee-item">
-        <KeyValuePair>
-          <p slot="key" class="value">{followee.name ?? followee.neuronId}</p>
-          <button
-            slot="value"
-            on:click={() => removeCurrentFollowee(followee.neuronId)}>x</button
-          >
-        </KeyValuePair>
+        <Value>{followee.name ?? followee.neuronId}</Value>
+        <button
+          class="text"
+          on:click={() => removeCurrentFollowee(followee.neuronId)}
+          ><IconClose /></button
+        >
       </li>
     {/each}
   </ul>
@@ -83,9 +82,18 @@
 {/if}
 
 <style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/card";
+
   ul {
-    list-style-type: none;
-    padding: 0;
+    @include card.list;
+  }
+
+  li {
+    @include card.list-item;
+
+    button {
+      display: flex;
+    }
   }
 
   .subtitle {

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
   import FollowTopicSection from "$lib/components/neurons/FollowTopicSection.svelte";
   import NewSnsFolloweeModal from "$lib/modals/sns/neurons/NewSnsFolloweeModal.svelte";
+  import { followeesByFunction } from "$lib/utils/sns-neuron.utils";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNeuron, SnsNervousSystemFunction } from "@dfinity/sns";
+  import type {
+    SnsNeuron,
+    SnsNervousSystemFunction,
+    SnsNeuronId,
+  } from "@dfinity/sns";
   import { fromNullable } from "@dfinity/utils";
+  import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+  import { KeyValuePair } from "@dfinity/gix-components";
+  import Hash from "../ui/Hash.svelte";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
@@ -12,19 +20,40 @@
   let showModal = false;
   const openModal = () => (showModal = true);
   const closeModal = () => (showModal = false);
+
+  let followees: SnsNeuronId[] = [];
+  $: followees = followeesByFunction({ neuron, functionId: nsFunction.id });
+
+  const removeCurrentFollowee = (followee: SnsNeuronId) => {
+    // TODO: Remove followee https://dfinity.atlassian.net/browse/GIX-1112
+    console.log("removeCurrentFollowee", followee);
+  };
 </script>
 
 <FollowTopicSection
   on:nnsOpen={openModal}
-  count={0}
+  count={followees.length}
   id={nsFunction.id.toString()}
 >
   <h3 slot="title">{nsFunction.name}</h3>
   <p slot="subtitle" class="subtitle description">
     {fromNullable(nsFunction.description)}
   </p>
-  <!-- TODO: Render Followees https://dfinity.atlassian.net/browse/GIX-1114 -->
-  <div>{`TODO: render followees ${neuron.followees.length}`}</div>
+  <ul>
+    {#each followees as followee (subaccountToHexString(followee.id))}
+      {@const followeeIdHex = subaccountToHexString(followee.id)}
+      <li data-tid="current-followee-item">
+        <KeyValuePair>
+          <p slot="key" class="value">
+            <Hash text={followeeIdHex} id={followeeIdHex} tagName="span" />
+          </p>
+          <button slot="value" on:click={() => removeCurrentFollowee(followee)}
+            >x</button
+          >
+        </KeyValuePair>
+      </li>
+    {/each}
+  </ul>
 </FollowTopicSection>
 
 {#if showModal}
@@ -39,5 +68,10 @@
 <style lang="scss">
   .subtitle {
     margin: 0 0 var(--padding) 0;
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 0;
   }
 </style>

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -10,8 +10,9 @@
   } from "@dfinity/sns";
   import { fromNullable } from "@dfinity/utils";
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
-  import { KeyValuePair } from "@dfinity/gix-components";
+  import { IconClose, Value } from "@dfinity/gix-components";
   import Hash from "../ui/Hash.svelte";
+  import { i18n } from "$lib/stores/i18n";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
@@ -43,14 +44,14 @@
     {#each followees as followee (subaccountToHexString(followee.id))}
       {@const followeeIdHex = subaccountToHexString(followee.id)}
       <li data-tid="current-followee-item">
-        <KeyValuePair>
-          <p slot="key" class="value">
-            <Hash text={followeeIdHex} id={followeeIdHex} tagName="span" />
-          </p>
-          <button slot="value" on:click={() => removeCurrentFollowee(followee)}
-            >x</button
-          >
-        </KeyValuePair>
+        <Value>
+          <Hash text={followeeIdHex} id={followeeIdHex} tagName="span" />
+        </Value>
+        <button
+          class="text"
+          aria-label={$i18n.core.remove}
+          on:click={() => removeCurrentFollowee(followee)}><IconClose /></button
+        >
       </li>
     {/each}
   </ul>
@@ -66,12 +67,20 @@
 {/if}
 
 <style lang="scss">
-  .subtitle {
-    margin: 0 0 var(--padding) 0;
-  }
+  @use "@dfinity/gix-components/styles/mixins/card";
 
   ul {
-    list-style-type: none;
-    padding: 0;
+    @include card.list;
+  }
+
+  li {
+    @include card.list-item;
+
+    button {
+      display: flex;
+    }
+  }
+  .subtitle {
+    margin: 0 0 var(--padding) 0;
   }
 </style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -16,7 +16,7 @@
     tagName="span"
   />
 
-  {#each followee.nsFunctions as nsFunction}
+  {#each followee.nsFunctions as nsFunction (nsFunction.id)}
     <Tag tagName="li">{nsFunction.name}</Tag>
   {/each}
 </TagsList>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -2,36 +2,21 @@
   import { Tag } from "@dfinity/gix-components";
   import type { SnsFolloweesByNeuron } from "$lib/utils/sns-neuron.utils";
   import Hash from "../ui/Hash.svelte";
+  import TagsList from "../ui/TagsList.svelte";
 
   export let followee: SnsFolloweesByNeuron;
 </script>
 
 <!-- TODO: Open Voting history modal https://dfinity.atlassian.net/browse/GIX-1156 -->
-<button id={followee.neuronIdHex} class="text">
-  <Hash text={followee.neuronIdHex} id={followee.neuronIdHex} tagName="span" />
-</button>
+<TagsList id={followee.neuronIdHex}>
+  <Hash
+    slot="title"
+    text={followee.neuronIdHex}
+    id={followee.neuronIdHex}
+    tagName="span"
+  />
 
-<ul aria-labelledby={followee.neuronIdHex}>
   {#each followee.nsFunctions as nsFunction}
     <Tag tagName="li">{nsFunction.name}</Tag>
   {/each}
-</ul>
-
-<style lang="scss">
-  button {
-    margin: 0 0 var(--padding-0_5x);
-    font-size: var(--font-size-h5);
-  }
-
-  ul {
-    display: flex;
-    gap: var(--padding-0_5x);
-    flex-wrap: wrap;
-
-    list-style: none;
-
-    margin-bottom: var(--padding);
-    padding: 0 0 var(--padding-2x);
-    border-bottom: 1px solid currentColor;
-  }
-</style>
+</TagsList>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { Tag } from "@dfinity/gix-components";
+  import type { SnsFolloweesByNeuron } from "$lib/utils/sns-neuron.utils";
+  import Hash from "../ui/Hash.svelte";
+
+  export let followee: SnsFolloweesByNeuron;
+</script>
+
+<!-- TODO: Open Voting history modal https://dfinity.atlassian.net/browse/GIX-1156 -->
+<button id={followee.neuronIdHex} class="text">
+  <Hash text={followee.neuronIdHex} id={followee.neuronIdHex} tagName="span" />
+</button>
+
+<ul aria-labelledby={followee.neuronIdHex}>
+  {#each followee.nsFunctions as nsFunction}
+    <Tag tagName="li">{nsFunction.name}</Tag>
+  {/each}
+</ul>
+
+<style lang="scss">
+  button {
+    margin: 0 0 var(--padding-0_5x);
+    font-size: var(--font-size-h5);
+  }
+
+  ul {
+    display: flex;
+    gap: var(--padding-0_5x);
+    flex-wrap: wrap;
+
+    list-style: none;
+
+    margin-bottom: var(--padding);
+    padding: 0 0 var(--padding-2x);
+    border-bottom: 1px solid currentColor;
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -12,7 +12,7 @@
     type SnsFolloweesByNeuron,
   } from "$lib/utils/sns-neuron.utils";
   import { isNullish, nonNullish } from "$lib/utils/utils";
-  import { KeyValuePairInfo, Spinner } from "@dfinity/gix-components";
+  import { KeyValuePairInfo } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNervousSystemFunction, SnsNeuron } from "@dfinity/sns";
   import { getContext } from "svelte";
@@ -21,7 +21,6 @@
   import Separator from "$lib/components/ui/Separator.svelte";
   import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import SnsFollowee from "./SnsFollowee.svelte";
-  import SkeletonCard from "../ui/SkeletonCard.svelte";
   import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
 
   $: {
@@ -90,7 +89,7 @@
   {#if showLoading}
     <div class="frame">
       <hr />
-      <SkeletonFollowees cardType="info" />
+      <SkeletonFollowees />
     </div>
   {/if}
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -49,7 +49,7 @@
 
   let nsFunctions: SnsNervousSystemFunction[];
   $: nsFunctions = nonNullish(rootCanisterId)
-    ? $snsFunctionsStore[rootCanisterId.toText()] ?? []
+    ? $snsFunctionsStore[rootCanisterId.toText()]?.nsFunctions ?? []
     : [];
 
   let followees: SnsFolloweesByNeuron[] = [];

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -6,15 +6,23 @@
     SELECTED_SNS_NEURON_CONTEXT_KEY,
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
-  import { hasPermissionToVote } from "$lib/utils/sns-neuron.utils";
+  import {
+    followeesByNeuronId,
+    hasPermissionToVote,
+    type SnsFolloweesByNeuron,
+  } from "$lib/utils/sns-neuron.utils";
   import { isNullish, nonNullish } from "$lib/utils/utils";
-  import { KeyValuePairInfo } from "@dfinity/gix-components";
+  import { KeyValuePairInfo, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNervousSystemFunction, SnsNeuron } from "@dfinity/sns";
   import { getContext } from "svelte";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import FollowSnsNeuronsButton from "./actions/FollowSnsNeuronsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+  import SnsFollowee from "./SnsFollowee.svelte";
+  import SkeletonCard from "../ui/SkeletonCard.svelte";
+  import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
 
   $: {
     if (rootCanisterId !== undefined) {
@@ -39,6 +47,26 @@
         neuron,
         identity: $authStore.identity,
       });
+
+  let nsFunctions: SnsNervousSystemFunction[];
+  $: nsFunctions = nonNullish(rootCanisterId)
+    ? $snsFunctionsStore[rootCanisterId.toText()] ?? []
+    : [];
+
+  let followees: SnsFolloweesByNeuron[] = [];
+  $: followees =
+    isNullish(neuron) || nsFunctions.length === 0
+      ? []
+      : followeesByNeuronId({
+          neuron,
+          nsFunctions,
+        });
+
+  let showLoading: boolean;
+  $: showLoading =
+    nonNullish(neuron) &&
+    neuron.followees.length > 0 &&
+    nsFunctions.length === 0;
 </script>
 
 <CardInfo>
@@ -48,6 +76,23 @@
       >{$i18n.neuron_detail.following_description}</svelte:fragment
     >
   </KeyValuePairInfo>
+
+  {#if followees.length > 0}
+    <div class="frame">
+      <hr />
+
+      {#each followees as followee}
+        <SnsFollowee {followee} />
+      {/each}
+    </div>
+  {/if}
+
+  {#if showLoading}
+    <div class="frame">
+      <hr />
+      <SkeletonFollowees cardType="info" />
+    </div>
+  {/if}
 
   <!-- TS doesn't understand that neuron is defined if allowedToManageFollows is true -->
   {#if allowedToManageFollows && nonNullish(neuron) && nonNullish(rootCanisterId)}
@@ -62,6 +107,10 @@
 <style lang="scss">
   h3 {
     line-height: var(--line-height-standard);
+  }
+
+  .frame {
+    padding-bottom: var(--padding-0_5x);
   }
 
   .actions {

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -24,7 +24,13 @@
 
 <div class="identifier" data-tid="sns-neuron-card-title">
   <div use:onIntersection on:nnsIntersecting data-tid="neuron-id-container">
-    <Hash id="neuron-id" {tagName} testId="neuron-id" text={neuronId} />
+    <Hash
+      id="neuron-id"
+      {tagName}
+      testId="neuron-id"
+      text={neuronId}
+      showCopy
+    />
   </div>
   {#if isHotkey}
     <span>{$i18n.neurons.hotkey_control}</span>

--- a/frontend/src/lib/components/summary/PrincipalText.svelte
+++ b/frontend/src/lib/components/summary/PrincipalText.svelte
@@ -11,7 +11,7 @@
 
 <p class="value principal" class:inline>
   <span>{$i18n.core.principal_is}</span>
-  <Hash id="neuron-id" text={principalText} tagName="p" />
+  <Hash id="neuron-id" text={principalText} tagName="p" showCopy />
 </p>
 
 <style lang="scss">

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -3,10 +3,11 @@
   import { Copy } from "@dfinity/gix-components";
   import Tooltip from "./Tooltip.svelte";
 
-  export let tagName: "h3" | "p" = "h3";
+  export let tagName: "h3" | "p" | "span" = "h3";
   export let testId: string | undefined = undefined;
   export let id: string;
   export let text: string;
+  export let showCopy = false;
 
   let shortenText: string;
   $: shortenText = shortenWithMiddleEllipsis(text);
@@ -14,11 +15,13 @@
 
 <span>
   <Tooltip {id} {text}>
-    <svelte:element this={tagName} data-tid={testId}
-      >{shortenText}</svelte:element
+    <svelte:element this={tagName} data-tid={testId}>
+      {shortenText}</svelte:element
     >
   </Tooltip>
-  <Copy value={text} />
+  {#if showCopy}
+    <Copy value={text} />
+  {/if}
 </span>
 
 <style lang="scss">

--- a/frontend/src/lib/components/ui/IdentifierHash.svelte
+++ b/frontend/src/lib/components/ui/IdentifierHash.svelte
@@ -4,4 +4,10 @@
   export let identifier: string;
 </script>
 
-<Hash id="identifier" tagName="p" testId="identifier" text={identifier} />
+<Hash
+  id="identifier"
+  tagName="p"
+  testId="identifier"
+  text={identifier}
+  showCopy
+/>

--- a/frontend/src/lib/components/ui/SkeletonFollowees.svelte
+++ b/frontend/src/lib/components/ui/SkeletonFollowees.svelte
@@ -34,6 +34,6 @@
   }
 
   .tag {
-    width: calc(8 * var(--padding));
+    width: calc(var(--padding-8x));
   }
 </style>

--- a/frontend/src/lib/components/ui/SkeletonFollowees.svelte
+++ b/frontend/src/lib/components/ui/SkeletonFollowees.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { SkeletonText } from "@dfinity/gix-components";
+</script>
+
+<div>
+  <div class="neuron-id">
+    <SkeletonText />
+  </div>
+  <div class="tags">
+    <div class="tag">
+      <SkeletonText />
+    </div>
+    <div class="tag">
+      <SkeletonText />
+    </div>
+    <div class="tag">
+      <SkeletonText />
+    </div>
+  </div>
+</div>
+
+<style lang="scss">
+  .neuron-id {
+    width: calc(16 * var(--padding));
+    padding-top: var(--padding-0_5x);
+  }
+
+  .tags {
+    display: flex;
+    gap: var(--padding-0_5x);
+    border-bottom: 1px solid currentColor;
+    margin-bottom: var(--padding);
+    padding-bottom: var(--padding-2x);
+  }
+
+  .tag {
+    width: calc(8 * var(--padding));
+  }
+</style>

--- a/frontend/src/lib/components/ui/SkeletonFollowees.svelte
+++ b/frontend/src/lib/components/ui/SkeletonFollowees.svelte
@@ -2,7 +2,7 @@
   import { SkeletonText } from "@dfinity/gix-components";
 </script>
 
-<div>
+<div data-tid="skeleton-followees">
   <div class="neuron-id">
     <SkeletonText />
   </div>

--- a/frontend/src/lib/components/ui/TagsList.svelte
+++ b/frontend/src/lib/components/ui/TagsList.svelte
@@ -9,7 +9,7 @@
   };
 </script>
 
-<button {id} class="text" on:click={onClick}>
+<button {id} class="text" on:click={onClick} data-tid="tag-list-title">
   <slot name="title" />
 </button>
 

--- a/frontend/src/lib/components/ui/TagsList.svelte
+++ b/frontend/src/lib/components/ui/TagsList.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let id: string;
+
+  const dispatcher = createEventDispatcher();
+  const onClick = () => {
+    dispatcher("nnsTitleClick");
+  };
+</script>
+
+<button {id} class="text" on:click={onClick}>
+  <slot name="title" />
+</button>
+
+<ul aria-labelledby={id}>
+  <slot />
+</ul>
+
+<style lang="scss">
+  button {
+    margin: 0 0 calc(0.5 * var(--padding));
+    font-size: var(--font-size-h5);
+  }
+
+  ul {
+    display: flex;
+    gap: calc(0.5 * var(--padding));
+    flex-wrap: wrap;
+
+    list-style: none;
+
+    margin-bottom: var(--padding);
+    padding: 0 0 calc(2 * var(--padding));
+    border-bottom: 1px solid currentColor;
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -690,6 +690,7 @@
     "ledger_too_old": "Sorry, the transaction is too old. Please try again.",
     "ledger_unsufficient_funds": "Sorry, the account doesn't have enough funds for this transaction.",
     "sns_add_followee": "There was an error while adding a followee.",
+    "sns_load_functions": "There was an error while loading the project topics.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   },
   "auth_accounts": {

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
@@ -13,7 +13,7 @@
 
   let functions: SnsNervousSystemFunction[] | undefined;
   $: functions = functionsToFollow(
-    $snsFunctionsStore[rootCanisterId.toString()]
+    $snsFunctionsStore[rootCanisterId.toString()]?.nsFunctions
   );
 </script>
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -435,18 +435,25 @@ export const stakeNeuron = async ({
 export const loadSnsNervousSystemFunctions = async (
   rootCanisterId: Principal
 ) => {
-  const identity = await getAuthenticatedIdentity();
-  // We load with a query call only. Nervous System Functions are public and not related to the user.
-  const functions = await getNervousSystemFunctions({
-    rootCanisterId,
-    identity,
-    certified: true,
-  });
+  try {
+    const identity = await getAuthenticatedIdentity();
+    // We load with a query call only. Nervous System Functions are public and not related to the user.
+    const functions = await getNervousSystemFunctions({
+      rootCanisterId,
+      identity,
+      certified: true,
+    });
 
-  snsFunctionsStore.setFunctions({
-    rootCanisterId,
-    functions,
-  });
+    snsFunctionsStore.setFunctions({
+      rootCanisterId,
+      functions,
+    });
+  } catch (err) {
+    toastsError({
+      labelKey: "error__sns.sns_load_functions",
+      err,
+    });
+  }
 };
 
 /**

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -441,7 +441,7 @@ export const loadSnsNervousSystemFunctions = async (
     const functions = await getNervousSystemFunctions({
       rootCanisterId,
       identity,
-      certified: true,
+      certified: false,
     });
 
     snsFunctionsStore.setFunctions({

--- a/frontend/src/lib/stores/sns-functions.store.ts
+++ b/frontend/src/lib/stores/sns-functions.store.ts
@@ -5,7 +5,10 @@ import { writable } from "svelte/store";
 export interface SnsNervousSystemFunctionsStore {
   // Each SNS Project is an entry in this Store.
   // We use the root canister id as the key to identify the nervous system functions.
-  [rootCanisterId: string]: SnsNervousSystemFunction[];
+  [rootCanisterId: string]: {
+    nsFunctions: SnsNervousSystemFunction[];
+    certified: boolean;
+  };
 }
 
 /**
@@ -23,14 +26,19 @@ const initSnsFunctionsStore = () => {
 
     setFunctions({
       rootCanisterId,
-      functions,
+      nsFunctions,
+      certified,
     }: {
       rootCanisterId: Principal;
-      functions: SnsNervousSystemFunction[];
+      nsFunctions: SnsNervousSystemFunction[];
+      certified: boolean;
     }) {
       update((currentState: SnsNervousSystemFunctionsStore) => ({
         ...currentState,
-        [rootCanisterId.toText()]: functions,
+        [rootCanisterId.toText()]: {
+          certified,
+          nsFunctions,
+        },
       }));
     },
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -724,6 +724,7 @@ interface I18nError__sns {
   ledger_too_old: string;
   ledger_unsufficient_funds: string;
   sns_add_followee: string;
+  sns_load_functions: string;
   sns_add_hotkey: string;
 }
 

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -361,9 +361,15 @@ export const followeesByNeuronId = ({
       for (const followee of followeesData.followees) {
         const followeeHex = subaccountToHexString(followee.id);
         if (acc[followeeHex]) {
-          acc[followeeHex].push(nsFunction);
+          acc = {
+            ...acc,
+            [followeeHex]: [...acc[followeeHex], nsFunction],
+          };
         } else {
-          acc[followeeHex] = [nsFunction];
+          acc = {
+            ...acc,
+            [followeeHex]: [nsFunction],
+          };
         }
       }
     }

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -307,6 +307,14 @@ export const functionsToFollow = (
 ): SnsNervousSystemFunction[] | undefined =>
   functions?.filter(({ id }) => id !== UNSPECIFIED_FUNCTION_ID);
 
+/**
+ * Returns the followees of a neuron in a specific ns function.
+ *
+ * @param {Object} params
+ * @param {SnsNeuron} params.neuron
+ * @param {bigint} params.functionId
+ * @returns {SnsNeuronId[]}
+ */
 export const followeesByFunction = ({
   neuron,
   functionId,
@@ -327,6 +335,16 @@ export interface SnsFolloweesByNeuron {
   nsFunctions: NervousSystemFunction[];
 }
 
+/**
+ * Returns a list of followees of a neuron.
+ *
+ * Each followee has then the list of ns functions that are followed.
+ *
+ * @param {Object} params
+ * @param {SnsNeuron} params.neuron
+ * @param {NervousSystemFunction[]} params.nsFunctions
+ * @returns {SnsFolloweesByNeuron[]}
+ */
 export const followeesByNeuronId = ({
   neuron,
   nsFunctions,
@@ -356,17 +374,4 @@ export const followeesByNeuronId = ({
     neuronIdHex,
     nsFunctions: followeesDictionary[neuronIdHex],
   }));
-};
-
-export const followeesByNsFunction = ({
-  neuron,
-  nsFunction,
-}: {
-  neuron: SnsNeuron;
-  nsFunction: NervousSystemFunction;
-}): SnsNeuronId[] => {
-  const followees = neuron.followees.find(
-    ([functionId]) => functionId === nsFunction.id
-  );
-  return followees?.[1].followees ?? [];
 };

--- a/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
@@ -2,23 +2,36 @@
  * @jest-environment jsdom
  */
 import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import type { SnsNeuron } from "@dfinity/sns";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
-import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+} from "../../../mocks/sns-neurons.mock";
 import { principal } from "../../../mocks/sns-projects.mock";
 
 describe("FollowSnsTopicSection", () => {
   const reload = jest.fn();
+  const followee1 = createMockSnsNeuron({ id: [1, 2, 3] });
+  const followee2 = createMockSnsNeuron({ id: [5, 6, 7] });
+  const followees = [followee1.id[0], followee2.id[0]];
+  const neuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    followees: [[nervousSystemFunctionMock.id, { followees }]],
+  };
 
   const renderComponent = (): RenderResult<SvelteComponent> =>
     renderSelectedSnsNeuronContext({
       Component: FollowSnsTopicSection,
       reload,
-      neuron: mockSnsNeuron,
+      neuron,
       props: {
-        neuron: mockSnsNeuron,
+        neuron,
         rootCanisterId: principal(2),
         nsFunction: nervousSystemFunctionMock,
       },
@@ -32,7 +45,23 @@ describe("FollowSnsTopicSection", () => {
     ).toBeInTheDocument();
   });
 
-  it.only("opens new followee modal", async () => {
+  it("renders followees for that topic", () => {
+    const { queryAllByTestId, getAllByText } = renderComponent();
+
+    expect(queryAllByTestId("current-followee-item").length).toBe(
+      followees.length
+    );
+    // Id appears as title and in the tooltip
+    [followee1, followee2].forEach((followee) => {
+      expect(
+        getAllByText(
+          shortenWithMiddleEllipsis(getSnsNeuronIdAsHexString(followee))
+        ).length
+      ).toBe(2);
+    });
+  });
+
+  it("opens new followee modal", async () => {
     const { getByTestId, queryByTestId } = renderComponent();
 
     const button = getByTestId("open-new-followee-modal");

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -5,14 +5,26 @@
 import SnsNeuronFollowingCard from "$lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte";
 import { loadSnsNervousSystemFunctions } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
-import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import {
+  SnsNeuronPermissionType,
+  type SnsNervousSystemFunction,
+  type SnsNeuron,
+} from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "../../../mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
-import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+} from "../../../mocks/sns-neurons.mock";
+import { rootCanisterIdMock } from "../../../mocks/sns.api.mock";
 
 jest.mock("../../../../../src/lib/services/sns-neurons.services", () => ({
   loadSnsNervousSystemFunctions: jest.fn(),
@@ -36,6 +48,36 @@ describe("SnsNeuronFollowingCard", () => {
           ]),
         },
       ],
+      followees: [],
+    };
+    const function0: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(0),
+      name: "function0",
+    };
+    const function1: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(1),
+      name: "function1",
+    };
+    const function2: SnsNervousSystemFunction = {
+      ...nervousSystemFunctionMock,
+      id: BigInt(2),
+      name: "function2",
+    };
+    const followee1 = createMockSnsNeuron({
+      id: [1, 2, 3, 4],
+    });
+    const followee2 = createMockSnsNeuron({
+      id: [5, 6, 7, 8],
+    });
+    const neuronWithFollowees: SnsNeuron = {
+      ...mockSnsNeuron,
+      followees: [
+        [function0.id, { followees: [followee1.id[0]] }],
+        [function1.id, { followees: [followee2.id[0]] }],
+        [function2.id, { followees: [followee1.id[0], followee2.id[0]] }],
+      ],
     };
 
     const reload = jest.fn();
@@ -46,7 +88,10 @@ describe("SnsNeuronFollowingCard", () => {
         neuron,
       });
 
-    afterEach(() => jest.clearAllMocks());
+    afterEach(() => {
+      jest.clearAllMocks();
+      snsFunctionsStore.reset();
+    });
 
     it("loads sns topics", async () => {
       renderCard(controlledNeuron);
@@ -54,6 +99,42 @@ describe("SnsNeuronFollowingCard", () => {
       await waitFor(() =>
         expect(loadSnsNervousSystemFunctions).toHaveBeenCalled()
       );
+    });
+
+    it("renders followees and their topics", () => {
+      // Use same rootCanisterId as in `renderSelectedSnsNeuronContext`
+      snsFunctionsStore.setFunctions({
+        rootCanisterId: rootCanisterIdMock,
+        functions: [function0, function1, function2],
+      });
+      const { getAllByText } = renderCard(neuronWithFollowees);
+
+      [followee1, followee2].forEach((followee) => {
+        expect(
+          getAllByText(
+            shortenWithMiddleEllipsis(getSnsNeuronIdAsHexString(followee))
+          ).length
+        ).toBe(2);
+      });
+
+      // 1 followee
+      expect(getAllByText(function0.name).length).toBe(1);
+      // 1 followee
+      expect(getAllByText(function1.name).length).toBe(1);
+      // 2 followees
+      expect(getAllByText(function2.name).length).toBe(2);
+    });
+
+    it("shows loading while no ns functions", () => {
+      snsFunctionsStore.reset();
+      const { queryByTestId } = renderCard(neuronWithFollowees);
+      expect(queryByTestId("skeleton-followees")).toBeInTheDocument();
+    });
+
+    it("does not render skeletong if no followees", () => {
+      snsFunctionsStore.reset();
+      const { queryByTestId } = renderCard(controlledNeuron);
+      expect(queryByTestId("skeleton-followees")).not.toBeInTheDocument();
     });
 
     it("renders button to follow neurons", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -105,7 +105,8 @@ describe("SnsNeuronFollowingCard", () => {
       // Use same rootCanisterId as in `renderSelectedSnsNeuronContext`
       snsFunctionsStore.setFunctions({
         rootCanisterId: rootCanisterIdMock,
-        functions: [function0, function1, function2],
+        nsFunctions: [function0, function1, function2],
+        certified: true,
       });
       const { getAllByText } = renderCard(neuronWithFollowees);
 

--- a/frontend/src/tests/lib/components/ui/Hash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Hash.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Hash from "$lib/components/ui/Hash.svelte";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { render } from "@testing-library/svelte";
+
+describe("Hash", () => {
+  const identifier = "12345678901234567890";
+  const testId = "tests-hash";
+
+  it("should render a hashed identifier", () => {
+    const { getByTestId } = render(Hash, {
+      props: { text: identifier, testId, id: identifier },
+    });
+
+    const small = getByTestId(testId);
+    expect(small?.textContent).toEqual(shortenWithMiddleEllipsis(identifier));
+  });
+
+  it("should render a tooltip with all identifier", () => {
+    const { container } = render(Hash, {
+      props: { text: identifier, testId, id: identifier },
+    });
+
+    const tooltipElement = container.querySelector("[role='tooltip']");
+    expect(tooltipElement?.textContent).toEqual(identifier);
+  });
+
+  it("should render the identifier as aria-label when copy icon", () => {
+    const { container } = render(Hash, {
+      props: { text: identifier, testId, id: identifier, showCopy: true },
+    });
+
+    const button = container.querySelector("button");
+    expect(
+      button?.getAttribute("aria-label").includes(identifier)
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/tests/lib/components/ui/TagsList.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TagsList.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import TagsListTest from "./TagsListTest.svelte";
+
+describe("CardBlock", () => {
+  it("should render a button and a ul", () => {
+    const { container } = render(TagsListTest);
+    expect(container.querySelector("button")).toBeInTheDocument();
+    expect(container.querySelector("ul")).toBeInTheDocument();
+  });
+
+  it("should render title and children", () => {
+    const { queryAllByTestId, queryByTestId } = render(TagsListTest);
+    expect(queryByTestId("title")).toBeInTheDocument();
+    expect(queryAllByTestId("item").length).toBe(2);
+  });
+
+  it("should trigger event on button click", (done) => {
+    const { component, queryByTestId } = render(TagsListTest);
+    component.$on("nnsTitleClick", () => done());
+    const button = queryByTestId("tag-list-title");
+    fireEvent.click(button);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/TagsListTest.svelte
+++ b/frontend/src/tests/lib/components/ui/TagsListTest.svelte
@@ -1,0 +1,9 @@
+<script>
+  import TagsList from "$lib/components/ui/TagsList.svelte";
+</script>
+
+<TagsList id="tid" on:nnsTitleClick>
+  <span data-tid="title" slot="title">title</span>
+  <li data-tid="item">item 1</li>
+  <li data-tid="item">item 2</li>
+</TagsList>

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -56,7 +56,8 @@ describe("FollowSnsNeuronsModal", () => {
     };
     snsFunctionsStore.setFunctions({
       rootCanisterId,
-      functions: [function0, function1, function2],
+      nsFunctions: [function0, function1, function2],
+      certified: true,
     });
     const { queryByTestId } = render(FollowSnsNeuronsModal, {
       props: {

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -577,6 +577,16 @@ describe("sns-neurons-services", () => {
       ]);
       expect(spyGetFunctions).toBeCalled();
     });
+
+    it("should show a toast if api throws an error", async () => {
+      jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockImplementation(() => Promise.reject("error"));
+
+      await loadSnsNervousSystemFunctions(mockPrincipal);
+
+      expect(toastsError).toBeCalled();
+    });
   });
 
   describe("addFollowee ", () => {

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -572,9 +572,11 @@ describe("sns-neurons-services", () => {
       await loadSnsNervousSystemFunctions(mockPrincipal);
 
       const store = get(snsFunctionsStore);
-      expect(store[mockPrincipal.toText()]).toEqual([
-        nervousSystemFunctionMock,
-      ]);
+      await waitFor(() =>
+        expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
+          nervousSystemFunctionMock,
+        ])
+      );
       expect(spyGetFunctions).toBeCalled();
     });
 

--- a/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
@@ -14,7 +14,8 @@ describe("sns functions store", () => {
   it("should set functions for one project", () => {
     snsFunctionsStore.setFunctions({
       rootCanisterId: mockPrincipal,
-      functions: [nervousSystemFunctionMock],
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
     });
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
@@ -23,7 +24,8 @@ describe("sns functions store", () => {
   it("should set functions for more than one project", () => {
     snsFunctionsStore.setFunctions({
       rootCanisterId: mockPrincipal,
-      functions: [nervousSystemFunctionMock],
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
     });
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
@@ -31,7 +33,8 @@ describe("sns functions store", () => {
     const rootCanister2 = Principal.from("aaaaa-aa");
     snsFunctionsStore.setFunctions({
       rootCanisterId: rootCanister2,
-      functions: [nervousSystemFunctionMock],
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
     });
     const store2 = get(snsFunctionsStore);
     expect(store2[rootCanister2.toText()]).toEqual([nervousSystemFunctionMock]);
@@ -40,14 +43,16 @@ describe("sns functions store", () => {
   it("should reset functions for more than one project", () => {
     snsFunctionsStore.setFunctions({
       rootCanisterId: mockPrincipal,
-      functions: [nervousSystemFunctionMock],
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
     });
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
 
     snsFunctionsStore.setFunctions({
       rootCanisterId: mockPrincipal,
-      functions: [],
+      nsFunctions: [],
+      certified: true,
     });
     const store2 = get(snsFunctionsStore);
     expect(store2[mockPrincipal.toText()]).toEqual([]);

--- a/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
@@ -18,7 +18,9 @@ describe("sns functions store", () => {
       certified: true,
     });
     const store = get(snsFunctionsStore);
-    expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
+    expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
+      nervousSystemFunctionMock,
+    ]);
   });
 
   it("should set functions for more than one project", () => {
@@ -28,7 +30,9 @@ describe("sns functions store", () => {
       certified: true,
     });
     const store = get(snsFunctionsStore);
-    expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
+    expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
+      nervousSystemFunctionMock,
+    ]);
 
     const rootCanister2 = Principal.from("aaaaa-aa");
     snsFunctionsStore.setFunctions({
@@ -37,7 +41,9 @@ describe("sns functions store", () => {
       certified: true,
     });
     const store2 = get(snsFunctionsStore);
-    expect(store2[rootCanister2.toText()]).toEqual([nervousSystemFunctionMock]);
+    expect(store2[rootCanister2.toText()]?.nsFunctions).toEqual([
+      nervousSystemFunctionMock,
+    ]);
   });
 
   it("should reset functions for more than one project", () => {
@@ -47,7 +53,9 @@ describe("sns functions store", () => {
       certified: true,
     });
     const store = get(snsFunctionsStore);
-    expect(store[mockPrincipal.toText()]).toEqual([nervousSystemFunctionMock]);
+    expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
+      nervousSystemFunctionMock,
+    ]);
 
     snsFunctionsStore.setFunctions({
       rootCanisterId: mockPrincipal,
@@ -55,6 +63,6 @@ describe("sns functions store", () => {
       certified: true,
     });
     const store2 = get(snsFunctionsStore);
-    expect(store2[mockPrincipal.toText()]).toEqual([]);
+    expect(store2[mockPrincipal.toText()]?.nsFunctions).toEqual([]);
   });
 });


### PR DESCRIPTION
# Motivation

User can see the followees of the sns neurons.

# Changes

* Extracted UI component TagsList from Followee component.
* Followee component uses new TagsList component
* New sns neuron util followeesByNeuronId.
* SnsNeuronFolloweingCard uses new util followeesByNeuronId and renders new component SnsFollowee.
* SnsFollowee is the counterpart of Followee and implements TagsList for sns neurons.
* New prop to Hash component to show or not the copy button. It was needed for Followee.
* New skeleton component SkeletonFollowees. Used while nsFunctions are loaded in sns neuron details.
* Add error management in loadSnsNeurvousSystemFunctions.

# Tests

* Test new TagsList component
* Test new sns neuron util followeesByNeuronId and followeesByFunction (which was not tested)
* Test new functionality in SnsNeuronFolloweingCard
* Test Hash componet which was not tested.
* Test error management in loadSnsNeurvousSystemFunctions.
