### PR TITLE
refactor: Factor out the rust build command

### DIFF
--- a/build-rs.sh
+++ b/build-rs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 ###############
 # Hjelpe meg!
@@ -12,7 +12,7 @@ print_help() {
 	    $(basename "$0") <canister_name> [cargo_flags]
 	EOF
 }
-[[ "${1:-}" == "--help" ]] || {
+[[ "${1:-}" != "--help" ]] || {
   print_help
   exit 0
 }

--- a/build-rs.sh
+++ b/build-rs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+###############
+# Hjelpe meg!
+###############
+print_help() {
+  cat <<-EOF
+	Builds a canister wasm file from Rust source code.
+
+	Usage:
+	    $(basename "$0") <canister_name> [cargo_flags]
+	EOF
+}
+[[ "${1:-}" == "--help" ]] || {
+  print_help
+  exit 0
+}
+
+###############
+# Set working dir, canister name and build args
+###############
+cd "$(dirname "$0")"
+canister_name="$1"
+cargo_args=(--target wasm32-unknown-unknown --release --package "$@")
+
+###############
+# cargo build # (output: target/release/.../${canister_name}.wasm)
+###############
+echo "Compiling rust package ${canister_name}"
+cargo build "${cargo_args[@]}"
+
+####################
+# ic-cdk-optimizer # (output: ${canister_name}.wasm)
+####################
+echo Optimising wasm
+ic-cdk-optimizer "./target/wasm32-unknown-unknown/release/${canister_name}.wasm" -o "./${canister_name}.wasm"
+gzip -f -n "${canister_name}.wasm"
+mv "${canister_name}.wasm.gz" "${canister_name}.wasm"
+ls -sh "./${canister_name}.wasm"
+sha256sum "./${canister_name}.wasm"

--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,7 @@ set -x
 ###############
 echo Compiling rust package
 if [[ $DFX_NETWORK != "mainnet" ]]; then
-  "$TOPLEVEL/build-rs.sh" --features mock_conversion_rate
+  "$TOPLEVEL/build-rs.sh" nns-dapp --features mock_conversion_rate
 else
-  "$TOPLEVEL/build-rs.sh"
+  "$TOPLEVEL/build-rs.sh" nns-dapp
 fi

--- a/build.sh
+++ b/build.sh
@@ -62,23 +62,11 @@ set -x
 "$TOPLEVEL/build-frontend.sh"
 
 ###############
-# cargo build # (output: target/release/.../nns-dapp.wasm)
+# backend # (output: nns-dapp.wasm)
 ###############
 echo Compiling rust package
-cargo_args=(--target wasm32-unknown-unknown --release --package nns-dapp)
 if [[ $DFX_NETWORK != "mainnet" ]]; then
-  cargo_args+=(--features mock_conversion_rate)
+  "$TOPLEVEL/build-rs.sh" --features mock_conversion_rate
+else
+  "$TOPLEVEL/build-rs.sh"
 fi
-
-(cd "$TOPLEVEL" && cargo build "${cargo_args[@]}")
-
-####################
-# ic-cdk-optimizer # (output: nns-dapp.wasm)
-####################
-echo Optimising wasm
-cd "$TOPLEVEL"
-ic-cdk-optimizer ./target/wasm32-unknown-unknown/release/nns-dapp.wasm -o ./nns-dapp.wasm
-gzip -f -n nns-dapp.wasm
-mv nns-dapp.wasm.gz nns-dapp.wasm
-ls -sh ./nns-dapp.wasm
-sha256sum ./nns-dapp.wasm


### PR DESCRIPTION
# Motivation
We now have two rust canisters.  They need the same commands to run so factor out the build script.

# Changes
- Move the Rust build steps into a separate script.

# Tests
- [x] The wasm created by this should be identical to the wasm on the merge-root with main. 
  - Both yield `e72857b431955309b4b0d1d8423320f32bee9a6178db46b177ef9b0d4b16e549`
  - This PR:  https://github.com/dfinity/nns-dapp/actions/runs/4025418459/jobs/6918615826
  - Main: https://github.com/dfinity/nns-dapp/actions/runs/4024511085/jobs/6916629090
