### PR TITLE
refactor: ckBTC transation modal move and call

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
@@ -11,11 +11,14 @@
   import { getBTCAddress } from "$lib/services/ckbtc-minter.services";
   import { toastsError } from "$lib/stores/toasts.store";
   import { emit } from "$lib/utils/events.utils";
-  import type { CkBTCWalletModal } from "$lib/types/wallet.modal";
+  import Footer from "$lib/components/layout/Footer.svelte";
+  import type { CkBTCWalletModal } from "../../types/wallet.modal";
+  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
 
   const context: CkBTCWalletContext =
     getContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY);
-  const { store, reloadAccount }: CkBTCWalletContext = context;
+  const { store, reloadAccount, reloadAccountFromStore }: CkBTCWalletContext =
+    context;
 
   const openReceive = async () => {
     // Button is disabled if no account anyway
@@ -50,11 +53,41 @@
 
     stopBusy("get-btc-address");
   };
+
+  const openSend = () => {
+    // Button is disabled if no account anyway
+    if (isNullish($store.account)) {
+      toastsError({
+        labelKey: "error__ckbtc.get_btc_no_account",
+      });
+      return;
+    }
+
+    emit<CkBTCWalletModal>({
+      message: "ckBTCWalletModal",
+      detail: {
+        type: "ckbtc-transaction",
+        data: { account: $store.account, reloadAccountFromStore },
+      },
+    });
+  };
 </script>
 
-<button
-  class="primary"
-  on:click={openReceive}
-  disabled={isNullish($store.account) || $busy}
-  data-tid="receive-ckbtc-transaction">{$i18n.ckbtc.receive}</button
->
+<Footer columns={$featureFlagsStore.ENABLE_CKBTC_RECEIVE ? 2 : 1}>
+  <button
+    class="primary"
+    on:click={openSend}
+    disabled={isNullish($store.account) || $busy}
+    data-tid="open-new-ckbtc-transaction"
+    >{$i18n.accounts.new_transaction}</button
+  >
+
+  {#if $featureFlagsStore.ENABLE_CKBTC_RECEIVE}
+    <button
+      class="secondary"
+      on:click={openReceive}
+      disabled={isNullish($store.account) || $busy}
+      data-tid="receive-ckbtc-transaction">{$i18n.ckbtc.receive}</button
+    >
+  {/if}
+</Footer>

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -9,7 +9,6 @@
     SegmentButton,
   } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import type { CkBTCWalletModalData } from "$lib/types/wallet.modal";
   import type { Account } from "$lib/types/account";
   import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
   import BITCOIN_LOGO from "$lib/assets/bitcoin.svg";
@@ -18,8 +17,9 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { updateBalance as updateBalanceService } from "$lib/services/ckbtc-minter.services";
   import { createEventDispatcher } from "svelte";
+  import type { CkBTCWalletReceiveModalData } from "$lib/types/wallet.modal";
 
-  export let data: CkBTCWalletModalData;
+  export let data: CkBTCWalletReceiveModalData;
 
   let account: Account;
   let btcAddress: string;

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionWalletModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionWalletModal.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { Account } from "$lib/types/account";
+  import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
+  import type { CkBTCWalletTransactionModalData } from "$lib/types/wallet.modal";
+  import { createEventDispatcher } from "svelte";
+  import { nonNullish } from "@dfinity/utils";
+  import {
+    ckBTCTokenFeeStore,
+    ckBTCTokenStore,
+  } from "$lib/derived/universes-tokens.derived";
+
+  export let data: CkBTCWalletTransactionModalData;
+
+  let account: Account;
+  let reloadAccountFromStore: () => void;
+
+  $: ({ account, reloadAccountFromStore } = data);
+
+  const dispatcher = createEventDispatcher();
+
+  const onTransferReloadSelectedAccount = async () => {
+    reloadAccountFromStore();
+    dispatcher("nnsClose");
+  };
+</script>
+
+{#if nonNullish($ckBTCTokenStore) && nonNullish($ckBTCTokenFeeStore)}
+  <CkBTCTransactionModal
+    on:nnsClose
+    on:nnsTransfer={onTransferReloadSelectedAccount}
+    selectedAccount={account}
+    loadTransactions
+    token={$ckBTCTokenStore.token}
+    transactionFee={$ckBTCTokenFeeStore}
+  />
+{/if}

--- a/frontend/src/lib/modals/accounts/CkBTCWalletModals.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCWalletModals.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type {
     CkBTCWalletModal,
-    CkBTCWalletModalData,
     CkBTCWalletModalType,
   } from "$lib/types/wallet.modal";
   import { nonNullish } from "@dfinity/utils";
   import CkBTCReceiveModal from "$lib/modals/accounts/CkBTCReceiveModal.svelte";
+  import CkBTCTransactionWalletModal from "$lib/modals/accounts/CkBTCTransactionWalletModal.svelte";
+  import type {
+    CkBTCWalletReceiveModalData,
+    CkBTCWalletTransactionModalData,
+  } from "../../types/wallet.modal";
 
   let modal: CkBTCWalletModal | undefined;
   const close = () => (modal = undefined);
@@ -13,12 +17,25 @@
   let type: CkBTCWalletModalType | undefined;
   $: type = modal?.type;
 
-  let data: CkBTCWalletModalData | undefined;
+  let data:
+    | CkBTCWalletTransactionModalData
+    | CkBTCWalletReceiveModalData
+    | undefined;
   $: data = (modal as CkBTCWalletModal | undefined)?.data;
+
+  let receiveData: CkBTCWalletReceiveModalData | undefined;
+  $: receiveData = data as CkBTCWalletReceiveModalData | undefined;
+
+  let transactionData: CkBTCWalletTransactionModalData | undefined;
+  $: transactionData = data as CkBTCWalletTransactionModalData | undefined;
 </script>
 
 <svelte:window on:ckBTCWalletModal={({ detail }) => (modal = detail)} />
 
-{#if type === "ckbtc-receive" && nonNullish(data)}
-  <CkBTCReceiveModal {data} on:nnsClose={close} />
+{#if type === "ckbtc-receive" && nonNullish(receiveData)}
+  <CkBTCReceiveModal data={receiveData} on:nnsClose={close} />
+{/if}
+
+{#if type === "ckbtc-transaction" && nonNullish(transactionData)}
+  <CkBTCTransactionWalletModal data={transactionData} on:nnsClose={close} />
 {/if}

--- a/frontend/src/lib/types/wallet.context.ts
+++ b/frontend/src/lib/types/wallet.context.ts
@@ -23,6 +23,7 @@ export interface WalletContext {
 
 export interface CkBTCWalletContext extends WalletContext {
   reloadAccount: () => Promise<void>;
+  reloadAccountFromStore: () => void;
 }
 
 export const WALLET_CONTEXT_KEY = Symbol("wallet");

--- a/frontend/src/lib/types/wallet.modal.ts
+++ b/frontend/src/lib/types/wallet.modal.ts
@@ -8,15 +8,22 @@ export interface WalletModal {
 }
 
 // CkBTC
-export type CkBTCWalletModalType = "ckbtc-receive";
+export type CkBTCWalletModalType = "ckbtc-receive" | "ckbtc-transaction";
 
 export interface CkBTCWalletModalData {
-  btcAddress: string;
   account: Account;
+}
+
+export interface CkBTCWalletTransactionModalData extends CkBTCWalletModalData {
+  reloadAccountFromStore: () => void;
+}
+
+export interface CkBTCWalletReceiveModalData extends CkBTCWalletModalData {
+  btcAddress: string;
   reloadAccount: () => Promise<void>;
 }
 
 export interface CkBTCWalletModal {
   type: CkBTCWalletModalType;
-  data: CkBTCWalletModalData;
+  data: CkBTCWalletReceiveModalData | CkBTCWalletTransactionModalData;
 }

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletContextTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletContextTest.svelte
@@ -20,6 +20,9 @@
   setContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY, {
     store: walletStore,
     reloadAccount: () => Promise.resolve(),
+    reloadAccountFromStore: () => {
+      // Do nothing here
+    },
   });
 </script>
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -6,10 +6,15 @@ import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte
 import type { Account } from "$lib/types/account";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
+import { tokensStore } from "../../../../lib/stores/tokens.store";
 import {
   mockCkBTCAddress,
   mockCkBTCMainAccount,
 } from "../../../mocks/ckbtc-accounts.mock";
+import {
+  mockTokensSubscribe,
+  mockUniversesTokens,
+} from "../../../mocks/tokens.mock";
 import CkBTCWalletContextTest from "./CkBTCWalletContextTest.svelte";
 
 jest.mock("$lib/services/ckbtc-minter.services", () => {
@@ -19,6 +24,14 @@ jest.mock("$lib/services/ckbtc-minter.services", () => {
 });
 
 describe("CkBTCWalletFooter", () => {
+  beforeAll(() => {
+    jest
+      .spyOn(tokensStore, "subscribe")
+      .mockImplementation(mockTokensSubscribe(mockUniversesTokens));
+  });
+
+  afterAll(() => jest.clearAllMocks());
+
   const renderWalletActions = (account?: Account) =>
     render(CkBTCWalletContextTest, {
       props: {
@@ -47,6 +60,19 @@ describe("CkBTCWalletFooter", () => {
 
     fireEvent.click(
       getByTestId("receive-ckbtc-transaction") as HTMLButtonElement
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector("div.modal")).not.toBeNull()
+    );
+  });
+
+  it("should open transaction modal", async () => {
+    const { getByTestId, container } =
+      renderWalletActions(mockCkBTCMainAccount);
+
+    fireEvent.click(
+      getByTestId("open-new-ckbtc-transaction") as HTMLButtonElement
     );
 
     await waitFor(() =>

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -30,8 +30,6 @@ describe("CkBTCWalletFooter", () => {
       .mockImplementation(mockTokensSubscribe(mockUniversesTokens));
   });
 
-  afterAll(() => jest.clearAllMocks());
-
   const renderWalletActions = (account?: Account) =>
     render(CkBTCWalletContextTest, {
       props: {


### PR DESCRIPTION
# Motivation

Ultimately the "Transaction" modal will / might most probably be used for ckBTC conversion too therefore we can move it - as we discussed in the footer, now worth the effort - and integrate it as the other modal.

For the same reason the "Receive" CTA can become a secondary button.

# Note

No functional changes.

# Changes

- integrate button to open modal with ckBTC wallet footer
- call modal with an event 
- style "Receive" as secondary

# Screenshot

<img width="1536" alt="Capture d’écran 2023-02-14 à 13 59 08" src="https://user-images.githubusercontent.com/16886711/218747331-e6e5f6e0-d472-44aa-afed-9661866782a8.png">

