### PR TITLE
style: undo scoped styles

### DIFF
--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -5,7 +5,7 @@
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>
 
-<main>
+<main class="sign-in">
   <h1>{$i18n.auth_accounts.title}</h1>
 
   <p>
@@ -14,16 +14,3 @@
 
   <SignIn />
 </main>
-
-<style lang="scss">
-  main {
-    display: flex;
-    flex-direction: column;
-  }
-  h1 {
-    line-height: var(--line-height-standard);
-  }
-  p {
-    margin-bottom: var(--padding-3x);
-  }
-</style>

--- a/frontend/src/lib/pages/SignInCanisters.svelte
+++ b/frontend/src/lib/pages/SignInCanisters.svelte
@@ -5,7 +5,7 @@
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>
 
-<main>
+<main class="sign-in">
   <h1>{$i18n.auth_canisters.title}</h1>
 
   <p>
@@ -14,16 +14,3 @@
 
   <SignIn />
 </main>
-
-<style lang="scss">
-  main {
-    display: flex;
-    flex-direction: column;
-  }
-  h1 {
-    line-height: var(--line-height-standard);
-  }
-  p {
-    margin-bottom: var(--padding-3x);
-  }
-</style>

--- a/frontend/src/lib/pages/SignInNeurons.svelte
+++ b/frontend/src/lib/pages/SignInNeurons.svelte
@@ -5,7 +5,7 @@
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>
 
-<main>
+<main class="sign-in">
   <h1>{$i18n.auth_neurons.title}</h1>
 
   <p>
@@ -14,16 +14,3 @@
 
   <SignIn />
 </main>
-
-<style lang="scss">
-  main {
-    display: flex;
-    flex-direction: column;
-  }
-  h1 {
-    line-height: var(--line-height-standard);
-  }
-  p {
-    margin-bottom: var(--padding-3x);
-  }
-</style>

--- a/frontend/src/lib/themes/global.scss
+++ b/frontend/src/lib/themes/global.scss
@@ -1,0 +1,12 @@
+main.sign-in {
+  display: flex;
+  flex-direction: column;
+
+  h1 {
+    line-height: var(--line-height-standard);
+  }
+
+  p {
+    margin-bottom: var(--padding-3x);
+  }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -50,5 +50,6 @@
 <style lang="scss" global>
   @import "@dfinity/gix-components/styles/global.scss";
   @import "../lib/themes/legacy";
+  @import "../lib/themes/global";
   @import "../lib/themes/variables";
 </style>


### PR DESCRIPTION
# Motivation

We have once again build reproducibility issue and despite the fact that we have fully remove the `vite-manifest.json` I suspect the style reproducibility we had to be the root cause.

Therefore undo the redo of the global style - i.e. undo PR #1671

