### PR TITLE
Additional tar flags to improve nns-dapp frontent reproducibility

### DIFF
--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -43,7 +43,7 @@ cp -R "$TOPLEVEL/frontend/public/" "$tarball_dir/"
 # brew install xz
 cd "$tarball_dir"
 
-# --mtime, --sort, --owner, --group, --numeric-owner and --pax-option are all
+# --mtime, --sort, --owner, --group, --numeric-owner and --format are all
 # there to get a tarball that's reproducible across different platforms.
 # See https://reproducible-builds.org/docs/archives/
 "$tar" cJv \
@@ -52,7 +52,6 @@ cd "$tarball_dir"
   --owner=0 \
   --group=0 \
   --numeric-owner \
-  #--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
   --format=ustar \
   --exclude .last_build_id \
   -f "$TOPLEVEL/assets.tar.xz" \

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -43,7 +43,7 @@ cp -R "$TOPLEVEL/frontend/public/" "$tarball_dir/"
 # brew install xz
 cd "$tarball_dir"
 
-"$tar" cJv --mtime='2021-05-07 17:00+00' --sort=name --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
+"$tar" cJv --mtime='2021-05-07 17:00Z' --sort=name --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime--exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
 
 cd "$TOPLEVEL"
 

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -52,7 +52,8 @@ cd "$tarball_dir"
     --owner=0 \
     --group=0 \
     --numeric-owner \
-    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+    #--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+    --format=ustar \
     --exclude .last_build_id \
     -f "$TOPLEVEL/assets.tar.xz" \
     .

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -43,7 +43,7 @@ cp -R "$TOPLEVEL/frontend/public/" "$tarball_dir/"
 # brew install xz
 cd "$tarball_dir"
 
-"$tar" cJv --mtime='2021-05-07 17:00Z' --sort=name --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime--exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
+"$tar" cJv --mtime='2021-05-07 17:00Z' --sort=name --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
 
 cd "$TOPLEVEL"
 

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -43,7 +43,19 @@ cp -R "$TOPLEVEL/frontend/public/" "$tarball_dir/"
 # brew install xz
 cd "$tarball_dir"
 
-"$tar" cJv --mtime='2021-05-07 17:00Z' --sort=name --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime --exclude .last_build_id -f "$TOPLEVEL/assets.tar.xz" .
+# --mtime, --sort, --owner, --group, --numeric-owner and --pax-option are all
+# there to get a tarball that's reproducible across different platforms.
+# See https://reproducible-builds.org/docs/archives/
+"$tar" cJv \
+    --mtime='2021-05-07 17:00Z' \
+    --sort=name \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+    --exclude .last_build_id \
+    -f "$TOPLEVEL/assets.tar.xz" \
+    .
 
 cd "$TOPLEVEL"
 

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -47,16 +47,16 @@ cd "$tarball_dir"
 # there to get a tarball that's reproducible across different platforms.
 # See https://reproducible-builds.org/docs/archives/
 "$tar" cJv \
-    --mtime='2021-05-07 17:00Z' \
-    --sort=name \
-    --owner=0 \
-    --group=0 \
-    --numeric-owner \
-    #--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    --format=ustar \
-    --exclude .last_build_id \
-    -f "$TOPLEVEL/assets.tar.xz" \
-    .
+  --mtime='2021-05-07 17:00Z' \
+  --sort=name \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  #--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+  --format=ustar \
+  --exclude .last_build_id \
+  -f "$TOPLEVEL/assets.tar.xz" \
+  .
 
 cd "$TOPLEVEL"
 


### PR DESCRIPTION
# Motivation

We are taking steps towards reproducible builds.
Because the frontend builds much faster than the entire canister, we separately check if the assets tarball is reproducible.
There are several potential reasons why the frontend tarball might differ:
1. The contents are different.
2. The same contents create different `.tar` archives because different metadata is included.
3. The same archive is compressed differently because different metadata is included.

# Changes

Add additional flags to the tar command to make the archive (more) reproducible.
I found these on https://reproducible-builds.org/docs/archives/
This change improves #2 from the list above.

# Tests

When inspecting the generated tarballs, I previously noticed that the same content produced different tarballs and I didn't see that after adding these flags. For the rest I'm relying on existing workflows to make sure this doesn't break anything else.

I've also noticed issues with the actual content being different but strangely in the last few runs that seems to have gone away. What I saw was that different tarballs had different css files with the same content. I suspect that different components (e.g. SignInNeuron and SignInCanister) have the same css and that the files got deduped in an inconsistent way.
