### PR TITLE
Chore: Show auto-stake for non-controlled neurons

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -54,9 +54,9 @@
       <NnsStakeMaturityButton {neuron} />
       <SpawnNeuronButton {neuron} />
     </div>
-
-    <NnsAutoStakeMaturity {neuron} />
   {/if}
+
+  <NnsAutoStakeMaturity {neuron} />
 </CardInfo>
 
 <Separator />

--- a/frontend/src/lib/components/neuron-detail/actions/AutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/AutoStakeMaturity.svelte
@@ -3,6 +3,7 @@
   import { Checkbox } from "@dfinity/gix-components";
 
   export let hasAutoStakeOn: boolean;
+  export let disabled = false;
 </script>
 
 <div class="auto-stake">
@@ -11,6 +12,7 @@
     inputId="auto-stake-maturity-checkbox"
     checked={hasAutoStakeOn}
     on:nnsChange
+    {disabled}
   >
     <span>{$i18n.neuron_detail.auto_stake_maturity}</span>
   </Checkbox>

--- a/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { hasAutoStakeMaturityOn } from "$lib/utils/neuron.utils";
+  import {
+    hasAutoStakeMaturityOn,
+    isNeuronControllable,
+  } from "$lib/utils/neuron.utils";
   import { getContext } from "svelte";
   import {
     NNS_NEURON_CONTEXT_KEY,
@@ -8,11 +11,20 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import AutoStakeMaturity from "$lib/components/neuron-detail/actions/AutoStakeMaturity.svelte";
+  import { authStore } from "$lib/stores/auth.store";
+  import { accountsStore } from "$lib/stores/accounts.store";
 
   export let neuron: NeuronInfo;
 
   let hasAutoStakeOn: boolean;
   $: hasAutoStakeOn = hasAutoStakeMaturityOn(neuron);
+
+  let disabled: boolean;
+  $: disabled = !isNeuronControllable({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $accountsStore,
+  });
 
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
@@ -21,6 +33,7 @@
 
 <AutoStakeMaturity
   bind:hasAutoStakeOn
+  {disabled}
   on:nnsChange={() =>
     openNnsNeuronModal({
       type: "auto-stake-maturity",

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
@@ -56,7 +56,9 @@
     <div class="actions" data-tid="stake-maturity-actions">
       <SnsStakeMaturityButton />
     </div>
+  {/if}
 
+  {#if ENABLE_SNS_2}
     <SnsAutoStakeMaturity />
   {/if}
 </CardInfo>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
@@ -25,12 +25,12 @@
   $: hasAutoStakeOn = hasAutoStakeMaturityOn(neuron);
 
   let disabled: boolean;
-  $: disabled = isNullish(neuron)
-    ? true
-    : !hasPermissionToStakeMaturity({
-        neuron,
-        identity: $authStore.identity,
-      });
+  $: disabled =
+    isNullish(neuron) ||
+    !hasPermissionToStakeMaturity({
+      neuron,
+      identity: $authStore.identity,
+    });
 </script>
 
 <AutoStakeMaturity

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte
@@ -7,7 +7,12 @@
     type SelectedSnsNeuronContext,
   } from "$lib/types/sns-neuron-detail.context";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { hasAutoStakeMaturityOn } from "$lib/utils/sns-neuron.utils";
+  import {
+    hasAutoStakeMaturityOn,
+    hasPermissionToStakeMaturity,
+  } from "$lib/utils/sns-neuron.utils";
+  import { isNullish } from "$lib/utils/utils";
+  import { authStore } from "$lib/stores/auth.store";
 
   const context: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -18,10 +23,19 @@
 
   let hasAutoStakeOn: boolean;
   $: hasAutoStakeOn = hasAutoStakeMaturityOn(neuron);
+
+  let disabled: boolean;
+  $: disabled = isNullish(neuron)
+    ? true
+    : !hasPermissionToStakeMaturity({
+        neuron,
+        identity: $authStore.identity,
+      });
 </script>
 
 <AutoStakeMaturity
   bind:hasAutoStakeOn
+  {disabled}
   on:nnsChange={() =>
     openSnsNeuronModal({
       type: "auto-stake-maturity",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -235,7 +235,7 @@
     "stake": "Stake",
     "amount_icp_stake": "$amount ICP Stake",
     "ic_stake": "ICP Stake",
-    "staked": "Staked",
+    "staked": "Of which staked",
     "inline_remaining": "$duration remaining",
     "remaining": "Remaining",
     "age": "Age",

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -4,7 +4,7 @@
 
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
@@ -87,11 +87,6 @@ describe("NnsAutoStakeMaturity", () => {
 
     expect(inputElement.checked).toBeTruthy();
     expect(inputElement.disabled).toBeTruthy();
-
-    inputElement && (await fireEvent.click(inputElement));
-
-    const modal = queryByTestId("auto-stake-confirm-modal");
-    waitFor(() => expect(modal).not.toBeInTheDocument());
   });
 
   const toggleAutoStake = async ({

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -4,7 +4,7 @@
 
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
@@ -66,6 +66,33 @@ describe("NnsAutoStakeMaturity", () => {
 
   it("renders unchecked if auto stake is undefined", () =>
     testCheckBox(undefined));
+
+  it("renders a disabled checkbox if neuron is not controllable", async () => {
+    const neuron = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: "not-user",
+        autoStakeMaturity: true,
+      },
+    };
+    const { queryByTestId } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: NnsAutoStakeMaturity,
+      },
+    });
+
+    const inputElement = queryByTestId("checkbox") as HTMLInputElement;
+
+    expect(inputElement.checked).toBeTruthy();
+    expect(inputElement.disabled).toBeTruthy();
+
+    inputElement && (await fireEvent.click(inputElement));
+
+    const modal = queryByTestId("auto-stake-confirm-modal");
+    waitFor(() => expect(modal).not.toBeInTheDocument());
+  });
 
   const toggleAutoStake = async ({
     neuronAutoStakeMaturity,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -72,6 +72,25 @@ describe("SnsAutoStakeMaturity", () => {
   it("renders unchecked if auto stake is undefined", () =>
     testCheckBox(undefined));
 
+  it("renders a disabled checkbox if neuron is not controllable", async () => {
+    const { queryByTestId } = render(SnsNeuronContextTest, {
+      props: {
+        neuron: {
+          ...mockSnsNeuron,
+          auto_stake_maturity: [true],
+          permissions: [],
+        },
+        rootCanisterId: mockPrincipal,
+        testComponent: SnsAutoStakeMaturity,
+      },
+    });
+
+    const inputElement = queryByTestId("checkbox") as HTMLInputElement;
+
+    expect(inputElement.checked).toBeTruthy();
+    expect(inputElement.disabled).toBeTruthy();
+  });
+
   const toggleAutoStake = async ({
     neuronAutoStakeMaturity,
   }: {


### PR DESCRIPTION
# Motivation

Users can see whether the neuron has auto-stake enabled or not for hotkey neurons.

# Changes

* Move `NnsAutoStakeMaturity` outside the `isControlled` case in NnsNeuronDetail.
* Move `SnsAutoStakeMaturity` outside the `isControlled` case in SnsNeuronDetail.
* Add `disabled` to AutoStakeMaturity component.
* Use `disabled` new prop in `NnsAutoStakeMaturity` and `SnsAutoStakeMaturity`.
* Change "Staked" key to "Of which staked". See screenshot.

# Tests

* Add a test case to check that checkbox is disabled for not controlled neurons. Both SNS and NNS.


<!-- Please provide any information or screenshots about the tests that have been done -->
