### PR TITLE
feat: disable TVL display when developing

### DIFF
--- a/frontend/src/lib/components/common/MenuMetrics.svelte
+++ b/frontend/src/lib/components/common/MenuMetrics.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
   import TotalValueLocked from "$lib/components/metrics/TotalValueLocked.svelte";
   import { layoutMenuOpen } from "@dfinity/gix-components";
+  import { ENABLE_TVL } from "$lib/constants/environment.constants";
 
   export let sticky = true;
 </script>
 
-<div class:open={$layoutMenuOpen} class:sticky>
-  <TotalValueLocked layout="stacked" />
-</div>
+{#if ENABLE_TVL}
+  <div class:open={$layoutMenuOpen} class:sticky>
+    <TotalValueLocked layout="stacked" />
+  </div>
+{/if}
 
 <style lang="scss">
   @use "@dfinity/gix-components/styles/mixins/media";

--- a/frontend/src/lib/components/login/LoginHeader.svelte
+++ b/frontend/src/lib/components/login/LoginHeader.svelte
@@ -8,13 +8,14 @@
   import nnsLogo from "$lib/assets/nns-logo.svg";
   import { i18n } from "$lib/stores/i18n";
   import TotalValueLocked from "$lib/components/metrics/TotalValueLocked.svelte";
+  import { ENABLE_TVL } from "$lib/constants/environment.constants";
 
   let innerWidth = 0;
   let displayTvl = false;
 
   // We have to use JS to activate the TVL metrics in the header or menu to avoid to make calls twice
   // Easier than introducing stores and logic at this point since this can only happen on the login screen.
-  $: displayTvl = innerWidth > BREAKPOINT_LARGE;
+  $: displayTvl = innerWidth > BREAKPOINT_LARGE && ENABLE_TVL;
 </script>
 
 <svelte:window bind:innerWidth />

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -35,3 +35,6 @@ export const IS_TESTNET: boolean =
   DFX_NETWORK !== "mainnet" &&
   FETCH_ROOT_KEY === true &&
   !HOST.includes(".ic0.app");
+
+// TODO: disable TVL display locally until we use the XCR canister to fetch teh ICP<>USD exchange rate and a certified endpoint to fetch the TVL
+export const ENABLE_TVL = !DEV;


### PR DESCRIPTION
# Motivation

Until we use proper certified endpoints, no need to stress the network with such queries when we are developing.
