### PR TITLE
chore: Update II init arguments for archive pull integration

### DIFF
--- a/rs/src/proposals.rs
+++ b/rs/src/proposals.rs
@@ -88,6 +88,18 @@ pub struct ArchiveConfig {
     pub polling_interval_ns: u64,
     // Max number of archive entries to be fetched in a single call.
     pub entries_fetch_limit: u16,
+    // How the entries get transferred to the archive.
+    // This is opt, so that the config parameter can be removed after switching from push to pull.
+    // Defaults to Push (legacy mode).
+    pub archive_integration: Option<ArchiveIntegration>,
+}
+
+#[derive(CandidType, Serialize, Deserialize)]
+pub enum ArchiveIntegration {
+    #[serde(rename = "push")]
+    Push,
+    #[serde(rename = "pull")]
+    Pull,
 }
 
 fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {


### PR DESCRIPTION
This PR updates the II init argument to include the flag to switch the archive from push to pull.

# Motivation

The II init arguments need to be rendered correctly -> types need to be up to date.
<!-- Describe the motivation that lead to the PR -->

# Changes

* Change the II init argument type.
<!-- List the changes that have been developed -->

# Tests

No tests.
<!-- Please provide any information or screenshots about the tests that have been done -->
