### PR TITLE
In governance.api.spec.ts reset all mocks before each test

### DIFF
--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -29,6 +29,8 @@ import { mockNeuron } from "../../mocks/neurons.mock";
 describe("neurons-api", () => {
   const mockGovernanceCanister = mock<GovernanceCanister>();
   beforeEach(() => {
+    jest.resetAllMocks();
+
     mockGovernanceCanister.listNeurons.mockImplementation(
       jest.fn().mockResolvedValue([])
     );
@@ -42,10 +44,6 @@ describe("neurons-api", () => {
     jest
       .spyOn(GovernanceCanister, "create")
       .mockImplementation(() => mockGovernanceCanister);
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
   });
 
   it("stakeNeuron creates a new neuron", async () => {


### PR DESCRIPTION
# Motivation

Cleaning up before a test is safer than after because you never know which test ran before you and whether it also cleaned up after itself.

# Changes

In governance.api.spec.ts reset all mocks before each test instead of after each test.

# Tests

Test only change
