### PR TITLE
Fix: Check minimum sns neuron stake

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -105,6 +105,7 @@
     "transaction_fee_not_found": "Sorry, there was an error loading the transaction fee.",
     "fetch_transactions": "Sorry, there was an error loading the transactions for this account.",
     "transaction_data": "Sorry, there was an error with the transaction $txId.",
+    "amount_not_enough_stake_sns_neuron": "Sorry, the amount is too small. You need a minimum of $amount $token to stake a $token neuron",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction."
   },
   "warning": {

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -21,7 +21,10 @@
     participateInSwap,
   } from "$lib/services/sns.services";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import type { NewTransaction } from "$lib/types/transaction";
+  import type {
+    NewTransaction,
+    ValidateAmountFn,
+  } from "$lib/types/transaction";
   import AdditionalInfoForm from "./AdditionalInfoForm.svelte";
   import AdditionalInfoReview from "./AdditionalInfoReview.svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
@@ -112,7 +115,7 @@
   };
 
   // Used for form inline validation
-  let validateAmount: (amount: number | undefined) => string | undefined;
+  let validateAmount: ValidateAmountFn;
   $: validateAmount = (amount: number | undefined) => {
     if (
       swapCommitment !== undefined &&

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -2,7 +2,10 @@
   import { createEventDispatcher } from "svelte";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
-  import type { NewTransaction } from "$lib/types/transaction";
+  import type {
+    NewTransaction,
+    ValidateAmountFn,
+  } from "$lib/types/transaction";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Token, TokenAmount } from "@dfinity/nns";
@@ -14,6 +17,7 @@
   import { mapNervousSystemParameters } from "$lib/utils/sns-parameters.utils";
   import type { NervousSystemParameters } from "@dfinity/sns";
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
+  import { nonNullish } from "$lib/utils/utils";
 
   export let token: Token;
   export let rootCanisterId: Principal;
@@ -44,11 +48,13 @@
           mapNervousSystemParameters(parameters).neuron_minimum_stake_e8s
         ) / E8S_PER_ICP
       : undefined;
-  let checkMinimumStake: (
-    amount: number | undefined
-  ) => string | undefined = () => undefined;
+  let checkMinimumStake: ValidateAmountFn = () => undefined;
   $: checkMinimumStake = (amount: number | undefined) => {
-    if (amount && minimumStake && amount < minimumStake) {
+    if (
+      nonNullish(amount) &&
+      nonNullish(minimumStake) &&
+      amount < minimumStake
+    ) {
       return replacePlaceholders(
         $i18n.error.amount_not_enough_stake_sns_neuron,
         {

--- a/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
@@ -10,6 +10,9 @@
   export let governanceCanisterId: Principal;
   export let transactionFee: TokenAmount;
   export let currentStep: WizardStep;
+  export let validateAmount: (
+    amount: number | undefined
+  ) => string | undefined = () => undefined;
 </script>
 
 <TransactionModal
@@ -19,6 +22,7 @@
   bind:currentStep
   {token}
   {transactionFee}
+  {validateAmount}
   destinationAddress={governanceCanisterId.toText()}
 >
   <slot name="title" slot="title" />

--- a/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
@@ -4,15 +4,14 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import type { Token, TokenAmount } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
+  import type { ValidateAmountFn } from "$lib/types/transaction";
 
   export let token: Token;
   export let rootCanisterId: Principal;
   export let governanceCanisterId: Principal;
   export let transactionFee: TokenAmount;
   export let currentStep: WizardStep;
-  export let validateAmount: (
-    amount: number | undefined
-  ) => string | undefined = () => undefined;
+  export let validateAmount: ValidateAmountFn = () => undefined;
 </script>
 
 <TransactionModal

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -112,19 +112,10 @@
         neuron: null,
       });
 
-      const shouldLoadParameters = isNullish(
-        $snsParametersStore?.[rootCanisterId?.toText() ?? ""]?.parameters
-      );
-      const loadTransactionFee = isNullish(
-        $snsSelectedTransactionFeeStore?.toE8s()
-      );
-
       await Promise.all([
         loadNeuron(),
-        shouldLoadParameters ? loadSnsParameters(rootCanisterId) : undefined,
-        loadTransactionFee
-          ? loadSnsTransactionFee({ rootCanisterId })
-          : undefined,
+        loadSnsParameters(rootCanisterId),
+        loadSnsTransactionFee({ rootCanisterId }),
       ]);
     } catch (err: unknown) {
       // $pageStore.universe might be an invalid principal, like empty or yolo

--- a/frontend/src/lib/services/sns-parameters.services.ts
+++ b/frontend/src/lib/services/sns-parameters.services.ts
@@ -4,11 +4,17 @@ import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
 import type { Principal } from "@dfinity/principal";
 import type { NervousSystemParameters } from "@dfinity/sns";
+import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 
 export const loadSnsParameters = async (
   rootCanisterId: Principal
 ): Promise<void> => {
+  const storeData = get(snsParametersStore);
+  // Do not load if already loaded and certified
+  if (storeData[rootCanisterId.toText()]?.certified === true) {
+    return;
+  }
   await queryAndUpdate<NervousSystemParameters, unknown>({
     request: ({ certified, identity }) =>
       nervousSystemParameters({

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -28,7 +28,7 @@ export const loadSnsTransactionFee = async ({
 }) => {
   const storeData = get(transactionsFeesStore);
   // Avoid loading the same data multiple times if the data loaded is certified
-  if (storeData.projects[rootCanisterId.toString()]?.certified) {
+  if (storeData.projects[rootCanisterId.toText()]?.certified) {
     return;
   }
   return queryAndUpdate<bigint, unknown>({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -109,6 +109,7 @@ interface I18nError {
   transaction_fee_not_found: string;
   fetch_transactions: string;
   transaction_data: string;
+  amount_not_enough_stake_sns_neuron: string;
   canister_invalid_transaction: string;
 }
 

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -5,3 +5,7 @@ export type NewTransaction = {
   destinationAddress: string;
   amount: number;
 };
+
+export type ValidateAmountFn = (
+  amount: number | undefined
+) => string | undefined;

--- a/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModal.spec.ts
@@ -9,6 +9,7 @@ import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
+import type { ValidateAmountFn } from "$lib/types/transaction";
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -42,7 +43,7 @@ describe("TransactionModal", () => {
     sourceAccount?: Account;
     transactionFee?: TokenAmount;
     rootCanisterId?: Principal;
-    validateAmount?: (amount: number | undefined) => string | undefined;
+    validateAmount?: ValidateAmountFn;
   }) =>
     renderModal({
       component: TransactionModal,

--- a/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
@@ -2,15 +2,18 @@
  * @jest-environment jsdom
  */
 
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
 import { stakeNeuron } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { page } from "$mocks/$app/stores";
 import { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
+import type { NervousSystemParameters } from "@dfinity/sns";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 import type { Subscriber } from "svelte/store";
 import {
@@ -19,8 +22,12 @@ import {
 } from "../../../mocks/auth.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import { mockSnsAccountsStoreSubscribe } from "../../../mocks/sns-accounts.mock";
+import { snsNervousSystemParametersMock } from "../../../mocks/sns-neurons.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../../mocks/transaction-fee.mock";
-import { enterAmount } from "../../../utils/neurons-modal.test-utils";
+import {
+  AMOUNT_INPUT_SELECTOR,
+  enterAmount,
+} from "../../../utils/neurons-modal.test-utils";
 
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
@@ -65,6 +72,8 @@ describe("SnsStakeNeuronModal", () => {
       });
 
     page.mock({ data: { universe: mockPrincipal.toText() } });
+
+    snsParametersStore.reset();
   });
 
   it("should stake a new sns neuron", async () => {
@@ -78,5 +87,33 @@ describe("SnsStakeNeuronModal", () => {
     fireEvent.click(confirmButton);
 
     await waitFor(() => expect(stakeNeuron).toBeCalled());
+  });
+
+  it("should show error if amount is less than minimum stake in parameter", async () => {
+    const minimumAmount = 1;
+    const snsParameters: NervousSystemParameters = {
+      ...snsNervousSystemParametersMock,
+      neuron_minimum_stake_e8s: [BigInt(minimumAmount * E8S_PER_ICP)],
+    };
+    snsParametersStore.setParameters({
+      rootCanisterId: mockPrincipal,
+      parameters: snsParameters,
+      certified: true,
+    });
+    const { getByTestId, container } = await renderTransactionModal();
+
+    await waitFor(() =>
+      expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+    );
+    const nextButton = getByTestId("transaction-button-next");
+    expect(nextButton?.hasAttribute("disabled")).toBeTruthy();
+
+    // Enter amount
+    const input = container.querySelector(AMOUNT_INPUT_SELECTOR);
+    input && fireEvent.input(input, { target: { value: minimumAmount / 2 } });
+    await waitFor(() =>
+      expect(getByTestId("input-error-message")).toBeInTheDocument()
+    );
+    expect(nextButton?.hasAttribute("disabled")).toBeTruthy();
   });
 });

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -78,19 +78,24 @@ describe("SnsNeuronDetail", () => {
 
   afterEach(() => {
     validNeuron = true;
+    jest.clearAllMocks();
   });
 
+  const props = {
+    neuronId: getSnsNeuronIdAsHexString(mockSnsNeuron),
+  };
+
   describe("when neuron and projects are valid and present", () => {
-    beforeEach(() =>
+    beforeEach(() => {
       page.mock({
         data: { universe: rootCanisterIdMock.toText() },
         routeId: AppPath.Neuron,
-      })
-    );
+      });
+    });
 
-    const props = {
-      neuronId: getSnsNeuronIdAsHexString(mockSnsNeuron),
-    };
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
     it("should get neuron", async () => {
       render(SnsNeuronDetail, props);
@@ -106,57 +111,55 @@ describe("SnsNeuronDetail", () => {
       expect(titleRow).not.toBeNull();
     });
 
-    it("should not load parameters and fee when available", async () => {
+    it("should load parameters and fee", async () => {
       render(SnsNeuronDetail, props);
 
-      await waitFor(() => expect(loadSnsParameters).not.toBeCalled());
-      await waitFor(() => expect(loadSnsTransactionFee).not.toBeCalled());
+      await waitFor(() => expect(loadSnsParameters).toBeCalled());
+      await waitFor(() => expect(loadSnsTransactionFee).toBeCalled());
+    });
+  });
+
+  describe("when stores are empty", () => {
+    beforeAll(() => {
+      // empty stores
+      jest
+        .spyOn(snsParametersStore, "subscribe")
+        .mockImplementation(buildMockSnsParametersStore(true));
+      jest
+        .spyOn(snsSelectedTransactionFeeStore, "subscribe")
+        .mockImplementation(mockSnsSelectedTransactionFeeStoreSubscribe(true));
     });
 
-    describe("", () => {
-      beforeAll(() => {
-        // empty stores
-        jest
-          .spyOn(snsParametersStore, "subscribe")
-          .mockImplementation(buildMockSnsParametersStore(true));
-        jest
-          .spyOn(snsSelectedTransactionFeeStore, "subscribe")
-          .mockImplementation(
-            mockSnsSelectedTransactionFeeStoreSubscribe(true)
-          );
-      });
-
-      afterAll(() => {
-        // restore stores
-        mockParametersStore();
-        mockFeeStore();
-      });
-
-      it("should load parameters and fee if not available", async () => {
-        render(SnsNeuronDetail, props);
-
-        await waitFor(() => expect(loadSnsParameters).toBeCalled());
-        await waitFor(() => expect(loadSnsTransactionFee).toBeCalled());
-      });
+    afterAll(() => {
+      // restore stores
+      mockParametersStore();
+      mockFeeStore();
     });
 
-    it("should render main information card", async () => {
-      const { queryByTestId } = render(SnsNeuronDetail, props);
+    it("should load parameters and fee if not available", async () => {
+      render(SnsNeuronDetail, props);
 
-      expect(queryByTestId("sns-neuron-card-title")).toBeInTheDocument();
+      await waitFor(() => expect(loadSnsParameters).toBeCalled());
+      await waitFor(() => expect(loadSnsTransactionFee).toBeCalled());
     });
+  });
 
-    it("should render hotkeys card", async () => {
-      const { queryByTestId } = render(SnsNeuronDetail, props);
+  it("should render main information card", async () => {
+    const { queryByTestId } = render(SnsNeuronDetail, props);
 
-      expect(queryByTestId("sns-hotkeys-card")).toBeInTheDocument();
-    });
+    expect(queryByTestId("sns-neuron-card-title")).toBeInTheDocument();
+  });
 
-    it("should render following card", async () => {
-      const { queryByTestId } = render(SnsNeuronDetail, props);
+  it("should render hotkeys card", async () => {
+    const { queryByTestId } = render(SnsNeuronDetail, props);
 
-      expect(queryByTestId("sns-neuron-following")).toBeInTheDocument();
-    });
+    expect(queryByTestId("sns-hotkeys-card")).toBeInTheDocument();
+  });
+
+  it("should render following card", async () => {
+    const { queryByTestId } = render(SnsNeuronDetail, props);
+
+    expect(queryByTestId("sns-neuron-following")).toBeInTheDocument();
   });
 
   describe("when project is an invalid canister id", () => {

--- a/frontend/src/tests/lib/services/sns-parameters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-parameters.services.spec.ts
@@ -11,7 +11,12 @@ import { snsNervousSystemParametersMock } from "../../mocks/sns-neurons.mock";
 
 describe("sns-parameters-services", () => {
   describe("loadSnsParameters", () => {
-    it("should call api.nervousSystemParameters and load neurons in store", async () => {
+    afterEach(() => {
+      snsParametersStore.reset();
+      jest.clearAllMocks();
+    });
+
+    it("should call api.nervousSystemParameters and load parameters in store", async () => {
       const spyQuery = jest
         .spyOn(governanceApi, "nervousSystemParameters")
         .mockImplementation(() =>
@@ -25,6 +30,22 @@ describe("sns-parameters-services", () => {
         snsNervousSystemParametersMock
       );
       expect(spyQuery).toBeCalled();
+    });
+
+    it("should not call api.nervousSystemParameters if parameters are in the store and certified", async () => {
+      snsParametersStore.setParameters({
+        rootCanisterId: mockPrincipal,
+        parameters: snsNervousSystemParametersMock,
+        certified: true,
+      });
+      const spyQuery = jest
+        .spyOn(governanceApi, "nervousSystemParameters")
+        .mockImplementation(() =>
+          Promise.resolve(snsNervousSystemParametersMock)
+        );
+
+      await services.loadSnsParameters(mockPrincipal);
+      expect(spyQuery).not.toBeCalled();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User should see an error if the amount to stake a sns neuron is lower than allowed.

# Changes

Main change:
* Use validateAmount of TransactionModal in SnsStakeNeuronModal.

Other changes:
* Call `loadSnsParameters` and `loadSnsTransactionFee` in SnsNeuronDetail. The service is the responsible to check whether it needs to load the resource or not.
* Change a `toString` for a `toText` in the principal in `loadSnsTransactionFee`.

# Tests

* New test case in SnsStakeNeuronModal.
* Change test case in SnsNeuronDetail.
* New test case in loadSnsParameters.
