### PR TITLE
i18n: Add proposal type Insert SNS-WASM Upgrade Path Entries to en.governance.json

### DIFF
--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -131,9 +131,10 @@
     "ChangeSubnetMembership": "Change Subnet Membership",
     "UpdateSubnetType": "Update Subnet Type",
     "ChangeSubnetTypeAssignment": "Change Subnet Type Assignment",
-    "UpdateSnsWasmSnsSubnetIds": "Update SNS Wasm Subnet Ids",
+    "UpdateSnsWasmSnsSubnetIds": "Update SNS-WASM Subnet Ids",
     "UpdateAllowedPrincipals": "Update Allowed Principals",
-    "RetireReplicaVersion": "Retire Replica Version"
+    "RetireReplicaVersion": "Retire Replica Version",
+    "InsertSnsWasmUpgradePathEntries": "Insert SNS-WASM Upgrade Path Entries"
   },
   "nns_functions_description": {
     "Unspecified": "",
@@ -170,8 +171,9 @@
     "ChangeSubnetMembership": "Change the membership (list) of nodes in a subnet by adding and/or removing nodes from the subnet. At the time the proposal is executed, the added nodes (if provided in the proposal) need to be unassigned and the removed nodes (if provided in the proposal) need to be assigned to the subnet. After the proposal is executed, the removed nodes become unassigned, and can be reassigned to other subnets via future proposals or completely removed from the network.",
     "UpdateSubnetType": "Add or remove a subnet type. A new subnet type can be added if it doesn’t already exist. An existing subnet type can be removed if no subnets are assigned to it. Subnet types can be used to choose the kind of subnet a canister should be created on.",
     "ChangeSubnetTypeAssignment": "Change the assignment of subnets to subnet types by either adding subnets to or removing subnets from a subnet type. A subnet can be assigned to a subnet type if the subnet is not already assigned to a different subnet type and is not already in the authorized subnets list (i.e., subnets authorized for certain principals) or the default subnets list (i.e., default subnets that new canisters are randomly created on). Once a subnet is assigned to a subnet type, it becomes available to users who can specify that they want their canisters to be created on subnets of that type.",
-    "UpdateSnsWasmSnsSubnetIds": "Update the list of SNS subnet IDs that SNS WASM will deploy SNS instances to.",
-    "UpdateAllowedPrincipals": "Update the SNS-wasm canister's list of allowed principals. This list guards which principals can deploy an SNS.",
-    "RetireReplicaVersion": "A proposal to retire previously elected and unused replica versions. The specified versions are removed from the list of blessed replica versions in the registry. This ensures that a replica can no longer be upgraded to these versions. The proposal will fail to remove replica version if that version is currently used by a subnet or unassigned node."
+    "UpdateSnsWasmSnsSubnetIds": "Update the list of SNS subnet IDs that SNS-WASM will deploy SNS instances to.",
+    "UpdateAllowedPrincipals": "Update the SNS-WASM canister's list of allowed principals. This list guards which principals can deploy an SNS.",
+    "RetireReplicaVersion": "A proposal to retire previously elected and unused replica versions. The specified versions are removed from the list of blessed replica versions in the registry. This ensures that a replica can no longer be upgraded to these versions. The proposal will fail to remove replica version if that version is currently used by a subnet or unassigned node.",
+    "InsertSnsWasmUpgradePathEntries": "Insert custom upgrade path entries into SNS-WASM for all SNSs, or for an SNS specified by its governance canister ID."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -951,6 +951,7 @@ interface I18nNns_functions {
   UpdateSnsWasmSnsSubnetIds: string;
   UpdateAllowedPrincipals: string;
   RetireReplicaVersion: string;
+  InsertSnsWasmUpgradePathEntries: string;
 }
 
 interface I18nNns_functions_description {
@@ -991,6 +992,7 @@ interface I18nNns_functions_description {
   UpdateSnsWasmSnsSubnetIds: string;
   UpdateAllowedPrincipals: string;
   RetireReplicaVersion: string;
+  InsertSnsWasmUpgradePathEntries: string;
 }
 
 interface I18n {


### PR DESCRIPTION
# Motivation

Add labels and descriptions to `en.governance.json` for new proposal type Insert SNS-WASM Upgrade Path Entries.

# Changes

- Added labels and descriptions to `en.governance.json` for new proposal type Insert SNS-WASM Upgrade Path Entries.
- Improved consistency of "SNS-WASM" canister terminology.
