### PR TITLE
Install jest-expect-message

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -2,6 +2,7 @@ import { Principal } from "@dfinity/principal";
 import { Crypto as SubtleCrypto } from "@peculiar/webcrypto";
 import "@testing-library/jest-dom";
 import { configure } from "@testing-library/svelte";
+import "jest-expect-message";
 // jsdom does not implement TextEncoder
 // Polyfill the encoders with node
 import { TextDecoder, TextEncoder } from "util";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "fake-indexeddb": "^4.0.1",
         "jest": "^29.4.2",
         "jest-environment-jsdom": "^29.4.2",
+        "jest-expect-message": "^1.1.3",
         "jest-mock-extended": "^3.0.1",
         "node-fetch": "^3.3.0",
         "postcss": "^8.4.21",
@@ -5523,6 +5524,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-expect-message": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
+      "dev": true
     },
     "node_modules/jest-get-type": {
       "version": "29.4.2",
@@ -12936,6 +12943,12 @@
         "jest-mock": "^29.4.2",
         "jest-util": "^29.4.2"
       }
+    },
+    "jest-expect-message": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
+      "dev": true
     },
     "jest-get-type": {
       "version": "29.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "fake-indexeddb": "^4.0.1",
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",
+    "jest-expect-message": "^1.1.3",
     "jest-mock-extended": "^3.0.1",
     "node-fetch": "^3.3.0",
     "postcss": "^8.4.21",

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -16,9 +16,10 @@ describe("featureFlags store", () => {
   it("should export all feature flags on the module with default values", () => {
     let feature: FeatureKey;
     for (feature in FEATURE_FLAG_ENVIRONMENT) {
-      expect(get(featureFlagsModule[feature])).toEqual(
-        FEATURE_FLAG_ENVIRONMENT[feature]
-      );
+      expect(
+        get(featureFlagsModule[feature]),
+        `FeatureFlag ${feature} should be exported from feature-flags.store.ts`
+      ).toEqual(FEATURE_FLAG_ENVIRONMENT[feature]);
     }
   });
 


### PR DESCRIPTION
# Motivation

It can be useful to debug a test if some expectations have a custom message conveying some state.
NPM package  `jest-expect-message` lets you pass a second (message) parameter to expect which is display when the expectation fails.
This is especially useful when an expectation inside a for loop fails because the message can indicate which iteration of the loop fails.
It's also useful when helper functions do expectation.

# Changes

Install jest-expect-message.
And use it as an example in `feature-flags.store.ts` to indicate which feature flag isn't exported if any of them isn't.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
