### PR TITLE
Chore: Add fee in SNS transactions

### DIFF
--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -76,6 +76,14 @@ export const transactionFee = async ({
   return fee;
 };
 
+/**
+ * Transfer SNS tokens from one account to another.
+ *
+ * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
+ *
+ * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.
+ */
 export const transfer = async ({
   identity,
   to,
@@ -84,6 +92,7 @@ export const transfer = async ({
   memo,
   fromSubAccount,
   createdAt,
+  fee,
 }: {
   identity: Identity;
   to: IcrcAccount;
@@ -92,6 +101,7 @@ export const transfer = async ({
   memo?: Uint8Array;
   fromSubAccount?: SubAccountArray;
   createdAt?: bigint;
+  fee: bigint;
 }): Promise<void> => {
   const { transfer: transferApi } = await wrapper({
     identity,
@@ -106,6 +116,7 @@ export const transfer = async ({
       subaccount: toNullable(to.subaccount),
     },
     created_at_time: createdAt ?? nowInBigIntNanoSeconds(),
+    fee,
     memo,
     from_subaccount:
       fromSubAccount !== undefined

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -374,18 +374,28 @@ export const querySnsNeuron = async ({
   return neuron;
 };
 
+/**
+ * Stake SNS neuron.
+ *
+ * param.fee is mandatory to ensure that it's show for hardware wallets.
+ * Otherwise, the fee would not show in the device and the user would not know how much they are paying.
+ *
+ * This als adds an extra layer of safety because we show the fee before the user confirms the transaction.
+ */
 export const stakeNeuron = async ({
   controller,
   stakeE8s,
   rootCanisterId,
   identity,
   source,
+  fee,
 }: {
   controller: Principal;
   stakeE8s: bigint;
   rootCanisterId: Principal;
   identity: Identity;
   source: IcrcAccount;
+  fee: bigint;
 }): Promise<SnsNeuronId> => {
   logWithTimestamp(
     `Staking neuron with ${Number(stakeE8s) / E8S_PER_ICP}: call...`
@@ -403,6 +413,7 @@ export const stakeNeuron = async ({
     source,
     controller,
     createdAt,
+    fee,
   });
 
   logWithTimestamp(

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -2,6 +2,7 @@ import { getSnsAccounts, transfer } from "$lib/api/sns-ledger.api";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { snsTransactionsStore } from "$lib/stores/sns-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
 import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
@@ -9,6 +10,7 @@ import { numberToE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { decodeIcrcAccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { loadAccountTransactions } from "./sns-transactions.services";
 import { loadSnsTransactionFee } from "./transaction-fees.services";
@@ -86,12 +88,20 @@ export const snsTransferTokens = async ({
     const identity: Identity = await getSnsAccountIdentity(source);
     const to = decodeIcrcAccount(destinationAddress);
 
+    const fee = get(transactionsFeesStore).projects[rootCanisterId.toText()]
+      ?.fee;
+
+    if (!fee) {
+      throw new Error("error.transaction_fee_not_found");
+    }
+
     await transfer({
       identity,
       to,
       fromSubAccount: source.subAccount,
       e8s,
       rootCanisterId,
+      fee,
     });
 
     await Promise.all([

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -536,12 +536,21 @@ export const stakeNeuron = async ({
     // TODO: Get identity depending on account to support HW accounts
     const identity = await getAuthenticatedIdentity();
     const stakeE8s = numberToE8s(amount);
+
+    const fee = get(transactionsFeesStore).projects[rootCanisterId.toText()]
+      ?.fee;
+
+    if (!fee) {
+      throw new Error("error.transaction_fee_not_found");
+    }
+
     await stakeNeuronApi({
       controller: identity.getPrincipal(),
       rootCanisterId,
       stakeE8s,
       identity,
       source: decodeIcrcAccount(account.identifier),
+      fee,
     });
     await Promise.all([
       loadSnsAccounts({ rootCanisterId }),

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -88,6 +88,7 @@ describe("sns-ledger api", () => {
         to: { owner: mockIdentity.getPrincipal() },
         e8s: BigInt(10_000_000),
         createdAt: BigInt(123456),
+        fee: BigInt(10_000),
       });
 
       expect(transferSpy).toBeCalled();

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -262,6 +262,7 @@ describe("sns-api", () => {
         owner: mockPrincipal,
       },
       controller: mockPrincipal,
+      fee: BigInt(10000),
     });
 
     expect(neuronId).toEqual(mockSnsNeuron.id);

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -119,7 +119,17 @@ describe("sns-accounts-services", () => {
       snsAccountsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
+
+    afterEach(() => {
+      transactionsFeesStore.reset();
+    });
+
     it("should call sns transfer tokens", async () => {
+      transactionsFeesStore.setFee({
+        rootCanisterId: mockPrincipal,
+        fee: BigInt(100),
+        certified: true,
+      });
       const spyTransfer = jest
         .spyOn(ledgerApi, "transfer")
         .mockResolvedValue(undefined);
@@ -138,6 +148,11 @@ describe("sns-accounts-services", () => {
     });
 
     it("should load transactions if flag is passed", async () => {
+      transactionsFeesStore.setFee({
+        rootCanisterId: mockPrincipal,
+        fee: BigInt(100),
+        certified: true,
+      });
       const spyTransfer = jest
         .spyOn(ledgerApi, "transfer")
         .mockResolvedValue(undefined);
@@ -157,6 +172,11 @@ describe("sns-accounts-services", () => {
     });
 
     it("should show toast and return success false if transfer fails", async () => {
+      transactionsFeesStore.setFee({
+        rootCanisterId: mockPrincipal,
+        fee: BigInt(100),
+        certified: true,
+      });
       const spyTransfer = jest
         .spyOn(ledgerApi, "transfer")
         .mockRejectedValue(new Error("test error"));
@@ -172,6 +192,27 @@ describe("sns-accounts-services", () => {
 
       expect(success).toBe(false);
       expect(spyTransfer).toBeCalled();
+      expect(spyAccounts).not.toBeCalled();
+      expect(spyOnToastsError).toBeCalled();
+    });
+
+    it("should show toast and return success false if there is no transaction fee", async () => {
+      transactionsFeesStore.reset();
+      const spyTransfer = jest
+        .spyOn(ledgerApi, "transfer")
+        .mockRejectedValue(new Error("test error"));
+      const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
+
+      const { success } = await services.snsTransferTokens({
+        rootCanisterId: mockPrincipal,
+        source: mockSnsMainAccount,
+        destinationAddress: "aaaaa-aa",
+        amount: 1,
+        loadTransactions: false,
+      });
+
+      expect(success).toBe(false);
+      expect(spyTransfer).not.toBeCalled();
       expect(spyAccounts).not.toBeCalled();
       expect(spyOnToastsError).toBeCalled();
     });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -590,7 +590,17 @@ describe("sns-neurons-services", () => {
   });
 
   describe("stakeNeuron", () => {
+    afterEach(() => {
+      transactionsFeesStore.reset();
+      jest.clearAllMocks();
+    });
+
     it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
+      transactionsFeesStore.setFee({
+        rootCanisterId: mockPrincipal,
+        fee: BigInt(100),
+        certified: true,
+      });
       const spyStake = jest
         .spyOn(api, "stakeNeuron")
         .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
@@ -608,6 +618,22 @@ describe("sns-neurons-services", () => {
       expect(spyStake).toBeCalled();
       expect(spyQuery).toBeCalled();
       expect(loadSnsAccounts).toBeCalled();
+    });
+
+    it("should not call sns api stakeNeuron if fee is not present", async () => {
+      transactionsFeesStore.reset();
+      const spyStake = jest
+        .spyOn(api, "stakeNeuron")
+        .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
+
+      const { success } = await stakeNeuron({
+        rootCanisterId: mockPrincipal,
+        amount: 2,
+        account: mockSnsMainAccount,
+      });
+
+      expect(success).toBeFalsy();
+      expect(spyStake).not.toBeCalled();
     });
   });
 


### PR DESCRIPTION
# Motivation

Prepare for SNS support for hardware wallets.

To ensure that HW users signs what's really happening, we added the fee in the SNS transactions.

# Changes

* Add "fee" param to sns.api function "stakeNeuron".
* Add "fee" param to sns-ledger.api function "transfer".
* Read fee and fail if not present in sns-accounts service "snsTransferTokens".
* Read fee and fail if not present in sns-neurons service "stakeNeuron".
* Upgrade ic-js

# Tests

* Adapt tests to new requirement.
