### PR TITLE
Export individual feature flags

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
@@ -13,7 +13,7 @@
   import { emit } from "$lib/utils/events.utils";
   import Footer from "$lib/components/layout/Footer.svelte";
   import type { CkBTCWalletModal } from "../../types/wallet.modal";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_CKBTC_RECEIVE } from "$lib/stores/feature-flags.store";
 
   const context: CkBTCWalletContext =
     getContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY);
@@ -73,7 +73,7 @@
   };
 </script>
 
-<Footer columns={$featureFlagsStore.ENABLE_CKBTC_RECEIVE ? 2 : 1}>
+<Footer columns={$ENABLE_CKBTC_RECEIVE ? 2 : 1}>
   <button
     class="primary"
     on:click={openSend}
@@ -82,7 +82,7 @@
     >{$i18n.accounts.new_transaction}</button
   >
 
-  {#if $featureFlagsStore.ENABLE_CKBTC_RECEIVE}
+  {#if $ENABLE_CKBTC_RECEIVE}
     <button
       class="secondary"
       on:click={openReceive}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
@@ -19,7 +19,7 @@
   import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte";
   import { isNullish } from "@dfinity/utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_2 } from "$lib/stores/feature-flags.store";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -42,7 +42,7 @@
     <h3 slot="value">{formattedTotalMaturity(neuron)}</h3>
   </KeyValuePair>
 
-  {#if hasStakedMaturity(neuron) && $featureFlagsStore.ENABLE_SNS_2}
+  {#if hasStakedMaturity(neuron) && $ENABLE_SNS_2}
     <KeyValuePair testId="staked-maturity">
       <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
 
@@ -52,13 +52,13 @@
     </KeyValuePair>
   {/if}
 
-  {#if allowedToStakeMaturity && $featureFlagsStore.ENABLE_SNS_2}
+  {#if allowedToStakeMaturity && $ENABLE_SNS_2}
     <div class="actions" data-tid="stake-maturity-actions">
       <SnsStakeMaturityButton />
     </div>
   {/if}
 
-  {#if $featureFlagsStore.ENABLE_SNS_2}
+  {#if $ENABLE_SNS_2}
     <SnsAutoStakeMaturity />
   {/if}
 </CardInfo>

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -12,12 +12,12 @@ export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
     ? undefined
     : (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string);
 
-export interface FeatureFlags {
-  ENABLE_SNS_2: boolean;
-  ENABLE_SNS_VOTING: boolean;
-  ENABLE_SNS_AGGREGATOR: boolean;
-  ENABLE_CKBTC_LEDGER: boolean;
-  ENABLE_CKBTC_RECEIVE: boolean;
+export interface FeatureFlags<T> {
+  ENABLE_SNS_2: T;
+  ENABLE_SNS_VOTING: T;
+  ENABLE_SNS_AGGREGATOR: T;
+  ENABLE_CKBTC_LEDGER: T;
+  ENABLE_CKBTC_RECEIVE: T;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface FeatureFlags {
  *
  * @see feature-flags.store.ts to use feature flags
  */
-export const FEATURE_FLAG_ENVIRONMENT: FeatureFlags = JSON.parse(
+export const FEATURE_FLAG_ENVIRONMENT: FeatureFlags<boolean> = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
     '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC_LEDGER": true, "ENABLE_CKBTC_RECEIVE": false}'
 );

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -20,6 +20,8 @@ export interface FeatureFlags<T> {
   ENABLE_CKBTC_RECEIVE: T;
 }
 
+export type FeatureKey = keyof FeatureFlags<boolean>;
+
 /**
  * DO NOT USE DIRECTLY
  *

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -2,13 +2,12 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import type { FeatureFlags } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   snsProjectsCommittedStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
-import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+import { ENABLE_CKBTC_LEDGER } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import { isUniverseCkBTC, pathSupportsCkBTC } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
@@ -22,13 +21,16 @@ export const CKBTC_UNIVERSE: Universe = {
 };
 
 const universesStore = derived<
-  [Readable<SnsFullProject[] | undefined>, Readable<FeatureFlags>],
+  [Readable<SnsFullProject[] | undefined>, Readable<boolean>],
   Universe[]
 >(
-  [snsProjectsCommittedStore, featureFlagsStore],
-  ([projects, featureFlags]: [SnsFullProject[] | undefined, FeatureFlags]) => [
+  [snsProjectsCommittedStore, ENABLE_CKBTC_LEDGER],
+  ([projects, ENABLE_CKBTC_LEDGER]: [
+    SnsFullProject[] | undefined,
+    boolean
+  ]) => [
     NNS_UNIVERSE,
-    ...(featureFlags.ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
+    ...(ENABLE_CKBTC_LEDGER ? [CKBTC_UNIVERSE] : []),
     ...(projects?.map(({ rootCanisterId, summary }) => ({
       canisterId: rootCanisterId.toText(),
       summary,

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -2,13 +2,12 @@ import {
   OWN_CANISTER_ID,
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
-import type { FeatureFlags } from "$lib/constants/environment.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import {
   NNS_UNIVERSE,
   selectableUniversesStore,
 } from "$lib/derived/selectable-universes.derived";
-import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+import { ENABLE_CKBTC_LEDGER } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
 import {
   isUniverseCkBTC,
@@ -41,13 +40,13 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Principal>, Readable<Page>, Readable<FeatureFlags>],
+  [Readable<Principal>, Readable<Page>, Readable<boolean>],
   Principal
 >(
-  [pageUniverseIdStore, pageStore, featureFlagsStore],
+  [pageUniverseIdStore, pageStore, ENABLE_CKBTC_LEDGER],
   ([canisterId, page, featureFlags]) => {
     // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (featureFlags.ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
+    if (ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
       return canisterId;
     }
 

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -30,7 +30,6 @@
   } from "$lib/derived/universes-tokens.derived";
   import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte";
   import CkBTCWalletModals from "$lib/modals/accounts/CkBTCWalletModals.svelte";
-  import { ENABLE_CKBTC_RECEIVE } from "$lib/stores/feature-flags.store";
 
   export let accountIdentifier: string | undefined | null = undefined;
 

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -30,6 +30,7 @@
   } from "$lib/derived/universes-tokens.derived";
   import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte";
   import CkBTCWalletModals from "$lib/modals/accounts/CkBTCWalletModals.svelte";
+  import { ENABLE_CKBTC_RECEIVE } from "$lib/stores/feature-flags.store";
 
   export let accountIdentifier: string | undefined | null = undefined;
 

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -3,13 +3,13 @@
   import { goto } from "$app/navigation";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
 
   export let proposalIdText: string | undefined | null = undefined;
 
   onMount(() => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
-    if (!$featureFlagsStore.ENABLE_SNS_VOTING) {
+    if (!$ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }), {
         replaceState: true,
       });

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -17,11 +17,11 @@
   } from "$lib/utils/sns-proposals.utils";
   import { loadSnsFilters } from "$lib/services/sns-filters.services";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
 
   onMount(async () => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
-    if (!$featureFlagsStore.ENABLE_SNS_VOTING) {
+    if (!$ENABLE_SNS_VOTING) {
       goto(buildProposalsUrl({ universe: OWN_CANISTER_ID.toText() }), {
         replaceState: true,
       });

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -24,7 +24,7 @@
   import { buildWalletUrl } from "$lib/utils/navigation.utils";
   import { pageStore } from "$lib/derived/page.derived";
   import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_CKBTC_LEDGER } from "$lib/stores/feature-flags.store";
 
   // Selected project ID on mount is excluded from load accounts balances. See documentation.
   let selectedUniverseId = $selectedUniverseIdStore;
@@ -55,7 +55,7 @@
 
   const loadCkBTCAccountsBalances = async () => {
     // ckBTC is not enabled, information shall and cannot be fetched
-    if (!$featureFlagsStore.ENABLE_CKBTC_LEDGER) {
+    if (!$ENABLE_CKBTC_LEDGER) {
       return;
     }
 

--- a/frontend/src/lib/routes/ProposalDetail.svelte
+++ b/frontend/src/lib/routes/ProposalDetail.svelte
@@ -5,16 +5,16 @@
   import type { AppPath } from "$lib/constants/routes.constants";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
 
   export let referrerPath: AppPath | undefined = undefined;
   export let proposalIdText: string | null | undefined;
 </script>
 
 <main>
-  {#if $isNnsUniverseStore || !$featureFlagsStore.ENABLE_SNS_VOTING}
+  {#if $isNnsUniverseStore || !$ENABLE_SNS_VOTING}
     <NnsProposalDetail {referrerPath} {proposalIdText} />
-  {:else if nonNullish($snsProjectSelectedStore) && $featureFlagsStore.ENABLE_SNS_VOTING}
+  {:else if nonNullish($snsProjectSelectedStore) && $ENABLE_SNS_VOTING}
     <SnsProposalDetail {proposalIdText} />
   {/if}
 </main>

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -6,18 +6,18 @@
   import type { AppPath } from "$lib/constants/routes.constants";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
 
   export let referrerPath: AppPath | undefined = undefined;
 </script>
 
 <main>
-  {#if $featureFlagsStore.ENABLE_SNS_VOTING}
+  {#if $ENABLE_SNS_VOTING}
     <SummaryUniverse />
   {/if}
-  {#if $isNnsUniverseStore || !$featureFlagsStore.ENABLE_SNS_VOTING}
+  {#if $isNnsUniverseStore || !$ENABLE_SNS_VOTING}
     <Proposals {referrerPath} />
-  {:else if nonNullish($snsProjectSelectedStore) && $featureFlagsStore.ENABLE_SNS_VOTING}
+  {:else if nonNullish($snsProjectSelectedStore) && $ENABLE_SNS_VOTING}
     <SnsProposals />
   {/if}
 </main>

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -6,7 +6,7 @@ import {
 } from "$lib/services/$public/sns.services";
 import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
 import { authStore } from "$lib/stores/auth.store";
-import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+import { ENABLE_SNS_AGGREGATOR } from "$lib/stores/feature-flags.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { get } from "svelte/store";
@@ -19,11 +19,9 @@ export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [];
-  const featureFlags = get(featureFlagsStore);
 
   const initSns: Promise<void>[] = [
-    featureFlags.ENABLE_SNS_AGGREGATOR &&
-    SNS_AGGREGATOR_CANISTER_URL !== undefined
+    get(ENABLE_SNS_AGGREGATOR) && SNS_AGGREGATOR_CANISTER_URL !== undefined
       ? loadSnsProjects()
       : loadSnsSummaries(),
   ];

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -63,9 +63,7 @@ if (browser) {
   (window as any).__featureFlagsStore = overrideFeatureFlagsStore;
 }
 
-const initFeatureFlagStore = (
-  key: FeatureKey
-): Readable<boolean> =>
+const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>
   derived(
     overrideFeatureFlagsStore,
     ($overrideFeatureFlagsStore) =>

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -2,6 +2,7 @@ import { browser } from "$app/environment";
 import {
   FEATURE_FLAG_ENVIRONMENT,
   type FeatureFlags,
+  type FeatureKey,
 } from "$lib/constants/environment.constants";
 import { storeLocalStorageKey } from "$lib/constants/stores.constants";
 import { derived, type Readable } from "svelte/store";
@@ -10,12 +11,12 @@ import { writableStored } from "./writable-stored";
 type OverrideFeatureFlagsData = Partial<FeatureFlags<boolean>>;
 export interface OverrideFeatureFlagsStore
   extends Readable<OverrideFeatureFlagsData> {
-  setFlag(flag: keyof FeatureFlags, value: boolean): void;
-  removeFlag(flag: keyof FeatureFlags): void;
+  setFlag(flag: FeatureKey, value: boolean): void;
+  removeFlag(flag: FeatureKey): void;
   reset: () => void;
 }
 
-const assertFeatureFlag = (flag: keyof FeatureFlags) => {
+const assertFeatureFlag = (flag: FeatureKey) => {
   if (!(flag in FEATURE_FLAG_ENVIRONMENT)) {
     throw new Error(`Unknown feature flag: ${flag}`);
   }
@@ -33,7 +34,7 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
   return {
     subscribe,
 
-    setFlag(flag: keyof FeatureFlags, value: boolean) {
+    setFlag(flag: FeatureKey, value: boolean) {
       assertFeatureFlag(flag);
       update((featureFlags) => ({
         ...featureFlags,
@@ -41,7 +42,7 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
       }));
     },
 
-    removeFlag(flag: keyof FeatureFlags) {
+    removeFlag(flag: FeatureKey) {
       assertFeatureFlag(flag);
       update((featureFlags) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -63,7 +64,7 @@ if (browser) {
 }
 
 const initFeatureFlagStore = (
-  key: keyof FeatureFlags<boolean>
+  key: FeatureKey
 ): Readable<boolean> =>
   derived(
     overrideFeatureFlagsStore,
@@ -73,7 +74,7 @@ const initFeatureFlagStore = (
 
 const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
   let featureFlagStores: Partial<FeatureFlags<Readable<boolean>>> = {};
-  let key: keyof FeatureFlags<boolean>;
+  let key: FeatureKey;
   for (key in FEATURE_FLAG_ENVIRONMENT) {
     featureFlagStores[key] = initFeatureFlagStore(key);
   }

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -70,14 +70,14 @@ const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>
       $overrideFeatureFlagsStore[key] ?? FEATURE_FLAG_ENVIRONMENT[key]
   );
 
-const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> =>
-  Object.keys(FEATURE_FLAG_ENVIRONMENT).reduce(
-    (features, key) => ({
-      ...features,
-      [key]: initFeatureFlagStore(key as FeatureKey),
-    }),
-    {} as Partial<FeatureFlags<Readable<boolean>>>
-  ) as FeatureFlags<Readable<boolean>>;
+const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
+  let featureFlagStores: Partial<FeatureFlags<Readable<boolean>>> = {};
+  let key: FeatureKey;
+  for (key in FEATURE_FLAG_ENVIRONMENT) {
+    featureFlagStores[key] = initFeatureFlagStore(key);
+  }
+  return featureFlagStores as FeatureFlags<Readable<boolean>>;
+};
 
 const featureFlagsStore = initFeatureFlagsStore();
 

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -79,7 +79,7 @@ const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
   return featureFlagStores as FeatureFlags<Readable<boolean>>;
 };
 
-export const featureFlagsStore = initFeatureFlagsStore();
+const featureFlagsStore = initFeatureFlagsStore();
 
 export const {
   ENABLE_SNS_2,

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -70,14 +70,14 @@ const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>
       $overrideFeatureFlagsStore[key] ?? FEATURE_FLAG_ENVIRONMENT[key]
   );
 
-const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
-  let featureFlagStores: Partial<FeatureFlags<Readable<boolean>>> = {};
-  let key: FeatureKey;
-  for (key in FEATURE_FLAG_ENVIRONMENT) {
-    featureFlagStores[key] = initFeatureFlagStore(key);
-  }
-  return featureFlagStores as FeatureFlags<Readable<boolean>>;
-};
+const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> =>
+  Object.keys(FEATURE_FLAG_ENVIRONMENT).reduce(
+    (features, key) => ({
+      ...features,
+      [key]: initFeatureFlagStore(key as FeatureKey),
+    }),
+    {} as Partial<FeatureFlags<Readable<boolean>>>
+  ) as FeatureFlags<Readable<boolean>>;
 
 const featureFlagsStore = initFeatureFlagsStore();
 

--- a/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/proposals/+layout.svelte
@@ -3,12 +3,10 @@
   import Content from "$lib/components/layout/Content.svelte";
   import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
   import type { SvelteComponent } from "svelte";
-  import { featureFlagsStore } from "$lib/stores/feature-flags.store";
+  import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
 
   let cmp: typeof SvelteComponent;
-  $: cmp = $featureFlagsStore.ENABLE_SNS_VOTING
-    ? UniverseSplitContent
-    : Content;
+  $: cmp = $ENABLE_SNS_VOTING ? UniverseSplitContent : Content;
 </script>
 
 <Layout>

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,6 +1,7 @@
 import {
   FEATURE_FLAG_ENVIRONMENT,
   type FeatureFlags,
+  type FeatureKey,
 } from "$lib/constants/environment.constants";
 import {
   featureFlagsStore,
@@ -9,14 +10,14 @@ import {
 import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
-  const noKey = "NO_KEY" as keyof FeatureFlags;
+  const noKey = "NO_KEY" as FeatureKey;
   const error = new Error(`Unknown feature flag: ${noKey}`);
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });
 
   it("should set default value to env var FEATURE_FLAG_ENVIRONMENT", () => {
-    let feature: keyof FeatureFlags<boolean>;
+    let feature: FeatureKey;
     for (feature in FEATURE_FLAG_ENVIRONMENT) {
       expect(get(featureFlagsStore[feature])).toEqual(
         FEATURE_FLAG_ENVIRONMENT[feature]
@@ -28,13 +29,13 @@ describe("featureFlags store", () => {
     const featureFlag = "ENABLE_SNS_2";
 
     overrideFeatureFlagsStore.setFlag(featureFlag, true);
-    const storeDataBefore = get(featureFlagsStore);
-    expect(storeDataBefore[featureFlag]).toEqual(true);
+    const enabledBefore = get(featureFlagsStore[featureFlag]);
+    expect(enabledBefore).toEqual(true);
 
     overrideFeatureFlagsStore.setFlag(featureFlag, false);
 
-    const storeDataAfter = get(featureFlagsStore);
-    expect(storeDataAfter[featureFlag]).toEqual(false);
+    const enabledAfter = get(featureFlagsStore[featureFlag]);
+    expect(enabledAfter).toEqual(false);
   });
 
   it("should throw if a non feature flag is set", () => {
@@ -45,17 +46,17 @@ describe("featureFlags store", () => {
 
   it("should remove feature flags", () => {
     const featureFlag = "ENABLE_SNS_2";
-    const storeDataBefore = get(featureFlagsStore);
-    const initialValue = storeDataBefore[featureFlag];
+    const featureStore = featureFlagsStore[featureFlag];
+    const initialValue = get(featureStore);
 
     overrideFeatureFlagsStore.setFlag(featureFlag, !initialValue);
 
-    const storeDataMid = get(featureFlagsStore);
-    expect(storeDataMid[featureFlag]).toEqual(!initialValue);
+    const enabledMid = get(featureStore);
+    expect(enabledMid).toEqual(!initialValue);
 
     overrideFeatureFlagsStore.removeFlag(featureFlag);
-    const storeDataAfter = get(featureFlagsStore);
-    expect(storeDataAfter[featureFlag]).toEqual(initialValue);
+    const enabledAfter = get(featureStore);
+    expect(enabledAfter).toEqual(initialValue);
   });
 
   it("should throw if a non feature flag is removed", () => {

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -3,9 +3,7 @@ import {
   type FeatureKey,
 } from "$lib/constants/environment.constants";
 import * as featureFlagsModule from "$lib/stores/feature-flags.store";
-import {
-  overrideFeatureFlagsStore,
-} from "$lib/stores/feature-flags.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { get } from "svelte/store";
 
 describe("featureFlags store", () => {

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -1,8 +1,8 @@
 import {
   FEATURE_FLAG_ENVIRONMENT,
-  type FeatureFlags,
   type FeatureKey,
 } from "$lib/constants/environment.constants";
+import * as featureFlagsModule from "$lib/stores/feature-flags.store";
 import {
   featureFlagsStore,
   overrideFeatureFlagsStore,
@@ -20,6 +20,15 @@ describe("featureFlags store", () => {
     let feature: FeatureKey;
     for (feature in FEATURE_FLAG_ENVIRONMENT) {
       expect(get(featureFlagsStore[feature])).toEqual(
+        FEATURE_FLAG_ENVIRONMENT[feature]
+      );
+    }
+  });
+
+  it("should export all feature flags on the module as boolean stores", () => {
+    let feature: FeatureKey;
+    for (feature in FEATURE_FLAG_ENVIRONMENT) {
+      expect(get(featureFlagsModule[feature])).toEqual(
         FEATURE_FLAG_ENVIRONMENT[feature]
       );
     }

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -16,9 +16,12 @@ describe("featureFlags store", () => {
   });
 
   it("should set default value to env var FEATURE_FLAG_ENVIRONMENT", () => {
-    const storeData = get(featureFlagsStore);
-
-    expect(storeData).toEqual(FEATURE_FLAG_ENVIRONMENT);
+    let feature: keyof FeatureFlags<boolean>;
+    for (feature in FEATURE_FLAG_ENVIRONMENT) {
+      expect(get(featureFlagsStore[feature])).toEqual(
+        FEATURE_FLAG_ENVIRONMENT[feature]
+      );
+    }
   });
 
   it("should change value when overrideFeatureFlagsStore is updated", () => {

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -4,7 +4,6 @@ import {
 } from "$lib/constants/environment.constants";
 import * as featureFlagsModule from "$lib/stores/feature-flags.store";
 import {
-  featureFlagsStore,
   overrideFeatureFlagsStore,
 } from "$lib/stores/feature-flags.store";
 import { get } from "svelte/store";
@@ -16,16 +15,7 @@ describe("featureFlags store", () => {
     overrideFeatureFlagsStore.reset();
   });
 
-  it("should set default value to env var FEATURE_FLAG_ENVIRONMENT", () => {
-    let feature: FeatureKey;
-    for (feature in FEATURE_FLAG_ENVIRONMENT) {
-      expect(get(featureFlagsStore[feature])).toEqual(
-        FEATURE_FLAG_ENVIRONMENT[feature]
-      );
-    }
-  });
-
-  it("should export all feature flags on the module as boolean stores", () => {
+  it("should export all feature flags on the module with default values", () => {
     let feature: FeatureKey;
     for (feature in FEATURE_FLAG_ENVIRONMENT) {
       expect(get(featureFlagsModule[feature])).toEqual(
@@ -35,15 +25,16 @@ describe("featureFlags store", () => {
   });
 
   it("should change value when overrideFeatureFlagsStore is updated", () => {
-    const featureFlag = "ENABLE_SNS_2";
+    const featureKey = "ENABLE_SNS_2";
+    const featureFlag = featureFlagsModule[featureKey];
 
-    overrideFeatureFlagsStore.setFlag(featureFlag, true);
-    const enabledBefore = get(featureFlagsStore[featureFlag]);
+    overrideFeatureFlagsStore.setFlag(featureKey, true);
+    const enabledBefore = get(featureFlag);
     expect(enabledBefore).toEqual(true);
 
-    overrideFeatureFlagsStore.setFlag(featureFlag, false);
+    overrideFeatureFlagsStore.setFlag(featureKey, false);
 
-    const enabledAfter = get(featureFlagsStore[featureFlag]);
+    const enabledAfter = get(featureFlag);
     expect(enabledAfter).toEqual(false);
   });
 
@@ -54,17 +45,17 @@ describe("featureFlags store", () => {
   });
 
   it("should remove feature flags", () => {
-    const featureFlag = "ENABLE_SNS_2";
-    const featureStore = featureFlagsStore[featureFlag];
-    const initialValue = get(featureStore);
+    const featureKey = "ENABLE_SNS_2";
+    const featureFlag = featureFlagsModule[featureKey];
+    const initialValue = get(featureFlag);
 
-    overrideFeatureFlagsStore.setFlag(featureFlag, !initialValue);
+    overrideFeatureFlagsStore.setFlag(featureKey, !initialValue);
 
-    const enabledMid = get(featureStore);
+    const enabledMid = get(featureFlag);
     expect(enabledMid).toEqual(!initialValue);
 
-    overrideFeatureFlagsStore.removeFlag(featureFlag);
-    const enabledAfter = get(featureStore);
+    overrideFeatureFlagsStore.removeFlag(featureKey);
+    const enabledAfter = get(featureFlag);
     expect(enabledAfter).toEqual(initialValue);
   });
 


### PR DESCRIPTION
# Motivation

This makes using a feature flag more similar to how it was before https://github.com/dfinity/nns-dapp/pull/1874.
It let's you import and write `$ENABLE_SNS_2` instead of `$featureFlagsStore.ENABLE_SNS_2`.

# Changes

Export feature flags from the module as individual boolean stores.
Also add a type `FeatureKey = keyof FeatureFlags<boolean>` for convenience.

# Tests

Added a test that each defined feature flag is also exported. And updated existing tests.
