### PR TITLE
Refactor: ProposalDetails components NNS agnostic

### DIFF
--- a/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
+++ b/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
@@ -31,7 +31,7 @@
   </p>
 
   <div class="summary">
-    <ProposalSummary proposal={proposal.proposal} />
+    <ProposalSummary summary={proposal.proposal.summary} />
   </div>
 {:else}
   <SkeletonText />

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import ProposalSystemInfoSection from "./ProposalSystemInfoSection.svelte";
-  import ProposalProposerInfoSection from "./ProposalProposerInfoSection.svelte";
+  import NnsProposalProposerInfoSection from "./NnsProposalProposerInfoSection.svelte";
   import ProposalVotingSection from "./ProposalVotingSection.svelte";
-  import ProposalProposerDataSection from "./ProposalProposerDataSection.svelte";
+  import NnsProposalProposerDataSection from "./NnsProposalProposerDataSection.svelte";
   import ProposalNavigation from "./ProposalNavigation.svelte";
   import { getContext } from "svelte";
   import {
@@ -27,9 +27,9 @@
       <ProposalVotingSection proposalInfo={$store.proposal} />
     </div>
     <div class="content-c">
-      <ProposalProposerInfoSection proposalInfo={$store.proposal} />
+      <NnsProposalProposerInfoSection proposalInfo={$store.proposal} />
 
-      <ProposalProposerDataSection proposalInfo={$store.proposal} />
+      <NnsProposalProposerDataSection proposalInfo={$store.proposal} />
     </div>
   </div>
 {:else}

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerActionsEntry.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import {
+    proposalActionFields,
+    proposalFirstActionKey,
+  } from "$lib/utils/proposals.utils";
+  import type { Proposal } from "@dfinity/nns";
+  import ProposalProposerActionsEntry from "./ProposalProposerActionsEntry.svelte";
+
+  export let proposal: Proposal | undefined;
+
+  let actionKey: string | undefined;
+  let actionFields: [string, unknown][] = [];
+  $: actionKey =
+    proposal !== undefined ? proposalFirstActionKey(proposal) : undefined;
+  $: actionFields =
+    proposal !== undefined ? proposalActionFields(proposal) : [];
+</script>
+
+<ProposalProposerActionsEntry {actionKey} {actionFields} />

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerDataSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerDataSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ProposalInfo } from "@dfinity/nns";
-  import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
-  import ProposalProposerActionsEntry from "./ProposalProposerActionsEntry.svelte";
+  import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
+  import NnsProposalProposerActionsEntry from "./NnsProposalProposerActionsEntry.svelte";
   import type { Proposal, ProposalId } from "@dfinity/nns";
   import { mapProposalInfo } from "$lib/utils/proposals.utils";
 
@@ -13,7 +13,7 @@
 </script>
 
 {#if proposal !== undefined}
-  <ProposalProposerActionsEntry {proposal} />
+  <NnsProposalProposerActionsEntry {proposal} />
 
-  <ProposalProposerPayloadEntry {proposal} proposalId={id} />
+  <NnsProposalProposerPayloadEntry {proposal} proposalId={id} />
 {/if}

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerInfoSection.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { mapProposalInfo } from "$lib/utils/proposals.utils";
+  import type { Proposal } from "@dfinity/nns";
+  import ProposalProposerInfoSection from "./ProposalProposerInfoSection.svelte";
+
+  export let proposalInfo: ProposalInfo;
+
+  let title: string | undefined;
+  let proposal: Proposal | undefined;
+  let url: string | undefined;
+
+  $: ({ title, proposal, url } = mapProposalInfo(proposalInfo));
+</script>
+
+<ProposalProposerInfoSection {title} summary={proposal?.summary} {url} />

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { ProposalId } from "@dfinity/nns";
+  import { loadProposalPayload } from "$lib/services/$public/proposals.services";
+  import { proposalPayloadsStore } from "$lib/stores/proposals.store";
+  import type { Proposal } from "@dfinity/nns";
+  import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
+  import { expandObject, isNullish } from "$lib/utils/utils";
+  import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
+
+  export let proposalId: ProposalId | undefined;
+  export let proposal: Proposal | undefined;
+
+  let payload: object | undefined | null;
+  let expandedPayload: object | undefined | null;
+  $: expandedPayload = isNullish(payload)
+    ? payload
+    : expandObject(payload as Record<string, unknown>);
+
+  $: $proposalPayloadsStore,
+    (payload =
+      proposalId !== undefined
+        ? $proposalPayloadsStore.get(proposalId)
+        : undefined);
+  $: if (
+    proposalId !== undefined &&
+    nnsFunctionKey !== undefined &&
+    !$proposalPayloadsStore.has(proposalId)
+  ) {
+    loadProposalPayload({
+      proposalId,
+    });
+  }
+
+  let nnsFunctionKey: string | undefined;
+  $: nnsFunctionKey = getNnsFunctionKey(proposal);
+</script>
+
+<ProposalProposerPayloadEntry {payload} />

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
@@ -4,17 +4,15 @@
   import { proposalPayloadsStore } from "$lib/stores/proposals.store";
   import type { Proposal } from "@dfinity/nns";
   import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
-  import { expandObject, isNullish } from "$lib/utils/utils";
   import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
 
   export let proposalId: ProposalId | undefined;
   export let proposal: Proposal | undefined;
 
   let payload: object | undefined | null;
-  let expandedPayload: object | undefined | null;
-  $: expandedPayload = isNullish(payload)
-    ? payload
-    : expandObject(payload as Record<string, unknown>);
+  // Only proposals with nnsFunctionKey and proposalId have payload
+  let nnsFunctionKey: string | undefined;
+  $: nnsFunctionKey = getNnsFunctionKey(proposal);
 
   $: $proposalPayloadsStore,
     (payload =
@@ -30,9 +28,9 @@
       proposalId,
     });
   }
-
-  let nnsFunctionKey: string | undefined;
-  $: nnsFunctionKey = getNnsFunctionKey(proposal);
 </script>
 
-<ProposalProposerPayloadEntry {payload} />
+<!-- Only proposals with nnsFunctionKey and proposalId have payload -->
+{#if nnsFunctionKey !== undefined && proposalId !== undefined}
+  <ProposalProposerPayloadEntry {payload} />
+{/if}

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -1,20 +1,9 @@
 <script lang="ts">
-  import {
-    proposalActionFields,
-    proposalFirstActionKey,
-  } from "$lib/utils/proposals.utils";
-  import type { Proposal } from "@dfinity/nns";
   import Json from "../common/Json.svelte";
   import { KeyValuePair } from "@dfinity/gix-components";
 
-  export let proposal: Proposal | undefined;
-
-  let actionKey: string | undefined;
-  let actionFields: [string, unknown][] = [];
-  $: actionKey =
-    proposal !== undefined ? proposalFirstActionKey(proposal) : undefined;
-  $: actionFields =
-    proposal !== undefined ? proposalActionFields(proposal) : [];
+  export let actionKey: string | undefined;
+  export let actionFields: [string, unknown][] = [];
 </script>
 
 <div class="content-cell-island">

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerInfoSection.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
-  import type { ProposalInfo } from "@dfinity/nns";
-  import { mapProposalInfo } from "$lib/utils/proposals.utils";
   import ProposalSummary from "./ProposalSummary.svelte";
-  import type { Proposal } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
 
-  export let proposalInfo: ProposalInfo;
-
-  let title: string | undefined;
-  let proposal: Proposal | undefined;
-  let url: string | undefined;
-
-  $: ({ title, proposal, url } = mapProposalInfo(proposalInfo));
+  export let title: string | undefined;
+  export let summary: string | undefined;
+  export let url: string | undefined;
 </script>
 
 <div class="content-cell-island">
@@ -20,7 +13,7 @@
   </h2>
 
   <div class="content-cell-details">
-    <ProposalSummary {proposal}>
+    <ProposalSummary {summary}>
       <svelte:fragment slot="title">
         <h1>{title ?? ""}</h1>
 

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -5,7 +5,7 @@
   import { expandObject, isNullish } from "$lib/utils/utils";
 
   // `undefined` means that the payload is not loaded yet
-  // `null` means that the payload is `null`
+  // `null` means that the payload was not found
   // `object` means that the payload is an object
   export let payload: object | undefined | null;
   let expandedPayload: object | undefined | null;

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -4,6 +4,9 @@
   import { SkeletonText } from "@dfinity/gix-components";
   import { expandObject, isNullish } from "$lib/utils/utils";
 
+  // `undefined` means that the payload is not loaded yet
+  // `null` means that the payload is `null`
+  // `object` means that the payload is an object
   export let payload: object | undefined | null;
   let expandedPayload: object | undefined | null;
   $: expandedPayload = isNullish(payload)
@@ -11,28 +14,27 @@
     : expandObject(payload as Record<string, unknown>);
 </script>
 
-{#if payload !== undefined && payload !== null}
-  <div class="content-cell-island">
-    <h2
-      class="content-cell-title"
-      data-tid="proposal-proposer-payload-entry-title"
-    >
-      {$i18n.proposal_detail.payload}
-    </h2>
+<div class="content-cell-island">
+  <h2
+    class="content-cell-title"
+    data-tid="proposal-proposer-payload-entry-title"
+  >
+    {$i18n.proposal_detail.payload}
+  </h2>
 
-    <div class="content-cell-details">
-      {#if expandedPayload !== undefined}
-        <div class="json" data-tid="json-wrapper">
-          <Json json={expandedPayload} />
-        </div>
-      {:else}
-        <SkeletonText />
-        <SkeletonText />
-        <SkeletonText />
-      {/if}
-    </div>
+  <div class="content-cell-details">
+    <!-- `null` payload should be shown as `null` -->
+    {#if expandedPayload !== undefined}
+      <div class="json" data-tid="json-wrapper">
+        <Json json={expandedPayload} />
+      </div>
+    {:else}
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+    {/if}
   </div>
-{/if}
+</div>
 
 <style lang="scss">
   .content-cell-island {

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -1,43 +1,17 @@
 <script lang="ts">
-  import type { ProposalId } from "@dfinity/nns";
   import Json from "../common/Json.svelte";
-  import { loadProposalPayload } from "$lib/services/$public/proposals.services";
-  import { proposalPayloadsStore } from "$lib/stores/proposals.store";
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
-  import type { Proposal } from "@dfinity/nns";
-  import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
   import { expandObject, isNullish } from "$lib/utils/utils";
 
-  export let proposalId: ProposalId | undefined;
-  export let proposal: Proposal | undefined;
-
-  let payload: object | undefined | null;
+  export let payload: object | undefined | null;
   let expandedPayload: object | undefined | null;
   $: expandedPayload = isNullish(payload)
     ? payload
     : expandObject(payload as Record<string, unknown>);
-
-  $: $proposalPayloadsStore,
-    (payload =
-      proposalId !== undefined
-        ? $proposalPayloadsStore.get(proposalId)
-        : undefined);
-  $: if (
-    proposalId !== undefined &&
-    nnsFunctionKey !== undefined &&
-    !$proposalPayloadsStore.has(proposalId)
-  ) {
-    loadProposalPayload({
-      proposalId,
-    });
-  }
-
-  let nnsFunctionKey: string | undefined;
-  $: nnsFunctionKey = getNnsFunctionKey(proposal);
 </script>
 
-{#if nnsFunctionKey !== undefined && proposalId !== undefined}
+{#if payload !== undefined && payload !== null}
   <div class="content-cell-island">
     <h2
       class="content-cell-title"

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-  import type { Proposal } from "@dfinity/nns";
   import Markdown from "$lib/components/ui/Markdown.svelte";
 
-  export let proposal: Proposal | undefined;
-
-  let summary: string | undefined;
-  $: summary = proposal?.summary;
+  export let summary: string | undefined;
 
   let showTitle: boolean;
   $: showTitle = $$slots.title !== undefined;

--- a/frontend/src/lib/pages/ProposalDetail.svelte
+++ b/frontend/src/lib/pages/ProposalDetail.svelte
@@ -11,7 +11,7 @@
   } from "$lib/types/selected-proposal.context";
   import { SELECTED_PROPOSAL_CONTEXT_KEY } from "$lib/types/selected-proposal.context";
   import { debugSelectedProposalStore } from "$lib/stores/debug.store";
-  import Proposal from "$lib/components/proposal-detail/Proposal.svelte";
+  import NnsProposal from "$lib/components/proposal-detail/NnsProposal.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
   import { authStore } from "$lib/stores/auth.store";
@@ -112,5 +112,5 @@
 </script>
 
 <main>
-  <Proposal />
+  <NnsProposal />
 </main>

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -4,7 +4,7 @@
 
 import { render, waitFor } from "@testing-library/svelte";
 import { mockProposalInfo } from "../../../mocks/proposal.mock";
-import ProposalTest from "./ProposalTest.svelte";
+import NnsProposalTest from "./NnsProposalTest.svelte";
 
 jest.mock("$lib/utils/html.utils", () => ({
   markdownToHTML: (value) => Promise.resolve(value),
@@ -12,7 +12,7 @@ jest.mock("$lib/utils/html.utils", () => ({
 
 describe("Proposal", () => {
   const renderProposalModern = () =>
-    render(ProposalTest, {
+    render(NnsProposalTest, {
       props: {
         proposalInfo: mockProposalInfo,
       },

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerActionsEntry.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsProposalProposerActionsEntry from "$lib/components/proposal-detail/NnsProposalProposerActionsEntry.svelte";
+import { proposalFirstActionKey } from "$lib/utils/proposals.utils";
+import type { Action, Proposal } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import {
+  mockProposalInfo,
+  proposalActionMotion,
+  proposalActionNnsFunction21,
+  proposalActionRewardNodeProvider,
+} from "../../../mocks/proposal.mock";
+
+const proposalWithMotionAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionMotion,
+} as Proposal;
+
+const proposalWithRewardNodeProviderAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionRewardNodeProvider,
+} as Proposal;
+
+const actionWithUndefined = {
+  Motion: {
+    motionText: undefined,
+  },
+} as Action;
+
+const proposalWithActionWithUndefined = {
+  ...mockProposalInfo.proposal,
+  action: actionWithUndefined,
+} as Proposal;
+
+describe("NnsProposalProposerActionsEntry", () => {
+  it("should render action key", () => {
+    const { getByText } = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithMotionAction,
+      },
+    });
+
+    const key = proposalFirstActionKey(proposalWithMotionAction) as string;
+    expect(getByText(key)).toBeInTheDocument();
+  });
+
+  it("should render action fields", () => {
+    const { getByText } = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithMotionAction,
+      },
+    });
+
+    const [key, value] = Object.entries(
+      (proposalWithMotionAction?.action as { Motion: object }).Motion
+    )[0];
+    expect(getByText(key)).toBeInTheDocument();
+    expect(getByText(value)).toBeInTheDocument();
+  });
+
+  it("should render object fields as JSON", () => {
+    const nodeProviderActions = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithRewardNodeProviderAction,
+      },
+    });
+
+    expect(nodeProviderActions.queryAllByTestId("json").length).toBe(2);
+  });
+
+  it("should render text fields as plane text", () => {
+    const motionActions = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithMotionAction,
+      },
+    });
+
+    expect(motionActions.queryAllByTestId("json").length).toBe(0);
+  });
+
+  it("should render undefined fields as 'undefined'", () => {
+    const { getByText } = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithActionWithUndefined,
+      },
+    });
+
+    expect(getByText("undefined")).toBeInTheDocument();
+  });
+
+  it("should render nnsFunction id", () => {
+    const proposalWithNnsFunctionAction = {
+      ...mockProposalInfo.proposal,
+      action: proposalActionNnsFunction21,
+    } as Proposal;
+
+    const { getByText } = render(NnsProposalProposerActionsEntry, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+      },
+    });
+
+    const [key, value] = Object.entries(
+      (
+        proposalWithNnsFunctionAction?.action as {
+          ExecuteNnsFunction: object;
+        }
+      ).ExecuteNnsFunction
+    )[0];
+
+    expect(getByText(key)).toBeInTheDocument();
+    expect(getByText(value)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerDataSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerDataSection.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
-import ProposalProposerDataSection from "$lib/components/proposal-detail/ProposalProposerDataSection.svelte";
+import NnsProposalProposerDataSection from "$lib/components/proposal-detail/NnsProposalProposerDataSection.svelte";
 import type { Proposal } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
@@ -12,7 +12,7 @@ import {
   proposalActionNnsFunction21,
 } from "../../../mocks/proposal.mock";
 
-describe("ProposalProposerDataSection", () => {
+describe("NnsProposalProposerDataSection", () => {
   const nnsDappMock = mock<NNSDappCanister>();
   nnsDappMock.getProposalPayload.mockResolvedValue({});
   jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
@@ -23,7 +23,7 @@ describe("ProposalProposerDataSection", () => {
   } as Proposal;
 
   it("should render entries", async () => {
-    const renderResult = render(ProposalProposerDataSection, {
+    const renderResult = render(NnsProposalProposerDataSection, {
       props: {
         proposalInfo: {
           ...mockProposalInfo,

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerInfoSection.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsProposalProposerInfoSection from "$lib/components/proposal-detail/NnsProposalProposerInfoSection.svelte";
+import { mapProposalInfo } from "$lib/utils/proposals.utils";
+import { render, waitFor } from "@testing-library/svelte";
+import { mockProposalInfo } from "../../../mocks/proposal.mock";
+
+jest.mock("$lib/utils/html.utils", () => ({
+  markdownToHTML: (value) => Promise.resolve(value),
+}));
+
+describe("NnsProposalProposerInfoSection", () => {
+  const { title, proposal, url } = mapProposalInfo(mockProposalInfo);
+
+  it("should render title", () => {
+    const renderResult = render(NnsProposalProposerInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByText } = renderResult;
+    expect(getByText(title as string)).toBeInTheDocument();
+  });
+
+  it("should render summary", async () => {
+    const renderResult = render(NnsProposalProposerInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByText } = renderResult;
+    await waitFor(() =>
+      expect(getByText(proposal?.summary as string)).toBeInTheDocument()
+    );
+  });
+
+  it("should render url", async () => {
+    const renderResult = render(NnsProposalProposerInfoSection, {
+      props: {
+        proposalInfo: mockProposalInfo,
+      },
+    });
+
+    const { getByText } = renderResult;
+    await waitFor(() => expect(getByText(url as string)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
+import NnsProposalProposerPayloadEntry from "$lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte";
+import { proposalPayloadsStore } from "$lib/stores/proposals.store";
+import type { Proposal } from "@dfinity/nns";
+import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
+import {
+  mockProposalInfo,
+  proposalActionNnsFunction21,
+} from "../../../mocks/proposal.mock";
+import { simplifyJson } from "../common/Json.spec";
+
+const proposalWithNnsFunctionAction = {
+  ...mockProposalInfo.proposal,
+  action: proposalActionNnsFunction21,
+} as Proposal;
+
+describe("NnsProposalProposerPayloadEntry", () => {
+  const nnsDappMock = mock<NNSDappCanister>();
+  jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
+
+  const nestedObj = { b: "c" };
+  const payloadWithJsonString = {
+    a: JSON.stringify(nestedObj),
+  };
+
+  afterAll(jest.clearAllMocks);
+
+  beforeEach(() => proposalPayloadsStore.reset);
+  it("should trigger getProposalPayload", async () => {
+    const nestedObj = { b: "c" };
+    const payloadWithJsonString = {
+      a: JSON.stringify(nestedObj),
+    };
+    const spyGetProposalPayload = jest
+      .spyOn(nnsDappMock, "getProposalPayload")
+      .mockImplementation(async () => payloadWithJsonString);
+    render(NnsProposalProposerPayloadEntry, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    await waitFor(() => expect(spyGetProposalPayload).toBeCalledTimes(1));
+  });
+
+  it("should parse JSON strings and render them", async () => {
+    jest
+      .spyOn(nnsDappMock, "getProposalPayload")
+      .mockImplementation(async () => payloadWithJsonString);
+    const { queryByTestId } = render(NnsProposalProposerPayloadEntry, {
+      props: {
+        proposal: proposalWithNnsFunctionAction,
+        proposalId: mockProposalInfo.id,
+      },
+    });
+
+    const jsonElement = queryByTestId("json-wrapper");
+    await waitFor(() =>
+      expect(simplifyJson(jsonElement.textContent)).toBe(
+        simplifyJson(JSON.stringify({ a: nestedObj }))
+      )
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalTest.svelte
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { setContext } from "svelte";
-  import { ProposalInfo } from "@dfinity/nns";
-  import Proposal from "$lib/components/proposal-detail/Proposal.svelte";
+  import type { ProposalInfo } from "@dfinity/nns";
+  import NnsProposal from "$lib/components/proposal-detail/NnsProposal.svelte";
   import {
     SELECTED_PROPOSAL_CONTEXT_KEY,
     type SelectedProposalStore,
@@ -18,4 +18,4 @@
   setContext(SELECTED_PROPOSAL_CONTEXT_KEY, { store });
 </script>
 
-<Proposal />
+<NnsProposal />

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerActionsEntry.spec.ts
@@ -3,67 +3,46 @@
  */
 
 import ProposalProposerActionsEntry from "$lib/components/proposal-detail/ProposalProposerActionsEntry.svelte";
-import { proposalFirstActionKey } from "$lib/utils/proposals.utils";
-import type { Action, Proposal } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import {
-  mockProposalInfo,
-  proposalActionMotion,
-  proposalActionNnsFunction21,
-  proposalActionRewardNodeProvider,
-} from "../../../mocks/proposal.mock";
-
-const proposalWithMotionAction = {
-  ...mockProposalInfo.proposal,
-  action: proposalActionMotion,
-} as Proposal;
-
-const proposalWithRewardNodeProviderAction = {
-  ...mockProposalInfo.proposal,
-  action: proposalActionRewardNodeProvider,
-} as Proposal;
-
-const actionWithUndefined = {
-  Motion: {
-    motionText: undefined,
-  },
-} as Action;
-
-const proposalWithActionWithUndefined = {
-  ...mockProposalInfo.proposal,
-  action: actionWithUndefined,
-} as Proposal;
 
 describe("ProposalProposerActionsEntry", () => {
   it("should render action key", () => {
     const { getByText } = render(ProposalProposerActionsEntry, {
       props: {
-        proposal: proposalWithMotionAction,
+        actionKey: "actionKey",
+        actionFields: [],
       },
     });
 
-    const key = proposalFirstActionKey(proposalWithMotionAction) as string;
-    expect(getByText(key)).toBeInTheDocument();
+    expect(getByText("actionKey")).toBeInTheDocument();
   });
 
   it("should render action fields", () => {
+    const key = "key";
+    const value = "value";
     const { getByText } = render(ProposalProposerActionsEntry, {
       props: {
-        proposal: proposalWithMotionAction,
+        actionKey: "actionKey",
+        actionFields: [[key, value]],
       },
     });
 
-    const [key, value] = Object.entries(
-      (proposalWithMotionAction?.action as { Motion: object }).Motion
-    )[0];
     expect(getByText(key)).toBeInTheDocument();
     expect(getByText(value)).toBeInTheDocument();
   });
 
   it("should render object fields as JSON", () => {
+    const key = "key";
+    const value = { key: "value" };
+    const key2 = "key2";
+    const value2 = { key: "value" };
     const nodeProviderActions = render(ProposalProposerActionsEntry, {
       props: {
-        proposal: proposalWithRewardNodeProviderAction,
+        actionKey: "actionKey",
+        actionFields: [
+          [key, value],
+          [key2, value2],
+        ],
       },
     });
 
@@ -71,9 +50,12 @@ describe("ProposalProposerActionsEntry", () => {
   });
 
   it("should render text fields as plane text", () => {
+    const key = "key";
+    const value = "value";
     const motionActions = render(ProposalProposerActionsEntry, {
       props: {
-        proposal: proposalWithMotionAction,
+        actionKey: "actionKey",
+        actionFields: [[key, value]],
       },
     });
 
@@ -81,36 +63,15 @@ describe("ProposalProposerActionsEntry", () => {
   });
 
   it("should render undefined fields as 'undefined'", () => {
+    const key = "key";
+    const value = { key: "value", anotherKey: undefined };
     const { getByText } = render(ProposalProposerActionsEntry, {
       props: {
-        proposal: proposalWithActionWithUndefined,
+        actionKey: "actionKey",
+        actionFields: [[key, value]],
       },
     });
 
     expect(getByText("undefined")).toBeInTheDocument();
-  });
-
-  it("should render nnsFunction id", () => {
-    const proposalWithNnsFunctionAction = {
-      ...mockProposalInfo.proposal,
-      action: proposalActionNnsFunction21,
-    } as Proposal;
-
-    const { getByText } = render(ProposalProposerActionsEntry, {
-      props: {
-        proposal: proposalWithNnsFunctionAction,
-      },
-    });
-
-    const [key, value] = Object.entries(
-      (
-        proposalWithNnsFunctionAction?.action as {
-          ExecuteNnsFunction: object;
-        }
-      ).ExecuteNnsFunction
-    )[0];
-
-    expect(getByText(key)).toBeInTheDocument();
-    expect(getByText(value)).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerInfoSection.spec.ts
@@ -1,24 +1,22 @@
 /**
  * @jest-environment jsdom
  */
-
 import ProposalProposerInfoSection from "$lib/components/proposal-detail/ProposalProposerInfoSection.svelte";
-import { mapProposalInfo } from "$lib/utils/proposals.utils";
 import { render, waitFor } from "@testing-library/svelte";
-import { mockProposalInfo } from "../../../mocks/proposal.mock";
 
 jest.mock("$lib/utils/html.utils", () => ({
   markdownToHTML: (value) => Promise.resolve(value),
 }));
 
 describe("ProposalProposerInfoSection", () => {
-  const { title, proposal, url } = mapProposalInfo(mockProposalInfo);
+  const title = "title";
+  const summary = "# Some Summary";
+  const url = "https://nns.ic0.app/";
+  const props = { title, summary, url };
 
   it("should render title", () => {
     const renderResult = render(ProposalProposerInfoSection, {
-      props: {
-        proposalInfo: mockProposalInfo,
-      },
+      props,
     });
 
     const { getByText } = renderResult;
@@ -27,25 +25,19 @@ describe("ProposalProposerInfoSection", () => {
 
   it("should render summary", async () => {
     const renderResult = render(ProposalProposerInfoSection, {
-      props: {
-        proposalInfo: mockProposalInfo,
-      },
+      props,
     });
 
     const { getByText } = renderResult;
-    await waitFor(() =>
-      expect(getByText(proposal?.summary as string)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(getByText(summary)).toBeInTheDocument());
   });
 
   it("should render url", async () => {
     const renderResult = render(ProposalProposerInfoSection, {
-      props: {
-        proposalInfo: mockProposalInfo,
-      },
+      props,
     });
 
     const { getByText } = renderResult;
-    await waitFor(() => expect(getByText(url as string)).toBeInTheDocument());
+    await waitFor(() => expect(getByText(url)).toBeInTheDocument());
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
@@ -1,69 +1,27 @@
 /**
  * @jest-environment jsdom
  */
-
-import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import ProposalProposerPayloadEntry from "$lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte";
-import { proposalPayloadsStore } from "$lib/stores/proposals.store";
-import type { Proposal } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
-import { mock } from "jest-mock-extended";
-import {
-  mockProposalInfo,
-  proposalActionNnsFunction21,
-} from "../../../mocks/proposal.mock";
 import { simplifyJson } from "../common/Json.spec";
 
-const proposalWithNnsFunctionAction = {
-  ...mockProposalInfo.proposal,
-  action: proposalActionNnsFunction21,
-} as Proposal;
-
 describe("ProposalProposerPayloadEntry", () => {
-  const nnsDappMock = mock<NNSDappCanister>();
-  jest.spyOn(NNSDappCanister, "create").mockImplementation(() => nnsDappMock);
-
   const nestedObj = { b: "c" };
   const payloadWithJsonString = {
     a: JSON.stringify(nestedObj),
   };
 
-  afterAll(jest.clearAllMocks);
-
-  beforeEach(() => proposalPayloadsStore.reset);
-  it("should trigger getProposalPayload", async () => {
-    const nestedObj = { b: "c" };
-    const payloadWithJsonString = {
-      a: JSON.stringify(nestedObj),
-    };
-    const spyGetProposalPayload = jest
-      .spyOn(nnsDappMock, "getProposalPayload")
-      .mockImplementation(async () => payloadWithJsonString);
-    render(ProposalProposerPayloadEntry, {
-      props: {
-        proposal: proposalWithNnsFunctionAction,
-        proposalId: mockProposalInfo.id,
-      },
-    });
-
-    await waitFor(() => expect(spyGetProposalPayload).toBeCalledTimes(1));
-  });
-
   it("should parse JSON strings and render them", async () => {
-    jest
-      .spyOn(nnsDappMock, "getProposalPayload")
-      .mockImplementation(async () => payloadWithJsonString);
     const { queryByTestId } = render(ProposalProposerPayloadEntry, {
       props: {
-        proposal: proposalWithNnsFunctionAction,
-        proposalId: mockProposalInfo.id,
+        payload: payloadWithJsonString,
       },
     });
 
     const jsonElement = queryByTestId("json-wrapper");
     await waitFor(() =>
       expect(simplifyJson(jsonElement.textContent)).toBe(
-        simplifyJson(JSON.stringify({ a: nestedObj }))
+        simplifyJson(JSON.stringify(payloadWithJsonString))
       )
     );
   });


### PR DESCRIPTION
# Motivation

Split some cards in ProposalDetails into NNS specific and NNS agnostic.

Preparing for adding Voting for SNS projects.

# Changes

* Change prop in ProposalSummary to be just the string summary.
* Split current ProposalProposerInfoSection into NnsProposalProposerInfoSection and ProposalProposerInfoSection.
* Split current ProposalProposerDataSection into NnsProposalProposerDataSection and ProposalProposerDataSection.
* Split current ProposalProposerActionsEntry into NnsProposalProposerActionsEntry and ProposalProposerActionsEntry.
* Split current ProposalProposerPayloadEntry into NnsProposalProposerPayloadEntry and ProposalProposerPayloadEntry.
* Rename Proposal.svelte to NnsProposal.svelte.

# Tests

* Adapt tests after refactor.
