### PR TITLE
GIX-1187: Api Service Layer Setup

### DIFF
--- a/frontend/src/lib/api-services/neurons.api-service.ts
+++ b/frontend/src/lib/api-services/neurons.api-service.ts
@@ -20,10 +20,10 @@ import {
   startDissolving,
   stopDissolving,
   type ApiAutoStakeMaturityParams,
-  type ApiCallNeuronParams,
   type ApiDisburseParams,
-  type ApiHotkeyCallParams,
   type ApiIncreaseDissolveDelayParams,
+  type ApiManageHotkeyParams,
+  type ApiManageNeuronParams,
   type ApiMergeMaturityParams,
   type ApiMergeNeuronsParams,
   type ApiQueryNeuronParams,
@@ -37,24 +37,24 @@ import {
 
 export const neuronsApiService = {
   // Read calls
+  queryKnownNeurons(params: ApiQueryParams) {
+    return queryKnownNeurons(params);
+  },
   queryNeuron(params: ApiQueryNeuronParams) {
     return queryNeuron(params);
   },
   queryNeurons(params: ApiQueryParams) {
     return queryNeurons(params);
   },
-  queryKnownNeurons(params: ApiQueryParams) {
-    return queryKnownNeurons(params);
-  },
 
   // Action calls
-  addHotkey(params: ApiHotkeyCallParams) {
+  addHotkey(params: ApiManageHotkeyParams) {
     return addHotkey(params);
   },
   autoStakeMaturity(params: ApiAutoStakeMaturityParams) {
     return autoStakeMaturity(params);
   },
-  claimOrRefreshNeuron(params: ApiCallNeuronParams) {
+  claimOrRefreshNeuron(params: ApiManageNeuronParams) {
     return claimOrRefreshNeuron(params);
   },
   disburse(params: ApiDisburseParams) {
@@ -63,10 +63,10 @@ export const neuronsApiService = {
   increaseDissolveDelay(params: ApiIncreaseDissolveDelayParams) {
     return increaseDissolveDelay(params);
   },
-  joinCommunityFund(params: ApiCallNeuronParams) {
+  joinCommunityFund(params: ApiManageNeuronParams) {
     return joinCommunityFund(params);
   },
-  leaveCommunityFund(params: ApiCallNeuronParams) {
+  leaveCommunityFund(params: ApiManageNeuronParams) {
     return leaveCommunityFund(params);
   },
   // @deprecated
@@ -76,7 +76,7 @@ export const neuronsApiService = {
   mergeNeurons(params: ApiMergeNeuronsParams) {
     return mergeNeurons(params);
   },
-  removeHotkey(params: ApiHotkeyCallParams) {
+  removeHotkey(params: ApiManageHotkeyParams) {
     return removeHotkey(params);
   },
   setFollowees(params: ApiSetFolloweesParams) {
@@ -94,10 +94,10 @@ export const neuronsApiService = {
   stakeNeuron(params: ApiStakeNeuronParams) {
     return stakeNeuron(params);
   },
-  startDissolving(params: ApiCallNeuronParams) {
+  startDissolving(params: ApiManageNeuronParams) {
     return startDissolving(params);
   },
-  stopDissolving(params: ApiCallNeuronParams) {
+  stopDissolving(params: ApiManageNeuronParams) {
     return stopDissolving(params);
   },
 };

--- a/frontend/src/lib/api-services/neurons.api-service.ts
+++ b/frontend/src/lib/api-services/neurons.api-service.ts
@@ -1,0 +1,103 @@
+import {
+  addHotkey,
+  autoStakeMaturity,
+  claimOrRefreshNeuron,
+  disburse,
+  increaseDissolveDelay,
+  joinCommunityFund,
+  leaveCommunityFund,
+  mergeMaturity,
+  mergeNeurons,
+  queryKnownNeurons,
+  queryNeuron,
+  queryNeurons,
+  removeHotkey,
+  setFollowees,
+  spawnNeuron,
+  splitNeuron,
+  stakeMaturity,
+  stakeNeuron,
+  startDissolving,
+  stopDissolving,
+  type ApiAutoStakeMaturityParams,
+  type ApiCallNeuronParams,
+  type ApiDisburseParams,
+  type ApiHotkeyCallParams,
+  type ApiIncreaseDissolveDelayParams,
+  type ApiMergeMaturityParams,
+  type ApiMergeNeuronsParams,
+  type ApiQueryNeuronParams,
+  type ApiQueryParams,
+  type ApiSetFolloweesParams,
+  type ApiSpawnNeuronParams,
+  type ApiSplitNeuronParams,
+  type ApiStakeMaturityParams,
+  type ApiStakeNeuronParams,
+} from "$lib/api/governance.api";
+
+export const neuronsApiService = {
+  // Read calls
+  queryNeuron(params: ApiQueryNeuronParams) {
+    return queryNeuron(params);
+  },
+  queryNeurons(params: ApiQueryParams) {
+    return queryNeurons(params);
+  },
+  queryKnownNeurons(params: ApiQueryParams) {
+    return queryKnownNeurons(params);
+  },
+
+  // Action calls
+  addHotkey(params: ApiHotkeyCallParams) {
+    return addHotkey(params);
+  },
+  autoStakeMaturity(params: ApiAutoStakeMaturityParams) {
+    return autoStakeMaturity(params);
+  },
+  claimOrRefreshNeuron(params: ApiCallNeuronParams) {
+    return claimOrRefreshNeuron(params);
+  },
+  disburse(params: ApiDisburseParams) {
+    return disburse(params);
+  },
+  increaseDissolveDelay(params: ApiIncreaseDissolveDelayParams) {
+    return increaseDissolveDelay(params);
+  },
+  joinCommunityFund(params: ApiCallNeuronParams) {
+    return joinCommunityFund(params);
+  },
+  leaveCommunityFund(params: ApiCallNeuronParams) {
+    return leaveCommunityFund(params);
+  },
+  // @deprecated
+  mergeMaturity(params: ApiMergeMaturityParams) {
+    return mergeMaturity(params);
+  },
+  mergeNeurons(params: ApiMergeNeuronsParams) {
+    return mergeNeurons(params);
+  },
+  removeHotkey(params: ApiHotkeyCallParams) {
+    return removeHotkey(params);
+  },
+  setFollowees(params: ApiSetFolloweesParams) {
+    return setFollowees(params);
+  },
+  spawnNeuron(params: ApiSpawnNeuronParams) {
+    return spawnNeuron(params);
+  },
+  splitNeuron(params: ApiSplitNeuronParams) {
+    return splitNeuron(params);
+  },
+  stakeMaturity(params: ApiStakeMaturityParams) {
+    return stakeMaturity(params);
+  },
+  stakeNeuron(params: ApiStakeNeuronParams) {
+    return stakeNeuron(params);
+  },
+  startDissolving(params: ApiCallNeuronParams) {
+    return startDissolving(params);
+  },
+  stopDissolving(params: ApiCallNeuronParams) {
+    return stopDissolving(params);
+  },
+};

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -18,17 +18,28 @@ import { GovernanceCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { ledgerCanister as getLedgerCanister } from "./ledger.api";
 
+/**
+ * COMMON TYPES
+ */
+
+// Type for ANY call
 type ApiCallParams = {
   identity: Identity;
 };
 
+// Type for read-only calls.
 export type ApiQueryParams = ApiCallParams & {
   certified: boolean;
 };
 
-export type ApiCallNeuronParams = ApiCallParams & {
+// Shared type for calls to manage a neuron
+export type ApiManageNeuronParams = ApiCallParams & {
   neuronId: NeuronId;
 };
+
+/**
+ * API FUNCTIONS
+ */
 
 export type ApiQueryNeuronParams = ApiQueryParams & {
   neuronId: NeuronId;
@@ -54,7 +65,7 @@ export const queryNeuron = async ({
   return response;
 };
 
-export type ApiIncreaseDissolveDelayParams = ApiCallNeuronParams & {
+export type ApiIncreaseDissolveDelayParams = ApiManageNeuronParams & {
   dissolveDelayInSeconds: number;
 };
 
@@ -84,7 +95,7 @@ export const increaseDissolveDelay = async ({
 export const joinCommunityFund = async ({
   neuronId,
   identity,
-}: ApiCallNeuronParams): Promise<void> => {
+}: ApiManageNeuronParams): Promise<void> => {
   logWithTimestamp(`Joining Community Fund (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -95,7 +106,7 @@ export const joinCommunityFund = async ({
 export const leaveCommunityFund = async ({
   neuronId,
   identity,
-}: ApiCallNeuronParams): Promise<void> => {
+}: ApiManageNeuronParams): Promise<void> => {
   logWithTimestamp(`Leaving Community Fund (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -103,7 +114,7 @@ export const leaveCommunityFund = async ({
   logWithTimestamp(`Leaving Community Fund (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiAutoStakeMaturityParams = ApiCallNeuronParams & {
+export type ApiAutoStakeMaturityParams = ApiManageNeuronParams & {
   autoStake: boolean;
 };
 
@@ -134,7 +145,7 @@ export const autoStakeMaturity = async ({
   );
 };
 
-export type ApiDisburseParams = ApiCallNeuronParams & {
+export type ApiDisburseParams = ApiManageNeuronParams & {
   toAccountId?: string;
   amount?: E8s;
 };
@@ -152,7 +163,7 @@ export const disburse = async ({
   logWithTimestamp(`Disburse neuron (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiMergeMaturityParams = ApiCallNeuronParams & {
+export type ApiMergeMaturityParams = ApiManageNeuronParams & {
   percentageToMerge: number;
 };
 
@@ -168,7 +179,7 @@ export const mergeMaturity = async ({
   logWithTimestamp(`Merge maturity (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiStakeMaturityParams = ApiCallNeuronParams & {
+export type ApiStakeMaturityParams = ApiManageNeuronParams & {
   percentageToStake: number;
 };
 
@@ -188,7 +199,7 @@ export const stakeMaturity = async ({
   logWithTimestamp(`Stake maturity (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiSpawnNeuronParams = ApiCallNeuronParams & {
+export type ApiSpawnNeuronParams = ApiManageNeuronParams & {
   // percentageToSpawn is not yet supported by the ledger IC app
   percentageToSpawn?: number;
 };
@@ -209,7 +220,8 @@ export const spawnNeuron = async ({
   return newNeuronId;
 };
 
-export type ApiHotkeyCallParams = ApiCallNeuronParams & {
+// Shared by addHotkey and removeHotkey
+export type ApiManageHotkeyParams = ApiManageNeuronParams & {
   principal: Principal;
 };
 
@@ -217,7 +229,7 @@ export const addHotkey = async ({
   neuronId,
   principal,
   identity,
-}: ApiHotkeyCallParams): Promise<void> => {
+}: ApiManageHotkeyParams): Promise<void> => {
   logWithTimestamp(`Add hotkey (for neuron ${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -229,7 +241,7 @@ export const removeHotkey = async ({
   neuronId,
   principal,
   identity,
-}: ApiHotkeyCallParams): Promise<void> => {
+}: ApiManageHotkeyParams): Promise<void> => {
   logWithTimestamp(`Remove hotkey (for neuron ${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -239,7 +251,7 @@ export const removeHotkey = async ({
   );
 };
 
-export type ApiSplitNeuronParams = ApiCallNeuronParams & {
+export type ApiSplitNeuronParams = ApiManageNeuronParams & {
   amount: bigint;
 };
 
@@ -290,7 +302,7 @@ export const mergeNeurons = async ({
 export const startDissolving = async ({
   neuronId,
   identity,
-}: ApiCallNeuronParams): Promise<void> => {
+}: ApiManageNeuronParams): Promise<void> => {
   logWithTimestamp(`Starting Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -301,7 +313,7 @@ export const startDissolving = async ({
 export const stopDissolving = async ({
   neuronId,
   identity,
-}: ApiCallNeuronParams): Promise<void> => {
+}: ApiManageNeuronParams): Promise<void> => {
   logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -309,7 +321,7 @@ export const stopDissolving = async ({
   logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiSetFolloweesParams = ApiCallNeuronParams & {
+export type ApiSetFolloweesParams = ApiManageNeuronParams & {
   topic: Topic;
   followees: NeuronId[];
 };
@@ -406,7 +418,7 @@ export const queryKnownNeurons = async ({
 export const claimOrRefreshNeuron = async ({
   neuronId,
   identity,
-}: ApiCallNeuronParams): Promise<NeuronId | undefined> => {
+}: ApiManageNeuronParams): Promise<NeuronId | undefined> => {
   logWithTimestamp(
     `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) call...`
   );
@@ -421,6 +433,10 @@ export const claimOrRefreshNeuron = async ({
   );
   return response;
 };
+
+/**
+ * CANISTER SERVICE CREATION
+ */
 
 // TODO: Apply pattern to other canister instantiation L2-371
 export const governanceCanister = async ({

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -18,15 +18,27 @@ import { GovernanceCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { ledgerCanister as getLedgerCanister } from "./ledger.api";
 
+type ApiCallParams = {
+  identity: Identity;
+};
+
+export type ApiQueryParams = ApiCallParams & {
+  certified: boolean;
+};
+
+export type ApiCallNeuronParams = ApiCallParams & {
+  neuronId: NeuronId;
+};
+
+export type ApiQueryNeuronParams = ApiQueryParams & {
+  neuronId: NeuronId;
+};
+
 export const queryNeuron = async ({
   neuronId,
   identity,
   certified,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-  certified: boolean;
-}): Promise<NeuronInfo | undefined> => {
+}: ApiQueryNeuronParams): Promise<NeuronInfo | undefined> => {
   logWithTimestamp(
     `Querying Neuron(${hashCode(neuronId)}) certified:${certified} call...`
   );
@@ -42,15 +54,15 @@ export const queryNeuron = async ({
   return response;
 };
 
+export type ApiIncreaseDissolveDelayParams = ApiCallNeuronParams & {
+  dissolveDelayInSeconds: number;
+};
+
 export const increaseDissolveDelay = async ({
   neuronId,
   dissolveDelayInSeconds,
   identity,
-}: {
-  neuronId: NeuronId;
-  dissolveDelayInSeconds: number;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiIncreaseDissolveDelayParams): Promise<void> => {
   logWithTimestamp(
     `Increasing Dissolve Delay(${hashCode(neuronId)}, ${hashCode(
       dissolveDelayInSeconds
@@ -72,10 +84,7 @@ export const increaseDissolveDelay = async ({
 export const joinCommunityFund = async ({
   neuronId,
   identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiCallNeuronParams): Promise<void> => {
   logWithTimestamp(`Joining Community Fund (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -86,10 +95,7 @@ export const joinCommunityFund = async ({
 export const leaveCommunityFund = async ({
   neuronId,
   identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiCallNeuronParams): Promise<void> => {
   logWithTimestamp(`Leaving Community Fund (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -97,15 +103,15 @@ export const leaveCommunityFund = async ({
   logWithTimestamp(`Leaving Community Fund (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiAutoStakeMaturityParams = ApiCallNeuronParams & {
+  autoStake: boolean;
+};
+
 export const autoStakeMaturity = async ({
   neuronId,
   autoStake,
   identity,
-}: {
-  neuronId: NeuronId;
-  autoStake: boolean;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiAutoStakeMaturityParams): Promise<void> => {
   logWithTimestamp(
     `${autoStake ? "Enable" : "Disable"} auto stake maturity (${hashCode(
       neuronId
@@ -128,17 +134,17 @@ export const autoStakeMaturity = async ({
   );
 };
 
+export type ApiDisburseParams = ApiCallNeuronParams & {
+  toAccountId?: string;
+  amount?: E8s;
+};
+
 export const disburse = async ({
   neuronId,
   toAccountId,
   amount,
   identity,
-}: {
-  neuronId: NeuronId;
-  toAccountId?: string;
-  amount?: E8s;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiDisburseParams): Promise<void> => {
   logWithTimestamp(`Disburse neuron (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -146,15 +152,15 @@ export const disburse = async ({
   logWithTimestamp(`Disburse neuron (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiMergeMaturityParams = ApiCallNeuronParams & {
+  percentageToMerge: number;
+};
+
 export const mergeMaturity = async ({
   neuronId,
   percentageToMerge,
   identity,
-}: {
-  neuronId: NeuronId;
-  percentageToMerge: number;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiMergeMaturityParams): Promise<void> => {
   logWithTimestamp(`Merge maturity (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -162,15 +168,15 @@ export const mergeMaturity = async ({
   logWithTimestamp(`Merge maturity (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiStakeMaturityParams = ApiCallNeuronParams & {
+  percentageToStake: number;
+};
+
 export const stakeMaturity = async ({
   neuronId,
   percentageToStake,
   identity,
-}: {
-  neuronId: NeuronId;
-  percentageToStake: number;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiStakeMaturityParams): Promise<void> => {
   logWithTimestamp(`Stake maturity (${hashCode(neuronId)}) call...`);
 
   const {
@@ -182,16 +188,16 @@ export const stakeMaturity = async ({
   logWithTimestamp(`Stake maturity (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiSpawnNeuronParams = ApiCallNeuronParams & {
+  // percentageToSpawn is not yet supported by the ledger IC app
+  percentageToSpawn?: number;
+};
+
 export const spawnNeuron = async ({
   neuronId,
   percentageToSpawn,
   identity,
-}: {
-  neuronId: NeuronId;
-  // percentageToSpawn is not yet supported by the ledger IC app
-  percentageToSpawn?: number;
-  identity: Identity;
-}): Promise<NeuronId> => {
+}: ApiSpawnNeuronParams): Promise<NeuronId> => {
   logWithTimestamp(`Spawn neuron (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -203,15 +209,15 @@ export const spawnNeuron = async ({
   return newNeuronId;
 };
 
+export type ApiHotkeyCallParams = ApiCallNeuronParams & {
+  principal: Principal;
+};
+
 export const addHotkey = async ({
   neuronId,
   principal,
   identity,
-}: {
-  neuronId: NeuronId;
-  principal: Principal;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiHotkeyCallParams): Promise<void> => {
   logWithTimestamp(`Add hotkey (for neuron ${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -223,11 +229,7 @@ export const removeHotkey = async ({
   neuronId,
   principal,
   identity,
-}: {
-  neuronId: NeuronId;
-  principal: Principal;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiHotkeyCallParams): Promise<void> => {
   logWithTimestamp(`Remove hotkey (for neuron ${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -237,15 +239,15 @@ export const removeHotkey = async ({
   );
 };
 
+export type ApiSplitNeuronParams = ApiCallNeuronParams & {
+  amount: bigint;
+};
+
 export const splitNeuron = async ({
   neuronId,
   amount,
   identity,
-}: {
-  neuronId: NeuronId;
-  amount: bigint;
-  identity: Identity;
-}): Promise<NeuronId> => {
+}: ApiSplitNeuronParams): Promise<NeuronId> => {
   logWithTimestamp(`Splitting Neuron (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -257,15 +259,16 @@ export const splitNeuron = async ({
   return response;
 };
 
+export type ApiMergeNeuronsParams = ApiCallParams & {
+  sourceNeuronId: NeuronId;
+  targetNeuronId: NeuronId;
+};
+
 export const mergeNeurons = async ({
   sourceNeuronId,
   targetNeuronId,
   identity,
-}: {
-  sourceNeuronId: NeuronId;
-  targetNeuronId: NeuronId;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiMergeNeuronsParams): Promise<void> => {
   logWithTimestamp(
     `Merging neurons (${hashCode(sourceNeuronId)}, ${hashCode(
       targetNeuronId
@@ -287,10 +290,7 @@ export const mergeNeurons = async ({
 export const startDissolving = async ({
   neuronId,
   identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiCallNeuronParams): Promise<void> => {
   logWithTimestamp(`Starting Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -301,10 +301,7 @@ export const startDissolving = async ({
 export const stopDissolving = async ({
   neuronId,
   identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}): Promise<void> => {
+}: ApiCallNeuronParams): Promise<void> => {
   logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -312,17 +309,17 @@ export const stopDissolving = async ({
   logWithTimestamp(`Stopping Dissolving (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiSetFolloweesParams = ApiCallNeuronParams & {
+  topic: Topic;
+  followees: NeuronId[];
+};
+
 export const setFollowees = async ({
   identity,
   neuronId,
   topic,
   followees,
-}: {
-  identity: Identity;
-  neuronId: NeuronId;
-  topic: Topic;
-  followees: NeuronId[];
-}): Promise<void> => {
+}: ApiSetFolloweesParams): Promise<void> => {
   logWithTimestamp(`Setting Followees (${hashCode(neuronId)}) call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -337,10 +334,7 @@ export const setFollowees = async ({
 export const queryNeurons = async ({
   identity,
   certified,
-}: {
-  identity: Identity;
-  certified: boolean;
-}): Promise<NeuronInfo[]> => {
+}: ApiQueryParams): Promise<NeuronInfo[]> => {
   logWithTimestamp(`Querying Neurons certified:${certified} call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -349,6 +343,13 @@ export const queryNeurons = async ({
   });
   logWithTimestamp(`Querying Neurons certified:${certified} complete.`);
   return response;
+};
+
+export type ApiStakeNeuronParams = ApiCallParams & {
+  stake: bigint;
+  controller: Principal;
+  ledgerCanisterIdentity: Identity;
+  fromSubAccount?: SubAccountArray;
 };
 
 /**
@@ -360,13 +361,7 @@ export const stakeNeuron = async ({
   ledgerCanisterIdentity,
   identity,
   fromSubAccount,
-}: {
-  stake: bigint;
-  controller: Principal;
-  ledgerCanisterIdentity: Identity;
-  identity: Identity;
-  fromSubAccount?: SubAccountArray;
-}): Promise<NeuronId> => {
+}: ApiStakeNeuronParams): Promise<NeuronId> => {
   logWithTimestamp(`Staking Neuron call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -390,10 +385,7 @@ export const stakeNeuron = async ({
 export const queryKnownNeurons = async ({
   identity,
   certified,
-}: {
-  identity: Identity;
-  certified: boolean;
-}): Promise<KnownNeuron[]> => {
+}: ApiQueryParams): Promise<KnownNeuron[]> => {
   logWithTimestamp(`Querying Known Neurons certified:${certified} call...`);
   const { canister } = await governanceCanister({ identity });
 
@@ -414,10 +406,7 @@ export const queryKnownNeurons = async ({
 export const claimOrRefreshNeuron = async ({
   neuronId,
   identity,
-}: {
-  neuronId: NeuronId;
-  identity: Identity;
-}): Promise<NeuronId | undefined> => {
+}: ApiCallNeuronParams): Promise<NeuronId | undefined> => {
   logWithTimestamp(
     `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) call...`
   );

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1,25 +1,5 @@
+import { neuronsApiService } from "$lib/api-services/neurons.api-service";
 import { makeDummyProposals as makeDummyProposalsApi } from "$lib/api/dev.api";
-import {
-  addHotkey as addHotkeyApi,
-  autoStakeMaturity,
-  claimOrRefreshNeuron,
-  disburse as disburseApi,
-  increaseDissolveDelay,
-  joinCommunityFund,
-  leaveCommunityFund,
-  mergeMaturity as mergeMaturityApi,
-  mergeNeurons as mergeNeuronsApi,
-  queryNeuron,
-  queryNeurons,
-  removeHotkey as removeHotkeyApi,
-  setFollowees,
-  spawnNeuron as spawnNeuronApi,
-  splitNeuron as splitNeuronApi,
-  stakeMaturity as stakeMaturityApi,
-  stakeNeuron as stakeNeuronApi,
-  startDissolving as startDissolvingApi,
-  stopDissolving as stopDissolvingApi,
-} from "$lib/api/governance.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import {
@@ -112,11 +92,13 @@ const getNeuron = async ({
   forceFetch?: boolean;
 }): Promise<NeuronInfo | undefined> => {
   if (forceFetch) {
-    return queryNeuron({ neuronId, identity, certified });
+    return neuronsApiService.queryNeuron({ neuronId, identity, certified });
   }
   const neuron = getNeuronFromStore(neuronId);
 
-  return neuron || queryNeuron({ neuronId, identity, certified });
+  return (
+    neuron || neuronsApiService.queryNeuron({ neuronId, identity, certified })
+  );
 };
 
 export const getNeuronFromStore = (
@@ -228,7 +210,7 @@ export const stakeNeuron = async ({
     }
     const { ledgerCanisterIdentity, controller, fromSubAccount, identity } =
       getStakeNeuronPropsByAccount({ account, accountIdentity });
-    const newNeuronId = await stakeNeuronApi({
+    const newNeuronId = await neuronsApiService.stakeNeuron({
       stake,
       identity,
       ledgerCanisterIdentity,
@@ -263,7 +245,8 @@ export const listNeurons = async ({
 } = {}): Promise<void> => {
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy,
-    request: ({ certified, identity }) => queryNeurons({ certified, identity }),
+    request: ({ certified, identity }) =>
+      neuronsApiService.queryNeurons({ certified, identity }),
     onLoad: async ({ response: neurons, certified }) => {
       neuronsStore.setNeurons({ neurons, certified });
 
@@ -316,7 +299,7 @@ export const updateDelay = async ({
     const neuronIdentity: Identity = await getIdentityOfControllerByNeuronId(
       neuronId
     );
-    await increaseDissolveDelay({
+    await neuronsApiService.increaseDissolveDelay({
       neuronId,
       dissolveDelayInSeconds,
       identity: neuronIdentity,
@@ -341,12 +324,15 @@ export const toggleCommunityFund = async (
     );
 
     if (hasJoinedCommunityFund(neuron)) {
-      await leaveCommunityFund({
+      await neuronsApiService.leaveCommunityFund({
         neuronId: neuron.neuronId,
         identity,
       });
     } else {
-      await joinCommunityFund({ neuronId: neuron.neuronId, identity });
+      await neuronsApiService.joinCommunityFund({
+        neuronId: neuron.neuronId,
+        identity,
+      });
     }
 
     await getAndLoadNeuron(neuron.neuronId);
@@ -375,7 +361,7 @@ export const toggleAutoStakeMaturity = async (
       minVersion: CANDID_PARSER_VERSION,
     });
 
-    await autoStakeMaturity({
+    await neuronsApiService.autoStakeMaturity({
       neuronId,
       identity,
       autoStake: !hasAutoStakeMaturityOn(neuron),
@@ -425,7 +411,11 @@ export const mergeNeurons = async ({
       });
     }
 
-    await mergeNeuronsApi({ sourceNeuronId, targetNeuronId, identity });
+    await neuronsApiService.mergeNeurons({
+      sourceNeuronId,
+      targetNeuronId,
+      identity,
+    });
     success = true;
 
     await listNeurons();
@@ -459,7 +449,7 @@ export const addHotkeyForHardwareWalletNeuron = async ({
     const identity: Identity = await getAuthenticatedIdentity();
     const ledgerIdentity = await getLedgerIdentityProxy(accountIdentifier);
 
-    await addHotkeyApi({
+    await neuronsApiService.addHotkey({
       neuronId,
       identity: ledgerIdentity,
       principal: identity.getPrincipal(),
@@ -500,7 +490,7 @@ export const addHotkey = async ({
       neuronId
     );
 
-    await addHotkeyApi({ neuronId, identity, principal });
+    await neuronsApiService.addHotkey({ neuronId, identity, principal });
 
     await getAndLoadNeuron(neuronId);
 
@@ -535,7 +525,7 @@ export const removeHotkey = async ({
       neuronId
     );
 
-    await removeHotkeyApi({ neuronId, identity, principal });
+    await neuronsApiService.removeHotkey({ neuronId, identity, principal });
     removed = true;
 
     await getAndLoadNeuron(neuronId);
@@ -580,7 +570,11 @@ export const splitNeuron = async ({
       throw new NotEnoughAmountError();
     }
 
-    await splitNeuronApi({ neuronId, identity, amount: amountE8s });
+    await neuronsApiService.splitNeuron({
+      neuronId,
+      identity,
+      amount: amountE8s,
+    });
 
     await listNeurons();
 
@@ -603,7 +597,7 @@ export const disburse = async ({
       neuronId
     );
 
-    await disburseApi({ neuronId, toAccountId, identity });
+    await neuronsApiService.disburse({ neuronId, toAccountId, identity });
 
     await Promise.all([syncAccounts(), listNeurons()]);
 
@@ -633,7 +627,11 @@ export const mergeMaturity = async ({
       minVersion: MIN_VERSION_STAKE_MATURITY_WORKAROUND,
     });
 
-    await mergeMaturityApi({ neuronId, percentageToMerge, identity });
+    await neuronsApiService.mergeMaturity({
+      neuronId,
+      percentageToMerge,
+      identity,
+    });
 
     await getAndLoadNeuron(neuronId);
 
@@ -662,7 +660,11 @@ export const stakeMaturity = async ({
       minVersion: CANDID_PARSER_VERSION,
     });
 
-    await stakeMaturityApi({ neuronId, percentageToStake, identity });
+    await neuronsApiService.stakeMaturity({
+      neuronId,
+      percentageToStake,
+      identity,
+    });
 
     await getAndLoadNeuron(neuronId);
 
@@ -686,7 +688,7 @@ export const spawnNeuron = async ({
       neuronId
     );
 
-    const newNeuronId = await spawnNeuronApi({
+    const newNeuronId = await neuronsApiService.spawnNeuron({
       neuronId,
       percentageToSpawn,
       identity,
@@ -710,7 +712,7 @@ export const startDissolving = async (
       neuronId
     );
 
-    await startDissolvingApi({ neuronId, identity });
+    await neuronsApiService.startDissolving({ neuronId, identity });
 
     await getAndLoadNeuron(neuronId);
 
@@ -730,7 +732,7 @@ export const stopDissolving = async (
       neuronId
     );
 
-    await stopDissolvingApi({ neuronId, identity });
+    await neuronsApiService.stopDissolving({ neuronId, identity });
 
     await getAndLoadNeuron(neuronId);
 
@@ -766,7 +768,7 @@ const setFolloweesHelper = async ({
     if (topic === Topic.ManageNeuron) {
       identity = await getIdentityOfControllerByNeuronId(neuron.neuronId);
     }
-    await setFollowees({
+    await neuronsApiService.setFollowees({
       identity,
       neuronId: neuron.neuronId,
       topic,
@@ -912,7 +914,9 @@ export const reloadNeuron = (neuronId: NeuronId) =>
   new Promise<void>((resolve) => {
     getAuthenticatedIdentity()
       // To update the neuron stake with the subaccount balance
-      .then((identity) => claimOrRefreshNeuron({ identity, neuronId }))
+      .then((identity) =>
+        neuronsApiService.claimOrRefreshNeuron({ identity, neuronId })
+      )
       .then(() => {
         loadNeuron({
           neuronId,

--- a/frontend/src/tests/lib/api-services/neurons.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/neurons.api-service.spec.ts
@@ -1,0 +1,262 @@
+import { neuronsApiService } from "$lib/api-services/neurons.api-service";
+import {
+  addHotkey,
+  autoStakeMaturity,
+  claimOrRefreshNeuron,
+  increaseDissolveDelay,
+  joinCommunityFund,
+  leaveCommunityFund,
+  mergeMaturity,
+  mergeNeurons,
+  queryKnownNeurons,
+  queryNeuron,
+  queryNeurons,
+  removeHotkey,
+  setFollowees,
+  spawnNeuron,
+  splitNeuron,
+  stakeMaturity,
+  stakeNeuron,
+  startDissolving,
+  stopDissolving,
+} from "$lib/api/governance.api";
+import { Topic } from "@dfinity/nns";
+import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
+
+jest.mock("$lib/api/governance.api", () => {
+  return {
+    addHotkey: jest.fn(),
+    autoStakeMaturity: jest.fn(),
+    claimOrRefreshNeuron: jest.fn(),
+    disburse: jest.fn(),
+    increaseDissolveDelay: jest.fn(),
+    joinCommunityFund: jest.fn(),
+    leaveCommunityFund: jest.fn(),
+    mergeMaturity: jest.fn(),
+    mergeNeurons: jest.fn(),
+    queryKnownNeurons: jest.fn(),
+    queryNeuron: jest.fn(),
+    queryNeurons: jest.fn(),
+    removeHotkey: jest.fn(),
+    setFollowees: jest.fn(),
+    spawnNeuron: jest.fn(),
+    splitNeuron: jest.fn(),
+    stakeMaturity: jest.fn(),
+    stakeNeuron: jest.fn(),
+    startDissolving: jest.fn(),
+    stopDissolving: jest.fn(),
+  };
+});
+
+describe("neurons api-service", () => {
+  const neuronId = BigInt(12);
+
+  // Read calls
+  describe("queryNeuron", () => {
+    it("should call queryNeuron api", () => {
+      const params = { neuronId, identity: mockIdentity, certified: true };
+      neuronsApiService.queryNeuron(params);
+      expect(queryNeuron).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("queryNeurons", () => {
+    it("should call queryNeurons api", () => {
+      const params = { identity: mockIdentity, certified: true };
+      neuronsApiService.queryNeurons(params);
+      expect(queryNeurons).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("queryKnownNeurons", () => {
+    it("should call queryKnownNeurons api", () => {
+      const params = { identity: mockIdentity, certified: true };
+      neuronsApiService.queryKnownNeurons(params);
+      expect(queryKnownNeurons).toHaveBeenCalledWith(params);
+    });
+  });
+
+  // Action calls
+  describe("addHotkey", () => {
+    it("should call addHotkey api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        principal: mockPrincipal,
+      };
+      neuronsApiService.addHotkey(params);
+      expect(addHotkey).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("autoStakeMaturity", () => {
+    it("should call autoStakeMaturity api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        autoStake: true,
+      };
+      neuronsApiService.autoStakeMaturity(params);
+      expect(autoStakeMaturity).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("claimOrRefreshNeuron", () => {
+    it("should call claimOrRefreshNeuron api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.claimOrRefreshNeuron(params);
+      expect(claimOrRefreshNeuron).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("disburse", () => {
+    it("should call disburse api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        autoStake: true,
+      };
+      neuronsApiService.autoStakeMaturity(params);
+      expect(autoStakeMaturity).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("increaseDissolveDelay", () => {
+    it("should call increaseDissolveDelay api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        dissolveDelayInSeconds: 2,
+      };
+      neuronsApiService.increaseDissolveDelay(params);
+      expect(increaseDissolveDelay).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("joinCommunityFund", () => {
+    it("should call joinCommunityFund api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.joinCommunityFund(params);
+      expect(joinCommunityFund).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("leaveCommunityFund", () => {
+    it("should call leaveCommunityFund api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.leaveCommunityFund(params);
+      expect(leaveCommunityFund).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("mergeMaturity", () => {
+    it("should call mergeMaturity api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        percentageToMerge: 0.2,
+      };
+      neuronsApiService.mergeMaturity(params);
+      expect(mergeMaturity).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("mergeNeurons", () => {
+    it("should call mergeNeurons api", () => {
+      const params = {
+        identity: mockIdentity,
+        sourceNeuronId: BigInt(2),
+        targetNeuronId: BigInt(20),
+      };
+      neuronsApiService.mergeNeurons(params);
+      expect(mergeNeurons).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("removeHotkey", () => {
+    it("should call removeHotkey api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        principal: mockPrincipal,
+      };
+      neuronsApiService.removeHotkey(params);
+      expect(removeHotkey).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("setFollowees", () => {
+    it("should call setFollowees api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        topic: Topic.ExchangeRate,
+        followees: [BigInt(2), BigInt(20)],
+      };
+      neuronsApiService.setFollowees(params);
+      expect(setFollowees).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("spawnNeuron", () => {
+    it("should call spawnNeuron api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.spawnNeuron(params);
+      expect(spawnNeuron).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("splitNeuron", () => {
+    it("should call splitNeuron api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        amount: BigInt(10_000_000),
+      };
+      neuronsApiService.splitNeuron(params);
+      expect(splitNeuron).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("stakeMaturity", () => {
+    it("should call stakeMaturity api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+        percentageToStake: 0.2,
+      };
+      neuronsApiService.stakeMaturity(params);
+      expect(stakeMaturity).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("stakeNeuron", () => {
+    it("should call stakeNeuron api", () => {
+      const params = {
+        identity: mockIdentity,
+        stake: BigInt(10_000_000),
+        controller: mockPrincipal,
+        ledgerCanisterIdentity: mockIdentity,
+        fromSubaccount: new Uint8Array(),
+      };
+      neuronsApiService.stakeNeuron(params);
+      expect(stakeNeuron).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("startDissolving", () => {
+    it("should call startDissolving api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.startDissolving(params);
+      expect(startDissolving).toHaveBeenCalledWith(params);
+    });
+  });
+  describe("stopDissolving", () => {
+    it("should call stopDissolving api", () => {
+      const params = {
+        neuronId,
+        identity: mockIdentity,
+      };
+      neuronsApiService.stopDissolving(params);
+      expect(stopDissolving).toHaveBeenCalledWith(params);
+    });
+  });
+});

--- a/frontend/src/tests/lib/api-services/neurons.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/neurons.api-service.spec.ts
@@ -3,6 +3,7 @@ import {
   addHotkey,
   autoStakeMaturity,
   claimOrRefreshNeuron,
+  disburse,
   increaseDissolveDelay,
   joinCommunityFund,
   leaveCommunityFund,
@@ -21,6 +22,7 @@ import {
   stopDissolving,
 } from "$lib/api/governance.api";
 import { Topic } from "@dfinity/nns";
+import { mockMainAccount } from "../../mocks/accounts.store.mock";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 
 jest.mock("$lib/api/governance.api", () => {
@@ -57,6 +59,7 @@ describe("neurons api-service", () => {
       const params = { neuronId, identity: mockIdentity, certified: true };
       neuronsApiService.queryNeuron(params);
       expect(queryNeuron).toHaveBeenCalledWith(params);
+      expect(queryNeuron).toHaveBeenCalledTimes(1);
     });
   });
   describe("queryNeurons", () => {
@@ -64,6 +67,7 @@ describe("neurons api-service", () => {
       const params = { identity: mockIdentity, certified: true };
       neuronsApiService.queryNeurons(params);
       expect(queryNeurons).toHaveBeenCalledWith(params);
+      expect(queryNeurons).toHaveBeenCalledTimes(1);
     });
   });
   describe("queryKnownNeurons", () => {
@@ -71,6 +75,7 @@ describe("neurons api-service", () => {
       const params = { identity: mockIdentity, certified: true };
       neuronsApiService.queryKnownNeurons(params);
       expect(queryKnownNeurons).toHaveBeenCalledWith(params);
+      expect(queryKnownNeurons).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -84,6 +89,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.addHotkey(params);
       expect(addHotkey).toHaveBeenCalledWith(params);
+      expect(addHotkey).toHaveBeenCalledTimes(1);
     });
   });
   describe("autoStakeMaturity", () => {
@@ -95,6 +101,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.autoStakeMaturity(params);
       expect(autoStakeMaturity).toHaveBeenCalledWith(params);
+      expect(autoStakeMaturity).toHaveBeenCalledTimes(1);
     });
   });
   describe("claimOrRefreshNeuron", () => {
@@ -105,6 +112,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.claimOrRefreshNeuron(params);
       expect(claimOrRefreshNeuron).toHaveBeenCalledWith(params);
+      expect(claimOrRefreshNeuron).toHaveBeenCalledTimes(1);
     });
   });
   describe("disburse", () => {
@@ -112,10 +120,12 @@ describe("neurons api-service", () => {
       const params = {
         neuronId,
         identity: mockIdentity,
-        autoStake: true,
+        toAccount: mockMainAccount.identifier,
+        amount: BigInt(10_000_000),
       };
-      neuronsApiService.autoStakeMaturity(params);
-      expect(autoStakeMaturity).toHaveBeenCalledWith(params);
+      neuronsApiService.disburse(params);
+      expect(disburse).toHaveBeenCalledWith(params);
+      expect(disburse).toHaveBeenCalledTimes(1);
     });
   });
   describe("increaseDissolveDelay", () => {
@@ -127,6 +137,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.increaseDissolveDelay(params);
       expect(increaseDissolveDelay).toHaveBeenCalledWith(params);
+      expect(increaseDissolveDelay).toHaveBeenCalledTimes(1);
     });
   });
   describe("joinCommunityFund", () => {
@@ -137,6 +148,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.joinCommunityFund(params);
       expect(joinCommunityFund).toHaveBeenCalledWith(params);
+      expect(joinCommunityFund).toHaveBeenCalledTimes(1);
     });
   });
   describe("leaveCommunityFund", () => {
@@ -147,6 +159,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.leaveCommunityFund(params);
       expect(leaveCommunityFund).toHaveBeenCalledWith(params);
+      expect(leaveCommunityFund).toHaveBeenCalledTimes(1);
     });
   });
   describe("mergeMaturity", () => {
@@ -158,6 +171,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.mergeMaturity(params);
       expect(mergeMaturity).toHaveBeenCalledWith(params);
+      expect(mergeMaturity).toHaveBeenCalledTimes(1);
     });
   });
   describe("mergeNeurons", () => {
@@ -169,6 +183,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.mergeNeurons(params);
       expect(mergeNeurons).toHaveBeenCalledWith(params);
+      expect(mergeNeurons).toHaveBeenCalledTimes(1);
     });
   });
   describe("removeHotkey", () => {
@@ -180,6 +195,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.removeHotkey(params);
       expect(removeHotkey).toHaveBeenCalledWith(params);
+      expect(removeHotkey).toHaveBeenCalledTimes(1);
     });
   });
   describe("setFollowees", () => {
@@ -192,6 +208,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.setFollowees(params);
       expect(setFollowees).toHaveBeenCalledWith(params);
+      expect(setFollowees).toHaveBeenCalledTimes(1);
     });
   });
   describe("spawnNeuron", () => {
@@ -202,6 +219,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.spawnNeuron(params);
       expect(spawnNeuron).toHaveBeenCalledWith(params);
+      expect(spawnNeuron).toHaveBeenCalledTimes(1);
     });
   });
   describe("splitNeuron", () => {
@@ -213,6 +231,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.splitNeuron(params);
       expect(splitNeuron).toHaveBeenCalledWith(params);
+      expect(splitNeuron).toHaveBeenCalledTimes(1);
     });
   });
   describe("stakeMaturity", () => {
@@ -224,6 +243,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.stakeMaturity(params);
       expect(stakeMaturity).toHaveBeenCalledWith(params);
+      expect(stakeMaturity).toHaveBeenCalledTimes(1);
     });
   });
   describe("stakeNeuron", () => {
@@ -237,6 +257,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.stakeNeuron(params);
       expect(stakeNeuron).toHaveBeenCalledWith(params);
+      expect(stakeNeuron).toHaveBeenCalledTimes(1);
     });
   });
   describe("startDissolving", () => {
@@ -247,6 +268,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.startDissolving(params);
       expect(startDissolving).toHaveBeenCalledWith(params);
+      expect(startDissolving).toHaveBeenCalledTimes(1);
     });
   });
   describe("stopDissolving", () => {
@@ -257,6 +279,7 @@ describe("neurons api-service", () => {
       };
       neuronsApiService.stopDissolving(params);
       expect(stopDissolving).toHaveBeenCalledWith(params);
+      expect(stopDissolving).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,4 +1,4 @@
-import * as api from "$lib/api/governance.api";
+import { neuronsApiService } from "$lib/api-services/neurons.api-service";
 import {
   DEFAULT_TRANSACTION_FEE_E8S,
   E8S_PER_ICP,
@@ -128,81 +128,81 @@ describe("neurons-services", () => {
   const newSpawnedNeuronId = BigInt(1234);
 
   const spyStakeNeuron = jest
-    .spyOn(api, "stakeNeuron")
+    .spyOn(neuronsApiService, "stakeNeuron")
     .mockImplementation(() => Promise.resolve(mockNeuron.neuronId));
 
   const spyGetNeuron = jest
-    .spyOn(api, "queryNeuron")
+    .spyOn(neuronsApiService, "queryNeuron")
     .mockImplementation(() => Promise.resolve(mockNeuron));
 
   const neurons = [sameControlledNeuron, controlledNeuron];
 
   const spyQueryNeurons = jest
-    .spyOn(api, "queryNeurons")
+    .spyOn(neuronsApiService, "queryNeurons")
     .mockImplementation(() => Promise.resolve(neurons));
 
   const spyIncreaseDissolveDelay = jest
-    .spyOn(api, "increaseDissolveDelay")
+    .spyOn(neuronsApiService, "increaseDissolveDelay")
     .mockImplementation(() => Promise.resolve());
 
   const spyJoinCommunityFund = jest
-    .spyOn(api, "joinCommunityFund")
+    .spyOn(neuronsApiService, "joinCommunityFund")
     .mockImplementation(() => Promise.resolve());
 
   const spyAutoStakeMaturity = jest
-    .spyOn(api, "autoStakeMaturity")
+    .spyOn(neuronsApiService, "autoStakeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spyLeaveCommunityFund = jest
-    .spyOn(api, "leaveCommunityFund")
+    .spyOn(neuronsApiService, "leaveCommunityFund")
     .mockImplementation(() => Promise.resolve());
 
   const spyDisburse = jest
-    .spyOn(api, "disburse")
+    .spyOn(neuronsApiService, "disburse")
     .mockImplementation(() => Promise.resolve());
 
   const spyMergeMaturity = jest
-    .spyOn(api, "mergeMaturity")
+    .spyOn(neuronsApiService, "mergeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spyStakeMaturity = jest
-    .spyOn(api, "stakeMaturity")
+    .spyOn(neuronsApiService, "stakeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spySpawnNeuron = jest
-    .spyOn(api, "spawnNeuron")
+    .spyOn(neuronsApiService, "spawnNeuron")
     .mockImplementation(() => Promise.resolve(newSpawnedNeuronId));
 
   const spyMergeNeurons = jest
-    .spyOn(api, "mergeNeurons")
+    .spyOn(neuronsApiService, "mergeNeurons")
     .mockImplementation(() => Promise.resolve());
 
   const spyAddHotkey = jest
-    .spyOn(api, "addHotkey")
+    .spyOn(neuronsApiService, "addHotkey")
     .mockImplementation(() => Promise.resolve());
 
   const spyRemoveHotkey = jest
-    .spyOn(api, "removeHotkey")
+    .spyOn(neuronsApiService, "removeHotkey")
     .mockImplementation(() => Promise.resolve());
 
   const spySplitNeuron = jest
-    .spyOn(api, "splitNeuron")
+    .spyOn(neuronsApiService, "splitNeuron")
     .mockImplementation(() => Promise.resolve(BigInt(11)));
 
   const spyStartDissolving = jest
-    .spyOn(api, "startDissolving")
+    .spyOn(neuronsApiService, "startDissolving")
     .mockImplementation(() => Promise.resolve());
 
   const spyStopDissolving = jest
-    .spyOn(api, "stopDissolving")
+    .spyOn(neuronsApiService, "stopDissolving")
     .mockImplementation(() => Promise.resolve());
 
   const spySetFollowees = jest
-    .spyOn(api, "setFollowees")
+    .spyOn(neuronsApiService, "setFollowees")
     .mockImplementation(() => Promise.resolve());
 
   const spyClaimOrRefresh = jest
-    .spyOn(api, "claimOrRefreshNeuron")
+    .spyOn(neuronsApiService, "claimOrRefreshNeuron")
     .mockImplementation(() => Promise.resolve(undefined));
 
   afterEach(() => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,4 +1,4 @@
-import { neuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as api from "$lib/api/governance.api";
 import {
   DEFAULT_TRANSACTION_FEE_E8S,
   E8S_PER_ICP,
@@ -128,81 +128,81 @@ describe("neurons-services", () => {
   const newSpawnedNeuronId = BigInt(1234);
 
   const spyStakeNeuron = jest
-    .spyOn(neuronsApiService, "stakeNeuron")
+    .spyOn(api, "stakeNeuron")
     .mockImplementation(() => Promise.resolve(mockNeuron.neuronId));
 
   const spyGetNeuron = jest
-    .spyOn(neuronsApiService, "queryNeuron")
+    .spyOn(api, "queryNeuron")
     .mockImplementation(() => Promise.resolve(mockNeuron));
 
   const neurons = [sameControlledNeuron, controlledNeuron];
 
   const spyQueryNeurons = jest
-    .spyOn(neuronsApiService, "queryNeurons")
+    .spyOn(api, "queryNeurons")
     .mockImplementation(() => Promise.resolve(neurons));
 
   const spyIncreaseDissolveDelay = jest
-    .spyOn(neuronsApiService, "increaseDissolveDelay")
+    .spyOn(api, "increaseDissolveDelay")
     .mockImplementation(() => Promise.resolve());
 
   const spyJoinCommunityFund = jest
-    .spyOn(neuronsApiService, "joinCommunityFund")
+    .spyOn(api, "joinCommunityFund")
     .mockImplementation(() => Promise.resolve());
 
   const spyAutoStakeMaturity = jest
-    .spyOn(neuronsApiService, "autoStakeMaturity")
+    .spyOn(api, "autoStakeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spyLeaveCommunityFund = jest
-    .spyOn(neuronsApiService, "leaveCommunityFund")
+    .spyOn(api, "leaveCommunityFund")
     .mockImplementation(() => Promise.resolve());
 
   const spyDisburse = jest
-    .spyOn(neuronsApiService, "disburse")
+    .spyOn(api, "disburse")
     .mockImplementation(() => Promise.resolve());
 
   const spyMergeMaturity = jest
-    .spyOn(neuronsApiService, "mergeMaturity")
+    .spyOn(api, "mergeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spyStakeMaturity = jest
-    .spyOn(neuronsApiService, "stakeMaturity")
+    .spyOn(api, "stakeMaturity")
     .mockImplementation(() => Promise.resolve());
 
   const spySpawnNeuron = jest
-    .spyOn(neuronsApiService, "spawnNeuron")
+    .spyOn(api, "spawnNeuron")
     .mockImplementation(() => Promise.resolve(newSpawnedNeuronId));
 
   const spyMergeNeurons = jest
-    .spyOn(neuronsApiService, "mergeNeurons")
+    .spyOn(api, "mergeNeurons")
     .mockImplementation(() => Promise.resolve());
 
   const spyAddHotkey = jest
-    .spyOn(neuronsApiService, "addHotkey")
+    .spyOn(api, "addHotkey")
     .mockImplementation(() => Promise.resolve());
 
   const spyRemoveHotkey = jest
-    .spyOn(neuronsApiService, "removeHotkey")
+    .spyOn(api, "removeHotkey")
     .mockImplementation(() => Promise.resolve());
 
   const spySplitNeuron = jest
-    .spyOn(neuronsApiService, "splitNeuron")
+    .spyOn(api, "splitNeuron")
     .mockImplementation(() => Promise.resolve(BigInt(11)));
 
   const spyStartDissolving = jest
-    .spyOn(neuronsApiService, "startDissolving")
+    .spyOn(api, "startDissolving")
     .mockImplementation(() => Promise.resolve());
 
   const spyStopDissolving = jest
-    .spyOn(neuronsApiService, "stopDissolving")
+    .spyOn(api, "stopDissolving")
     .mockImplementation(() => Promise.resolve());
 
   const spySetFollowees = jest
-    .spyOn(neuronsApiService, "setFollowees")
+    .spyOn(api, "setFollowees")
     .mockImplementation(() => Promise.resolve());
 
   const spyClaimOrRefresh = jest
-    .spyOn(neuronsApiService, "claimOrRefreshNeuron")
+    .spyOn(api, "claimOrRefreshNeuron")
     .mockImplementation(() => Promise.resolve(undefined));
 
   afterEach(() => {


### PR DESCRIPTION
# Motivation

Setup the api service layer for neurons. This will allow us to use caching in upcoming PRs.

# Changes

* New neuronsApiService object that is used in neuron.services and uses governance.api.
* The neuron services do not use the governance api anymore.
* Create types for all api function signatures to be used in neuronsApiService.

The idea is the following:

```
// Move from:
neuron service --> governance api
// To:
neuron service --> neuron api service (can provide caching) --> governance api
```

# Tests

* Change tests in neuron.services.
* Add test for all neuron api services methods.
