### PR TITLE
Explicitly remove temp dir in tarxzhash

### DIFF
--- a/scripts/tarxzhash
+++ b/scripts/tarxzhash
@@ -62,6 +62,10 @@ function do_hash {
   # SHA256 the collection of all hashes of all files.
   sha256sum "$hashfile"
   popd >/dev/null
+
+  if [ "$keep" == "false" ]; then
+    rm -rf -- "$tmpdir"
+  fi
 }
 
 for file in "$@"; do


### PR DESCRIPTION
# Motivation

The tarxzhash script leaves behind temp dirs if called on more than 1 input.
I assumed that trap would take care of all of them but setting a trap for a signal seems to replace the previous trap.

# Changes

Explicitly remove the temp dir for each input.

# Tests

Called manually with 2 inputs, both with and without -k arg.
