### PR TITLE
GIX-1245: Add aggregator url to build step

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -8,12 +8,8 @@ import { findHtmlFiles } from "./build.utils.mjs";
 
 dotenv.config();
 
-// Aggregator canister enabled ONLY in small12 for now
-const enableSnsAggregatorCanister = process.env.VITE_DFX_NETWORK === "small12";
-
-// TODO: Use env var https://dfinity.atlassian.net/browse/GIX-1245
-const aggregatorCanisterUrl =
-  "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network";
+const aggregatorCanisterUrl = process.env.VITE_AGGREGATOR_CANISTER_URL;
+const isAggregatorCanisterUrlDefined = aggregatorCanisterUrl.length > 0;
 
 const buildCsp = (htmlFile) => {
   // 1. We extract the start script parsed by SvelteKit into the html file
@@ -127,7 +123,7 @@ const updateCSP = (indexHtml) => {
         content="default-src 'none';
         connect-src 'self' ${cspConnectSrc()};
         img-src 'self' data: https://nns.ic0.app/ https://nns.raw.ic0.app/ ${
-          enableSnsAggregatorCanister ? aggregatorCanisterUrl : ""
+          isAggregatorCanisterUrlDefined ? aggregatorCanisterUrl : ""
         };
         child-src 'self';
         manifest-src 'self';
@@ -153,7 +149,7 @@ const cspConnectSrc = () => {
     process.env.VITE_LEDGER_CANISTER_URL,
   ];
 
-  if (enableSnsAggregatorCanister) {
+  if (isAggregatorCanisterUrlDefined) {
     src.push(aggregatorCanisterUrl);
   }
 

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -141,6 +141,7 @@ const updateCSP = (indexHtml) => {
 };
 
 const cspConnectSrc = () => {
+  // TODO: Use `URL` to check if the URL is valid and not introduce a security issue
   const src = [
     process.env.VITE_IDENTITY_SERVICE_URL,
     process.env.VITE_OWN_CANISTER_URL,

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -269,8 +269,9 @@ export const querySnsProjects = async (): Promise<CachedSns[]> => {
   }
   try {
     const data: CachedSnsDto[] = await response.json();
+    const convertedData = convertDtoData(data);
     logWithTimestamp("Loading SNS projects from aggregator canister completed");
-    return convertDtoData(data);
+    return convertedData;
   } catch (err) {
     console.error("Error converting data", err);
     throw new Error("Error converting data from aggregator canister");

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -3,6 +3,7 @@ import {
   AGGREGATOR_CANISTER_PATH,
   AGGREGATOR_CANISTER_VERSION,
 } from "$lib/constants/sns.constants";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { nonNullish } from "$lib/utils/utils";
 import type {
   IcrcMetadataResponseEntries,
@@ -259,6 +260,7 @@ const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>
   data.map(convertSnsData);
 
 export const querySnsProjects = async (): Promise<CachedSns[]> => {
+  logWithTimestamp("Loading SNS projects from aggregator canister...");
   const response = await fetch(
     `${SNS_AGGREGATOR_CANISTER_URL}/${AGGREGATOR_CANISTER_VERSION}${AGGREGATOR_CANISTER_PATH}`
   );
@@ -267,6 +269,7 @@ export const querySnsProjects = async (): Promise<CachedSns[]> => {
   }
   try {
     const data: CachedSnsDto[] = await response.json();
+    logWithTimestamp("Loading SNS projects from aggregator canister completed");
     return convertDtoData(data);
   } catch (err) {
     console.error("Error converting data", err);

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -7,13 +7,10 @@ export const FETCH_ROOT_KEY: boolean =
 // TODO: Add as env var https://dfinity.atlassian.net/browse/GIX-1245
 // Local development needs `.raw` to avoid CORS issues for now.
 // TODO: Fix CORS issues
-export const SNS_AGGREGATOR_CANISTER_URL =
-  import.meta.env.SNS_AGGREGATOR_CANISTER_URL ??
-  (DFX_NETWORK === "small12"
-    ? DEV
-      ? "https://5v72r-4aaaa-aaaaa-aabnq-cai.raw.small12.testnet.dfinity.network"
-      : "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network"
-    : undefined);
+export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
+  (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string) === ""
+    ? undefined
+    : (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string);
 
 interface FEATURE_FLAGS {
   ENABLE_SNS_2: boolean;


### PR DESCRIPTION
# Motivation

Add the sns aggregator url to the build step for nns-dapp frontend.

# Changes

* Use exposed env var VITE_AGGREGATOR_CANISTER_URL in build.csp.mjs to set correct CSP rules.
* Use VITE_AGGREGATOR_CANISTER_URL to set SNS_AGGREGATOR_CANISTER_URL
