### PR TITLE
fix: force destroy wallet page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
@@ -3,12 +3,17 @@
   import Content from "$lib/components/layout/Content.svelte";
   import { goto } from "$app/navigation";
   import { accountsPathStore } from "$lib/derived/paths.derived";
+  import { isNullish } from "$lib/utils/utils";
+  import { navigating } from "$app/stores";
 
   const back = (): Promise<void> => goto($accountsPathStore);
 </script>
 
-<Layout>
-  <Content {back}>
-    <slot />
-  </Content>
-</Layout>
+<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
+{#if isNullish($navigating)}
+  <Layout>
+    <Content {back}>
+      <slot />
+    </Content>
+  </Layout>
+{/if}


### PR DESCRIPTION
# Motivation

For the same SvelteKit issue as for the "Login" page we noticed that on destroy of the CkBTCWallet page was not called. 
This fixes the issue for that particular page. We might want to have  a look to apply it to all routes later.

# Issues

SvelteKit issue https://github.com/sveltejs/kit/issues/5434

# Changes

- destroy layout and all children on navigation to "force" the destroy of the components
