### PR TITLE
GIX-1136: Do not use universe in proposals and canisters

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -8,7 +8,6 @@
   import { onDestroy } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
-  import { pageStore } from "$lib/derived/page.derived";
   import { buildProposalUrl } from "$lib/utils/navigation.utils";
 
   export let proposalInfo: ProposalInfo | undefined;
@@ -21,7 +20,6 @@
 
     await goto(
       buildProposalUrl({
-        universe: $pageStore.universe,
         proposalId: nextProposal.id,
       })
     );
@@ -35,7 +33,6 @@
 
     await goto(
       buildProposalUrl({
-        universe: $pageStore.universe,
         proposalId: previousProposal.id,
       })
     );

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -11,7 +11,6 @@
   import ProposalCountdown from "./ProposalCountdown.svelte";
   import { keyOfOptional } from "$lib/utils/utils";
   import { goto } from "$app/navigation";
-  import { pageStore } from "$lib/derived/page.derived";
   import { buildProposalUrl } from "$lib/utils/navigation.utils";
   import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
 
@@ -33,7 +32,6 @@
   const showProposal = async () =>
     await goto(
       buildProposalUrl({
-        universe: $pageStore.universe,
         proposalId: `${id}`,
       })
     );

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -19,10 +19,10 @@ export const neuronsPathStore = derived<Readable<Page>, string>(
 
 export const proposalsPathStore = derived<Readable<Page>, string>(
   pageStore,
-  ({ universe }) => buildProposalsUrl({ universe })
+  () => buildProposalsUrl()
 );
 
 export const canistersPathStore = derived<Readable<Page>, string>(
   pageStore,
-  ({ universe }) => buildCanistersUrl({ universe })
+  () => buildCanistersUrl()
 );

--- a/frontend/src/lib/pages/Auth.svelte
+++ b/frontend/src/lib/pages/Auth.svelte
@@ -32,7 +32,6 @@
         const { length, [length - 1]: last } = hash.split("/");
         await goto(
           buildProposalUrl({
-            universe: OWN_CANISTER_ID_TEXT,
             proposalId: last,
           }),
           { replaceState: true }

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -16,7 +16,6 @@
   } from "$lib/utils/navigation.utils";
   import LinkCanisterModal from "$lib/modals/canisters/LinkCanisterModal.svelte";
   import { goto } from "$app/navigation";
-  import { pageStore } from "$lib/derived/page.derived";
   import Summary from "$lib/components/summary/Summary.svelte";
   import PrincipalText from "$lib/components/summary/PrincipalText.svelte";
 
@@ -52,7 +51,6 @@
   const goToCanisterDetails = (canisterId: CanisterId) => async () =>
     await goto(
       buildCanisterUrl({
-        universe: $pageStore.universe,
         canister: canisterId.toText(),
       })
     );

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -35,21 +35,32 @@ const buildUrl = ({
   params = {},
 }: {
   path: AppPath;
-  universe: string;
+  universe?: string;
   params?: Record<string, string>;
-}): string =>
-  `${path}/?${UNIVERSE_PARAM}=${universe}${Object.entries(params)
-    .map(([key, value]) => `&${key}=${value}`)
-    .join("")}`;
+}): string => {
+  const queryParams = new URLSearchParams();
+
+  if (universe !== undefined) {
+    queryParams.set(UNIVERSE_PARAM, universe);
+  }
+
+  Object.entries(params).forEach(([key, value]) => {
+    queryParams.set(key, value);
+  });
+
+  const hasQueryParams = queryParams.toString().length > 0;
+
+  return `${path}/${hasQueryParams ? "?" : ""}${queryParams.toString()}`;
+};
 
 export const buildAccountsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Accounts, universe });
 export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
-export const buildProposalsUrl = ({ universe }: { universe: string }) =>
-  buildUrl({ path: AppPath.Proposals, universe });
-export const buildCanistersUrl = ({ universe }: { universe: string }) =>
-  buildUrl({ path: AppPath.Canisters, universe });
+export const buildProposalsUrl = () =>
+  buildUrl({ path: AppPath.Proposals, universe: undefined });
+export const buildCanistersUrl = () =>
+  buildUrl({ path: AppPath.Canisters, universe: undefined });
 
 export const buildWalletUrl = ({
   universe,
@@ -78,27 +89,19 @@ export const buildNeuronUrl = ({
   });
 
 export const buildProposalUrl = ({
-  universe,
   proposalId,
 }: {
-  universe: string;
   proposalId: ProposalId | string;
 }): string =>
   buildUrl({
     path: AppPath.Proposal,
-    universe,
+    universe: undefined,
     params: { [PROPOSAL_PARAM]: `${proposalId}` },
   });
 
-export const buildCanisterUrl = ({
-  universe,
-  canister,
-}: {
-  universe: string;
-  canister: string;
-}): string =>
+export const buildCanisterUrl = ({ canister }: { canister: string }): string =>
   buildUrl({
     path: AppPath.Canister,
-    universe,
+    universe: undefined,
     params: { [CANISTER_PARAM]: canister },
   });

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -55,42 +55,34 @@ describe("paths derived stores", () => {
   });
 
   describe("proposalsPathStore", () => {
-    it("should return NNS proposals path as default", () => {
+    it("should not return universe when NNS", () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
 
       const $store = get(proposalsPathStore);
-      expect($store).toBe(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
+      expect($store).toBe(`${AppPath.Proposals}/`);
     });
 
-    it("should return SNS proposals path", () => {
+    it("should not return universe when SNS", () => {
       page.mock({ data: { universe: mockSnsCanisterIdText } });
 
       const $store = get(proposalsPathStore);
-      expect($store).toBe(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}`
-      );
+      expect($store).toBe(`${AppPath.Proposals}/`);
     });
   });
 
   describe("canistersPathStore", () => {
-    it("should return NNS canisters path as default", () => {
+    it("should not return universe when NNS", () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
 
       const $store = get(canistersPathStore);
-      expect($store).toBe(
-        `${AppPath.Canisters}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
+      expect($store).toBe(`${AppPath.Canisters}/`);
     });
 
-    it("should return SNS canisters path", () => {
+    it("should not return universe when SNS", () => {
       page.mock({ data: { universe: mockSnsCanisterIdText } });
 
       const $store = get(canistersPathStore);
-      expect($store).toBe(
-        `${AppPath.Canisters}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}`
-      );
+      expect($store).toBe(`${AppPath.Canisters}/`);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -110,23 +110,17 @@ describe("navigation-utils", () => {
     it("should build proposal url", () => {
       expect(
         buildProposalUrl({
-          universe: OWN_CANISTER_ID_TEXT,
           proposalId: "123",
         })
-      ).toEqual(
-        `${AppPath.Proposal}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${PROPOSAL_PARAM}=123`
-      );
+      ).toEqual(`${AppPath.Proposal}/?${PROPOSAL_PARAM}=123`);
     });
 
     it("should build canister url", () => {
       expect(
         buildCanisterUrl({
-          universe: OWN_CANISTER_ID_TEXT,
           canister: "123",
         })
-      ).toEqual(
-        `${AppPath.Canister}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${CANISTER_PARAM}=123`
-      );
+      ).toEqual(`${AppPath.Canister}/?${CANISTER_PARAM}=123`);
     });
 
     it("should build accounts url", () => {
@@ -150,23 +144,11 @@ describe("navigation-utils", () => {
     });
 
     it("should build voting url", () => {
-      expect(
-        buildProposalsUrl({
-          universe: OWN_CANISTER_ID_TEXT,
-        })
-      ).toEqual(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
+      expect(buildProposalsUrl()).toEqual(`${AppPath.Proposals}/`);
     });
 
     it("should build canisters url", () => {
-      expect(
-        buildCanistersUrl({
-          universe: OWN_CANISTER_ID_TEXT,
-        })
-      ).toEqual(
-        `${AppPath.Canisters}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
+      expect(buildCanistersUrl()).toEqual(`${AppPath.Canisters}/`);
     });
   });
 });


### PR DESCRIPTION
# Motivation

User is not confused by the universe query param in the url in proposals and canisters pages.

# Changes

* Remove universe param from "buildProposalUrl", "buildProposalsUrl",  "buildCanistersUrl" and "buildCanisterUrl".
* Remove universe param when using any of the utils above.
* "universe" param in "buildUrl" is now optional.
* Change implementation of "buildUrl" to use URLSearchParams.

# Tests

* Fix tests after refactor
