### PR TITLE
feat: update tcycles fee in static label

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -342,7 +342,7 @@
     "enter_amount": "Enter Amount",
     "review_create_canister": "Review Canister Creation",
     "t_cycles": "T Cycles",
-    "minimum_cycles_text_1": "Minimum amount: 2T Cycles (inclusive of 1T Cycles fee if creating a new canister)",
+    "minimum_cycles_text_1": "Minimum amount: 2T Cycles (inclusive of 0.1T Cycles fee if creating a new canister)",
     "minimum_cycles_text_2": "Transaction fee of $amount is charged to the source account.",
     "transaction_fee": "The Transaction fee of $amount is charged to the source account.",
     "review_cycles_purchase": "Review Cycles Purchase",


### PR DESCRIPTION
# Motivation

The T cycles fee to create a canister is 0.1 not 1 as displayed in a static hint we are displaying on the interactive modal to create canister.

Source: https://internetcomputer.org/docs/current/developer-docs/deploy/computation-and-storage-costs/

Resolves #1635

# Changes

- update i18n label with cycles
