### PR TITLE
Kloet/hash check

### DIFF
--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -53,3 +53,29 @@ jobs:
           name: nns-dapp-assets-${{ matrix.os }}
           path: assets.tar.xz
           retention-days: 3
+      - name: 'Output the wasm hash'
+        run: |
+          mkdir -p hashes
+          sha256sum nns-dapp.wasm > "hashes/nns-dapp-wasm_sha256_${{ matrix.os }}_${{ matrix.time }}.txt"
+      - name: 'Output the assets hash'
+        run: |
+          sha256sum assets.tar.xz > "hashes/assets_sha256_${{ matrix.os }}_${{ matrix.time }}.txt"
+      - name: 'Upload hashes'
+        uses: actions/upload-artifact@v3
+        with:
+          name: hashes
+          path: hashes/*.txt
+  compare_hashes:
+    runs-on: ubuntu-latest
+    needs: [native_asset_build]
+    steps:
+      - name: Get hashes
+        uses: actions/download-artifact@v3
+        with:
+          name: hashes
+          path: hashes
+      - name: Print hashes
+        run: |
+          echo Hashes:
+          grep -r . hashes/ | awk -F: '{printf "%s: %s\n", $2, $1}' | sort
+          (( $(cat hashes/*.txt | sort | uniq | wc -l) == 2 ))

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -78,4 +78,6 @@ jobs:
         run: |
           echo Hashes:
           grep -r . hashes/ | awk -F: '{printf "%s: %s\n", $2, $1}' | sort
-          (( $(cat hashes/*.txt | sort | uniq | wc -l) == 2 ))
+          # If the assets hashes differ, the wasm hashes will also
+          # differ, so we only check the wasm hashes.
+          (( $(cat hashes/nns-dapp-wasm_*.txt | sort | uniq | wc -l) == 1 ))

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -67,7 +67,7 @@ jobs:
           path: hashes/*.txt
   compare_hashes:
     runs-on: ubuntu-latest
-    needs: [native_asset_build]
+    needs: [docker_build]
     steps:
       - name: Get hashes
         uses: actions/download-artifact@v3


### PR DESCRIPTION
# Motivation

We want community members who vote on an nns-dapp upgrade proposal to be able to verify that the proposal contains the code from the repository.
So we want to run our build on different platforms and get the same result.

# Changes

At the end of the `Reproducible` workflow, take the hashes of the results and compare them.

# Tests

https://github.com/dfinity/nns-dapp/actions/runs/4051564732
https://github.com/dfinity/nns-dapp/actions/runs/4045667028