### PR TITLE
style: transaction list alignment

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -88,7 +88,7 @@
     }
 
     display: grid;
-    grid-template-columns: repeat(2, auto);
+    grid-template-columns: 48px auto;
     align-items: flex-start;
     column-gap: var(--padding-2x);
 


### PR DESCRIPTION
# Motivation

We noticed while testing an existing style issue in the alignment of the transaction on medium screen.

# Screenshots

<img width="985" alt="Capture d’écran 2023-02-07 à 15 45 33" src="https://user-images.githubusercontent.com/16886711/217277703-affbbd94-b8f1-4bc8-bfdf-4461248f5fd4.png">
<img width="985" alt="Capture d’écran 2023-02-07 à 15 45 41" src="https://user-images.githubusercontent.com/16886711/217277725-dcd2dcaf-f4e8-4df1-89cf-bdbeba4a9cd0.png">

