### PR TITLE
feat: remove "copy" amount from token switcher and move it to wallet details

### DIFF
--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -73,7 +73,7 @@
         $token: tokenSymbol,
       })}
     >
-      <AmountDisplay amount={accountBalance} inline />
+      <AmountDisplay copy amount={accountBalance} inline />
     </Tooltip>
   </KeyValuePair>
 
@@ -99,5 +99,9 @@
 <style lang="scss">
   p {
     margin: 0;
+  }
+
+  div {
+    --token-font-size: var(--font-size-h3);
   }
 </style>

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -9,6 +9,7 @@
   export let singleLine = false;
   export let title = false;
   export let copy = false;
+  export let text = false;
   export let inheritSize = false;
   export let sign: "+" | "-" | "" = "";
   export let detailed = false;
@@ -20,6 +21,7 @@
   class:inheritSize
   class:title
   class:copy
+  class:text
   class:plus-sign={sign === "+"}
   data-tid="token-value-label"
 >
@@ -78,6 +80,7 @@
     }
 
     &.title,
+    &.text,
     &.copy {
       display: block;
       word-break: break-word;
@@ -87,7 +90,8 @@
       }
     }
 
-    &.title {
+    &.title,
+    &.copy.title {
       span.value {
         @include fonts.h2(true);
 
@@ -97,9 +101,11 @@
       }
     }
 
+    &.text,
     &.copy {
       span.value {
-        @include fonts.standard(true);
+        font-size: var(--token-font-size, var(--font-size-standard));
+        font-weight: var(--font-weight-bold);
 
         // Custom line-height in case the value is spread on multiple lines - we have to amend the particular size of the copy button
         line-height: 1.8;

--- a/frontend/src/lib/components/universe/ProjectBalance.svelte
+++ b/frontend/src/lib/components/universe/ProjectBalance.svelte
@@ -6,7 +6,7 @@
 </script>
 
 {#if nonNullish($selectedProjectBalance.balance)}
-  <AmountDisplay copy amount={$selectedProjectBalance.balance} />
+  <AmountDisplay text amount={$selectedProjectBalance.balance} />
 {:else}
   <div class="skeleton">
     <SkeletonText />


### PR DESCRIPTION
# Motivation

We need the "copy" amount button because that's the way user can copy the effective amount with decimals. However, if there are many tokens, the "universe / token switcher" becomes crowded of "copy" buttons.

That's why this PR removes it from the switcher and add move the feature to wallet details.

# PRs

This PR -> #1677 -> main

# Screenshots

<img width="1536" alt="Capture d’écran 2023-01-16 à 19 46 03" src="https://user-images.githubusercontent.com/16886711/212747839-b8311bcf-3384-4adf-a32e-6e22867e3340.png">

<img width="1536" alt="Capture d’écran 2023-01-16 à 19 46 08" src="https://user-images.githubusercontent.com/16886711/212747851-ffb4103e-2537-46fe-a5d1-fc805a6db9fd.png">
