### PR TITLE
Chore: remove loadMainTransactionFee

### DIFF
--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,15 +1,10 @@
-import { loadMainTransactionFee } from "$lib/services/transaction-fees.services";
 import { syncAccounts } from "./accounts.services";
 import { listNeurons } from "./neurons.services";
 
 export const initAppPrivateData = (): Promise<
   [PromiseSettledResult<void[]>]
 > => {
-  const initNns: Promise<void>[] = [
-    syncAccounts(),
-    listNeurons(),
-    loadMainTransactionFee(),
-  ];
+  const initNns: Promise<void>[] = [syncAccounts(), listNeurons()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -1,23 +1,9 @@
-import { transactionFee as nnsTransactionFee } from "$lib/api/ledger.api";
 import { transactionFee as snsTransactionFee } from "$lib/api/sns-ledger.api";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Principal } from "@dfinity/principal/lib/cjs";
 import { get } from "svelte/store";
-import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
-
-export const loadMainTransactionFee = async () => {
-  try {
-    const identity = await getAuthenticatedIdentity();
-    const fee = await nnsTransactionFee({ identity });
-    transactionsFeesStore.setMain(fee);
-  } catch (error: unknown) {
-    // Swallow error and continue with the DEFAULT_TRANSACTION_FEE value
-    console.error("Error getting the transaction fee from the ledger");
-    console.error(error);
-  }
-};
 
 export const loadSnsTransactionFee = async ({
   rootCanisterId,

--- a/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -1,58 +1,11 @@
-import * as api from "$lib/api/ledger.api";
 import * as snsApi from "$lib/api/sns-ledger.api";
-import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
-import {
-  loadMainTransactionFee,
-  loadSnsTransactionFee,
-} from "$lib/services/transaction-fees.services";
-import {
-  mainTransactionFeeStore,
-  transactionsFeesStore,
-} from "$lib/stores/transaction-fees.store";
+import { loadSnsTransactionFee } from "$lib/services/transaction-fees.services";
+import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { get } from "svelte/store";
-import {
-  mockPrincipal,
-  resetIdentity,
-  setNoIdentity,
-} from "../../mocks/auth.store.mock";
+import { mockPrincipal } from "../../mocks/auth.store.mock";
 
 describe("transactionFee-services", () => {
   const fee = BigInt(30_000);
-
-  describe("loadMainTransactionFee", () => {
-    let spyTranactionFeeApi;
-    beforeEach(() => {
-      spyTranactionFeeApi = jest
-        .spyOn(api, "transactionFee")
-        .mockResolvedValue(fee);
-      // Avoid to print errors during test
-      jest.spyOn(console, "error").mockImplementation(() => undefined);
-    });
-
-    afterEach(() =>
-      transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
-    );
-
-    it("set transaction fee to the ledger canister value", async () => {
-      await loadMainTransactionFee();
-
-      expect(spyTranactionFeeApi).toHaveBeenCalled();
-
-      const storeFee = get(mainTransactionFeeStore);
-      expect(storeFee).toEqual(Number(fee));
-    });
-
-    it("should not set new fee if no identity", async () => {
-      setNoIdentity();
-
-      await loadMainTransactionFee();
-
-      const storeFee = get(mainTransactionFeeStore);
-      expect(storeFee).toEqual(DEFAULT_TRANSACTION_FEE_E8S);
-
-      resetIdentity();
-    });
-  });
 
   describe("loadSnsTransactionFee", () => {
     describe("success", () => {


### PR DESCRIPTION
# Motivation

Reduce number of update calls.

In this instance, the ICP transaction fee call.

# Changes

* Remove `loadMainTransactionFee` call from app.services.ts
* Remove service `loadMainTransactionFee`.

# Tests

* Remove test for service `loadMainTransactionFee`.
