### PR TITLE
Kloet/multi part

### DIFF
--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -64,17 +64,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const CanisterId = IDL.Principal;
   const NeuronId = IDL.Nat64;
-  const MultiPartTransactionStatus = IDL.Variant({
-    Queued: IDL.Null,
-    Error: IDL.Text,
-    Refunded: IDL.Tuple(BlockHeight, IDL.Text),
-    CanisterCreated: CanisterId,
-    Complete: IDL.Null,
-    NotFound: IDL.Null,
-    NeuronCreated: NeuronId,
-    PendingSync: IDL.Null,
-    ErrorWithRefundPending: IDL.Text,
-  });
   const GetProposalPayloadResponse = IDL.Variant({
     Ok: IDL.Text,
     Err: IDL.Text,
@@ -196,11 +185,6 @@ export const idlFactory = ({ IDL }) => {
     get_multi_part_transaction_errors: IDL.Func(
       [],
       [IDL.Vec(MultiPartTransactionError)],
-      []
-    ),
-    get_multi_part_transaction_status: IDL.Func(
-      [IDL.Principal, BlockHeight],
-      [MultiPartTransactionStatus],
       []
     ),
     get_proposal_payload: IDL.Func(

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -185,25 +185,6 @@ type GetProposalPayloadResponse =
         Err: text;
     };
 
-type MultiPartTransactionStatus =
-    variant {
-        NeuronCreated: NeuronId;
-        CanisterCreated: CanisterId;
-        Complete;
-        Refunded: record { BlockHeight; text; };
-        Error: text;
-        ErrorWithRefundPending: text;
-        NotFound;
-        PendingSync;
-        Queued;
-    };
-
-type MultiPartTransactionError =
-    record {
-        block_height: BlockHeight;
-        error_message: text;
-    };
-
 type Stats =
     record {
         accounts_count: nat64;
@@ -252,8 +233,6 @@ service : {
     attach_canister: (AttachCanisterRequest) -> (AttachCanisterResponse);
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
-    get_multi_part_transaction_status: (principal, BlockHeight) -> (MultiPartTransactionStatus) query;
-    get_multi_part_transaction_errors: () -> (vec MultiPartTransactionError) query;
     get_stats: () -> (Stats) query;
     add_pending_notify_swap: (AddPendingNotifySwapRequest) -> (AddPendingTransactionResponse);
 

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -64,17 +64,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const CanisterId = IDL.Principal;
   const NeuronId = IDL.Nat64;
-  const MultiPartTransactionStatus = IDL.Variant({
-    Queued: IDL.Null,
-    Error: IDL.Text,
-    Refunded: IDL.Tuple(BlockHeight, IDL.Text),
-    CanisterCreated: CanisterId,
-    Complete: IDL.Null,
-    NotFound: IDL.Null,
-    NeuronCreated: NeuronId,
-    PendingSync: IDL.Null,
-    ErrorWithRefundPending: IDL.Text,
-  });
   const GetProposalPayloadResponse = IDL.Variant({
     Ok: IDL.Text,
     Err: IDL.Text,
@@ -196,11 +185,6 @@ export const idlFactory = ({ IDL }) => {
     get_multi_part_transaction_errors: IDL.Func(
       [],
       [IDL.Vec(MultiPartTransactionError)],
-      ["query"]
-    ),
-    get_multi_part_transaction_status: IDL.Func(
-      [IDL.Principal, BlockHeight],
-      [MultiPartTransactionStatus],
       ["query"]
     ),
     get_proposal_payload: IDL.Func(

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -78,16 +78,6 @@ export interface MultiPartTransactionError {
   error_message: string;
   block_height: BlockHeight;
 }
-export type MultiPartTransactionStatus =
-  | { Queued: null }
-  | { Error: string }
-  | { Refunded: [BlockHeight, string] }
-  | { CanisterCreated: CanisterId }
-  | { Complete: null }
-  | { NotFound: null }
-  | { NeuronCreated: NeuronId }
-  | { PendingSync: null }
-  | { ErrorWithRefundPending: string };
 export interface Receive {
   fee: ICPTs;
   from: AccountIdentifierString;
@@ -183,10 +173,6 @@ export default interface _SERVICE {
   get_multi_part_transaction_errors: () => Promise<
     Array<MultiPartTransactionError>
   >;
-  get_multi_part_transaction_status: (
-    arg_0: Principal,
-    arg_1: BlockHeight
-  ) => Promise<MultiPartTransactionStatus>;
   get_proposal_payload: (arg_0: bigint) => Promise<GetProposalPayloadResponse>;
   get_stats: () => Promise<Stats>;
   get_transactions: (

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -184,25 +184,6 @@ type GetProposalPayloadResponse =
         Err: text;
     };
 
-type MultiPartTransactionStatus =
-    variant {
-        NeuronCreated: NeuronId;
-        CanisterCreated: CanisterId;
-        Complete;
-        Refunded: record { BlockHeight; text; };
-        Error: text;
-        ErrorWithRefundPending: text;
-        NotFound;
-        PendingSync;
-        Queued;
-    };
-
-type MultiPartTransactionError =
-    record {
-        block_height: BlockHeight;
-        error_message: text;
-    };
-
 type Stats =
     record {
         accounts_count: nat64;
@@ -251,8 +232,6 @@ service : {
     attach_canister: (AttachCanisterRequest) -> (AttachCanisterResponse);
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
-    get_multi_part_transaction_status: (principal, BlockHeight) -> (MultiPartTransactionStatus) query;
-    get_multi_part_transaction_errors: () -> (vec MultiPartTransactionError) query;
     get_stats: () -> (Stats) query;
     add_pending_notify_swap: (AddPendingNotifySwapRequest) -> (AddPendingTransactionResponse);
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -769,7 +769,6 @@ impl AccountsStore {
     pub fn attach_newly_created_canister(
         &mut self,
         principal: PrincipalId,
-        block_height: BlockIndex,
         canister_id: CanisterId,
     ) {
         let account_identifier = AccountIdentifier::from(principal).to_vec();
@@ -781,8 +780,6 @@ impl AccountsStore {
                 canister_id,
             });
             sort_canisters(&mut account.canisters);
-            self.multi_part_transactions_processor
-                .update_status(block_height, MultiPartTransactionStatus::CanisterCreated(canister_id));
         }
     }
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -790,18 +790,6 @@ impl AccountsStore {
         );
     }
 
-    pub fn process_transaction_refund_completed(
-        &mut self,
-        original_transaction_block_height: BlockIndex,
-        refund_block_height: BlockIndex,
-        error_message: String,
-    ) {
-        self.multi_part_transactions_processor.update_status(
-            original_transaction_block_height,
-            MultiPartTransactionStatus::Refunded(refund_block_height, error_message),
-        );
-    }
-
     pub fn process_multi_part_transaction_error(
         &mut self,
         block_height: BlockIndex,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -819,11 +819,6 @@ impl AccountsStore {
         self.neurons_topped_up_count += 1;
     }
 
-    pub fn mark_canister_topped_up(&mut self, original_transaction_block_height: BlockIndex) {
-        self.multi_part_transactions_processor
-            .update_status(original_transaction_block_height, MultiPartTransactionStatus::Complete);
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     pub fn get_transactions_count(&self) -> u32 {
         self.transactions.len() as u32

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1,7 +1,7 @@
 use crate::constants::{MEMO_CREATE_CANISTER, MEMO_TOP_UP_CANISTER};
 use crate::metrics_encoder::MetricsEncoder;
 use crate::multi_part_transactions_processor::{
-    MultiPartTransactionStatus, MultiPartTransactionToBeProcessed,
+    MultiPartTransactionToBeProcessed,
     MultiPartTransactionsProcessor,
 };
 use crate::state::StableState;

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1,7 +1,7 @@
 use crate::constants::{MEMO_CREATE_CANISTER, MEMO_TOP_UP_CANISTER};
 use crate::metrics_encoder::MetricsEncoder;
 use crate::multi_part_transactions_processor::{
-    MultiPartTransactionError, MultiPartTransactionStatus, MultiPartTransactionToBeProcessed,
+    MultiPartTransactionStatus, MultiPartTransactionToBeProcessed,
     MultiPartTransactionsProcessor,
 };
 use crate::state::StableState;
@@ -835,22 +835,6 @@ impl AccountsStore {
 
     pub fn get_block_height_synced_up_to(&self) -> Option<BlockIndex> {
         self.block_height_synced_up_to
-    }
-
-    pub fn get_multi_part_transaction_status(
-        &self,
-        caller: PrincipalId,
-        block_height: BlockIndex,
-    ) -> MultiPartTransactionStatus {
-        if self.get_block_height_synced_up_to().unwrap_or(0) < block_height {
-            MultiPartTransactionStatus::PendingSync
-        } else {
-            self.multi_part_transactions_processor.get_status(caller, block_height)
-        }
-    }
-
-    pub fn get_multi_part_transaction_errors(&self) -> Vec<MultiPartTransactionError> {
-        self.multi_part_transactions_processor.get_errors()
     }
 
     pub fn try_take_next_transaction_to_process(&mut self) -> Option<(BlockIndex, MultiPartTransactionToBeProcessed)> {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -815,10 +815,8 @@ impl AccountsStore {
         self.neuron_accounts.get_mut(&account_identifier).unwrap().neuron_id = Some(neuron_id);
     }
 
-    pub fn mark_neuron_topped_up(&mut self, block_height: BlockIndex) {
+    pub fn mark_neuron_topped_up(&mut self) {
         self.neurons_topped_up_count += 1;
-        self.multi_part_transactions_processor
-            .update_status(block_height, MultiPartTransactionStatus::Complete);
     }
 
     pub fn mark_canister_topped_up(&mut self, original_transaction_block_height: BlockIndex) {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -601,7 +601,6 @@ impl AccountsStore {
                 } else if let Some(neuron_details) = self.neuron_accounts.get(&to) {
                     // Handle the case where people top up their neuron from an external account
                     self.multi_part_transactions_processor.push(
-                        neuron_details.principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::TopUpNeuron(neuron_details.principal, neuron_details.memo),
                     );
@@ -792,7 +791,6 @@ impl AccountsStore {
 
     pub fn enqueue_transaction_to_be_refunded(&mut self, args: RefundTransactionArgs) {
         self.multi_part_transactions_processor.push(
-            args.recipient_principal,
             args.original_transaction_block_height,
             MultiPartTransactionToBeProcessed::RefundTransaction(args),
         );
@@ -905,12 +903,13 @@ impl AccountsStore {
 
     pub fn enqueue_multi_part_transaction(
         &mut self,
-        principal: PrincipalId,
+        // TODO: Remove unused parameter
+        _principal: PrincipalId,
         block_height: BlockIndex,
         transaction: MultiPartTransactionToBeProcessed,
     ) {
         self.multi_part_transactions_processor
-            .push(principal, block_height, transaction);
+            .push(block_height, transaction);
     }
 
     pub fn get_stats(&self) -> Stats {
@@ -1286,7 +1285,6 @@ impl AccountsStore {
         match transaction_type {
             TransactionType::ParticipateSwap(swap_canister_id) => {
                 self.multi_part_transactions_processor.push(
-                    principal,
                     block_height,
                     MultiPartTransactionToBeProcessed::ParticipateSwap(principal, from, to, swap_canister_id),
                 );
@@ -1300,7 +1298,6 @@ impl AccountsStore {
                 };
                 self.neuron_accounts.insert(to, neuron_details);
                 self.multi_part_transactions_processor.push(
-                    principal,
                     block_height,
                     MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo),
                 );
@@ -1309,7 +1306,6 @@ impl AccountsStore {
                 if let Some(neuron_account) = self.neuron_accounts.get(&to) {
                     // We need to use the memo from the original stake neuron transaction
                     self.multi_part_transactions_processor.push(
-                        principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::TopUpNeuron(neuron_account.principal, neuron_account.memo),
                     );
@@ -1318,7 +1314,6 @@ impl AccountsStore {
             TransactionType::CreateCanister => {
                 if to == AccountIdentifier::new(CYCLES_MINTING_CANISTER_ID.into(), Some((&principal).into())) {
                     self.multi_part_transactions_processor.push(
-                        principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
                     );
@@ -1329,7 +1324,6 @@ impl AccountsStore {
                         refund_address: from,
                     };
                     self.multi_part_transactions_processor.push(
-                        principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::CreateCanister(args),
                     );
@@ -1338,7 +1332,6 @@ impl AccountsStore {
             TransactionType::TopUpCanister(canister_id) => {
                 if to == AccountIdentifier::new(CYCLES_MINTING_CANISTER_ID.into(), Some((&canister_id.get()).into())) {
                     self.multi_part_transactions_processor.push(
-                        principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::TopUpCanisterV2(principal, canister_id),
                     );
@@ -1350,7 +1343,6 @@ impl AccountsStore {
                         refund_address: from,
                     };
                     self.multi_part_transactions_processor.push(
-                        principal,
                         block_height,
                         MultiPartTransactionToBeProcessed::TopUpCanister(args),
                     );

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -523,10 +523,7 @@ impl AccountsStore {
         &mut self,
         from: AccountIdentifier,
         to: AccountIdentifier,
-        block_height: BlockIndex,
     ) {
-        self.multi_part_transactions_processor
-            .update_status(block_height, MultiPartTransactionStatus::Complete);
         self.remove_pending_transaction((from, to));
     }
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -903,8 +903,6 @@ impl AccountsStore {
 
     pub fn enqueue_multi_part_transaction(
         &mut self,
-        // TODO: Remove unused parameter
-        _principal: PrincipalId,
         block_height: BlockIndex,
         transaction: MultiPartTransactionToBeProcessed,
     ) {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -790,22 +790,6 @@ impl AccountsStore {
         );
     }
 
-    pub fn process_multi_part_transaction_error(
-        &mut self,
-        block_height: BlockIndex,
-        error: String,
-        refund_pending: bool,
-    ) {
-        let status = if refund_pending {
-            MultiPartTransactionStatus::ErrorWithRefundPending(error)
-        } else {
-            MultiPartTransactionStatus::Error(error)
-        };
-
-        self.multi_part_transactions_processor
-            .update_status(block_height, status);
-    }
-
     pub fn get_next_transaction_index(&self) -> TransactionIndex {
         match self.transactions.back() {
             Some(t) => t.transaction_index + 1,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -808,14 +808,11 @@ impl AccountsStore {
     pub fn mark_neuron_created(
         &mut self,
         principal: &PrincipalId,
-        block_height: BlockIndex,
         memo: Memo,
         neuron_id: NeuronId,
     ) {
         let account_identifier = Self::generate_stake_neuron_address(principal, memo);
         self.neuron_accounts.get_mut(&account_identifier).unwrap().neuron_id = Some(neuron_id);
-        self.multi_part_transactions_processor
-            .update_status(block_height, MultiPartTransactionStatus::NeuronCreated(neuron_id));
     }
 
     pub fn mark_neuron_topped_up(&mut self, block_height: BlockIndex) {

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -227,7 +227,7 @@ fn add_participate_pending_transaction_and_complete() {
     let same_buyer = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
     let same_from_account_identifier = AccountIdentifier::new(same_buyer, None);
     // Set transaction as complete
-    store.complete_pending_transaction(same_from_account_identifier, to_account_identifier, 1);
+    store.complete_pending_transaction(same_from_account_identifier, to_account_identifier);
 
     // There should be no more pending transactions
     match store.get_pending_transaction(same_from_account_identifier, to_account_identifier) {
@@ -397,7 +397,7 @@ fn add_and_complete_multiple_pending_transactions() {
     }
 
     // Set transaction as complete buyer 1
-    store.complete_pending_transaction(from_account_identifier, to_account_identifier, 1);
+    store.complete_pending_transaction(from_account_identifier, to_account_identifier);
 
     // There should be no more pending transactions
     match store.get_pending_transaction(from_account_identifier, to_account_identifier) {

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -1,7 +1,6 @@
 use crate::accounts_store::{CreateCanisterArgs, RefundTransactionArgs, TopUpCanisterArgs};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_nns_common::types::NeuronId;
 use icp_ledger::AccountIdentifier;
 use icp_ledger::{BlockIndex, Memo};
 use serde::Deserialize;
@@ -23,19 +22,6 @@ pub enum MultiPartTransactionToBeProcessed {
     TopUpCanisterV2(PrincipalId, CanisterId),
     // ParticipateSwap(buyer_id, from, to, swap_canister_id)
     ParticipateSwap(PrincipalId, AccountIdentifier, AccountIdentifier, CanisterId),
-}
-
-#[derive(Clone, CandidType, Deserialize)]
-pub enum MultiPartTransactionStatus {
-    NeuronCreated(NeuronId),
-    CanisterCreated(CanisterId),
-    Complete,
-    Refunded(BlockIndex, String),
-    Error(String),
-    ErrorWithRefundPending(String),
-    NotFound,
-    PendingSync,
-    Queued,
 }
 
 #[derive(Clone, CandidType, Deserialize)]

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -57,10 +57,6 @@ impl MultiPartTransactionsProcessor {
         self.queue.pop_front()
     }
 
-    // TODO(dskloetd): Remove this method and all calls to it.
-    pub fn update_status(&mut self, _block_height: BlockIndex, _status: MultiPartTransactionStatus) {
-    }
-
     pub fn get_queue_length(&self) -> u32 {
         self.queue.len() as u32
     }

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -47,8 +47,6 @@ pub struct MultiPartTransactionError {
 impl MultiPartTransactionsProcessor {
     pub fn push(
         &mut self,
-        // TODO: Remove unused parameter
-        _principal: PrincipalId,
         block_height: BlockIndex,
         transaction_to_be_processed: MultiPartTransactionToBeProcessed,
     ) {
@@ -82,7 +80,6 @@ mod tests {
 
         for i in 0..10 {
             processor.push(
-                principal,
                 i,
                 MultiPartTransactionToBeProcessed::StakeNeuron(principal, Memo(i)),
             );

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -5,15 +5,11 @@ use ic_nns_common::types::NeuronId;
 use icp_ledger::AccountIdentifier;
 use icp_ledger::{BlockIndex, Memo};
 use serde::Deserialize;
-use std::collections::{BTreeMap, VecDeque};
-
-const MAX_ERRORS_TO_HOLD: usize = 500;
+use std::collections::VecDeque;
 
 #[derive(Default, CandidType, Deserialize)]
 pub struct MultiPartTransactionsProcessor {
     queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
-    statuses: BTreeMap<BlockIndex, (PrincipalId, MultiPartTransactionStatus)>,
-    errors: VecDeque<MultiPartTransactionError>,
 }
 
 #[derive(Clone, CandidType, Deserialize)]
@@ -51,59 +47,24 @@ pub struct MultiPartTransactionError {
 impl MultiPartTransactionsProcessor {
     pub fn push(
         &mut self,
-        principal: PrincipalId,
+        // TODO: Remove unused parameter
+        _principal: PrincipalId,
         block_height: BlockIndex,
         transaction_to_be_processed: MultiPartTransactionToBeProcessed,
     ) {
         self.queue.push_back((block_height, transaction_to_be_processed));
-        self.statuses
-            .insert(block_height, (principal, MultiPartTransactionStatus::Queued));
     }
 
     pub fn take_next(&mut self) -> Option<(BlockIndex, MultiPartTransactionToBeProcessed)> {
         self.queue.pop_front()
     }
 
-    pub fn update_status(&mut self, block_height: BlockIndex, status: MultiPartTransactionStatus) {
-        match &status {
-            MultiPartTransactionStatus::Error(msg) => self.append_error(MultiPartTransactionError {
-                block_height,
-                error_message: msg.clone(),
-            }),
-            MultiPartTransactionStatus::ErrorWithRefundPending(msg) => self.append_error(MultiPartTransactionError {
-                block_height,
-                error_message: msg.clone(),
-            }),
-            _ => {}
-        };
-
-        if let Some((_, s)) = self.statuses.get_mut(&block_height) {
-            *s = status;
-        }
-    }
-
-    pub fn get_status(&self, principal: PrincipalId, block_height: BlockIndex) -> MultiPartTransactionStatus {
-        self.statuses
-            .get(&block_height)
-            .filter(|(p, _)| *p == principal)
-            .map(|(_, t)| t)
-            .cloned()
-            .unwrap_or(MultiPartTransactionStatus::NotFound)
-    }
-
-    pub fn get_errors(&self) -> Vec<MultiPartTransactionError> {
-        self.errors.iter().cloned().collect()
+    // TODO(dskloetd): Remove this method and all calls to it.
+    pub fn update_status(&mut self, _block_height: BlockIndex, _status: MultiPartTransactionStatus) {
     }
 
     pub fn get_queue_length(&self) -> u32 {
         self.queue.len() as u32
-    }
-
-    fn append_error(&mut self, error: MultiPartTransactionError) {
-        self.errors.push_back(error);
-        if self.errors.len() > MAX_ERRORS_TO_HOLD {
-            self.errors.pop_front();
-        }
     }
 }
 
@@ -137,45 +98,5 @@ mod tests {
         }
 
         assert!(processor.take_next().is_none());
-    }
-
-    #[test]
-    fn status_updated_correctly() {
-        let mut processor = MultiPartTransactionsProcessor::default();
-        let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
-
-        processor.push(
-            principal,
-            1,
-            MultiPartTransactionToBeProcessed::StakeNeuron(principal, Memo(0)),
-        );
-        assert!(matches!(
-            processor.get_status(principal, 1),
-            MultiPartTransactionStatus::Queued
-        ));
-
-        processor.update_status(1, MultiPartTransactionStatus::Complete);
-        assert!(matches!(
-            processor.get_status(principal, 1),
-            MultiPartTransactionStatus::Complete
-        ));
-    }
-
-    #[test]
-    fn errors_are_stored_when_status_is_updated() {
-        let mut processor = MultiPartTransactionsProcessor::default();
-        let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
-        let error_message = "Error!".to_string();
-
-        processor.push(
-            principal,
-            1,
-            MultiPartTransactionToBeProcessed::StakeNeuron(principal, Memo(0)),
-        );
-        processor.update_status(1, MultiPartTransactionStatus::Error(error_message.clone()));
-
-        let errors = processor.get_errors();
-        assert_eq!(errors[0].block_height, 1);
-        assert_eq!(errors[0].error_message, error_message);
     }
 }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -269,15 +269,7 @@ async fn handle_refund(args: RefundTransactionArgs) {
     };
 
     match ledger::send(send_request.clone()).await {
-        Ok(block_height) => {
-            STATE.with(|s| {
-                s.accounts_store.borrow_mut().process_transaction_refund_completed(
-                    args.original_transaction_block_height,
-                    block_height,
-                    args.error_message,
-                )
-            });
-        }
+        Ok(_block_height) => (), 
         Err(error) => {
             STATE.with(|s| {
                 s.accounts_store.borrow_mut().process_multi_part_transaction_error(

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -25,7 +25,7 @@ pub async fn run_periodic_tasks() {
     if let Some((block_height, transaction_to_process)) = maybe_transaction_to_process {
         match transaction_to_process {
             MultiPartTransactionToBeProcessed::ParticipateSwap(principal, from, to, swap_canister_id) => {
-                handle_participate_swap(block_height, principal, from, to, swap_canister_id).await;
+                handle_participate_swap(principal, from, to, swap_canister_id).await;
             }
             MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo) => {
                 handle_stake_neuron(block_height, principal, memo).await;
@@ -61,7 +61,6 @@ pub async fn run_periodic_tasks() {
 }
 
 async fn handle_participate_swap(
-    block_height: BlockIndex,
     principal: PrincipalId,
     from: AccountIdentifier,
     to: AccountIdentifier,
@@ -74,7 +73,7 @@ async fn handle_participate_swap(
         STATE.with(|s| {
             s.accounts_store
                 .borrow_mut()
-                .complete_pending_transaction(from, to, block_height)
+                .complete_pending_transaction(from, to)
         });
     }
 }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -153,7 +153,7 @@ async fn handle_create_canister(block_height: BlockIndex, args: CreateCanisterAr
 
 async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: PrincipalId, canister_id: CanisterId) {
     match top_up_canister_v2(block_height, canister_id).await {
-        Ok(Ok(_)) => STATE.with(|s| s.accounts_store.borrow_mut().mark_canister_topped_up(block_height)),
+        Ok(Ok(_)) => (),
         Ok(Err(NotifyError::Processing)) => {
             STATE.with(|s| {
                 s.accounts_store.borrow_mut().enqueue_multi_part_transaction(
@@ -169,7 +169,7 @@ async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: Principa
 
 async fn handle_top_up_canister(block_height: BlockIndex, args: TopUpCanisterArgs) {
     match top_up_canister(args.canister_id, args.amount).await {
-        Ok(Ok(_)) => STATE.with(|s| s.accounts_store.borrow_mut().mark_canister_topped_up(block_height)),
+        Ok(Ok(_)) => (),
         Ok(Err(error)) => {
             let was_refunded = matches!(error, NotifyError::Refunded { .. });
             if was_refunded {

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -115,7 +115,6 @@ async fn handle_create_canister_v2(block_height: BlockIndex, controller: Princip
         Ok(Err(NotifyError::Processing)) => {
             STATE.with(|s| {
                 s.accounts_store.borrow_mut().enqueue_multi_part_transaction(
-                    controller,
                     block_height,
                     MultiPartTransactionToBeProcessed::CreateCanisterV2(controller),
                 )
@@ -193,7 +192,6 @@ async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: Principa
         Ok(Err(NotifyError::Processing)) => {
             STATE.with(|s| {
                 s.accounts_store.borrow_mut().enqueue_multi_part_transaction(
-                    principal,
                     block_height,
                     MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
                 )

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -31,7 +31,7 @@ pub async fn run_periodic_tasks() {
                 handle_stake_neuron(principal, memo).await;
             }
             MultiPartTransactionToBeProcessed::TopUpNeuron(principal, memo) => {
-                handle_top_up_neuron(block_height, principal, memo).await;
+                handle_top_up_neuron(principal, memo).await;
             }
             MultiPartTransactionToBeProcessed::CreateCanister(args) => {
                 handle_create_canister(block_height, args).await;
@@ -89,9 +89,9 @@ async fn handle_stake_neuron(principal: PrincipalId, memo: Memo) {
     }
 }
 
-async fn handle_top_up_neuron(block_height: BlockIndex, principal: PrincipalId, memo: Memo) {
+async fn handle_top_up_neuron(principal: PrincipalId, memo: Memo) {
     match claim_or_refresh_neuron(principal, memo).await {
-        Ok(_) => STATE.with(|s| s.accounts_store.borrow_mut().mark_neuron_topped_up(block_height)),
+        Ok(_) => STATE.with(|s| s.accounts_store.borrow_mut().mark_neuron_topped_up()),
         Err(_error) => (),
     }
 }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -28,7 +28,7 @@ pub async fn run_periodic_tasks() {
                 handle_participate_swap(principal, from, to, swap_canister_id).await;
             }
             MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo) => {
-                handle_stake_neuron(block_height, principal, memo).await;
+                handle_stake_neuron(principal, memo).await;
             }
             MultiPartTransactionToBeProcessed::TopUpNeuron(principal, memo) => {
                 handle_top_up_neuron(block_height, principal, memo).await;
@@ -78,12 +78,12 @@ async fn handle_participate_swap(
     }
 }
 
-async fn handle_stake_neuron(block_height: BlockIndex, principal: PrincipalId, memo: Memo) {
+async fn handle_stake_neuron(principal: PrincipalId, memo: Memo) {
     match claim_or_refresh_neuron(principal, memo).await {
         Ok(neuron_id) => STATE.with(|s| {
             s.accounts_store
                 .borrow_mut()
-                .mark_neuron_created(&principal, block_height, memo, neuron_id)
+                .mark_neuron_created(&principal, memo, neuron_id)
         }),
         Err(_error) => (),
     }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -109,7 +109,7 @@ async fn handle_create_canister_v2(block_height: BlockIndex, controller: Princip
         Ok(Ok(canister_id)) => STATE.with(|s| {
             s.accounts_store
                 .borrow_mut()
-                .attach_newly_created_canister(controller, block_height, canister_id)
+                .attach_newly_created_canister(controller, canister_id)
         }),
         Ok(Err(NotifyError::Processing)) => {
             STATE.with(|s| {
@@ -143,7 +143,7 @@ async fn handle_create_canister(block_height: BlockIndex, args: CreateCanisterAr
         Ok(Ok(canister_id)) => STATE.with(|s| {
             s.accounts_store
                 .borrow_mut()
-                .attach_newly_created_canister(args.controller, block_height, canister_id)
+                .attach_newly_created_canister(args.controller, canister_id)
         }),
         Ok(Err(error)) => {
             let was_refunded = matches!(error, NotifyError::Refunded { .. });


### PR DESCRIPTION
# Motivation

The canister end points `get_multi_part_transaction_status` and `get_multi_part_transaction_errors` are no longer used. So we want to clean up the unused code.

We can remove them from:
[main.rs](https://github.com/dfinity/nns-dapp/blob/57e1154e070429cf9381c50a7c8c65c3137e93c7/rs/backend/src/main.rs#L229),
[backend nns-dapp.did](https://github.com/dfinity/nns-dapp/blob/57e1154e070429cf9381c50a7c8c65c3137e93c7/rs/backend/nns-dapp.did#L254),
[frontend nns-dapp.did](https://github.com/dfinity/nns-dapp/blob/6ee4d73e0b3ac3e9ee10e500b963ad2d73df3d71/frontend/src/lib/canisters/nns-dapp/nns-dapp.did#L255),
[nns-dapp.types.ts](https://github.com/dfinity/nns-dapp/blob/6ee4d73e0b3ac3e9ee10e500b963ad2d73df3d71/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts#L186),
[nns-dapp.certified.idl.js](https://github.com/dfinity/nns-dapp/blob/6ee4d73e0b3ac3e9ee10e500b963ad2d73df3d71/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js#L201),
[nns-dapp.idl.js](https://github.com/dfinity/nns-dapp/blob/6ee4d73e0b3ac3e9ee10e500b963ad2d73df3d71/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js#L201),

Then we can remove code that is only called by these functions and we realize that this was the only code reading MultiPartTransactionsProcessor [statuses](https://github.com/dfinity/nns-dapp/blob/main/rs/backend/src/multi_part_transactions_processor.rs#L15) and errors. So those fields, and the code that writes to them can be removed as well. This involves mostly a lot of calls to `update_status` and some functions that didn't do anything other than calling `update_status()`.

In order to review the changes I recommend looking a 1 commit at a time.

# Changes

Removed `get_multi_part_transaction_status` and `get_multi_part_transaction_errors` and related dead code.

# Tests

Some tests were removed. No new tests were added.
