### PR TITLE
GIX-1187: List neurons per page

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -10,11 +10,15 @@
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
-
-  // Neurons are fetch on page load. No need to do it in the route.
+  import { onMount } from "svelte";
+  import { listNeurons } from "$lib/services/neurons.services";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
+
+  onMount(() => {
+    listNeurons();
+  });
 
   const goToNeuronDetails = async (id: NeuronId) =>
     await goto(

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -15,9 +15,15 @@
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
   import { authStore } from "$lib/stores/auth.store";
+  import { listNeurons } from "$lib/services/neurons.services";
+  import { isSignedIn } from "$lib/utils/auth.utils";
 
   export let proposalIdText: string | undefined | null = undefined;
   export let referrerPath: AppPath | undefined = undefined;
+
+  $: if (isSignedIn($authStore.identity)) {
+    listNeurons();
+  }
 
   const mapProposalId = (
     proposalIdText: string | undefined | null = undefined

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -24,10 +24,16 @@
     filteredProposals,
   } from "$lib/derived/proposals.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import { listNeurons } from "$lib/services/neurons.services";
+  import { isSignedIn } from "$lib/utils/auth.utils";
 
   export let referrerPath: AppPath | undefined = undefined;
   // It's exported so that we can test the value
   export let disableInfiniteScroll = false;
+
+  $: if (isSignedIn($authStore.identity)) {
+    listNeurons();
+  }
 
   let loading = false;
   let hidden = false;

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,10 +1,9 @@
 import { syncAccounts } from "./accounts.services";
-import { listNeurons } from "./neurons.services";
 
 export const initAppPrivateData = (): Promise<
   [PromiseSettledResult<void[]>]
 > => {
-  const initNns: Promise<void>[] = [syncAccounts(), listNeurons()];
+  const initNns: Promise<void>[] = [syncAccounts()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -249,15 +249,15 @@ export const listNeurons = async ({
     request: ({ certified, identity }) =>
       neuronsApiService.queryNeurons({ certified, identity }),
     onLoad: async ({ response: neurons, certified }) => {
-      // Skip if we already have certified neurons
-      // Otherwise we depend on the order of the responses
-      if (certifiedNeuronsSet) {
+      if (!certified && certifiedNeuronsSet) {
+        // Skip if we already have certified neurons
+        // Otherwise we depend on the order of the responses
         return;
       }
       if (certified) {
         certifiedNeuronsSet = true;
-        neuronsStore.setNeurons({ neurons, certified });
       }
+      neuronsStore.setNeurons({ neurons, certified });
 
       callback?.(certified);
     },

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -243,12 +243,21 @@ export const listNeurons = async ({
   callback?: (certified: boolean) => void;
   strategy?: QueryAndUpdateStrategy;
 } = {}): Promise<void> => {
+  let certifiedNeuronsSet = false;
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy,
     request: ({ certified, identity }) =>
       neuronsApiService.queryNeurons({ certified, identity }),
     onLoad: async ({ response: neurons, certified }) => {
-      neuronsStore.setNeurons({ neurons, certified });
+      // Skip if we already have certified neurons
+      // Otherwise we depend on the order of the responses
+      if (certifiedNeuronsSet) {
+        return;
+      }
+      if (certified) {
+        certifiedNeuronsSet = true;
+        neuronsStore.setNeurons({ neurons, certified });
+      }
 
       callback?.(certified);
     },

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -243,20 +243,11 @@ export const listNeurons = async ({
   callback?: (certified: boolean) => void;
   strategy?: QueryAndUpdateStrategy;
 } = {}): Promise<void> => {
-  let certifiedNeuronsSet = false;
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy,
     request: ({ certified, identity }) =>
       neuronsApiService.queryNeurons({ certified, identity }),
     onLoad: async ({ response: neurons, certified }) => {
-      if (!certified && certifiedNeuronsSet) {
-        // Skip if we already have certified neurons
-        // Otherwise we depend on the order of the responses
-        return;
-      }
-      if (certified) {
-        certifiedNeuronsSet = true;
-      }
       neuronsStore.setNeurons({ neurons, certified });
 
       callback?.(certified);

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -9,17 +9,20 @@ import * as authServices from "$lib/services/auth.services";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { NeuronState } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
-import { mockGetIdentity, mockIdentity } from "../../mocks/auth.store.mock";
+import { mockIdentity } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
 
 jest.mock("$lib/api/governance.api");
 
 describe("NnsNeurons", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    neuronsStore.reset();
+  });
+
   describe("with enough neurons", () => {
     beforeEach(() => {
-      jest.resetAllMocks();
-      neuronsStore.reset();
       resetNeuronsApiService();
       const mockNeuron2 = {
         ...mockNeuron,
@@ -36,7 +39,7 @@ describe("NnsNeurons", () => {
       };
       jest
         .spyOn(authServices, "getAuthenticatedIdentity")
-        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+        .mockResolvedValue(mockIdentity);
       jest
         .spyOn(api, "queryNeurons")
         .mockResolvedValue([mockNeuron, spawningNeuron, mockNeuron2]);
@@ -68,12 +71,10 @@ describe("NnsNeurons", () => {
 
   describe("no neurons", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      neuronsStore.reset();
       resetNeuronsApiService();
       jest
         .spyOn(authServices, "getAuthenticatedIdentity")
-        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+        .mockResolvedValue(mockIdentity);
       jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
@@ -88,11 +89,9 @@ describe("NnsNeurons", () => {
 
   describe("navigating", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      neuronsStore.reset();
       jest
         .spyOn(authServices, "getAuthenticatedIdentity")
-        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+        .mockResolvedValue(mockIdentity);
       jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -19,12 +19,12 @@ jest.mock("$lib/api/governance.api");
 describe("NnsNeurons", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    resetNeuronsApiService();
     neuronsStore.reset();
   });
 
   describe("with enough neurons", () => {
     beforeEach(() => {
-      resetNeuronsApiService();
       const mockNeuron2 = {
         ...mockNeuron,
         neuronId: BigInt(223),
@@ -72,7 +72,6 @@ describe("NnsNeurons", () => {
 
   describe("no neurons", () => {
     beforeEach(() => {
-      resetNeuronsApiService();
       jest
         .spyOn(authServices, "getAuthenticatedIdentity")
         .mockResolvedValue(mockIdentity);
@@ -97,7 +96,6 @@ describe("NnsNeurons", () => {
     });
 
     it("should call query neurons twice when rendered", async () => {
-      resetNeuronsApiService();
       render(NnsNeurons);
 
       await waitFor(() =>
@@ -113,7 +111,6 @@ describe("NnsNeurons", () => {
     });
 
     it("should NOT call query neurons after being visited", async () => {
-      resetNeuronsApiService();
       render(NnsNeurons);
 
       await waitFor(() =>

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -2,37 +2,25 @@
  * @jest-environment jsdom
  */
 
+import { resetNeuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as api from "$lib/api/governance.api";
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
-import { authStore } from "$lib/stores/auth.store";
+import * as authServices from "$lib/services/auth.services";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { NeuronState } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
-import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+import { mockGetIdentity, mockIdentity } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
-import {
-  buildMockNeuronsStoreSubscribe,
-  mockFullNeuron,
-  mockNeuron,
-} from "../../mocks/neurons.mock";
+import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
 
-jest.mock("$lib/services/neurons.services", () => {
-  return {
-    listNeurons: jest.fn().mockResolvedValue(undefined),
-  };
-});
+jest.mock("$lib/api/governance.api");
 
 describe("NnsNeurons", () => {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  let authStoreMock: jest.MockedFunction<any>;
-
-  beforeEach(() => {
-    authStoreMock = jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-  });
-
   describe("with enough neurons", () => {
     beforeEach(() => {
+      jest.resetAllMocks();
+      neuronsStore.reset();
+      resetNeuronsApiService();
       const mockNeuron2 = {
         ...mockNeuron,
         neuronId: BigInt(223),
@@ -40,38 +28,33 @@ describe("NnsNeurons", () => {
       const spawningNeuron = {
         ...mockNeuron,
         state: NeuronState.Spawning,
-        neuronId: BigInt(223),
+        neuronId: BigInt(224),
         fullNeuron: {
           ...mockFullNeuron,
           spawnAtTimesSeconds: BigInt(12312313),
         },
       };
       jest
-        .spyOn(neuronsStore, "subscribe")
-        .mockImplementation(
-          buildMockNeuronsStoreSubscribe([
-            mockNeuron,
-            mockNeuron2,
-            spawningNeuron,
-          ])
-        );
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+      jest
+        .spyOn(api, "queryNeurons")
+        .mockResolvedValue([mockNeuron, spawningNeuron, mockNeuron2]);
     });
 
-    afterEach(() => jest.resetAllMocks());
-
-    it("should render spawning neurons as disabled", () => {
+    it("should render spawning neurons as disabled", async () => {
       const { queryAllByTestId } = render(NnsNeurons);
 
+      // Wait for the neurons to be loaded and rendered
+      await waitFor(() => {
+        const neuronCards = queryAllByTestId("neuron-card");
+        return expect(neuronCards.length).toBe(3);
+      });
       const neuronCards = queryAllByTestId("neuron-card");
       const disabledCards = neuronCards.filter(
         (card) => card.getAttribute("aria-disabled") === "true"
       );
       expect(disabledCards.length).toBe(1);
-    });
-
-    it("should subscribe to store", () => {
-      render(NnsNeurons);
-      expect(authStoreMock).toHaveBeenCalled();
     });
 
     it("should render a NeuronCard", async () => {
@@ -84,16 +67,69 @@ describe("NnsNeurons", () => {
   });
 
   describe("no neurons", () => {
-    beforeAll(() => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      neuronsStore.reset();
+      resetNeuronsApiService();
       jest
-        .spyOn(neuronsStore, "subscribe")
-        .mockImplementation(buildMockNeuronsStoreSubscribe([]));
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+      jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
-    it("should render an empty message", () => {
+    it("should render an empty message", async () => {
       const { getByText } = render(NnsNeurons);
 
-      expect(getByText(en.neurons.text)).toBeInTheDocument();
+      await waitFor(() =>
+        expect(getByText(en.neurons.text)).toBeInTheDocument()
+      );
+    });
+  });
+
+  describe("navigating", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      neuronsStore.reset();
+      jest
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockImplementation(() => Promise.resolve(mockGetIdentity()));
+      jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
+    });
+
+    it("should call query neurons twice when rendered", async () => {
+      resetNeuronsApiService();
+      render(NnsNeurons);
+
+      await waitFor(() =>
+        expect(api.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
+      expect(api.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+    });
+
+    it("should NOT call query neurons after being visited", async () => {
+      resetNeuronsApiService();
+      render(NnsNeurons);
+
+      await waitFor(() =>
+        expect(api.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
+      expect(api.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+
+      render(NnsNeurons);
+
+      await waitFor(() => expect(api.queryNeurons).toHaveBeenCalledTimes(2));
     });
   });
 });

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -9,6 +9,7 @@ import * as authServices from "$lib/services/auth.services";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { NeuronState } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "../../mocks/neurons.mock";
@@ -127,6 +128,11 @@ describe("NnsNeurons", () => {
       });
 
       render(NnsNeurons);
+
+      // We wait to make sure there are no more calls
+      await tick();
+      await tick();
+      await tick();
 
       await waitFor(() => expect(api.queryNeurons).toHaveBeenCalledTimes(2));
     });

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import { resetNeuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as governanceApi from "$lib/api/governance.api";
 import ProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -22,6 +24,8 @@ import {
   mockProposals,
 } from "../../mocks/proposals.store.mock";
 import { silentConsoleErrors } from "../../utils/utils.test-utils";
+
+jest.mock("$lib/api/governance.api");
 
 describe("ProposalDetail", () => {
   jest
@@ -61,25 +65,58 @@ describe("ProposalDetail", () => {
     proposalIdText: `${mockProposals[0].id}`,
   };
 
-  it("should render proposal detail if not signed in", async () => {
-    authStoreMock.next({
-      identity: undefined,
+  describe.only("logged in user", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      resetNeuronsApiService();
+      authStoreMock.next({
+        identity: mockIdentity,
+      });
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
+    });
+    it("should render proposal detail if signed in", async () => {
+      const { queryByTestId } = render(ProposalDetail, props);
+      await waitFor(() =>
+        expect(queryByTestId("proposal-details-grid")).toBeInTheDocument()
+      );
     });
 
-    const { queryByTestId } = render(ProposalDetail, props);
-    await waitFor(() =>
-      expect(queryByTestId("proposal-details-grid")).toBeInTheDocument()
-    );
+    it("should query neurons", async () => {
+      render(ProposalDetail, props);
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
+      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+    });
   });
 
-  it("should render proposal detail if signed in", async () => {
-    authStoreMock.next({
-      identity: mockIdentity,
+  describe("logged out user", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      resetNeuronsApiService();
+      authStoreMock.next({
+        identity: undefined,
+      });
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
+    });
+    it("should render proposal detail if not signed in", async () => {
+      const { queryByTestId } = render(ProposalDetail, props);
+      await waitFor(() =>
+        expect(queryByTestId("proposal-details-grid")).toBeInTheDocument()
+      );
     });
 
-    const { queryByTestId } = render(ProposalDetail, props);
-    await waitFor(() =>
-      expect(queryByTestId("proposal-details-grid")).toBeInTheDocument()
-    );
+    it("should NOT query neurons", async () => {
+      render(ProposalDetail, props);
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).not.toHaveBeenCalled()
+      );
+    });
   });
 });

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -40,6 +40,10 @@ describe("ProposalDetail", () => {
   beforeAll(silentConsoleErrors);
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    resetNeuronsApiService();
+    jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
+
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -50,11 +54,9 @@ describe("ProposalDetail", () => {
 
     jest
       .spyOn(GovernanceCanister, "create")
-      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+      .mockReturnValue(mockGovernanceCanister);
 
-    jest
-      .spyOn(LedgerCanister, "create")
-      .mockImplementation((): LedgerCanister => mockLedgerCanister);
+    jest.spyOn(LedgerCanister, "create").mockReturnValue(mockLedgerCanister);
 
     jest
       .spyOn(neuronsStore, "subscribe")
@@ -65,14 +67,11 @@ describe("ProposalDetail", () => {
     proposalIdText: `${mockProposals[0].id}`,
   };
 
-  describe.only("logged in user", () => {
+  describe("logged in user", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      resetNeuronsApiService();
       authStoreMock.next({
         identity: mockIdentity,
       });
-      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
     });
     it("should render proposal detail if signed in", async () => {
       const { queryByTestId } = render(ProposalDetail, props);
@@ -98,12 +97,9 @@ describe("ProposalDetail", () => {
 
   describe("logged out user", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      resetNeuronsApiService();
       authStoreMock.next({
         identity: undefined,
       });
-      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
     });
     it("should render proposal detail if not signed in", async () => {
       const { queryByTestId } = render(ProposalDetail, props);

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import { resetNeuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as governanceApi from "$lib/api/governance.api";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { authStore, type AuthStore } from "$lib/stores/auth.store";
@@ -35,6 +37,8 @@ import {
   mockProposalsStoreSubscribe,
 } from "../../mocks/proposals.store.mock";
 
+jest.mock("$lib/api/governance.api");
+
 describe("NnsProposals", () => {
   const nothingFound = (
     container: HTMLElement
@@ -62,6 +66,35 @@ describe("NnsProposals", () => {
     });
 
     afterAll(() => jest.clearAllMocks());
+
+    describe("neurons", () => {
+      beforeEach(() => {
+        // TODO: Mock the canister call instead of the service
+        const mockGovernanceCanister: MockGovernanceCanister =
+          new MockGovernanceCanister([]);
+        jest
+          .spyOn(GovernanceCanister, "create")
+          .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+        jest.clearAllMocks();
+        neuronsStore.reset();
+        resetNeuronsApiService();
+        jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
+      });
+      it("should load neurons", async () => {
+        render(NnsProposals);
+
+        await waitFor(() =>
+          expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+            identity: mockIdentity,
+            certified: true,
+          })
+        );
+        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: false,
+        });
+      });
+    });
 
     describe("Matching results", () => {
       const mockGovernanceCanister: MockGovernanceCanister =
@@ -194,6 +227,28 @@ describe("NnsProposals", () => {
     });
 
     afterAll(() => jest.clearAllMocks());
+
+    describe("neurons", () => {
+      beforeEach(() => {
+        // TODO: Mock the canister call instead of the service
+        const mockGovernanceCanister: MockGovernanceCanister =
+          new MockGovernanceCanister([]);
+        jest
+          .spyOn(GovernanceCanister, "create")
+          .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+        jest.clearAllMocks();
+        neuronsStore.reset();
+        resetNeuronsApiService();
+        jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
+      });
+      it("should NOT load neurons", async () => {
+        render(NnsProposals);
+
+        await waitFor(() =>
+          expect(governanceApi.queryNeurons).not.toHaveBeenCalled()
+        );
+      });
+    });
 
     describe("Matching results", () => {
       const mockGovernanceCanister: MockGovernanceCanister =

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -235,7 +235,7 @@ describe("NnsProposals", () => {
           new MockGovernanceCanister([]);
         jest
           .spyOn(GovernanceCanister, "create")
-          .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+          .mockReturnValue(mockGovernanceCanister);
         jest.clearAllMocks();
         neuronsStore.reset();
         resetNeuronsApiService();

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -74,7 +74,7 @@ describe("NnsProposals", () => {
           new MockGovernanceCanister([]);
         jest
           .spyOn(GovernanceCanister, "create")
-          .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
+          .mockReturnValue(mockGovernanceCanister);
         jest.clearAllMocks();
         neuronsStore.reset();
         resetNeuronsApiService();

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -64,7 +64,7 @@ describe("NnsProposals", () => {
 
     describe("neurons", () => {
       beforeEach(() => {
-        // TODO: Mock the canister call instead of the service
+        // TODO: Mock the canister call instead of the canister itself
         const mockGovernanceCanister: MockGovernanceCanister =
           new MockGovernanceCanister([]);
         jest
@@ -223,7 +223,7 @@ describe("NnsProposals", () => {
 
     describe("neurons", () => {
       beforeEach(() => {
-        // TODO: Mock the canister call instead of the service
+        // TODO: Mock the canister call instead of the canister itself
         const mockGovernanceCanister: MockGovernanceCanister =
           new MockGovernanceCanister([]);
         jest

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -34,6 +34,8 @@ jest.mock("$lib/services/sns-parameters.services", () => {
   };
 });
 
+jest.mock("$lib/api/governance.api");
+
 describe("Neurons", () => {
   beforeAll(() =>
     jest

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -15,6 +15,8 @@ import {
   mockSnsFullProject,
 } from "../../mocks/sns-projects.mock";
 
+jest.mock("$lib/api/governance.api");
+
 describe("ProposalDetail", () => {
   beforeAll(() => {
     jest

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -40,6 +40,8 @@ jest.mock("$lib/services/$public/sns-proposals.services", () => {
   };
 });
 
+jest.mock("$lib/api/governance.api");
+
 describe("Proposals", () => {
   beforeAll(() =>
     jest

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -322,7 +322,6 @@ describe("neurons-services", () => {
 
     beforeEach(() => {
       resetNeuronsApiService();
-      jest.clearAllMocks();
     });
 
     it("should list neurons", async () => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -217,6 +217,7 @@ describe("neurons-services", () => {
     resetIdentity();
     resetAccountIdentity();
     toastsStore.reset();
+    resetNeuronsApiService();
   });
 
   describe("stake new neuron", () => {
@@ -320,10 +321,6 @@ describe("neurons-services", () => {
       .spyOn(api, "queryNeurons")
       .mockResolvedValue(neurons);
 
-    beforeEach(() => {
-      resetNeuronsApiService();
-    });
-
     it("should list neurons", async () => {
       const oldNeuronsList = get(definedNeuronsStore);
       expect(oldNeuronsList).toEqual([]);
@@ -348,6 +345,8 @@ describe("neurons-services", () => {
         identity: mockIdentity,
         certified: false,
       });
+
+      expect(spyQueryNeurons).toHaveBeenCalledTimes(2);
 
       await listNeurons();
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -337,19 +337,6 @@ describe("neurons-services", () => {
       expect(newNeuronsList).toEqual(neurons);
     });
 
-    it("should not set uncertified if the response come after certified", async () => {
-      const oldData = get(neuronsStore);
-      expect(oldData.neurons).toBeUndefined();
-
-      await listNeurons();
-
-      expect(spyQueryNeurons).toHaveBeenCalled();
-
-      const newNeurons = get(neuronsStore);
-      expect(newNeurons.neurons).toEqual(neurons);
-      expect(newNeurons.certified).toEqual(true);
-    });
-
     it("should not call api when called twice and cache is not reset", async () => {
       await listNeurons();
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -318,7 +318,7 @@ describe("neurons-services", () => {
   describe("list neurons", () => {
     const spyQueryNeurons = jest
       .spyOn(api, "queryNeurons")
-      .mockImplementation(() => Promise.resolve(neurons));
+      .mockResolvedValue(neurons);
 
     beforeEach(() => {
       resetNeuronsApiService();

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import { resetNeuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as governanceApi from "$lib/api/governance.api";
 import { queryProposal } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
@@ -20,6 +22,8 @@ import {
 } from "../mocks/auth.store.mock";
 import { mockNeuron } from "../mocks/neurons.mock";
 import { mockProposalInfo } from "../mocks/proposal.mock";
+
+jest.mock("$lib/api/governance.api");
 
 const proposal = {
   ...mockProposalInfo,
@@ -55,22 +59,29 @@ describe("Proposal detail page when not logged in user", () => {
 
   describe("when logged in user", () => {
     beforeEach(() => {
+      jest.clearAllMocks();
+      neuronsStore.reset();
+      resetNeuronsApiService();
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([mockNeuron]);
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
     });
 
-    it("should render proposal with certified data", async () => {
-      neuronsStore.setNeurons({
-        neurons: [mockNeuron],
-        certified: true,
-      });
+    it.only("should render proposal with certified data", async () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       const { queryByTestId } = render(NnsProposalDetail, {
         props: {
           proposalIdText: proposal.id.toString(),
         },
       });
+
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
 
       await waitFor(() => expect(queryProposal).toHaveBeenCalledTimes(2));
 
@@ -80,7 +91,9 @@ describe("Proposal detail page when not logged in user", () => {
         ).toBeInTheDocument()
       );
       expect(queryByTestId("proposal-system-info-details")).toBeInTheDocument();
-      expect(queryByTestId("voting-confirmation-toolbar")).toBeInTheDocument();
+      await waitFor(() =>
+        expect(queryByTestId("voting-confirmation-toolbar")).toBeInTheDocument()
+      );
       expect(queryByTestId("login-button")).not.toBeInTheDocument();
 
       expect(queryProposal).toHaveBeenCalledWith({
@@ -94,10 +107,31 @@ describe("Proposal detail page when not logged in user", () => {
         identity: mockIdentity,
       });
     });
+
+    it("should query neurons", async () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      render(NnsProposalDetail, {
+        props: {
+          proposalIdText: proposal.id.toString(),
+        },
+      });
+
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
+      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+    });
   });
 
   describe("when not logged in user", () => {
     beforeEach(() => {
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreNoIdentitySubscribe);
@@ -128,6 +162,19 @@ describe("Proposal detail page when not logged in user", () => {
         certified: false,
         identity: new AnonymousIdentity(),
       });
+    });
+
+    it("should NOT query neurons", async () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      render(NnsProposalDetail, {
+        props: {
+          proposalIdText: proposal.id.toString(),
+        },
+      });
+
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).not.toHaveBeenCalled()
+      );
     });
   });
 });

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -2,11 +2,14 @@
  * @jest-environment jsdom
  */
 
+import { resetNeuronsApiService } from "$lib/api-services/neurons.api-service";
+import * as governanceApi from "$lib/api/governance.api";
 import { queryProposals } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import NnsProposals from "$lib/pages/NnsProposals.svelte";
 import { authStore, type AuthStore } from "$lib/stores/auth.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { waitFor } from "@testing-library/dom";
@@ -30,6 +33,8 @@ jest.mock("$lib/api/proposals.api", () => {
   };
 });
 
+jest.mock("$lib/api/governance.api");
+
 describe("NnsProposals", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -37,12 +42,15 @@ describe("NnsProposals", () => {
 
   describe("when signed in user", () => {
     beforeEach(() => {
+      neuronsStore.reset();
+      resetNeuronsApiService();
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
     });
 
-    it("should list uncertified proposals", async () => {
+    it("should list proposals certified and uncertified", async () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       const { queryAllByTestId } = render(NnsProposals);
 
@@ -64,6 +72,22 @@ describe("NnsProposals", () => {
         identity: mockIdentity,
       });
     });
+
+    it("should query neurons", async () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      render(NnsProposals);
+
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          certified: true,
+        })
+      );
+      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+    });
   });
 
   describe("when not signed in user", () => {
@@ -75,6 +99,7 @@ describe("NnsProposals", () => {
 
           return () => undefined;
         });
+      jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
     });
 
     it("should list uncertified proposals", async () => {
@@ -92,6 +117,15 @@ describe("NnsProposals", () => {
         filters: DEFAULT_PROPOSALS_FILTERS,
         identity: new AnonymousIdentity(),
       });
+    });
+
+    it("should NOT query neurons", async () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      render(NnsProposals);
+
+      await waitFor(() =>
+        expect(governanceApi.queryNeurons).not.toHaveBeenCalled()
+      );
     });
   });
 });

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -38,12 +38,12 @@ jest.mock("$lib/api/governance.api");
 describe("NnsProposals", () => {
   afterEach(() => {
     jest.clearAllMocks();
+    neuronsStore.reset();
+    resetNeuronsApiService();
   });
 
   describe("when signed in user", () => {
     beforeEach(() => {
-      neuronsStore.reset();
-      resetNeuronsApiService();
       jest.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
       jest
         .spyOn(authStore, "subscribe")


### PR DESCRIPTION
# Motivation

Reduce number of update calls.

Do not load neurons unless they will be used. To accomplish that, we load the neurons in the pages they are needed.

# Changes

* Remove `listNeurons` from `app.services.ts`.
* Add `listNeurons` call in NnsNeurons.svelte.
* Add `listNeurons` call in NnsProposals.svelte if user is signed in.
* Add `listNeurons` call in NnsProposalDetail.svelte if user is signed in.

Minor change:
* `listNeurons` relied on the order of the responses to set the neurons. I changed that.

# Tests

* Test new functionality in the page tests.
* Mock import in the routes tests.
* Test new functionality in the workflows NnsProposalDetail and NnsProposals.
* Test change in `listNeurons` service.
