### PR TITLE
GIX-1326: Add missing param to SNS Aggregator

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -792,7 +792,10 @@
         "HOST": "https://medium07.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC_LEDGER": false,
+          "ENABLE_CKBTC_RECEIVE": false
         }
       },
       "providers": [

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -212,6 +212,7 @@ pub struct Params {
   pub  sns_token_e8s: u64,
   pub  max_participant_icp_e8s: u64,
   pub  min_icp_e8s: u64,
+  pub sale_delay_seconds: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -224,6 +225,7 @@ pub struct Swap {
   pub  buyers: Vec<(String,BuyerState,)>,
   pub  params: Option<Params>,
   pub  open_sns_token_swap_proposal_id: Option<u64>,
+  pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -110,6 +110,8 @@ pub struct SlowSwap {
     /// When the swap is committed, this field is initialized according
     /// to the outcome of the swap.
     pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
+    /// When the sale proposal is executed, this field is initialized accordingly
+    pub decentralization_sale_open_timestamp_seconds: ::core::option::Option<u64>,
 }
 
 impl From<&Swap> for SlowSwap {
@@ -119,6 +121,7 @@ impl From<&Swap> for SlowSwap {
             init: upstream.init.clone(),
             params: upstream.params.clone(),
             open_sns_token_swap_proposal_id: upstream.open_sns_token_swap_proposal_id,
+            decentralization_sale_open_timestamp_seconds: upstream.decentralization_sale_open_timestamp_seconds,
         }
     }
 }


### PR DESCRIPTION
# Motivation

There was a missing parameter in the SNS Aggregator `decentralization_sale_open_timestamp_seconds`

# Changes

* Add missing param in SNS Aggregator.

# Tests

* Tests are not setup yet.
