### PR TITLE
GIX-1151: Identify SNS top up neuron transaction

### DIFF
--- a/frontend/src/lib/utils/sns-transactions.utils.ts
+++ b/frontend/src/lib/utils/sns-transactions.utils.ts
@@ -115,7 +115,11 @@ const getSnsTransactionType = ({
   if (transfer !== undefined) {
     // A transaction to an account owned by the governance canister stakes a neuron.
     if (transfer.to.owner.toText() === governanceCanisterId?.toText()) {
-      return AccountTransactionType.StakeNeuron;
+      // Staking a neuron uses a memo, but topping up a neuron does not.
+      if (transfer.memo.length > 0) {
+        return AccountTransactionType.StakeNeuron;
+      }
+      return AccountTransactionType.TopUpNeuron;
     }
     return AccountTransactionType.Send;
   }

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -80,6 +80,7 @@ describe("SnsTransactionCard", () => {
       subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
     };
     const stakeNeuronTransaction = createSnstransactionWithId(toGov, from);
+    stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
     const { getByText } = renderTransactionCard(
       mockSnsMainAccount,
       stakeNeuronTransaction,

--- a/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-transactions.utils.spec.ts
@@ -193,6 +193,7 @@ describe("sns-transaction utils", () => {
         toGovernance,
         from
       );
+      stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
       const data = mapSnsTransaction({
         transaction: stakeNeuronTransaction,
         account: mockSnsMainAccount,
@@ -202,6 +203,28 @@ describe("sns-transaction utils", () => {
       expect(data.isSend).toBe(true);
       expect(data.isReceive).toBe(false);
       expect(data.type).toBe(AccountTransactionType.StakeNeuron);
+    });
+
+    it("maps top up neuron transaction", () => {
+      const governanceCanisterId = principal(2);
+      const toGovernance = {
+        owner: governanceCanisterId,
+        subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+      };
+      const topUpNeuronTransaction = createSnstransactionWithId(
+        toGovernance,
+        from
+      );
+      topUpNeuronTransaction.transaction.transfer[0].memo = [];
+      const data = mapSnsTransaction({
+        transaction: topUpNeuronTransaction,
+        account: mockSnsMainAccount,
+        toSelfTransaction: false,
+        governanceCanisterId,
+      });
+      expect(data.isSend).toBe(true);
+      expect(data.isReceive).toBe(false);
+      expect(data.type).toBe(AccountTransactionType.TopUpNeuron);
     });
 
     it("maps received transaction", () => {


### PR DESCRIPTION
# Motivation

Differentiate the transaction of staking and topping up SNS neurons in the Wallet page.

# Changes

* Add case in `getSnsTransactionType` for sns transactions that differentiates staking and topping up a neuron.

# Tests

* Add test for new case.
