### PR TITLE
Refactor: ProposalCard agnostic of NNS

### DIFF
--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -7,7 +7,7 @@
   } from "$lib/stores/sns.store";
   import { isNullish } from "$lib/utils/utils";
   import SkeletonProposalCard from "$lib/components/ui/SkeletonProposalCard.svelte";
-  import ProposalCard from "../proposals/ProposalCard.svelte";
+  import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
   import { listSnsProposals } from "$lib/services/$public/sns.services";
 
   let loading = false;
@@ -32,7 +32,7 @@
 {:else}
   <ul class="card-grid">
     {#each $openSnsProposalsStore as proposalInfo (proposalInfo.id)}
-      <ProposalCard {proposalInfo} />
+      <NnsProposalCard {proposalInfo} />
     {/each}
   </ul>
 {/if}

--- a/frontend/src/lib/components/proposals/Countdown.svelte
+++ b/frontend/src/lib/components/proposals/Countdown.svelte
@@ -2,10 +2,9 @@
   import { onDestroy, onMount } from "svelte";
   import { nowInSeconds, secondsToDuration } from "$lib/utils/date.utils";
   import { i18n } from "$lib/stores/i18n";
-  import type { ProposalInfo } from "@dfinity/nns";
   import { AUTH_SESSION_DURATION } from "$lib/constants/identity.constants";
 
-  export let proposalInfo: ProposalInfo;
+  export let deadlineTimestampSeconds: bigint | undefined;
 
   const ZERO = BigInt(0);
 
@@ -20,8 +19,8 @@
 
   const next = () => {
     if (
-      proposalInfo.deadlineTimestampSeconds === undefined ||
-      proposalInfo.deadlineTimestampSeconds < ZERO
+      deadlineTimestampSeconds === undefined ||
+      deadlineTimestampSeconds < ZERO
     ) {
       clearCountdown();
       return;
@@ -32,7 +31,7 @@
       return;
     }
 
-    countdown = proposalInfo.deadlineTimestampSeconds - BigInt(nowInSeconds());
+    countdown = deadlineTimestampSeconds - BigInt(nowInSeconds());
 
     // No need to schedule an update if the countdown is longer than an hour plus the auth session duration because even if we refresh,
     // the display value would remain the same until the end of the session

--- a/frontend/src/lib/components/proposals/NnsProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import {
+    type ProposalInfo,
+    type NeuronId,
+    type ProposalId,
+    ProposalStatus,
+  } from "@dfinity/nns";
+  import { mapProposalInfo } from "$lib/utils/proposals.utils";
+  import { goto } from "$app/navigation";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { buildProposalUrl } from "$lib/utils/navigation.utils";
+  import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
+  import ProposalCard from "./ProposalCard.svelte";
+
+  export let proposalInfo: ProposalInfo;
+  export let hidden = false;
+
+  let status: ProposalStatus = ProposalStatus.Unknown;
+  let id: ProposalId | undefined;
+  let title: string | undefined;
+  let color: ProposalStatusColor | undefined;
+
+  let topic: string | undefined;
+  let proposer: NeuronId | undefined;
+  let type: string | undefined;
+
+  $: ({ status, id, title, color, topic, proposer, type } =
+    mapProposalInfo(proposalInfo));
+
+  const showProposal = async () =>
+    await goto(
+      buildProposalUrl({
+        universe: $pageStore.universe,
+        proposalId: `${id}`,
+      })
+    );
+</script>
+
+<ProposalCard
+  {hidden}
+  on:click={showProposal}
+  {status}
+  {id}
+  {title}
+  {color}
+  {topic}
+  proposer={String(proposer)}
+  {type}
+  deadlineTimestampSeconds={proposalInfo.deadlineTimestampSeconds}
+/>

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -1,84 +1,66 @@
 <script lang="ts">
-  import { Card, Value } from "@dfinity/gix-components";
-  import {
-    type ProposalInfo,
-    type NeuronId,
-    type ProposalId,
-    ProposalStatus,
-  } from "@dfinity/nns";
+  import { Card, KeyValuePair, Value } from "@dfinity/gix-components";
+  import { ProposalStatus } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
-  import { mapProposalInfo } from "$lib/utils/proposals.utils";
-  import ProposalCountdown from "./ProposalCountdown.svelte";
   import { keyOfOptional } from "$lib/utils/utils";
-  import { goto } from "$app/navigation";
-  import { pageStore } from "$lib/derived/page.derived";
-  import { buildProposalUrl } from "$lib/utils/navigation.utils";
   import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
+  import Countdown from "./Countdown.svelte";
 
-  export let proposalInfo: ProposalInfo;
   export let hidden = false;
-
-  let status: ProposalStatus = ProposalStatus.Unknown;
-  let id: ProposalId | undefined;
-  let title: string | undefined;
-  let color: ProposalStatusColor | undefined;
-
-  let topic: string | undefined;
-  let proposer: NeuronId | undefined;
-  let type: string | undefined;
-
-  $: ({ status, id, title, color, topic, proposer, type } =
-    mapProposalInfo(proposalInfo));
-
-  const showProposal = async () =>
-    await goto(
-      buildProposalUrl({
-        universe: $pageStore.universe,
-        proposalId: `${id}`,
-      })
-    );
+  export let status: ProposalStatus = ProposalStatus.Unknown;
+  export let id: bigint | undefined;
+  export let title: string | undefined;
+  export let color: ProposalStatusColor | undefined;
+  export let topic: string | undefined;
+  export let proposer: string | undefined;
+  export let type: string | undefined;
+  export let deadlineTimestampSeconds: bigint | undefined;
 </script>
 
 <li class:hidden>
-  <Card
-    role="link"
-    on:click={showProposal}
-    testId="proposal-card"
-    withArrow={true}
-  >
-    <div class="card-meta id" data-proposal-id={id}>
+  <Card role="link" on:click testId="proposal-card" withArrow={true}>
+    <div class="id" data-proposal-id={id}>
       <Value ariaLabel={$i18n.proposal_detail.id_prefix}>{id}</Value>
     </div>
 
-    <div class="card-meta">
-      <span>{$i18n.proposal_detail.type_prefix}</span>
-      <Value ariaLabel={$i18n.proposal_detail.type_prefix}>{type}</Value>
-    </div>
+    <div class="meta-data">
+      {#if type !== undefined}
+        <KeyValuePair>
+          <span slot="key">{$i18n.proposal_detail.type_prefix}</span>
+          <span
+            slot="value"
+            class="meta-data-value"
+            aria-label={$i18n.proposal_detail.type_prefix}>{type}</span
+          >
+        </KeyValuePair>
+      {/if}
 
-    <div class="card-meta">
-      <span>{$i18n.proposal_detail.topic_prefix}</span>
-      <Value>{topic ?? ""}</Value>
-    </div>
+      {#if topic !== undefined}
+        <KeyValuePair>
+          <span slot="key">{$i18n.proposal_detail.topic_prefix}</span>
+          <span slot="value" class="meta-data-value">{topic ?? ""}</span>
+        </KeyValuePair>
+      {/if}
 
-    {#if proposer !== undefined}
-      <div class="card-meta">
-        <span>{$i18n.proposal_detail.proposer_prefix}</span>
-        <Value>{proposer}</Value>
-      </div>
-    {/if}
+      {#if proposer !== undefined}
+        <KeyValuePair>
+          <span slot="key">{$i18n.proposal_detail.proposer_prefix}</span>
+          <span slot="value" class="meta-data-value">{proposer}</span>
+        </KeyValuePair>
+      {/if}
+    </div>
 
     <blockquote class="title-placeholder">
       <p class="description">{title}</p>
     </blockquote>
 
-    <div class="card-meta">
-      <p class={`${color ?? ""} status`}>
+    <KeyValuePair>
+      <p slot="key" class={`${color ?? ""} status`}>
         {keyOfOptional({ obj: $i18n.status, key: ProposalStatus[status] }) ??
           ""}
       </p>
-
-      <ProposalCountdown {proposalInfo} />
-    </div>
+      <Countdown slot="value" {deadlineTimestampSeconds} />
+    </KeyValuePair>
   </Card>
 </li>
 
@@ -91,30 +73,32 @@
     visibility: hidden;
   }
 
+  .id {
+    display: flex;
+    justify-content: flex-end;
+
+    margin-bottom: var(--padding);
+
+    :global(.value) {
+      color: var(--tertiary);
+    }
+  }
+
+  .meta-data {
+    margin-bottom: var(--padding);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    // Prevent texts that need two lines leave space on the right side
+    & .meta-data-value {
+      text-align: right;
+    }
+  }
+
   .title-container {
     @include card.stacked-title;
-  }
-
-  .title {
-    @include text.clamp(3);
-
-    @include media.min-width(small) {
-      margin: 0 var(--padding-2x) 0 0;
-    }
-
-    color: var(--value-color);
-  }
-
-  .card-meta {
-    @include card.meta;
-
-    &.id {
-      justify-content: flex-end;
-
-      :global(.value) {
-        color: var(--tertiary);
-      }
-    }
   }
 
   .title-placeholder {

--- a/frontend/src/lib/components/proposals/ProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/ProposalsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import ProposalCard from "./ProposalCard.svelte";
+  import NnsProposalCard from "./NnsProposalCard.svelte";
   import { InfiniteScroll } from "@dfinity/gix-components";
   import ProposalsFilters from "./ProposalsFilters.svelte";
   import { i18n } from "$lib/stores/i18n";
@@ -22,7 +22,7 @@
   disabled={disableInfiniteScroll || loading}
 >
   {#each $filteredProposals.proposals as proposalInfo (proposalInfo.id)}
-    <ProposalCard {hidden} {proposalInfo} />
+    <NnsProposalCard {hidden} {proposalInfo} />
   {/each}
 </InfiniteScroll>
 

--- a/frontend/src/tests/lib/components/proposals/Countdown.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/Countdown.spec.ts
@@ -2,20 +2,17 @@
  * @jest-environment jsdom
  */
 
-import ProposalCountdown from "$lib/components/proposals/ProposalCountdown.svelte";
+import Countdown from "$lib/components/proposals/Countdown.svelte";
 import { secondsToDuration } from "$lib/utils/date.utils";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 import { mockProposals } from "../../../mocks/proposals.store.mock";
 
-describe("ProposalCountdown", () => {
+describe("Countdown", () => {
   it("should render no countdown", () => {
-    const { container } = render(ProposalCountdown, {
+    const { container } = render(Countdown, {
       props: {
-        proposalInfo: {
-          ...mockProposals[0],
-          deadlineTimestampSeconds: undefined,
-        },
+        deadlineTimestampSeconds: undefined,
       },
     });
 
@@ -23,9 +20,9 @@ describe("ProposalCountdown", () => {
   });
 
   it("should render countdown", () => {
-    const { container } = render(ProposalCountdown, {
+    const { container } = render(Countdown, {
       props: {
-        proposalInfo: mockProposals[0],
+        deadlineTimestampSeconds: mockProposals[0].deadlineTimestampSeconds,
       },
     });
 

--- a/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsProposalCard from "$lib/components/proposals/NnsProposalCard.svelte";
+import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
+import { authStore } from "$lib/stores/auth.store";
+import { proposalsFiltersStore } from "$lib/stores/proposals.store";
+import { secondsToDuration } from "$lib/utils/date.utils";
+import type { Proposal, ProposalInfo } from "@dfinity/nns";
+import { GovernanceCanister, ProposalStatus, Topic } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
+import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
+import en from "../../../mocks/i18n.mock";
+import { mockProposals } from "../../../mocks/proposals.store.mock";
+
+describe("NnsProposalCard", () => {
+  const mockGovernanceCanister: MockGovernanceCanister =
+    new MockGovernanceCanister(mockProposals);
+
+  beforeEach(() => {
+    jest
+      .spyOn(GovernanceCanister, "create")
+      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
+  it("should render a proposal title", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    const firstProposal = mockProposals[0] as ProposalInfo;
+    expect(
+      getByText((firstProposal.proposal as Proposal).title as string)
+    ).toBeInTheDocument();
+  });
+
+  it("should render a proposal status", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(getByText(en.status.Open)).toBeInTheDocument();
+  });
+
+  it("should render a proposer", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(
+      getByText(`${mockProposals[0].proposer}`, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render a proposal id", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(
+      getByText(`${mockProposals[0].id}`, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render a proposal topic", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(
+      getByText(`${en.topics[Topic[mockProposals[0].topic]]}`, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should render a proposal a type", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(getByText(en.actions.RegisterKnownNeuron)).toBeInTheDocument();
+  });
+
+  it("should render deadline", () => {
+    const { getByText } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    const durationTillDeadline =
+      (mockProposals[0].deadlineTimestampSeconds as bigint) -
+      BigInt(Math.round(Date.now() / 1000));
+
+    const text = `${secondsToDuration(durationTillDeadline)} ${
+      en.proposal_detail.remaining
+    }`;
+
+    expect(getByText(text)).toBeInTheDocument();
+  });
+
+  it("should render accessible info without label", () => {
+    const { container } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: mockProposals[0],
+      },
+    });
+
+    expect(
+      container.querySelector(`[aria-label="${en.proposal_detail.id_prefix}"]`)
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        `[aria-label="${en.proposal_detail.type_prefix}"]`
+      )
+    ).not.toBeNull();
+  });
+
+  it("should render a specific color for the status", () => {
+    proposalsFiltersStore.filterStatus([
+      ...DEFAULT_PROPOSALS_FILTERS.status,
+      ProposalStatus.Executed,
+    ]);
+
+    const { container } = render(NnsProposalCard, {
+      props: {
+        proposalInfo: {
+          ...mockProposals[1],
+          status: ProposalStatus.Executed,
+        },
+      },
+    });
+
+    expect(container.querySelector(".success")).not.toBeNull();
+
+    proposalsFiltersStore.filterStatus(DEFAULT_PROPOSALS_FILTERS.status);
+  });
+});

--- a/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -3,50 +3,36 @@
  */
 
 import ProposalCard from "$lib/components/proposals/ProposalCard.svelte";
-import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
-import { authStore } from "$lib/stores/auth.store";
-import { proposalsFiltersStore } from "$lib/stores/proposals.store";
-import { secondsToDuration } from "$lib/utils/date.utils";
-import type { Proposal, ProposalInfo } from "@dfinity/nns";
-import { GovernanceCanister, ProposalStatus, Topic } from "@dfinity/nns";
+import { ProposalStatusColor } from "$lib/constants/proposals.constants";
+import { nowInSeconds, secondsToDuration } from "$lib/utils/date.utils";
+import { ProposalStatus } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
-import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
 import en from "../../../mocks/i18n.mock";
-import { mockProposals } from "../../../mocks/proposals.store.mock";
 
 describe("ProposalCard", () => {
-  const mockGovernanceCanister: MockGovernanceCanister =
-    new MockGovernanceCanister(mockProposals);
-
-  beforeEach(() => {
-    jest
-      .spyOn(GovernanceCanister, "create")
-      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
-
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-  });
-
-  it("should render a proposal title", () => {
+  const nowSeconds = Math.floor(nowInSeconds());
+  const props = {
+    hidden: false,
+    status: ProposalStatus.Open,
+    id: BigInt(112),
+    title: "Test Proposal",
+    color: ProposalStatusColor.PRIMARY,
+    topic: "Test Topic",
+    proposer: "1233444",
+    type: "Test Type",
+    deadlineTimestampSeconds: BigInt(nowSeconds + 3600),
+  };
+  it("should render a title", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
-    const firstProposal = mockProposals[0] as ProposalInfo;
-    expect(
-      getByText((firstProposal.proposal as Proposal).title as string)
-    ).toBeInTheDocument();
+    expect(getByText(props.title)).toBeInTheDocument();
   });
 
   it("should render a proposal status", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
     expect(getByText(en.status.Open)).toBeInTheDocument();
@@ -54,60 +40,43 @@ describe("ProposalCard", () => {
 
   it("should render a proposer", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
-    expect(
-      getByText(`${mockProposals[0].proposer}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(getByText(props.proposer, { exact: false })).toBeInTheDocument();
   });
 
   it("should render a proposal id", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
-    expect(
-      getByText(`${mockProposals[0].id}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(getByText(`${props.id}`, { exact: false })).toBeInTheDocument();
   });
 
   it("should render a proposal topic", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
-    expect(
-      getByText(`${en.topics[Topic[mockProposals[0].topic]]}`, { exact: false })
-    ).toBeInTheDocument();
+    expect(getByText(props.topic, { exact: false })).toBeInTheDocument();
   });
 
   it("should render a proposal a type", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
-    expect(getByText(en.actions.RegisterKnownNeuron)).toBeInTheDocument();
+    expect(getByText(props.type)).toBeInTheDocument();
   });
 
   it("should render deadline", () => {
     const { getByText } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
     const durationTillDeadline =
-      (mockProposals[0].deadlineTimestampSeconds as bigint) -
-      BigInt(Math.round(Date.now() / 1000));
+      props.deadlineTimestampSeconds - BigInt(nowSeconds);
 
     const text = `${secondsToDuration(durationTillDeadline)} ${
       en.proposal_detail.remaining
@@ -118,9 +87,7 @@ describe("ProposalCard", () => {
 
   it("should render accessible info without label", () => {
     const { container } = render(ProposalCard, {
-      props: {
-        proposalInfo: mockProposals[0],
-      },
+      props,
     });
 
     expect(
@@ -134,22 +101,13 @@ describe("ProposalCard", () => {
   });
 
   it("should render a specific color for the status", () => {
-    proposalsFiltersStore.filterStatus([
-      ...DEFAULT_PROPOSALS_FILTERS.status,
-      ProposalStatus.Executed,
-    ]);
-
     const { container } = render(ProposalCard, {
       props: {
-        proposalInfo: {
-          ...mockProposals[1],
-          status: ProposalStatus.Executed,
-        },
+        ...props,
+        color: ProposalStatusColor.SUCCESS,
       },
     });
 
     expect(container.querySelector(".success")).not.toBeNull();
-
-    proposalsFiltersStore.filterStatus(DEFAULT_PROPOSALS_FILTERS.status);
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -8,7 +8,6 @@ import { openSnsNeuronModal } from "$lib/utils/modals.utils";
 import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import { mockPrincipal } from "../../../../mocks/auth.store.mock";
 import en from "../../../../mocks/i18n.mock";
 import {
   mockSnsNeuron,
@@ -34,10 +33,9 @@ describe("SplitSnsNeuronButton", () => {
     neuron: {
       ...mockSnsNeuron,
     },
-    rootCanisterId: mockPrincipal,
     parameters: {
       ...snsNervousSystemParametersMock,
-      neuron_minimum_stake_e8s: [neuronMinimumStake],
+      neuron_minimum_stake_e8s: [neuronMinimumStake] as [bigint],
     },
     transactionFee,
     token: mockToken,


### PR DESCRIPTION
# Motivation

Refactor the ProposalCard into NnsProposalCard and a NNS agnostic one ProposalCard.

Preparing for adding Voting for SNS projects.

# Changes

* Split current ProposalCard into two: NnsProposalCard and ProposalCard.
* New ProposalCard expects primitive props and renders them in the UI.
* Refactored the rendering of ProposalCard to use KeyValuePair component.
* New NnsProposalCard expects a proposal, extracts the details and renders a ProposalCard.
* Refactor ProposalCountdown to Countdown and pass only the timestamp deadline in seconds to make it agnostic of NNS Proposal.

# Tests

* Tests for both splited components ProposalCard and NnsProposalCard.
* Fix other tests after change in props and renamings.
* Fix warning during test.
