### PR TITLE
Fix: Dissolved neuron if dissolved in the past

### DIFF
--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -38,7 +38,9 @@ export const getSnsNeuronState = ({
       : NeuronState.Locked;
   }
   if ("WhenDissolvedTimestampSeconds" in dissolveState) {
-    return dissolveState.WhenDissolvedTimestampSeconds < Date.now() / 1000
+    // In case `nowInSeconds` ever changes and doesn't return an integer we use Math.floor
+    return dissolveState.WhenDissolvedTimestampSeconds <
+      BigInt(Math.floor(nowInSeconds()))
       ? NeuronState.Dissolved
       : NeuronState.Dissolving;
   }

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -38,7 +38,9 @@ export const getSnsNeuronState = ({
       : NeuronState.Locked;
   }
   if ("WhenDissolvedTimestampSeconds" in dissolveState) {
-    return NeuronState.Dissolving;
+    return dissolveState.WhenDissolvedTimestampSeconds < Date.now() / 1000
+      ? NeuronState.Dissolved
+      : NeuronState.Dissolving;
   }
   return NeuronState.Unspecified;
 };

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -119,6 +119,20 @@ describe("sns-neuron utils", () => {
       expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
     });
 
+    it("returns DISSOLVED if dissolve in the past", () => {
+      const neuron = createMockSnsNeuron({
+        id: [1, 2, 3, 4],
+        state: NeuronState.Dissolving,
+      });
+      const dissolveState = neuron.dissolve_state[0];
+      if ("WhenDissolvedTimestampSeconds" in dissolveState) {
+        dissolveState.WhenDissolvedTimestampSeconds = BigInt(
+          Math.floor(Date.now() / 1000 - 3600)
+        );
+      }
+      expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
+    });
+
     it("returns DISSOLVED when DissolveDelaySeconds=0", () => {
       const neuron = createMockSnsNeuron({
         id: [1, 2, 3, 4],


### PR DESCRIPTION
# Motivation

User can't disburse sns neurons because data shows "WhenDissolvedTimestampSeconds" state.

# Changes

* Check whether WhenDissolvedTimestampSeconds is in the past and set it to Unlocked state.

# Tests

* Add test with new case.
