### PR TITLE
Handle missing logo

### DIFF
--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -105,7 +105,7 @@ impl State {
             let path = format!("{prefix}/sns/root/{root_canister_str}/logo.{LOGO_FMT}");
             let asset = Asset {
                 headers: Vec::new(),
-                bytes: logo_binary(upstream_data.meta.logo.as_ref().map(|s| s.as_str()).unwrap_or("")),
+                bytes: logo_binary(upstream_data.meta.logo.as_deref().unwrap_or("")),
             };
             insert_asset(path, asset);
         }

--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -105,7 +105,7 @@ impl State {
             let path = format!("{prefix}/sns/root/{root_canister_str}/logo.{LOGO_FMT}");
             let asset = Asset {
                 headers: Vec::new(),
-                bytes: logo_binary(upstream_data.meta.logo.as_ref().expect("Missing logo")),
+                bytes: logo_binary(upstream_data.meta.logo.as_ref().map(|s| s.as_str()).unwrap_or("")),
             };
             insert_asset(path, asset);
         }


### PR DESCRIPTION
# Motivation
The sns aggregator provides a logo URL for every SNS.  This can be used directly in HTML without a custom API call.  The code that generates this URL does not, however, handle the case where the logo is not provided.

# Changes
- If the logo is not provided, provide an empty file.  Note: It can be debated whether we should return a 404, an empty file or some default image.  The priority now is to make the canister not break.  _maybe_ the 404 is the better option, as it allows fallback images, although it will print error messages in the console and red error messages shout "page is broken" which isn't nice either.  Maybe certify a pretty HTML message explaining that the SNS has no logo along with the 404 so that there are no error messages in the console and users have a good experience.  Once we have agreed, this would be a good follow-up task.  It is not a trivial matter of just changing the default text so would better be done in a separate PR.

# Tests
* See here for an SNS that has no logo but that has been scraped successfully: https://s55qq-oqaaa-aaaaa-aaakq-cai.benchmarklarge.dfinity.network/v1/sns/list/latest/slow.json
![Screenshot from 2023-02-09 18-10-32](https://user-images.githubusercontent.com/5982633/217887387-9f8c0c43-08f0-4a62-9dc0-bdd4cbfe1efb.png)

