### PR TITLE
Zip the wasm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -121,5 +121,7 @@ fi
 echo Optimising wasm
 cd "$TOPLEVEL"
 ic-cdk-optimizer ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
+gzip -f -n nns-dapp.wasm
+mv nns-dapp.wasm.gz nns-dapp.wasm
 ls -sh ./nns-dapp.wasm
 sha256sum ./nns-dapp.wasm


### PR DESCRIPTION
# Motivation
WASM too big.  Zipping helps.

# Changes
- gzip the wasm file

# Tests
Deployed nns-dapp to small12 by proposal using thiscompressed wasm code.