### PR TITLE
feat: A minimal launchpad e2e test

### DIFF
--- a/e2e-tests/specs/launchpad.e2e.ts
+++ b/e2e-tests/specs/launchpad.e2e.ts
@@ -1,0 +1,41 @@
+import { register } from "../common/register";
+import { waitForImages } from "../common/waitForImages";
+import { waitForLoad } from "../common/waitForLoad";
+import { skipUnlessBrowserIs } from "../common/test";
+
+describe("View launchpad while logged out", () => {
+  before(function () {
+    skipUnlessBrowserIs.bind(this)(["chrome", "firefox"]);
+  });
+
+  it("Views the launchpad whil elogged out", async () => {
+    await browser.url("/launchpad/");
+    await waitForLoad(browser);
+    await waitForImages(browser);
+    await browser.pause(2000); // Wait a second for the back-end data to load
+    await browser["screenshot"]("launchpad-while-logged-out");
+  });
+});
+
+describe("View launchpad when logged in", () => {
+  before(function () {
+    skipUnlessBrowserIs.bind(this)(["chrome"]);
+  });
+  it("Registers and logs in as a user", async () => {
+    await browser.url("/");
+    const userId = await register(browser);
+    console.log(`Created user: ${JSON.stringify(userId)}`);
+    await waitForLoad(browser);
+    await waitForImages(browser);
+    await browser.pause(2000); // Wait a second for the back-end data to load
+    await browser["screenshot"]("launchpad-login");
+  });
+
+  it("Views the launchpad while logged in", async () => {
+    await browser.url("/launchpad/");
+    await waitForLoad(browser);
+    await waitForImages(browser);
+    await browser.pause(2000); // Wait a second for the back-end data to load
+    await browser["screenshot"]("launchpad-while-logged-in");
+  });
+});


### PR DESCRIPTION
# Motivation
An e2e test is needed for load generation.  It doesn't need to actually test anything, it just needs to load the launchpad to stress the network.

Proper e2e tests are in the pipeline for the launchpad, however stress testing doesn't cared about delicacies such as using tids to click buttons.  So the stress-testing e2e test can be used now without waiting for tids et al.

# Changes
- Add an e2e test that loads the launchpad, first logged out then logged in.

# Tests
- I have run this e2e test locally and it will be run in CI.