### PR TITLE
Update II in the e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
       # IDENTITY_SERVICE_URL needs to match `e2e-tests/test.js`
       - name: Deploy NNS canisters
         run: |
+          scripts/dfx-software-ii-cache
           dfx nns install
 
       - name: Deploy NNS Dapp

--- a/dfx.json
+++ b/dfx.json
@@ -31,7 +31,7 @@
       "type": "custom",
       "wasm": "internet_identity.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm\" -o internet_identity.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-12-01/internet_identity_dev.wasm\" -o internet_identity.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"

--- a/dfx.json
+++ b/dfx.json
@@ -31,7 +31,7 @@
       "type": "custom",
       "wasm": "internet_identity.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-12-01/internet_identity_dev.wasm\" -o internet_identity.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm\" -o internet_identity.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"

--- a/scripts/dfx-software-ii-cache
+++ b/scripts/dfx-software-ii-cache
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+print_help() {
+	cat <<-EOF
+	Downloads the internet_identity wasm and installs it in the dfx cache.
+
+	Note: Doing this will set the II version deployed by 'dfx nns install'
+	      to the version specified in our 'dfx.json'.  Our version is usually
+	      newer.
+	EOF
+}
+
+# Source the optparse.bash file ---------------------------------------------------
+source "$SOURCE_DIR/optparse.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(optparse.build)"
+set -euo pipefail
+
+: "Get the wasm.  I thought this is what 'dfx build' was meant to do but the build does no such thing.  Silly me."
+jq -r '.canisters.internet_identity.build' dfx.json | bash -euxo pipefail
+: Put the wasm into the cache, for use by 'dfx nns install'
+WASMS_DIR="$(dfx cache show)/wasms"
+mkdir -p "$WASMS_DIR"
+cp "$(jq -r '.canisters.internet_identity.wasm' dfx.json)" "$WASMS_DIR"

--- a/scripts/dfx-software-ii-cache
+++ b/scripts/dfx-software-ii-cache
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 	Downloads the internet_identity wasm and installs it in the dfx cache.
 
 	Note: Doing this will set the II version deployed by 'dfx nns install'

--- a/scripts/optparse.bash
+++ b/scripts/optparse.bash
@@ -1,0 +1,179 @@
+# Optparse - a BASH argument parser
+# Heavily modified from an original by:
+# Optparse - a BASH wrapper for getopts < doesn't use optparse any more.  Just bash.
+# https://github.com/nk412/optparse
+# Copyright (c) 2015 Nagarjuna Kumarappan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Author: Nagarjuna Kumarappan <nagarjuna.412@gmail.com>
+
+optparse_usage=""
+optparse_contractions=""
+optparse_defaults=""
+optparse_arguments_string=""
+
+# -----------------------------------------------------------------------------------------------------------------------------
+function optparse.throw_error() {
+	local message="$1"
+	echo "OPTPARSE: ERROR: $message"
+	exit 1
+}
+
+# -----------------------------------------------------------------------------------------------------------------------------
+function optparse.define() {
+	if [ $# -lt 3 ]; then
+		optparse.throw_error "optparse.define <short> <long> <variable> [<desc>] [<default>] [<value>] [<nargs>]"
+	fi
+	local nargs=""
+	for option_id in $(seq 1 $#); do
+		local option
+		option="$(eval "echo \$$option_id")"
+		local key
+		key="$(echo "$option" | awk -F "=" '{print $1}')"
+		local value
+		value="$(echo "$option" | awk -F "=" '{print $2}')"
+
+		#essentials: shortname, longname, description
+		if [ "$key" = "short" ]; then
+			local shortname="$value"
+			if [ ${#shortname} -ne 1 ]; then
+				optparse.throw_error "short name expected to be one character long"
+			fi
+			local short="-${shortname}"
+		elif [ "$key" = "long" ]; then
+			local longname="$value"
+			if [ ${#longname} -lt 2 ]; then
+				optparse.throw_error "long name expected to be atleast one character long"
+			fi
+			local long="--${longname}"
+		elif [ "$key" = "desc" ]; then
+			local desc="$value"
+		elif [ "$key" = "default" ]; then
+			local default="$value"
+		elif [ "$key" = "variable" ]; then
+			local variable="$value"
+		elif [ "$key" = "value" ]; then
+			local val="$value"
+		elif [ "$key" = "nargs" ]; then
+			local nargs="$value"
+		fi
+	done
+
+	if [ "$variable" = "" ]; then
+		optparse.throw_error "You must give a variable for option: ($short/$long)"
+	fi
+
+	if [ "$val" = "" ]; then
+		val="\$OPTARG"
+	fi
+
+	# build OPTIONS and help
+	optparse_usage="${optparse_usage}#NL#TB${short} $(printf "%-25s %s" "${long}:" "${desc}")"
+	if [ "$default" != "" ] && [ "${nargs:-}" != "0" ]; then
+		optparse_usage="${optparse_usage} [default:$default]"
+	fi
+	if [ "${nargs:-}" == "" ]; then
+		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"\$1\"; shift 1;;"
+	elif [ "${nargs:-}" == "0" ]; then
+		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=\"true\";;"
+	else
+		optparse_contractions="${optparse_contractions}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
+	fi
+	if [ "$default" != "" ]; then
+		optparse_defaults="${optparse_defaults}#NL${variable}=${default}"
+	fi
+	optparse_arguments_string="${optparse_arguments_string}${shortname}"
+	if [ "$val" = "\$OPTARG" ]; then
+		optparse_arguments_string="${optparse_arguments_string}:"
+	fi
+}
+
+# -----------------------------------------------------------------------------------------------------------------------------
+function optparse.build() {
+	local build_file
+	build_file="$(mktemp -t "optparse-XXXXXX.tmp")"
+
+	# Building getopts header here
+
+	# Function usage
+	cat <<EOF >"$build_file"
+function usage(){
+cat << XXX
+usage: \$(basename "\$0") [OPTIONS]
+
+OPTIONS:
+        $optparse_usage
+
+        -? --help  :  usage
+
+        --verbose  :  show debug info
+
+XXX
+}
+
+# Set default variable values
+$optparse_defaults
+
+# Contract long options into short options
+while [ \$# -ne 0 ]; do
+        param="\$1"
+        shift 1
+
+        case "\$param" in
+                $optparse_contractions
+                "-?"|--help)
+			print_help
+			echo
+                        usage
+                        exit 0;;
+		--verbose)
+			set -x;;
+		--)
+			break ;;
+                -*)
+                        echo -e "Unrecognized option: \$param"
+                        usage
+                        exit 1 ;;
+                *)
+			set "\$param" "\${@}"
+			break ;;
+        esac
+done
+
+# Clean up after self
+rm $build_file
+
+EOF
+
+	# shellcheck disable=SC2094
+		cat <<<"$(sed 's/#NL/\n/g' "$build_file")" > "$build_file"
+	# shellcheck disable=SC2094
+		cat <<<"$(sed "s/#TB/\t/g" "$build_file")" > "$build_file"
+
+	# Unset global variables
+	unset optparse_usage
+	unset optparse_arguments_string
+	unset optparse_defaults
+	unset optparse_contractions
+
+	# Return file name to parent
+	echo "$build_file"
+}
+# -----------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Motivation
In the e2e tests we use the II version bundles with dfx nns install.  This is fine most of the time, except that it is quite old and doesn't match testnets that use newer II.  It would be good to be able to specify an II to use.

# Changes
- Add a script to put the II version specified in dfx.json in the wasm cache, for dfx nns install to use.
- Add a script that provides --help and --verbose to the above.

# Tests
- [x] Explicitly set the old version of II; tests should pass.
- [ ] Update the version of II.  Tests are expected to fail.
- [ ] Fix the tests
  - [ ] Registration flow
  - [ ] Login flow