### PR TITLE
Chore: Disable Followee button SNS

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -55,9 +55,3 @@
     <Tag tagName="li">{topicTitle(topic)}</Tag>
   {/each}
 </TagsList>
-
-<style lang="scss">
-  button {
-    font-size: var(--font-size-h5);
-  }
-</style>

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -40,12 +40,24 @@
     });
 </script>
 
-<TagsList {id} on:nnsTitleClick={openVotingHistory}>
-  <svelte:fragment slot="title">
+<TagsList {id}>
+  <button
+    slot="title"
+    name="title"
+    {id}
+    class="text"
+    on:click={openVotingHistory}
+  >
     {name}
-  </svelte:fragment>
+  </button>
 
   {#each followee.topics as topic}
     <Tag tagName="li">{topicTitle(topic)}</Tag>
   {/each}
 </TagsList>
+
+<style lang="scss">
+  button {
+    font-size: var(--font-size-h5);
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -9,12 +9,13 @@
 
 <!-- TODO: Open Voting history modal https://dfinity.atlassian.net/browse/GIX-1156 -->
 <TagsList id={followee.neuronIdHex}>
-  <Hash
-    slot="title"
-    text={followee.neuronIdHex}
-    id={followee.neuronIdHex}
-    tagName="span"
-  />
+  <h5 slot="title">
+    <Hash
+      text={followee.neuronIdHex}
+      id={followee.neuronIdHex}
+      tagName="span"
+    />
+  </h5>
 
   {#each followee.nsFunctions as nsFunction (nsFunction.id)}
     <Tag tagName="li">{nsFunction.name}</Tag>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -9,13 +9,12 @@
 
 <!-- TODO: Open Voting history modal https://dfinity.atlassian.net/browse/GIX-1156 -->
 <TagsList id={followee.neuronIdHex}>
-  <h5 slot="title">
-    <Hash
-      text={followee.neuronIdHex}
-      id={followee.neuronIdHex}
-      tagName="span"
-    />
-  </h5>
+  <Hash
+    text={followee.neuronIdHex}
+    id={followee.neuronIdHex}
+    tagName="h5"
+    slot="title"
+  />
 
   {#each followee.nsFunctions as nsFunction (nsFunction.id)}
     <Tag tagName="li">{nsFunction.name}</Tag>

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -3,7 +3,7 @@
   import { Copy } from "@dfinity/gix-components";
   import Tooltip from "./Tooltip.svelte";
 
-  export let tagName: "h3" | "p" | "span" = "h3";
+  export let tagName: "h3" | "p" | "span" | "h5" = "h3";
   export let testId: string | undefined = undefined;
   export let id: string;
   export let text: string;

--- a/frontend/src/lib/components/ui/TagsList.svelte
+++ b/frontend/src/lib/components/ui/TagsList.svelte
@@ -2,19 +2,13 @@
   export let id: string;
 </script>
 
-<div data-tid="tag-list-title">
-  <slot name="title" />
-</div>
+<slot name="title" />
 
 <ul aria-labelledby={id}>
   <slot />
 </ul>
 
 <style lang="scss">
-  div {
-    margin: 0 0 calc(0.5 * var(--padding));
-  }
-
   ul {
     display: flex;
     gap: calc(0.5 * var(--padding));
@@ -22,7 +16,7 @@
 
     list-style: none;
 
-    margin-bottom: var(--padding);
+    margin: var(--padding-0_5x) 0 var(--padding) 0;
     padding: 0 0 calc(2 * var(--padding));
     border-bottom: 1px solid currentColor;
   }

--- a/frontend/src/lib/components/ui/TagsList.svelte
+++ b/frontend/src/lib/components/ui/TagsList.svelte
@@ -1,26 +1,18 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-
   export let id: string;
-
-  const dispatcher = createEventDispatcher();
-  const onClick = () => {
-    dispatcher("nnsTitleClick");
-  };
 </script>
 
-<button {id} class="text" on:click={onClick} data-tid="tag-list-title">
+<div data-tid="tag-list-title">
   <slot name="title" />
-</button>
+</div>
 
 <ul aria-labelledby={id}>
   <slot />
 </ul>
 
 <style lang="scss">
-  button {
+  div {
     margin: 0 0 calc(0.5 * var(--padding));
-    font-size: var(--font-size-h5);
   }
 
   ul {

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -192,14 +192,14 @@ const anonymiseStoreState = async () => {
     snsNeurons: await anonymizeSnsTypeStore(
       snsNeurons,
       async ({ certified, neurons }) => ({
-        certified: certified,
+        certified,
         neurons: await mapPromises(neurons, anonymizeSnsNeuron),
       })
     ),
     snsAccounts: await anonymizeSnsTypeStore(
       snsAccounts,
       async ({ certified, accounts }) => ({
-        certified: certified,
+        certified,
         accounts: await mapPromises(accounts, anonymizeAccount),
       })
     ),

--- a/frontend/src/tests/lib/components/ui/TagsList.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TagsList.spec.ts
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import TagsListTest from "./TagsListTest.svelte";
 
 describe("CardBlock", () => {
-  it("should render a button and a ul", () => {
+  it("should render a div and a ul", () => {
     const { container } = render(TagsListTest);
-    expect(container.querySelector("button")).toBeInTheDocument();
+    expect(container.querySelector("div")).toBeInTheDocument();
     expect(container.querySelector("ul")).toBeInTheDocument();
   });
 
@@ -16,12 +16,5 @@ describe("CardBlock", () => {
     const { queryAllByTestId, queryByTestId } = render(TagsListTest);
     expect(queryByTestId("title")).toBeInTheDocument();
     expect(queryAllByTestId("item").length).toBe(2);
-  });
-
-  it("should trigger event on button click", (done) => {
-    const { component, queryByTestId } = render(TagsListTest);
-    component.$on("nnsTitleClick", () => done());
-    const button = queryByTestId("tag-list-title");
-    fireEvent.click(button);
   });
 });

--- a/frontend/src/tests/lib/components/ui/TagsList.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TagsList.spec.ts
@@ -6,9 +6,8 @@ import { render } from "@testing-library/svelte";
 import TagsListTest from "./TagsListTest.svelte";
 
 describe("CardBlock", () => {
-  it("should render a div and a ul", () => {
+  it("should render a ul", () => {
     const { container } = render(TagsListTest);
-    expect(container.querySelector("div")).toBeInTheDocument();
     expect(container.querySelector("ul")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
# Motivation

User has not yet access to the voting history of followees in SNS. Therefore, we should not render it as a button.

# Changes

* TagsList doesn't render a button. Just the slot for the title.
* Followee component passes a button as title to TagsList.
* SnsFollowee component passes an h5 as title to TagsList.

# Tests

* Fix tests after refactor.
