### PR TITLE
Chore: Enable followees and dissolve delay in SNS neurons

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -20,7 +20,7 @@
   import DissolveSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte";
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
-  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
+  import { ENABLE_SNS } from "$lib/constants/environment.constants";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -61,8 +61,7 @@
   </KeyValuePair>
 
   <div class="buttons">
-    {#if allowedToDissolve && ENABLE_SNS_2}
-      <!-- TODO: Enable when voting power calculation is accurate -->
+    {#if allowedToDissolve && ENABLE_SNS}
       <IncreaseSnsDissolveDelayButton />
     {/if}
     {#if neuronState === NeuronState.Dissolved && allowedToDisburse}

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -18,7 +18,6 @@
   import SnsNeuronMaturityCard from "$lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
   import { AppPath } from "$lib/constants/routes.constants";
-  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
   import SnsNeuronFollowingCard from "$lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte";
   import SnsNeuronInfoStake from "$lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte";
   import { Island } from "@dfinity/gix-components";
@@ -112,9 +111,7 @@
         <SnsNeuronMetaInfoCard />
         <SnsNeuronInfoStake />
         <SnsNeuronMaturityCard />
-        {#if ENABLE_SNS_2}
-          <SnsNeuronFollowingCard />
-        {/if}
+        <SnsNeuronFollowingCard />
         <SnsNeuronHotkeysCard />
       {/if}
     </section>

--- a/frontend/src/lib/utils/page.utils.ts
+++ b/frontend/src/lib/utils/page.utils.ts
@@ -2,6 +2,16 @@ import { AppPath, ROUTE_ID_GROUP_APP } from "$lib/constants/routes.constants";
 import { isNullish } from "$lib/utils/utils";
 import type { Navigation } from "@sveltejs/kit";
 
+/**
+ * Returns an AppPath for a given path.
+ *
+ * Ex: /(app)/accounts/ returns AppPath.Accounts
+ * Ex: /(app)/proposal/ returns AppPath.Proposal
+ * Ex: (app)/accounts/ returns AppPath.Accounts
+ *
+ * @param routeId
+ * @returns {AppPath}
+ */
 export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
   if (isNullish(routeId)) {
     return AppPath.Authentication;
@@ -10,6 +20,10 @@ export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
   const index = Object.values(AppPath).indexOf(
     routeId
       .replace(ROUTE_ID_GROUP_APP, "")
+      // Substitute two or more slashes together with one.
+      // Sometimes the routeId is like this: /(app)/accounts others like this: (app)/accounts
+      .replace(/\/{2,}/, "/")
+      // Remove trailing slash if present
       .replace(/\/$/, "") as unknown as AppPath
   );
   const key = Object.keys(AppPath)[index];

--- a/frontend/src/lib/utils/page.utils.ts
+++ b/frontend/src/lib/utils/page.utils.ts
@@ -7,7 +7,6 @@ import type { Navigation } from "@sveltejs/kit";
  *
  * Ex: /(app)/accounts/ returns AppPath.Accounts
  * Ex: /(app)/proposal/ returns AppPath.Proposal
- * Ex: (app)/accounts/ returns AppPath.Accounts
  *
  * @param routeId
  * @returns {AppPath}
@@ -20,9 +19,6 @@ export const pathForRouteId = (routeId: string | null | undefined): AppPath => {
   const index = Object.values(AppPath).indexOf(
     routeId
       .replace(ROUTE_ID_GROUP_APP, "")
-      // Substitute two or more slashes together with one.
-      // Sometimes the routeId is like this: /(app)/accounts others like this: (app)/accounts
-      .replace(/\/{2,}/, "/")
       // Remove trailing slash if present
       .replace(/\/$/, "") as unknown as AppPath
   );

--- a/frontend/src/tests/lib/utils/page.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/page.utils.spec.ts
@@ -18,5 +18,9 @@ describe("page.utils", () => {
     expect(pathForRouteId(`${ROUTE_ID_GROUP_APP}${AppPath.Accounts}`)).toEqual(
       AppPath.Accounts
     );
+    // Check also with initial slash
+    expect(pathForRouteId(`/${ROUTE_ID_GROUP_APP}${AppPath.Accounts}`)).toEqual(
+      AppPath.Accounts
+    );
   });
 });

--- a/frontend/src/tests/lib/utils/page.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/page.utils.spec.ts
@@ -18,9 +18,5 @@ describe("page.utils", () => {
     expect(pathForRouteId(`${ROUTE_ID_GROUP_APP}${AppPath.Accounts}`)).toEqual(
       AppPath.Accounts
     );
-    // Check also with initial slash
-    expect(pathForRouteId(`/${ROUTE_ID_GROUP_APP}${AppPath.Accounts}`)).toEqual(
-      AppPath.Accounts
-    );
   });
 });


### PR DESCRIPTION
# Motivation

Enable followee management and increasing dissolve delay.

# Changes

* Add comment in `pathForRouteId`
* Remove ENABLE_SNS_2 from SnsNeuronFollowingCard and IncreaseSnsDissolveDelayButton
