### PR TITLE
feat: neuron card icp inline and align sns card style

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -90,7 +90,11 @@
 
     &.title {
       span.value {
-        @include fonts.h1(true);
+        @include fonts.h2(true);
+
+        @include media.min-width(medium) {
+          @include fonts.h1(true);
+        }
       }
     }
 

--- a/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
@@ -40,6 +40,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/card";
+  @use "../../themes/mixins/neuron";
 
   // TODO: avoid root global styling
   :global(div.modal article > div) {
@@ -51,10 +52,6 @@
   }
 
   .content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    width: 100%;
+    @include neuron.neuron-card-content;
   }
 </style>

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -20,7 +20,7 @@
   });
 </script>
 
-<div class="lock" data-tid="neuron-card-title">
+<div class="title" data-tid="neuron-card-title">
   <svelte:element this={tagName} data-tid="neuron-id"
     >{neuron.neuronId}</svelte:element
   >
@@ -35,9 +35,15 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/styles/mixins/fonts";
 
-  .lock {
+  .title {
     @include card.stacked-title;
     word-break: break-word;
+  }
+
+  p {
+    margin: 0 0 var(--padding-0_5x);
+    @include fonts.standard(true);
   }
 </style>

--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -12,7 +12,7 @@
     type MergeableNeuron,
   } from "$lib/utils/neuron.utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
-  import NeuronCard from "./NeuronCard.svelte";
+  import NnsNeuronCard from "./NnsNeuronCard.svelte";
 
   let selectedNeuronIds: NeuronId[] = [];
 
@@ -57,7 +57,7 @@
     {#each neurons as { neuron, selected, mergeable, messageKey } (neuron.neuronId)}
       <li>
         {#if mergeable}
-          <NeuronCard
+          <NnsNeuronCard
             on:click={() => toggleNeuronId(neuron.neuronId)}
             role="checkbox"
             {selected}
@@ -68,7 +68,7 @@
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
             text={translate({ labelKey: messageKey ?? "error.not_mergeable" })}
           >
-            <NeuronCard disabled role="checkbox" {neuron} />
+            <NnsNeuronCard disabled role="checkbox" {neuron} />
           </Tooltip>
         {/if}
       </li>

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
-  <SnsNeuronCardTitle slot="start" {neuron} />
+  <SnsNeuronCardTitle slot="start" {neuron} tagName="p" />
 
   <div class="content">
     <SnsNeuronAmount {neuron} />
@@ -33,11 +33,9 @@
 </NeuronCardContainer>
 
 <style lang="scss">
-  .content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  @use "../../themes/mixins/neuron";
 
-    width: 100%;
+  .content {
+    @include neuron.neuron-card-content;
   }
 </style>

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -23,7 +23,12 @@
 </script>
 
 <div class="identifier" data-tid="sns-neuron-card-title">
-  <div use:onIntersection on:nnsIntersecting data-tid="neuron-id-container">
+  <div
+    use:onIntersection
+    on:nnsIntersecting
+    data-tid="neuron-id-container"
+    class="hash"
+  >
     <Hash
       id="neuron-id"
       {tagName}
@@ -38,11 +43,11 @@
 </div>
 
 <style lang="scss">
-  @use "../../../../node_modules/@dfinity/gix-components/styles/mixins/media";
-  @use "../../../../node_modules/@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/styles/mixins/fonts";
 
-  .identifier {
-    @include card.stacked-title;
-    word-break: break-word;
+  .hash {
+    @include fonts.standard(true);
   }
 </style>

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -23,6 +23,7 @@
 </script>
 
 <div class="identifier" data-tid="sns-neuron-card-title">
+  <!-- Forward on:nnsIntersecting to parent to update title on scroll -->
   <div
     use:onIntersection
     on:nnsIntersecting

--- a/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
+++ b/frontend/src/lib/modals/neurons/VotingHistoryModal.svelte
@@ -4,7 +4,7 @@
   import { i18n } from "$lib/stores/i18n";
   import type { NeuronInfo } from "@dfinity/nns";
   import { Spinner } from "@dfinity/gix-components";
-  import NeuronCard from "$lib/components/neurons/NeuronCard.svelte";
+  import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import { toastsError } from "$lib/stores/toasts.store";
   import { createEventDispatcher, onMount } from "svelte";
   import VotingHistoryCard from "$lib/components/neurons/VotingHistoryCard.svelte";
@@ -39,7 +39,7 @@
 
   {#if neuron !== undefined}
     <div class="content legacy">
-      <NeuronCard proposerNeuron {neuron} />
+      <NnsNeuronCard proposerNeuron {neuron} />
 
       <VotingHistoryCard {neuron} />
     </div>

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import NeuronCard from "$lib/components/neurons/NeuronCard.svelte";
+  import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import type { NeuronId } from "@dfinity/nns";
   import { neuronsStore, sortedNeuronStore } from "$lib/stores/neurons.store";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
@@ -35,14 +35,14 @@
           id="spawning-neuron-card"
           text={$i18n.neuron_detail.spawning_neuron_info}
         >
-          <NeuronCard
+          <NnsNeuronCard
             disabled
             ariaLabel={$i18n.neurons.aria_label_neuron_card}
             {neuron}
           />
         </Tooltip>
       {:else}
-        <NeuronCard
+        <NnsNeuronCard
           role="link"
           ariaLabel={$i18n.neurons.aria_label_neuron_card}
           on:click={async () => await goToNeuronDetails(neuron.neuronId)}

--- a/frontend/src/lib/themes/mixins/_neuron.scss
+++ b/frontend/src/lib/themes/mixins/_neuron.scss
@@ -1,3 +1,5 @@
+@use "@dfinity/gix-components/styles/mixins/media";
+
 @mixin maturity-card-info {
   h3 {
     line-height: var(--line-height-standard);
@@ -12,5 +14,20 @@
 
   .staked-maturity {
     margin: var(--padding-0_5x) 0 0;
+  }
+}
+
+@mixin neuron-card-content {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+
+  gap: var(--padding-0_5x);
+  padding-bottom: var(--padding);
+
+  @include media.min-width(medium) {
   }
 }

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import NeuronCard from "$lib/components/neurons/NeuronCard.svelte";
+import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import { formatToken } from "$lib/utils/token.utils";
@@ -16,7 +16,7 @@ import {
 import en from "../../../mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "../../../mocks/neurons.mock";
 
-describe("NeuronCard", () => {
+describe("NnsNeuronCard", () => {
   beforeAll(() => {
     jest
       .spyOn(authStore, "subscribe")
@@ -24,7 +24,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders a Card", () => {
-    const { container } = render(NeuronCard, {
+    const { container } = render(NnsNeuronCard, {
       props: { neuron: mockNeuron },
     });
 
@@ -35,7 +35,7 @@ describe("NeuronCard", () => {
 
   it("is clickable", async () => {
     const spyClick = jest.fn();
-    const { container, component } = render(NeuronCard, {
+    const { container, component } = render(NnsNeuronCard, {
       props: {
         neuron: mockNeuron,
       },
@@ -52,7 +52,7 @@ describe("NeuronCard", () => {
   it("renders role and aria-label passed", async () => {
     const role = "link";
     const ariaLabel = "test label";
-    const { container } = render(NeuronCard, {
+    const { container } = render(NnsNeuronCard, {
       props: {
         neuron: mockNeuron,
         role,
@@ -67,7 +67,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders the neuron stake and identifier", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: mockNeuron,
       },
@@ -92,7 +92,7 @@ describe("NeuronCard", () => {
         spawnAtTimesSeconds: BigInt(3600 * 24 * 6 + 3600 * 4),
       },
     };
-    const { queryByTestId } = render(NeuronCard, {
+    const { queryByTestId } = render(NnsNeuronCard, {
       props: {
         neuron,
       },
@@ -102,7 +102,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders the community fund label when neuron part of community fund", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -115,7 +115,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders the hotkey_control label when neuron is not controlled by current user but by hotkey", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -133,7 +133,7 @@ describe("NeuronCard", () => {
 
   it("renders proper text when status is LOCKED", async () => {
     const MORE_THAN_ONE_YEAR = 60 * 60 * 24 * 365 * 1.5;
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -148,7 +148,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders proper text when status is DISSOLVED", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -161,7 +161,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders proper text when status is SPAWNING", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -179,7 +179,7 @@ describe("NeuronCard", () => {
 
   it("renders proper text when status is DISSOLVING", async () => {
     const ONE_YEAR_FROM_NOW = SECONDS_IN_YEAR + Math.round(Date.now() / 1000);
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {
           ...mockNeuron,
@@ -199,7 +199,7 @@ describe("NeuronCard", () => {
   });
 
   it("renders voting power in `proposerNeuron` version", async () => {
-    const { getByText } = render(NeuronCard, {
+    const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: mockNeuron,
         proposerNeuron: true,


### PR DESCRIPTION
# Changes

- inline neuron card big amount (`999'999'999.0000000 ICP`)
- refactor `NeuronCard` to `NnsNeuronCard`
- align Sns neuron card style (title and same inline for values)

# Screenshots
<img width="897" alt="Capture d’écran 2023-01-02 à 13 31 55" src="https://user-images.githubusercontent.com/16886711/210232092-28b03856-c623-4fab-84eb-4a46d0270b7a.png">
<img width="1536" alt="Capture d’écran 2023-01-02 à 13 32 06" src="https://user-images.githubusercontent.com/16886711/210232100-5249865c-c4fd-4528-8547-3c7de60232be.png">
<img width="1536" alt="Capture d’écran 2023-01-02 à 13 32 28" src="https://user-images.githubusercontent.com/16886711/210232102-33b94cb8-0642-4ac6-8400-16e6e33fb71c.png">
<img width="1536" alt="Capture d’écran 2023-01-02 à 13 31 53" src="https://user-images.githubusercontent.com/16886711/210232079-fb61c990-af69-4c77-a95d-ede86442c7a9.png">
