### PR TITLE
Fix: votingPower calculation for SNS neurons

### DIFF
--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -644,14 +644,20 @@ export const snsNeuronVotingPower = ({
   const {
     voting_power_percentage_multiplier,
     aging_since_timestamp_seconds,
-    maturity_e8s_equivalent,
+    staked_maturity_e8s_equivalent,
   } = neuron;
   const dissolveDelay =
     dissolveDelayInSeconds < maxDissolveDelaySeconds
       ? dissolveDelayInSeconds
       : maxDissolveDelaySeconds;
   const stakeE8s = BigInt(
-    Math.max(Number(getSnsNeuronStake(neuron) + maturity_e8s_equivalent), 0)
+    Math.max(
+      Number(
+        getSnsNeuronStake(neuron) +
+          (fromNullable(staked_maturity_e8s_equivalent) ?? BigInt(0))
+      ),
+      0
+    )
   );
   const ageSeconds = BigInt(
     Math.max(nowSeconds - Number(aging_since_timestamp_seconds), 0)

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -1498,6 +1498,35 @@ describe("sns-neuron utils", () => {
       );
     });
 
+    // https://gitlab.com/dfinity-lab/public/ic/-/blob/d621f8f05b8c6302ce0b9a007ed4aeec7e7b2f51/rs/sns/governance/src/neuron.rs#L727
+    it("should calculate fully boosted voting power with staked maturity", () => {
+      const baseStake = 100n;
+      const stakedMaturity = 100n;
+      const neuron: SnsNeuron = {
+        ...votingPowerNeuron,
+        staked_maturity_e8s_equivalent: [stakedMaturity],
+        cached_neuron_stake_e8s: baseStake,
+      };
+      const votingPower = snsNeuronVotingPower({
+        neuron,
+        newDissolveDelayInSeconds: 100n,
+        snsParameters: {
+          max_dissolve_delay_seconds: [100n],
+          max_neuron_age_for_age_bonus: [100n],
+          max_dissolve_delay_bonus_percentage: [100n],
+          max_age_bonus_percentage: [25n],
+          neuron_minimum_dissolve_delay_to_vote_seconds: [0n],
+        } as unknown as NervousSystemParameters,
+      });
+
+      expect(votingPower).toEqual(
+        ((Number(baseStake) + Number(stakedMaturity)) *
+          2 * // dissolve_delay boost
+          5) /
+          4 // voting power boost
+      );
+    });
+
     // https://gitlab.com/dfinity-lab/public/ic/-/blob/master/rs/sns/governance/src/neuron.rs#L747
     it("should calculate voting power with bonus thresholds zero", () => {
       const neuron: SnsNeuron = {


### PR DESCRIPTION
# Motivation

The user would see an invalid simulated voting power calculation if it had some maturity or staked maturity.

# Changes

* Take into account the staked_maturity_e8s_equivalent not maturity_e8s_equivalent for SNS neuron voting power.

# Tests

* Add a test for the new case.
