### PR TITLE
Correct setup for HW version test in neurons.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -800,7 +800,10 @@ describe("neurons-services", () => {
           controller: smallerVersionIdentity.getPrincipal().toText(),
         },
       };
-      neuronsStore.pushNeurons({ neurons: [neuron1, neuron2], certified: true });
+      neuronsStore.pushNeurons({
+        neurons: [neuron1, neuron2],
+        certified: true,
+      });
 
       await mergeNeurons({
         sourceNeuronId: neuron1.neuronId,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -211,6 +211,7 @@ describe("neurons-services", () => {
     neuronsStore.reset();
     accountsStore.reset();
     resetIdentity();
+    resetAccountIdentity();
   });
 
   describe("stake new neuron", () => {
@@ -306,8 +307,6 @@ describe("neurons-services", () => {
 
       expect(response).toBeUndefined();
       expect(toastsShow).toBeCalled();
-
-      resetAccountIdentity();
     });
   });
 
@@ -511,6 +510,8 @@ describe("neurons-services", () => {
           controller: smallerVersionIdentity.getPrincipal().toText(),
         },
       };
+      neuronsStore.pushNeurons({ neurons: [neuron], certified: true });
+
       await toggleAutoStakeMaturity(neuron);
 
       expect(toastsShow).toHaveBeenCalled();
@@ -1468,7 +1469,6 @@ describe("neurons-services", () => {
       neuronsStore.setNeurons({ neurons: [neuron], certified: true });
       const call = () => getIdentityOfControllerByNeuronId(neuron.neuronId);
       expect(call).rejects.toThrow(NotAuthorizedNeuronError);
-      resetAccountIdentity();
     });
   });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -800,6 +800,8 @@ describe("neurons-services", () => {
           controller: smallerVersionIdentity.getPrincipal().toText(),
         },
       };
+      neuronsStore.pushNeurons({ neurons: [neuron1, neuron2], certified: true });
+
       await mergeNeurons({
         sourceNeuronId: neuron1.neuronId,
         targetNeuronId: neuron2.neuronId,


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/1815 I discovered that two tests don't actually test what they're supposed to test. I didn't want to hide the fixes between many other changes so I made a separate PR.

Without the change, the error toast is actually about not being the controller of the neuron in one case, and about not merging neurons with the same ID in another case, rather than about the HW version being behind.

# Changes

Push the mock neurons to the store before calling the function under test.

Additional minor change: Move resetAccountIdentity() to beforeEach. If we rely on the tests to clean this up, then if one of those tests fails, then other tests start failing as well for confusing reasons.

# Tests

Changes are test-only. But https://github.com/dfinity/nns-dapp/pull/1815 will have additional changes to make the tests more robust.
