### PR TITLE
Fix: Dissolve delay msg sns neuron & Project detail fix

### DIFF
--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -84,7 +84,7 @@
   minDelayInSeconds={Number(neuronDissolveDelaySeconds)}
   maxDelayInSeconds={maxSnsDelayInSeconds}
   {calculateVotingPower}
-  minDissolveDelayDescription={$i18n.neurons.dissolve_delay_description}
+  {minDissolveDelayDescription}
 >
   <Hash
     slot="neuron-id"

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -22,6 +22,10 @@
   import { debugSelectedProjectStore } from "$lib/derived/debug.derived";
   import { goto } from "$app/navigation";
 
+  export let rootCanisterId: string | undefined | null;
+
+  $: rootCanisterId, reload();
+
   const loadSummary = (rootCanisterId: string) =>
     loadSnsSummary({
       rootCanisterId,
@@ -101,8 +105,6 @@
           )?.swapCommitment
         : undefined;
   };
-
-  export let rootCanisterId: string | undefined | null;
 
   /**
    * We load all the sns summaries and swap commitments on the global scale of the app. That's why we subscribe to these stores - i.e. each times they change, we can try to find the current root canister id within these data.

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -54,16 +54,16 @@ describe("ProjectDetail", () => {
       rootCanisterId: mockSnsFullProject.rootCanisterId.toText(),
     };
 
-    it("should load summary", () => {
+    it("should load summary", async () => {
       render(ProjectDetail, props);
 
-      waitFor(() => expect(loadSnsSummary).toBeCalled());
+      await waitFor(() => expect(loadSnsSummary).toBeCalled());
     });
 
-    it("should load swap state", () => {
+    it("should load swap state", async () => {
       render(ProjectDetail, props);
 
-      waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
+      await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
     });
 
     it("should render info section", async () => {


### PR DESCRIPTION
# Motivation

Two small bugs:
* Dissolve delay message for sns neurons.
* loadSnsSummary and loadSnsSwapCommitment were not called when user accessed ProjectDetail.

# Changes

* Use minDissolveDelayDescription in SetSnsDissolveDelay.svelte
* Reload data in ProjectDetail when rootCanister changes. Loaded also when the user enters here.

# Tests

* Fix broken test in ProjectDetail
