### PR TITLE
Draft: Dockerize nns-dapp-specs

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -1,0 +1,64 @@
+# Use this with
+#
+# docker build . -t nns-dapp-specs
+# docker run -d nns-dapp-specs > CONTAINER.txt
+# Await docker inspect -f '{{.State.Running}}' $(cat CONTAINER.txt) == "false"
+# docker logs $(cat CONTAINER.txt) > report.txt
+
+FROM ubuntu:20.04 as builder
+SHELL ["bash", "-c"]
+
+ARG rust_version=1.63.0
+ENV NODE_VERSION=16.17.1
+
+ENV TZ=UTC
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt -yq update && \
+    apt -yqq install --no-install-recommends curl ca-certificates \
+        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
+        git jq
+
+# Install node
+RUN curl --fail -sSf https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+
+# Install Rust and Cargo in /opt
+ENV RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo \
+    PATH=/opt/cargo/bin:$PATH
+
+RUN curl --fail https://sh.rustup.rs -sSf \
+        | sh -s -- -y --default-toolchain ${rust_version}-x86_64-unknown-linux-gnu --no-modify-path && \
+    rustup default ${rust_version}-x86_64-unknown-linux-gnu && \
+    rustup target add wasm32-unknown-unknown
+
+ENV PATH=/cargo/bin:$PATH
+
+# Install IC CDK optimizer
+RUN cargo install --version 0.3.1 ic-cdk-optimizer
+
+# Pre-build all cargo dependencies. Because cargo doesn't have a build option
+# to build only the dependencies, we pretend that our project is a simple, empty
+# `lib.rs`. Then we remove the dummy source files to make sure cargo rebuild
+# everything once the actual source code is COPYed (and e.g. doesn't trip on
+# timestamps being older)
+COPY Cargo.lock .
+COPY Cargo.toml .
+COPY rs/Cargo.toml rs/Cargo.toml
+RUN mkdir -p rs/src && touch rs/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -rf rs/src
+
+# Install dfx
+COPY dfx.json dfx.json
+RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+
+# --- End of common part ---
+
+RUN apt-get -y install moreutils jq
+ADD . /e2e-tests

--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -8,16 +8,13 @@
 FROM ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 
-ARG rust_version=1.63.0
 ENV NODE_VERSION=16.17.1
 
 ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    apt -yq update && \
-    apt -yqq install --no-install-recommends curl ca-certificates \
-        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
-        git jq
+    apt-get -yq update && \
+    apt-get -yqq install --no-install-recommends ca-certificates curl moreutils jq
 
 # Install node
 RUN curl --fail -sSf https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
@@ -29,36 +26,15 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-# Install Rust and Cargo in /opt
-ENV RUSTUP_HOME=/opt/rustup \
-    CARGO_HOME=/opt/cargo \
-    PATH=/opt/cargo/bin:$PATH
-
-RUN curl --fail https://sh.rustup.rs -sSf \
-        | sh -s -- -y --default-toolchain ${rust_version}-x86_64-unknown-linux-gnu --no-modify-path && \
-    rustup default ${rust_version}-x86_64-unknown-linux-gnu && \
-    rustup target add wasm32-unknown-unknown
-
-ENV PATH=/cargo/bin:$PATH
-
-# Install IC CDK optimizer
-RUN cargo install --version 0.3.1 ic-cdk-optimizer
-
-# Pre-build all cargo dependencies. Because cargo doesn't have a build option
-# to build only the dependencies, we pretend that our project is a simple, empty
-# `lib.rs`. Then we remove the dummy source files to make sure cargo rebuild
-# everything once the actual source code is COPYed (and e.g. doesn't trip on
-# timestamps being older)
-COPY Cargo.lock .
-COPY Cargo.toml .
-COPY rs/Cargo.toml rs/Cargo.toml
-RUN mkdir -p rs/src && touch rs/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -rf rs/src
-
-# Install dfx
-COPY dfx.json dfx.json
-RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-
 # --- End of common part ---
 
 RUN apt-get -y install moreutils jq
+
+# Install Chrome
+RUN curl -sL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb > google-chrome-stable_current_amd64.deb
+RUN apt-get -y install ./google-chrome-stable_current_amd64.deb
+
 ADD . /e2e-tests
+WORKDIR /e2e-tests
+RUN npm install chromedriver@109
+RUN npm ci

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -14,6 +14,7 @@ import { Options as WebDriverOptions, Capabilities } from "@wdio/types";
 function capabilitiesFromEnv(): Capabilities.RemoteCapabilities {
   const browsers = process.env.WDIO_BROWSER ?? "all";
   const headless = (process.env.WDIO_VIEW ?? "headless") === "headless";
+  const in_docker = fs.existsSync("/.dockerenv"); 
   const useChrome = ["all", "chrome"].includes(browsers);
   const useFirefox = ["all", "firefox"].includes(browsers);
   const capabilities: Capabilities.RemoteCapabilities = [];
@@ -21,7 +22,9 @@ function capabilitiesFromEnv(): Capabilities.RemoteCapabilities {
     const chrome = {
       browserName: "chrome",
       "goog:chromeOptions": {
-        args: headless ? ["headless", "disable-gpu"] : [],
+        args: [
+        ].concat(in_docker ? ['--no-sandbox'] : [])
+         .concat(headless ? ["headless", "disable-gpu"] : [])
       },
       acceptInsecureCerts: true,
     };

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -14,7 +14,7 @@ import { Options as WebDriverOptions, Capabilities } from "@wdio/types";
 function capabilitiesFromEnv(): Capabilities.RemoteCapabilities {
   const browsers = process.env.WDIO_BROWSER ?? "all";
   const headless = (process.env.WDIO_VIEW ?? "headless") === "headless";
-  const in_docker = fs.existsSync("/.dockerenv"); 
+  const in_docker = existsSync("/.dockerenv");
   const useChrome = ["all", "chrome"].includes(browsers);
   const useFirefox = ["all", "firefox"].includes(browsers);
   const capabilities: Capabilities.RemoteCapabilities = [];


### PR DESCRIPTION
# Motivation

* Make e2e spec tests easier to reproduce
* Enable replicated e2e testing

# Changes

* Add e2e-tests/Dockerfile
* Add an option `--no-sandbox` while running wdio-based spec tests inside Docker

# Tests

* `docker run -it -e WDIO_BROWSER=chrome nns-dapp-specs npm run test -- --spec specs/launchpad.e2e.ts`

Should generate

```
[0-0] RUNNING in chrome - /specs/launchpad.e2e.ts
[0-0] Created identity 10006
[0-0] Created user: {"identityAnchor":"10006"}
[0-0] PASSED in chrome - /specs/launchpad.e2e.ts

 "spec" Reporter:
------------------------------------------------------------------
[chrome 109.0.5414.74 linux #0-0] Running: chrome (v109.0.5414.74) on linux
[chrome 109.0.5414.74 linux #0-0] Session ID: 73c05cc097546a2e6ed74361197f0d47
[chrome 109.0.5414.74 linux #0-0]
[chrome 109.0.5414.74 linux #0-0] » /specs/launchpad.e2e.ts
[chrome 109.0.5414.74 linux #0-0] View launchpad while logged out
[chrome 109.0.5414.74 linux #0-0]    ✓ Views the launchpad whil elogged out
[chrome 109.0.5414.74 linux #0-0]
[chrome 109.0.5414.74 linux #0-0] View launchpad when logged in
[chrome 109.0.5414.74 linux #0-0]    ✓ Registers and logs in as a user
[chrome 109.0.5414.74 linux #0-0]    ✓ Views the launchpad while logged in
[chrome 109.0.5414.74 linux #0-0]
[chrome 109.0.5414.74 linux #0-0] 3 passing (46.7s)
```