### PR TITLE
Minimal landing page for the sns aggregator

### DIFF
--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -268,3 +268,17 @@ pub fn insert_favicon() {
         }
     });
 }
+
+/// Insert a home page into the certified assets.
+pub fn insert_home_page() {
+    STATE.with(|state| {
+        let path = "/index.html";
+        if state.stable.borrow().assets.borrow().get(path).is_none() {
+            let asset = Asset {
+                headers: Vec::new(),
+                bytes: include_bytes!("index.html").to_vec(),
+            };
+            insert_asset(path, asset);
+        }
+    });
+}

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>title</title>
+    <title>SNS aggregator</title>
   </head>
   <body>
 	  <h1>SNS aggregator</h1>

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+  </head>
+  <body>
+	  <h1>SNS aggregator</h1>
+	  <p>The aggregator collects information on all deployed SNS and re-publishes aggegate values as certified query calls.  This data is intended for use by any canister that wishes to provide dashboards.  The data will typically be updated about once per minute.  Collecting the data from this aggregator will typically be much faster than collecting the same data directly from the SNSs.</p>
+	  <ul>
+		  <li><a href="/v1/sns/list/latest/slow.json">The latest SNSs</li>
+	  </ul>
+  </body>
+</html>

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -12,7 +12,7 @@ mod tests;
 
 use std::time::Duration;
 
-use assets::{insert_favicon, AssetHashes, HttpRequest, HttpResponse};
+use assets::{insert_favicon, AssetHashes, HttpRequest, HttpResponse, insert_home_page};
 use candid::{candid_method, export_service};
 use ic_cdk::api::call::{self};
 use ic_cdk::timer::set_timer_interval;
@@ -156,6 +156,7 @@ fn setup(config: Option<Config>) {
     }
     // Browsers complain if they don't get pretty pictures.  So do I.
     insert_favicon();
+    insert_home_page();
 
     // Schedules data collection from the SNSs.
     //

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -12,7 +12,7 @@ mod tests;
 
 use std::time::Duration;
 
-use assets::{insert_favicon, AssetHashes, HttpRequest, HttpResponse, insert_home_page};
+use assets::{insert_favicon, insert_home_page, AssetHashes, HttpRequest, HttpResponse};
 use candid::{candid_method, export_service};
 use ic_cdk::api::call::{self};
 use ic_cdk::timer::set_timer_interval;


### PR DESCRIPTION
# Motivation
It would be useful for the sns aggregator to have a home page with basic health check information.

This PR adds a home page with nothing but a description and a link to the latest SNS info.  To be expanded and made pretty but as a question of priority, more data and pretty can come later.

# Changes
* Add an index.html

# Tests
* You can see it live here: https://s55qq-oqaaa-aaaaa-aaakq-cai.benchmarklarge.dfinity.network/ (note that the canister is being redeployed frequently so the link in the page will often show nothing.
![Screenshot from 2023-02-09 14-06-16](https://user-images.githubusercontent.com/5982633/217887069-e9cbfde4-41d4-482e-bb69-05dc4f996f51.png)
Clicking the link goes to the JSON for the latest SNSs
![Screenshot from 2023-02-09 18-10-32](https://user-images.githubusercontent.com/5982633/217887387-9f8c0c43-08f0-4a62-9dc0-bdd4cbfe1efb.png)
