### PR TITLE
Fix actually using the ENABLE_CKBTC_LEDGER store.

### DIFF
--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -44,9 +44,9 @@ export const selectedUniverseIdStore: Readable<Principal> = derived<
   Principal
 >(
   [pageUniverseIdStore, pageStore, ENABLE_CKBTC_LEDGER],
-  ([canisterId, page, featureFlags]) => {
+  ([canisterId, page, enableCkbtcLedger]) => {
     // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (ENABLE_CKBTC_LEDGER && pathSupportsCkBTC(page)) {
+    if (enableCkbtcLedger && pathSupportsCkBTC(page)) {
       return canisterId;
     }
 

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -20,6 +20,10 @@ const assertValidFeatureFlag = (flag: FeatureKey) => {
   if (!(flag in FEATURE_FLAG_ENVIRONMENT)) {
     throw new Error(`Unknown feature flag: ${flag}`);
   }
+};
+
+const assertEditableFeatureFlag = (flag: FeatureKey) => {
+  assertValidFeatureFlag(flag);
   if (!EDITABLE_FEATURE_FLAGS.includes(flag)) {
     throw new Error(`Feature flag is not editable: ${flag}`);
   }
@@ -80,9 +84,14 @@ interface FeatureFlagsConsoleInterface
 const initSingleFeatureConsoleInterface = (
   key: FeatureKey
 ): FeatureFlagConsoleInterface => ({
-  overrideWith: (value: boolean) =>
-    overrideFeatureFlagsStore.setFlag(key, value),
-  removeOverride: () => overrideFeatureFlagsStore.removeFlag(key),
+  overrideWith: (value: boolean) => {
+    assertEditableFeatureFlag(key);
+    overrideFeatureFlagsStore.setFlag(key, value);
+  },
+  removeOverride: () => {
+    assertEditableFeatureFlag(key);
+    overrideFeatureFlagsStore.removeFlag(key);
+  },
 });
 
 const listFeatureFlagsToConsole = () => {

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -12,6 +12,7 @@ import {
   isNnsUniverseStore,
   selectedUniverseIdStore,
 } from "$lib/derived/selected-universe.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { get } from "svelte/store";
 import { mockSnsCanisterIdText } from "../../mocks/sns.api.mock";
@@ -44,17 +45,25 @@ describe("selected universe derived stores", () => {
       });
     });
 
-    it("should be ckBTC universe", () => {
+    it("should be ckBTC inside ckBTC universe", () => {
       const $store = get(isCkBTCUniverseStore);
 
       expect($store).toEqual(true);
     });
 
-    it("should not be ckBTC universe", () => {
+    it("should not be ckBTC outside ckBTC universe", () => {
       page.mock({ data: { universe: mockSnsCanisterIdText } });
       const $store = get(isCkBTCUniverseStore);
 
       expect($store).toBe(false);
+    });
+
+    it("should not be ckBTC with feature flag disabled", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_LEDGER", true);
+      expect(get(isCkBTCUniverseStore)).toBe(true);
+
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_LEDGER", false);
+      expect(get(isCkBTCUniverseStore)).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
+++ b/frontend/src/tests/lib/stores/feature-flags.store.spec.ts
@@ -45,10 +45,10 @@ describe("featureFlags store", () => {
     );
   });
 
-  it("should throw if a non editable feature flag is set", () => {
-    expect(() =>
-      overrideFeatureFlagsStore.setFlag(notEditable, false)
-    ).toThrowError(notEditableError);
+  it("should not throw if a non editable feature flag is set", () => {
+    // This is allowed for testing.
+    // Below we test that the user can't set a non-editable feature flag.
+    overrideFeatureFlagsStore.setFlag(notEditable, false);
   });
 
   it("should remove feature flags", () => {
@@ -71,10 +71,10 @@ describe("featureFlags store", () => {
     );
   });
 
-  it("should throw if a non editable feature flag is removed", () => {
-    expect(() => overrideFeatureFlagsStore.removeFlag(notEditable)).toThrow(
-      notEditableError
-    );
+  it("should not throw if a non editable feature flag is removed", () => {
+    // This is allowed for testing.
+    // Below we test that the user can't set a non-editable feature flag.
+    overrideFeatureFlagsStore.removeFlag(notEditable);
   });
 
   describe("console interface", () => {
@@ -125,6 +125,20 @@ describe("featureFlags store", () => {
       );
       consoleInterface.list();
       expect(recordedLogs).toEqual(expect.arrayContaining([expectedOutput]));
+    });
+
+    it("should throw if a non-editable feature flag is set", () => {
+      const consoleInterface = featureFlagsModule.initConsoleInterface();
+      const call = () =>
+        consoleInterface.TEST_FLAG_NOT_EDITABLE.overrideWith(false);
+      expect(call).toThrowError(notEditableError);
+    });
+
+    it("should throw if a non-editable feature flag is removed", () => {
+      const consoleInterface = featureFlagsModule.initConsoleInterface();
+      const call = () =>
+        consoleInterface.TEST_FLAG_NOT_EDITABLE.removeOverride();
+      expect(call).toThrowError(notEditableError);
     });
   });
 });


### PR DESCRIPTION
# Motivation

1. `npm run lint` was accidentally removed from `npm run check` (in https://github.com/dfinity/nns-dapp/pull/1397) and therefore not run on CI.
2. So we failed to catch an unused variable and were using a store (always true) instead of the value of the store (true or false).

The specific issue is that we always consider ENABLE_CKBTC_LEDGER to be true for the purpose of determining the selectedUniverseId.

# Changes

1. Correctly use the value of the ENABLE_CKBTC_LEDGER.
2. Add a unit test where we disabled ENABLE_CKBTC_LEDGER and verify that it affects the selected universe.
3. Change `feature-flags.store.ts` to allow overriding non-editable feature flags.
4. Add unit tests to make sure that non-editable feature flags still can't be set through the console interface.

# Tests
Unit tests in `selected-universe.derived.spec.ts` and `feature-flags.store.spec.ts`.
Verified that the unit tests fail without the fixes.
No manual testing.
