### PR TITLE
feat: ckBTC transactions on wallet detail page

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
@@ -24,6 +24,7 @@
 {#if modal === "NewTransaction" && nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
   <CkBTCTransactionModal
     on:nnsClose={closeModal}
+    on:nnsTransfer={closeModal}
     token={$ckBTCTokenStore.token}
     transactionFee={$ckBTCTokenFeeStore}
   />

--- a/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
@@ -3,7 +3,10 @@
   import Footer from "$lib/components/layout/Footer.svelte";
   import { nonNullish } from "$lib/utils/utils";
   import { ckBTCAccountsStore } from "$lib/stores/ckbtc-accounts.store";
-  import { ckBTCTokenFeeStore } from "$lib/derived/universes-tokens.derived";
+  import {
+    ckBTCTokenFeeStore,
+    ckBTCTokenStore,
+  } from "$lib/derived/universes-tokens.derived";
   import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
   import { hasAccounts } from "$lib/utils/accounts.utils";
 
@@ -14,11 +17,16 @@
   let canMakeTransactions = false;
   $: canMakeTransactions =
     hasAccounts($ckBTCAccountsStore.accounts) &&
-    nonNullish($ckBTCTokenFeeStore);
+    nonNullish($ckBTCTokenFeeStore) &&
+    nonNullish($ckBTCTokenStore);
 </script>
 
-{#if modal === "NewTransaction"}
-  <CkBTCTransactionModal on:nnsClose={closeModal} />
+{#if modal === "NewTransaction" && nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
+  <CkBTCTransactionModal
+    on:nnsClose={closeModal}
+    token={$ckBTCTokenStore.token}
+    transactionFee={$ckBTCTokenFeeStore}
+  />
 {/if}
 
 {#if canMakeTransactions}

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -46,7 +46,7 @@
 
     if (success) {
       toastsSuccess({ labelKey: "accounts.transaction_success" });
-      dispatcher("nnsClose");
+      dispatcher("nnsTransfer");
     }
   };
 </script>

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -9,15 +9,15 @@
   import type { Account } from "$lib/types/account";
   import type { WizardStep } from "@dfinity/gix-components";
   import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import {
-    ckBTCTokenFeeStore,
-    ckBTCTokenStore,
-  } from "$lib/derived/universes-tokens.derived";
-  import { nonNullish } from "$lib/utils/utils";
   import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
+  import type { TokenAmount } from "@dfinity/nns";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
+
+  export let token: IcrcTokenMetadata;
+  export let transactionFee: TokenAmount;
 
   let currentStep: WizardStep;
 
@@ -49,28 +49,23 @@
       dispatcher("nnsClose");
     }
   };
-
-  // TODO: review usage of nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)
 </script>
 
-<!-- Checks for type safety but, already performs in parent -->
-{#if nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
-  <TransactionModal
-    rootCanisterId={CKBTC_UNIVERSE_CANISTER_ID}
-    on:nnsSubmit={transfer}
-    on:nnsClose
-    bind:currentStep
-    token={$ckBTCTokenStore.token}
-    transactionFee={$ckBTCTokenFeeStore}
-    sourceAccount={selectedAccount}
+<TransactionModal
+  rootCanisterId={CKBTC_UNIVERSE_CANISTER_ID}
+  on:nnsSubmit={transfer}
+  on:nnsClose
+  bind:currentStep
+  {token}
+  {transactionFee}
+  sourceAccount={selectedAccount}
+>
+  <svelte:fragment slot="title"
+    >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
   >
-    <svelte:fragment slot="title"
-      >{title ?? $i18n.accounts.new_transaction}</svelte:fragment
-    >
-    <p slot="description" class="value">
-      {replacePlaceholders($i18n.accounts.sns_transaction_description, {
-        $token: $ckBTCTokenStore.token.symbol,
-      })}
-    </p>
-  </TransactionModal>
-{/if}
+  <p slot="description" class="value">
+    {replacePlaceholders($i18n.accounts.sns_transaction_description, {
+      $token: token.symbol,
+    })}
+  </p>
+</TransactionModal>

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -143,7 +143,7 @@
         class="primary"
         on:click={() => (showNewTransactionModal = true)}
         disabled={isNullish($selectedAccountStore.account) || $busy}
-        data-tid="open-new-sns-transaction"
+        data-tid="open-new-ckbtc-transaction"
         >{$i18n.accounts.new_transaction}</button
       >
     </Footer>

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Island, Spinner } from "@dfinity/gix-components";
+  import { busy, Island, Spinner } from "@dfinity/gix-components";
   import Summary from "$lib/components/summary/Summary.svelte";
   import WalletSummary from "$lib/components/accounts/WalletSummary.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
@@ -13,7 +13,7 @@
   import { setContext } from "svelte/internal";
   import { findAccount, hasAccounts } from "$lib/utils/accounts.utils";
   import { ckBTCAccountsStore } from "$lib/stores/ckbtc-accounts.store";
-  import { nonNullish } from "$lib/utils/utils";
+  import { isNullish, nonNullish } from "$lib/utils/utils";
   import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
   import { toastsError } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -21,8 +21,12 @@
   import { goto } from "$app/navigation";
   import { AppPath } from "$lib/constants/routes.constants";
   import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsList.svelte";
+  import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
+  import Footer from "$lib/components/layout/Footer.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
+
+  let showNewTransactionModal = false;
 
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
@@ -113,4 +117,22 @@
       {/if}
     </section>
   </main>
+
+  <Footer columns={1}>
+    <button
+      class="primary"
+      on:click={() => (showNewTransactionModal = true)}
+      disabled={isNullish($selectedAccountStore.account) || $busy}
+      data-tid="open-new-sns-transaction"
+      >{$i18n.accounts.new_transaction}</button
+    >
+  </Footer>
 </Island>
+
+{#if showNewTransactionModal}
+  <CkBTCTransactionModal
+    on:nnsClose={() => (showNewTransactionModal = false)}
+    selectedAccount={$selectedAccountStore.account}
+    loadTransactions
+  />
+{/if}

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -45,9 +45,7 @@
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);
 
-  const loadAccount = async (): Promise<{
-    state: "loaded" | "not_found" | "unknown";
-  }> => {
+  const setSelectedAccount = () => {
     selectedAccountStore.set({
       account: findAccount({
         identifier: accountIdentifier,
@@ -55,6 +53,17 @@
       }),
       neurons: [],
     });
+  };
+
+  const onTransferReloadSelectedAccount = () => {
+    setSelectedAccount();
+    showNewTransactionModal = false;
+  };
+
+  const loadAccount = async (): Promise<{
+    state: "loaded" | "not_found" | "unknown";
+  }> => {
+    setSelectedAccount();
 
     // We found an account in store for the provided account identifier, all data are set
     if (nonNullish($selectedAccountStore.account)) {
@@ -144,6 +153,7 @@
 {#if showNewTransactionModal && nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
   <CkBTCTransactionModal
     on:nnsClose={() => (showNewTransactionModal = false)}
+    on:nnsTransfer={onTransferReloadSelectedAccount}
     selectedAccount={$selectedAccountStore.account}
     loadTransactions
     token={$ckBTCTokenStore.token}

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -23,6 +23,10 @@
   import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsList.svelte";
   import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
+  import {
+    ckBTCTokenFeeStore,
+    ckBTCTokenStore,
+  } from "$lib/derived/universes-tokens.derived";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -97,6 +101,12 @@
   };
 
   $: accountIdentifier, (async () => await loadData())();
+
+  let canMakeTransactions = false;
+  $: canMakeTransactions =
+    hasAccounts($ckBTCAccountsStore.accounts) &&
+    nonNullish($ckBTCTokenFeeStore) &&
+    nonNullish($ckBTCTokenStore);
 </script>
 
 <Island>
@@ -118,21 +128,25 @@
     </section>
   </main>
 
-  <Footer columns={1}>
-    <button
-      class="primary"
-      on:click={() => (showNewTransactionModal = true)}
-      disabled={isNullish($selectedAccountStore.account) || $busy}
-      data-tid="open-new-sns-transaction"
-      >{$i18n.accounts.new_transaction}</button
-    >
-  </Footer>
+  {#if canMakeTransactions}
+    <Footer columns={1}>
+      <button
+        class="primary"
+        on:click={() => (showNewTransactionModal = true)}
+        disabled={isNullish($selectedAccountStore.account) || $busy}
+        data-tid="open-new-sns-transaction"
+        >{$i18n.accounts.new_transaction}</button
+      >
+    </Footer>
+  {/if}
 </Island>
 
-{#if showNewTransactionModal}
+{#if showNewTransactionModal && nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
   <CkBTCTransactionModal
     on:nnsClose={() => (showNewTransactionModal = false)}
     selectedAccount={$selectedAccountStore.account}
     loadTransactions
+    token={$ckBTCTokenStore.token}
+    transactionFee={$ckBTCTokenFeeStore}
   />
 {/if}

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -8,14 +8,16 @@ import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.sv
 import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
 import { ckBTCAccountsStore } from "$lib/stores/ckbtc-accounts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { page } from "$mocks/$app/stores";
+import { TokenAmount } from "@dfinity/nns";
 import { waitFor } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../../mocks/auth.store.mock";
-import { mockCkBTCMainAccount } from "../../../mocks/ckbtc-accounts.mock";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "../../../mocks/ckbtc-accounts.mock";
 import { renderModal } from "../../../mocks/modal.mock";
-import { mockUniversesTokens } from "../../../mocks/tokens.mock";
 import { testTransferTokens } from "../../../utils/transaction-modal.test.utils";
 
 jest.mock("$lib/services/ckbtc-accounts.services", () => {
@@ -30,6 +32,11 @@ describe("CkBTCTransactionModal", () => {
       component: CkBTCTransactionModal,
       props: {
         selectedAccount,
+        token: mockCkBTCToken,
+        transactionFee: TokenAmount.fromE8s({
+          amount: mockCkBTCToken.fee,
+          token: mockCkBTCToken,
+        }),
       },
     });
 
@@ -44,8 +51,6 @@ describe("CkBTCTransactionModal", () => {
       accounts: [mockCkBTCMainAccount],
       certified: true,
     });
-
-    tokensStore.setTokens(mockUniversesTokens);
 
     page.mock({
       data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -8,9 +8,11 @@ import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
 import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
 import { ckBTCAccountsStore } from "$lib/stores/ckbtc-accounts.store";
 import { page } from "$mocks/$app/stores";
-import { render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mockCkBTCMainAccount } from "../../mocks/ckbtc-accounts.mock";
 import en from "../../mocks/i18n.mock";
+import { mockUniversesTokens } from "../../mocks/tokens.mock";
+import { tokensStore } from "$lib/stores/tokens.store";
 
 jest.mock("$lib/services/ckbtc-accounts.services", () => {
   return {
@@ -59,6 +61,8 @@ describe("CkBTCWallet", () => {
         certified: true,
       });
 
+      tokensStore.setTokens(mockUniversesTokens);
+
       page.mock({
         data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
         routeId: AppPath.Wallet,
@@ -89,6 +93,23 @@ describe("CkBTCWallet", () => {
       await waitFor(() =>
         expect(queryByTestId("wallet-summary")).toBeInTheDocument()
       );
+    });
+
+    it("should open new transaction modal", async () => {
+      const { queryByTestId, getByTestId } = render(CkBTCWallet, props);
+
+      await waitFor(() =>
+        expect(queryByTestId("open-new-ckbtc-transaction")).toBeInTheDocument()
+      );
+
+      const button = getByTestId(
+        "open-new-ckbtc-transaction"
+      ) as HTMLButtonElement;
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(getByTestId("transaction-step-1")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -5,18 +5,47 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
-import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
+import {
+  ckBTCTransferTokens,
+  syncCkBTCAccounts,
+} from "$lib/services/ckbtc-accounts.services";
+import { authStore } from "$lib/stores/auth.store";
 import { ckBTCAccountsStore } from "$lib/stores/ckbtc-accounts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
+import { TokenAmount } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import { mockCkBTCMainAccount } from "../../mocks/ckbtc-accounts.mock";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "../../mocks/ckbtc-accounts.mock";
 import en from "../../mocks/i18n.mock";
 import { mockUniversesTokens } from "../../mocks/tokens.mock";
-import { tokensStore } from "$lib/stores/tokens.store";
+import { testTransferTokens } from "../../utils/transaction-modal.test.utils";
+
+const expectedBalanceAfterTransfer = TokenAmount.fromE8s({
+  amount: BigInt(11_111),
+  token: mockCkBTCToken,
+});
 
 jest.mock("$lib/services/ckbtc-accounts.services", () => {
   return {
     syncCkBTCAccounts: jest.fn().mockResolvedValue(undefined),
+    ckBTCTransferTokens: jest.fn().mockImplementation(async () => {
+      ckBTCAccountsStore.set({
+        accounts: [
+          {
+            ...mockCkBTCMainAccount,
+            balance: expectedBalanceAfterTransfer,
+          },
+        ],
+        certified: true,
+      });
+
+      return { success: true };
+    }),
   };
 });
 
@@ -56,6 +85,10 @@ describe("CkBTCWallet", () => {
 
   describe("accounts loaded", () => {
     beforeAll(() => {
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreSubscribe);
+
       ckBTCAccountsStore.set({
         accounts: [mockCkBTCMainAccount],
         certified: true,
@@ -110,6 +143,40 @@ describe("CkBTCWallet", () => {
       await waitFor(() => {
         expect(getByTestId("transaction-step-1")).toBeInTheDocument();
       });
+    });
+
+    it("should update account after transfer tokens", async () => {
+      const result = render(CkBTCWallet, props);
+
+      const { queryByTestId, getByTestId } = result;
+
+      // Check original sum
+      await waitFor(() =>
+        expect(getByTestId("token-value")?.textContent ?? "").toEqual(
+          `${formatToken({ value: mockCkBTCMainAccount.balance.toE8s() })}`
+        )
+      );
+
+      // Make transfer
+      await waitFor(() =>
+        expect(queryByTestId("open-new-ckbtc-transaction")).toBeInTheDocument()
+      );
+
+      const button = getByTestId(
+        "open-new-ckbtc-transaction"
+      ) as HTMLButtonElement;
+      await fireEvent.click(button);
+
+      await testTransferTokens(result);
+
+      await waitFor(() => expect(ckBTCTransferTokens).toBeCalled());
+
+      // Account should have been updated and sum should be reflected
+      await waitFor(() =>
+        expect(getByTestId("token-value")?.textContent ?? "").toEqual(
+          `${formatToken({ value: expectedBalanceAfterTransfer.toE8s() })}`
+        )
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

Add CTA to execute a ckBTC transaction on wallet detail page.

# Changes

- add footer action to instantiate ckBTC transaction and pass selected account
- modify dispatch on success to reload account data
- duplicate properties fee and token as [requested](https://github.com/dfinity/nns-dapp/pull/1812#discussion_r1095949160)

# Screenshot

![demo2](https://user-images.githubusercontent.com/16886711/216910695-d79c140a-f901-4265-92a6-535146229220.gif)

