### PR TITLE
GIX-1322: Add featureFlags store to window and method

### DIFF
--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -11,8 +11,15 @@ type OverrideFeatureFlagsData = Partial<FeatureFlags>;
 export interface OverrideFeatureFlagsStore
   extends Readable<OverrideFeatureFlagsData> {
   setFlag(flag: keyof FeatureFlags, value: boolean): void;
+  removeFlag(flag: keyof FeatureFlags): void;
   reset: () => void;
 }
+
+const assertFeatureFlag = (flag: keyof FeatureFlags) => {
+  if (!(flag in FEATURE_FLAG_ENVIRONMENT)) {
+    throw new Error(`Unknown feature flag: ${flag}`);
+  }
+};
 
 /**
  * A store that contains the feature flags that have been overridden by the user.
@@ -27,10 +34,20 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
     subscribe,
 
     setFlag(flag: keyof FeatureFlags, value: boolean) {
+      assertFeatureFlag(flag);
       update((featureFlags) => ({
         ...featureFlags,
         [flag]: value,
       }));
+    },
+
+    removeFlag(flag: keyof FeatureFlags) {
+      assertFeatureFlag(flag);
+      update((featureFlags) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [flag]: _, ...rest } = featureFlags;
+        return rest;
+      });
     },
 
     reset: () => set({}),

--- a/frontend/src/tests/lib/components/ContextWrapperTest.svelte
+++ b/frontend/src/tests/lib/components/ContextWrapperTest.svelte
@@ -2,7 +2,7 @@
   import { setContext, SvelteComponent } from "svelte";
 
   export let Component: SvelteComponent;
-  export let contextKey: string;
+  export let contextKey: symbol;
   export let contextValue: unknown;
   export let props: object = {};
 

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -10,6 +10,7 @@ import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
   const noKey = "NO_KEY" as keyof FeatureFlags;
+  const error = new Error(`Unknown feature flag: ${noKey}`);
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });
@@ -34,7 +35,9 @@ describe("featureFlags store", () => {
   });
 
   it("should throw if a non feature flag is set", () => {
-    expect(() => overrideFeatureFlagsStore.setFlag(noKey, false)).toThrow();
+    expect(() => overrideFeatureFlagsStore.setFlag(noKey, false)).toThrowError(
+      error
+    );
   });
 
   it("should remove feature flags", () => {
@@ -53,6 +56,6 @@ describe("featureFlags store", () => {
   });
 
   it("should throw if a non feature flag is removed", () => {
-    expect(() => overrideFeatureFlagsStore.removeFlag(noKey)).toThrow();
+    expect(() => overrideFeatureFlagsStore.removeFlag(noKey)).toThrow(error);
   });
 });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,4 +1,7 @@
-import { FEATURE_FLAG_ENVIRONMENT } from "$lib/constants/environment.constants";
+import {
+  FEATURE_FLAG_ENVIRONMENT,
+  type FeatureFlags,
+} from "$lib/constants/environment.constants";
 import {
   featureFlagsStore,
   overrideFeatureFlagsStore,
@@ -6,6 +9,7 @@ import {
 import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
+  const noKey = "NO_KEY" as keyof FeatureFlags;
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });
@@ -18,6 +22,8 @@ describe("featureFlags store", () => {
 
   it("should change value when overrideFeatureFlagsStore is updated", () => {
     const featureFlag = "ENABLE_SNS_2";
+
+    overrideFeatureFlagsStore.setFlag(featureFlag, true);
     const storeDataBefore = get(featureFlagsStore);
     expect(storeDataBefore[featureFlag]).toEqual(true);
 
@@ -25,5 +31,28 @@ describe("featureFlags store", () => {
 
     const storeDataAfter = get(featureFlagsStore);
     expect(storeDataAfter[featureFlag]).toEqual(false);
+  });
+
+  it("should throw if a non feature flag is set", () => {
+    expect(() => overrideFeatureFlagsStore.setFlag(noKey, false)).toThrow();
+  });
+
+  it("should remove feature flags", () => {
+    const featureFlag = "ENABLE_SNS_2";
+    const storeDataBefore = get(featureFlagsStore);
+    const initialValue = storeDataBefore[featureFlag];
+
+    overrideFeatureFlagsStore.setFlag(featureFlag, !initialValue);
+
+    const storeDataMid = get(featureFlagsStore);
+    expect(storeDataMid[featureFlag]).toEqual(!initialValue);
+
+    overrideFeatureFlagsStore.removeFlag(featureFlag);
+    const storeDataAfter = get(featureFlagsStore);
+    expect(storeDataAfter[featureFlag]).toEqual(initialValue);
+  });
+
+  it("should throw if a non feature flag is removed", () => {
+    expect(() => overrideFeatureFlagsStore.removeFlag(noKey)).toThrow();
   });
 });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,11 +1,29 @@
 import { FEATURE_FLAG_ENVIRONMENT } from "$lib/constants/environment.constants";
-import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+import {
+  featureFlagsStore,
+  overrideFeatureFlagsStore,
+} from "$lib/stores/feature-flags.store";
 import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
+  beforeEach(() => {
+    overrideFeatureFlagsStore.reset();
+  });
+
   it("should set default value to env var FEATURE_FLAG_ENVIRONMENT", () => {
     const storeData = get(featureFlagsStore);
 
     expect(storeData).toEqual(FEATURE_FLAG_ENVIRONMENT);
+  });
+
+  it("should change value when overrideFeatureFlagsStore is updated", () => {
+    const featureFlag = "ENABLE_SNS_2";
+    const storeDataBefore = get(featureFlagsStore);
+    expect(storeDataBefore[featureFlag]).toEqual(true);
+
+    overrideFeatureFlagsStore.setFlag(featureFlag, false);
+
+    const storeDataAfter = get(featureFlagsStore);
+    expect(storeDataAfter[featureFlag]).toEqual(false);
   });
 });


### PR DESCRIPTION
# Motivation

We want to be able to toggle feature flags in mainnet.

# Changes

* Add `setFlag` method to `overrideFeatureFlagsStore`.
* Expose `overrideFeatureFlagsStore` to `window`.

# Tests

* Test for `setFlag` method in `overrideFeatureFlagsStore`.
* Test functionality of `overrideFeatureFlagsStore` in a component using the feature flag.
