### PR TITLE
style: proposal markdown display improvements

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -93,6 +93,10 @@
       padding: var(--padding-2x) 0;
     }
 
+    :global(th) {
+      font-weight: 400;
+    }
+
     :global(pre) {
       // make the <code> scrollable
       overflow-x: auto;

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Markdown from "$lib/components/ui/Markdown.svelte";
+  import { nonNullish } from "$lib/utils/utils";
 
   export let summary: string | undefined;
 
@@ -10,6 +11,10 @@
 <div class="markdown">
   {#if showTitle}
     <div class="title"><slot name="title" /></div>
+
+    {#if nonNullish(summary) && summary !== ""}
+      <hr />
+    {/if}
   {/if}
 
   <Markdown text={summary} />
@@ -17,21 +22,45 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";
-
-  .title {
-    margin-bottom: var(--padding-4x);
-  }
+  @use "@dfinity/gix-components/styles/mixins/fonts";
 
   .markdown {
     overflow-wrap: break-word;
 
-    :global(a) {
-      font-size: inherit;
+    :global(*) {
+      color: var(--label-color);
     }
 
-    :global(pre) {
-      // make the <code> scrollable
-      overflow-x: auto;
+    :global(strong) {
+      font-weight: var(--font-weight-bold);
+    }
+
+    :global(a) {
+      @include fonts.standard;
+      color: var(--tertiary);
+
+      &:hover,
+      &:active {
+        color: var(--primary);
+      }
+    }
+
+    :global(h1) {
+      @include fonts.h4;
+      margin-bottom: var(--padding-2x);
+    }
+
+    :global(h2) {
+      @include fonts.h5;
+      margin-bottom: var(--padding-2x);
+    }
+
+    :global(h3),
+    :global(h4),
+    :global(h5),
+    :global(h6) {
+      @include fonts.standard(true);
+      margin-bottom: var(--padding);
     }
 
     :global(h1),
@@ -40,31 +69,70 @@
     :global(h4),
     :global(h5),
     :global(h6) {
-      line-height: var(--line-height-standard);
-      font-weight: normal;
-      color: inherit;
+      color: var(--value-color);
+      font-weight: 400;
     }
 
-    :global(h1) {
-      font-size: var(--font-size-h4);
+    :global(table),
+    :global(pre) {
+      background: var(--input-background);
+      color: var(--input-background-contrast);
+      border-radius: var(--border-radius);
     }
 
-    :global(h2) {
-      font-size: var(--font-size-h5);
-    }
-
-    :global(h3),
-    :global(h4),
-    :global(h5),
-    :global(h6) {
-      zoom: 0.8;
+    :global(table *),
+    :global(pre) {
+      @include fonts.small;
     }
 
     :global(table) {
       display: block;
       overflow: auto;
-      padding: var(--padding) 0 var(--padding);
       margin: var(--padding) 0 var(--padding-2x);
+      border-spacing: var(--padding-2x) 0;
+      padding: var(--padding-2x) 0;
+    }
+
+    :global(pre) {
+      // make the <code> scrollable
+      overflow-x: auto;
+
+      margin: var(--padding-3x) 0 var(--padding-4x);
+      padding: var(--padding-2x);
+    }
+
+    :global(code) {
+      font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
+        Liberation Mono, monospace;
+    }
+
+    :global(p),
+    :global(ul),
+    :global(ol),
+    :global(dl) {
+      margin: 0 0 var(--padding-3x);
+    }
+
+    :global(hr) {
+      color: var(--line);
+      margin: var(--padding-3x) 0;
+    }
+  }
+
+  @include media.dark-theme {
+    .markdown {
+      :global(a) {
+        &:hover,
+        &:active {
+          color: var(--primary-contrast);
+        }
+      }
+
+      :global(table),
+      :global(pre) {
+        background: var(--card-background);
+        color: var(--card-background-contrast);
+      }
     }
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -78,6 +78,9 @@
       background: var(--input-background);
       color: var(--input-background-contrast);
       border-radius: var(--border-radius);
+
+      font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
+        Liberation Mono, monospace;
     }
 
     :global(table *),
@@ -103,11 +106,6 @@
 
       margin: var(--padding-3x) 0 var(--padding-4x);
       padding: var(--padding-2x);
-    }
-
-    :global(code) {
-      font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
-        Liberation Mono, monospace;
     }
 
     :global(p),


### PR DESCRIPTION
# Motivation

Hard to style with `:global` and without that a huge variety of test content but following style rules should improve a bit the display of the markdown of the proposals. Let me know if you have better ideas!

# Changes

- tweak `:global` of the `.markdown`

# Screenshots

<img width="1536" alt="Capture d’écran 2023-01-11 à 12 29 48" src="https://user-images.githubusercontent.com/16886711/211795891-9d2c787a-1c04-4241-b195-a180b032248e.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 29 53" src="https://user-images.githubusercontent.com/16886711/211795915-fa76066e-fa37-4390-b38c-fbcf940bcf91.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 29 57" src="https://user-images.githubusercontent.com/16886711/211795926-d6b9959f-0ba3-4e9a-beec-1a925df21f41.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 01" src="https://user-images.githubusercontent.com/16886711/211795930-2169b5e4-82ea-4f50-b8fb-0f45d4b3a7b7.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 03" src="https://user-images.githubusercontent.com/16886711/211795934-485c34e4-70ff-4a31-a8e0-f0a3c305d47d.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 11" src="https://user-images.githubusercontent.com/16886711/211795937-b2e20db1-7be6-4478-9ae6-873fbe7498f1.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 14" src="https://user-images.githubusercontent.com/16886711/211795941-6254addf-997d-4894-9151-13a8bba7e6f2.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 20" src="https://user-images.githubusercontent.com/16886711/211795947-442ba5b8-747e-4f40-bcce-ee3e6e03c717.png">
<img width="1536" alt="Capture d’écran 2023-01-11 à 12 30 23" src="https://user-images.githubusercontent.com/16886711/211795950-1314ac52-6c2e-4a0b-9fae-427d5eda4d38.png">
