### PR TITLE
fix: neuron voting history infinite scroll not triggered

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1650,9 +1650,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.1.0-next-2022-12-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-12-21.1.tgz",
-      "integrity": "sha512-Gjrqg1gw+SncNI6J3iMoj0LomMxGC5YtnWP/QMDSLZJ6UY1547ukpokUvs6iiTuX8knNLvEO0Px1RZpBTcVu+A==",
+      "version": "2.1.0-next-2022-12-30.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-12-30.1.tgz",
+      "integrity": "sha512-TTwI+JKBk1F9qRh4u7Q0jIswO4u2Mf4Blk0kQdZSbLChuXal+qqk27U87sT8vcsGj9FKARlQRNY6oYauEkKCqw==",
       "dependencies": {
         "dompurify": "^2.4.1"
       },
@@ -10962,9 +10962,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.1.0-next-2022-12-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-12-21.1.tgz",
-      "integrity": "sha512-Gjrqg1gw+SncNI6J3iMoj0LomMxGC5YtnWP/QMDSLZJ6UY1547ukpokUvs6iiTuX8knNLvEO0Px1RZpBTcVu+A==",
+      "version": "2.1.0-next-2022-12-30.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.1.0-next-2022-12-30.1.tgz",
+      "integrity": "sha512-TTwI+JKBk1F9qRh4u7Q0jIswO4u2Mf4Blk0kQdZSbLChuXal+qqk27U87sT8vcsGj9FKARlQRNY6oYauEkKCqw==",
       "requires": {
         "dompurify": "^2.4.1"
       }


### PR DESCRIPTION
# Motivation

Under certain circonstances (see related PRs) the "voting history" on the "neuron detail" view was not active /refreshed. 
This PR bumps the gix-cmp that contains a fix for the `InfiniteScroll` component that, per extension, resolve the issue.

# PRs

- [X] https://github.com/dfinity/gix-components/pull/141
- [X] https://github.com/dfinity/gix-components/pull/142

# Changes

- bump gix-cmp
