### PR TITLE
feat: if proposal reward status has settled hide vote pane from detail page

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalVotingSection.svelte
@@ -2,11 +2,21 @@
   import type { ProposalInfo } from "@dfinity/nns";
   import VotesResults from "./VotesResults.svelte";
   import VotingCard from "./VotingCard/VotingCard.svelte";
+  import { ProposalRewardStatus } from "@dfinity/nns";
 
   export let proposalInfo: ProposalInfo;
+
+  let rewardStatus: ProposalRewardStatus;
+  $: ({ rewardStatus } = proposalInfo);
+
+  let settled: boolean;
+  $: settled = rewardStatus === ProposalRewardStatus.Settled;
 </script>
 
 <div class="content-cell-island">
   <VotesResults {proposalInfo} />
-  <VotingCard {proposalInfo} />
+
+  {#if !settled}
+    <VotingCard {proposalInfo} />
+  {/if}
 </div>

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -101,9 +101,7 @@ describe("ProposalVotingSection", () => {
         queryByText(en.proposal_detail.voting_results)
       ).toBeInTheDocument();
       expect(() => getByTestId("voting-confirmation-toolbar")).toThrow();
-      expect(
-        queryByText(en.proposal_detail__ineligible.headline)
-      ).toBeNull();
+      expect(queryByText(en.proposal_detail__ineligible.headline)).toBeNull();
     });
   });
 

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -5,7 +5,12 @@
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import { ProposalStatus, type Ballot, type NeuronInfo } from "@dfinity/nns";
+import {
+  ProposalRewardStatus,
+  ProposalStatus,
+  type Ballot,
+  type NeuronInfo,
+} from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import {
   authStoreMock,
@@ -49,13 +54,11 @@ describe("ProposalVotingSection", () => {
     jest.resetAllMocks();
   });
 
-  const props = {
-    proposalInfo: {
-      ...mockProposalInfo,
-      ballots: neuronIds.map((neuronId) => ({ neuronId } as Ballot)),
-      proposalTimestampSeconds: BigInt(2000),
-      status: ProposalStatus.Open,
-    },
+  const proposalInfo = {
+    ...mockProposalInfo,
+    ballots: neuronIds.map((neuronId) => ({ neuronId } as Ballot)),
+    proposalTimestampSeconds: BigInt(2000),
+    status: ProposalStatus.Open,
   };
 
   describe("signed in", () => {
@@ -67,7 +70,12 @@ describe("ProposalVotingSection", () => {
 
     it("should render vote blocks", () => {
       const { queryByText, getByTestId } = render(ProposalVotingSectionTest, {
-        props,
+        props: {
+          proposalInfo: {
+            ...proposalInfo,
+            rewardStatus: ProposalRewardStatus.AcceptVotes,
+          },
+        },
       });
 
       expect(
@@ -77,6 +85,25 @@ describe("ProposalVotingSection", () => {
       expect(
         queryByText(en.proposal_detail__ineligible.headline)
       ).toBeInTheDocument();
+    });
+
+    it("should not render vote blocks if reward status has settled", () => {
+      const { queryByText, getByTestId } = render(ProposalVotingSectionTest, {
+        props: {
+          proposalInfo: {
+            ...proposalInfo,
+            rewardStatus: ProposalRewardStatus.Settled,
+          },
+        },
+      });
+
+      expect(
+        queryByText(en.proposal_detail.voting_results)
+      ).toBeInTheDocument();
+      expect(() => getByTestId("voting-confirmation-toolbar")).toThrow();
+      expect(
+        queryByText(en.proposal_detail__ineligible.headline)
+      ).toBeNull();
     });
   });
 
@@ -89,7 +116,9 @@ describe("ProposalVotingSection", () => {
 
     it("should not render vote blocks", () => {
       const { queryByText, getByTestId } = render(ProposalVotingSectionTest, {
-        props,
+        props: {
+          proposalInfo,
+        },
       });
 
       expect(() => getByTestId("voting-confirmation-toolbar")).toThrow();


### PR DESCRIPTION
# Motivation

- When the proposal reward status has settled, the `ballots` array of the proposal objects are emptied in the canister to spare memory space. 

- The `recentBallots` provided in the neurons can contain up to 100 proposal information

Above two statements could lead to a display misinterpretation in NNS-dapp. Indeed, the frontend might not be able to determine if a neuron has voted and if proposal that has settled are browsed, it might also display these with an incorrect labelling such as having a dissolve delay < 6 months while it is not the case.

Therefore, at least as shorterm solution, we have decided to hide the "Neurons" voting pane from the proposal detail page when, and only when, the reward status as settled.

# Notes

Not displaying misinterpreted information is safer that displaying these. Adding a label "we cannot compute such information" can also lead to questionning, therefore above seem the most acceptable solution.

Archiving the information in the Governance canister would need a quite certain work and resources.

# Source

This was originally reported on the forum https://forum.dfinity.org/t/visual-error-or-malfunction-voting-neurons/17072

# Changes

- do not display "Neuron" bottom sheet / collapsible if reward status is settled
