### PR TITLE
feat: rename proposal navigation previous/next to newer/older

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -87,7 +87,7 @@
     <button
       class="ghost"
       type="button"
-      aria-label={$i18n.proposal_detail.previous}
+      aria-label={$i18n.proposal_detail.newer}
       on:click={previous}
       class:hidden={proposalInfo !== undefined &&
         previousProposal === undefined}
@@ -95,19 +95,19 @@
       data-tid="proposal-nav-previous"
     >
       <IconWest />
-      {$i18n.core.previous}</button
+      {$i18n.proposal_detail.newer_short}</button
     >
 
     <button
       class="ghost"
       type="button"
-      aria-label={$i18n.proposal_detail.next}
+      aria-label={$i18n.proposal_detail.older}
       on:click={next}
       class:hidden={proposalInfo !== undefined && nextProposal === undefined}
       disabled={proposalInfo !== undefined && nextProposal === undefined}
       data-tid="proposal-nav-next"
     >
-      {$i18n.core.next}
+      {$i18n.proposal_detail.older_short}
       <IconEast />
     </button>
   </div>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -430,8 +430,10 @@
     "no_more_info": "No particular information.",
     "voting_results": "Voting Results",
     "remaining": "remaining",
-    "next": "Navigate to next proposal",
-    "previous": "Navigate to previous proposal",
+    "older": "Navigate to older proposal",
+    "newer": "Navigate to newer proposal",
+    "older_short": "Older",
+    "newer_short": "Newer",
     "sign_in": "Sign in to vote"
   },
   "proposal_detail__vote": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -449,8 +449,10 @@ interface I18nProposal_detail {
   no_more_info: string;
   voting_results: string;
   remaining: string;
-  next: string;
-  previous: string;
+  older: string;
+  newer: string;
+  older_short: string;
+  newer_short: string;
   sign_in: string;
 }
 


### PR DESCRIPTION
# Motivation

Rename acitons previous/next to newer/older on proposal detail page when the navigation is activated.

Discussed with Mischa.

# Screenshots

Specification:

![image](https://user-images.githubusercontent.com/16886711/205930252-0d0a03bc-8698-4ad7-a9d5-01366b501e75.png)

Realization:

<img width="1536" alt="Capture d’écran 2022-12-06 à 14 42 36" src="https://user-images.githubusercontent.com/16886711/205930301-75230085-70bd-4b0b-8a9b-e2a3547cd83f.png">



