### PR TITLE
fix: SvelteKit route not destroyed - "Login" over "Accounts" page

### DIFF
--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -7,33 +7,40 @@
   import LoginFooter from "$lib/components/login/LoginFooter.svelte";
   import LoginHeader from "$lib/components/login/LoginHeader.svelte";
   import LoginBackground from "$lib/components/login/LoginBackground.svelte";
+  import { navigating } from "$app/stores";
+  import { isNullish } from "$lib/utils/utils";
 
   onMount(async () => await initAppAuth());
+
+  $: console.log("Nav", $navigating);
 </script>
 
-<Layout layout="stretch">
-  <Banner />
+<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
+{#if isNullish($navigating)}
+  <Layout layout="stretch">
+    <Banner />
 
-  <LoginMenuItems slot="menu-items" />
+    <LoginMenuItems slot="menu-items" />
 
-  <div class="content">
-    <ContentBackdrop />
+    <div class="content">
+      <ContentBackdrop />
 
-    <div class="scroll-container">
-      <main data-tid="auth-page">
-        <LoginHeader />
+      <div class="scroll-container">
+        <main data-tid="auth-page">
+          <LoginHeader />
 
-        <article>
-          <LoginBackground />
+          <article>
+            <LoginBackground />
 
-          <slot />
-        </article>
+            <slot />
+          </article>
 
-        <LoginFooter />
-      </main>
+          <LoginFooter />
+        </main>
+      </div>
     </div>
-  </div>
-</Layout>
+  </Layout>
+{/if}
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -11,8 +11,6 @@
   import { isNullish } from "$lib/utils/utils";
 
   onMount(async () => await initAppAuth());
-
-  $: console.log("Nav", $navigating);
 </script>
 
 <!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->


### PR DESCRIPTION
# Motivation

We noticed a weird issue that leads - under edge case conditions - to the main "Login" elements not being removed from the DOM after navigation - i.e. the route being not fully destroyed.

This looks pretty similar to SvelteKit known issue https://github.com/sveltejs/kit/issues/5434

# Preconditions

1. not the fastest login flow - i.e. after II has granted the authorization, fetching JS and navigating from "Login" to "Accounts" take a bit of time. I simulated this by adding 2000ms of delay in the `auth.store` that handles `onSuccess` callback

2. user on purpose does not stay in NNS-dapp tab while the sign-in is in progress

3. no JS should be cached

# Reproduction flow

- open a browser in incognito (it seems to happen more often with Safari but locally could reproduce with Chrome too)
- go to google.com
- open new tab with nns-dapp
- click refresh because sw holds
- click sign-in
- click refresh in II tab because sw holds
- sign- in in II
- when it comes back to nns-dapp tab, quickly switch to google tab before sign-in process over
- wait a bit
- go to nns-dapp tab

# Changes / Workaround

- force the layout of the route that does not gets removed to be displayed only when navigation is over

# Screenshots

<img width="1536" alt="Capture d’écran 2023-01-20 à 15 17 29" src="https://user-images.githubusercontent.com/16886711/213725181-e5326999-b87d-481a-8792-9547f912d3b6.png">
<img width="1536" alt="Capture d’écran 2023-01-20 à 15 23 21" src="https://user-images.githubusercontent.com/16886711/213725196-a8312dd5-a375-421d-b942-83fe9bf69000.png">

