### PR TITLE
build: enable ckBTC ledger and index for mainnet

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -122,8 +122,8 @@ featureFlags=$(echo "$json" | jq -r ".FEATURE_FLAGS" | jq tostring)
 host=$(echo "$json" | jq -r ".HOST")
 identityServiceUrl=$(echo "$json" | jq -r ".IDENTITY_SERVICE_URL")
 aggregatorCanisterUrl=$(echo "$json" | jq -r '.SNS_AGGREGATOR_URL // ""')
-ckbtcIndexCanisterId=$(echo "$json" | jq -r '.CKBTC_INDEX_CANISTER_ID // ""')
 ckbtcLedgerCanisterId=$(echo "$json" | jq -r '.CKBTC_LEDGER_CANISTER_ID // ""')
+ckbtcIndexCanisterId=$(echo "$json" | jq -r '.CKBTC_INDEX_CANISTER_ID // ""')
 
 echo "VITE_DFX_NETWORK=$dfxNetwork
 VITE_CYCLES_MINTING_CANISTER_ID=$cmcCanisterId
@@ -139,8 +139,8 @@ VITE_FEATURE_FLAGS=$featureFlags
 VITE_HOST=$host
 VITE_IDENTITY_SERVICE_URL=$identityServiceUrl
 VITE_AGGREGATOR_CANISTER_URL=${aggregatorCanisterUrl:-}
-VITE_CKBTC_INDEX_CANISTER_ID=${ckbtcIndexCanisterId:-}
-VITE_CKBTC_LEDGER_CANISTER_ID=${ckbtcLedgerCanisterId:-}" | tee "$ENV_FILE"
+VITE_CKBTC_LEDGER_CANISTER_ID=${ckbtcLedgerCanisterId:-}
+VITE_CKBTC_INDEX_CANISTER_ID=${ckbtcIndexCanisterId:-}" | tee "$ENV_FILE"
 
 echo "Config has been defined in '${ENV_FILE}'" >&2
 
@@ -150,10 +150,10 @@ export IDENTITY_SERVICE_URL
 SNS_AGGREGATOR_URL="${aggregatorCanisterUrl:-}"
 export SNS_AGGREGATOR_URL
 
-CKBTC_INDEX_CANISTER_ID="${ckbtcIndexCanisterId:-}"
-export CKBTC_INDEX_CANISTER_ID
 CKBTC_LEDGER_CANISTER_ID="${ckbtcLedgerCanisterId:-}"
 export CKBTC_LEDGER_CANISTER_ID
+CKBTC_INDEX_CANISTER_ID="${ckbtcIndexCanisterId:-}"
+export CKBTC_INDEX_CANISTER_ID
 
 GOVERNANCE_CANISTER_ID="$governanceCanisterId"
 export GOVERNANCE_CANISTER_ID

--- a/dfx.json
+++ b/dfx.json
@@ -207,7 +207,7 @@
           "ENABLE_SNS_2": false,
           "ENABLE_SNS_VOTING": false,
           "ENABLE_SNS_AGGREGATOR": false,
-          "ENABLE_CKBTC_LEDGER": false
+          "ENABLE_CKBTC_LEDGER": true
         }
       },
       "providers": [

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -20,8 +20,8 @@ export const CKBTC_MINTER_CANISTER_ID = Principal.fromText(
   "q3fc5-haaaa-aaaaa-aaahq-cai"
 );
 
-// We fallback to hardcoded canister IDs because ckBTC is not deployed on every environment at the moment and we do not want to introduce constants that can be undefined
-// Feature flag should be set accordingly. Feature flag is active on mainnet, the fallback are the one to use on mainnet.
+// We fallback to hardcoded canister IDs because ckBTC is not deployed on every environment at the moment and, we do not want to introduce constants that can be undefined.
+// The feature flags should be set accordingly. The feature is active on mainnet, therefore the fallback values are the one to use on mainnet.
 const MAINNET_CKBTC_LEDGER_CANISTER_ID = "mxzaz-hqaaa-aaaar-qaada-cai";
 const MAINNET_CKBTC_INDEX_CANISTER_ID = "n5wcd-faaaa-aaaar-qaaea-cai";
 

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -1,3 +1,4 @@
+import { isStringDefinedNotEmpty } from "$lib/utils/utils";
 import { Principal } from "@dfinity/principal";
 
 export const OWN_CANISTER_ID_TEXT = import.meta.env
@@ -14,14 +15,27 @@ export const CYCLES_MINTING_CANISTER_ID = Principal.fromText(
 );
 export const WASM_CANISTER_ID = import.meta.env.VITE_WASM_CANISTER_ID;
 
-// TODO: environment variables for ckBTC canister IDs
+// TODO: environment variables for ckBTC "minter" canister ID
 export const CKBTC_MINTER_CANISTER_ID = Principal.fromText(
   "q3fc5-haaaa-aaaaa-aaahq-cai"
 );
+
+// We fallback to hardcoded canister IDs because ckBTC is not deployed on every environment at the moment and we do not want to introduce constants that can be undefined
+// Feature flag should be set accordingly. Feature flag is active on mainnet, the fallback are the one to use on mainnet.
+const MAINNET_CKBTC_LEDGER_CANISTER_ID = "mxzaz-hqaaa-aaaar-qaada-cai";
+const MAINNET_CKBTC_INDEX_CANISTER_ID = "n5wcd-faaaa-aaaar-qaaea-cai";
+
+const ENV_CKBTC_LEDGER_CANISTER_ID = import.meta.env.CKBTC_LEDGER_CANISTER_ID;
+const ENV_CKBTC_INDEX_CANISTER_ID = import.meta.env.CKBTC_INDEX_CANISTER_ID;
+
 export const CKBTC_LEDGER_CANISTER_ID = Principal.fromText(
-  "q4eej-kyaaa-aaaaa-aaaha-cai"
+  isStringDefinedNotEmpty(ENV_CKBTC_LEDGER_CANISTER_ID)
+    ? ENV_CKBTC_LEDGER_CANISTER_ID
+    : MAINNET_CKBTC_LEDGER_CANISTER_ID
 );
 export const CKBTC_INDEX_CANISTER_ID = Principal.fromText(
-  "si2b5-pyaaa-aaaaa-aaaja-cai"
+  isStringDefinedNotEmpty(ENV_CKBTC_INDEX_CANISTER_ID)
+    ? ENV_CKBTC_INDEX_CANISTER_ID
+    : MAINNET_CKBTC_INDEX_CANISTER_ID
 );
 export const CKBTC_UNIVERSE_CANISTER_ID = CKBTC_LEDGER_CANISTER_ID;

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -25,8 +25,10 @@ export const CKBTC_MINTER_CANISTER_ID = Principal.fromText(
 const MAINNET_CKBTC_LEDGER_CANISTER_ID = "mxzaz-hqaaa-aaaar-qaada-cai";
 const MAINNET_CKBTC_INDEX_CANISTER_ID = "n5wcd-faaaa-aaaar-qaaea-cai";
 
-const ENV_CKBTC_LEDGER_CANISTER_ID = import.meta.env.CKBTC_LEDGER_CANISTER_ID;
-const ENV_CKBTC_INDEX_CANISTER_ID = import.meta.env.CKBTC_INDEX_CANISTER_ID;
+const ENV_CKBTC_LEDGER_CANISTER_ID = import.meta.env
+  .VITE_CKBTC_LEDGER_CANISTER_ID;
+const ENV_CKBTC_INDEX_CANISTER_ID = import.meta.env
+  .VITE_CKBTC_INDEX_CANISTER_ID;
 
 export const CKBTC_LEDGER_CANISTER_ID = Principal.fromText(
   isStringNonNullishNotEmpty(ENV_CKBTC_LEDGER_CANISTER_ID)

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -1,4 +1,4 @@
-import { isStringDefinedNotEmpty } from "$lib/utils/utils";
+import { isStringNonNullishNotEmpty } from "$lib/utils/utils";
 import { Principal } from "@dfinity/principal";
 
 export const OWN_CANISTER_ID_TEXT = import.meta.env
@@ -29,12 +29,12 @@ const ENV_CKBTC_LEDGER_CANISTER_ID = import.meta.env.CKBTC_LEDGER_CANISTER_ID;
 const ENV_CKBTC_INDEX_CANISTER_ID = import.meta.env.CKBTC_INDEX_CANISTER_ID;
 
 export const CKBTC_LEDGER_CANISTER_ID = Principal.fromText(
-  isStringDefinedNotEmpty(ENV_CKBTC_LEDGER_CANISTER_ID)
+  isStringNonNullishNotEmpty(ENV_CKBTC_LEDGER_CANISTER_ID)
     ? ENV_CKBTC_LEDGER_CANISTER_ID
     : MAINNET_CKBTC_LEDGER_CANISTER_ID
 );
 export const CKBTC_INDEX_CANISTER_ID = Principal.fromText(
-  isStringDefinedNotEmpty(ENV_CKBTC_INDEX_CANISTER_ID)
+  isStringNonNullishNotEmpty(ENV_CKBTC_INDEX_CANISTER_ID)
     ? ENV_CKBTC_INDEX_CANISTER_ID
     : MAINNET_CKBTC_INDEX_CANISTER_ID
 );

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -26,7 +26,7 @@ export const {
   ENABLE_CKBTC_LEDGER,
 }: FEATURE_FLAGS = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
-    '{"ENABLE_SNS_2":false,"ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": false}'
+    '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": true}'
 );
 
 export const IS_TESTNET: boolean =

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -348,5 +348,5 @@ export const expandObject = (
     return acc;
   }, {} as Record<string, unknown>);
 
-export const isStringDefinedNotEmpty = (value?: string): boolean =>
+export const isStringNonNullishNotEmpty = (value?: string): boolean =>
   nonNullish(value) && value !== "";

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -347,3 +347,6 @@ export const expandObject = (
     }
     return acc;
   }, {} as Record<string, unknown>);
+
+export const isStringDefinedNotEmpty = (value?: string): boolean =>
+  nonNullish(value) && value !== "";

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -161,6 +161,10 @@ export const nonNullish = <T>(
   argument: T | undefined | null
 ): argument is NonNullable<T> => !isNullish(argument);
 
+/** Not null and not undefined and not empty */
+export const isStringNonNullishNotEmpty = (value?: string): boolean =>
+  nonNullish(value) && value !== "";
+
 export const mapPromises = async <T, R>(
   items: Array<T> | undefined,
   fun: (args: T) => Promise<R>
@@ -347,6 +351,3 @@ export const expandObject = (
     }
     return acc;
   }, {} as Record<string, unknown>);
-
-export const isStringNonNullishNotEmpty = (value?: string): boolean =>
-  nonNullish(value) && value !== "";

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   isHash,
   isNullish,
   isPngAsset,
+  isStringNonNullishNotEmpty,
   nonNullish,
   poll,
   PollingLimitExceededError,
@@ -210,6 +211,26 @@ describe("utils", () => {
       expect(nonNullish(1)).toBeTruthy();
       expect(nonNullish("")).toBeTruthy();
       expect(nonNullish([])).toBeTruthy();
+    });
+  });
+
+  describe("isNullish", () => {
+    it("should determine nullable", () => {
+      expect(isNullish(null)).toBeTruthy();
+      expect(isNullish(undefined)).toBeTruthy();
+      expect(isNullish(0)).toBeFalsy();
+      expect(isNullish(1)).toBeFalsy();
+      expect(isNullish("")).toBeFalsy();
+      expect(isNullish([])).toBeFalsy();
+    });
+  });
+
+  describe("isStringNonNullishNotEmpty", () => {
+    it("should determine not empty", () => {
+      expect(isStringNonNullishNotEmpty(null)).toBeFalsy();
+      expect(isStringNonNullishNotEmpty(undefined)).toBeFalsy();
+      expect(isStringNonNullishNotEmpty("")).toBeFalsy();
+      expect(isStringNonNullishNotEmpty("test")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
# Motivation

Enable ckBTC ledger and index on mainnet and propose it in next version.

# Changes

- enable ckBTC on **mainnet**
- enable ckBTC per default
- integrate ckBTC canister IDs configuration and fallback to mainnet canister IDs
- update order of fields in script
- add a new utils to test if a string is not null, not undefined and not empty
