### PR TITLE
refactor: projects sns prefix and folder

### DIFF
--- a/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { projectsStore } from "$lib/derived/projects.derived";
+  import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
   import type { Account } from "$lib/types/account";
   import { mapSnsTransaction } from "$lib/utils/sns-transactions.utils";
   import type { Transaction } from "$lib/utils/transactions.utils";
@@ -13,7 +13,7 @@
   export let rootCanisterId: Principal;
 
   let governanceCanisterId: Principal | undefined;
-  $: governanceCanisterId = $projectsStore?.find(
+  $: governanceCanisterId = $snsProjectsStore?.find(
     ({ rootCanisterId: currentId }) =>
       currentId.toText() === rootCanisterId.toText()
   )?.summary.governanceCanisterId;

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -2,7 +2,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
-  import type { SnsFullProject } from "$lib/derived/projects.derived";
+  import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import { Card } from "@dfinity/gix-components";
   import Logo from "$lib/components/ui/Logo.svelte";
   import { Spinner } from "@dfinity/gix-components";

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { SnsFullProject } from "$lib/derived/projects.derived";
+  import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import type {
     SnsSummary,
     SnsSwapCommitment,

--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -5,9 +5,9 @@
   import { isNullish } from "$lib/utils/utils";
   import { snsQueryStore, snsSummariesStore } from "$lib/stores/sns.store";
   import {
-    activePadProjectsStore,
+    snsProjectsActivePadStore,
     type SnsFullProject,
-  } from "$lib/derived/projects.derived";
+  } from "$lib/derived/sns/sns-projects.derived";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { filterProjectsStatus } from "$lib/utils/projects.utils";
   import { Html } from "@dfinity/gix-components";
@@ -17,7 +17,7 @@
   let projects: SnsFullProject[] | undefined;
   $: projects = filterProjectsStatus({
     swapLifecycle: status,
-    projects: $activePadProjectsStore,
+    projects: $snsProjectsActivePadStore,
   });
 
   let loading = false;

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronsFooter.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronsFooter.svelte
@@ -3,7 +3,7 @@
   import { Modal, Spinner } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
-  import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+  import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 
   type ModalKey = "stake-neuron";

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -1,5 +1,5 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { projectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
@@ -110,7 +110,7 @@ export const initDebugStore = () =>
       snsTransactionsStore,
       selectedSnsNeuronStore,
       transactionsStore,
-      projectsStore,
+      snsProjectsStore,
       snsFunctionsStore,
       transactionsFeesStore,
     ],

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -4,9 +4,9 @@ import {
 } from "$lib/constants/canister-ids.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
-  committedProjectsStore,
+  snsProjectsCommittedStore,
   type SnsFullProject,
-} from "$lib/derived/projects.derived";
+} from "$lib/derived/sns/sns-projects.derived";
 import type { Universe } from "$lib/types/universe";
 import { isUniverseCkBTC, pathSupportsCkBTC } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
@@ -22,7 +22,7 @@ export const CKBTC_UNIVERSE: Universe = {
 const universesStore = derived<
   Readable<SnsFullProject[] | undefined>,
   Universe[]
->(committedProjectsStore, (projects: SnsFullProject[] | undefined) => [
+>(snsProjectsCommittedStore, (projects: SnsFullProject[] | undefined) => [
   NNS_UNIVERSE,
   CKBTC_UNIVERSE,
   ...(projects?.map(({ rootCanisterId, summary }) => ({

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -24,7 +24,7 @@ export interface SnsFullProject {
  *
  * @return SnsFullProject[] | undefined What we called project - i.e. the summary and swap of a Sns with the user commitment
  */
-export const projectsStore: Readable<SnsFullProject[] | undefined> = derived(
+export const snsProjectsStore: Readable<SnsFullProject[] | undefined> = derived(
   [snsSummariesStore, snsSwapCommitmentsStore],
   ([summaries, $snsSwapStatesStore]): SnsFullProject[] | undefined =>
     summaries?.map((summary) => {
@@ -43,16 +43,16 @@ export const projectsStore: Readable<SnsFullProject[] | undefined> = derived(
     })
 );
 
-export const activePadProjectsStore = derived<
+export const snsProjectsActivePadStore = derived<
   Readable<SnsFullProject[] | undefined>,
   SnsFullProject[] | undefined
->(projectsStore, (projects: SnsFullProject[] | undefined) =>
+>(snsProjectsStore, (projects: SnsFullProject[] | undefined) =>
   filterActiveProjects(projects)
 );
 
-export const committedProjectsStore = derived<
+export const snsProjectsCommittedStore = derived<
   Readable<SnsFullProject[] | undefined>,
   SnsFullProject[] | undefined
->(projectsStore, (projects: SnsFullProject[] | undefined) =>
+>(snsProjectsStore, (projects: SnsFullProject[] | undefined) =>
   filterCommittedProjects(projects)
 );

--- a/frontend/src/lib/derived/sns/sns-selected-project-new-tx-data.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project-new-tx-data.derived.ts
@@ -1,9 +1,9 @@
 import type { Token, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
-import { selectedUniverseIdStore } from "./selected-universe.derived";
-import { snsSelectedTransactionFeeStore } from "./sns/sns-selected-transaction-fee.store";
-import { snsTokenSymbolSelectedStore } from "./sns/sns-token-symbol-selected.store";
+import { selectedUniverseIdStore } from "../selected-universe.derived";
+import { snsSelectedTransactionFeeStore } from "./sns-selected-transaction-fee.store";
+import { snsTokenSymbolSelectedStore } from "./sns-token-symbol-selected.store";
 
 interface SnsNewTxData {
   token: Token;

--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -1,8 +1,8 @@
+import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import {
   snsProjectsStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
-import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";

--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -1,7 +1,7 @@
 import {
-  projectsStore,
+  snsProjectsStore,
   type SnsFullProject,
-} from "$lib/derived/projects.derived";
+} from "$lib/derived/sns/sns-projects.derived";
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
 import type { Principal } from "@dfinity/principal";
@@ -22,7 +22,7 @@ export const snsOnlyProjectStore = derived<
 
 export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =
   derived(
-    [selectedUniverseIdStore, projectsStore],
+    [selectedUniverseIdStore, snsProjectsStore],
     ([$selectedUniverseIdStore, $projectsStore]) =>
       $projectsStore?.find(
         ({ rootCanisterId }) =>

--- a/frontend/src/lib/derived/sns/sns-sorted-neurons.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-sorted-neurons.derived.ts
@@ -6,9 +6,9 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { derived, type Readable } from "svelte/store";
-import { selectedUniverseIdStore } from "./selected-universe.derived";
+import { selectedUniverseIdStore } from "../selected-universe.derived";
 
-export const sortedSnsNeuronStore: Readable<SnsNeuron[]> = derived(
+export const snsSortedNeuronStore: Readable<SnsNeuron[]> = derived(
   [snsNeuronsStore, selectedUniverseIdStore],
   ([store, selectedSnsRootCanisterId]) => {
     const projectStore = store[selectedSnsRootCanisterId.toText()];
@@ -21,12 +21,12 @@ export const sortedSnsNeuronStore: Readable<SnsNeuron[]> = derived(
 );
 
 export const sortedSnsUserNeuronsStore: Readable<SnsNeuron[]> = derived(
-  [sortedSnsNeuronStore],
+  [snsSortedNeuronStore],
   ([sortedNeurons]) =>
     sortedNeurons.filter((neuron) => !isCommunityFund(neuron))
 );
 
 export const sortedSnsCFNeuronsStore: Readable<SnsNeuron[]> = derived(
-  [sortedSnsNeuronStore],
+  [snsSortedNeuronStore],
   ([sortedNeurons]) => sortedNeurons.filter(isCommunityFund)
 );

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -3,10 +3,10 @@
   import Proposals from "$lib/components/launchpad/Proposals.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { committedProjectsStore } from "$lib/derived/projects.derived";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 
   let showCommitted = false;
-  $: showCommitted = ($committedProjectsStore?.length ?? []) > 0;
+  $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;
 </script>
 
 <main>

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -3,7 +3,7 @@
   import {
     sortedSnsCFNeuronsStore,
     sortedSnsUserNeuronsStore,
-  } from "$lib/derived/sorted-sns-neurons.derived";
+  } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { i18n } from "$lib/stores/i18n";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import SnsNeuronCard from "$lib/components/sns-neurons/SnsNeuronCard.svelte";

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -9,9 +9,9 @@
   import SnsAccountsFooter from "$lib/components/accounts/SnsAccountsFooter.svelte";
   import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import {
-    committedProjectsStore,
+    snsProjectsCommittedStore,
     type SnsFullProject,
-  } from "$lib/derived/projects.derived";
+  } from "$lib/derived/sns/sns-projects.derived";
   import { isNullish, nonNullish } from "$lib/utils/utils";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 
@@ -41,7 +41,7 @@
     });
   };
 
-  $: (async () => await loadSnsAccountsBalances($committedProjectsStore))();
+  $: (async () => await loadSnsAccountsBalances($snsProjectsCommittedStore))();
 </script>
 
 <main>

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -6,9 +6,9 @@ import {
   querySnsSwapState,
 } from "$lib/api/sns.api";
 import {
-  projectsStore,
+  snsProjectsStore,
   type SnsFullProject,
-} from "$lib/derived/projects.derived";
+} from "$lib/derived/sns/sns-projects.derived";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -181,7 +181,7 @@ export const getSwapAccount = async (
 const getProjectFromStore = (
   rootCanisterId: Principal
 ): SnsFullProject | undefined =>
-  get(projectsStore)?.find(
+  get(snsProjectsStore)?.find(
     ({ rootCanisterId: id }) => id.toText() === rootCanisterId.toText()
   );
 

--- a/frontend/src/lib/stores/accounts.store.ts
+++ b/frontend/src/lib/stores/accounts.store.ts
@@ -16,7 +16,7 @@ export interface AccountsStore extends Readable<AccountsStoreData> {
 /**
  * A store that contains the account information.
  */
-export const initAccountsStore = (): AccountsStore => {
+const initAccountsStore = (): AccountsStore => {
   const initialAccounts: AccountsStoreData = {
     main: undefined,
     subAccounts: undefined,

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,4 +1,4 @@
-import type { SnsFullProject } from "$lib/derived/projects.derived";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type {
   SnsSummary,
   SnsSummarySwap,

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionCard.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsTransactionCard from "$lib/components/accounts/SnsTransactionCard.svelte";
-import { projectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
@@ -46,7 +46,7 @@ describe("SnsTransactionCard", () => {
 
   beforeEach(() => {
     jest
-      .spyOn(projectsStore, "subscribe")
+      .spyOn(snsProjectsStore, "subscribe")
       .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
   });
 

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsNeuronsFooter from "$lib/components/sns-neurons/SnsNeuronsFooter.svelte";
-import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { NeuronState, TokenAmount } from "@dfinity/nns";

--- a/frontend/src/tests/lib/components/summary/SummaryLogo.spec.ts
+++ b/frontend/src/tests/lib/components/summary/SummaryLogo.spec.ts
@@ -5,7 +5,7 @@
 import SummaryLogo from "$lib/components/summary/SummaryLogo.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { IC_LOGO } from "$lib/constants/icp.constants";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import { page } from "$mocks/$app/stores";
 import { render } from "@testing-library/svelte";
@@ -33,7 +33,7 @@ describe("SummaryLogo", () => {
         .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
 
       jest
-        .spyOn(committedProjectsStore, "subscribe")
+        .spyOn(snsProjectsCommittedStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
     });
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -3,7 +3,7 @@
  */
 import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
 import { AppPath } from "$lib/constants/routes.constants";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
@@ -32,7 +32,7 @@ describe("SelectUniverseDropdown", () => {
     .mockImplementation(mockTokenStore);
 
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeAll(() => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -4,7 +4,7 @@
 
 import SelectUniverseList from "$lib/components/universe/SelectUniverseList.svelte";
 import { AppPath } from "$lib/constants/routes.constants";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { page } from "$mocks/$app/stores";
 import { fireEvent, render } from "@testing-library/svelte";
 import {
@@ -30,7 +30,7 @@ describe("SelectUniverseList", () => {
   ];
 
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe(projects));
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNavList.spec.ts
@@ -5,7 +5,7 @@
 import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { page } from "$mocks/$app/stores";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -16,7 +16,7 @@ import {
 
 describe("SelectUniverseNavList", () => {
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
@@ -3,7 +3,7 @@ import {
   OWN_CANISTER_ID,
 } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
 import { page } from "$mocks/$app/stores";
 import { get } from "svelte/store";
@@ -46,7 +46,7 @@ describe("selectable universes derived stores", () => {
   describe("with projects", () => {
     beforeAll(() =>
       jest
-        .spyOn(committedProjectsStore, "subscribe")
+        .spyOn(snsProjectsCommittedStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]))
     );
 

--- a/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
@@ -3,8 +3,8 @@ import {
   OWN_CANISTER_ID,
 } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { page } from "$mocks/$app/stores";
 import { get } from "svelte/store";
 import {

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -1,16 +1,16 @@
 import {
-  activePadProjectsStore,
-  committedProjectsStore,
-  projectsStore,
-} from "$lib/derived/projects.derived";
+  snsProjectsActivePadStore,
+  snsProjectsCommittedStore,
+  snsProjectsStore,
+} from "$lib/derived/sns/sns-projects.derived";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 import {
   mockSnsSummaryList,
   mockSnsSwapCommitment,
-} from "../../mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
+} from "../../../mocks/sns-projects.mock";
+import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
 describe("projects.derived", () => {
   describe("projectsDerived", () => {
@@ -35,7 +35,7 @@ describe("projects.derived", () => {
           lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
         })
       );
-      const projects = get(projectsStore);
+      const projects = get(snsProjectsStore);
       expect(projects).toHaveLength(2);
     });
   });
@@ -59,7 +59,7 @@ describe("projects.derived", () => {
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
-      const open = get(activePadProjectsStore);
+      const open = get(snsProjectsActivePadStore);
       expect(open?.length).toEqual(1);
 
       snsQueryStore.setData(
@@ -67,13 +67,13 @@ describe("projects.derived", () => {
           lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
         })
       );
-      const open2 = get(activePadProjectsStore);
+      const open2 = get(snsProjectsActivePadStore);
       expect(open2?.length).toEqual(2);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Unspecified] })
       );
-      const noOpen = get(activePadProjectsStore);
+      const noOpen = get(snsProjectsActivePadStore);
       expect(noOpen?.length).toEqual(0);
     });
 
@@ -82,13 +82,13 @@ describe("projects.derived", () => {
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Committed] })
       );
 
-      const committed = get(committedProjectsStore);
+      const committed = get(snsProjectsCommittedStore);
       expect(committed?.length).toEqual(1);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
-      const noCommitted = get(committedProjectsStore);
+      const noCommitted = get(snsProjectsCommittedStore);
       expect(noCommitted?.length).toEqual(0);
     });
   });

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { snsSelectedProjectNewTxData } from "$lib/derived/selected-project-new-tx-data.derived";
+import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { mapOptionalToken } from "$lib/utils/sns.utils";
@@ -10,8 +10,8 @@ import { page } from "$mocks/$app/stores";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
-import { mockSnsSwapCommitment } from "../../mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
+import { mockSnsSwapCommitment } from "../../../mocks/sns-projects.mock";
+import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
 describe("selected-project-new-transaction-data derived store", () => {
   describe("snsSelectedProjectNewTxData", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import {
-  sortedSnsCFNeuronsStore,
   snsSortedNeuronStore,
+  sortedSnsCFNeuronsStore,
   sortedSnsUserNeuronsStore,
 } from "$lib/derived/sns/sns-sorted-neurons.derived";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -3,22 +3,22 @@
  */
 import {
   sortedSnsCFNeuronsStore,
-  sortedSnsNeuronStore,
+  snsSortedNeuronStore,
   sortedSnsUserNeuronsStore,
-} from "$lib/derived/sorted-sns-neurons.derived";
+} from "$lib/derived/sns/sns-sorted-neurons.derived";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { page } from "$mocks/$app/stores";
 import { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import { mockPrincipal } from "../../mocks/auth.store.mock";
-import { createMockSnsNeuron } from "../../mocks/sns-neurons.mock";
+import { mockPrincipal } from "../../../mocks/auth.store.mock";
+import { createMockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
 describe("sortedSnsNeuronStore", () => {
   afterEach(() => snsNeuronsStore.reset());
   it("returns an empty array if no neurons", () => {
-    expect(get(sortedSnsNeuronStore).length).toBe(0);
+    expect(get(snsSortedNeuronStore).length).toBe(0);
   });
 
   it("should sort neurons by createdTimestampSeconds", async () => {
@@ -54,7 +54,7 @@ describe("sortedSnsNeuronStore", () => {
     page.mock({ data: { universe: mockPrincipal.toText() } });
 
     await waitFor(() =>
-      expect(get(sortedSnsNeuronStore)).toEqual([
+      expect(get(snsSortedNeuronStore)).toEqual([
         neurons[1],
         neurons[2],
         neurons[0],
@@ -96,7 +96,7 @@ describe("sortedSnsNeuronStore", () => {
     page.mock({ data: { universe: mockPrincipal.toText() } });
 
     await waitFor(() =>
-      expect(get(sortedSnsNeuronStore)).toEqual([neurons[1], neurons[2]])
+      expect(get(snsSortedNeuronStore)).toEqual([neurons[1], neurons[2]])
     );
   });
 
@@ -162,7 +162,7 @@ describe("sortedSnsNeuronStore", () => {
     page.mock({ data: { universe: mockPrincipal.toText() } });
 
     await waitFor(() =>
-      expect(get(sortedSnsNeuronStore)).toEqual([
+      expect(get(snsSortedNeuronStore)).toEqual([
         neurons1[1],
         neurons1[2],
         neurons1[0],
@@ -172,7 +172,7 @@ describe("sortedSnsNeuronStore", () => {
     page.mock({ data: { universe: principal2.toText() } });
 
     await waitFor(() =>
-      expect(get(sortedSnsNeuronStore)).toEqual([
+      expect(get(snsSortedNeuronStore)).toEqual([
         neurons2[2],
         neurons2[0],
         neurons2[1],

--- a/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
+++ b/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { pageStore } from "$lib/derived/page.derived";
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import SelectUniverseModal from "$lib/modals/universe/SelectUniverseModal.svelte";
 import { page } from "$mocks/$app/stores";
 import { fireEvent } from "@testing-library/svelte";
@@ -17,7 +17,7 @@ import {
 
 describe("SelectUniverseModal", () => {
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeAll(() => {

--- a/frontend/src/tests/lib/pages/Launchpad.spec.ts
+++ b/frontend/src/tests/lib/pages/Launchpad.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import Launchpad from "$lib/pages/Launchpad.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { render } from "@testing-library/svelte";
@@ -44,7 +44,7 @@ describe("Launchpad", () => {
 
   it("should render titles", () => {
     jest
-      .spyOn(committedProjectsStore, "subscribe")
+      .spyOn(snsProjectsCommittedStore, "subscribe")
       .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
     const { getByText } = render(Launchpad);
 
@@ -56,7 +56,7 @@ describe("Launchpad", () => {
 
   it("should not render committed project title if no committed projects", () => {
     jest
-      .spyOn(committedProjectsStore, "subscribe")
+      .spyOn(snsProjectsCommittedStore, "subscribe")
       .mockImplementation(mockProjectSubscribe([]));
 
     const { queryByText } = render(Launchpad);

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { committedProjectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
@@ -39,7 +39,7 @@ describe("SnsAccounts", () => {
         .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
 
       jest
-        .spyOn(committedProjectsStore, "subscribe")
+        .spyOn(snsProjectsCommittedStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
       page.mock({ data: { universe: mockPrincipal.toText() } });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -6,7 +6,7 @@ import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.d
 import {
   sortedSnsCFNeuronsStore,
   sortedSnsUserNeuronsStore,
-} from "$lib/derived/sorted-sns-neurons.derived";
+} from "$lib/derived/sns/sns-sorted-neurons.derived";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { syncSnsNeurons } from "$lib/services/sns-neurons.services";

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -5,9 +5,9 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import {
-  committedProjectsStore,
-  projectsStore,
-} from "$lib/derived/projects.derived";
+  snsProjectsCommittedStore,
+  snsProjectsStore,
+} from "$lib/derived/sns/sns-projects.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import Accounts from "$lib/routes/Accounts.svelte";
 import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
@@ -46,11 +46,11 @@ describe("Accounts", () => {
   });
 
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   jest
-    .spyOn(projectsStore, "subscribe")
+    .spyOn(snsProjectsStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -4,7 +4,7 @@
 
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { projectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import Neurons from "$lib/routes/Neurons.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
@@ -42,7 +42,7 @@ describe("Neurons", () => {
   );
 
   jest
-    .spyOn(projectsStore, "subscribe")
+    .spyOn(snsProjectsStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -4,7 +4,7 @@
 
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { projectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import ProposalDetail from "$lib/routes/ProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
@@ -45,7 +45,7 @@ describe("ProposalDetail", () => {
   describe("SnsProposalDetail", () => {
     beforeAll(() => {
       jest
-        .spyOn(projectsStore, "subscribe")
+        .spyOn(snsProjectsStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
       page.mock({

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -8,9 +8,9 @@ import {
 } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import {
-  committedProjectsStore,
-  projectsStore,
-} from "$lib/derived/projects.derived";
+  snsProjectsCommittedStore,
+  snsProjectsStore,
+} from "$lib/derived/sns/sns-projects.derived";
 import Proposals from "$lib/routes/Proposals.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
@@ -48,7 +48,7 @@ describe("Proposals", () => {
   );
 
   jest
-    .spyOn(committedProjectsStore, "subscribe")
+    .spyOn(snsProjectsCommittedStore, "subscribe")
     .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
   beforeEach(() => {
@@ -64,7 +64,7 @@ describe("Proposals", () => {
   describe("sns", () => {
     beforeAll(() => {
       jest
-        .spyOn(projectsStore, "subscribe")
+        .spyOn(snsProjectsStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
     });
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -3,7 +3,7 @@
  */
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { projectsStore } from "$lib/derived/projects.derived";
+import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
@@ -44,7 +44,7 @@ describe("Wallet", () => {
   describe("sns context", () => {
     beforeAll(() => {
       jest
-        .spyOn(projectsStore, "subscribe")
+        .spyOn(snsProjectsStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
       page.mock({

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,4 +1,4 @@
-import type { SnsFullProject } from "$lib/derived/projects.derived";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -1,4 +1,4 @@
-import type { SnsFullProject } from "$lib/derived/projects.derived";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type {
   SnsSummary,
   SnsSummaryMetadata,


### PR DESCRIPTION
# Motivation

Sometimes we used `sns` as prefix and folder for the derived stores, sometimes not. This PR aligns the Sns related derived stores by moving all of them under `derived/sns` and prefixing with `sns`.

Per extension, it makes clearer the distinction between "universes" and "project term used for sns".

# Changes

No functional changes. Only refactoring.
