### PR TITLE
Feat: Support stake maturity hw

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -14,7 +14,6 @@
   import {
     isNeuronControllable,
     formattedStakedMaturity,
-    isNeuronControlledByHardwareWallet,
     formattedTotalMaturity,
   } from "$lib/utils/neuron.utils";
   import { accountsStore } from "$lib/stores/accounts.store";
@@ -26,12 +25,6 @@
   $: isControllable = isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
-  });
-
-  let controlledByHardwareWallet: boolean;
-  $: controlledByHardwareWallet = isNeuronControlledByHardwareWallet({
-    neuron,
     accounts: $accountsStore,
   });
 </script>
@@ -62,9 +55,7 @@
       <SpawnNeuronButton {neuron} />
     </div>
 
-    {#if !controlledByHardwareWallet}
-      <NnsAutoStakeMaturity {neuron} />
-    {/if}
+    <NnsAutoStakeMaturity {neuron} />
   {/if}
 </CardInfo>
 

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -9,6 +9,7 @@ export const SPAWN_VARIANCE_PERCENTAGE = 0.95;
 
 // HW versions
 export const MIN_VERSION_STAKE_MATURITY_WORKAROUND = "2.0.7";
+export const MIN_VERSION_STAKE_MATURITY = "2.2.1";
 
 export const DISSOLVE_DELAY_MULTIPLIER = 1;
 export const AGE_MULTIPLIER = 0.25;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -8,8 +8,10 @@ export const MAX_CONCURRENCY = 10;
 export const SPAWN_VARIANCE_PERCENTAGE = 0.95;
 
 // HW versions
+// Version published in december 2022
 export const MIN_VERSION_STAKE_MATURITY_WORKAROUND = "2.0.7";
-export const MIN_VERSION_STAKE_MATURITY = "2.2.1";
+// Version published in January 2023
+export const CANDID_PARSER_VERSION = "2.2.1";
 
 export const DISSOLVE_DELAY_MULTIPLIER = 1;
 export const AGE_MULTIPLIER = 0.25;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -632,7 +632,7 @@
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right hardware wallet?",
     "access_denied": "Access denied to use the ledger device.",
     "user_rejected_transaction": "The transaction was rejected on the ledger device.",
-    "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to $minVersion as soon as it is available.",
+    "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to at least version $minVersion.",
     "browser_not_supported": "Sorry, the browser does not support the WebHID API needed to connect the hardware wallet. Check support in https://caniuse.com/?search=WebHID",
     "incorrect_identifier": "Wallet account identifier doesn't match. Are you sure you connected the right hardware wallet? Expected identifier: $identifier. Wallet identifier: $ledgerIdentifier."
   },

--- a/frontend/src/lib/modals/neurons/NnsStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeMaturityModal.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import { stopBusy } from "$lib/stores/busy.store";
-  import { mergeMaturity, stakeMaturity } from "$lib/services/neurons.services";
+  import { stakeMaturity } from "$lib/services/neurons.services";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import StakeMaturityModal from "$lib/modals/neurons/StakeMaturityModal.svelte";
-  import {
-    formattedMaturity,
-    isNeuronControlledByHardwareWallet,
-  } from "$lib/utils/neuron.utils";
+  import { formattedMaturity } from "$lib/utils/neuron.utils";
   import { createEventDispatcher } from "svelte";
-  import { accountsStore } from "$lib/stores/accounts.store";
 
   export let neuron: NeuronInfo;
 
@@ -24,24 +20,13 @@
     detail: { percentageToStake },
   }: CustomEvent<{ percentageToStake: number }>) => {
     const { neuronId } = neuron;
-    const controlledByHardwareWallet = isNeuronControlledByHardwareWallet({
-      neuron,
-      accounts: $accountsStore,
-    });
 
     startBusyNeuron({ initiator: "stake-maturity", neuronId });
 
-    const { success } = await (controlledByHardwareWallet
-      ? // Temprorary solution (call mergeMaturity for HW, but the backend does stake) because Ledger doesn't support staking yet.
-        // If Ledger includes the Staking Maturity transaction in the next version, this workaround can be removed. And the same flow for HW and non-HW can be used.
-        mergeMaturity({
-          neuronId,
-          percentageToMerge: percentageToStake,
-        })
-      : stakeMaturity({
-          neuronId,
-          percentageToStake,
-        }));
+    const { success } = await stakeMaturity({
+      neuronId,
+      percentageToStake,
+    });
 
     if (success) {
       toastsSuccess({

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -22,7 +22,10 @@ import {
 } from "$lib/api/governance.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
-import { MIN_VERSION_STAKE_MATURITY_WORKAROUND } from "$lib/constants/neurons.constants";
+import {
+  MIN_VERSION_STAKE_MATURITY,
+  MIN_VERSION_STAKE_MATURITY_WORKAROUND,
+} from "$lib/constants/neurons.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -595,6 +598,7 @@ export const disburse = async ({
   }
 };
 
+// TODO: Remove as soon as Stake Maturity is proven for Hardware Wallets
 export const mergeMaturity = async ({
   neuronId,
   percentageToMerge,
@@ -635,6 +639,11 @@ export const stakeMaturity = async ({
     const identity: Identity = await getIdentityOfControllerByNeuronId(
       neuronId
     );
+
+    await assertLedgerVersion({
+      identity,
+      minVersion: MIN_VERSION_STAKE_MATURITY,
+    });
 
     await stakeMaturityApi({ neuronId, percentageToStake, identity });
 

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -23,7 +23,7 @@ import {
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import {
-  MIN_VERSION_STAKE_MATURITY,
+  CANDID_PARSER_VERSION,
   MIN_VERSION_STAKE_MATURITY_WORKAROUND,
 } from "$lib/constants/neurons.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
@@ -368,6 +368,11 @@ export const toggleAutoStakeMaturity = async (
       neuronId
     );
 
+    await assertLedgerVersion({
+      identity,
+      minVersion: CANDID_PARSER_VERSION,
+    });
+
     await autoStakeMaturity({
       neuronId,
       identity,
@@ -642,7 +647,7 @@ export const stakeMaturity = async ({
 
     await assertLedgerVersion({
       identity,
-      minVersion: MIN_VERSION_STAKE_MATURITY,
+      minVersion: CANDID_PARSER_VERSION,
     });
 
     await stakeMaturityApi({ neuronId, percentageToStake, identity });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -226,15 +226,17 @@ describe("NnsNeuronMaturityCard", () => {
       expect(getByTestId("stake-maturity-button")).not.toBeNull();
     });
 
-    it("should not render auto stake maturity action for hardware wallet", () => {
-      const { getByTestId } = render(NeuronContextActionsTest, {
+    it("should render auto stake maturity action for hardware wallet", () => {
+      const { container } = render(NeuronContextActionsTest, {
         props: {
           neuron: neuronHW,
           testComponent: NnsNeuronMaturityCard,
         },
       });
 
-      expect(() => getByTestId("auto-stake-maturity-checkbox")).toThrow();
+      expect(
+        container.querySelector("#auto-stake-maturity-checkbox")
+      ).toBeInTheDocument();
     });
 
     it("should render stake maturity description", () => {

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import NnsStakeMaturityModal from "$lib/modals/neurons/NnsStakeMaturityModal.svelte";
-import { mergeMaturity, stakeMaturity } from "$lib/services/neurons.services";
+import { stakeMaturity } from "$lib/services/neurons.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -109,7 +109,7 @@ describe("NnsStakeMaturityModal", () => {
         )
     );
 
-    it("should call mergeMaturity service on confirm click for HW", async () => {
+    it("should call stakeMaturity service on confirm click for HW", async () => {
       const renderResult: RenderResult<SvelteComponent> =
         await renderNnsStakeMaturityModal(neuronHW);
 
@@ -125,7 +125,7 @@ describe("NnsStakeMaturityModal", () => {
       expect(confirmButton).toBeInTheDocument();
       confirmButton && (await fireEvent.click(confirmButton));
 
-      expect(mergeMaturity).toBeCalled();
+      expect(stakeMaturity).toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -18,6 +18,7 @@ import { numberToE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, LedgerCanister, TokenAmount, Topic } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { LedgerError, type ResponseVersion } from "@zondax/ledger-icp";
 import { mock } from "jest-mock-extended";
 import { tick } from "svelte/internal";
 import { get } from "svelte/store";
@@ -32,6 +33,7 @@ import {
   resetIdentity,
   setNoIdentity,
 } from "../../mocks/auth.store.mock";
+import { MockLedgerIdentity } from "../../mocks/ledger.identity.mock";
 import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
 
 const {
@@ -509,6 +511,32 @@ describe("neurons-services", () => {
       expect(toastsShow).toHaveBeenCalled();
       expect(spyAutoStakeMaturity).not.toHaveBeenCalled();
     });
+
+    it("should not toggle auto stake maturity if hw version is lower than candid parser version", async () => {
+      const version: ResponseVersion = {
+        testMode: false,
+        major: 1,
+        minor: 9,
+        patch: 9,
+        deviceLocked: false,
+        targetId: "test",
+        returnCode: LedgerError.NoErrors,
+      };
+      const smallerVersionIdentity = new MockLedgerIdentity({ version });
+      setAccountIdentity(smallerVersionIdentity);
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: smallerVersionIdentity.getPrincipal().toText(),
+        },
+      };
+      await toggleAutoStakeMaturity(neuron);
+
+      expect(toastsShow).toHaveBeenCalled();
+      expect(spyAutoStakeMaturity).not.toHaveBeenCalled();
+      resetIdentity();
+    });
   });
 
   describe("disburse", () => {
@@ -628,6 +656,39 @@ describe("neurons-services", () => {
 
       const { success } = await services.stakeMaturity({
         neuronId: controlledNeuron.neuronId,
+        percentageToStake: 50,
+      });
+
+      expect(toastsShow).toHaveBeenCalled();
+      expect(spyStakeMaturity).not.toHaveBeenCalled();
+      expect(success).toBe(false);
+
+      resetIdentity();
+    });
+
+    it("should not stake maturity if lower HW version than required", async () => {
+      const version: ResponseVersion = {
+        testMode: false,
+        major: 1,
+        minor: 9,
+        patch: 9,
+        deviceLocked: false,
+        targetId: "test",
+        returnCode: LedgerError.NoErrors,
+      };
+      const smallerVersionIdentity = new MockLedgerIdentity({ version });
+      setAccountIdentity(smallerVersionIdentity);
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockFullNeuron,
+          controller: smallerVersionIdentity.getPrincipal().toText(),
+        },
+      };
+      neuronsStore.pushNeurons({ neurons: [neuron], certified: true });
+
+      const { success } = await services.stakeMaturity({
+        neuronId: neuron.neuronId,
         percentageToStake: 50,
       });
 


### PR DESCRIPTION
# Motivation

Users with hardware wallet can turn auto-stake maturity on and off and use the endpoint stake_matyrity instead of merge_maturity with the redirection

# Changes

* Enable AutoStakeMaturity always.
* Add constant with new HW version.
* Change message of version not supported to make it more general.
* NnsStakeMaturityModal uses always service stakeMaturity.
* Add a version assert in service stakeMaturity.

# Tests

* Change test for NnsStakeMaturityModal
* Add case for stakeMaturity service.
* Add case for autoStakeMaturity service.
