### PR TITLE
chore: Update threshold

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: "Verify that the WASM module is small enough to deploy"
         run: |
          wasm_size="$(wc -c < "${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm")"
-         max_size=3670016
+         max_size=3145728
          echo "WASM size:          $wasm_size"
          echo "Max supported size: $max_size"
          (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }


### PR DESCRIPTION
# Motivation
The threshold for ingress message size is lower than the threshold in the CI test.

# Changes
- Update (lower) the ingress message size to the one given in the error message when making a proposal.

# TODO
- Perhaps probe mainnet to detect if the threshold changes.
- Do an upgrade test; we could replicate the problem on a testnet when  installing via proposal instead of when installing directly.