### PR TITLE
Expose feature flags in the console in a way that allows for autocomplete

### DIFF
--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -104,7 +104,8 @@ const listFeatureFlagsToConsole = () => {
   }
 };
 
-const initConsoleInterface = (): FeatreFlagsConsoleInterface => {
+// Exported for testing.
+export const initConsoleInterface = (): FeatreFlagsConsoleInterface => {
   const consoleInterface: Partial<FeatreFlagsConsoleInterface> = {};
   let key: FeatureKey;
   for (key in FEATURE_FLAG_ENVIRONMENT) {

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -87,7 +87,8 @@ const initSingleFeatureConsoleInterface = (
 
 const listFeatureFlagsToConsole = () => {
   const overrideStates = get(overrideFeatureFlagsStore);
-  for (const key in FEATURE_FLAG_ENVIRONMENT) {
+  let key: FeatureKey;
+  for (key in FEATURE_FLAG_ENVIRONMENT) {
     const override = overrideStates[key];
     const defaultValue = FEATURE_FLAG_ENVIRONMENT[key];
     const value = override ?? defaultValue;

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -113,7 +113,9 @@ export const initConsoleInterface = (): FeatureFlagsConsoleInterface => {
 
 if (browser) {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  (window as any).__featureFlags = initConsoleInterface();
+  (
+    window as unknown as { __featureFlags: FeatureFlagsConsoleInterface }
+  ).__featureFlags = initConsoleInterface();
 }
 
 const initFeatureFlagStore = (key: FeatureKey): Readable<boolean> =>

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -67,19 +67,19 @@ const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
 // Exported for testing purposes
 export const overrideFeatureFlagsStore = initOverrideFeatureFlagsStore();
 
-interface FeatreFlagConsoleInterface {
+interface FeatureFlagConsoleInterface {
   overrideWith(value: boolean): void;
   removeOverride(): void;
 }
 
-interface FeatreFlagsConsoleInterface
-  extends FeatureFlags<FeatreFlagConsoleInterface> {
+interface FeatureFlagsConsoleInterface
+  extends FeatureFlags<FeatureFlagConsoleInterface> {
   list(): void;
 }
 
 const initSingleFeatureConsoleInterface = (
   key: FeatureKey
-): FeatreFlagConsoleInterface => ({
+): FeatureFlagConsoleInterface => ({
   overrideWith: (value: boolean) =>
     overrideFeatureFlagsStore.setFlag(key, value),
   removeOverride: () => overrideFeatureFlagsStore.removeFlag(key),
@@ -87,26 +87,19 @@ const initSingleFeatureConsoleInterface = (
 
 const listFeatureFlagsToConsole = () => {
   const overrideStates = get(overrideFeatureFlagsStore);
-  let key: FeatureKey;
-  for (key in FEATURE_FLAG_ENVIRONMENT) {
+  for (const key in FEATURE_FLAG_ENVIRONMENT) {
     const override = overrideStates[key];
     const defaultValue = FEATURE_FLAG_ENVIRONMENT[key];
     const value = override ?? defaultValue;
     console.log(
-      key,
-      value,
-      "(override",
-      override,
-      "default",
-      defaultValue,
-      ")"
+      `${key} ${value} (override ${override} default ${defaultValue})`
     );
   }
 };
 
 // Exported for testing.
-export const initConsoleInterface = (): FeatreFlagsConsoleInterface => {
-  const consoleInterface: Partial<FeatreFlagsConsoleInterface> = {};
+export const initConsoleInterface = (): FeatureFlagsConsoleInterface => {
+  const consoleInterface: Partial<FeatureFlagsConsoleInterface> = {};
   let key: FeatureKey;
   for (key in FEATURE_FLAG_ENVIRONMENT) {
     consoleInterface[key] = initSingleFeatureConsoleInterface(key);
@@ -114,7 +107,7 @@ export const initConsoleInterface = (): FeatreFlagsConsoleInterface => {
   return {
     ...consoleInterface,
     list: listFeatureFlagsToConsole,
-  } as FeatreFlagsConsoleInterface;
+  } as FeatureFlagsConsoleInterface;
 };
 
 if (browser) {

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -75,4 +75,57 @@ describe("featureFlags store", () => {
       notEditableError
     );
   });
+
+  describe("console interface", () => {
+    let recordedLogs: Array<string> = [];
+
+    beforeEach(() => {
+      recordedLogs.length = 0;
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((...args) =>
+          recordedLogs.push(args.map((s) => s ?? "undefined").join(" "))
+        );
+    });
+
+    it("should list features", () => {
+      const consoleInterface = featureFlagsModule.initConsoleInterface();
+      consoleInterface.list();
+
+      expect(recordedLogs).toEqual(
+        expect.arrayContaining([
+          "TEST_FLAG_EDITABLE true (override undefined default true )",
+        ])
+      );
+    });
+
+    it("should expose override methods", () => {
+      const consoleInterface = featureFlagsModule.initConsoleInterface();
+
+      consoleInterface.TEST_FLAG_EDITABLE.overrideWith(false);
+
+      const expectedOutput =
+        "TEST_FLAG_EDITABLE false (override false default true )";
+      expect(recordedLogs).not.toEqual(
+        expect.arrayContaining([expectedOutput])
+      );
+      consoleInterface.list();
+      expect(recordedLogs).toEqual(expect.arrayContaining([expectedOutput]));
+    });
+
+    it("should expose remove override methods", () => {
+      const consoleInterface = featureFlagsModule.initConsoleInterface();
+
+      consoleInterface.TEST_FLAG_EDITABLE.overrideWith(false);
+      consoleInterface.TEST_FLAG_EDITABLE.removeOverride();
+
+      const expectedOutput =
+        "TEST_FLAG_EDITABLE true (override undefined default true )";
+      expect(recordedLogs).not.toEqual(
+        expect.arrayContaining([expectedOutput])
+      );
+      consoleInterface.list();
+      expect(recordedLogs).toEqual(expect.arrayContaining([expectedOutput]));
+    });
+  });
 });

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -83,9 +83,7 @@ describe("featureFlags store", () => {
       recordedLogs.length = 0;
       jest
         .spyOn(console, "log")
-        .mockImplementation((...args) =>
-          recordedLogs.push(args.map((s) => s ?? "undefined").join(" "))
-        );
+        .mockImplementation((s) => recordedLogs.push(s));
     });
 
     it("should list features", () => {
@@ -94,7 +92,7 @@ describe("featureFlags store", () => {
 
       expect(recordedLogs).toEqual(
         expect.arrayContaining([
-          "TEST_FLAG_EDITABLE true (override undefined default true )",
+          "TEST_FLAG_EDITABLE true (override undefined default true)",
         ])
       );
     });
@@ -105,7 +103,7 @@ describe("featureFlags store", () => {
       consoleInterface.TEST_FLAG_EDITABLE.overrideWith(false);
 
       const expectedOutput =
-        "TEST_FLAG_EDITABLE false (override false default true )";
+        "TEST_FLAG_EDITABLE false (override false default true)";
       expect(recordedLogs).not.toEqual(
         expect.arrayContaining([expectedOutput])
       );
@@ -120,7 +118,7 @@ describe("featureFlags store", () => {
       consoleInterface.TEST_FLAG_EDITABLE.removeOverride();
 
       const expectedOutput =
-        "TEST_FLAG_EDITABLE true (override undefined default true )";
+        "TEST_FLAG_EDITABLE true (override undefined default true)";
       expect(recordedLogs).not.toEqual(
         expect.arrayContaining([expectedOutput])
       );


### PR DESCRIPTION
# Motivation

Making it easier to find the correct feature flags in the console.
By having the names of the feature flags directly on the object, instead of passed as strings, the console will autocomplete those names for you.

Enabling a feature now goes like this:
`> __featureFlags.ENABLE_SNS_AGGREGATOR.overrideWith(true);`

You can also get a list of features and states like this:
```
> __featureFlags.list()
ENABLE_CKBTC_LEDGER false (override undefined default false )
ENABLE_CKBTC_RECEIVE false (override undefined default false )
ENABLE_SNS_2 true (override undefined default true )
ENABLE_SNS_AGGREGATOR false (override undefined default false )
ENABLE_SNS_VOTING true (override undefined default true )
```

# Changes

Expose the feature flags in the console with fields with the names of the features on the window._featureFlags object.

# Tests

Tested manually in the console and tests added to feature-flags.store.spec.ts
