### PR TITLE
In scripts/docker-build only expand "${@}" if it is set

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -49,7 +49,7 @@ DOCKER_BUILDKIT=1 docker build \
   --build-arg OWN_CANISTER_ID="$OWN_CANISTER_ID" \
   -t "$image_name" \
   -o "$OUTDIR" . \
-  "${@}"
+  "${@+${@}}"
 set +x
 
 for file in "${assets[@]}"; do


### PR DESCRIPTION
This is a second attempt of https://github.com/dfinity/nns-dapp/pull/1751 because it got stuck.
Also it seems that this is only necessary for old bash version, which new Macs come with.

This fixes the bug with `unbound variable` in scripts/docker-build.

The problem is that we use `set -u` which forbids using unset variables but then we pass `${@}` to `docker build` which is unset by default. This behavior was added in [this commit], presumably for convenience, and probably not caught because it wasn't empty at the time.

The fix is to replace `"${@}"` with `"${@+${@}}"`.
`${foo+bar}` expands to `bar` but only if `${foo}` is not unset.

[this commit]: https://github.com/dfinity/nns-dapp/blame/main/scripts/docker-build#L52, 