### PR TITLE
Comments in aggregator code + cleanup

### DIFF
--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -7,6 +7,7 @@ use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
+/// A standard HTTP header
 type HeaderField = (String, String);
 
 /// The standardised data structure for HTTP responses as supported natively by the replica.
@@ -35,6 +36,7 @@ pub struct HttpResponse {
     pub body: ByteBuf,
 }
 
+/// The domain separator used to distinguish HTTP asset hashes from others.
 const LABEL_ASSETS: &[u8] = b"http_assets";
 
 /// A tree containing the hashes of all the assets; used for certification.
@@ -96,6 +98,7 @@ impl Assets {
     }
 }
 
+/// The mime type of an asset, based on the path suffix.
 fn content_type_of(request_path: &str) -> Option<&'static str> {
     if request_path.ends_with('/') {
         return Some("text/html");
@@ -136,6 +139,7 @@ fn security_headers() -> Vec<HeaderField> {
     ]
 }
 
+/// Generates a header used by clients to verify the integrity of the data.
 fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> (String, String) {
     let certificate = ic_cdk::api::data_certificate().unwrap_or_else(|| {
         panic!("data certificate is only available in query calls");
@@ -193,6 +197,7 @@ pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
     });
 }
 
+/// System call to certify the root hash.
 fn update_root_hash(a: &AssetHashes) {
     let prefixed_root_hash = &labeled_hash(LABEL_ASSETS, &a.0.root_hash());
     ic_cdk::api::set_certified_data(&prefixed_root_hash[..]);

--- a/rs/sns_aggregator/src/conversion.rs
+++ b/rs/sns_aggregator/src/conversion.rs
@@ -1,3 +1,5 @@
+//! Methods for converting between types
+
 /// `ic_cdk` and `dfinity core` have different CanisterId types so we need to convert.  Genius.
 ///
 /// We use a macro rather than importing PrincipalId from the core types as the core types may differ between SNS canisters.

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -1,5 +1,6 @@
 //! Entry points for the caching canister.
 #![warn(missing_docs)]
+#![warn(clippy::missing_docs_in_private_items)]
 pub mod assets;
 mod conversion;
 mod state;
@@ -37,6 +38,17 @@ fn http_request(/* req: HttpRequest */) /* -> HttpResponse */
     call::reply((response,));
 }
 
+/// Function called when a canister is first created IF it is created
+/// with this code.
+///
+/// Note: If the canister os created with e.g. `dfx canister create`
+///       and then deployed normally, `init(..)` is never called.
+#[ic_cdk_macros::init]
+fn init() {
+    insert_favicon();
+}
+
+/// Function called before upgrade to a new wasm.
 #[ic_cdk_macros::post_upgrade]
 fn post_upgrade() {
     // Browsers complain if they don't get pretty pictures.  So do I.
@@ -49,9 +61,4 @@ fn post_upgrade() {
         Duration::from_secs(1),
         || ic_cdk::spawn(crate::upstream::update_cache()),
     );
-}
-
-#[ic_cdk_macros::init]
-fn init() {
-    insert_favicon();
 }

--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -1,3 +1,4 @@
+//! The state of the canister
 use crate::assets::{insert_asset, Asset};
 use crate::convert_canister_id;
 use crate::types::slow::logo_binary;
@@ -34,6 +35,13 @@ thread_local! {
 }
 
 impl State {
+    /// The maximum number of SNS included in a response.
+    ///
+    /// Pages are pre-computed to contain indices [0..PAGE_SIZE-1], [PAGE_SIZE..2*PAGE_SIZE-1] and so on.
+    ///
+    /// Also, the list of most recent SNSs is limited to the page size.
+    pub const PAGE_SIZE: u64 = 10;
+
     /// Adds an SNS into the state accessible via certfied query calls.
     pub fn insert_sns(index: u64, upstream_data: UpstreamData) -> Result<(), anyhow::Error> {
         Self::insert_sns_v1(index, upstream_data)
@@ -73,9 +81,8 @@ impl State {
             };
             insert_asset(path, asset);
         }
-        const PAGE_SIZE: u64 = 10;
         // If this is in the last N, update latest.
-        if upstream_data.index + PAGE_SIZE > STATE.with(|state| state.sns_aggregator.borrow().max_index) {
+        if upstream_data.index + State::PAGE_SIZE > STATE.with(|state| state.sns_aggregator.borrow().max_index) {
             let path = format!("{prefix}/sns/list/latest/slow.json");
             let json_data = STATE.with(|s| {
                 let slow_data: Vec<_> = s
@@ -84,7 +91,7 @@ impl State {
                     .upstream_data
                     .values()
                     .rev()
-                    .take(PAGE_SIZE as usize)
+                    .take(State::PAGE_SIZE as usize)
                     .map(SlowSnsData::from)
                     .collect();
                 serde_json::to_string(&slow_data).expect("Failed to serialise all SNSs")

--- a/rs/sns_aggregator/src/types.rs
+++ b/rs/sns_aggregator/src/types.rs
@@ -1,11 +1,17 @@
+//! Types used by the aggregator
+
+// Types generated from .did interface files
 pub mod ic_sns_governance;
 pub mod ic_sns_ledger;
 pub mod ic_sns_root;
 pub mod ic_sns_swap;
 pub mod ic_sns_wasm;
+
+// Other types
 pub mod slow;
 pub mod state;
 
+// Re-export commonly used types to ensure that different versions of the same type are not used.
 pub use ic_cdk::export::candid::{CandidType, Deserialize};
 pub use ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 pub use ic_sns_ledger::{Tokens as SnsTokens, Value as Icrc1Value};

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
-  #![allow(dead_code)]
+#![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 use ic_cdk::api::call::CallResult;

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
-  #![allow(dead_code)]
+#![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
-  #![allow(dead_code)]
+#![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
-  #![allow(dead_code)]
+#![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
-  #![allow(dead_code)]
+#![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -3,7 +3,7 @@ use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunc
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
 use crate::types::ic_sns_swap::{DerivedState, GetStateResponse, Init, Params, Swap};
 use crate::types::ic_sns_wasm::DeployedSns;
-use crate::types::upstream::UpstreamData;
+use crate::types::state::UpstreamData;
 use crate::Icrc1Value;
 use candid::CandidType;
 use candid::Nat;
@@ -80,9 +80,12 @@ pub fn logo_binary(data_url: &str) -> Vec<u8> {
     base64::decode(data_url.strip_prefix(LOGO_PREFIX).expect("Unsupported URL prefix")).unwrap_or_default()
 }
 
+/// Slowly changing information about an SNS canister's swap state.
 #[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SlowSwapState {
+    /// Slowly changing information extracted directly from an SNS canister.
     pub swap: Option<SlowSwap>,
+    /// Slowly changing information deduced about a swap state.
     pub derived: Option<SlowDerivedState>,
 }
 impl From<&GetStateResponse> for SlowSwapState {
@@ -94,6 +97,7 @@ impl From<&GetStateResponse> for SlowSwapState {
     }
 }
 
+/// Slow information about an SNS extracted from its swap canister.
 #[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SlowSwap {
     /// The current lifecycle of the swap.
@@ -119,8 +123,10 @@ impl From<&Swap> for SlowSwap {
     }
 }
 
+/// Slow informaton about an SNS extracted from its derived state.
 #[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq, serde::Serialize)]
 pub struct SlowDerivedState {
+    /// Current approximate total ICP committed to an SNS.
     pub buyer_total_icp_e8s: u64,
     /// Current approximate rate SNS tokens per ICP.
     pub sns_tokens_per_icp: f32,

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -1,8 +1,9 @@
+//! Slowly changing information about an SNS
 use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
 use crate::types::ic_sns_swap::{DerivedState, GetStateResponse, Init, Params, Swap};
 use crate::types::ic_sns_wasm::DeployedSns;
-use crate::types::state::UpstreamData;
+use crate::types::upstream::UpstreamData;
 use crate::Icrc1Value;
 use candid::CandidType;
 use candid::Nat;

--- a/rs/sns_aggregator/src/types/state.rs
+++ b/rs/sns_aggregator/src/types/state.rs
@@ -1,22 +1,24 @@
+//! Data types for storing upstream SNS data.
 use super::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use super::ic_sns_ledger::Value as Icrc1Value;
 use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::GetStateResponse;
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
-use ic_cdk::{api::management_canister::provisional::CanisterId, export::Principal};
+use ic_cdk::api::management_canister::provisional::CanisterId;
 use std::collections::BTreeMap;
 
 use candid::Nat;
 use serde::Serialize;
 
+/// Data retrieved from upstream and stored as is, without aggregation or processing.
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
 pub struct SnsCache {
-    // A list of SNSs that need to be populated in the cache.
+    /// A list of SNSs that need to be populated in the cache.
     pub sns_to_get: Vec<(SnsIndex, DeployedSns)>,
-    // Data obtained about each SNS
+    /// Data obtained about each SNS
     pub upstream_data: BTreeMap<CanisterId, UpstreamData>,
-    // Time of last partial update
+    /// Time of last partial update
     pub last_partial_update: u64,
     /// Time of last complete cycle
     pub last_update: u64,
@@ -24,11 +26,11 @@ pub struct SnsCache {
     pub max_index: u64,
 }
 
+/// The index of an SNS in the list provided by the nns-sns-wasm canister.
 pub type SnsIndex = u64;
 
 /// Information about an SNS that changes relatively slowly and that is common, i.e. not user specific.
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
-
 pub struct UpstreamData {
     /// Index of the SNS in the SNS wasms canister
     pub index: u64,
@@ -46,44 +48,4 @@ pub struct UpstreamData {
     pub icrc1_metadata: Vec<(String, Icrc1Value)>,
     /// The ledger fee, presumably a transaction fee.
     pub icrc1_fee: Nat,
-}
-
-// TODO: Derive from Candid
-#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
-pub struct CanisterStatusResultV2 {
-    status: CanisterStatusType,
-    module_hash: Option<Vec<u8>>,
-    controller: candid::Principal,
-    settings: DefiniteCanisterSettingsArgs,
-    memory_size: candid::Nat,
-    cycles: candid::Nat,
-    // this is for compat with Spec 0.12/0.13
-    balance: Vec<(Vec<u8>, candid::Nat)>,
-    freezing_threshold: candid::Nat,
-    idle_cycles_burned_per_day: candid::Nat,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, CandidType)]
-pub enum CanisterStatusType {
-    #[serde(rename = "running")]
-    Running,
-    #[serde(rename = "stopping")]
-    Stopping,
-    #[serde(rename = "stopped")]
-    Stopped,
-}
-
-// Struct used for encoding/decoding
-/// `(record {
-///     controller : principal;
-///     compute_allocation: nat;
-///     memory_allocation: opt nat;
-/// })`
-#[derive(Clone, CandidType, Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub struct DefiniteCanisterSettingsArgs {
-    controller: Principal,
-    controllers: Vec<Principal>,
-    compute_allocation: candid::Nat,
-    memory_allocation: candid::Nat,
-    freezing_threshold: candid::Nat,
 }

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -58,7 +58,9 @@ cd "$GIT_ROOT"
   cat <<-EOF
 	#![cfg_attr(rustfmt, rustfmt_skip)]
 	#![allow(clippy::all)]
+	#![allow(clippy::missing_docs_in_private_items)]
 	#![allow(non_camel_case_types)]
+	#![allow(dead_code)]
 
 	use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 	use ic_cdk::api::call::CallResult;


### PR DESCRIPTION
# Motivation
The aggregator code is largely uncommented.  The code is not stable but a lot of the comments can be filled in already.

# Changes
* Add a clippy for undocumented code.
* Exempt autogenerated code from the clippy.
* Document code
* Minor cleanup

# Tests
There is no change in functionality.  Tests are sorely needed, but not in this PR.