### PR TITLE
chore: update II init argument type

### DIFF
--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -74,7 +74,7 @@ struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(UserNumber, UserNumber)>,
     pub archive_module_hash: Option<[u8; 32]>,
     pub canister_creation_cycles_cost: Option<u64>,
-    pub memory_migration_batch_size: Option<u32>,
+    pub layout_migration_batch_size: Option<u32>,
 }
 
 fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {


### PR DESCRIPTION
# Motivation

This PR is required so that the next II migration proposal argument is properly rendered.
<!-- Describe the motivation that lead to the PR -->

# Changes

* Change of the `InternetIdentityInit` rust type to be in line with the latest II release.

<!-- List the changes that have been developed -->

# Tests

* There is no test for this typing I assume?
<!-- Please provide any information or screenshots about the tests that have been done -->
