### PR TITLE
Chore: Enable Merge HW controlled neurons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.5-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.5-next-2023-01-23.tgz",
-      "integrity": "sha512-pJ+nA/yYB/DC7YL38V5fvaqBO2dB6IdJQ6xPXHMv386I7D71cFWEfcIwLiRxOYBCmsonqf1y7Kd0UEa27uNrXg==",
+      "version": "0.0.5-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.5-next-2023-01-23.1.tgz",
+      "integrity": "sha512-j0MFo1YEY7+19mUFzKxAPQbjgI16QwuFXjzW5RLJPNelQOzoUGEPezQ6tKanMSD1UFCOj7zw7BXGuPgZA5CXpA==",
       "peerDependencies": {
         "@dfinity/utils": "^0.0.8-next"
       }
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.12.0-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.12.0-next-2023-01-23.tgz",
-      "integrity": "sha512-knK/SJ+qIEPvesiIyTrOw4fc8zKkMHT7M28sjWakk9q6HE1HGnerTUh72Mo60Z0hYJVL62nPnHAKhKLZ57yShg==",
+      "version": "0.12.0-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.12.0-next-2023-01-23.1.tgz",
+      "integrity": "sha512-s7THcvqSoenCvHg96bL2ib1of1YX5phUsxzLJimbJ9ZOFmHsugkTGoJOClLpcmSBc6KwR130mKGKfTMkkQwssQ==",
       "dependencies": {
         "crc": "^4.2.0",
         "crc-32": "^1.2.2",
@@ -1700,9 +1700,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.9-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.9-next-2023-01-23.tgz",
-      "integrity": "sha512-DfiWtAtvWGNaz36egT7tu5eUNtM2pLblSkPeC66TQVAFT2QhMONqpkV40d4P9KLoU3mvFHeCyp38h9ywJDzDnQ==",
+      "version": "0.0.9-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.9-next-2023-01-23.1.tgz",
+      "integrity": "sha512-W7Y6qxQXY14LP/3ZkZ2ceIfYAhEnivwglrktBiuxaMopmCpqBRLRkD1oso22hXT2dLltmErjG3jZt8UPYFlTmA==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.8-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.8-next-2023-01-23.tgz",
-      "integrity": "sha512-/pYTqVNslnpoVipXR01yNu8UXEmgFWxxOzvOPGKpc7Ll6eMQJDCmLKdkBqECCX351p1Et0r5Z68NqB1lRn8O9Q=="
+      "version": "0.0.8-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.8-next-2023-01-23.1.tgz",
+      "integrity": "sha512-3Dv3Gfv6yh0KHlv7kDMKIyxHIFpfbEou8yyq0eZLcKIh+jiPwrLMsOvfbAqPoMCkFA7InvcFgcJUIFtSn9q1LQ=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.16.9",
@@ -10956,9 +10956,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.5-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.5-next-2023-01-23.tgz",
-      "integrity": "sha512-pJ+nA/yYB/DC7YL38V5fvaqBO2dB6IdJQ6xPXHMv386I7D71cFWEfcIwLiRxOYBCmsonqf1y7Kd0UEa27uNrXg==",
+      "version": "0.0.5-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.5-next-2023-01-23.1.tgz",
+      "integrity": "sha512-j0MFo1YEY7+19mUFzKxAPQbjgI16QwuFXjzW5RLJPNelQOzoUGEPezQ6tKanMSD1UFCOj7zw7BXGuPgZA5CXpA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10980,9 +10980,9 @@
       }
     },
     "@dfinity/nns": {
-      "version": "0.12.0-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.12.0-next-2023-01-23.tgz",
-      "integrity": "sha512-knK/SJ+qIEPvesiIyTrOw4fc8zKkMHT7M28sjWakk9q6HE1HGnerTUh72Mo60Z0hYJVL62nPnHAKhKLZ57yShg==",
+      "version": "0.12.0-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.12.0-next-2023-01-23.1.tgz",
+      "integrity": "sha512-s7THcvqSoenCvHg96bL2ib1of1YX5phUsxzLJimbJ9ZOFmHsugkTGoJOClLpcmSBc6KwR130mKGKfTMkkQwssQ==",
       "requires": {
         "crc": "^4.2.0",
         "crc-32": "^1.2.2",
@@ -11001,17 +11001,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.9-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.9-next-2023-01-23.tgz",
-      "integrity": "sha512-DfiWtAtvWGNaz36egT7tu5eUNtM2pLblSkPeC66TQVAFT2QhMONqpkV40d4P9KLoU3mvFHeCyp38h9ywJDzDnQ==",
+      "version": "0.0.9-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.9-next-2023-01-23.1.tgz",
+      "integrity": "sha512-W7Y6qxQXY14LP/3ZkZ2ceIfYAhEnivwglrktBiuxaMopmCpqBRLRkD1oso22hXT2dLltmErjG3jZt8UPYFlTmA==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.8-next-2023-01-23",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.8-next-2023-01-23.tgz",
-      "integrity": "sha512-/pYTqVNslnpoVipXR01yNu8UXEmgFWxxOzvOPGKpc7Ll6eMQJDCmLKdkBqECCX351p1Et0r5Z68NqB1lRn8O9Q=="
+      "version": "0.0.8-next-2023-01-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.8-next-2023-01-23.1.tgz",
+      "integrity": "sha512-3Dv3Gfv6yh0KHlv7kDMKIyxHIFpfbEou8yyq0eZLcKIh+jiPwrLMsOvfbAqPoMCkFA7InvcFgcJUIFtSn9q1LQ=="
     },
     "@esbuild/android-arm": {
       "version": "0.16.9",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -257,7 +257,6 @@
     "cannot_merge_neuron_community": "Neurons that joined the Community Fund can't be merged.",
     "cannot_merge_neuron_spawning": "Neurons that are spawning can't be merged.",
     "cannot_merge_neuron_hotkey": "You cannot merge neurons controlled by a hotkey.",
-    "cannot_merge_hardware_wallet": "Merging of neurons controlled via hardware wallet is not yet supported.",
     "only_merge_two": "You can only merge two neurons at a time.",
     "need_two_to_merge": "You need at least two neurons to merge",
     "irreversible_action": "This action is irreversible.",

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -28,6 +28,7 @@ import {
 } from "$lib/constants/neurons.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import {
@@ -60,6 +61,7 @@ import {
   isEnoughToStakeNeuron,
   isHotKeyControllable,
   isIdentityController,
+  isNeuronControlledByHardwareWallet,
   userAuthorizedNeuron,
   validTopUpAmount,
 } from "$lib/utils/neuron.utils";
@@ -409,9 +411,17 @@ export const mergeNeurons = async ({
         translate({ labelKey: messageKey ?? "error.governance_error" })
       );
     }
+
     const identity: Identity = await getIdentityOfControllerByNeuronId(
       targetNeuronId
     );
+    const accounts = get(accountsStore);
+    if (isNeuronControlledByHardwareWallet({ neuron: neuron2, accounts })) {
+      await assertLedgerVersion({
+        identity,
+        minVersion: CANDID_PARSER_VERSION,
+      });
+    }
 
     await mergeNeuronsApi({ sourceNeuronId, targetNeuronId, identity });
     success = true;

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -399,13 +399,13 @@ export const mergeNeurons = async ({
 }): Promise<NeuronId | undefined> => {
   let success = false;
   try {
-    const { neuron: neuron1 } = await getIdentityAndNeuronHelper(
+    const { neuron: sourceNeuron } = await getIdentityAndNeuronHelper(
       sourceNeuronId
     );
-    const { neuron: neuron2 } = await getIdentityAndNeuronHelper(
+    const { neuron: targetNeuron } = await getIdentityAndNeuronHelper(
       targetNeuronId
     );
-    const { isValid, messageKey } = canBeMerged([neuron1, neuron2]);
+    const { isValid, messageKey } = canBeMerged([sourceNeuron, targetNeuron]);
     if (!isValid) {
       throw new CannotBeMerged(
         translate({ labelKey: messageKey ?? "error.governance_error" })
@@ -416,7 +416,9 @@ export const mergeNeurons = async ({
       targetNeuronId
     );
     const accounts = get(accountsStore);
-    if (isNeuronControlledByHardwareWallet({ neuron: neuron2, accounts })) {
+    if (
+      isNeuronControlledByHardwareWallet({ neuron: targetNeuron, accounts })
+    ) {
       await assertLedgerVersion({
         identity,
         minVersion: CANDID_PARSER_VERSION,

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -267,7 +267,6 @@ interface I18nNeurons {
   cannot_merge_neuron_community: string;
   cannot_merge_neuron_spawning: string;
   cannot_merge_neuron_hotkey: string;
-  cannot_merge_hardware_wallet: string;
   only_merge_two: string;
   need_two_to_merge: string;
   irreversible_action: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -441,17 +441,8 @@ export const isSpawning = (neuron: NeuronInfo): boolean =>
   neuron.state === NeuronState.Spawning;
 
 // Tested with `mapMergeableNeurons`
-const isMergeableNeuron = ({
-  neuron,
-  accounts,
-}: {
-  neuron: NeuronInfo;
-  accounts: AccountsStoreData;
-}): boolean =>
-  !hasJoinedCommunityFund(neuron) &&
-  !isSpawning(neuron) &&
-  // Merging hardware wallet neurons is not yet supported
-  isNeuronControllableByUser({ neuron, mainAccount: accounts.main });
+const isMergeableNeuron = (neuron: NeuronInfo): boolean =>
+  !hasJoinedCommunityFund(neuron) && !isSpawning(neuron);
 
 const getMergeableNeuronMessageKey = ({
   neuron,
@@ -465,9 +456,6 @@ const getMergeableNeuronMessageKey = ({
   }
   if (isSpawning(neuron)) {
     return "neurons.cannot_merge_neuron_spawning";
-  }
-  if (isNeuronControlledByHardwareWallet({ neuron, accounts })) {
-    return "neurons.cannot_merge_hardware_wallet";
   }
   if (!isNeuronControllable({ neuron, accounts })) {
     return "neurons.cannot_merge_neuron_hotkey";
@@ -504,7 +492,7 @@ export const mapMergeableNeurons = ({
       selected: selectedNeurons
         .map(({ neuronId }) => neuronId)
         .includes(neuron.neuronId),
-      mergeable: isMergeableNeuron({ neuron, accounts }),
+      mergeable: isMergeableNeuron(neuron),
       messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
     }))
     // Then we calculate the neuron with the current selection

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -441,8 +441,16 @@ export const isSpawning = (neuron: NeuronInfo): boolean =>
   neuron.state === NeuronState.Spawning;
 
 // Tested with `mapMergeableNeurons`
-const isMergeableNeuron = (neuron: NeuronInfo): boolean =>
-  !hasJoinedCommunityFund(neuron) && !isSpawning(neuron);
+const isMergeableNeuron = ({
+  neuron,
+  accounts,
+}: {
+  neuron: NeuronInfo;
+  accounts: AccountsStoreData;
+}): boolean =>
+  !hasJoinedCommunityFund(neuron) &&
+  !isSpawning(neuron) &&
+  isNeuronControllable({ neuron, accounts });
 
 const getMergeableNeuronMessageKey = ({
   neuron,
@@ -487,14 +495,16 @@ export const mapMergeableNeurons = ({
 }): MergeableNeuron[] =>
   neurons
     // First we consider the neuron on itself
-    .map((neuron: NeuronInfo) => ({
-      neuron,
-      selected: selectedNeurons
-        .map(({ neuronId }) => neuronId)
-        .includes(neuron.neuronId),
-      mergeable: isMergeableNeuron(neuron),
-      messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
-    }))
+    .map((neuron: NeuronInfo) => {
+      return {
+        neuron,
+        selected: selectedNeurons
+          .map(({ neuronId }) => neuronId)
+          .includes(neuron.neuronId),
+        mergeable: isMergeableNeuron({ neuron, accounts }),
+        messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
+      };
+    })
     // Then we calculate the neuron with the current selection
     .map(({ mergeable, selected, messageKey, neuron }: MergeableNeuron) => {
       // If not mergeable by itself or already selected, we keep the data.

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -495,16 +495,14 @@ export const mapMergeableNeurons = ({
 }): MergeableNeuron[] =>
   neurons
     // First we consider the neuron on itself
-    .map((neuron: NeuronInfo) => {
-      return {
-        neuron,
-        selected: selectedNeurons
-          .map(({ neuronId }) => neuronId)
-          .includes(neuron.neuronId),
-        mergeable: isMergeableNeuron({ neuron, accounts }),
-        messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
-      };
-    })
+    .map((neuron: NeuronInfo) => ({
+      neuron,
+      selected: selectedNeurons
+        .map(({ neuronId }) => neuronId)
+        .includes(neuron.neuronId),
+      mergeable: isMergeableNeuron({ neuron, accounts }),
+      messageKey: getMergeableNeuronMessageKey({ neuron, accounts }),
+    }))
     // Then we calculate the neuron with the current selection
     .map(({ mergeable, selected, messageKey, neuron }: MergeableNeuron) => {
       // If not mergeable by itself or already selected, we keep the data.

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -182,7 +182,6 @@ describe("MergeNeuronsModal", () => {
     });
   });
 
-  // Merging of neurons controlled via hardware wallet is not yet supported.
   describe("when mergeable neurons by hardware wallet", () => {
     const controller = mockHardwareWalletAccount.principal?.toText() as string;
     const mergeableNeuron1 = {
@@ -196,7 +195,7 @@ describe("MergeNeuronsModal", () => {
       fullNeuron: { ...mockFullNeuron, controller },
     };
     const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
-    it("does not allow user to select neurons", async () => {
+    it("allows user to select neurons", async () => {
       const { queryAllByTestId } = await renderMergeModal(mergeableNeurons, [
         mockHardwareWalletAccount,
       ]);
@@ -213,11 +212,10 @@ describe("MergeNeuronsModal", () => {
       // Elements might change after every click
       [neuronElement1, neuronElement2] = queryAllByTestId("neuron-card");
 
-      expect(neuronElement1.classList.contains("selected")).toBe(false);
+      expect(neuronElement1.classList.contains("selected")).toBe(true);
     });
   });
 
-  // Merging of neurons controlled via hardware wallet is not yet supported.
   describe("when neurons from main user and hardware wallet", () => {
     const neuronHW = {
       ...mockNeuron,
@@ -236,6 +234,7 @@ describe("MergeNeuronsModal", () => {
       },
     };
     const neurons = [neuronMain, neuronHW];
+
     it("does not allow to select two neurons with different controller", async () => {
       const { queryAllByTestId } = await renderMergeModal(neurons, [
         mockHardwareWalletAccount,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -772,7 +772,7 @@ describe("neurons-services", () => {
       accountsStore.reset();
     });
 
-    it("should update neuron", async () => {
+    it("should merge neurons", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       await mergeNeurons({
         sourceNeuronId: neurons[0].neuronId,
@@ -782,7 +782,7 @@ describe("neurons-services", () => {
       expect(spyMergeNeurons).toHaveBeenCalled();
     });
 
-    it("should not update neuron if no identity", async () => {
+    it("should not merge neurons if no identity", async () => {
       setNoIdentity();
 
       await mergeNeurons({
@@ -796,7 +796,7 @@ describe("neurons-services", () => {
       resetIdentity();
     });
 
-    it("should not update neuron if different controllers", async () => {
+    it("should not merge neurons if different controllers", async () => {
       const neuron = {
         ...mockNeuron,
         neuronId: BigInt(5555),
@@ -819,7 +819,7 @@ describe("neurons-services", () => {
       expect(spyMergeNeurons).not.toHaveBeenCalled();
     });
 
-    it("should not update neuron if lower HW version than required", async () => {
+    it("should not merge neurons if lower HW version than required", async () => {
       const version: ResponseVersion = {
         testMode: false,
         major: 1,


### PR DESCRIPTION
# Motivation

Users can merge neurons controlled by HWs.

# Changes

* Check HW version in mergeNeurons service.
* Change in isMergeableNeuron util, check whether neuron is controllable instead checking if it's HW controlled.
* Remove case of HW controlled neuron in getMergeableNeuronMessageKey.

# Tests

* Change test case that allows merging HW controlled neurons.
* Add new test to check that mergeNeurons checks the HW version.
