### PR TITLE
GIX-1212: Add Proposal Status filter

### DIFF
--- a/frontend/src/lib/components/proposals/FiltersWrapper.svelte
+++ b/frontend/src/lib/components/proposals/FiltersWrapper.svelte
@@ -1,0 +1,28 @@
+<div class="filters" data-tid="proposals-filters">
+  <slot />
+</div>
+
+<style lang="scss">
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0 0 var(--padding-3x);
+
+    --checkbox-flex-direction: row-reverse;
+    --checkbox-font-size: var(--font-size-small);
+
+    :global(button) {
+      margin: var(--padding) var(--padding) 0 0;
+    }
+
+    > :global(div.checkbox) {
+      width: fit-content;
+      padding: var(--padding) calc(0.75 * var(--padding));
+      margin: var(--padding) 0 0;
+    }
+  }
+
+  :global(section > div.checkbox) {
+    margin: 0 0 var(--padding);
+  }
+</style>

--- a/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
@@ -9,6 +9,7 @@
   import FiltersButton from "$lib/components/ui/FiltersButton.svelte";
   import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
   import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
+  import FiltersWrapper from "./FiltersWrapper.svelte";
 
   let modalFilters: ProposalsFilterModalProps | undefined = undefined;
 
@@ -43,7 +44,7 @@
   ).length;
 </script>
 
-<div class="filters" data-tid="nns-proposal-filters">
+<FiltersWrapper>
   <FiltersButton
     testId="filters-by-topics"
     totalFilters={totalFiltersTopic}
@@ -88,40 +89,9 @@
       text="block">{$i18n.voting.hide_unavailable_proposals}</Checkbox
     >
   </SignedInOnly>
-</div>
+</FiltersWrapper>
 
 <NnsProposalsFilterModal
   props={modalFilters}
   on:nnsClose={() => (modalFilters = undefined)}
 />
-
-<style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-
-  .filters {
-    display: flex;
-    flex-wrap: wrap;
-    padding: 0 0 var(--padding-3x);
-
-    --checkbox-flex-direction: row-reverse;
-    --checkbox-font-size: var(--font-size-small);
-
-    :global(button) {
-      margin: var(--padding) var(--padding) 0 0;
-
-      @include media.min-width(large) {
-        margin: 0 var(--padding) 0 0;
-      }
-    }
-
-    > :global(div.checkbox) {
-      width: fit-content;
-      padding: var(--padding) calc(0.75 * var(--padding));
-      margin: var(--padding) 0 0;
-    }
-  }
-
-  :global(section > div.checkbox) {
-    margin: 0 0 var(--padding);
-  }
-</style>

--- a/frontend/src/lib/components/proposals/NnsProposalsList.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import NnsProposalCard from "./NnsProposalCard.svelte";
   import { InfiniteScroll } from "@dfinity/gix-components";
-  import ProposalsFilters from "./ProposalsFilters.svelte";
+  import NnsProposalsFilters from "./NnsProposalsFilters.svelte";
   import { filteredProposals } from "$lib/derived/proposals.derived";
   import NoProposals from "./NoProposals.svelte";
   import LoadingProposals from "./LoadingProposals.svelte";
@@ -14,7 +14,7 @@
   export let loadingAnimation: "spinner" | "skeleton" | undefined;
 </script>
 
-<ProposalsFilters />
+<NnsProposalsFilters />
 
 <ListLoader loading={loadingAnimation === "spinner"}>
   <InfiniteScroll

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { snsProjectIdSelectedStore } from "$lib/derived/selected-project.derived";
+  import SnsFilterStatusModal from "$lib/modals/sns/proposals/SnsFilterStatusModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import {
+    snsFiltesStore,
+    type ProjectFiltersStoreData,
+  } from "$lib/stores/sns-filters.store";
+  import type { Principal } from "@dfinity/principal";
+  import FiltersWrapper from "../proposals/FiltersWrapper.svelte";
+  import FiltersButton from "../ui/FiltersButton.svelte";
+
+  let modal: "topics" | "rewards" | "status" | undefined = undefined;
+
+  let rootCanisterId: Principal;
+  $: rootCanisterId = $snsProjectIdSelectedStore;
+  let filtersStore: ProjectFiltersStoreData | undefined;
+  $: filtersStore = $snsFiltesStore[rootCanisterId.toText()];
+
+  const openFilters = () => {
+    modal = "status";
+  };
+
+  const close = () => {
+    modal = undefined;
+  };
+</script>
+
+<FiltersWrapper>
+  <FiltersButton
+    testId="filters-by-status"
+    totalFilters={filtersStore?.decisionStatus.length ?? 0}
+    activeFilters={filtersStore?.decisionStatus.filter(({ checked }) => checked)
+      .length ?? 0}
+    on:nnsFilter={openFilters}>{$i18n.voting.status}</FiltersButton
+  >
+</FiltersWrapper>
+
+{#if modal === "status"}
+  <SnsFilterStatusModal
+    filters={filtersStore?.decisionStatus}
+    {rootCanisterId}
+    on:nnsClose={close}
+  />
+{/if}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -7,6 +7,7 @@
   import NoProposals from "../proposals/NoProposals.svelte";
   import LoadingProposals from "../proposals/LoadingProposals.svelte";
   import ListLoader from "../proposals/ListLoader.svelte";
+  import SnsProposalsFilters from "./SnsProposalsFilters.svelte";
 
   export let proposals: SnsProposalData[] | undefined;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
@@ -14,23 +15,21 @@
   export let loadingNextPage = false;
 </script>
 
-<!-- TODO: Remove when implementing filters https://dfinity.atlassian.net/browse/GIX-1212 -->
-<div data-tid="sns-proposals-page">
-  {#if proposals === undefined}
-    <LoadingProposals />
-  {:else if proposals.length === 0}
-    <NoProposals />
-  {:else}
-    <ListLoader loading={loadingNextPage}>
-      <InfiniteScroll
-        layout="grid"
-        on:nnsIntersect
-        disabled={disableInfiniteScroll}
-      >
-        {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
-          <SnsProposalCard {proposalData} {nsFunctions} />
-        {/each}
-      </InfiniteScroll>
-    </ListLoader>
-  {/if}
-</div>
+<SnsProposalsFilters />
+{#if proposals === undefined}
+  <LoadingProposals />
+{:else if proposals.length === 0}
+  <NoProposals />
+{:else}
+  <ListLoader loading={loadingNextPage}>
+    <InfiniteScroll
+      layout="grid"
+      on:nnsIntersect
+      disabled={disableInfiniteScroll}
+    >
+      {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
+        <SnsProposalCard {proposalData} {nsFunctions} />
+      {/each}
+    </InfiniteScroll>
+  </ListLoader>
+{/if}

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -46,7 +46,7 @@
 </script>
 
 {#if !loading}
-  <Modal {visible} on:nnsClose role="alert">
+  <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
     <slot slot="title" name="title" />
 
     {#if filters}

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import FilterModal from "$lib/modals/common/FilterModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+  import type { Filter } from "$lib/types/filters";
+  import type { Principal } from "@dfinity/principal";
+  import type { SnsProposalDecisionStatus } from "@dfinity/sns";
+  import { createEventDispatcher } from "svelte";
+
+  export let rootCanisterId: Principal;
+  export let filters: Filter<SnsProposalDecisionStatus>[] = [];
+
+  // This is a temporary value to be used inside the modal. It's initialized based on the prop filters;
+  let selectedFilters: SnsProposalDecisionStatus[] =
+    filters.filter(({ checked }) => checked).map(({ value }) => value) ?? [];
+  // This is a temporary value to be used inside the modal
+  let filtersValues: Filter<SnsProposalDecisionStatus>[];
+  $: filtersValues = filters.map((filter) => ({
+    ...filter,
+    checked: selectedFilters.includes(filter.value),
+  }));
+
+  const dispatch = createEventDispatcher();
+  let filter: () => void;
+  $: filter = () => {
+    snsFiltesStore.checkDecisionStatus({
+      checkedDecisionStatus: selectedFilters,
+      rootCanisterId,
+    });
+    dispatch("nnsClose");
+  };
+
+  const onChange = ({
+    detail: { filter },
+  }: CustomEvent<{
+    filter: Filter<SnsProposalDecisionStatus> | undefined;
+  }>) => {
+    if (filter === undefined) return;
+    selectedFilters = [
+      ...selectedFilters.filter((status) => status !== filter?.value),
+      // Toggle the checked value
+      ...(filter.checked ? [] : [filter.value]),
+    ];
+  };
+</script>
+
+<FilterModal
+  on:nnsClose
+  on:nnsConfirm={filter}
+  on:nnsChange={onChange}
+  filters={filtersValues}
+>
+  <span slot="title">{$i18n.voting.status}</span>
+</FilterModal>

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
@@ -23,7 +23,7 @@
   const dispatch = createEventDispatcher();
   let filter: () => void;
   $: filter = () => {
-    snsFiltesStore.checkDecisionStatus({
+    snsFiltesStore.setCheckDecisionStatus({
       checkedDecisionStatus: selectedFilters,
       rootCanisterId,
     });
@@ -35,7 +35,9 @@
   }: CustomEvent<{
     filter: Filter<SnsProposalDecisionStatus> | undefined;
   }>) => {
-    if (filter === undefined) return;
+    if (filter === undefined) {
+      return;
+    }
     selectedFilters = [
       ...selectedFilters.filter((status) => status !== filter?.value),
       // Toggle the checked value

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -17,7 +17,9 @@
     lastProposalId,
     sortSnsProposalsById,
   } from "$lib/utils/sns-proposals.utils";
-  onMount(() => {
+  import { loadSnsFilters } from "$lib/services/sns-filters.services";
+
+  onMount(async () => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
     if (!ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }), {
@@ -32,6 +34,7 @@
         await Promise.all([
           loadSnsProposals({ rootCanisterId: selectedProjectCanisterId }),
           loadSnsNervousSystemFunctions(selectedProjectCanisterId),
+          loadSnsFilters(selectedProjectCanisterId),
         ]);
       }
     }

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -5,9 +5,10 @@ import type { Principal } from "@dfinity/principal";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
 import { get } from "svelte/store";
 
+// TODO: Set default filters
 export const loadSnsFilters = async (rootCanisterId: Principal) => {
   const i18nKeys = get(i18n);
-  const projectData = get(snsFiltesStore)[rootCanisterId.toText()] ?? {
+  const filtersProjectData = get(snsFiltesStore)[rootCanisterId.toText()] ?? {
     topics: [],
     rewardStatus: [],
     decisionStatus: [],
@@ -16,8 +17,8 @@ export const loadSnsFilters = async (rootCanisterId: Principal) => {
     return {
       id: String(value),
       value,
-      name: i18nKeys.sns_status[value] ?? "Unspecified",
-      checked: projectData.decisionStatus.some(
+      name: i18nKeys.sns_status[value] ?? i18nKeys.core.unspecified,
+      checked: filtersProjectData.decisionStatus.some(
         ({ checked, id }) => checked && id === String(value)
       ),
     };

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -1,0 +1,36 @@
+import { i18n } from "$lib/stores/i18n";
+import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import { enumValues } from "$lib/utils/enum.utils";
+import type { Principal } from "@dfinity/principal";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { get } from "svelte/store";
+
+export const loadSnsFilters = async (rootCanisterId: Principal) => {
+  const i18nKeys = get(i18n);
+  const projectData = get(snsFiltesStore)[rootCanisterId.toText()] ?? {
+    topics: [],
+    rewardStatus: [],
+    decisionStatus: [],
+  };
+  const mapDecisionStatus = (value: SnsProposalDecisionStatus) => {
+    return {
+      id: String(value),
+      value,
+      name: i18nKeys.sns_status[value] ?? "Unspecified",
+      checked: projectData.decisionStatus.some(
+        ({ checked, id }) => checked && id === String(value)
+      ),
+    };
+  };
+  const decisionStatus = enumValues(SnsProposalDecisionStatus)
+    .filter(
+      (status) =>
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED !==
+        status
+    )
+    .map(mapDecisionStatus);
+  snsFiltesStore.setDecisionStatus({
+    rootCanisterId,
+    decisionStatus,
+  });
+};

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -1,0 +1,86 @@
+import type { Filter } from "$lib/types/filters";
+import type { Principal } from "@dfinity/principal";
+import type {
+  SnsNervousSystemFunction,
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
+import { writable } from "svelte/store";
+
+export interface ProjectFiltersStoreData {
+  topics: Filter<SnsNervousSystemFunction>[];
+  rewardStatus: Filter<SnsProposalRewardStatus>[];
+  decisionStatus: Filter<SnsProposalDecisionStatus>[];
+}
+
+interface SnsFiltersStoreData {
+  [rootCanisterId: string]: ProjectFiltersStoreData;
+}
+
+/**
+ * A store that contains the filters of the SNS proposals for each project.
+ */
+export const initSnsFiltersStore = () => {
+  const { subscribe, set, update } = writable<SnsFiltersStoreData>({});
+
+  return {
+    subscribe,
+
+    setDecisionStatus({
+      rootCanisterId,
+      decisionStatus,
+    }: {
+      rootCanisterId: Principal;
+      decisionStatus: Filter<SnsProposalDecisionStatus>[];
+    }) {
+      update((currentState: SnsFiltersStoreData) => {
+        const projectFilters = currentState[rootCanisterId.toText()] || {
+          topics: [],
+          rewardStatus: [],
+          decisionStatus: [],
+        };
+
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            ...projectFilters,
+            decisionStatus,
+          },
+        };
+      });
+    },
+
+    checkDecisionStatus({
+      rootCanisterId,
+      checkedDecisionStatus,
+    }: {
+      rootCanisterId: Principal;
+      checkedDecisionStatus: SnsProposalDecisionStatus[];
+    }) {
+      update((currentState: SnsFiltersStoreData) => {
+        const projectFilters = currentState[rootCanisterId.toText()] || {
+          topics: [],
+          rewardStatus: [],
+          decisionStatus: [],
+        };
+
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            ...projectFilters,
+            decisionStatus: projectFilters.decisionStatus.map(
+              (decisionStatus) => ({
+                ...decisionStatus,
+                checked: checkedDecisionStatus.includes(decisionStatus.value),
+              })
+            ),
+          },
+        };
+      });
+    },
+
+    reset: () => set({}),
+  };
+};
+
+export const snsFiltesStore = initSnsFiltersStore();

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -5,7 +5,7 @@ import type {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
 } from "@dfinity/sns";
-import { writable } from "svelte/store";
+import { writable, type Readable } from "svelte/store";
 
 export interface ProjectFiltersStoreData {
   topics: Filter<SnsNervousSystemFunction>[];
@@ -17,10 +17,24 @@ interface SnsFiltersStoreData {
   [rootCanisterId: string]: ProjectFiltersStoreData;
 }
 
+interface ProjectFiltersStore extends Readable<SnsFiltersStoreData> {
+  setDecisionStatus: (data: {
+    rootCanisterId: Principal;
+    decisionStatus: Filter<SnsProposalDecisionStatus>[];
+  }) => void;
+  setCheckDecisionStatus: (data: {
+    rootCanisterId: Principal;
+    checkedDecisionStatus: SnsProposalDecisionStatus[];
+  }) => void;
+  reset: () => void;
+}
+
 /**
  * A store that contains the filters of the SNS proposals for each project.
+ *
+ * TODO: persist to localstorage
  */
-export const initSnsFiltersStore = () => {
+export const initSnsFiltersStore = (): ProjectFiltersStore => {
   const { subscribe, set, update } = writable<SnsFiltersStoreData>({});
 
   return {
@@ -50,7 +64,7 @@ export const initSnsFiltersStore = () => {
       });
     },
 
-    checkDecisionStatus({
+    setCheckDecisionStatus({
       rootCanisterId,
       checkedDecisionStatus,
     }: {

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import ProposalsFilters from "$lib/components/proposals/ProposalsFilters.svelte";
+import NnsProposalsFilters from "$lib/components/proposals/NnsProposalsFilters.svelte";
 import {
   DEFAULT_PROPOSALS_FILTERS,
   DEPRECATED_TOPICS,
@@ -20,7 +20,7 @@ import {
 } from "../../../mocks/auth.store.mock";
 import en from "../../../mocks/i18n.mock";
 
-describe("ProposalsFilters", () => {
+describe("NnsProposalsFilters", () => {
   const shouldRenderFilter = ({
     container,
     activeFilters,
@@ -47,7 +47,7 @@ describe("ProposalsFilters", () => {
       .mockImplementation(mutableMockAuthStoreSubscribe);
 
     it("should render topics filters", () => {
-      const { container } = render(ProposalsFilters);
+      const { container } = render(NnsProposalsFilters);
 
       const nonShownTopicsLength = [
         PROPOSAL_FILTER_UNSPECIFIED_VALUE,
@@ -63,7 +63,7 @@ describe("ProposalsFilters", () => {
     });
 
     it("should render rewards filters", () => {
-      const { container } = render(ProposalsFilters);
+      const { container } = render(NnsProposalsFilters);
 
       shouldRenderFilter({
         container,
@@ -74,7 +74,7 @@ describe("ProposalsFilters", () => {
     });
 
     it("should render proposals filters", () => {
-      const { container } = render(ProposalsFilters);
+      const { container } = render(NnsProposalsFilters);
 
       shouldRenderFilter({
         container,
@@ -92,7 +92,7 @@ describe("ProposalsFilters", () => {
       });
 
       it("should render a checkbox", () => {
-        const { container } = render(ProposalsFilters);
+        const { container } = render(NnsProposalsFilters);
 
         const input: HTMLInputElement | null = container.querySelector("input");
 
@@ -109,7 +109,7 @@ describe("ProposalsFilters", () => {
       });
 
       it("should not render a checkbox", () => {
-        const { getByTestId } = render(ProposalsFilters);
+        const { getByTestId } = render(NnsProposalsFilters);
 
         expect(() => getByTestId("hide-unavailable-proposals")).toThrow();
       });
@@ -129,7 +129,7 @@ describe("ProposalsFilters", () => {
       ];
       proposalsFiltersStore.filterTopics(activeFilters);
 
-      const { container } = render(ProposalsFilters);
+      const { container } = render(NnsProposalsFilters);
 
       const nonShownTopicsLength = [
         PROPOSAL_FILTER_UNSPECIFIED_VALUE,

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsProposalsFilters from "$lib/components/sns-proposals/SnsProposalsFilters.svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+
+describe("SnsProposalsFilters", () => {
+  it("should render status filter button", () => {
+    const { queryByTestId } = render(SnsProposalsFilters);
+
+    expect(queryByTestId("filters-by-status")).toBeInTheDocument();
+  });
+
+  it("should show filter modal when status filter is clicked", async () => {
+    const { queryByTestId } = render(SnsProposalsFilters);
+
+    const statusFilterButton = queryByTestId("filters-by-status");
+    statusFilterButton && fireEvent.click(statusFilterButton);
+
+    await waitFor(() =>
+      expect(queryByTestId("filter-modal")).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/modals/sns/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterStatusModal.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsFilterStatusModal from "$lib/modals/sns/proposals/SnsFilterStatusModal.svelte";
+import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import type { Filter } from "$lib/types/filters";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import en from "../../../mocks/i18n.mock";
+import { clickByTestId } from "../../../utils/utils.test-utils";
+
+describe("SnsFilterStatusModal", () => {
+  afterEach(() => {
+    snsFiltesStore.reset();
+  });
+  const filters: Filter<SnsProposalDecisionStatus>[] = [
+    {
+      id: "1",
+      name: "status-1",
+      value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      checked: true,
+    },
+    {
+      id: "2",
+      name: "status-2",
+      value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+      checked: false,
+    },
+  ];
+  const props = {
+    rootCanisterId: mockPrincipal,
+    filters,
+  };
+
+  it("should display modal", () => {
+    const { container } = render(SnsFilterStatusModal, {
+      props,
+    });
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should render title", () => {
+    const { getByText } = render(SnsFilterStatusModal, {
+      props,
+    });
+
+    expect(getByText(en.voting.status)).toBeInTheDocument();
+  });
+
+  it("should render checkboxes", () => {
+    const { container } = render(SnsFilterStatusModal, {
+      props,
+    });
+
+    expect(container.querySelectorAll("input[type=checkbox]")).toHaveLength(
+      filters.length
+    );
+  });
+
+  it("should forward close modal event", (done) => {
+    const { container, component } = render(SnsFilterStatusModal, {
+      props,
+    });
+
+    component.$on("nnsClose", () => {
+      done();
+    });
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      "button:first-of-type"
+    );
+
+    button && fireEvent.click(button);
+  });
+
+  it("should filter filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltesStore.setDecisionStatus({
+      rootCanisterId: mockPrincipal,
+      decisionStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterStatusModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    const firstInput = inputs[0];
+    fireEvent.click(firstInput);
+    await waitFor(() => expect(firstInput.checked).toBeTruthy());
+
+    const secondInput = inputs[1];
+    fireEvent.click(secondInput);
+    await waitFor(() => expect(secondInput.checked).toBeTruthy());
+
+    await clickByTestId(queryByTestId, "apply-filters");
+
+    const statuses =
+      get(snsFiltesStore)[mockPrincipal.toText()]?.decisionStatus;
+
+    expect(statuses.filter(({ checked }) => checked).length).toEqual(2);
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -5,6 +5,7 @@
 import SnsProposals from "$lib/pages/SnsProposals.svelte";
 import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
 import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
+import { loadSnsFilters } from "$lib/services/sns-filters.services";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { page } from "$mocks/$app/stores";
 import { render, waitFor } from "@testing-library/svelte";
@@ -21,6 +22,12 @@ jest.mock("$lib/services/$public/sns.services", () => {
 jest.mock("$lib/services/$public/sns-proposals.services", () => {
   return {
     loadSnsProposals: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock("$lib/services/sns-filters.services", () => {
+  return {
+    loadSnsFilters: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -50,6 +57,7 @@ describe("SnsProposals", () => {
 
         expect(loadSnsNervousSystemFunctions).toBeCalled();
         expect(loadSnsProposals).toBeCalled();
+        expect(loadSnsFilters).toBeCalled();
       });
 
       it("should render a spinner while searching proposals", async () => {

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -2,13 +2,16 @@
  * @jest-environment jsdom
  */
 
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  OWN_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import { committedProjectsStore } from "$lib/derived/projects.derived";
 import Proposals from "$lib/routes/Proposals.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
 import { waitFor } from "@testing-library/dom";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import {
   mockProjectSubscribe,
@@ -52,18 +55,57 @@ describe("Proposals", () => {
 
   it("should render NnsProposals by default", () => {
     const { queryByTestId } = render(Proposals);
-    expect(queryByTestId("nns-proposal-filters")).toBeInTheDocument();
+    expect(queryByTestId("proposals-filters")).toBeInTheDocument();
   });
 
   it("should render project page when a project is selected", async () => {
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
-
     const { queryByTestId } = render(Proposals);
 
+    expect(queryByTestId("proposals-filters")).toBeInTheDocument();
+
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
+
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
+
     await waitFor(() =>
-      expect(queryByTestId("sns-proposals-page")).toBeInTheDocument()
+      expect(queryByTestId("proposals-filters")).toBeInTheDocument()
+    );
+  });
+
+  it("should be able to go back to nns after going to a project", async () => {
+    const { queryByTestId } = render(Proposals);
+
+    expect(queryByTestId("proposals-filters")).toBeInTheDocument();
+
+    const selectElement = queryByTestId(
+      "select-project-dropdown"
+    ) as HTMLSelectElement | null;
+
+    const projectCanisterId = mockSnsFullProject.rootCanisterId.toText();
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: projectCanisterId },
+      });
+
+    await waitFor(() =>
+      expect(queryByTestId("proposals-filters")).toBeInTheDocument()
+    );
+
+    selectElement &&
+      fireEvent.change(selectElement, {
+        target: { value: OWN_CANISTER_ID.toText() },
+      });
+    await waitFor(() =>
+      expect(queryByTestId("proposals-filters")).toBeInTheDocument()
     );
   });
 });

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -1,0 +1,28 @@
+import { loadSnsFilters } from "$lib/services/sns-filters.services";
+import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import { enumSize } from "$lib/utils/enum.utils";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+
+describe("sns-filters services", () => {
+  describe("loadSnsFilters", () => {
+    afterEach(() => {
+      snsFiltesStore.reset();
+    });
+    it("should load the sns filters store with status but not Unspecified", async () => {
+      await loadSnsFilters(mockPrincipal);
+
+      const projectStore = get(snsFiltesStore)[mockPrincipal.toText()];
+
+      expect(projectStore.decisionStatus).toHaveLength(
+        enumSize(SnsProposalDecisionStatus) - 1
+      );
+      expect(
+        projectStore.decisionStatus.map(({ value }) => value)
+      ).not.toContainEqual(
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED
+      );
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
@@ -35,7 +35,7 @@ describe("sns-filters store", () => {
     expect(projectStore2.decisionStatus).toEqual(decisionStatus);
   });
 
-  it("checkDecisionStatus should check filters in different projects", () => {
+  it("setCheckDecisionStatus should check filters in different projects", () => {
     const rootCanisterId = mockPrincipal;
     const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
     const decisionStatus = [
@@ -61,7 +61,7 @@ describe("sns-filters store", () => {
     ).toEqual(0);
 
     const statuses = decisionStatus.map(({ value }) => value);
-    snsFiltesStore.checkDecisionStatus({
+    snsFiltesStore.setCheckDecisionStatus({
       rootCanisterId,
       checkedDecisionStatus: statuses,
     });
@@ -80,7 +80,7 @@ describe("sns-filters store", () => {
       projectStore3.decisionStatus.filter(({ checked }) => checked).length
     ).toEqual(0);
 
-    snsFiltesStore.checkDecisionStatus({
+    snsFiltesStore.setCheckDecisionStatus({
       rootCanisterId: rootCanisterId2,
       checkedDecisionStatus: [
         SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
@@ -98,7 +98,7 @@ describe("sns-filters store", () => {
     ).toEqual(statuses.length);
 
     // Uncheck from Project 2
-    snsFiltesStore.checkDecisionStatus({
+    snsFiltesStore.setCheckDecisionStatus({
       rootCanisterId,
       checkedDecisionStatus: [
         SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,

--- a/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
@@ -1,0 +1,112 @@
+import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import { Principal } from "@dfinity/principal";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { get } from "svelte/store";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
+
+describe("sns-filters store", () => {
+  it("should setDecisionStatus in different projects", () => {
+    const rootCanisterId = mockPrincipal;
+    const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+    const decisionStatus = [
+      {
+        id: "1",
+        name: "status-1",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        checked: true,
+      },
+      {
+        id: "2",
+        name: "status-2",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+        checked: true,
+      },
+    ];
+    snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+
+    const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
+    expect(projectStore.decisionStatus).toEqual(decisionStatus);
+
+    snsFiltesStore.setDecisionStatus({
+      rootCanisterId: rootCanisterId2,
+      decisionStatus,
+    });
+    const projectStore2 = get(snsFiltesStore)[rootCanisterId2.toText()];
+    expect(projectStore2.decisionStatus).toEqual(decisionStatus);
+  });
+
+  it("checkDecisionStatus should check filters in different projects", () => {
+    const rootCanisterId = mockPrincipal;
+    const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+    const decisionStatus = [
+      {
+        id: "1",
+        name: "status-1",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        checked: false,
+      },
+      {
+        id: "2",
+        name: "status-2",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+        checked: false,
+      },
+    ];
+
+    // Project rootCanisterId
+    snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+    const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
+    expect(
+      projectStore.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(0);
+
+    const statuses = decisionStatus.map(({ value }) => value);
+    snsFiltesStore.checkDecisionStatus({
+      rootCanisterId,
+      checkedDecisionStatus: statuses,
+    });
+    const projectStore2 = get(snsFiltesStore)[rootCanisterId2.toText()];
+    expect(
+      projectStore2.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(statuses.length);
+
+    // Project rootCanisterId2
+    snsFiltesStore.setDecisionStatus({
+      rootCanisterId: rootCanisterId2,
+      decisionStatus,
+    });
+    const projectStore3 = get(snsFiltesStore)[rootCanisterId2.toText()];
+    expect(
+      projectStore3.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(0);
+
+    snsFiltesStore.checkDecisionStatus({
+      rootCanisterId: rootCanisterId2,
+      checkedDecisionStatus: [
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      ],
+    });
+    const projectStore4 = get(snsFiltesStore)[rootCanisterId2.toText()];
+    expect(
+      projectStore4.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(1);
+
+    // Project 1 has not changed
+    const projectStore5 = get(snsFiltesStore)[rootCanisterId.toText()];
+    expect(
+      projectStore5.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(statuses.length);
+
+    // Uncheck from Project 2
+    snsFiltesStore.checkDecisionStatus({
+      rootCanisterId,
+      checkedDecisionStatus: [
+        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      ],
+    });
+    const projectStore6 = get(snsFiltesStore)[rootCanisterId.toText()];
+    expect(
+      projectStore6.decisionStatus.filter(({ checked }) => checked).length
+    ).toEqual(1);
+  });
+});


### PR DESCRIPTION
# Motivation

User can filter proposal by decision status.

IMPORTANT: This PR includes setup of filters, button, modal and store. Not yet updating the proposals list.

# Changes

Main changes:
* SnsProposalsFilters.svelte will include all filters buttons and render each modal.
* SnsFilterStatusModal.svelte shows filters and performs the actions in the store.
* sns-filters.store manages filters for SNS projects.
* loadSnsFilters in sns-filters.services.

The idea to store the Filter type in the store is to use the same concept for all SNS filters. Recall that SNS topics is not an enum, instead is the list of nervous functions. Which have a name, id and description.

I believe this is a good idea also for NNS. (for later) This way the UI doesn't care or know where the filters come from. Whether an enum or from a backend. The UI components are more reusable. We just need to add the logic of filling up the store with the data.

Minor changes:
* New UI component FiltersWrapper.svelte to be reused in SNS and NNS filters.
* ProposalsFilters.svelte to NnsProposalsFilters.svelte

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
