### PR TITLE
Chore: Enable Unspecific topic in sns

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -591,6 +591,7 @@
   },
   "sns_neuron_detail": {
     "header": "Neuron",
+    "all_topic": "All topics",
     "add_hotkey_info": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp.",
     "add_hotkey_tooltip": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp."
   },

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -591,7 +591,7 @@
   },
   "sns_neuron_detail": {
     "header": "Neuron",
-    "all_topic": "All topics",
+    "all_topics": "All topics",
     "add_hotkey_info": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp.",
     "add_hotkey_tooltip": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp."
   },

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
-  import { functionsToFollow } from "$lib/utils/sns-neuron.utils";
   import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
   import { Modal, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
@@ -12,9 +11,7 @@
   export let rootCanisterId: Principal;
 
   let functions: SnsNervousSystemFunction[] | undefined;
-  $: functions = functionsToFollow(
-    $snsFunctionsStore[rootCanisterId.toString()]?.nsFunctions
-  );
+  $: functions = $snsFunctionsStore[rootCanisterId.toString()]?.nsFunctions;
 </script>
 
 <Modal on:nnsClose testId="follow-sns-neurons-modal">

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -445,7 +445,8 @@ export const loadSnsNervousSystemFunctions = async (
         certified,
       }),
     onLoad: async ({ response: nsFunctions, certified }) => {
-      // TODO: Can we change the name in the backend?
+      // TODO: Ideally, the name from the backend is user-friendly.
+      // https://dfinity.atlassian.net/browse/GIX-1169
       const snsNervousSystemFunctions = nsFunctions.map((nsFunction) => {
         if (nsFunction.id === BigInt(0)) {
           const translationKeys = get(i18n);

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -451,7 +451,7 @@ export const loadSnsNervousSystemFunctions = async (
           const translationKeys = get(i18n);
           return {
             ...nsFunction,
-            name: translationKeys.sns_neuron_detail.all_topic,
+            name: translationKeys.sns_neuron_detail.all_topics,
           };
         }
         return nsFunction;

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -16,6 +16,7 @@ import {
   stakeNeuron as stakeNeuronApi,
 } from "$lib/api/sns.api";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
+import { i18n } from "$lib/stores/i18n";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import {
   snsNeuronsStore,
@@ -444,9 +445,20 @@ export const loadSnsNervousSystemFunctions = async (
         certified,
       }),
     onLoad: async ({ response: nsFunctions, certified }) => {
+      // TODO: Can we change the name in the backend?
+      const snsNervousSystemFunctions = nsFunctions.map((nsFunction) => {
+        if (nsFunction.id === BigInt(0)) {
+          const translationKeys = get(i18n);
+          return {
+            ...nsFunction,
+            name: translationKeys.sns_neuron_detail.all_topic,
+          };
+        }
+        return nsFunction;
+      });
       snsFunctionsStore.setFunctions({
         rootCanisterId,
-        nsFunctions,
+        nsFunctions: snsNervousSystemFunctions,
         certified,
       });
     },

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -617,7 +617,7 @@ interface I18nSns_project_detail {
 
 interface I18nSns_neuron_detail {
   header: string;
-  all_topic: string;
+  all_topics: string;
   add_hotkey_info: string;
   add_hotkey_tooltip: string;
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -617,6 +617,7 @@ interface I18nSns_project_detail {
 
 interface I18nSns_neuron_detail {
   header: string;
+  all_topic: string;
   add_hotkey_info: string;
   add_hotkey_tooltip: string;
 }

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -1,11 +1,8 @@
-import {
-  HOTKEY_PERMISSIONS,
-  UNSPECIFIED_FUNCTION_ID,
-} from "$lib/constants/sns-neurons.constants";
+import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { formatToken } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
-import type { SnsNervousSystemFunction, SnsNeuronId } from "@dfinity/sns";
+import type { SnsNeuronId } from "@dfinity/sns";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import type { NervousSystemFunction } from "@dfinity/sns/dist/candid/sns_governance";
 import { fromNullable } from "@dfinity/utils";
@@ -294,18 +291,6 @@ export const needsRefresh = ({
   neuron: SnsNeuron;
   balanceE8s: bigint;
 }): boolean => balanceE8s !== neuron.cached_neuron_stake_e8s;
-
-/**
- * Returns the functions that are available to follow.
- *
- * For now it filters out only the UNSPECIFIED function.
- * https://github.com/dfinity/ic/blob/5248f11c18ca564881bbb82a4eb6915efb7ca62f/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto#L582
- *
- */
-export const functionsToFollow = (
-  functions: SnsNervousSystemFunction[] | undefined
-): SnsNervousSystemFunction[] | undefined =>
-  functions?.filter(({ id }) => id !== UNSPECIFIED_FUNCTION_ID);
 
 /**
  * Returns the followees of a neuron in a specific ns function.

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -72,7 +72,7 @@ describe("FollowSnsNeuronsModal", () => {
 
     expect(
       queryByTestId(`follow-topic-${function0.id}-section`)
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       queryByTestId(`follow-topic-${function1.id}-section`)
     ).toBeInTheDocument();

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -6,7 +6,6 @@ import {
   followeesByFunction,
   followeesByNeuronId,
   formattedSnsMaturity,
-  functionsToFollow,
   getSnsDissolvingTimeInSeconds,
   getSnsLockedTimeInSeconds,
   getSnsNeuronByHexId,
@@ -841,26 +840,6 @@ describe("sns-neuron utils", () => {
           balanceE8s: BigInt(2),
         })
       ).toBeFalsy();
-    });
-  });
-
-  describe("functionsToFollow", () => {
-    it("filters out function with id 0", () => {
-      const function0: SnsNervousSystemFunction = {
-        ...nervousSystemFunctionMock,
-        id: BigInt(0),
-      };
-      const function1: SnsNervousSystemFunction = {
-        ...nervousSystemFunctionMock,
-        id: BigInt(1),
-      };
-      const function2: SnsNervousSystemFunction = {
-        ...nervousSystemFunctionMock,
-        id: BigInt(2),
-      };
-      expect(functionsToFollow([function0, function1, function2]).length).toBe(
-        2
-      );
     });
   });
 


### PR DESCRIPTION
# Motivation

Users can set followees for all topics using on nervous system function.

# Changes

* Remove the util functionsToFollow that filtered out the function with id 0.
* In the service loadSnsNervousSystemFunctions, change the name of the function with id 0 from "Unspecified" to "All Topics" to be more user friendly.

# Tests

* Remove test for functionsToFollow.
* Fix test that show topic with id 0.
