### PR TITLE
build: bump ic-js to next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1653,11 +1653,11 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-29.1.tgz",
-      "integrity": "sha512-tqu6Z6fpDOInOn1tMukYATcMI9acp3Kc37Cn6IOHLGoUDMQmHhPQxtPAtjzH+NLOToR0CKhI/nzyz1TCJaxzQg==",
+      "version": "0.0.4-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2022-12-06.tgz",
+      "integrity": "sha512-zN0qOLFO3FPRarl7A62IJgKgd3R7FnbLBQixjiGfC5Djs9PnN12LKqIY5prmTrkGVQ27FPu2IBJa0mg06vmfHA==",
       "peerDependencies": {
-        "@dfinity/utils": "^0.0.6-next"
+        "@dfinity/utils": "^0.0.7-next"
       }
     },
     "node_modules/@dfinity/gix-components": {
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-29.1.tgz",
-      "integrity": "sha512-+XgAWT9iWqlVqshv2477n00uqfp+EaKRYg5Eh8AeEgU3T/UAirMo2f9y/e7IESru+sAQDXf3i81m3z+zVy+blg==",
+      "version": "0.11.0-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2022-12-06.tgz",
+      "integrity": "sha512-ihDYvjLzEceAl5bRkEkj0QMNDB9ZCzIVSslB/oXurHz0+T2zZvShSH8/CMhqy8Om3cuHuT2jOxWr8cvCG4d6wg==",
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -1701,7 +1701,7 @@
         "randombytes": "^2.1.0"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^0.0.6-next"
+        "@dfinity/utils": "^0.0.7-next"
       }
     },
     "node_modules/@dfinity/principal": {
@@ -1713,20 +1713,20 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-29.1.tgz",
-      "integrity": "sha512-2+oRgkUffX4ERbMDRMZrWjItzT9DuevI5fl0zjwrofCrrPPsHL54TTlxgQdStUYi+pujkigauZRS1n67Xgf/LA==",
+      "version": "0.0.8-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2022-12-06.tgz",
+      "integrity": "sha512-k1ntnsZKd2+hpT1qPNFFNhWXG1DLOzvjkB98t9QYjmvTcD9TUaZKhoC3UXGxt1AA6mjTPsjp/W+oLQRb9RcC+A==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^0.0.6-next"
+        "@dfinity/utils": "^0.0.7-next"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-29.1.tgz",
-      "integrity": "sha512-LyuVjJR51ysMZ7eV2VvAm3RcrsKkjRbCj34Rs7fmSl2Fq4bKMQHoDtBoGH/YGuQe/UVecz8mCDDPXRqpgojpLg=="
+      "version": "0.0.7-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2022-12-06.tgz",
+      "integrity": "sha512-t29lov/lh8HLE6nTcXptDb70f0bCY38Uq/MEvlQeJ6nE02wX9NXwzSAKiJRZZABh5CTk+EaqWQBENEzSAjB2MA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.10",
@@ -11091,9 +11091,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.3-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.3-next-2022-11-29.1.tgz",
-      "integrity": "sha512-tqu6Z6fpDOInOn1tMukYATcMI9acp3Kc37Cn6IOHLGoUDMQmHhPQxtPAtjzH+NLOToR0CKhI/nzyz1TCJaxzQg==",
+      "version": "0.0.4-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2022-12-06.tgz",
+      "integrity": "sha512-zN0qOLFO3FPRarl7A62IJgKgd3R7FnbLBQixjiGfC5Djs9PnN12LKqIY5prmTrkGVQ27FPu2IBJa0mg06vmfHA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -11119,9 +11119,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.10.0-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.10.0-next-2022-11-29.1.tgz",
-      "integrity": "sha512-+XgAWT9iWqlVqshv2477n00uqfp+EaKRYg5Eh8AeEgU3T/UAirMo2f9y/e7IESru+sAQDXf3i81m3z+zVy+blg==",
+      "version": "0.11.0-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2022-12-06.tgz",
+      "integrity": "sha512-ihDYvjLzEceAl5bRkEkj0QMNDB9ZCzIVSslB/oXurHz0+T2zZvShSH8/CMhqy8Om3cuHuT2jOxWr8cvCG4d6wg==",
       "requires": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -11139,17 +11139,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.7-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.7-next-2022-11-29.1.tgz",
-      "integrity": "sha512-2+oRgkUffX4ERbMDRMZrWjItzT9DuevI5fl0zjwrofCrrPPsHL54TTlxgQdStUYi+pujkigauZRS1n67Xgf/LA==",
+      "version": "0.0.8-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2022-12-06.tgz",
+      "integrity": "sha512-k1ntnsZKd2+hpT1qPNFFNhWXG1DLOzvjkB98t9QYjmvTcD9TUaZKhoC3UXGxt1AA6mjTPsjp/W+oLQRb9RcC+A==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.6-next-2022-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.6-next-2022-11-29.1.tgz",
-      "integrity": "sha512-LyuVjJR51ysMZ7eV2VvAm3RcrsKkjRbCj34Rs7fmSl2Fq4bKMQHoDtBoGH/YGuQe/UVecz8mCDDPXRqpgojpLg=="
+      "version": "0.0.7-next-2022-12-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2022-12-06.tgz",
+      "integrity": "sha512-t29lov/lh8HLE6nTcXptDb70f0bCY38Uq/MEvlQeJ6nE02wX9NXwzSAKiJRZZABh5CTk+EaqWQBENEzSAjB2MA=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.10",


### PR DESCRIPTION
# Motivation

ic-js `v0.10.0` has been released so we can jump to `next` versions.

# Changes

- bump nns, sns, cmc and utils to next / nightly versions

