### PR TITLE
GIX-1209: Setup SNS proposals list page

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -116,7 +116,8 @@
         "OWN_CANISTER_URL": "https://nns.ic0.app",
         "IDENTITY_SERVICE_URL": "https://identity.ic0.app/",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": false
+          "ENABLE_SNS_2": false,
+          "ENABLE_SNS_VOTING": false
         }
       },
       "providers": [
@@ -129,7 +130,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": false
+          "ENABLE_SNS_2": false,
+          "ENABLE_SNS_VOTING": false
         }
       },
       "providers": [
@@ -142,7 +144,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -155,7 +158,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small14.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -168,7 +172,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small13.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -181,7 +186,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small12.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -194,7 +200,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small11.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -207,7 +214,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://large02.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -220,7 +228,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small09.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -233,7 +242,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "https://small06.dfinity.network",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "providers": [
@@ -246,7 +256,8 @@
         "FETCH_ROOT_KEY": true,
         "HOST": "http://localhost:8080",
         "FEATURE_FLAGS": {
-          "ENABLE_SNS_2": true
+          "ENABLE_SNS_2": true,
+          "ENABLE_SNS_VOTING": true
         }
       },
       "bind": "127.0.0.1:8080",

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -34,6 +34,7 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
   FETCH_ROOT_KEY: false,
   WASM_CANISTER_ID: "u7xn3-ciaaa-aaaaa-aaa4a-cai",
   ENABLE_SNS_2: true,
+  ENABLE_SNS_VOTING: true,
   STAKE_MATURITY: true,
 }));
 

--- a/frontend/src/lib/components/common/RouteModule.svelte
+++ b/frontend/src/lib/components/common/RouteModule.svelte
@@ -17,7 +17,7 @@
       case AppPath.Neurons:
         return (await import("../../routes/Neurons.svelte")).default;
       case AppPath.Proposals:
-        return (await import("../../pages/Proposals.svelte")).default;
+        return (await import("../../routes/Proposals.svelte")).default;
       case AppPath.Canisters:
         return (await import("../../pages/Canisters.svelte")).default;
       case AppPath.Wallet:

--- a/frontend/src/lib/components/proposals/ProposalsFilters.svelte
+++ b/frontend/src/lib/components/proposals/ProposalsFilters.svelte
@@ -43,7 +43,7 @@
   ).length;
 </script>
 
-<div class="filters">
+<div class="filters" data-tid="nns-proposal-filters">
   <FiltersButton
     testId="filters-by-topics"
     totalFilters={totalFiltersTopic}

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -7,11 +7,12 @@ export const WASM_CANISTER_ID = import.meta.env.VITE_WASM_CANISTER_ID;
 
 interface FEATURE_FLAGS {
   ENABLE_SNS_2: boolean;
+  ENABLE_SNS_VOTING: boolean;
 }
 
-export const { ENABLE_SNS_2 }: FEATURE_FLAGS = JSON.parse(
+export const { ENABLE_SNS_2, ENABLE_SNS_VOTING }: FEATURE_FLAGS = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
-    '{"ENABLE_SNS_2":false}'
+    '{"ENABLE_SNS_2":false,"ENABLE_SNS_VOTING": false}'
 );
 
 export const IS_TESTNET: boolean =

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -26,11 +26,12 @@
   import { authStore } from "$lib/stores/auth.store";
 
   export let referrerPath: AppPath | undefined = undefined;
+  // It's exported so that we can test the value
+  export let disableInfiniteScroll = false;
 
   let loading = false;
   let hidden = false;
   let initialized = false;
-  let disableInfiniteScroll = false;
 
   const loadFinished = ({ paginationOver }: { paginationOver: boolean }) => {
     loading = false;
@@ -155,13 +156,11 @@
     : "skeleton";
 </script>
 
-<main data-tid={`proposals-scroll-${disableInfiniteScroll ? "off" : "on"}`}>
-  <ProposalsList
-    {hidden}
-    {nothingFound}
-    {disableInfiniteScroll}
-    {loading}
-    {loadingAnimation}
-    on:nnsIntersect={findNextProposals}
-  />
-</main>
+<ProposalsList
+  {hidden}
+  {nothingFound}
+  {disableInfiniteScroll}
+  {loading}
+  {loadingAnimation}
+  on:nnsIntersect={findNextProposals}
+/>

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -1,1 +1,16 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
+  import { buildProposalsUrl } from "$lib/utils/navigation.utils";
+  import { onMount } from "svelte";
+
+  onMount(() => {
+    // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
+    if (!ENABLE_SNS_VOTING) {
+      goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }));
+    }
+  });
+</script>
+
 <div data-tid="sns-proposals-page">To be developed</div>

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -1,0 +1,1 @@
+<div data-tid="sns-proposals-page">To be developed</div>

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -13,7 +13,7 @@
   {#if ENABLE_SNS_VOTING}
     <Summary />
   {/if}
-  {#if $isNnsProjectStore}
+  {#if $isNnsProjectStore || !ENABLE_SNS_VOTING}
     <Proposals />
   {:else if $snsProjectIdSelectedStore !== undefined && ENABLE_SNS_VOTING}
     <SnsProposals />

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Proposals from "$lib/pages/NnsProposals.svelte";
+  import {
+    isNnsProjectStore,
+    snsProjectIdSelectedStore,
+  } from "$lib/derived/selected-project.derived";
+  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
+  import SnsProposals from "$lib/pages/SnsProposals.svelte";
+  import Summary from "$lib/components/summary/Summary.svelte";
+</script>
+
+<main>
+  {#if ENABLE_SNS_VOTING}
+    <Summary />
+  {/if}
+  {#if $isNnsProjectStore}
+    <Proposals />
+  {:else if $snsProjectIdSelectedStore !== undefined && ENABLE_SNS_VOTING}
+    <SnsProposals />
+  {/if}
+</main>

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
-import Proposals from "$lib/pages/Proposals.svelte";
+import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { authStore, type AuthStore } from "$lib/stores/auth.store";
 import { neuronsStore, type NeuronsStore } from "$lib/stores/neurons.store";
 import {
@@ -35,7 +35,7 @@ import {
   mockProposalsStoreSubscribe,
 } from "../../mocks/proposals.store.mock";
 
-describe("Proposals", () => {
+describe("NnsProposals", () => {
   const nothingFound = (
     container: HTMLElement
   ): HTMLParagraphElement | undefined =>
@@ -79,7 +79,7 @@ describe("Proposals", () => {
       );
 
       it("should render filters", () => {
-        const { getByText } = render(Proposals);
+        const { getByText } = render(NnsProposals);
 
         expect(getByText("Topics")).toBeInTheDocument();
         expect(getByText("Reward Status")).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe("Proposals", () => {
       });
 
       it("should render a spinner while searching proposals", async () => {
-        const { getByTestId } = render(Proposals);
+        const { getByTestId } = render(NnsProposals);
 
         proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
 
@@ -104,7 +104,7 @@ describe("Proposals", () => {
       it("should render proposals", () => {
         mockLoadProposals();
 
-        const { getByText } = render(Proposals);
+        const { getByText } = render(NnsProposals);
 
         const firstProposal = mockProposals[0] as ProposalInfo;
         const secondProposal = mockProposals[1] as ProposalInfo;
@@ -123,7 +123,7 @@ describe("Proposals", () => {
           .spyOn(neuronsStore, "subscribe")
           .mockImplementation(buildMockNeuronsStoreSubscribe([mockNeuron]));
 
-        const { container } = render(Proposals);
+        const { container } = render(NnsProposals);
 
         proposalsFiltersStore.toggleExcludeVotedProposals();
 
@@ -137,15 +137,19 @@ describe("Proposals", () => {
       it("should disable infinite scroll when all proposals loaded", async () => {
         mockLoadProposals();
 
-        const { getByTestId } = render(Proposals);
+        const { component } = render(NnsProposals);
 
+        // How to check the value of a prop in a Svelte component
+        // https://github.com/testing-library/svelte-testing-library/issues/117
         await waitFor(() =>
-          expect(getByTestId("proposals-scroll-off")).not.toBeNull()
+          expect(
+            component.$$.ctx[component.$$.props["disableInfiniteScroll"]]
+          ).toBe(false)
         );
       });
 
       it("should not render not found text on init", () => {
-        const { container } = render(Proposals);
+        const { container } = render(NnsProposals);
 
         const p: HTMLParagraphElement | undefined = nothingFound(container);
 
@@ -168,7 +172,7 @@ describe("Proposals", () => {
           .spyOn(proposalsStore, "subscribe")
           .mockImplementation(mockEmptyProposalsStoreSubscribe);
 
-        const { container } = render(Proposals);
+        const { container } = render(NnsProposals);
 
         await waitFor(() => {
           const p: HTMLParagraphElement | undefined = nothingFound(container);
@@ -209,7 +213,7 @@ describe("Proposals", () => {
       it("should render proposals", () => {
         mockLoadProposals();
 
-        const { getByText } = render(Proposals);
+        const { getByText } = render(NnsProposals);
 
         const firstProposal = mockProposals[0] as ProposalInfo;
         const secondProposal = mockProposals[1] as ProposalInfo;
@@ -224,7 +228,7 @@ describe("Proposals", () => {
       it("should render proposals also when ", () => {
         mockLoadProposals();
 
-        const { getByText } = render(Proposals);
+        const { getByText } = render(NnsProposals);
 
         const firstProposal = mockProposals[0] as ProposalInfo;
         const secondProposal = mockProposals[1] as ProposalInfo;
@@ -260,7 +264,7 @@ describe("Proposals", () => {
         identity: undefined,
       });
 
-      render(Proposals);
+      render(NnsProposals);
 
       authStoreMock.next({
         identity: mockIdentity,
@@ -274,7 +278,7 @@ describe("Proposals", () => {
         identity: mockIdentity,
       });
 
-      render(Proposals);
+      render(NnsProposals);
 
       authStoreMock.next({
         identity: undefined,

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  OWN_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
+import Proposals from "$lib/routes/Proposals.svelte";
+import { authStore } from "$lib/stores/auth.store";
+import { committedProjectsStore } from "$lib/stores/projects.store";
+import { page } from "$mocks/$app/stores";
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import {
+  mockProjectSubscribe,
+  mockSnsFullProject,
+} from "../../mocks/sns-projects.mock";
+
+jest.mock("$lib/services/$public/sns.services", () => {
+  return {
+    loadSnsSummaries: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/$public/proposals.services", () => {
+  return {
+    listProposals: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("Proposals", () => {
+  beforeAll(() =>
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe)
+  );
+
+  jest
+    .spyOn(committedProjectsStore, "subscribe")
+    .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
+
+  beforeEach(() => {
+    // Reset to default value
+    page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+  });
+
+  it("should render NnsProposals by default", () => {
+    const { queryByTestId } = render(Proposals);
+    expect(queryByTestId("nns-proposal-filters")).toBeInTheDocument();
+  });
+
+  it("should render dropdown to select project", () => {
+    const { queryByTestId } = render(Proposals);
+    expect(queryByTestId("select-project-dropdown")).toBeInTheDocument();
+  });
+
+  it("should render project page when a project is selected in the dropdown", async () => {
+    const { queryByTestId } = render(Proposals);
+
+    expect(queryByTestId("nns-proposal-filters")).toBeInTheDocument();
+
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
+
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
+
+    await waitFor(() =>
+      expect(queryByTestId("sns-proposals-page")).toBeInTheDocument()
+    );
+  });
+
+  it("should be able to go back to nns after going to a project", async () => {
+    const { queryByTestId } = render(Proposals);
+
+    expect(queryByTestId("nns-proposal-filters")).toBeInTheDocument();
+
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
+
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
+
+    await waitFor(() =>
+      expect(queryByTestId("sns-proposals-page")).toBeInTheDocument()
+    );
+
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: OWN_CANISTER_ID.toText() },
+      });
+    await waitFor(() =>
+      expect(queryByTestId("nns-proposal-filters")).toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

Set up the page for the SNS proposals list.

# Changes

* Rename current pages/Proposals to NnsProposals
* New route component Proposals that renders project dropdown and then chooses either NnsProposals or SnsProposals.
* Add new feature flag: `ENABLE_SNS_VOTING`

# Tests

* Fix tests after renaming and refactor.
* New test for new route Proposals.
