### PR TITLE
Use get() instead of subscribing to the toastsStore.

### DIFF
--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -60,11 +60,8 @@ const {
   topUpNeuron,
 } = services;
 
-let toasts: ToastMsg[] = [];
-toastsStore.subscribe((t) => (toasts = t));
-
 const expectToastError = (contained: string) =>
-  expect(toasts).toMatchObject([
+  expect(get(toastsStore)).toMatchObject([
     {
       level: "error",
       text: expect.stringContaining(contained),

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -18,7 +18,6 @@ import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
-import type { ToastMsg } from "@dfinity/gix-components";
 import { toastsStore } from "@dfinity/gix-components";
 import { ICPToken, LedgerCanister, TokenAmount, Topic } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";


### PR DESCRIPTION
# Motivation

Small cleanup.
I didn't know about `get()` from svelte before.

# Changes

Use `get()` on the toastsStore instead of subscribing.

# Tests

Test only.
