### PR TITLE
GIX-1187: New Api Service Layer for NNS Neurons

### DIFF
--- a/frontend/src/lib/api-services/nns-neurons.api-services.ts
+++ b/frontend/src/lib/api-services/nns-neurons.api-services.ts
@@ -1,0 +1,164 @@
+import { queryNeurons, spawnNeuron } from "$lib/api/governance.api";
+import { CACHE_EXPIRATION_SECONDS } from "$lib/constants/api-services.constants";
+import { nowInSeconds } from "$lib/utils/date.utils";
+import { nonNullish } from "$lib/utils/utils";
+import type { Identity } from "@dfinity/agent";
+import type { NeuronId, NeuronInfo } from "@dfinity/nns";
+import type { Principal } from "@dfinity/principal";
+
+type CallParams = {
+  identity: Identity;
+};
+
+type QueryParmas = {
+  certified: boolean;
+} & CallParams;
+
+/**
+ * Caches two types:
+ * - Neurons
+ * - List of neuron ids for a given principal. This is needed to know whether we have ALL neurons for a given principal.
+ */
+type NnsNeuronsCache = {
+  // Store all neurons.
+  neurons: {
+    [neuronId: string]: {
+      neuron: NeuronInfo;
+      timestampSeconds: number;
+      certified: boolean;
+    };
+  };
+  // List of neurons for a given principal.
+  list: {
+    [principal: string]: {
+      ids: NeuronId[];
+      timestampSeconds: number;
+      certified: boolean;
+    };
+  };
+};
+
+/**
+ * Cached data.
+ *
+ * Rules:
+ * - Certified data can be returned when asked for not certified data.
+ * - Non certified data is ignored when asked for certified data.
+ */
+class Cache {
+  private data: NnsNeuronsCache = {
+    neurons: {},
+    list: {},
+  };
+
+  constructor(private cacheExpirationSeconds: number) {}
+
+  getNeurons({
+    certified,
+    principal,
+  }: {
+    principal: Principal;
+    certified: boolean;
+  }): NeuronInfo[] | undefined {
+    const neuronIds = this.data.list[principal.toText()];
+    const nowSeconds = nowInSeconds();
+    if (
+      neuronIds?.ids !== undefined &&
+      (neuronIds.certified === certified || neuronIds.certified)
+    ) {
+      const neurons = neuronIds.ids
+        .map((neuronId) => this.data.neurons[String(neuronId)])
+        .filter(nonNullish)
+        .filter(({ certified: c }) => c === certified || c)
+        .filter(
+          ({ timestampSeconds }) =>
+            this.cacheExpirationSeconds > nowSeconds - timestampSeconds
+        )
+        .map(({ neuron }) => neuron);
+      if (neurons.length === neuronIds.ids.length) {
+        return neurons;
+      }
+    }
+  }
+
+  setNeurons({
+    neurons,
+    principal,
+    certified,
+  }: {
+    neurons: NeuronInfo[];
+    principal: Principal;
+    certified: boolean;
+  }) {
+    const timestampSeconds = nowInSeconds();
+    const neuronIds = neurons.map(({ neuronId }) => neuronId);
+    this.data.list[principal.toText()] = {
+      ids: neuronIds,
+      timestampSeconds,
+      certified,
+    };
+    neurons.forEach((neuron) => {
+      this.data.neurons[String(neuron.neuronId)] = {
+        neuron,
+        timestampSeconds,
+        certified,
+      };
+    });
+  }
+
+  reset() {
+    this.data = {
+      neurons: {},
+      list: {},
+    };
+  }
+}
+
+/**
+ * This is a service that interacts with api functions.
+ *
+ * It is a singleton that is shared across the app.
+ *
+ * Naming convention:
+ * - getXxx: returns a cached value if it exists, otherwise calls the api function
+ * - queryXxx: always calls the api function and updates the cache
+ * - <verb>Neuron: calls the api function and removes the cached related values
+ */
+export const NnsNeuronsApiService = {
+  cache: new Cache(CACHE_EXPIRATION_SECONDS),
+  async getNeurons({
+    identity,
+    certified,
+  }: QueryParmas): Promise<NeuronInfo[]> {
+    const principal = identity.getPrincipal();
+    const cachedNeurons = this.cache.getNeurons({
+      principal,
+      certified: certified,
+    });
+    if (cachedNeurons !== undefined) {
+      return cachedNeurons;
+    }
+    const neurons = await queryNeurons({ identity, certified });
+    this.cache.setNeurons({ neurons, principal, certified: certified });
+    return neurons;
+  },
+  async queryNeurons({
+    certified,
+    identity,
+  }: QueryParmas): Promise<NeuronInfo[]> {
+    const principal = identity.getPrincipal();
+    const neurons = await queryNeurons({ identity, certified });
+    this.cache.setNeurons({ neurons, principal, certified });
+    return neurons;
+  },
+  async spawnNeuron(
+    params: {
+      neuronId: NeuronId;
+      percentageToSpawn?: number;
+    } & CallParams
+  ): Promise<NeuronId> {
+    const newNeuronId = await spawnNeuron(params);
+    this.cache.reset();
+    return newNeuronId;
+  },
+};

--- a/frontend/src/lib/constants/api-services.constants.ts
+++ b/frontend/src/lib/constants/api-services.constants.ts
@@ -1,0 +1,3 @@
+import { SECONDS_IN_MINUTE } from "./constants";
+
+export const CACHE_EXPIRATION_SECONDS = SECONDS_IN_MINUTE * 5;

--- a/frontend/src/lib/derived/is-logged-in.derived.ts
+++ b/frontend/src/lib/derived/is-logged-in.derived.ts
@@ -1,0 +1,7 @@
+import { authStore } from "$lib/stores/auth.store";
+import { isSignedIn } from "$lib/utils/auth.utils";
+import { derived } from "svelte/store";
+
+export const isLoggedInStore = derived(authStore, ($store) =>
+  isSignedIn($store.identity)
+);

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -10,8 +10,13 @@
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
+  import { onMount } from "svelte";
+  import { listNeurons } from "$lib/services/neurons.services";
 
   // Neurons are fetch on page load. No need to do it in the route.
+  onMount(() => {
+    listNeurons({ useCache: true });
+  });
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -14,7 +14,8 @@
   import NnsProposal from "$lib/components/proposal-detail/NnsProposal.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
-  import { authStore } from "$lib/stores/auth.store";
+  import { listNeurons } from "$lib/services/neurons.services";
+  import { isLoggedInStore } from "$lib/derived/is-logged-in.derived";
 
   export let proposalIdText: string | undefined | null = undefined;
   export let referrerPath: AppPath | undefined = undefined;
@@ -83,7 +84,7 @@
     });
   };
 
-  $: $authStore.identity,
+  $: $isLoggedInStore,
     proposalId,
     (async () => {
       if (proposalId === undefined) {
@@ -98,6 +99,9 @@
       });
 
       await findProposal();
+      if ($isLoggedInStore) {
+        await listNeurons({ useCache: true });
+      }
     })();
 
   // END: loading and navigation

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -24,6 +24,9 @@
     filteredProposals,
   } from "$lib/derived/proposals.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import { isSignedIn } from "$lib/utils/auth.utils";
+  import { listNeurons } from "$lib/services/neurons.services";
+  import { isLoggedInStore } from "$lib/derived/is-logged-in.derived";
 
   export let referrerPath: AppPath | undefined = undefined;
   // It's exported so that we can test the value
@@ -124,6 +127,12 @@
   );
 
   $: $authStore.identity, (() => proposalsFiltersStore.reload())();
+  $: $isLoggedInStore,
+    (() => {
+      if ($isLoggedInStore) {
+        listNeurons({ useCache: true });
+      }
+    })();
 
   onDestroy(unsubscribe);
 

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,15 +1,10 @@
 import { loadMainTransactionFee } from "$lib/services/transaction-fees.services";
 import { syncAccounts } from "./accounts.services";
-import { listNeurons } from "./neurons.services";
 
 export const initAppPrivateData = (): Promise<
   [PromiseSettledResult<void[]>]
 > => {
-  const initNns: Promise<void>[] = [
-    syncAccounts(),
-    listNeurons(),
-    loadMainTransactionFee(),
-  ];
+  const initNns: Promise<void>[] = [syncAccounts(), loadMainTransactionFee()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.


### PR DESCRIPTION
# Motivation

We want to reuse certified data instead of doing many update calls to CI.

# Changes

* New entity: Api Service. For now only NnsNeuronsApiService.
* New folder for these entities api-services.
* New api service: NnsNeuronsApiService
* Use new api service in `listNeurons` from neuron services.
* Add temporary `useCache` flag to `listNeurons`. Default to `false`.
* Remove `listNeurons` from initial call in app.services. Instead, added call in Proposals and Neurons pages.

# Tests

PENDING to approve this new pattern.
