### PR TITLE
Chore: Load commitment for logged in Project Detail

### DIFF
--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -21,10 +21,15 @@
   import { toastsError } from "$lib/stores/toasts.store";
   import { debugSelectedProjectStore } from "$lib/derived/debug.derived";
   import { goto } from "$app/navigation";
+  import { nonNullish } from "$lib/utils/utils";
+  import { isSignedIn } from "$lib/utils/auth.utils";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let rootCanisterId: string | undefined | null;
 
-  $: rootCanisterId, reload();
+  $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
+    loadCommitment(rootCanisterId);
+  }
 
   const loadSummary = (rootCanisterId: string) =>
     loadSnsSummary({
@@ -36,7 +41,7 @@
       },
     });
 
-  const loadSwapState = (rootCanisterId: string) =>
+  const loadCommitment = (rootCanisterId: string) =>
     loadSnsSwapCommitment({
       rootCanisterId,
       onError: () => {
@@ -54,7 +59,7 @@
 
     await Promise.all([
       loadSummary(rootCanisterId),
-      loadSwapState(rootCanisterId),
+      loadCommitment(rootCanisterId),
     ]);
   };
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -9,12 +9,14 @@ import {
   loadSnsSummary,
   loadSnsSwapCommitment,
 } from "$lib/services/sns.services";
+import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { page } from "$mocks/$app/stores";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
+import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { mockSnsFullProject } from "../../mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
@@ -26,6 +28,10 @@ jest.mock("$lib/services/sns.services", () => {
 });
 
 describe("ProjectDetail", () => {
+  const props = {
+    rootCanisterId: mockSnsFullProject.rootCanisterId.toText(),
+  };
+
   describe("present project in store", () => {
     page.mock({ data: { universe: null } });
 
@@ -50,20 +56,16 @@ describe("ProjectDetail", () => {
       jest.clearAllMocks();
     });
 
-    const props = {
-      rootCanisterId: mockSnsFullProject.rootCanisterId.toText(),
-    };
-
-    it("should load summary", async () => {
+    it("should not load summary", async () => {
       render(ProjectDetail, props);
 
-      await waitFor(() => expect(loadSnsSummary).toBeCalled());
+      await waitFor(() => expect(loadSnsSummary).not.toBeCalled());
     });
 
-    it("should load swap state", async () => {
+    it("should not load user's commitnemtn", async () => {
       render(ProjectDetail, props);
 
-      await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
+      await waitFor(() => expect(loadSnsSwapCommitment).not.toBeCalled());
     });
 
     it("should render info section", async () => {
@@ -80,6 +82,20 @@ describe("ProjectDetail", () => {
       await waitFor(() =>
         expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument()
       );
+    });
+  });
+
+  describe("logged in user", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreSubscribe);
+    });
+
+    it("should load user's commitment", async () => {
+      render(ProjectDetail, props);
+
+      await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
     });
   });
 


### PR DESCRIPTION
# Motivation

Reduce number of update calls.

In the Project Detail page, the project summary doesn't need to be loaded. But the commitment yes, only for logged in users.

# Changes

* Call `loadCommitment` in ProjectDetail.svelte only for logged in users.
* Rename `loadSwapState` to `loadCommitment` in ProjectDetail.svelte helper.

# Tests

* Add test for the new case.
