### PR TITLE
GIX-1137: Confirmation remove current user hotkey

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -2,7 +2,6 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { AppPath } from "$lib/constants/routes.constants";
   import { IconClose, Value } from "@dfinity/gix-components";
-  import { getAuthenticatedIdentity } from "$lib/services/auth.services";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { removeHotkey } from "$lib/services/neurons.services";
   import { accountsStore } from "$lib/stores/accounts.store";
@@ -15,8 +14,25 @@
   import AddHotkeyButton from "./actions/AddHotkeyButton.svelte";
   import { goto } from "$app/navigation";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import ConfirmRemoveCurrentUserHotkey from "$lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte";
 
   export let neuron: NeuronInfo;
+
+  let currentIdentityString: string | undefined;
+  $: currentIdentityString = $authStore.identity?.getPrincipal().toText();
+
+  let showConfirmationHotkey: string | undefined;
+  const closeConfirmation = () => {
+    showConfirmationHotkey = undefined;
+  };
+  const maybeRemove = async (hotkey: string) => {
+    // Require confirmation if the user is removing itself from the hotkeys.
+    if (currentIdentityString === hotkey) {
+      showConfirmationHotkey = hotkey;
+    } else {
+      remove(hotkey);
+    }
+  };
 
   let isControllable: boolean;
   $: isControllable = isNeuronControllable({
@@ -36,11 +52,8 @@
       neuronId: neuron.neuronId,
       principalString: hotkey,
     });
-    const currentIdentityPrincipal = (await getAuthenticatedIdentity())
-      .getPrincipal()
-      .toText();
     // If the user removes itself from the hotkeys, it has no more access to the detail page.
-    if (currentIdentityPrincipal === hotkey && maybeNeuronId !== undefined) {
+    if (currentIdentityString === hotkey && maybeNeuronId !== undefined) {
       toastsShow({
         level: "success",
         labelKey: "neurons.remove_hotkey_success",
@@ -65,7 +78,7 @@
             <button
               class="text"
               aria-label={$i18n.core.remove}
-              on:click={() => remove(hotkey)}
+              on:click={() => maybeRemove(hotkey)}
               data-tid="remove-hotkey-button"><IconClose size="18px" /></button
             >
           {/if}
@@ -82,12 +95,17 @@
 
 <Separator />
 
+{#if showConfirmationHotkey !== undefined}
+  <!-- The extra const is required for TS to understand that showConfirmationHotkey is a string, not undefined -->
+  {@const hotkey = showConfirmationHotkey}
+  <ConfirmRemoveCurrentUserHotkey
+    on:nnsClose={closeConfirmation}
+    on:nnsConfirm={() => remove(hotkey)}
+  />
+{/if}
+
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/card";
-
-  h3 {
-    line-height: var(--line-height-standard);
-  }
 
   .actions {
     display: flex;

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -30,7 +30,7 @@
     if (currentIdentityString === hotkey) {
       showConfirmationHotkey = hotkey;
     } else {
-      remove(hotkey);
+      await remove(hotkey);
     }
   };
 
@@ -106,6 +106,10 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/card";
+
+  h3 {
+    line-height: var(--line-height-standard);
+  }
 
   .actions {
     display: flex;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -66,7 +66,7 @@
     if (currentIdentityString === hotkey) {
       showConfirmationHotkey = hotkey;
     } else {
-      remove(hotkey);
+      await remove(hotkey);
     }
   };
 
@@ -91,6 +91,7 @@
       });
 
       await goto($neuronsPathStore);
+      return;
     }
     if (success) {
       await reload();
@@ -165,6 +166,10 @@
     display: flex;
     align-items: center;
     gap: var(--padding-0_5x);
+  }
+
+  h3 {
+    line-height: var(--line-height-standard);
   }
 
   .warning {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -218,6 +218,8 @@
     "add_user_as_hotkey": "Add Principal to Hotkeys",
     "add_user_as_hotkey_message": "To see and manage this neuron in the NNS app, please add the NNS app as a hotkey.",
     "add_user_as_hotkey_success": "Your principal was added to the neuron successfully.",
+    "remove_user_hotkey_confirm_title": "Confirm Removal of Hotkey",
+    "remove_user_hotkey_confirm_text": "Are you sure you want to remove your principal from the hotkeys of the neuron?",
     "remove_hotkey_success": "Hotkey removed successfully.",
     "neuron_create_success": "Neuron created successfully.",
     "your_principal": "Your NNS Principal",

--- a/frontend/src/lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte
+++ b/frontend/src/lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte
@@ -24,8 +24,4 @@
   p {
     @include confirmation-modal.text;
   }
-
-  h3 {
-    line-height: var(--line-height-standard);
-  }
 </style>

--- a/frontend/src/lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte
+++ b/frontend/src/lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import ConfirmationModal from "../ConfirmationModal.svelte";
+</script>
+
+<ConfirmationModal on:nnsClose on:nnsConfirm>
+  <div data-tid="remove-current-user-hotkey-confirmation">
+    <h4>{$i18n.neurons.remove_user_hotkey_confirm_title}</h4>
+    <p>{$i18n.neurons.remove_user_hotkey_confirm_text}</p>
+  </div>
+</ConfirmationModal>
+
+<style lang="scss">
+  @use "../../themes/mixins/confirmation-modal";
+
+  div {
+    @include confirmation-modal.wrapper;
+  }
+
+  h4 {
+    @include confirmation-modal.title;
+  }
+
+  p {
+    @include confirmation-modal.text;
+  }
+
+  h3 {
+    line-height: var(--line-height-standard);
+  }
+</style>

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
   import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
-  import NeuronHotkeysCard from "$lib/components/neuron-detail/NeuronHotkeysCard.svelte";
+  import NnsNeuronHotkeysCard from "$lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte";
   import NnsNeuronMaturityCard from "$lib/components/neuron-detail/NnsNeuronMaturityCard.svelte";
   import NnsNeuronMetaInfoCard from "$lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte";
   import NnsNeuronInfoStake from "$lib/components/neuron-detail/NnsNeuronInfoStake.svelte";
@@ -137,7 +137,7 @@
           <NeuronProposalsCard {neuron} />
         {/if}
 
-        <NeuronHotkeysCard {neuron} />
+        <NnsNeuronHotkeysCard {neuron} />
         <NeuronVotingHistoryCard {neuron} />
       {:else}
         <SkeletonCard size="large" cardType="info" separator />

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -228,6 +228,8 @@ interface I18nNeurons {
   add_user_as_hotkey: string;
   add_user_as_hotkey_message: string;
   add_user_as_hotkey_success: string;
+  remove_user_hotkey_confirm_title: string;
+  remove_user_hotkey_confirm_text: string;
   remove_hotkey_success: string;
   neuron_create_success: string;
   your_principal: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import NeuronHotkeysCard from "$lib/components/neuron-detail/NeuronHotkeysCard.svelte";
+import NnsNeuronHotkeysCard from "$lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import { removeHotkey } from "$lib/services/neurons.services";
@@ -24,7 +24,7 @@ jest.mock("$lib/services/neurons.services", () => {
   };
 });
 
-describe("NeuronHotkeysCard", () => {
+describe("NnsNeuronHotkeysCard", () => {
   const hotKeys = [
     "djzvl-qx6kb-xyrob-rl5ki-elr7y-ywu43-l54d7-ukgzw-qadse-j6oml-5qe",
     "ucmt2-grxhb-qutyd-sp76m-amcvp-3h6sr-lqnoj-fik7c-bbcc3-irpdn-oae",
@@ -56,7 +56,7 @@ describe("NeuronHotkeysCard", () => {
     const { queryByText } = render(NeuronContextActionsTest, {
       props: {
         neuron: controlledNeuron,
-        testComponent: NeuronHotkeysCard,
+        testComponent: NnsNeuronHotkeysCard,
       },
     });
 
@@ -67,7 +67,7 @@ describe("NeuronHotkeysCard", () => {
     const { queryByTestId } = render(NeuronContextActionsTest, {
       props: {
         neuron: controlledNeuron,
-        testComponent: NeuronHotkeysCard,
+        testComponent: NnsNeuronHotkeysCard,
       },
     });
 
@@ -80,7 +80,7 @@ describe("NeuronHotkeysCard", () => {
       {
         props: {
           neuron: unControlledNeuron,
-          testComponent: NeuronHotkeysCard,
+          testComponent: NnsNeuronHotkeysCard,
         },
       }
     );
@@ -93,7 +93,7 @@ describe("NeuronHotkeysCard", () => {
     const { queryByText } = render(NeuronContextActionsTest, {
       props: {
         neuron: controlledNeuron,
-        testComponent: NeuronHotkeysCard,
+        testComponent: NnsNeuronHotkeysCard,
       },
     });
 
@@ -105,7 +105,7 @@ describe("NeuronHotkeysCard", () => {
     const { queryAllByTestId } = render(NeuronContextActionsTest, {
       props: {
         neuron: controlledNeuron,
-        testComponent: NeuronHotkeysCard,
+        testComponent: NnsNeuronHotkeysCard,
       },
     });
 
@@ -127,12 +127,15 @@ describe("NeuronHotkeysCard", () => {
       },
     };
 
-    const { queryAllByTestId } = render(NeuronContextActionsTest, {
-      props: {
-        neuron,
-        testComponent: NeuronHotkeysCard,
-      },
-    });
+    const { queryAllByTestId, queryByTestId } = render(
+      NeuronContextActionsTest,
+      {
+        props: {
+          neuron,
+          testComponent: NnsNeuronHotkeysCard,
+        },
+      }
+    );
 
     const removeButtons = queryAllByTestId("remove-hotkey-button");
     expect(removeButtons.length).toBeGreaterThan(0);
@@ -141,6 +144,14 @@ describe("NeuronHotkeysCard", () => {
 
     await fireEvent.click(firstButton);
     expect(removeHotkey).toBeCalled();
+
+    await waitFor(() =>
+      expect(
+        queryByTestId("remove-current-user-hotkey-confirmation")
+      ).toBeInTheDocument()
+    );
+    const confirmButton = queryByTestId("confirm-yes");
+    confirmButton && fireEvent.click(confirmButton);
 
     await waitFor(() => expect(get(pageStore).path).toEqual(AppPath.Neurons));
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -120,7 +120,6 @@ describe("SnsNeuronHotkeysCard", () => {
     const confirmButton = queryByTestId("confirm-yes");
     confirmButton && fireEvent.click(confirmButton);
 
-    await waitFor(() => expect(reload).toBeCalledWith());
-    expect(removeHotkey).toBeCalled();
+    await waitFor(() => expect(removeHotkey).toBeCalled());
   });
 });


### PR DESCRIPTION
# Motivation

User should confirm before removing itself from hotkeys. Both NNS and SNS neurons.

# Changes

* Rename NeuronHotkeysCard.svelten to NnsNeuronHotkeysCard.svelte.
* Add extra function to [Sns / Nns]NeuronHotkeysCard called "maybeRemove" to check whether it should open the modal or remove hotkey.
* New UI component ConfirmRemoveCurrentUserHotkey to share modal in Sns and Nns.
* New state `showConfirmationHotkey` in [Sns / Nns]NeuronHotkeysCard to open ConfirmRemoveCurrentUserHotkey.

# Tests

* Change tests after file rename.
* Add test case to NnsNeuronHotkeysCard.
* Add test case to SnsNeuronHotkeysCard.
