### PR TITLE
GIX-1322: Setup featureFlags store

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -44,11 +44,13 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
   HOST: "https://ic0.app",
   DEV: false,
   FETCH_ROOT_KEY: false,
-  ENABLE_SNS_2: true,
-  ENABLE_SNS_VOTING: true,
-  ENABLE_SNS_AGGREGATOR: true,
-  ENABLE_CKBTC_LEDGER: true,
-  ENABLE_CKBTC_RECEIVE: true,
+  FEATURE_FLAGS: {
+    ENABLE_SNS_2: true,
+    ENABLE_SNS_VOTING: true,
+    ENABLE_SNS_AGGREGATOR: true,
+    ENABLE_CKBTC_LEDGER: true,
+    ENABLE_CKBTC_RECEIVE: true,
+  },
   SNS_AGGREGATOR_CANISTER_URL:
     "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network",
   STAKE_MATURITY: true,

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -44,7 +44,7 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
   HOST: "https://ic0.app",
   DEV: false,
   FETCH_ROOT_KEY: false,
-  FEATURE_FLAGS: {
+  FEATURE_FLAG_ENVIRONMENT: {
     ENABLE_SNS_2: true,
     ENABLE_SNS_VOTING: true,
     ENABLE_SNS_AGGREGATOR: true,

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
@@ -19,7 +19,7 @@
   import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte";
   import { isNullish } from "@dfinity/utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_SNS_2 } from "$lib/constants/environment.constants";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -42,7 +42,7 @@
     <h3 slot="value">{formattedTotalMaturity(neuron)}</h3>
   </KeyValuePair>
 
-  {#if hasStakedMaturity(neuron) && ENABLE_SNS_2}
+  {#if hasStakedMaturity(neuron) && $featureFlagsStore.ENABLE_SNS_2}
     <KeyValuePair testId="staked-maturity">
       <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
 
@@ -52,13 +52,13 @@
     </KeyValuePair>
   {/if}
 
-  {#if allowedToStakeMaturity && ENABLE_SNS_2}
+  {#if allowedToStakeMaturity && $featureFlagsStore.ENABLE_SNS_2}
     <div class="actions" data-tid="stake-maturity-actions">
       <SnsStakeMaturityButton />
     </div>
   {/if}
 
-  {#if ENABLE_SNS_2}
+  {#if $featureFlagsStore.ENABLE_SNS_2}
     <SnsAutoStakeMaturity />
   {/if}
 </CardInfo>

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -25,7 +25,7 @@ export interface FeatureFlags {
  *
  * @see feature-flags.store.ts to use feature flags
  */
-export const FEATURE_FLAGS: FeatureFlags = JSON.parse(
+export const FEATURE_FLAG_ENVIRONMENT: FeatureFlags = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
     '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": true, "ENABLE_CKBTC_RECEIVE": false}'
 );

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -12,7 +12,7 @@ export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
     ? undefined
     : (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string);
 
-export interface FEATURE_FLAGS {
+export interface FeatureFlags {
   ENABLE_SNS_2: boolean;
   ENABLE_SNS_VOTING: boolean;
   ENABLE_SNS_AGGREGATOR: boolean;
@@ -25,7 +25,7 @@ export interface FEATURE_FLAGS {
  *
  * @see feature-flags.store.ts to use feature flags
  */
-export const FEATURE_FLAGS: FEATURE_FLAGS = JSON.parse(
+export const FEATURE_FLAGS: FeatureFlags = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
     '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": true, "ENABLE_CKBTC_RECEIVE": false}'
 );

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -12,7 +12,7 @@ export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
     ? undefined
     : (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string);
 
-interface FEATURE_FLAGS {
+export interface FEATURE_FLAGS {
   ENABLE_SNS_2: boolean;
   ENABLE_SNS_VOTING: boolean;
   ENABLE_SNS_AGGREGATOR: boolean;
@@ -20,13 +20,12 @@ interface FEATURE_FLAGS {
   ENABLE_CKBTC_RECEIVE: boolean;
 }
 
-export const {
-  ENABLE_SNS_2,
-  ENABLE_SNS_VOTING,
-  ENABLE_SNS_AGGREGATOR,
-  ENABLE_CKBTC_LEDGER,
-  ENABLE_CKBTC_RECEIVE,
-}: FEATURE_FLAGS = JSON.parse(
+/**
+ * DO NOT USE DIRECTLY
+ *
+ * @see feature-flags.store.ts to use feature flags
+ */
+export const FEATURE_FLAGS: FEATURE_FLAGS = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
     '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": true, "ENABLE_CKBTC_RECEIVE": false}'
 );

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,5 +1,5 @@
 export enum storeLocalStorageKey {
   ProposalFilters = "nnsProposalFilters",
   Theme = "nnsTheme",
-  FeatureFlags = "nnsFeatureFlags",
+  FeatureFlags = "nnsOverrideFeatureFlags",
 }

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,4 +1,5 @@
 export enum storeLocalStorageKey {
   ProposalFilters = "nnsProposalFilters",
   Theme = "nnsTheme",
+  FeatureFlags = "nnsFeatureFlags",
 }

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -2,12 +2,13 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import { ENABLE_CKBTC_LEDGER } from "$lib/constants/environment.constants";
+import type { FEATURE_FLAGS } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   snsProjectsCommittedStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
+import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import { isUniverseCkBTC, pathSupportsCkBTC } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
@@ -21,16 +22,19 @@ export const CKBTC_UNIVERSE: Universe = {
 };
 
 const universesStore = derived<
-  Readable<SnsFullProject[] | undefined>,
+  [Readable<SnsFullProject[] | undefined>, Readable<FEATURE_FLAGS>],
   Universe[]
->(snsProjectsCommittedStore, (projects: SnsFullProject[] | undefined) => [
-  NNS_UNIVERSE,
-  ...(ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
-  ...(projects?.map(({ rootCanisterId, summary }) => ({
-    canisterId: rootCanisterId.toText(),
-    summary,
-  })) ?? []),
-]);
+>(
+  [snsProjectsCommittedStore, featureFlagsStore],
+  ([projects, featueFlags]: [SnsFullProject[] | undefined, FEATURE_FLAGS]) => [
+    NNS_UNIVERSE,
+    ...(featueFlags.ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
+    ...(projects?.map(({ rootCanisterId, summary }) => ({
+      canisterId: rootCanisterId.toText(),
+      summary,
+    })) ?? []),
+  ]
+);
 
 export const selectableUniversesStore = derived<
   [Readable<Universe[]>, Readable<Page>],

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -2,7 +2,7 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import type { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import type { FeatureFlags } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   snsProjectsCommittedStore,
@@ -22,13 +22,13 @@ export const CKBTC_UNIVERSE: Universe = {
 };
 
 const universesStore = derived<
-  [Readable<SnsFullProject[] | undefined>, Readable<FEATURE_FLAGS>],
+  [Readable<SnsFullProject[] | undefined>, Readable<FeatureFlags>],
   Universe[]
 >(
   [snsProjectsCommittedStore, featureFlagsStore],
-  ([projects, featueFlags]: [SnsFullProject[] | undefined, FEATURE_FLAGS]) => [
+  ([projects, featureFlags]: [SnsFullProject[] | undefined, FeatureFlags]) => [
     NNS_UNIVERSE,
-    ...(featueFlags.ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
+    ...(featureFlags.ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
     ...(projects?.map(({ rootCanisterId, summary }) => ({
       canisterId: rootCanisterId.toText(),
       summary,

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -2,7 +2,7 @@ import {
   OWN_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import type { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import type { FeatureFlags } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   NNS_UNIVERSE,
@@ -41,13 +41,13 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Principal>, Readable<Page>, Readable<FEATURE_FLAGS>],
+  [Readable<Principal>, Readable<Page>, Readable<FeatureFlags>],
   Principal
 >(
   [pageUniverseIdStore, pageStore, featureFlagsStore],
-  ([canisterId, page, featueFlags]) => {
+  ([canisterId, page, featureFlags]) => {
     // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (featueFlags.ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
+    if (featureFlags.ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
       return canisterId;
     }
 

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -2,12 +2,13 @@ import {
   OWN_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import { ENABLE_CKBTC_LEDGER } from "$lib/constants/environment.constants";
+import type { FEATURE_FLAGS } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   NNS_UNIVERSE,
   selectableUniversesStore,
 } from "$lib/derived/selectable-universes.derived";
+import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import {
   isUniverseCkBTC,
@@ -40,16 +41,19 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Principal>, Readable<Page>],
+  [Readable<Principal>, Readable<Page>, Readable<FEATURE_FLAGS>],
   Principal
->([pageUniverseIdStore, pageStore], ([canisterId, page]) => {
-  // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-  if (ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
-    return canisterId;
-  }
+>(
+  [pageUniverseIdStore, pageStore, featureFlagsStore],
+  ([canisterId, page, featueFlags]) => {
+    // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
+    if (featueFlags.ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
+      return canisterId;
+    }
 
-  return isUniverseCkBTC(canisterId) ? OWN_CANISTER_ID : canisterId;
-});
+    return isUniverseCkBTC(canisterId) ? OWN_CANISTER_ID : canisterId;
+  }
+);
 
 /**
  * Is the selected universe Nns?

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -30,9 +30,9 @@
     ckBTCTokenFeeStore,
     ckBTCTokenStore,
   } from "$lib/derived/universes-tokens.derived";
-  import { ENABLE_CKBTC_RECEIVE } from "$lib/constants/environment.constants";
   import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte";
   import CkBTCWalletModals from "$lib/modals/accounts/CkBTCWalletModals.svelte";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -151,8 +151,8 @@
   </main>
 
   {#if canMakeTransactions}
-    <Footer columns={ENABLE_CKBTC_RECEIVE ? 2 : 1}>
-      {#if ENABLE_CKBTC_RECEIVE}
+    <Footer columns={$featureFlagsStore.ENABLE_CKBTC_RECEIVE ? 2 : 1}>
+      {#if $featureFlagsStore.ENABLE_CKBTC_RECEIVE}
         <CkBTCWalletFooter />
       {/if}
 

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -2,14 +2,14 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   export let proposalIdText: string | undefined | null = undefined;
 
   onMount(() => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
-    if (!ENABLE_SNS_VOTING) {
+    if (!$featureFlagsStore.ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }), {
         replaceState: true,
       });

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -3,7 +3,6 @@
   import type { Unsubscriber } from "svelte/store";
   import { goto } from "$app/navigation";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
   import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
   import type { SnsProposalData } from "@dfinity/sns";
@@ -18,10 +17,11 @@
   } from "$lib/utils/sns-proposals.utils";
   import { loadSnsFilters } from "$lib/services/sns-filters.services";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   onMount(async () => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
-    if (!ENABLE_SNS_VOTING) {
+    if (!$featureFlagsStore.ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }), {
         replaceState: true,
       });

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -19,12 +19,12 @@
   import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
   import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
-  import { ENABLE_CKBTC_LEDGER } from "$lib/constants/environment.constants";
   import type { Account } from "$lib/types/account";
   import { goto } from "$app/navigation";
   import { buildWalletUrl } from "$lib/utils/navigation.utils";
   import { pageStore } from "$lib/derived/page.derived";
   import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   // Selected project ID on mount is excluded from load accounts balances. See documentation.
   let selectedUniverseId = $selectedUniverseIdStore;
@@ -55,7 +55,7 @@
 
   const loadCkBTCAccountsBalances = async () => {
     // ckBTC is not enabled, information shall and cannot be fetched
-    if (!ENABLE_CKBTC_LEDGER) {
+    if (!$featureFlagsStore.ENABLE_CKBTC_LEDGER) {
       return;
     }
 

--- a/frontend/src/lib/routes/ProposalDetail.svelte
+++ b/frontend/src/lib/routes/ProposalDetail.svelte
@@ -2,19 +2,19 @@
   import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
   import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
-  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
   import type { AppPath } from "$lib/constants/routes.constants";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   export let referrerPath: AppPath | undefined = undefined;
   export let proposalIdText: string | null | undefined;
 </script>
 
 <main>
-  {#if $isNnsUniverseStore || !ENABLE_SNS_VOTING}
+  {#if $isNnsUniverseStore || !$featureFlagsStore.ENABLE_SNS_VOTING}
     <NnsProposalDetail {referrerPath} {proposalIdText} />
-  {:else if nonNullish($snsProjectSelectedStore) && ENABLE_SNS_VOTING}
+  {:else if nonNullish($snsProjectSelectedStore) && $featureFlagsStore.ENABLE_SNS_VOTING}
     <SnsProposalDetail {proposalIdText} />
   {/if}
 </main>

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
   import Proposals from "$lib/pages/NnsProposals.svelte";
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
-  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
   import SnsProposals from "$lib/pages/SnsProposals.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import type { AppPath } from "$lib/constants/routes.constants";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   export let referrerPath: AppPath | undefined = undefined;
 </script>
 
 <main>
-  {#if ENABLE_SNS_VOTING}
+  {#if $featureFlagsStore.ENABLE_SNS_VOTING}
     <SummaryUniverse />
   {/if}
-  {#if $isNnsUniverseStore || !ENABLE_SNS_VOTING}
+  {#if $isNnsUniverseStore || !$featureFlagsStore.ENABLE_SNS_VOTING}
     <Proposals {referrerPath} />
-  {:else if nonNullish($snsProjectSelectedStore) && ENABLE_SNS_VOTING}
+  {:else if nonNullish($snsProjectSelectedStore) && $featureFlagsStore.ENABLE_SNS_VOTING}
     <SnsProposals />
   {/if}
 </main>

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -1,16 +1,15 @@
 import { browser } from "$app/environment";
-import {
-  ENABLE_SNS_AGGREGATOR,
-  SNS_AGGREGATOR_CANISTER_URL,
-} from "$lib/constants/environment.constants";
+import { SNS_AGGREGATOR_CANISTER_URL } from "$lib/constants/environment.constants";
 import {
   loadSnsProjects,
   loadSnsSummaries,
 } from "$lib/services/$public/sns.services";
 import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
 import { authStore } from "$lib/stores/auth.store";
+import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { get } from "svelte/store";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -20,9 +19,11 @@ export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [];
+  const featueFlags = get(featureFlagsStore);
 
   const initSns: Promise<void>[] = [
-    ENABLE_SNS_AGGREGATOR && SNS_AGGREGATOR_CANISTER_URL !== undefined
+    featueFlags.ENABLE_SNS_AGGREGATOR &&
+    SNS_AGGREGATOR_CANISTER_URL !== undefined
       ? loadSnsProjects()
       : loadSnsSummaries(),
   ];

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -19,10 +19,10 @@ export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [];
-  const featueFlags = get(featureFlagsStore);
+  const featureFlags = get(featureFlagsStore);
 
   const initSns: Promise<void>[] = [
-    featueFlags.ENABLE_SNS_AGGREGATOR &&
+    featureFlags.ENABLE_SNS_AGGREGATOR &&
     SNS_AGGREGATOR_CANISTER_URL !== undefined
       ? loadSnsProjects()
       : loadSnsSummaries(),

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -1,9 +1,12 @@
-import { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import {
+  FEATURE_FLAGS,
+  type FeatureFlags,
+} from "$lib/constants/environment.constants";
 import { storeLocalStorageKey } from "$lib/constants/stores.constants";
 import { derived, type Readable } from "svelte/store";
 import { writableStored } from "./writable-stored";
 
-type OverrideFeatureFlagsData = Partial<FEATURE_FLAGS>;
+type OverrideFeatureFlagsData = Partial<FeatureFlags>;
 export interface OverrideFeatureFlagsStore
   extends Readable<OverrideFeatureFlagsData> {
   reset: () => void;

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -1,28 +1,36 @@
 import { FEATURE_FLAGS } from "$lib/constants/environment.constants";
 import { storeLocalStorageKey } from "$lib/constants/stores.constants";
-import type { Readable } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
 import { writableStored } from "./writable-stored";
 
-export interface FeatureFlagsStore extends Readable<FEATURE_FLAGS> {
+type OverrideFeatureFlagsData = Partial<FEATURE_FLAGS>;
+export interface OverrideFeatureFlagsStore
+  extends Readable<OverrideFeatureFlagsData> {
   reset: () => void;
 }
 
 /**
- * A store that contains the feature flags.
+ * A store that contains the feature flags that have been overridden by the user.
  */
-export const initFeatureFlagsStore = (): FeatureFlagsStore => {
-  const defaultFlags: FEATURE_FLAGS = FEATURE_FLAGS;
-
-  const { subscribe, set } = writableStored<FEATURE_FLAGS>({
+const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
+  const { subscribe, set } = writableStored<OverrideFeatureFlagsData>({
     key: storeLocalStorageKey.FeatureFlags,
-    defaultValue: defaultFlags,
+    defaultValue: {},
   });
 
   return {
     subscribe,
     // TODO: Expose a method to change one feature flag that raises error if feature flag does not exist
-    reset: () => set(defaultFlags),
+    reset: () => set({}),
   };
 };
 
-export const featureFlagsStore = initFeatureFlagsStore();
+const overrideFeatureFlagsStore = initOverrideFeatureFlagsStore();
+
+export const featureFlagsStore = derived(
+  overrideFeatureFlagsStore,
+  ($overrideFeatureFlagsStore) => ({
+    ...FEATURE_FLAGS,
+    ...$overrideFeatureFlagsStore,
+  })
+);

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -1,5 +1,5 @@
 import {
-  FEATURE_FLAGS,
+  FEATURE_FLAG_ENVIRONMENT,
   type FeatureFlags,
 } from "$lib/constants/environment.constants";
 import { storeLocalStorageKey } from "$lib/constants/stores.constants";
@@ -33,7 +33,7 @@ const overrideFeatureFlagsStore = initOverrideFeatureFlagsStore();
 export const featureFlagsStore = derived(
   overrideFeatureFlagsStore,
   ($overrideFeatureFlagsStore) => ({
-    ...FEATURE_FLAGS,
+    ...FEATURE_FLAG_ENVIRONMENT,
     ...$overrideFeatureFlagsStore,
   })
 );

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -1,0 +1,28 @@
+import { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import { storeLocalStorageKey } from "$lib/constants/stores.constants";
+import type { Readable } from "svelte/store";
+import { writableStored } from "./writable-stored";
+
+export interface FeatureFlagsStore extends Readable<FEATURE_FLAGS> {
+  reset: () => void;
+}
+
+/**
+ * A store that contains the feature flags.
+ */
+export const initFeatureFlagsStore = (): FeatureFlagsStore => {
+  const defaultFlags: FEATURE_FLAGS = FEATURE_FLAGS;
+
+  const { subscribe, set } = writableStored<FEATURE_FLAGS>({
+    key: storeLocalStorageKey.FeatureFlags,
+    defaultValue: defaultFlags,
+  });
+
+  return {
+    subscribe,
+    // TODO: Expose a method to change one feature flag that raises error if feature flag does not exist
+    reset: () => set(defaultFlags),
+  };
+};
+
+export const featureFlagsStore = initFeatureFlagsStore();

--- a/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
@@ -3,10 +3,12 @@
   import Content from "$lib/components/layout/Content.svelte";
   import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
   import type { SvelteComponent } from "svelte";
-  import { ENABLE_SNS_VOTING } from "$lib/constants/environment.constants";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   let cmp: typeof SvelteComponent;
-  $: cmp = ENABLE_SNS_VOTING ? UniverseSplitContent : Content;
+  $: cmp = $featureFlagsStore.ENABLE_SNS_VOTING
+    ? UniverseSplitContent
+    : Content;
 </script>
 
 <Layout>

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,11 +1,11 @@
-import { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import { FEATURE_FLAG_ENVIRONMENT } from "$lib/constants/environment.constants";
 import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
-  it("should set default value to env var FEATURE_FLAGS", () => {
+  it("should set default value to env var FEATURE_FLAG_ENVIRONMENT", () => {
     const storeData = get(featureFlagsStore);
 
-    expect(storeData).toEqual(FEATURE_FLAGS);
+    expect(storeData).toEqual(FEATURE_FLAG_ENVIRONMENT);
   });
 });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,0 +1,11 @@
+import { FEATURE_FLAGS } from "$lib/constants/environment.constants";
+import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+import { get } from "svelte/store";
+
+describe("featureFlags store", () => {
+  it("should set default value to env var FEATURE_FLAGS", () => {
+    const storeData = get(featureFlagsStore);
+
+    expect(storeData).toEqual(FEATURE_FLAGS);
+  });
+});


### PR DESCRIPTION
# Motivation

Be able to manage feature flags in mainnet.

First step: feature flags are read from a store instead of env vars.

# Changes

* New store `faetureFlagsStore` in `feature-flags.store.ts`.
* Export `FEATURE_FLAGS` in `environment.constants` instead of the individual flags.
* Read from the store when a flag wants to be read. These are most files changes.

# Tests

* Change the jest.mock import to the whole `FEATURE_FLAGS` in the setup.
* Add a test to check that store is initialized to the env vars values.
