### PR TITLE
Add a tool to compute the SHA256 of a .tar.xz at different levels.

### DIFF
--- a/scripts/tarxzhash
+++ b/scripts/tarxzhash
@@ -34,8 +34,8 @@ function do_hash {
 
   echo "tmpdir = $tmpdir"
 
-  cp "$tar_xz_file" $tmpdir
-  pushd $tmpdir >/dev/null
+  cp "$tar_xz_file" "$tmpdir"
+  pushd "$tmpdir" >/dev/null
 
   tar_file="${file_base}.tar"
   tar_xz_file="${tar_file}.xz"
@@ -56,7 +56,7 @@ function do_hash {
   find . -type f | LC_ALL=C sort >"../$content_file"
 
   # SHA256 each individual file.
-  cat "../$content_file" | xargs sha256sum >"../$hashfile"
+  xargs sha256sum <"../$content_file" >"../$hashfile"
   popd >/dev/null
 
   # SHA256 the collection of all hashes of all files.
@@ -65,5 +65,5 @@ function do_hash {
 }
 
 for file in "$@"; do
-  do_hash $file
+  do_hash "$file"
 done

--- a/scripts/tarxzhash
+++ b/scripts/tarxzhash
@@ -12,8 +12,7 @@ set -euo pipefail
 
 # Do we want to keep the temp directory with extracted/generated files?
 keep=false
-if [ "$1" == "-k" ]
-then
+if [ "$1" == "-k" ]; then
   shift
   keep=true
 fi
@@ -21,8 +20,7 @@ fi
 function do_hash {
   tar_xz_file=$1
 
-  if [ "$tar_xz_file" == "${tar_xz_file%.tar.xz}" ]
-  then
+  if [ "$tar_xz_file" == "${tar_xz_file%.tar.xz}" ]; then
     echo "Parameter should end with '.tar.xz'."
     exit 1
   fi
@@ -30,15 +28,14 @@ function do_hash {
   file_base=$(basename "${tar_xz_file%.tar.xz}")
 
   tmpdir=$(mktemp -d -t "nns-dapp-$file_base" 2>/dev/null)
-  if [ "$keep" == "false" ]
-  then
+  if [ "$keep" == "false" ]; then
     trap 'rm -rf -- "$tmpdir"' EXIT
   fi
 
   echo "tmpdir = $tmpdir"
 
   cp "$tar_xz_file" $tmpdir
-  pushd $tmpdir > /dev/null
+  pushd $tmpdir >/dev/null
 
   tar_file="${file_base}.tar"
   tar_xz_file="${tar_file}.xz"
@@ -54,21 +51,19 @@ function do_hash {
 
   # List the contents in deterministic order.
   mkdir content
-  pushd content > /dev/null
+  pushd content >/dev/null
   tar xf "../$tar_file"
-  find . -type f | LC_ALL=C sort > "../$content_file"
+  find . -type f | LC_ALL=C sort >"../$content_file"
 
   # SHA256 each individual file.
-  cat "../$content_file" | xargs sha256sum > "../$hashfile"
-  popd > /dev/null
+  cat "../$content_file" | xargs sha256sum >"../$hashfile"
+  popd >/dev/null
 
   # SHA256 the collection of all hashes of all files.
   sha256sum "$hashfile"
-  popd > /dev/null
+  popd >/dev/null
 }
 
-
-for file in "$@"
-do
+for file in "$@"; do
   do_hash $file
 done

--- a/scripts/tarxzhash
+++ b/scripts/tarxzhash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Usage: tarxzhash [ -k ] assets.tar.xz [ other_assets.tar.xz, ... ]
+#
+# For one or more given .tar.xz files it outputs the SHA256 of the original
+# .tar.xz file, the SHA256 of the uncompressed .tar file, and the SHA256 of the
+# contents.
+#
+# -k can be used to keep the temporary directory instead of deleting it.
+
+set -euo pipefail
+
+# Do we want to keep the temp directory with extracted/generated files?
+keep=false
+if [ "$1" == "-k" ]
+then
+  shift
+  keep=true
+fi
+
+function do_hash {
+  tar_xz_file=$1
+
+  if [ "$tar_xz_file" == "${tar_xz_file%.tar.xz}" ]
+  then
+    echo "Parameter should end with '.tar.xz'."
+    exit 1
+  fi
+
+  file_base=$(basename "${tar_xz_file%.tar.xz}")
+
+  tmpdir=$(mktemp -d -t "nns-dapp-$file_base" 2>/dev/null)
+  if [ "$keep" == "false" ]
+  then
+    trap 'rm -rf -- "$tmpdir"' EXIT
+  fi
+
+  echo "tmpdir = $tmpdir"
+
+  cp "$tar_xz_file" $tmpdir
+  pushd $tmpdir > /dev/null
+
+  tar_file="${file_base}.tar"
+  tar_xz_file="${tar_file}.xz"
+  content_file="$file_base.content"
+  hashfile="$content_file.hashes"
+
+  # SHA256 the original compressed tarball
+  sha256sum "$tar_xz_file"
+
+  # SHA256 the uncompressed tarball
+  unxz -k "$tar_xz_file"
+  sha256sum "$tar_file"
+
+  # List the contents in deterministic order.
+  mkdir content
+  pushd content > /dev/null
+  tar xf "../$tar_file"
+  find . -type f | LC_ALL=C sort > "../$content_file"
+
+  # SHA256 each individual file.
+  cat "../$content_file" | xargs sha256sum > "../$hashfile"
+  popd > /dev/null
+
+  # SHA256 the collection of all hashes of all files.
+  sha256sum "$hashfile"
+  popd > /dev/null
+}
+
+
+for file in "$@"
+do
+  do_hash $file
+done

--- a/scripts/tarxzhash
+++ b/scripts/tarxzhash
@@ -18,7 +18,7 @@ if [ "$1" == "-k" ]; then
 fi
 
 function do_hash {
-  tar_xz_file=$1
+  tar_xz_file="$1"
 
   if [ "$tar_xz_file" == "${tar_xz_file%.tar.xz}" ]; then
     echo "Parameter should end with '.tar.xz'."


### PR DESCRIPTION
# Motivation

We are trying to make the build reproducible.
We are first working on the assets.tar.xz with the frontend build.
In my investigation why the build isn't reproducible, I've found it useful to automate the extraction and apply SHA256 at different level of the archive.

# Changes

Adds a shell script which extracts a .tar.xz and computes the SHA256 of the .tar.xz, the .tar and the individual files.

# Tests

Ran the tool on the assets.tar.xz generated by build-frontend.sh.
