### PR TITLE
fix: page store path for SvelteKit breaking changes

### DIFF
--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@sveltejs/kit";
 import { writable } from "svelte/store";
-import { OWN_CANISTER_ID_TEXT } from "../../src/lib/constants/canister-ids.constants";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 
 const initPageStoreMock = () => {
   const { subscribe, set } = writable<Partial<Page>>({

--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -1,4 +1,5 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { ROUTE_ID_GROUP_APP } from "$lib/constants/routes.constants";
 import type { Page } from "@sveltejs/kit";
 import { writable } from "svelte/store";
 
@@ -26,7 +27,7 @@ const initPageStoreMock = () => {
     }) =>
       set({
         data,
-        route: { id: `/(app)${routeId}` },
+        route: { id: `${ROUTE_ID_GROUP_APP}${routeId}` },
       }),
   };
 };

--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -26,7 +26,7 @@ const initPageStoreMock = () => {
     }) =>
       set({
         data,
-        route: { id: `(app)${routeId}` },
+        route: { id: `/(app)${routeId}` },
       }),
   };
 };

--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -1,6 +1,6 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { Page } from "@sveltejs/kit";
 import { writable } from "svelte/store";
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 
 const initPageStoreMock = () => {
   const { subscribe, set } = writable<Partial<Page>>({

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -12,8 +12,8 @@ export enum AppPath {
   Project = "/project",
 }
 
-// SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId
-export const ROUTE_ID_GROUP_APP = "(app)";
+// SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.
+export const ROUTE_ID_GROUP_APP = "/(app)";
 
 export const UNIVERSE_PARAM = "u";
 


### PR DESCRIPTION
# Motivation

Last version of SvelteKit (bumped in #1612) contains another breaking changes. The route id of the `$app/stores.page` store now also prefix route group with `/`.

Used to be: `(app)/neuron`
Is now:  `/(app)/neuron`

This breaks our route matcher `pathForRouteId`
# Changes

- the related constant for the group `(app)` should be adapted to `/(app)`

# Tests

We cannot detect this with unit test because we have to mock the SvelteKit store. We could have detect it with e2e tests. I detected it on the "Sns neuron detail" page because the Skeleton did not disappeared.
