### PR TITLE
GIX-1043: Add sns stores to debug store

### DIFF
--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -8,8 +8,12 @@ import {
   anonymizeKnownNeuron,
   anonymizeNeuronInfo,
   anonymizeProposal,
+  anonymizeSnsNeuron,
   anonymizeSnsSummary,
   anonymizeSnsSwapCommitment,
+  anonymizeSnsTypeStore,
+  anonymizeTransaction,
+  anonymizeTransactionStore,
   cutAndAnonymize,
 } from "$lib/utils/anonymize.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
@@ -129,6 +133,13 @@ const anonymiseStoreState = async () => {
     selectedAccount,
     selectedProposal,
     selectedProject,
+    snsNeurons,
+    snsAccounts,
+    selectedSnsNeuron,
+    snsFunctions,
+    snsTransactions,
+    transactionsFees,
+    transactions,
   } = get(debugStore);
 
   return {
@@ -178,6 +189,33 @@ const anonymiseStoreState = async () => {
         selectedProject.swapCommitment
       ),
     },
+    snsNeurons: await anonymizeSnsTypeStore(
+      snsNeurons,
+      async ({ certified, neurons }) => ({
+        certified: certified,
+        neurons: await mapPromises(neurons, anonymizeSnsNeuron),
+      })
+    ),
+    snsAccounts: await anonymizeSnsTypeStore(
+      snsAccounts,
+      async ({ certified, accounts }) => ({
+        certified: certified,
+        accounts: await mapPromises(accounts, anonymizeAccount),
+      })
+    ),
+    selectedSnsNeuron: {
+      selected: selectedSnsNeuron.selected,
+      neuron: await anonymizeSnsNeuron(selectedSnsNeuron.neuron),
+    },
+    transactions: await mapPromises(transactions, (transaction) =>
+      anonymizeTransaction({ transaction, account: accounts?.main })
+    ),
+    snsFunctions,
+    snsTransactions: await anonymizeSnsTypeStore(
+      snsTransactions,
+      anonymizeTransactionStore
+    ),
+    transactionsFees,
   };
 };
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -17,7 +17,10 @@
     type WalletStore,
   } from "$lib/types/wallet.context";
   import { getAccountFromStore } from "$lib/utils/accounts.utils";
-  import { debugSelectedAccountStore } from "$lib/stores/debug.store";
+  import {
+    debugSelectedAccountStore,
+    debugTransactions,
+  } from "$lib/stores/debug.store";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
   import type {
     AccountIdentifierString,
@@ -55,8 +58,8 @@
     neurons: [],
   });
 
-  // TODO: Add transactions to debug store https://dfinity.atlassian.net/browse/GIX-1043
   debugSelectedAccountStore(selectedAccountStore);
+  $: debugTransactions(transactions);
 
   setContext<WalletContext>(WALLET_CONTEXT_KEY, {
     store: selectedAccountStore,

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -23,6 +23,7 @@
   import SnsNeuronInfoStake from "$lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte";
   import { Island } from "@dfinity/gix-components";
   import SnsNeuronModals from "$lib/modals/sns/neurons/SnsNeuronModals.svelte";
+  import { debugSelectedSnsNeuronStore } from "$lib/stores/debug.store";
 
   export let neuronId: string | null | undefined;
 
@@ -35,6 +36,8 @@
     store: selectedSnsNeuronStore,
     reload: () => loadNeuron({ forceFetch: true }),
   });
+
+  debugSelectedSnsNeuronStore(selectedSnsNeuronStore);
 
   // BEGIN: loading and navigation
 

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -50,7 +50,6 @@
     neurons: [],
   });
 
-  // TODO: Add transactions to debug store https://dfinity.atlassian.net/browse/GIX-1043
   debugSelectedAccountStore(selectedAccountStore);
 
   setContext<WalletContext>(WALLET_CONTEXT_KEY, {

--- a/frontend/src/lib/stores/debug.store.ts
+++ b/frontend/src/lib/stores/debug.store.ts
@@ -158,11 +158,11 @@ export const initDebugStore = () =>
       selectedProject: $selectedProjectStore,
       snsNeurons: $snsNeuronsStore,
       snsAccounts: $snsAccountsStore,
-      snsTransactionsStore: $snsTransactionsStore,
-      selectedSnsNeuronStore: $selectedSnsNeuronStore,
-      transactionsStore: $transactionsStore,
-      projectsStore: $projectsStore,
-      snsFunctionsStore: $snsFunctionsStore,
-      transactionsFeesStore: $transactionsFeesStore,
+      snsTransactions: $snsTransactionsStore,
+      selectedSnsNeuron: $selectedSnsNeuronStore,
+      transactions: $transactionsStore,
+      projects: $projectsStore,
+      snsFunctions: $snsFunctionsStore,
+      transactionsFees: $transactionsFeesStore,
     })
   );

--- a/frontend/src/lib/stores/debug.store.ts
+++ b/frontend/src/lib/stores/debug.store.ts
@@ -1,20 +1,34 @@
+import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { AddAccountStore } from "$lib/types/add-account.context";
 import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
 import type { ProjectDetailStore } from "$lib/types/project-detail.context";
 import type { SelectedProposalStore } from "$lib/types/selected-proposal.context";
+import type { SelectedSnsNeuronStore } from "$lib/types/sns-neuron-detail.context";
 import type { WalletStore } from "$lib/types/wallet.context";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
-import { derived, readable, type Readable, type Writable } from "svelte/store";
+import {
+  derived,
+  readable,
+  writable,
+  type Readable,
+  type Writable,
+} from "svelte/store";
 import { accountsStore } from "./accounts.store";
 import { canistersStore } from "./canisters.store";
 import { knownNeuronsStore } from "./knownNeurons.store";
 import { neuronsStore } from "./neurons.store";
+import { projectsStore } from "./projects.store";
 import {
   proposalPayloadsStore,
   proposalsFiltersStore,
   proposalsStore,
   votingNeuronSelectStore,
 } from "./proposals.store";
+import { snsAccountsStore } from "./sns-accounts.store";
+import { snsFunctionsStore } from "./sns-functions.store";
+import { snsNeuronsStore } from "./sns-neurons.store";
+import { snsTransactionsStore } from "./sns-transactions.store";
+import { transactionsFeesStore } from "./transaction-fees.store";
 import { voteRegistrationStore } from "./vote-registration.store";
 
 const createDerivedStore = <T>(store: Writable<T>): Readable<T> =>
@@ -56,6 +70,17 @@ let selectedProjectStore: Readable<ProjectDetailStore> = readable({
 export const debugSelectedProjectStore = (
   store: Writable<ProjectDetailStore>
 ) => (selectedProjectStore = createDerivedStore(store));
+let selectedSnsNeuronStore: Readable<SelectedSnsNeuronStore> = readable({
+  selected: undefined,
+  neuron: undefined,
+});
+export const debugSelectedSnsNeuronStore = (
+  store: Writable<SelectedSnsNeuronStore>
+) => (selectedSnsNeuronStore = createDerivedStore(store));
+const transactionsStore = writable<Transaction[] | undefined>(undefined);
+export const debugTransactions = (transactions: Transaction[] | undefined) => {
+  transactionsStore.set(transactions);
+};
 
 /**
  * Collects state of all available stores (also from context)
@@ -80,6 +105,14 @@ export const initDebugStore = () =>
       selectedProposalStore,
       voteRegistrationStore,
       selectedProjectStore,
+      snsNeuronsStore,
+      snsAccountsStore,
+      snsTransactionsStore,
+      selectedSnsNeuronStore,
+      transactionsStore,
+      projectsStore,
+      snsFunctionsStore,
+      transactionsFeesStore,
     ],
     ([
       $busyStore,
@@ -98,6 +131,14 @@ export const initDebugStore = () =>
       $selectedProposalStore,
       $voteRegistrationStore,
       $selectedProjectStore,
+      $snsNeuronsStore,
+      $snsAccountsStore,
+      $snsTransactionsStore,
+      $selectedSnsNeuronStore,
+      $transactionsStore,
+      $projectsStore,
+      $snsFunctionsStore,
+      $transactionsFeesStore,
     ]) => ({
       busy: $busyStore,
       accounts: $accountsStore,
@@ -115,5 +156,13 @@ export const initDebugStore = () =>
       selectedProposal: $selectedProposalStore,
       voteRegistrationStore: $voteRegistrationStore,
       selectedProject: $selectedProjectStore,
+      snsNeurons: $snsNeuronsStore,
+      snsAccounts: $snsAccountsStore,
+      snsTransactionsStore: $snsTransactionsStore,
+      selectedSnsNeuronStore: $selectedSnsNeuronStore,
+      transactionsStore: $transactionsStore,
+      projectsStore: $projectsStore,
+      snsFunctionsStore: $snsFunctionsStore,
+      transactionsFeesStore: $transactionsFeesStore,
     })
   );

--- a/frontend/src/lib/stores/sns-transactions.store.ts
+++ b/frontend/src/lib/stores/sns-transactions.store.ts
@@ -3,7 +3,7 @@ import type { Principal } from "@dfinity/principal";
 import type { SnsTransactionWithId } from "@dfinity/sns";
 import { writable } from "svelte/store";
 
-interface SnsTransactions {
+export interface SnsTransactions {
   // Each SNS Account is an entry in this Store.
   // We use the account string representation as the key to identify the transactions.
   [accountIdentifier: string]: {


### PR DESCRIPTION
# Motivation

To be able to debug we need information. The SNS data was not added to the debug store and therefore not accessible throght the debug prompt.

# Changes

* Add sns related stores to debug store.

# Tests

Not applicable
