### PR TITLE
GIX-1210: Fetch render sns proposals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.4-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2022-12-29.tgz",
-      "integrity": "sha512-VTyoscJn1DHkOht0OC0J+cZFrN79DCoAj/+EREH7zL7WCZ6gLb9xzykRusJNdOsb82Wtp4SXFEbaRg89uN29qA==",
+      "version": "0.0.4-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2023-01-09.1.tgz",
+      "integrity": "sha512-bLl5ZeaxXczXxWz+MK8+KRaxEDwWfgfASvmJBP5OBSZashSGC01Mg7hEPo1/Ev0KOhCeAU7pGPIOhgJJZC1diQ==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.7-next"
       }
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.11.0-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2022-12-29.tgz",
-      "integrity": "sha512-mnBavuROEI2gbq5yrak/0XHlUbrnjioMgqWo5d5W0zip3mBkge9NwQr4ZUD3xsu0Tf4ydtaavBK7KXP7iQmtsQ==",
+      "version": "0.11.0-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2023-01-09.1.tgz",
+      "integrity": "sha512-8EFpmuU37+G/RqPtsPmMhq7W7kXVbEgjLCeJfIKOFqHQIcR2+hWdk9dCrqtC5vjr1sbR4OEL2+tyWX+cNduAAw==",
       "dependencies": {
         "crc": "^4.2.0",
         "crc-32": "^1.2.2",
@@ -1700,9 +1700,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.8-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2022-12-29.tgz",
-      "integrity": "sha512-4fRttX4/QjklQqFi8BdnVCdbaUfMac3K66BEpnPa9TOpUo6uNe6Iqy4RR+EwJG4AGKOtFwtB7z6heFCRZl82hQ==",
+      "version": "0.0.8-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2023-01-09.1.tgz",
+      "integrity": "sha512-YJc9fm0KuDvpeDoooUqLC3TuSqJwVGqcInNXDlZlN7kdjBs8QYB56KL8hIq+kqoL8O+zpfdJ5u4bILsXL//3Pg==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.7-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2022-12-29.tgz",
-      "integrity": "sha512-v9sS8d687WlYlsst8i/rgK+yNyjUAWkB8txZB1nugs+P3mtZL4B4Lh1ZhCUqtpatsAizPAMP8TEDY4p5o7PLsg=="
+      "version": "0.0.7-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2023-01-09.1.tgz",
+      "integrity": "sha512-DA+1j2Xt7d+XomO51kr/tCUIreVMmcHPHu4gZKMNlf7HLxFC3mCzSw66lYGpwg7F3ypX2l/esMDCwzO2S+Zzhw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.16.9",
@@ -10956,9 +10956,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.4-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2022-12-29.tgz",
-      "integrity": "sha512-VTyoscJn1DHkOht0OC0J+cZFrN79DCoAj/+EREH7zL7WCZ6gLb9xzykRusJNdOsb82Wtp4SXFEbaRg89uN29qA==",
+      "version": "0.0.4-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.4-next-2023-01-09.1.tgz",
+      "integrity": "sha512-bLl5ZeaxXczXxWz+MK8+KRaxEDwWfgfASvmJBP5OBSZashSGC01Mg7hEPo1/Ev0KOhCeAU7pGPIOhgJJZC1diQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10980,9 +10980,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.11.0-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2022-12-29.tgz",
-      "integrity": "sha512-mnBavuROEI2gbq5yrak/0XHlUbrnjioMgqWo5d5W0zip3mBkge9NwQr4ZUD3xsu0Tf4ydtaavBK7KXP7iQmtsQ==",
+      "version": "0.11.0-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.11.0-next-2023-01-09.1.tgz",
+      "integrity": "sha512-8EFpmuU37+G/RqPtsPmMhq7W7kXVbEgjLCeJfIKOFqHQIcR2+hWdk9dCrqtC5vjr1sbR4OEL2+tyWX+cNduAAw==",
       "requires": {
         "crc": "^4.2.0",
         "crc-32": "^1.2.2",
@@ -11001,17 +11001,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.8-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2022-12-29.tgz",
-      "integrity": "sha512-4fRttX4/QjklQqFi8BdnVCdbaUfMac3K66BEpnPa9TOpUo6uNe6Iqy4RR+EwJG4AGKOtFwtB7z6heFCRZl82hQ==",
+      "version": "0.0.8-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.8-next-2023-01-09.1.tgz",
+      "integrity": "sha512-YJc9fm0KuDvpeDoooUqLC3TuSqJwVGqcInNXDlZlN7kdjBs8QYB56KL8hIq+kqoL8O+zpfdJ5u4bILsXL//3Pg==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.7-next-2022-12-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2022-12-29.tgz",
-      "integrity": "sha512-v9sS8d687WlYlsst8i/rgK+yNyjUAWkB8txZB1nugs+P3mtZL4B4Lh1ZhCUqtpatsAizPAMP8TEDY4p5o7PLsg=="
+      "version": "0.0.7-next-2023-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.7-next-2023-01-09.1.tgz",
+      "integrity": "sha512-DA+1j2Xt7d+XomO51kr/tCUIreVMmcHPHu4gZKMNlf7HLxFC3mCzSw66lYGpwg7F3ypX2l/esMDCwzO2S+Zzhw=="
     },
     "@esbuild/android-arm": {
       "version": "0.16.9",

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -413,7 +413,7 @@ export const autoStakeMaturity = async ({
   );
 };
 
-export const getProposals = async ({
+export const queryProposals = async ({
   rootCanisterId,
   identity,
   certified,

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -4,6 +4,7 @@ import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type {
   NervousSystemParameters,
+  SnsListProposalsParams,
   SnsNervousSystemFunction,
   SnsNeuronId,
   SnsNeuronPermissionType,
@@ -410,4 +411,29 @@ export const autoStakeMaturity = async ({
   logWithTimestamp(
     `${autoStake ? "Enable" : "Disable"} auto stake maturity complete.`
   );
+};
+
+export const getProposals = async ({
+  rootCanisterId,
+  identity,
+  certified,
+  params,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+  params: SnsListProposalsParams;
+}) => {
+  logWithTimestamp(`Getting proposals call...`);
+
+  const { listProposals } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified,
+  });
+
+  const proposals = await listProposals(params);
+
+  logWithTimestamp(`Getting proposals call complete.`);
+  return proposals;
 };

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -14,7 +14,7 @@
   $: loading = isNullish($snsProposalsStore);
 
   const load = () => {
-    if ($snsProposalsStore === undefined) {
+    if (isNullish($snsProposalsStore)) {
       loadProposalsSnsCF();
     }
   };

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -8,14 +8,14 @@
   import { isNullish } from "$lib/utils/utils";
   import SkeletonProposalCard from "$lib/components/ui/SkeletonProposalCard.svelte";
   import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
-  import { listSnsProposals } from "$lib/services/$public/sns.services";
+  import { loadProposalsSnsCF } from "$lib/services/$public/sns.services";
 
   let loading = false;
   $: loading = isNullish($snsProposalsStore);
 
   const load = () => {
     if ($snsProposalsStore === undefined) {
-      listSnsProposals();
+      loadProposalsSnsCF();
     }
   };
 

--- a/frontend/src/lib/components/proposals/NnsProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalCard.svelte
@@ -34,7 +34,7 @@
 <ProposalCard
   {hidden}
   on:click={showProposal}
-  status={statusString}
+  {statusString}
   {id}
   {title}
   {color}

--- a/frontend/src/lib/components/proposals/NnsProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalCard.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-  import {
-    type ProposalInfo,
-    type NeuronId,
-    type ProposalId,
-    ProposalStatus,
-  } from "@dfinity/nns";
+  import type { ProposalInfo, NeuronId, ProposalId } from "@dfinity/nns";
   import { mapProposalInfo } from "$lib/utils/proposals.utils";
   import { goto } from "$app/navigation";
   import { pageStore } from "$lib/derived/page.derived";
@@ -15,7 +10,7 @@
   export let proposalInfo: ProposalInfo;
   export let hidden = false;
 
-  let status: ProposalStatus = ProposalStatus.Unknown;
+  let statusString: string;
   let id: ProposalId | undefined;
   let title: string | undefined;
   let color: ProposalStatusColor | undefined;
@@ -24,7 +19,7 @@
   let proposer: NeuronId | undefined;
   let type: string | undefined;
 
-  $: ({ status, id, title, color, topic, proposer, type } =
+  $: ({ status, id, title, color, topic, proposer, type, statusString } =
     mapProposalInfo(proposalInfo));
 
   const showProposal = async () =>
@@ -39,7 +34,7 @@
 <ProposalCard
   {hidden}
   on:click={showProposal}
-  {status}
+  status={statusString}
   {id}
   {title}
   {color}

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import { Card, KeyValuePair, Value } from "@dfinity/gix-components";
-  import { ProposalStatus } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
-  import { keyOfOptional } from "$lib/utils/utils";
   import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
   import Countdown from "./Countdown.svelte";
 
   export let hidden = false;
-  export let status: ProposalStatus = ProposalStatus.Unknown;
+  export let status: string | undefined;
   export let id: bigint | undefined;
   export let title: string | undefined;
   export let color: ProposalStatusColor | undefined;
   export let topic: string | undefined;
   export let proposer: string | undefined;
-  export let type: string | undefined;
+  export let type: string | undefined = undefined;
   export let deadlineTimestampSeconds: bigint | undefined;
 </script>
 
@@ -56,8 +54,7 @@
 
     <KeyValuePair>
       <p slot="key" class={`${color ?? ""} status`}>
-        {keyOfOptional({ obj: $i18n.status, key: ProposalStatus[status] }) ??
-          ""}
+        {status}
       </p>
       <Countdown slot="value" {deadlineTimestampSeconds} />
     </KeyValuePair>

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -5,7 +5,7 @@
   import Countdown from "./Countdown.svelte";
 
   export let hidden = false;
-  export let status: string | undefined;
+  export let statusString: string | undefined;
   export let id: bigint | undefined;
   export let title: string | undefined;
   export let color: ProposalStatusColor | undefined;
@@ -54,7 +54,7 @@
 
     <KeyValuePair>
       <p slot="key" class={`${color ?? ""} status`}>
-        {status}
+        {statusString}
       </p>
       <Countdown slot="value" {deadlineTimestampSeconds} />
     </KeyValuePair>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { loadSnsNervousSystemFunctions } from "$lib/services/sns-neurons.services";
+  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -54,7 +54,7 @@
 <ProposalCard
   {hidden}
   on:click={showProposal}
-  status={statusString}
+  {statusString}
   id={id?.id}
   {title}
   {color}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
+  import { goto } from "$app/navigation";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { buildProposalUrl } from "$lib/utils/navigation.utils";
+  import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
+  import ProposalCard from "$lib/components/proposals/ProposalCard.svelte";
+  import type {
+    SnsNervousSystemFunction,
+    SnsNeuronId,
+    SnsProposalData,
+    SnsProposalId,
+  } from "@dfinity/sns";
+  import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+
+  export let proposalData: SnsProposalData;
+  export let nsFunctions: SnsNervousSystemFunction[] | undefined;
+  export let hidden = false;
+
+  let statusString: string;
+  let id: SnsProposalId | undefined;
+  let title: string | undefined;
+  let color: ProposalStatusColor | undefined;
+
+  let topic: string | undefined;
+  let proposer: SnsNeuronId | undefined;
+  let proposerString: string | undefined;
+  $: proposerString =
+    proposer !== undefined
+      ? shortenWithMiddleEllipsis(subaccountToHexString(proposer.id))
+      : undefined;
+  let deadlineTimestampSeconds: bigint | undefined;
+
+  $: ({
+    statusString,
+    id,
+    title,
+    color,
+    topic,
+    proposer,
+    current_deadline_timestamp_seconds: deadlineTimestampSeconds,
+  } = mapProposalInfo({ proposalData, nsFunctions }));
+
+  const showProposal = async () =>
+    await goto(
+      buildProposalUrl({
+        universe: $pageStore.universe,
+        proposalId: `${id}`,
+      })
+    );
+</script>
+
+<ProposalCard
+  {hidden}
+  on:click={showProposal}
+  status={statusString}
+  id={id?.id}
+  {title}
+  {color}
+  {topic}
+  proposer={proposerString}
+  {deadlineTimestampSeconds}
+/>

--- a/frontend/src/lib/constants/sns-proposals.constants.ts
+++ b/frontend/src/lib/constants/sns-proposals.constants.ts
@@ -1,0 +1,22 @@
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { ProposalStatusColor } from "./proposals.constants";
+
+export const DEFAULT_SNS_PROPOSALS_PAGE_SIZE = 100;
+// Reference: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L42
+export const SNS_MIN_NUMBER_VOTES_FOR_PROPOSAL_RATIO = 0.03;
+
+export const SNS_PROPOSAL_COLOR: Record<
+  SnsProposalDecisionStatus,
+  ProposalStatusColor | undefined
+> = {
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED]:
+    ProposalStatusColor.SUCCESS,
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN]:
+    ProposalStatusColor.WARNING,
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED]: undefined,
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_REJECTED]:
+    ProposalStatusColor.ERROR,
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED]: undefined,
+  [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED]:
+    ProposalStatusColor.ERROR,
+};

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -726,5 +726,33 @@
   "auth_sns": {
     "title": "Service Nervous Systems (SNS)",
     "text": "Put the autonomy in DAO. No centralized power, no administrative overhead, no legal headache, only code and its community."
+  },
+  "sns_rewards_status": {
+    "0": "Unknown",
+    "1": "Accepting Votes",
+    "2": "Ready to Settle",
+    "3": "Settled"
+  },
+  "sns_rewards_description": {
+    "0": "",
+    "1": "The proposal is still accepting votes, for the purpose of voting rewards.",
+    "2": "The proposal is no longer accepting votes. It is due to settle in the next reward event.",
+    "3": "The proposal has been taken into account in a reward event."
+  },
+  "sns_status": {
+    "0": "Unknown",
+    "1": "Open",
+    "2": "Rejected",
+    "3": "Adopted",
+    "4": "Executed",
+    "5": "Failed"
+  },
+  "sns_status_description": {
+    "0": "",
+    "1": "A decision has not yet been made to adopt or reject the proposal.",
+    "2": "The proposal has been rejected.",
+    "3": "The proposal has been adopted. Either execution has not yet started, or it has started but the outcome is not yet known.",
+    "4": "The proposal was adopted and successfully executed.",
+    "5": "The proposal was adopted, but execution failed."
   }
 }

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -18,7 +18,7 @@
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import { fromNullable } from "@dfinity/utils";
 
-  onMount(async () => {
+  onMount(() => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
     if (!ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }));
@@ -52,6 +52,7 @@
       : undefined;
 </script>
 
+<!-- TODO: Remove when implementing filters https://dfinity.atlassian.net/browse/GIX-1212 -->
 <div data-tid="sns-proposals-page">
   {#if proposals === undefined}
     <div class="card-grid" data-tid="proposals-loading">

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -1,16 +1,71 @@
 <script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import type { Unsubscriber } from "svelte/store";
   import { goto } from "$app/navigation";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
+  import { snsOnlyProjectStore } from "$lib/derived/selected-project.derived";
+  import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
-  import { onMount } from "svelte";
+  import type { SnsProposalData } from "@dfinity/sns";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+  import SnsProposalCard from "$lib/components/sns-proposals/SnsProposalCard.svelte";
+  import { InfiniteScroll } from "@dfinity/gix-components";
+  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
+  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+  import type { SnsNervousSystemFunction } from "@dfinity/sns";
+  import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
+  import { fromNullable } from "@dfinity/utils";
 
-  onMount(() => {
+  onMount(async () => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
     if (!ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }));
     }
   });
+
+  const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
+    async (selectedProjectCanisterId) => {
+      if (selectedProjectCanisterId !== undefined) {
+        await Promise.all([
+          loadSnsProposals({ rootCanisterId: selectedProjectCanisterId }),
+          loadSnsNervousSystemFunctions(selectedProjectCanisterId),
+        ]);
+      }
+    }
+  );
+
+  onDestroy(unsubscribe);
+
+  // `undefined` means that we haven't loaded the proposals yet.
+  let proposals: SnsProposalData[] | undefined;
+  $: proposals =
+    $snsOnlyProjectStore !== undefined
+      ? $snsProposalsStore[$snsOnlyProjectStore.toText()]?.proposals
+      : undefined;
+
+  let nsFunctions: SnsNervousSystemFunction[] | undefined;
+  $: nsFunctions =
+    $snsOnlyProjectStore !== undefined
+      ? $snsFunctionsStore[$snsOnlyProjectStore.toText()]?.nsFunctions
+      : undefined;
 </script>
 
-<div data-tid="sns-proposals-page">To be developed</div>
+<div data-tid="sns-proposals-page">
+  {#if proposals === undefined}
+    <div class="card-grid" data-tid="proposals-loading">
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+    </div>
+  {:else if proposals.length === 0}
+    <p class="description">{$i18n.voting.nothing_found}</p>
+  {:else}
+    <InfiniteScroll layout="grid">
+      {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
+        <SnsProposalCard {proposalData} {nsFunctions} />
+      {/each}
+    </InfiniteScroll>
+  {/if}
+</div>

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -1,4 +1,4 @@
-import { getProposals } from "$lib/api/sns-governance.api";
+import { queryProposals } from "$lib/api/sns-governance.api";
 import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import type { Principal } from "@dfinity/principal";
@@ -13,7 +13,7 @@ export const loadSnsProposals = async ({
   return queryAndUpdate<SnsProposalData[], unknown>({
     identityType: "current",
     request: ({ certified, identity }) =>
-      getProposals({
+      queryProposals({
         params: { limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE },
         identity,
         certified,

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -1,0 +1,30 @@
+import { getProposals } from "$lib/api/sns-governance.api";
+import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
+import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+import type { Principal } from "@dfinity/principal";
+import type { SnsProposalData } from "@dfinity/sns";
+import { queryAndUpdate } from "../utils.services";
+
+export const loadSnsProposals = async ({
+  rootCanisterId,
+}: {
+  rootCanisterId: Principal;
+}) => {
+  return queryAndUpdate<SnsProposalData[], unknown>({
+    identityType: "current",
+    request: ({ certified, identity }) =>
+      getProposals({
+        params: { limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE },
+        identity,
+        certified,
+        rootCanisterId,
+      }),
+    onLoad: ({ response: proposals, certified }) => {
+      snsProposalsStore.setProposals({
+        rootCanisterId,
+        proposals,
+        certified,
+      });
+    },
+  });
+};

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -1,11 +1,17 @@
+import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { queryAllSnsMetadata, querySnsSwapStates } from "$lib/api/sns.api";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
+import { i18n } from "$lib/stores/i18n";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsProposalsStore, snsQueryStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
 import { toToastError } from "$lib/utils/error.utils";
 import { Topic, type ProposalInfo } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+import type { SnsNervousSystemFunction } from "@dfinity/sns";
+import { get } from "svelte/store";
 
 export const loadSnsSummaries = (): Promise<void> => {
   snsQueryStore.setLoadingState();
@@ -39,7 +45,7 @@ export const loadSnsSummaries = (): Promise<void> => {
   });
 };
 
-export const listSnsProposals = async (): Promise<void> => {
+export const loadProposalsSnsCF = async (): Promise<void> => {
   snsProposalsStore.setLoadingState();
 
   return queryAndUpdate<ProposalInfo[], unknown>({
@@ -72,5 +78,53 @@ export const listSnsProposals = async (): Promise<void> => {
       );
     },
     logMessage: "Syncing Sns proposals",
+  });
+};
+
+// This is a public service.
+export const loadSnsNervousSystemFunctions = async (
+  rootCanisterId: Principal
+) => {
+  const store = get(snsFunctionsStore);
+  // Avoid loading the same data multiple times if the data loaded is certified
+  if (store[rootCanisterId.toText()]?.certified) {
+    return;
+  }
+  return queryAndUpdate<SnsNervousSystemFunction[], Error>({
+    request: ({ certified, identity }) =>
+      getNervousSystemFunctions({
+        rootCanisterId,
+        identity,
+        certified,
+      }),
+    onLoad: async ({ response: nsFunctions, certified }) => {
+      // TODO: Ideally, the name from the backend is user-friendly.
+      // https://dfinity.atlassian.net/browse/GIX-1169
+      const snsNervousSystemFunctions = nsFunctions.map((nsFunction) => {
+        if (nsFunction.id === BigInt(0)) {
+          const translationKeys = get(i18n);
+          return {
+            ...nsFunction,
+            name: translationKeys.sns_neuron_detail.all_topics,
+          };
+        }
+        return nsFunction;
+      });
+      snsFunctionsStore.setFunctions({
+        rootCanisterId,
+        nsFunctions: snsNervousSystemFunctions,
+        certified,
+      });
+    },
+    identityType: "current",
+    onError: ({ certified, error }) => {
+      if (certified) {
+        toastsError({
+          labelKey: "error__sns.sns_load_functions",
+          err: error,
+        });
+      }
+    },
+    logMessage: `Getting SNS ${rootCanisterId.toText()} nervous system functions`,
   });
 };

--- a/frontend/src/lib/stores/sns-proposals.store.ts
+++ b/frontend/src/lib/stores/sns-proposals.store.ts
@@ -1,0 +1,80 @@
+import type { Principal } from "@dfinity/principal";
+import type { SnsProposalData } from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
+import { writable } from "svelte/store";
+
+export interface ProjectProposalStore {
+  proposals: SnsProposalData[];
+  // certified is an optimistic value - i.e. it represents the last value that has been pushed in store
+  certified: boolean | undefined;
+}
+export interface SnsProposalsStore {
+  // Each SNS Project is an entry in this Store.
+  // We use the root canister id as the key to identify the neurons for a specific project.
+  [rootCanisterId: string]: ProjectProposalStore;
+}
+
+/**
+ * A store that contains the sns proposals for each project.
+ *
+ * - setProposals: replace the current list of proposals for a specific sns project with a new list
+ * - addProposals: add new proposals to the list of proposals for a specific sns project
+ */
+const initSnsProposalsStore = () => {
+  const { subscribe, update, set } = writable<SnsProposalsStore>({});
+
+  return {
+    subscribe,
+
+    setProposals({
+      rootCanisterId,
+      proposals,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      proposals: SnsProposalData[];
+      certified: boolean | undefined;
+    }) {
+      update((currentState: SnsProposalsStore) => ({
+        ...currentState,
+        [rootCanisterId.toText()]: {
+          proposals: proposals,
+          certified,
+        },
+      }));
+    },
+
+    addProposals({
+      rootCanisterId,
+      proposals,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      proposals: SnsProposalData[];
+      certified: boolean | undefined;
+    }) {
+      update((currentState: SnsProposalsStore) => {
+        const newIds = new Set(proposals.map(({ id }) => fromNullable(id)?.id));
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            proposals: [
+              ...proposals,
+              ...(currentState[rootCanisterId.toText()]?.proposals.filter(
+                (proposal) => !newIds.has(fromNullable(proposal.id)?.id)
+              ) ?? []),
+            ],
+            certified,
+          },
+        };
+      });
+    },
+
+    // Used in tests
+    reset() {
+      set({});
+    },
+  };
+};
+
+export const snsProposalsStore = initSnsProposalsStore();

--- a/frontend/src/lib/stores/sns-proposals.store.ts
+++ b/frontend/src/lib/stores/sns-proposals.store.ts
@@ -10,7 +10,7 @@ export interface ProjectProposalStore {
 }
 export interface SnsProposalsStore {
   // Each SNS Project is an entry in this Store.
-  // We use the root canister id as the key to identify the neurons for a specific project.
+  // We use the root canister id as the key to identify the proposals for a specific project.
   [rootCanisterId: string]: ProjectProposalStore;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -767,6 +767,38 @@ interface I18nAuth_sns {
   text: string;
 }
 
+interface I18nSns_rewards_status {
+  0: string;
+  1: string;
+  2: string;
+  3: string;
+}
+
+interface I18nSns_rewards_description {
+  0: string;
+  1: string;
+  2: string;
+  3: string;
+}
+
+interface I18nSns_status {
+  0: string;
+  1: string;
+  2: string;
+  3: string;
+  4: string;
+  5: string;
+}
+
+interface I18nSns_status_description {
+  0: string;
+  1: string;
+  2: string;
+  3: string;
+  4: string;
+  5: string;
+}
+
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -992,6 +1024,10 @@ interface I18n {
   auth_proposals: I18nAuth_proposals;
   auth_canisters: I18nAuth_canisters;
   auth_sns: I18nAuth_sns;
+  sns_rewards_status: I18nSns_rewards_status;
+  sns_rewards_description: I18nSns_rewards_description;
+  sns_status: I18nSns_status;
+  sns_status_description: I18nSns_status_description;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -1,0 +1,237 @@
+import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
+import {
+  SNS_MIN_NUMBER_VOTES_FOR_PROPOSAL_RATIO,
+  SNS_PROPOSAL_COLOR,
+} from "$lib/constants/sns-proposals.constants";
+import { i18n } from "$lib/stores/i18n";
+import type {
+  SnsAction,
+  SnsBallot,
+  SnsNervousSystemFunction,
+  SnsNeuronId,
+  SnsProposalData,
+  SnsProposalId,
+  SnsTally,
+} from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
+import { get } from "svelte/store";
+import { nowInSeconds } from "./date.utils";
+
+export type SnsProposalDataMap = {
+  // Mapped directly from SnsProposalData directly
+  id?: SnsProposalId;
+  payload_text_rendering?: string;
+  action: bigint;
+  ballots: Array<[string, SnsBallot]>;
+  reward_event_round: bigint;
+  failed_timestamp_seconds: bigint;
+  proposal_creation_timestamp_seconds: bigint;
+  initial_voting_period_seconds: bigint;
+  reject_cost_e8s: bigint;
+  latest_tally?: SnsTally;
+  wait_for_quiet_deadline_increase_seconds: bigint;
+  decided_timestamp_seconds: bigint;
+  proposer?: SnsNeuronId;
+  is_eligible_for_rewards: boolean;
+  executed_timestamp_seconds: bigint;
+
+  // Extracted from SnsProposalData.wait_for_quiet_state
+  current_deadline_timestamp_seconds?: bigint;
+
+  // Extracted from SnsProposalData.proposal
+  title: string;
+  url?: string;
+  summary: string;
+  actionData?: SnsAction;
+
+  // TODO: Should come from backend
+  status: SnsProposalDecisionStatus;
+  rewardStatus: SnsProposalRewardStatus;
+
+  // Added by us
+  statusString: string;
+  statusDescription: string;
+  rewardStatusString: string;
+  rewardStatusDescription: string;
+  color: ProposalStatusColor | undefined;
+
+  // Mapped from Nervous Functions
+  topic?: string;
+  topicDescription?: string;
+};
+
+export const mapProposalInfo = ({
+  proposalData,
+  nsFunctions,
+}: {
+  proposalData: SnsProposalData;
+  nsFunctions: SnsNervousSystemFunction[] | undefined;
+}): SnsProposalDataMap => {
+  const {
+    proposal,
+    proposer,
+    id,
+    payload_text_rendering,
+    action,
+    ballots,
+    reward_event_round,
+    failed_timestamp_seconds,
+    proposal_creation_timestamp_seconds,
+    initial_voting_period_seconds,
+    reject_cost_e8s,
+    latest_tally,
+    wait_for_quiet_deadline_increase_seconds,
+    decided_timestamp_seconds,
+    is_eligible_for_rewards,
+    executed_timestamp_seconds,
+    wait_for_quiet_state,
+  } = proposalData;
+
+  const proposalInfo = fromNullable(proposal);
+  const actionData =
+    proposalInfo !== undefined ? fromNullable(proposalInfo.action) : undefined;
+
+  const nsFunction = nsFunctions?.find(({ id }) => id === action);
+
+  const rewardStatus = snsRewardStatus(proposalData);
+  const decisionStatus = snsDecisionStatus(proposalData);
+
+  const {
+    sns_rewards_status,
+    sns_rewards_description,
+    sns_status,
+    sns_status_description,
+  } = get(i18n);
+
+  return {
+    // Mapped directly from SnsProposalData directly
+    id: fromNullable(id),
+    payload_text_rendering: fromNullable(payload_text_rendering),
+    action,
+    ballots,
+    reward_event_round,
+    failed_timestamp_seconds,
+    proposal_creation_timestamp_seconds,
+    initial_voting_period_seconds: initial_voting_period_seconds,
+    reject_cost_e8s,
+    latest_tally: fromNullable(latest_tally),
+    wait_for_quiet_deadline_increase_seconds,
+    decided_timestamp_seconds,
+    proposer: fromNullable(proposer),
+    is_eligible_for_rewards,
+    executed_timestamp_seconds,
+
+    // Extracted from SnsProposalData.wait_for_quiet_state
+    current_deadline_timestamp_seconds:
+      fromNullable(wait_for_quiet_state)?.current_deadline_timestamp_seconds,
+
+    // Extracted from SnsProposalData.proposal
+    title: proposalInfo?.title ?? "",
+    url: proposalInfo?.url,
+    summary: proposalInfo?.summary ?? "",
+    actionData,
+
+    // TODO: Ideally this should come from the backend and we didn't need to calculate it
+    status: decisionStatus,
+    rewardStatus,
+
+    statusString: sns_status[decisionStatus],
+    statusDescription: sns_status_description[decisionStatus],
+    rewardStatusString: sns_rewards_status[rewardStatus],
+    rewardStatusDescription: sns_rewards_description[rewardStatus],
+    color: SNS_PROPOSAL_COLOR[decisionStatus],
+
+    // Mapped from Nervous Functions
+    topic: nsFunction?.name,
+    topicDescription: nsFunction?.description[0],
+  };
+};
+
+/**
+ * Returns whether the proposal is accepted or not based on the data.
+ *
+ * Reference: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L931
+ * @param {SnsProposalData} proposal
+ * @returns {boolean}
+ */
+export const isAccepted = ({ latest_tally }: SnsProposalData): boolean => {
+  const tally = fromNullable(latest_tally);
+  if (tally === undefined) {
+    return false;
+  }
+  return (
+    Number(tally.yes) >=
+      Number(tally.no) * SNS_MIN_NUMBER_VOTES_FOR_PROPOSAL_RATIO &&
+    tally.yes > tally.no
+  );
+};
+
+/**
+ * Returns the decision status of a proposal based on the data.
+ *
+ * Refecence: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L717
+ * @param {SnsProposalData} proposal
+ * @returns {SnsProposalDecisionStatus}
+ */
+export const snsDecisionStatus = (
+  proposal: SnsProposalData
+): SnsProposalDecisionStatus => {
+  const {
+    decided_timestamp_seconds,
+    executed_timestamp_seconds,
+    failed_timestamp_seconds,
+  } = proposal;
+  if (decided_timestamp_seconds === BigInt(0)) {
+    return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN;
+  }
+
+  if (isAccepted(proposal)) {
+    if (executed_timestamp_seconds > BigInt(0)) {
+      return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED;
+    }
+    if (failed_timestamp_seconds > BigInt(0)) {
+      return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED;
+    }
+    return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED;
+  }
+
+  return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_REJECTED;
+};
+
+/**
+ * Returns the status of a proposal based on the data.
+ *
+ * Reference: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L735
+ *
+ * @param {SnsProposalData} proposal
+ * @returns {SnsProposalRewardStatus}
+ */
+export const snsRewardStatus = ({
+  reward_event_round,
+  wait_for_quiet_state,
+  is_eligible_for_rewards,
+}: SnsProposalData): SnsProposalRewardStatus => {
+  if (reward_event_round > 0) {
+    return SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED;
+  }
+
+  const now = nowInSeconds();
+  const deadline =
+    fromNullable(wait_for_quiet_state)?.current_deadline_timestamp_seconds;
+  if (!deadline) {
+    // Reference: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L760
+    throw new Error("Proposal must have a wait_for_quiet_state.");
+  }
+  if (now > deadline) {
+    return SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES;
+  }
+
+  if (is_eligible_for_rewards) {
+    return SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE;
+  }
+  return SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED;
+};

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -9,9 +9,9 @@ import {
   disburse,
   getNervousSystemFunctions,
   getNeuronBalance,
-  getProposals,
   increaseDissolveDelay,
   nervousSystemParameters,
+  queryProposals,
   refreshNeuron,
   removeNeuronPermissions,
   setFollowees,
@@ -304,7 +304,7 @@ describe("sns-api", () => {
   });
 
   it("should get proposals", async () => {
-    const res = await getProposals({
+    const res = await queryProposals({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
       certified: false,

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -9,6 +9,7 @@ import {
   disburse,
   getNervousSystemFunctions,
   getNeuronBalance,
+  getProposals,
   increaseDissolveDelay,
   nervousSystemParameters,
   refreshNeuron,
@@ -43,6 +44,7 @@ import {
   mockQueryMetadataResponse,
   mockQueryTokenResponse,
 } from "../../mocks/sns-projects.mock";
+import { mockSnsProposal } from "../../mocks/sns-proposals.mock";
 import {
   deployedSnsMock,
   governanceCanisterIdMock,
@@ -60,6 +62,7 @@ jest.mock("$lib/api/agent.api", () => {
 
 describe("sns-api", () => {
   const ledgerCanisterMock = mock<LedgerCanister>();
+  const proposals = [mockSnsProposal];
   const addNeuronPermissionsSpy = jest.fn().mockResolvedValue(undefined);
   const removeNeuronPermissionsSpy = jest.fn().mockResolvedValue(undefined);
   const disburseSpy = jest.fn().mockResolvedValue(undefined);
@@ -73,6 +76,7 @@ describe("sns-api", () => {
   const setTopicFolloweesSpy = jest.fn().mockResolvedValue(undefined);
   const stakeMaturitySpy = jest.fn().mockResolvedValue(undefined);
   const autoStakeMaturitySpy = jest.fn().mockResolvedValue(undefined);
+  const listProposalsSpy = jest.fn().mockResolvedValue(proposals);
   const nervousSystemFunctionsMock: SnsListNervousSystemFunctionsResponse = {
     reserved_ids: new BigUint64Array(),
     functions: [nervousSystemFunctionMock],
@@ -121,6 +125,7 @@ describe("sns-api", () => {
         setTopicFollowees: setTopicFolloweesSpy,
         stakeMaturity: stakeMaturitySpy,
         autoStakeMaturity: autoStakeMaturitySpy,
+        listProposals: listProposalsSpy,
       })
     );
   });
@@ -296,5 +301,17 @@ describe("sns-api", () => {
 
     expect(nervousSystemParametersSpy).toBeCalled();
     expect(res).toEqual(snsNervousSystemParametersMock);
+  });
+
+  it("should get proposals", async () => {
+    const res = await getProposals({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      certified: false,
+      params: {},
+    });
+
+    expect(listProposalsSpy).toBeCalled();
+    expect(res).toEqual(proposals);
   });
 });

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import Proposals from "$lib/components/launchpad/Proposals.svelte";
-import { listSnsProposals } from "$lib/services/$public/sns.services";
+import { loadProposalsSnsCF } from "$lib/services/$public/sns.services";
 import { snsProposalsStore } from "$lib/stores/sns.store";
 import { ProposalStatus, type ProposalInfo } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -12,7 +12,7 @@ import { mockProposalInfo } from "../../../mocks/proposal.mock";
 
 jest.mock("$lib/services/$public/sns.services", () => {
   return {
-    listSnsProposals: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadProposalsSnsCF: jest.fn().mockResolvedValue(Promise.resolve()),
   };
 });
 
@@ -26,13 +26,13 @@ describe("Proposals", () => {
 
   afterAll(jest.clearAllMocks);
 
-  it("should trigger listSnsProposals", () => {
+  it("should trigger loadProposalsSnsCF", () => {
     render(Proposals);
 
-    expect(listSnsProposals).toBeCalled();
+    expect(loadProposalsSnsCF).toBeCalled();
   });
 
-  it("should not trigger listSnsProposals if already loaded", () => {
+  it("should not trigger loadProposalsSnsCF if already loaded", () => {
     snsProposalsStore.setProposals({
       proposals: [],
       certified: true,
@@ -40,7 +40,7 @@ describe("Proposals", () => {
 
     render(Proposals);
 
-    expect(listSnsProposals).toBeCalled();
+    expect(loadProposalsSnsCF).toBeCalled();
   });
 
   it("should display skeletons", async () => {

--- a/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
@@ -4,31 +4,15 @@
 
 import NnsProposalCard from "$lib/components/proposals/NnsProposalCard.svelte";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
-import { authStore } from "$lib/stores/auth.store";
 import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import { secondsToDuration } from "$lib/utils/date.utils";
 import type { Proposal, ProposalInfo } from "@dfinity/nns";
-import { GovernanceCanister, ProposalStatus, Topic } from "@dfinity/nns";
+import { ProposalStatus, Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
-import { MockGovernanceCanister } from "../../../mocks/governance.canister.mock";
 import en from "../../../mocks/i18n.mock";
 import { mockProposals } from "../../../mocks/proposals.store.mock";
 
 describe("NnsProposalCard", () => {
-  const mockGovernanceCanister: MockGovernanceCanister =
-    new MockGovernanceCanister(mockProposals);
-
-  beforeEach(() => {
-    jest
-      .spyOn(GovernanceCanister, "create")
-      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
-
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-  });
-
   it("should render a proposal title", () => {
     const { getByText } = render(NnsProposalCard, {
       props: {

--- a/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -12,7 +12,7 @@ describe("ProposalCard", () => {
   const nowSeconds = Math.floor(nowInSeconds());
   const props = {
     hidden: false,
-    status: "Open",
+    statusString: "Open",
     id: BigInt(112),
     title: "Test Proposal",
     color: ProposalStatusColor.PRIMARY,

--- a/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -5,7 +5,6 @@
 import ProposalCard from "$lib/components/proposals/ProposalCard.svelte";
 import { ProposalStatusColor } from "$lib/constants/proposals.constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
-import { ProposalStatus } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 
@@ -13,7 +12,7 @@ describe("ProposalCard", () => {
   const nowSeconds = Math.floor(nowInSeconds());
   const props = {
     hidden: false,
-    status: ProposalStatus.Open,
+    status: "Open",
     id: BigInt(112),
     title: "Test Proposal",
     color: ProposalStatusColor.PRIMARY,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsNeuronFollowingCard from "$lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte";
-import { loadSnsNervousSystemFunctions } from "$lib/services/sns-neurons.services";
+import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
@@ -26,7 +26,7 @@ import {
 } from "../../../mocks/sns-neurons.mock";
 import { rootCanisterIdMock } from "../../../mocks/sns.api.mock";
 
-jest.mock("../../../../../src/lib/services/sns-neurons.services", () => ({
+jest.mock("../../../../../src/lib/services/$public/sns.services", () => ({
   loadSnsNervousSystemFunctions: jest.fn(),
 }));
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -11,7 +11,7 @@ import { mockSnsNeuron } from "../../../../mocks/sns-neurons.mock";
 import { mockTokenStore } from "../../../../mocks/sns-projects.mock";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
-jest.mock("$lib/services/sns-neurons.services", () => {
+jest.mock("$lib/services/$public/sns.services", () => {
   return {
     loadSnsNervousSystemFunctions: jest.fn(),
   };

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsNeuronCard from "$lib/components/sns-neurons/SnsNeuronCard.svelte";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { authStore } from "$lib/stores/auth.store";
@@ -150,7 +150,8 @@ describe("SnsNeuronCard", () => {
   });
 
   it("renders proper text when status is DISSOLVING", async () => {
-    const ONE_YEAR_FROM_NOW = SECONDS_IN_YEAR + Math.round(Date.now() / 1000);
+    // Add one day of buffer to avoid flakiness
+    const ONE_YEAR_FROM_NOW = SECONDS_IN_YEAR + nowInSeconds() + SECONDS_IN_DAY;
     const { getByText } = render(SnsNeuronCard, {
       props: {
         neuron: {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsProposalCard from "$lib/components/sns-proposals/SnsProposalCard.svelte";
+import { SECONDS_IN_HOUR } from "$lib/constants/constants";
+import { nowInSeconds } from "$lib/utils/date.utils";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+import type { SnsProposalData } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import en from "../../../mocks/i18n.mock";
+import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
+import { mockSnsProposal } from "../../../mocks/sns-proposals.mock";
+
+describe("SnsProposalCard", () => {
+  const props = { proposalData: mockSnsProposal, nsFunctions: [] };
+  it("should render a proposal title", () => {
+    const { getByText } = render(SnsProposalCard, {
+      props,
+    });
+
+    expect(
+      getByText(mockSnsProposal.proposal[0].title as string)
+    ).toBeInTheDocument();
+  });
+
+  it("should render a proposal status", () => {
+    const { getByText } = render(SnsProposalCard, {
+      props,
+    });
+
+    expect(getByText(en.sns_status["1"])).toBeInTheDocument();
+  });
+
+  it("should render a proposer", () => {
+    const { getByText } = render(SnsProposalCard, {
+      props,
+    });
+
+    const proposerString = shortenWithMiddleEllipsis(
+      subaccountToHexString(mockSnsProposal.proposer[0]?.id)
+    );
+    expect(getByText(proposerString, { exact: false })).toBeInTheDocument();
+  });
+
+  it("should render a proposal id", () => {
+    const { queryAllByText } = render(SnsProposalCard, {
+      props,
+    });
+
+    expect(
+      queryAllByText(String(mockSnsProposal.id[0]?.id), { exact: false }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should render a proposal topic", () => {
+    const nsFunctions = [nervousSystemFunctionMock];
+    const proposalData = {
+      ...mockSnsProposal,
+      action: nervousSystemFunctionMock.id,
+    };
+    const { getByText } = render(SnsProposalCard, {
+      props: {
+        proposalData,
+        nsFunctions,
+      },
+    });
+
+    expect(getByText(nervousSystemFunctionMock.name)).toBeInTheDocument();
+  });
+
+  // TODO: fix this test after rebasing main with https://github.com/dfinity/nns-dapp/pull/1689
+  xit("should render deadline", () => {
+    const proposalData: SnsProposalData = {
+      ...mockSnsProposal,
+      wait_for_quiet_state: [
+        {
+          current_deadline_timestamp_seconds: BigInt(
+            nowInSeconds() + SECONDS_IN_HOUR
+          ),
+        },
+      ],
+    };
+    render(SnsProposalCard, {
+      props: {
+        proposalData,
+        nsFunctions: [],
+      },
+    });
+  });
+
+  it("should not render accessible labels", () => {
+    const { container } = render(SnsProposalCard, {
+      props,
+    });
+
+    expect(
+      container.querySelector(`[aria-label="${en.proposal_detail.id_prefix}"]`)
+    ).toBeInTheDocument();
+  });
+
+  it("should render a specific color for the status", () => {
+    const proposalData: SnsProposalData = {
+      ...mockSnsProposal,
+      decided_timestamp_seconds: BigInt(2222),
+      latest_tally: [
+        {
+          yes: BigInt(10),
+          no: BigInt(3),
+          total: BigInt(30),
+          timestamp_seconds: BigInt(2222),
+        },
+      ],
+      executed_timestamp_seconds: BigInt(nowInSeconds()),
+    };
+    const { container } = render(SnsProposalCard, {
+      props: {
+        proposalData,
+        nsFunctions: [],
+      },
+    });
+
+    expect(container.querySelector(".success")).not.toBeNull();
+  });
+});

--- a/frontend/src/tests/lib/pages/Launchpad.spec.ts
+++ b/frontend/src/tests/lib/pages/Launchpad.spec.ts
@@ -20,7 +20,7 @@ import {
 jest.mock("$lib/services/$public/sns.services", () => {
   return {
     loadSnsSummaries: jest.fn().mockResolvedValue(Promise.resolve()),
-    listSnsProposals: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadProposalsSnsCF: jest.fn().mockResolvedValue(Promise.resolve()),
   };
 });
 

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -34,6 +34,11 @@ jest.mock("$lib/services/transaction-fees.services", () => {
     loadSnsTransactionFee: jest.fn(),
   };
 });
+jest.mock("$lib/services/$public/sns.services", () => {
+  return {
+    loadSnsNervousSystemFunctions: jest.fn(),
+  };
+});
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
     getSnsNeuron: jest.fn().mockImplementation(({ onLoad, onError }) => {
@@ -43,7 +48,6 @@ jest.mock("$lib/services/sns-neurons.services", () => {
         onError();
       }
     }),
-    loadSnsNervousSystemFunctions: jest.fn(),
   };
 });
 

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsProposals from "$lib/pages/SnsProposals.svelte";
+import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
+import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
+import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+import { page } from "$mocks/$app/stores";
+import { render, waitFor } from "@testing-library/svelte";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import en from "../../mocks/i18n.mock";
+import { mockSnsProposal } from "../../mocks/sns-proposals.mock";
+
+jest.mock("$lib/services/$public/sns.services", () => {
+  return {
+    loadSnsNervousSystemFunctions: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/$public/sns-proposals.services", () => {
+  return {
+    loadSnsProposals: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("SnsProposals", () => {
+  const nothingFound = (
+    container: HTMLElement
+  ): HTMLParagraphElement | undefined =>
+    Array.from(container.querySelectorAll("p")).filter(
+      (p) => p.textContent === en.voting.nothing_found
+    )[0];
+
+  describe("logged in user", () => {
+    beforeEach(() => {
+      // Reset to default value
+      page.mock({ data: { universe: mockPrincipal.toText() } });
+    });
+
+    afterAll(() => jest.clearAllMocks());
+
+    describe("Matching results", () => {
+      beforeEach(() => {
+        snsProposalsStore.reset();
+      });
+      it("should load proposals and nervous system functions functions", () => {
+        render(SnsProposals);
+
+        expect(loadSnsNervousSystemFunctions).toBeCalled();
+        expect(loadSnsProposals).toBeCalled();
+      });
+
+      it("should render a spinner while searching proposals", async () => {
+        const { getByTestId } = render(SnsProposals);
+
+        await waitFor(() =>
+          expect(getByTestId("proposals-loading")).not.toBeNull()
+        );
+      });
+
+      it("should render proposals", () => {
+        const proposals = [mockSnsProposal];
+        snsProposalsStore.setProposals({
+          rootCanisterId: mockPrincipal,
+          proposals,
+          certified: true,
+        });
+
+        const { queryAllByTestId } = render(SnsProposals);
+
+        expect(queryAllByTestId("proposal-card").length).toBe(proposals.length);
+      });
+
+      it("should not render not found text on init", () => {
+        const { container } = render(SnsProposals);
+
+        const p: HTMLParagraphElement | undefined = nothingFound(container);
+
+        expect(p).toBeUndefined();
+      });
+    });
+
+    describe("No results", () => {
+      beforeEach(() => {
+        // Reset to default value
+        page.mock({ data: { universe: mockPrincipal.toText() } });
+      });
+
+      it("should render not found text", async () => {
+        snsProposalsStore.setProposals({
+          rootCanisterId: mockPrincipal,
+          proposals: [],
+          certified: true,
+        });
+
+        const { container } = render(SnsProposals);
+
+        await waitFor(() => {
+          const p: HTMLParagraphElement | undefined = nothingFound(container);
+          expect(p).not.toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe("when not logged in", () => {
+    afterAll(() => jest.clearAllMocks());
+
+    describe("Matching results", () => {
+      beforeEach(() => snsProposalsStore.reset());
+
+      it("should render proposals", () => {
+        const proposals = [mockSnsProposal];
+        snsProposalsStore.setProposals({
+          rootCanisterId: mockPrincipal,
+          proposals,
+          certified: true,
+        });
+
+        const { queryAllByTestId } = render(SnsProposals);
+
+        expect(queryAllByTestId("proposal-card").length).toBe(proposals.length);
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -21,12 +21,19 @@ import {
 jest.mock("$lib/services/$public/sns.services", () => {
   return {
     loadSnsSummaries: jest.fn().mockResolvedValue(undefined),
+    loadSnsNervousSystemFunctions: jest.fn().mockResolvedValue(undefined),
   };
 });
 
 jest.mock("$lib/services/$public/proposals.services", () => {
   return {
     listProposals: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/$public/sns-proposals.services", () => {
+  return {
+    loadSnsProposals: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as governanceApi from "$lib/api/sns-governance.api";
+import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+import { toastsError } from "$lib/stores/toasts.store";
+import { waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { nervousSystemFunctionMock } from "../../../mocks/sns-functions.mock";
+
+jest.mock("$lib/stores/toasts.store", () => {
+  return {
+    toastsError: jest.fn(),
+  };
+});
+
+describe("SNS public services", () => {
+  describe("loadSnsNervousSystemFunctions", () => {
+    beforeEach(() => {
+      snsFunctionsStore.reset();
+      jest.clearAllMocks();
+    });
+    it("should call sns api getNervousSystemFunctions and load the nervous system functions store", async () => {
+      const spyGetFunctions = jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
+
+      await loadSnsNervousSystemFunctions(mockPrincipal);
+
+      const store = get(snsFunctionsStore);
+      await waitFor(() =>
+        expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
+          nervousSystemFunctionMock,
+        ])
+      );
+      expect(spyGetFunctions).toBeCalled();
+    });
+
+    it("should not call api if nervous functions are in the store and certified", async () => {
+      snsFunctionsStore.setFunctions({
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      });
+      const spyGetFunctions = jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
+
+      await loadSnsNervousSystemFunctions(mockPrincipal);
+
+      expect(spyGetFunctions).not.toBeCalled();
+    });
+
+    it("should show a toast if api throws an error", async () => {
+      jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockImplementation(() => Promise.reject("error"));
+
+      await loadSnsNervousSystemFunctions(mockPrincipal);
+
+      await waitFor(() => expect(toastsError).toBeCalled());
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -18,7 +18,6 @@ import {
   toggleAutoStakeMaturity,
   updateDelay,
 } from "$lib/services/sns-neurons.services";
-import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -45,7 +44,6 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
-import { nervousSystemFunctionMock } from "../../mocks/sns-functions.mock";
 import {
   buildMockSnsNeuronsStoreSubscribe,
   mockSnsNeuron,
@@ -60,7 +58,6 @@ const {
   splitNeuron,
   stakeNeuron,
   loadNeurons,
-  loadSnsNervousSystemFunctions: loadSnsNervousSystemFunctions,
   addFollowee,
 } = services;
 
@@ -672,34 +669,6 @@ describe("sns-neurons-services", () => {
         percentageToStake,
         identity,
       });
-    });
-  });
-
-  describe("loadSnsNervousSystemFunctions", () => {
-    it("should call sns api getNervousSystemFunctions and load the nervous system functions store", async () => {
-      const spyGetFunctions = jest
-        .spyOn(governanceApi, "getNervousSystemFunctions")
-        .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
-
-      await loadSnsNervousSystemFunctions(mockPrincipal);
-
-      const store = get(snsFunctionsStore);
-      await waitFor(() =>
-        expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
-          nervousSystemFunctionMock,
-        ])
-      );
-      expect(spyGetFunctions).toBeCalled();
-    });
-
-    it("should show a toast if api throws an error", async () => {
-      jest
-        .spyOn(governanceApi, "getNervousSystemFunctions")
-        .mockImplementation(() => Promise.reject("error"));
-
-      await loadSnsNervousSystemFunctions(mockPrincipal);
-
-      expect(toastsError).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
@@ -1,0 +1,84 @@
+import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+import { Principal } from "@dfinity/principal";
+import type { SnsProposalData } from "@dfinity/sns";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+import { mockSnsProposal } from "../../mocks/sns-proposals.mock";
+
+describe("SNS Proposals stores", () => {
+  const snsProposal1: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(2) }],
+  };
+  const snsProposal2: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(2) }],
+  };
+  const snsProposal3: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(3) }],
+  };
+  describe("snsProposalsStore", () => {
+    afterEach(() => snsProposalsStore.reset());
+    it("should set proposals for a project", () => {
+      const proposals: SnsProposalData[] = [
+        snsProposal1,
+        snsProposal2,
+        snsProposal3,
+      ];
+      snsProposalsStore.setProposals({
+        rootCanisterId: mockPrincipal,
+        proposals,
+        certified: true,
+      });
+
+      const proposalsInStore = get(snsProposalsStore);
+      expect(proposalsInStore[mockPrincipal.toText()].proposals).toEqual(
+        proposals
+      );
+    });
+
+    it("should add proposals for another project", () => {
+      const proposals: SnsProposalData[] = [snsProposal1, snsProposal2];
+      snsProposalsStore.setProposals({
+        rootCanisterId: mockPrincipal,
+        proposals,
+        certified: true,
+      });
+      const proposals2: SnsProposalData[] = [snsProposal3];
+      const principal2 = Principal.fromText("aaaaa-aa");
+      snsProposalsStore.setProposals({
+        rootCanisterId: principal2,
+        proposals: proposals2,
+        certified: true,
+      });
+      const proposalsInStore = get(snsProposalsStore);
+      expect(proposalsInStore[mockPrincipal.toText()].proposals).toEqual(
+        proposals
+      );
+      expect(proposalsInStore[principal2.toText()].proposals).toEqual(
+        proposals2
+      );
+    });
+
+    it("should add proposals to a project with proposals", () => {
+      const proposals: SnsProposalData[] = [snsProposal1, snsProposal2];
+      snsProposalsStore.setProposals({
+        rootCanisterId: mockPrincipal,
+        proposals,
+        certified: true,
+      });
+      const proposals2: SnsProposalData[] = [snsProposal3];
+      snsProposalsStore.addProposals({
+        rootCanisterId: mockPrincipal,
+        proposals: proposals2,
+        certified: true,
+      });
+
+      const proposalsInStore = get(snsProposalsStore);
+      expect(proposalsInStore[mockPrincipal.toText()].proposals.length).toEqual(
+        3
+      );
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -1,0 +1,173 @@
+import { nowInSeconds } from "$lib/utils/date.utils";
+import {
+  isAccepted,
+  snsDecisionStatus,
+  snsRewardStatus,
+} from "$lib/utils/sns-proposals.utils";
+import type { SnsProposalData } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
+import { mockSnsProposal } from "../../mocks/sns-proposals.mock";
+
+describe("sns-proposals utils", () => {
+  const acceptedTally = {
+    yes: BigInt(10),
+    no: BigInt(2),
+    total: BigInt(20),
+    timestamp_seconds: BigInt(1),
+  };
+  const rejectedTally = {
+    yes: BigInt(10),
+    no: BigInt(20),
+    total: BigInt(30),
+    timestamp_seconds: BigInt(1),
+  };
+  describe("isAccepted", () => {
+    it("should return true if the proposal is accepted", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        latest_tally: [acceptedTally],
+      };
+      expect(isAccepted(proposal)).toBe(true);
+    });
+
+    it("should return false if the proposal is accepted", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        latest_tally: [rejectedTally],
+      };
+      expect(isAccepted(proposal)).toBe(false);
+    });
+  });
+
+  describe("snsDecisionStatus", () => {
+    it("should return OPEN status", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        decided_timestamp_seconds: BigInt(0),
+      };
+      expect(snsDecisionStatus(proposal)).toBe(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN
+      );
+    });
+
+    it("should return EXECUTED status", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        decided_timestamp_seconds: BigInt(10),
+        executed_timestamp_seconds: BigInt(10),
+        latest_tally: [acceptedTally],
+      };
+      expect(snsDecisionStatus(proposal)).toBe(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED
+      );
+    });
+
+    it("should return FAILED status", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        decided_timestamp_seconds: BigInt(10),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(10),
+        latest_tally: [acceptedTally],
+      };
+      expect(snsDecisionStatus(proposal)).toBe(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED
+      );
+    });
+
+    it("should return ADOPTED status", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        decided_timestamp_seconds: BigInt(10),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(0),
+        latest_tally: [acceptedTally],
+      };
+      expect(snsDecisionStatus(proposal)).toBe(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED
+      );
+    });
+
+    it("should return REJECTED status", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        decided_timestamp_seconds: BigInt(10),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(0),
+        latest_tally: [rejectedTally],
+      };
+      expect(snsDecisionStatus(proposal)).toBe(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_REJECTED
+      );
+    });
+  });
+
+  describe("snsRewardStatus", () => {
+    beforeEach(() => {
+      const now = Date.now();
+      jest.useFakeTimers().setSystemTime(now);
+    });
+    it("should return SETTLED", () => {
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: BigInt(2),
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED
+      );
+    });
+
+    it("should return ACCEPT_VOTES", () => {
+      const now = BigInt(nowInSeconds());
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: BigInt(0),
+        wait_for_quiet_state: [
+          {
+            current_deadline_timestamp_seconds: now - BigInt(100),
+          },
+        ],
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES
+      );
+    });
+
+    it("should return READY_TO_SETTLE", () => {
+      const now = BigInt(nowInSeconds());
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: BigInt(0),
+        wait_for_quiet_state: [
+          {
+            current_deadline_timestamp_seconds: now + BigInt(100),
+          },
+        ],
+        is_eligible_for_rewards: true,
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE
+      );
+    });
+
+    it("should return SETTLED if no case matches", () => {
+      const now = BigInt(nowInSeconds());
+      const proposal: SnsProposalData = {
+        ...mockSnsProposal,
+        reward_event_round: BigInt(0),
+        wait_for_quiet_state: [
+          {
+            current_deadline_timestamp_seconds: now + BigInt(100),
+          },
+        ],
+        is_eligible_for_rewards: false,
+      };
+      expect(snsRewardStatus(proposal)).toBe(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED
+      );
+    });
+  });
+});

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -1,0 +1,45 @@
+import type { SnsProposalData } from "@dfinity/sns";
+import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+
+export const mockSnsProposal: SnsProposalData = {
+  id: [
+    {
+      id: BigInt(2),
+    },
+  ],
+  payload_text_rendering: ["Payload text rendering"],
+  action: BigInt(2),
+  failure_reason: [],
+  ballots: [],
+  reward_event_round: BigInt(1),
+  failed_timestamp_seconds: BigInt(0),
+  proposal_creation_timestamp_seconds: BigInt(12313123),
+  initial_voting_period_seconds: BigInt(0),
+  reject_cost_e8s: BigInt(10_000_000),
+  latest_tally: [
+    {
+      no: BigInt(10),
+      yes: BigInt(10),
+      total: BigInt(100_000),
+      timestamp_seconds: BigInt(22),
+    },
+  ],
+  wait_for_quiet_deadline_increase_seconds: BigInt(0),
+  decided_timestamp_seconds: BigInt(0),
+  proposal: [
+    {
+      title: "Proposal title",
+      summary: "Proposal description",
+      url: "https://example.com",
+      action: [{ UpgradeSnsToNextVersion: {} }],
+    },
+  ],
+  proposer: [{ id: arrayOfNumberToUint8Array([1, 2, 3, 0, 0, 1]) }],
+  wait_for_quiet_state: [
+    {
+      current_deadline_timestamp_seconds: BigInt(10),
+    },
+  ],
+  is_eligible_for_rewards: true,
+  executed_timestamp_seconds: BigInt(0),
+};


### PR DESCRIPTION
# Motivation

User can see the list of proposals for a specific SNS project.

# Changes

Major changes to review:
* New component: SnsProposalCard.
* New sns proposal utils: mapProposalInfo. This one maps the type "SnsProposalData" to a more UI friendly version, adapted to be integrated with SnsProposalCard. Following the same pattern as in NNS.
* New sns governance api: getProposals.
* Implementation of SnsProposals. It was a dummy page before.
* New sns proposal service: loadSnsProposals
* New sns proposals store: snsProposalsStore

Other changes:
* Rename listSnsProposals to loadProposalsSnsCF.
* Move loadSnsNervousSystemFunctions to a public service.
* Minor changes in ProposalCard to make it totally agnostic of NNS.
* Duplication of i18n keys for statuses and reward statues. Enums might evolve differently.

# Tests

* Test new api functions.
* Test new store.
* Test new component.
* Add test cases for SnsProposals.
* Fix broken tests.
* Test new sns proposal utils.
