### PR TITLE
Silence popd printouts

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 #
 
 : "Move into the repository root directory"
-pushd "$(dirname "${BASH_SOURCE[0]}")"
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 ENV_FILE=${ENV_OUTPUT_FILE:-$PWD/frontend/.env}
 
 : "Scan environment:"
@@ -144,5 +144,5 @@ WASM_CANISTER_ID="$wasmCanisterId"
 export WASM_CANISTER_ID
 
 : "Return to the original working directory."
-popd
+popd >/dev/null
 echo FIN >&2


### PR DESCRIPTION
# Motivation
pushd and popd print a path.  This isn't very helpful in the script and makes parsing the output harder. Small thing, but better silenced.

# Changes
- Send the pushd and popd directories to /dev/null

# Tests
Functionality is unchanged.  Existing tests should suffice.