### PR TITLE
Fix: Rounding error in sns transactions

### DIFF
--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -10,7 +10,6 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
   import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
-  import { numberToE8s } from "$lib/utils/token.utils";
   import type { Account } from "$lib/types/account";
   import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
 
@@ -37,7 +36,7 @@
     const { success } = await snsTransferTokens({
       source: sourceAccount,
       destinationAddress,
-      e8s: numberToE8s(amount),
+      amount,
       loadTransactions,
       rootCanisterId: $snsProjectIdSelectedStore,
     });

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -14,7 +14,6 @@
   import type { NewTransaction } from "$lib/types/transaction";
   import { increaseStakeNeuron } from "$lib/services/sns-neurons.services";
   import type { SnsNeuronId } from "@dfinity/sns";
-  import { numberToE8s } from "$lib/utils/token.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 
@@ -57,7 +56,7 @@
 
     const { success } = await increaseStakeNeuron({
       rootCanisterId,
-      amount: numberToE8s(amount),
+      amount,
       account,
       neuronId,
     });

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -4,7 +4,6 @@
   import { i18n } from "$lib/stores/i18n";
   import type { NewTransaction } from "$lib/types/transaction";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { numberToE8s } from "$lib/utils/token.utils";
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Token, TokenAmount } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
@@ -41,7 +40,7 @@
 
     const { success } = await stakeNeuron({
       rootCanisterId,
-      amount: numberToE8s(detail.amount),
+      amount: detail.amount,
       account: detail.sourceAccount,
     });
 

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -5,6 +5,7 @@ import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
 import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
+import { numberToE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import { decodeSnsAccount } from "@dfinity/sns";
@@ -71,16 +72,17 @@ export const snsTransferTokens = async ({
   rootCanisterId,
   source,
   destinationAddress,
-  e8s,
+  amount,
   loadTransactions,
 }: {
   rootCanisterId: Principal;
   source: Account;
   destinationAddress: string;
-  e8s: bigint;
+  amount: number;
   loadTransactions: boolean;
 }): Promise<{ success: boolean }> => {
   try {
+    const e8s = numberToE8s(amount);
     const identity: Identity = await getSnsAccountIdentity(source);
     const to = decodeSnsAccount(destinationAddress);
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -53,6 +53,7 @@ import {
 } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
+import { loadSnsAccounts } from "./sns-accounts.services";
 import {
   checkSnsNeuronBalances,
   neuronNeedsRefresh,
@@ -428,6 +429,7 @@ export const increaseStakeNeuron = async ({
       identity,
       source: decodeSnsAccount(account.identifier),
     });
+    await loadSnsAccounts({ rootCanisterId });
 
     return { success: true };
   } catch (err) {
@@ -461,7 +463,10 @@ export const stakeNeuron = async ({
       identity,
       source: decodeSnsAccount(account.identifier),
     });
-    await loadNeurons({ rootCanisterId, certified: true });
+    await Promise.all([
+      loadSnsAccounts({ rootCanisterId }),
+      loadNeurons({ rootCanisterId, certified: true }),
+    ]);
     return { success: true };
   } catch (err) {
     toastsError(

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -37,6 +37,7 @@ import {
   hasAutoStakeMaturityOn,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
+import { numberToE8s } from "$lib/utils/token.utils";
 import { hexStringToBytes } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
@@ -413,7 +414,7 @@ export const increaseStakeNeuron = async ({
   neuronId,
 }: {
   rootCanisterId: Principal;
-  amount: bigint;
+  amount: number;
   account: Account;
   neuronId: SnsNeuronId;
 }): Promise<{ success: boolean }> => {
@@ -421,11 +422,12 @@ export const increaseStakeNeuron = async ({
     // TODO: Get identity depending on account to support HW accounts
     const identity = await getAuthenticatedIdentity();
 
+    const stakeE8s = numberToE8s(amount);
     await increaseStakeNeuronApi({
       // We can cast it because we already checked that the neuron id is not undefined
       neuronId,
       rootCanisterId,
-      stakeE8s: amount,
+      stakeE8s,
       identity,
       source: decodeSnsAccount(account.identifier),
     });
@@ -450,16 +452,17 @@ export const stakeNeuron = async ({
   account,
 }: {
   rootCanisterId: Principal;
-  amount: bigint;
+  amount: number;
   account: Account;
 }): Promise<{ success: boolean }> => {
   try {
     // TODO: Get identity depending on account to support HW accounts
     const identity = await getAuthenticatedIdentity();
+    const stakeE8s = numberToE8s(amount);
     await stakeNeuronApi({
       controller: identity.getPrincipal(),
       rootCanisterId,
-      stakeE8s: amount,
+      stakeE8s,
       identity,
       source: decodeSnsAccount(account.identifier),
     });

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -123,6 +123,15 @@ export const convertTCyclesToIcpNumber = ({
   exchangeRate: bigint;
 }): number => tCycles / (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);
 
+/**
+ * Returns the number of E8s for the given amount.
+ *
+ * E8s have a precision of 8 decimals. An error is thrown if the amount has more than 8 decimals.
+ *
+ * @param {number} amount
+ * @returns {bigint}
+ * @throws {Error} If the amount has more than 8 decimals.
+ */
 export const numberToE8s = (amount: number): bigint =>
   TokenAmount.fromNumber({
     amount,

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -124,4 +124,7 @@ export const convertTCyclesToIcpNumber = ({
 }): number => tCycles / (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);
 
 export const numberToE8s = (amount: number): bigint =>
-  BigInt(Math.floor(amount * E8S_PER_ICP));
+  TokenAmount.fromNumber({
+    amount,
+    token: ICPToken,
+  }).toE8s();

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1010,7 +1010,9 @@ describe("neurons-services", () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       const amount = 2.2;
       const transactionFee = DEFAULT_TRANSACTION_FEE_E8S / E8S_PER_ICP;
-      const amountWithFee = amount + transactionFee;
+      // To avoid rounding errors, we round the amount with the fee to the nearest 8 decimals
+      const amountWithFee =
+        Math.round((amount + transactionFee) * E8S_PER_ICP) / E8S_PER_ICP;
       await services.splitNeuron({
         neuronId: controlledNeuron.neuronId,
         amount,

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -128,7 +128,7 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
-        e8s: BigInt(10_000_000),
+        amount: 1,
         loadTransactions: false,
       });
 
@@ -146,7 +146,7 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
-        e8s: BigInt(10_000_000),
+        amount: 1,
         loadTransactions: true,
       });
 
@@ -166,7 +166,7 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
-        e8s: BigInt(10_000_000),
+        amount: 1,
         loadTransactions: false,
       });
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -23,6 +23,7 @@ import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
+import { numberToE8s } from "$lib/utils/token.utils";
 import { bytesToHexString } from "$lib/utils/utils";
 import { Principal } from "@dfinity/principal";
 import {
@@ -564,7 +565,7 @@ describe("sns-neurons-services", () => {
 
       const { success } = await stakeNeuron({
         rootCanisterId: mockPrincipal,
-        amount: BigInt(200_000_000),
+        amount: 2,
         account: mockSnsMainAccount,
       });
 
@@ -582,7 +583,7 @@ describe("sns-neurons-services", () => {
         .mockImplementation(() => Promise.resolve());
 
       const rootCanisterId = mockPrincipal;
-      const amount = BigInt(200_000_000);
+      const amount = 2;
       const identity = mockIdentity;
       const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;
       const account = mockSnsMainAccount;
@@ -600,7 +601,7 @@ describe("sns-neurons-services", () => {
       expect(spyOnIncreaseStakeNeuron).toBeCalledWith({
         neuronId,
         rootCanisterId,
-        stakeE8s: amount,
+        stakeE8s: numberToE8s(amount),
         identity,
         source: identifier,
       });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -5,6 +5,7 @@
 import * as governanceApi from "$lib/api/sns-governance.api";
 import * as api from "$lib/api/sns.api";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
+import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
 import * as services from "$lib/services/sns-neurons.services";
 import {
   disburse,
@@ -56,6 +57,12 @@ const {
 jest.mock("$lib/stores/toasts.store", () => {
   return {
     toastsError: jest.fn(),
+  };
+});
+
+jest.mock("$lib/services/sns-accounts.services", () => {
+  return {
+    loadSnsAccounts: jest.fn(),
   };
 });
 
@@ -547,7 +554,7 @@ describe("sns-neurons-services", () => {
   });
 
   describe("stakeNeuron", () => {
-    it("should call sns api stakeNeuron and query neurons again", async () => {
+    it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
       const spyStake = jest
         .spyOn(api, "stakeNeuron")
         .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
@@ -564,11 +571,12 @@ describe("sns-neurons-services", () => {
       expect(success).toBeTruthy();
       expect(spyStake).toBeCalled();
       expect(spyQuery).toBeCalled();
+      expect(loadSnsAccounts).toBeCalled();
     });
   });
 
   describe("increaseStakeNeuron", () => {
-    it("should call api.increaseStakeNeuron", async () => {
+    it("should call api.increaseStakeNeuron and load sns accounts", async () => {
       const spyOnIncreaseStakeNeuron = jest
         .spyOn(api, "increaseStakeNeuron")
         .mockImplementation(() => Promise.resolve());
@@ -596,6 +604,7 @@ describe("sns-neurons-services", () => {
         identity,
         source: identifier,
       });
+      expect(loadSnsAccounts).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -5,6 +5,7 @@ import {
   formattedTransactionFeeICP,
   formatToken,
   getMaxTransactionAmount,
+  numberToE8s,
   sumTokenAmounts,
 } from "$lib/utils/token.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
@@ -223,6 +224,15 @@ describe("token-utils", () => {
           exchangeRate: BigInt(10_000),
         })
       ).toBe(4.32);
+    });
+  });
+
+  describe("numberToE8s", () => {
+    it("converts number to e8s", () => {
+      expect(numberToE8s(1.14)).toBe(BigInt(114_000_000));
+      expect(numberToE8s(1)).toBe(BigInt(100_000_000));
+      expect(numberToE8s(3.14)).toBe(BigInt(314_000_000));
+      expect(numberToE8s(0.14)).toBe(BigInt(14_000_000));
     });
   });
 });


### PR DESCRIPTION
# Motivation

Fix two bugs:

* Rounding issue in SNS transactions.
* Account balance was not updated after staking or topping up sns neurons.

# Changes

* Change implementation of `numberToE8s` to use `TokenAmount.fromNumber`.
* Call `loadSnsAccounts` service after staking or topping up sns neuron.

# Tests

* Fix test.
* Add test for new test cases of loadSnsAccounts call.
* Add tests for token utils `numberToE8s`.
