### PR TITLE
fix: getOldestTxIdFromStore cannot read properties of undefined

### DIFF
--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -189,7 +189,7 @@ export const getOldestTxIdFromStore = ({
   }
   return accountData.transactions.sort((a, b) =>
     Number(a.transaction.timestamp - b.transaction.timestamp)
-  )[0].id;
+  )[0]?.id;
 };
 /**
  * Returns whether all transactions of an SNS account have been loaded.

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -245,6 +245,27 @@ describe("icrc-transaction utils", () => {
         })
       ).toBeUndefined();
     });
+
+    it("returns undefined if empty data", () => {
+      const rootCanisterId = mockSnsMainAccount.principal;
+      const transactions = [];
+      const store: IcrcTransactionsStoreData = {
+        [rootCanisterId.toText()]: {
+          [mockSnsMainAccount.identifier]: {
+            transactions,
+            completed: false,
+            oldestTxId: BigInt(1234),
+          },
+        },
+      };
+      expect(
+        getOldestTxIdFromStore({
+          store,
+          canisterId: rootCanisterId,
+          account: mockSnsMainAccount,
+        })
+      ).toBeUndefined();
+    });
   });
 
   describe("isTransactionsCompleted", () => {


### PR DESCRIPTION
# Motivation

`getOldestTxIdFromStore` does not handle empty transactions which can lead to an "Cannot read properties of undefined (reading 'id')" issue.

# How to reproduce

Accounts -> SNS-1 -> Wallet -> No transactions -> Back -> Wallet -> Issue.

# Changes

- `accountData.transactions` can be empty => `accountData.transactions[0]?.id` instead of `accountData.transactions[0].id`

# Screenshots

Mainnet:

<img width="1536" alt="Capture d’écran 2023-02-06 à 14 56 04" src="https://user-images.githubusercontent.com/16886711/216992082-49110024-3d34-49b7-b55f-5a217b404d2d.png">

Reproduced locally:

<img width="1536" alt="Capture d’écran 2023-02-06 à 14 50 31" src="https://user-images.githubusercontent.com/16886711/216992176-59eaeff1-fdf4-4f93-b648-133c94fb1ab5.png">
