### PR TITLE
Chore: Restrict feature flags functionality

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -50,6 +50,8 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
     ENABLE_SNS_AGGREGATOR: true,
     ENABLE_CKBTC_LEDGER: true,
     ENABLE_CKBTC_RECEIVE: true,
+    TEST_FLAG_EDITABLE: true,
+    TEST_FLAG_NOT_EDITABLE: true,
   },
   SNS_AGGREGATOR_CANISTER_URL:
     "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network",

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -19,8 +19,8 @@ export interface FeatureFlags<T> {
   ENABLE_CKBTC_LEDGER: T;
   ENABLE_CKBTC_RECEIVE: T;
   // Used only in tests and set up in jest-setup.ts
-  TEST_FLAG_EDITABLE?: T;
-  TEST_FLAG_NOT_EDITABLE?: T;
+  TEST_FLAG_EDITABLE: T;
+  TEST_FLAG_NOT_EDITABLE: T;
 }
 
 export type FeatureKey = keyof FeatureFlags<boolean>;

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -18,6 +18,9 @@ export interface FeatureFlags<T> {
   ENABLE_SNS_AGGREGATOR: T;
   ENABLE_CKBTC_LEDGER: T;
   ENABLE_CKBTC_RECEIVE: T;
+  // Used only in tests and set up in jest-setup.ts
+  TEST_FLAG_EDITABLE?: T;
+  TEST_FLAG_NOT_EDITABLE?: T;
 }
 
 export type FeatureKey = keyof FeatureFlags<boolean>;

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -72,19 +72,15 @@ if (browser) {
   (window as any).__featureFlagsStore = overrideFeatureFlagsStore;
 }
 
-const initFeatureFlagStore = (key: FeatureKey): Readable<boolean | undefined> =>
+const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>
   derived(
     overrideFeatureFlagsStore,
     ($overrideFeatureFlagsStore) =>
       $overrideFeatureFlagsStore[key] ?? FEATURE_FLAG_ENVIRONMENT[key]
   );
 
-const initFeatureFlagsStore = (): FeatureFlags<
-  Readable<boolean | undefined>
-> => {
-  const featureFlagStores: Partial<
-    FeatureFlags<Readable<boolean | undefined>>
-  > = {};
+const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
+  const featureFlagStores: Partial<FeatureFlags<Readable<boolean>>> = {};
   let key: FeatureKey;
   for (key in FEATURE_FLAG_ENVIRONMENT) {
     featureFlagStores[key] = initFeatureFlagStore(key);

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -16,11 +16,19 @@ export interface OverrideFeatureFlagsStore
   reset: () => void;
 }
 
-const assertFeatureFlag = (flag: FeatureKey) => {
+const assertValidFeatureFlag = (flag: FeatureKey) => {
   if (!(flag in FEATURE_FLAG_ENVIRONMENT)) {
     throw new Error(`Unknown feature flag: ${flag}`);
   }
+  if (!EDITABLE_FEATURE_FLAGS.includes(flag)) {
+    throw new Error(`Feature flag is not editable: ${flag}`);
+  }
 };
+
+const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
+  "ENABLE_SNS_AGGREGATOR",
+  "ENABLE_SNS_2",
+];
 
 /**
  * A store that contains the feature flags that have been overridden by the user.
@@ -35,7 +43,7 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
     subscribe,
 
     setFlag(flag: FeatureKey, value: boolean) {
-      assertFeatureFlag(flag);
+      assertValidFeatureFlag(flag);
       update((featureFlags) => ({
         ...featureFlags,
         [flag]: value,
@@ -43,7 +51,7 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
     },
 
     removeFlag(flag: FeatureKey) {
-      assertFeatureFlag(flag);
+      assertValidFeatureFlag(flag);
       update((featureFlags) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [flag]: _, ...rest } = featureFlags;

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -28,6 +28,7 @@ const assertValidFeatureFlag = (flag: FeatureKey) => {
 const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
   "ENABLE_SNS_AGGREGATOR",
   "ENABLE_SNS_2",
+  "TEST_FLAG_EDITABLE",
 ];
 
 /**
@@ -71,15 +72,19 @@ if (browser) {
   (window as any).__featureFlagsStore = overrideFeatureFlagsStore;
 }
 
-const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>
+const initFeatureFlagStore = (key: FeatureKey): Readable<boolean | undefined> =>
   derived(
     overrideFeatureFlagsStore,
     ($overrideFeatureFlagsStore) =>
       $overrideFeatureFlagsStore[key] ?? FEATURE_FLAG_ENVIRONMENT[key]
   );
 
-const initFeatureFlagsStore = (): FeatureFlags<Readable<boolean>> => {
-  let featureFlagStores: Partial<FeatureFlags<Readable<boolean>>> = {};
+const initFeatureFlagsStore = (): FeatureFlags<
+  Readable<boolean | undefined>
+> => {
+  const featureFlagStores: Partial<
+    FeatureFlags<Readable<boolean | undefined>>
+  > = {};
   let key: FeatureKey;
   for (key in FEATURE_FLAG_ENVIRONMENT) {
     featureFlagStores[key] = initFeatureFlagStore(key);
@@ -95,4 +100,7 @@ export const {
   ENABLE_SNS_AGGREGATOR,
   ENABLE_CKBTC_LEDGER,
   ENABLE_CKBTC_RECEIVE,
+  // Used only in tests only
+  TEST_FLAG_EDITABLE,
+  TEST_FLAG_NOT_EDITABLE,
 } = featureFlagsStore;

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -9,9 +9,9 @@ import { get } from "svelte/store";
 describe("featureFlags store", () => {
   const noKey = "NO_KEY" as FeatureKey;
   const noKeyError = `Unknown feature flag: ${noKey}`;
-  const notEditable = "TEST_FLAG_NOT_EDITABLE" as FeatureKey;
+  const notEditable: FeatureKey = "TEST_FLAG_NOT_EDITABLE";
   const notEditableError = `Feature flag is not editable: ${notEditable}`;
-  const editableFlag = "TEST_FLAG_EDITABLE" as FeatureKey;
+  const editableFlag: FeatureKey = "TEST_FLAG_EDITABLE";
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -9,8 +9,9 @@ import { get } from "svelte/store";
 describe("featureFlags store", () => {
   const noKey = "NO_KEY" as FeatureKey;
   const noKeyError = `Unknown feature flag: ${noKey}`;
-  const noEditable = "ENABLE_SNS_VOTING" as FeatureKey;
-  const noEditableError = `Feature flag is not editable: ${noEditable}`;
+  const notEditable = "TEST_FLAG_NOT_EDITABLE" as FeatureKey;
+  const notEditableError = `Feature flag is not editable: ${notEditable}`;
+  const editableFlag = "TEST_FLAG_EDITABLE" as FeatureKey;
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });
@@ -25,14 +26,13 @@ describe("featureFlags store", () => {
   });
 
   it("should change value when overrideFeatureFlagsStore is updated", () => {
-    const featureKey = "ENABLE_SNS_2";
-    const featureFlag = featureFlagsModule[featureKey];
+    const featureFlag = featureFlagsModule[editableFlag];
 
-    overrideFeatureFlagsStore.setFlag(featureKey, true);
+    overrideFeatureFlagsStore.setFlag(editableFlag, true);
     const enabledBefore = get(featureFlag);
     expect(enabledBefore).toEqual(true);
 
-    overrideFeatureFlagsStore.setFlag(featureKey, false);
+    overrideFeatureFlagsStore.setFlag(editableFlag, false);
 
     const enabledAfter = get(featureFlag);
     expect(enabledAfter).toEqual(false);
@@ -46,21 +46,20 @@ describe("featureFlags store", () => {
 
   it("should throw if a non editable feature flag is set", () => {
     expect(() =>
-      overrideFeatureFlagsStore.setFlag(noEditable, false)
-    ).toThrowError(noEditableError);
+      overrideFeatureFlagsStore.setFlag(notEditable, false)
+    ).toThrowError(notEditableError);
   });
 
   it("should remove feature flags", () => {
-    const featureKey = "ENABLE_SNS_2";
-    const featureFlag = featureFlagsModule[featureKey];
+    const featureFlag = featureFlagsModule[editableFlag];
     const initialValue = get(featureFlag);
 
-    overrideFeatureFlagsStore.setFlag(featureKey, !initialValue);
+    overrideFeatureFlagsStore.setFlag(editableFlag, !initialValue);
 
     const enabledMid = get(featureFlag);
     expect(enabledMid).toEqual(!initialValue);
 
-    overrideFeatureFlagsStore.removeFlag(featureKey);
+    overrideFeatureFlagsStore.removeFlag(editableFlag);
     const enabledAfter = get(featureFlag);
     expect(enabledAfter).toEqual(initialValue);
   });
@@ -72,8 +71,8 @@ describe("featureFlags store", () => {
   });
 
   it("should throw if a non editable feature flag is removed", () => {
-    expect(() => overrideFeatureFlagsStore.removeFlag(noEditable)).toThrow(
-      noEditableError
+    expect(() => overrideFeatureFlagsStore.removeFlag(notEditable)).toThrow(
+      notEditableError
     );
   });
 });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -8,7 +8,9 @@ import { get } from "svelte/store";
 
 describe("featureFlags store", () => {
   const noKey = "NO_KEY" as FeatureKey;
-  const error = new Error(`Unknown feature flag: ${noKey}`);
+  const noKeyError = `Unknown feature flag: ${noKey}`;
+  const noEditable = "ENABLE_SNS_VOTING" as FeatureKey;
+  const noEditableError = `Feature flag is not editable: ${noEditable}`;
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
   });
@@ -38,8 +40,14 @@ describe("featureFlags store", () => {
 
   it("should throw if a non feature flag is set", () => {
     expect(() => overrideFeatureFlagsStore.setFlag(noKey, false)).toThrowError(
-      error
+      noKeyError
     );
+  });
+
+  it("should throw if a non editable feature flag is set", () => {
+    expect(() =>
+      overrideFeatureFlagsStore.setFlag(noEditable, false)
+    ).toThrowError(noEditableError);
   });
 
   it("should remove feature flags", () => {
@@ -58,6 +66,14 @@ describe("featureFlags store", () => {
   });
 
   it("should throw if a non feature flag is removed", () => {
-    expect(() => overrideFeatureFlagsStore.removeFlag(noKey)).toThrow(error);
+    expect(() => overrideFeatureFlagsStore.removeFlag(noKey)).toThrow(
+      noKeyError
+    );
+  });
+
+  it("should throw if a non editable feature flag is removed", () => {
+    expect(() => overrideFeatureFlagsStore.removeFlag(noEditable)).toThrow(
+      noEditableError
+    );
   });
 });


### PR DESCRIPTION
# Motivation

Do not allow to set any feature flags. Ideally, we would only allow the ones approved by security.

# Changes

* Rename `assertFeatureFlag` to `assertValidFeatureFlag` in `features-flags.store.ts`.
* Add list of EDITABLE_FEATURE_FLAGS.
* Check that flag is included in EDITABLE_FEATURE_FLAGS in `assertValidFeatureFlag`.

# Tests

* Test new functionality.
