### PR TITLE
chore: remove sns2 flag from split neuron and increase stake

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -21,7 +21,6 @@
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
   import SnsIncreaseStakeButton from "$lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte";
-  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -65,9 +64,7 @@
     {#if allowedToDissolve}
       <IncreaseSnsDissolveDelayButton />
     {/if}
-    {#if ENABLE_SNS_2}
-      <SnsIncreaseStakeButton />
-    {/if}
+    <SnsIncreaseStakeButton />
     {#if neuronState === NeuronState.Dissolved && allowedToDisburse}
       <DisburseSnsButton />
     {:else if canDissolve}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -26,7 +26,6 @@
   import SplitSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte";
   import type { Principal } from "@dfinity/principal";
   import type { NervousSystemParameters } from "@dfinity/sns";
-  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
 
   export let parameters: NervousSystemParameters;
   export let token: Token;
@@ -86,7 +85,7 @@
     <SnsNeuronStateRemainingTime {neuron} inline={false} />
 
     <div class="buttons">
-      {#if ENABLE_SNS_2 && allowedToSplit}
+      {#if allowedToSplit}
         <SplitSnsNeuronButton {neuron} {parameters} {token} {transactionFee} />
       {/if}
     </div>


### PR DESCRIPTION
# Motivation

Make `split sns neuron` and `increase sns stake` buttons publicly available.

# Changes

- remove `ENABLE_SNS_2` flag from `split sns neuron` and `increase sns stake` buttons.
