### PR TITLE
Fix: Neurons Detail Page issue

### DIFF
--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -28,12 +28,17 @@
     NnsNeuronStore,
   } from "$lib/types/nns-neuron-detail.context";
   import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
-  import { setContext } from "svelte";
+  import { onMount, setContext } from "svelte";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
   import NnsNeuronProposalsCard from "$lib/components/neuron-detail/NnsNeuronProposalsCard.svelte";
   import Summary from "$lib/components/summary/Summary.svelte";
+  import { listNeurons } from "$lib/services/neurons.services";
 
   export let neuronIdText: string | undefined | null;
+
+  onMount(() => {
+    listNeurons();
+  });
 
   const mapNeuronId = (
     neuronIdText: string | undefined | null

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -36,7 +36,7 @@ describe("NeuronDetail", () => {
   beforeEach(() => {
     neuronsStore.reset();
     voteRegistrationStore.reset();
-    jest.spyOn(api, "queryNeurons").mockResolvedValue([neuron]);
+    jest.spyOn(api, "queryNeurons").mockResolvedValue([neuron, mockNeuron]);
   });
 
   it("should query neurons", async () => {
@@ -49,6 +49,17 @@ describe("NeuronDetail", () => {
     const { container } = render(NnsNeuronDetail, props);
 
     expect(querySkeleton(container)).not.toBeNull();
+  });
+
+  it("should show the proper neuron id", async () => {
+    const { getByTestId } = render(NnsNeuronDetail, props);
+
+    await waitFor(() => {
+      const neuronIdElement = getByTestId("neuron-id");
+      expect(neuronIdElement).not.toBeNull();
+      expect(neuronIdElement.textContent).toEqual(`${neuronId}`);
+      expect(neuronIdElement.textContent).not.toEqual(`${mockNeuron.neuronId}`);
+    });
   });
 
   const testTitle = async ({

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as api from "$lib/api/governance.api";
 import { dispatchIntersecting } from "$lib/directives/intersection.directives";
 import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
@@ -13,37 +14,36 @@ import en from "../../mocks/i18n.mock";
 import { mockNeuron } from "../../mocks/neurons.mock";
 import { mockVoteRegistration } from "../../mocks/proposal.mock";
 
+// Used when NeuronFollowingCard is mounted
 jest.mock("$lib/services/known-neurons.services", () => {
   return {
     listKnownNeurons: jest.fn().mockResolvedValue(undefined),
   };
 });
 
-jest.mock("$lib/services/neurons.services", () => {
-  return {
-    ...(jest.requireActual("$lib/services/neurons.services") as object),
-    loadNeuron: jest.fn(),
-  };
-});
+jest.mock("$lib/api/governance.api");
 
 describe("NeuronDetail", () => {
-  const neuronId = BigInt(666);
-  const fillNeuronStore = () =>
-    neuronsStore.setNeurons({
-      neurons: [{ ...mockNeuron, neuronId }],
-      certified: true,
-    });
-  const querySkeleton = (container: HTMLElement): HTMLElement | null =>
-    container.querySelector('[data-tid="skeleton-card"]');
-
-  afterEach(() => {
-    neuronsStore.reset();
-    voteRegistrationStore.reset();
-  });
-
+  const neuronId = BigInt(314);
+  const neuron = { ...mockNeuron, neuronId };
   const props = {
     neuronIdText: `${neuronId}`,
   };
+
+  const querySkeleton = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector('[data-tid="skeleton-card"]');
+
+  beforeEach(() => {
+    neuronsStore.reset();
+    voteRegistrationStore.reset();
+    jest.spyOn(api, "queryNeurons").mockResolvedValue([neuron]);
+  });
+
+  it("should query neurons", async () => {
+    render(NnsNeuronDetail, props);
+
+    await waitFor(() => expect(api.queryNeurons).toHaveBeenCalled());
+  });
 
   it("should display skeletons", () => {
     const { container } = render(NnsNeuronDetail, props);
@@ -59,8 +59,6 @@ describe("NeuronDetail", () => {
     text: string;
   }) => {
     const { getByTestId } = render(NnsNeuronDetail, props);
-
-    fillNeuronStore();
 
     await waitFor(() => expect(getByTestId("neuron-id")).not.toBeNull());
 
@@ -83,23 +81,17 @@ describe("NeuronDetail", () => {
   it("should hide skeletons after neuron data are available", async () => {
     const { container } = render(NnsNeuronDetail, props);
 
-    fillNeuronStore();
-
     await waitFor(() => expect(querySkeleton(container)).toBeNull());
   });
 
   it("should render nns project name", async () => {
     const { getByTestId } = render(NnsNeuronDetail, props);
 
-    fillNeuronStore();
-
     await waitFor(() => expect(getByTestId("projects-summary")).not.toBeNull());
   });
 
   it("should show skeletons when neuron is in voting process", async () => {
     const { container } = render(NnsNeuronDetail, props);
-
-    fillNeuronStore();
 
     await waitFor(() => expect(querySkeleton(container)).toBeNull());
 


### PR DESCRIPTION
# Motivation

User sees a loading page when going directly to the neuron page deep link.

# Changes

* Call `listNeuron` on mount of NnsNeuronDetail.svelte

# Tests

* Add test to NnsNeuronDetail.svelte to check that api is called.
* Adapt test use the api mock instead of filling store direclty.
