### PR TITLE
feat: update copyright IC 2023

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -136,7 +136,7 @@
     "about": "About",
     "voting_rewards": "Voting rewards",
     "logo": "Network Nervous System logo",
-    "copyright": "© 2022 Internet Computer",
+    "copyright": "© 2023 Internet Computer",
     "github_link": "Link to NNS-dapp repo on GitHub",
     "background": "An abstract image for design and presentation purpose only"
   },


### PR DESCRIPTION
# Motivation

According Maurice, the copyright year should always be current year.

# Changes

- no over-engineering, just 2022 changed in 2023

