### PR TITLE
fix: Set nns-dapp canister ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
           export FILENAME=".dfx/local/canister_ids.json"
           export DFX_NETWORK=local
           export DFX_CANISTER_NAME="nns-dapp"
+          test -f "$FILENAME" || { echo "{}" > "$FILENAME" ; }
           jq '. * {(env.DFX_CANISTER_NAME): {(env.DFX_NETWORK): (env.DFX_CANISTER_ID)}}' "$FILENAME" | grep . | sponge "$FILENAME"
           dfx canister id nns-dapp
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Set nns-dapp canister ID
         run: |
+          set -x
           sudo apt-get install -yy moreutils
           export DFX_CANISTER_ID="$(sed -nr 's,^nns-dapp +http://([-a-z0-9]+).*,\1,g;ta;b;:a;p;q' ,nns-install)"
           export FILENAME=".dfx/local/canister_ids.json"
@@ -84,6 +85,7 @@ jobs:
           test -f "$FILENAME" || { echo "{}" > "$FILENAME" ; }
           jq '. * {(env.DFX_CANISTER_NAME): {(env.DFX_NETWORK): (env.DFX_CANISTER_ID)}}' "$FILENAME" | grep . | sponge "$FILENAME"
           dfx canister id nns-dapp
+          jq -r '.canisters | keys | .[]' dfx.json | while read line ; do printf "%-30s   %s\n" "$(dfx canister id "$line" 2>/dev/null || echo "unknown")" "$line" ; done
 
       - name: Deploy NNS Dapp
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,17 @@ jobs:
       # IDENTITY_SERVICE_URL needs to match `e2e-tests/test.js`
       - name: Deploy NNS canisters
         run: |
-          dfx nns install
+          dfx nns install | tee ,nns-install
+
+      - name: Set nns-dapp canister ID
+        run: |
+          sudo apt-get install -yy moreutils
+          export DFX_CANISTER_ID="$(sed -nr 's,^nns-dapp +http://([-a-z0-9]+).*,\1,g;ta;b;:a;p;q' ,nns-install)"
+          export FILENAME=".dfx/local/canister_ids.json"
+          export DFX_NETWORK=local
+          export DFX_CANISTER_NAME="nns-dapp"
+          jq '. * {(env.DFX_CANISTER_NAME): {(env.DFX_NETWORK): (env.DFX_CANISTER_ID)}}' "$FILENAME" | grep . | sponge "$FILENAME"
+          dfx canister id nns-dapp
 
       - name: Deploy NNS Dapp
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Set nns-dapp canister ID
         run: |
+          # Note: The nns-dapp deployed by 'dfx nns install' is replaced by the current build.
+          # The canister ID must match, so that the build can be used by future releases of 'dfx nns install'.
           set -x
           sudo apt-get install -yy moreutils
           export DFX_CANISTER_ID="$(sed -nr 's,^nns-dapp +http://([-a-z0-9]+).*,\1,g;ta;b;:a;p;q' ,nns-install)"


### PR DESCRIPTION
# Motivation
CI builds a wasm file for use on localhost.  Unfortunately it has the wrong own canister ID.  `dfx nns install` is not saving the canister ID of nns-dapp, so the build happens with a new and incorrect canister ID.

# Changes
- Capture the nns-dapp canister ID from stdout and save it.  That way the build is for the correct canister ID.

Note: This should be fixed upstream but the dfx release cycle is slow and this would be broken in the meantime.

# Tests
- I have verified that the own canister ID error is now gone, when used for local deployments.
- There is another error I see with the local deployment but that will need to be addressed in another PR.