### PR TITLE
Bump snsdemo

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -51,8 +51,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Feb 2 2023, includes a placeholder for the sns_aggregator canister ID.
-          ref: '4bb32a400cf672950616d82a0fcfc37f79b9d3e4'
+          # Version from Thu Fep 9 with dfx 0.13.xxx
+          ref: 'd2e132dcd11cbc4b54ecc1f10d0dc9e67cb61da7'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -52,7 +52,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Thu Fep 9 with dfx 0.13.xxx
-          ref: 'd2e132dcd11cbc4b54ecc1f10d0dc9e67cb61da7'
+          ref: '60a7369b864f72f1d0103462c8e979d1976ab109'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,17 +61,14 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Mon Jan 16 10:10:47
-          ref: 'e1d7dd4c10fb8a731a534ae2ef4b08474fea5f6b'
+          # Version from Thu Feb 9 with dfx version 0.13.xxx
+          ref: 'd2e132dcd11cbc4b54ecc1f10d0dc9e67cb61da7'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
-      - name: Update dfx
-        run: |
-          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
       - name: Deploy NNS and SNS canisters
         run: |
           # Note: This deploys standard NNS canisters but with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
+      - name: Update dfx
+        run: |
+          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
       - name: Deploy NNS and SNS canisters
         run: |
           # Note: This deploys standard NNS canisters but with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Thu Feb 9 with dfx version 0.13.xxx
-          ref: 'd2e132dcd11cbc4b54ecc1f10d0dc9e67cb61da7'
+          ref: '60a7369b864f72f1d0103462c8e979d1976ab109'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.12.1",
+  "dfx": "0.13.0-downgrade.1",
   "canisters": {
     "nns-governance": {
       "type": "custom",


### PR DESCRIPTION
# Motivation
Update the version of snsdemo to one that uses dfx v13.

To be used together with https://github.com/dfinity/nns-dapp/pull/1844 but without the version jumping.

# Changes
- Bump the version of dfx as recommended by @mraszyk 
- Bump the version of snsdemo to one using the same dfx.

# Tests
See CI