### PR TITLE
GIX-1112: Remove SNS Followee

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -275,6 +275,7 @@
     "unfollow": "Unfollow",
     "same_neuron": "You can't add the same neuron as followee.",
     "followee_does_not_exist": "Neuron with id $neuronId does not exist.",
+    "neuron_not_followee": "Sorry, you can't unfollow neuron $neuronId because you are not following it.",
     "already_followed": "You are already following this neuron."
   },
   "follow_neurons": {
@@ -690,6 +691,7 @@
     "ledger_too_old": "Sorry, the transaction is too old. Please try again.",
     "ledger_unsufficient_funds": "Sorry, the account doesn't have enough funds for this transaction.",
     "sns_add_followee": "There was an error while adding a followee.",
+    "sns_remove_followee": "There was an error while unfollowing the neuron.",
     "sns_load_functions": "There was an error while loading the project topics.",
     "sns_add_hotkey": "There was an error adding the hotkey."
   },

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -462,7 +462,7 @@ export const loadSnsNervousSystemFunctions = async (
   });
 
 /**
- * Makes a call to add a followee to the neuron.
+ * Makes a call to add a followee to the neuron for a specific topic
  *
  * The new set of followees needs to be calculated before the call.
  *
@@ -545,9 +545,74 @@ export const addFollowee = async ({
 
     return { success: true };
   } catch (error) {
-    console.log(error);
     toastsError({
       labelKey: "error__sns.sns_add_followee",
+      err: error,
+    });
+    return { success: false };
+  }
+};
+
+/**
+ * Makes a call to remove a followee to the neuron for a specific ns function.
+ *
+ * The new set of followees needs to be calculated before the call.
+ *
+ * Shows toasts error if:
+ * - The followee is not in the list of followees.
+ * - The call throws an error.
+ *
+ * @param {Object}
+ * @param {Principal} rootCanisterId
+ * @param {SnsNeuron} neuron
+ * @param {SnsNeuronId} followee
+ * @param {bigint} functionId
+ * @returns
+ */
+export const removeFollowee = async ({
+  neuron,
+  functionId,
+  followee,
+  rootCanisterId,
+}: {
+  neuron: SnsNeuron;
+  functionId: bigint;
+  followee: SnsNeuronId;
+  rootCanisterId: Principal;
+}): Promise<{ success: boolean }> => {
+  const identity = await getNeuronIdentity();
+  const followeeHex = subaccountToHexString(followee.id);
+
+  const topicFollowees = followeesByFunction({ neuron, functionId });
+  // Do not allow to remove a neuron id who is already followed
+  if (
+    topicFollowees?.find(
+      ({ id }) => subaccountToHexString(id) === followeeHex
+    ) === undefined
+  ) {
+    toastsError({
+      labelKey: "new_followee.neuron_not_followee",
+    });
+    return { success: false };
+  }
+  try {
+    const newFollowees: SnsNeuronId[] = topicFollowees?.filter(
+      ({ id }) => subaccountToHexString(id) !== followeeHex
+    );
+
+    await setFollowees({
+      rootCanisterId,
+      identity,
+      // We can cast it because we already checked that the neuron id is not undefined
+      neuronId: fromNullable(neuron.id) as SnsNeuronId,
+      functionId,
+      followees: newFollowees,
+    });
+
+    return { success: true };
+  } catch (error) {
+    toastsError({
+      labelKey: "error__sns.sns_remove_followee",
       err: error,
     });
     return { success: false };

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -584,7 +584,7 @@ export const removeFollowee = async ({
   const followeeHex = subaccountToHexString(followee.id);
 
   const topicFollowees = followeesByFunction({ neuron, functionId });
-  // Do not allow to remove a neuron id who is already followed
+  // Do not allow to unfollow a neuron who is not a followee
   if (
     topicFollowees?.find(
       ({ id }) => subaccountToHexString(id) === followeeHex

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -36,6 +36,7 @@ export type BusyStateInitiatorType =
   | "stake-sns-neuron"
   | "dissolve-sns-action"
   | "add-sns-followee"
+  | "remove-sns-followee"
   | "disburse-sns-neuron";
 
 export interface BusyState {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -286,6 +286,7 @@ interface I18nNew_followee {
   unfollow: string;
   same_neuron: string;
   followee_does_not_exist: string;
+  neuron_not_followee: string;
   already_followed: string;
 }
 
@@ -724,6 +725,7 @@ interface I18nError__sns {
   ledger_too_old: string;
   ledger_unsufficient_funds: string;
   sns_add_followee: string;
+  sns_remove_followee: string;
   sns_load_functions: string;
   sns_add_hotkey: string;
 }

--- a/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/FollowSnsTopicSection.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
+import { removeFollowee } from "$lib/services/sns-neurons.services";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -14,6 +15,10 @@ import {
   mockSnsNeuron,
 } from "../../../mocks/sns-neurons.mock";
 import { principal } from "../../../mocks/sns-projects.mock";
+
+jest.mock("$lib/services/sns-neurons.services", () => ({
+  removeFollowee: jest.fn().mockReturnValue({ success: true }),
+}));
 
 describe("FollowSnsTopicSection", () => {
   const reload = jest.fn();
@@ -71,5 +76,18 @@ describe("FollowSnsTopicSection", () => {
     await waitFor(() =>
       expect(queryByTestId("add-followee-button")).toBeInTheDocument()
     );
+  });
+
+  it("removes followee", async () => {
+    const { queryAllByTestId } = renderComponent();
+
+    const followeeElements = queryAllByTestId("current-followee-item");
+    expect(followeeElements.length).toBe(followees.length);
+
+    const followeeToRemove = followeeElements[0];
+    const removeButton = followeeToRemove.querySelector("button");
+    fireEvent.click(removeButton);
+
+    await waitFor(() => expect(removeFollowee).toBeCalled());
   });
 });

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -5,8 +5,10 @@
 import FollowSnsNeuronsModal from "$lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import { render } from "@testing-library/svelte";
+import { render, type RenderResult } from "@testing-library/svelte";
+import type { SvelteComponent } from "svelte";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { renderSelectedSnsNeuronContext } from "../../../mocks/context-wrapper.mock";
 import en from "../../../mocks/i18n.mock";
 import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
 import { mockSnsNeuron } from "../../../mocks/sns-neurons.mock";
@@ -16,6 +18,18 @@ describe("FollowSnsNeuronsModal", () => {
     ...mockSnsNeuron,
   };
   const rootCanisterId = mockPrincipal;
+  const reload = jest.fn();
+
+  const renderNewSnsFolloweeModal = (): RenderResult<SvelteComponent> =>
+    renderSelectedSnsNeuronContext({
+      Component: FollowSnsNeuronsModal,
+      reload,
+      neuron,
+      props: {
+        rootCanisterId,
+        neuron,
+      },
+    });
 
   afterEach(() => {
     snsFunctionsStore.reset();
@@ -32,12 +46,7 @@ describe("FollowSnsNeuronsModal", () => {
   });
 
   it("renders spinner if no functions to follow", () => {
-    const { queryByTestId } = render(FollowSnsNeuronsModal, {
-      props: {
-        neuron,
-        rootCanisterId,
-      },
-    });
+    const { queryByTestId } = renderNewSnsFolloweeModal();
     expect(queryByTestId("spinner")).toBeInTheDocument();
   });
 
@@ -59,12 +68,7 @@ describe("FollowSnsNeuronsModal", () => {
       nsFunctions: [function0, function1, function2],
       certified: true,
     });
-    const { queryByTestId } = render(FollowSnsNeuronsModal, {
-      props: {
-        neuron,
-        rootCanisterId,
-      },
-    });
+    const { queryByTestId } = renderNewSnsFolloweeModal();
 
     expect(
       queryByTestId(`follow-topic-${function0.id}-section`)


### PR DESCRIPTION
# Motivation

User can unfollow other neurons in SNS projects.

# Changes

* New sns neuron service "removeFollowee".
* FollowSnsTopicSection uses new service to unfollow a neuron and access store to reload the neuron after calling the service.

# Tests

* Fix broken test FollowSnsNeuronModal because now it needs to be wrapped with the sns neuron context.
* Add test case to FollowSnsTopicSection to unfollow a neuron.
* Test new sns neuron service removeFollowee.
