### PR TITLE
Allow Json expand/collapse with keyboard navigation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --plugin-search-dir . --check . && eslint --max-warnings 3 .",
+    "lint": "prettier --plugin-search-dir . --check . && eslint --max-warnings 1 .",
     "format": "prettier --plugin-search-dir . --write .",
     "test": "TZ=UTC jest",
     "update:next": "npm update @dfinity/utils @dfinity/ledger @dfinity/nns @dfinity/sns @dfinity/cmc @dfinity/ckbtc",

--- a/frontend/src/lib/components/common/Json.svelte
+++ b/frontend/src/lib/components/common/Json.svelte
@@ -64,36 +64,24 @@
 </script>
 
 {#if isExpandable && hasChildren}
-  {#if collapsed}
-    <span
-      data-tid={testId}
-      class="key"
-      class:expanded={!collapsed}
-      class:collapsed
-      class:root
-      class:arrow={isExpandable && hasChildren}
-      role="button"
-      aria-label={$i18n.core.toggle}
-      tabindex="0"
-      on:click|stopPropagation={toggle}
-      >{keyLabel}
+  <button
+    data-tid={testId}
+    class="key"
+    class:expanded={!collapsed}
+    class:collapsed
+    class:root
+    class:arrow={isExpandable && hasChildren}
+    aria-label={$i18n.core.toggle}
+    tabindex="0"
+    on:click|stopPropagation={toggle}
+    >{keyLabel}
+    {#if collapsed}
       <span class="bracket">{openBracket} ... {closeBracket}</span>
-    </span>
-  {:else}
-    <!-- key -->
-    <span
-      data-tid={testId}
-      class="key"
-      class:expanded={!collapsed}
-      class:collapsed
-      class:root
-      class:arrow={isExpandable && hasChildren}
-      role="button"
-      aria-label={$i18n.core.toggle}
-      tabindex="0"
-      on:click|stopPropagation={toggle}
-      >{keyLabel}<span class="bracket open">{openBracket}</span></span
-    >
+    {:else}
+      <span class="bracket open">{openBracket}</span>
+    {/if}
+  </button>
+  {#if !collapsed}
     <!-- children -->
     <ul>
       {#each children as [key, value]}

--- a/frontend/src/tests/lib/components/common/Json.spec.ts
+++ b/frontend/src/tests/lib/components/common/Json.spec.ts
@@ -146,6 +146,34 @@ describe("Json", () => {
     );
   });
 
+  it("should keep focus on button when collapsed or expanded", async () => {
+    const json = {
+      obj: {
+        first: 1,
+        second: 2,
+      },
+    };
+    const { container, getAllByRole } = render(Json, {
+      props: { json },
+    });
+    const isCollapsed = () =>
+      simplifyJson(container.textContent) === "{obj:{...}}";
+
+    const button = () => getAllByRole("button")[1];
+
+    button().focus();
+    expect(button()).toHaveFocus();
+    expect(isCollapsed()).toBe(false);
+
+    await fireEvent.click(button());
+    expect(isCollapsed()).toBe(true);
+    expect(button()).toHaveFocus();
+
+    await fireEvent.click(button());
+    expect(isCollapsed()).toBe(false);
+    expect(button()).toHaveFocus();
+  });
+
   it("should render role=button", async () => {
     const json = {
       obj: {


### PR DESCRIPTION
# Motivation

I was seeing lint warnings about the Json element having a click event handler but not a key event handler.
Looking at the element I also noticed quite some code duplication.
A different element was rendered when the json is expanded than when it is collapsed.
This results in the element losing focus when expanded or collapsed, which means even if it has a key event handler, you can't press space/enter multiple times to collapse/expand multiple times.
Button elements automatically receive click events when space/enter is pressed so changing the element to a button solved the original problem.

# Changes

1. Changed the element to be a button so it receives click events on space/enter.
2. Removed code duplication so the button retains focus when rerendered.
3. Added a test to make sure the button remains focused when expanded/collapsed.
4. Lowered the number of allowed lint warnings.
The element still looks the same when rendered as a button:
<img width="176" alt="image" src="https://user-images.githubusercontent.com/122978264/219597994-22e24d6c-50bb-495d-9860-962bc957138c.png">

# Tests

Manual testing + additional unit test.