### PR TITLE
GIX-1192: Handle overload in UI

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -6,7 +6,7 @@
     getAccountByRootCanister,
     getAccountsByRootCanister,
   } from "$lib/utils/accounts.utils";
-  import { Dropdown, DropdownItem } from "@dfinity/gix-components";
+  import { Dropdown, DropdownItem, Spinner } from "@dfinity/gix-components";
   import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
   import type { Principal } from "@dfinity/principal";
 
@@ -34,16 +34,9 @@
 </script>
 
 {#if selectableAccounts.length === 0}
-  <Dropdown
-    name="account"
-    disabled
-    selectedValue="no-accounts"
-    testId="select-account-dropdown"
-  >
-    <DropdownItem value="no-accounts">
-      {$i18n.accounts.no_account_select}
-    </DropdownItem>
-  </Dropdown>
+  <div class="select">
+    <Spinner size="small" inline />
+  </div>
 {:else}
   <Dropdown
     name="account"
@@ -57,3 +50,18 @@
     {/each}
   </Dropdown>
 {/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/styles/mixins/form";
+  .select {
+    @include form.input;
+
+    position: relative;
+    box-sizing: border-box;
+
+    padding: var(--padding-2x);
+    border-radius: var(--border-radius);
+
+    width: var(--dropdown-width, auto);
+  }
+</style>

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -100,16 +100,16 @@
 
 <form on:submit|preventDefault={goNext} data-tid="transaction-step-1">
   <div class="select-account">
-    {#if selectedAccount !== undefined}
-      <KeyValuePair>
-        <span slot="key" class="label">{$i18n.accounts.source}</span>
+    <KeyValuePair>
+      <span slot="key" class="label">{$i18n.accounts.source}</span>
+      {#if selectedAccount !== undefined}
         <AmountDisplay
           slot="value"
           singleLine
           amount={selectedAccount?.balance}
         />
-      </KeyValuePair>
-    {/if}
+      {/if}
+    </KeyValuePair>
 
     {#if canSelectSource}
       <SelectAccountDropdown {rootCanisterId} bind:selectedAccount />

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -102,13 +102,13 @@
   <div class="select-account">
     <KeyValuePair>
       <span slot="key" class="label">{$i18n.accounts.source}</span>
-      {#if selectedAccount !== undefined}
-        <AmountDisplay
-          slot="value"
-          singleLine
-          amount={selectedAccount?.balance}
-        />
-      {/if}
+      <!-- svelte:fragment needed to avoid warnings -->
+      <!-- Svelte issue: https://github.com/sveltejs/svelte/issues/5604 -->
+      <svelte:fragment slot="value">
+        {#if selectedAccount !== undefined}
+          <AmountDisplay singleLine amount={selectedAccount?.balance} />
+        {/if}
+      </svelte:fragment>
     </KeyValuePair>
 
     {#if canSelectSource}

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -93,7 +93,6 @@
   };
 </script>
 
-<!-- TODO: Fetch SNS params and use minimum neuron stake for validation -->
 <SnsTransactionModal
   {rootCanisterId}
   on:nnsSubmit={stake}

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -4,6 +4,12 @@
   import { i18n } from "$lib/stores/i18n";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { onMount } from "svelte";
+  import { loadSnsSwapCommitments } from "$lib/services/sns.services";
+
+  onMount(() => {
+    loadSnsSwapCommitments();
+  });
 
   let showCommitted = false;
   $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;

--- a/frontend/src/lib/proxy/sns.services.proxy.ts
+++ b/frontend/src/lib/proxy/sns.services.proxy.ts
@@ -1,6 +1,0 @@
-const importSnsServices = () => import("../services/sns.services");
-
-export const loadSnsSwapCommitmentsProxy = async (): Promise<void> => {
-  const { loadSnsSwapCommitments } = await importSnsServices();
-  return loadSnsSwapCommitments();
-};

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,10 +1,9 @@
-import { loadSnsSwapCommitmentsProxy } from "$lib/proxy/sns.services.proxy";
 import { loadMainTransactionFee } from "$lib/services/transaction-fees.services";
 import { syncAccounts } from "./accounts.services";
 import { listNeurons } from "./neurons.services";
 
 export const initAppPrivateData = (): Promise<
-  [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
+  [PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [
     syncAccounts(),
@@ -12,10 +11,8 @@ export const initAppPrivateData = (): Promise<
     loadMainTransactionFee(),
   ];
 
-  const initSns: Promise<void>[] = [loadSnsSwapCommitmentsProxy()];
-
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
-  return Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
+  return Promise.allSettled([Promise.all(initNns)]);
 };

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -45,7 +45,7 @@ import { queryAndUpdate } from "./utils.services";
  * Therefore, this can be called before the projects are loaded.
  */
 export const loadSnsSwapCommitments = async (): Promise<void> => {
-  const commtimentsCanisterIds = new Set(
+  const commitmentsCanisterIds = new Set(
     (get(snsSwapCommitmentsStore) ?? [])
       .filter(({ certified }) => certified)
       .map(({ swapCommitment: { rootCanisterId } }) => rootCanisterId.toText())
@@ -57,9 +57,9 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
   );
   // Skip if we have commitments for all projects.
   if (
-    commtimentsCanisterIds.size > 0 &&
-    commtimentsCanisterIds.size >= snsProjectsCanisterIds.size &&
-    [...snsProjectsCanisterIds].every((id) => commtimentsCanisterIds.has(id))
+    commitmentsCanisterIds.size > 0 &&
+    commitmentsCanisterIds.size >= snsProjectsCanisterIds.size &&
+    [...snsProjectsCanisterIds].every((id) => commitmentsCanisterIds.has(id))
   ) {
     return;
   }

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -9,7 +9,11 @@ import {
   snsProjectsStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
-import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import {
+  snsQueryStore,
+  snsSummariesStore,
+  snsSwapCommitmentsStore,
+} from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
@@ -30,9 +34,35 @@ import { getAccountIdentity, syncAccounts } from "./accounts.services";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
-export const loadSnsSwapCommitments = (): Promise<void> => {
-  snsSwapCommitmentsStore.setLoadingState();
-
+/**
+ * Loads the user commitments for all projects.
+ *
+ * If the commitments are already loaded, it will not reload them.
+ *
+ * We rely that the projects are already loaded to skip loading the commitments.
+ * If commitments is 0, it will load them always.
+ *
+ * Therefore, this can be called before the projects are loaded.
+ */
+export const loadSnsSwapCommitments = async (): Promise<void> => {
+  const commtimentsCanisterIds = new Set(
+    (get(snsSwapCommitmentsStore) ?? [])
+      .filter(({ certified }) => certified)
+      .map(({ swapCommitment: { rootCanisterId } }) => rootCanisterId.toText())
+  );
+  const snsProjectsCanisterIds = new Set(
+    (get(snsSummariesStore) ?? []).map(({ rootCanisterId }) =>
+      rootCanisterId.toText()
+    )
+  );
+  // Skip if we have commitments for all projects.
+  if (
+    commtimentsCanisterIds.size > 0 &&
+    commtimentsCanisterIds.size >= snsProjectsCanisterIds.size &&
+    [...snsProjectsCanisterIds].every((id) => commtimentsCanisterIds.has(id))
+  ) {
+    return;
+  }
   return queryAndUpdate<SnsSwapCommitment[], unknown>({
     request: ({ certified, identity }) =>
       querySnsSwapCommitments({ certified, identity }),
@@ -52,7 +82,7 @@ export const loadSnsSwapCommitments = (): Promise<void> => {
       }
 
       // hide unproven data
-      snsSwapCommitmentsStore.setLoadingState();
+      snsSwapCommitmentsStore.reset();
 
       toastsError(
         toToastError({
@@ -112,7 +142,7 @@ export const loadSnsSwapCommitment = async ({
   onError,
 }: {
   rootCanisterId: string;
-  onError: () => void;
+  onError?: () => void;
 }) =>
   queryAndUpdate<SnsSwapCommitment, unknown>({
     request: ({ certified, identity }) =>
@@ -137,7 +167,7 @@ export const loadSnsSwapCommitment = async ({
         })
       );
 
-      onError();
+      onError?.();
     },
     logMessage: "Syncing Sns swap commitment",
   });

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -228,10 +228,6 @@ const initSnsSwapCommitmentsStore = () => {
     reset() {
       set(undefined);
     },
-
-    setLoadingState() {
-      set(null);
-    },
   };
 };
 

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -12,12 +12,6 @@ import {
 } from "../../../mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
-jest.mock("$lib/services/sns.services", () => {
-  return {
-    loadSnsSwapCommitments: jest.fn().mockResolvedValue(Promise.resolve()),
-  };
-});
-
 describe("Projects", () => {
   beforeEach(() => {
     snsQueryStore.reset();

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -25,12 +25,6 @@ jest.mock("$lib/services/sns.services", () => {
   };
 });
 
-jest.mock("$lib/services/sns.services", () => {
-  return {
-    loadSnsSwapCommitments: jest.fn().mockResolvedValue(Promise.resolve()),
-  };
-});
-
 describe("ProjectDetail", () => {
   describe("present project in store", () => {
     page.mock({ data: { universe: null } });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -3,17 +3,10 @@
  */
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
-import { loadSnsSwapCommitments } from "$lib/services/sns.services";
 import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import { mockAccountDetails } from "../../mocks/accounts.store.mock";
 import { mockNeuron } from "../../mocks/neurons.mock";
-
-jest.mock("$lib/services/sns.services", () => {
-  return {
-    loadSnsSwapCommitments: jest.fn().mockResolvedValue(Promise.resolve()),
-  };
-});
 
 describe("app-services", () => {
   const mockLedgerCanister = mock<LedgerCanister>();
@@ -63,11 +56,5 @@ describe("app-services", () => {
     await expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(
       numberOfCalls
     );
-  });
-
-  it("should init Sns", async () => {
-    await initAppPrivateData();
-
-    await expect(loadSnsSwapCommitments).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Motivation

Two main motivations:

* Handle gracefully when something is not loaded (such as accounts for the transaction modal)
* Load resources in the page that they are needed, to reduce load in the IC.

# Changes

* Use a Spinner in SelectableDropdownAccount when accounts are being loaded.
* Move "loadSnsSwapCommitments" to Launchpad instead of on init.
* "loadSnsSwapCommitments" does not query commitments again if they already loaded.

# Tests

* Add test for spinner in SelectableDropdownAccount.
* New test for loadSnsSwapCommitments.
