### PR TITLE
Chore: Update Internet Identity Init type

### DIFF
--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -27,7 +27,6 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::ops::DerefMut;
-use std::str::FromStr;
 
 type Json = String;
 

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -73,7 +73,7 @@ struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(UserNumber, UserNumber)>,
     pub archive_module_hash: Option<[u8; 32]>,
     pub canister_creation_cycles_cost: Option<u64>,
-    pub memory_migration_batch_size: Option<u64>,
+    pub memory_migration_batch_size: Option<u32>,
 }
 
 fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -66,6 +66,7 @@ fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_
     cache.insert(proposal_id, payload_json);
 }
 
+// Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
 // Types used to decode arg's payload of nns_function type 4 for II upgrades
 pub type UserNumber = u64;
 #[derive(CandidType, Serialize, Deserialize)]
@@ -81,7 +82,7 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
         return "[]".to_owned();
     }
     // If canister id is II
-    // use InternetIdentityInit type https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/internet_identity.did#L141
+    // use InternetIdentityInit type
     let idl_type = if canister_id == Some(IDENTITY_CANISTER_ID) {
         let idl_type = internal_candid_type_to_idl_type(&InternetIdentityInit::ty());
         IDLType::OptT(Box::new(idl_type))

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -83,8 +83,7 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
     }
     // If canister id is II
     // use InternetIdentityInit type https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/internet_identity.did#L141
-    let ii_small11 = CanisterId::from_str("qhbym-qaaaa-aaaaa-aaafq-cai").unwrap();
-    let idl_type = if canister_id == Some(IDENTITY_CANISTER_ID) || canister_id == Some(ii_small11) {
+    let idl_type = if canister_id == Some(IDENTITY_CANISTER_ID) {
         let idl_type = internal_candid_type_to_idl_type(&InternetIdentityInit::ty());
         IDLType::OptT(Box::new(idl_type))
     } else {

--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -27,6 +27,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::ops::DerefMut;
+use std::str::FromStr;
 
 type Json = String;
 
@@ -73,6 +74,7 @@ struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(UserNumber, UserNumber)>,
     pub archive_module_hash: Option<[u8; 32]>,
     pub canister_creation_cycles_cost: Option<u64>,
+    pub memory_migration_batch_size: Option<u64>,
 }
 
 fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
@@ -81,7 +83,8 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
     }
     // If canister id is II
     // use InternetIdentityInit type https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/internet_identity.did#L141
-    let idl_type = if canister_id == Some(IDENTITY_CANISTER_ID) {
+    let ii_small11 = CanisterId::from_str("qhbym-qaaaa-aaaaa-aaafq-cai").unwrap();
+    let idl_type = if canister_id == Some(IDENTITY_CANISTER_ID) || canister_id == Some(ii_small11) {
         let idl_type = internal_candid_type_to_idl_type(&InternetIdentityInit::ty());
         IDLType::OptT(Box::new(idl_type))
     } else {


### PR DESCRIPTION
# Motivation

User can see the latest "memory_migration_batch_size" argument name used when upgrading the II canister.

# Changes

* Add "memory_migration_batch_size" to InternetIdentityInit hardcoded type.

# Tests

Not applicable, only UI changes.
