### PR TITLE
Rm unused docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,24 +62,6 @@ RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs
 COPY dfx.json dfx.json
 RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
-# Start the second container
-FROM builder AS build
-SHELL ["bash", "-c"]
-ARG DFX_NETWORK=mainnet
-RUN echo "DFX_NETWORK: '$DFX_NETWORK'"
-
-ARG OWN_CANISTER_ID
-RUN echo "OWN_CANISTER_ID: '$OWN_CANISTER_ID'"
-
-# Build
-# ... put only git-tracked files in the build directory
-COPY . /build
-WORKDIR /build
-RUN find . -type f | sed 's/^..//g' > ../build-inputs.txt
-RUN ./build.sh
-
-RUN ls -sh nns-dapp.wasm; sha256sum nns-dapp.wasm
-
 FROM builder AS build_frontend
 ARG DFX_NETWORK=mainnet
 RUN echo "DFX_NETWORK: '$DFX_NETWORK'"


### PR DESCRIPTION
# Motivation
The dockerfile no longer uses the "build" container. The default docker target is scratch, which uses:
```
FROM scratch AS scratch
COPY --from=build_nnsdapp /build/nns-dapp.wasm /
COPY --from=build_nnsdapp /build/assets.tar.xz /
COPY --from=build_aggregate /build/sns_aggregator.wasm /
COPY --from=build_aggregate /build/sns_aggregator_dev.wasm /
```
Some users _may_ be using docker, giving `build` explicitly as the target.  If so, now is the time to say.  We can look at your use case and figure out the best way forwards.

# Changes
- Remove the `build` target from docker.

# Tests
See CI