### PR TITLE
Enforce npm and nodejs version range

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Deploy NNS and SNS canisters
         run: |
           # Note: This deploys standard NNS canisters but with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,10 @@ jobs:
     env:
       DFX_NETWORK: mainnet
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install rust formatter
@@ -66,6 +70,10 @@ jobs:
     env:
       DFX_NETWORK: mainnet
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dfx
@@ -93,6 +101,10 @@ jobs:
     env:
       DFX_NETWORK: mainnet
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dfx
@@ -117,6 +129,10 @@ jobs:
     env:
       DFX_NETWORK: mainnet
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dfx

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -35,6 +35,10 @@ jobs:
                   exit 1
                   ;;
           esac
+      - uses: actions/setup-node@v3
+        with:
+          # Note: The node version SHOULD match the dockerfile
+          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dfx

--- a/e2e-tests/.npmrc
+++ b/e2e-tests/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,6 +7,10 @@
     "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },
+  "engines" : {
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@wdio/cli": "^7.16.13",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,9 +7,9 @@
     "lint": "npx tsc --noEmit true --project . && eslint --max-warnings 0 './**/*.{js,ts}'",
     "format": "prettier --write --plugin-search-dir=. ."
   },
-  "engines" : {
-    "npm" : ">=8.0.0 <9.0.0",
-    "node" : ">=16.0.0 <17.0.0"
+  "engines": {
+    "npm": ">=8.0.0 <9.0.0",
+    "node": ">=16.0.0 <17.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,9 +21,9 @@
     "update:gix": "npm update @dfinity/gix-components",
     "upgrade:next": "npm rm @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger @dfinity/ckbtc && npm i @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger@next @dfinity/ckbtc@next"
   },
-  "engines" : {
-    "npm" : ">=8.0.0 <9.0.0",
-    "node" : ">=16.0.0 <17.0.0"
+  "engines": {
+    "npm": ">=8.0.0 <9.0.0",
+    "node": ">=16.0.0 <17.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-inject": "^5.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,10 @@
     "update:gix": "npm update @dfinity/gix-components",
     "upgrade:next": "npm rm @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger @dfinity/ckbtc && npm i @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger@next @dfinity/ckbtc@next"
   },
+  "engines" : {
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
+  },
   "devDependencies": {
     "@rollup/plugin-inject": "^5.0.3",
     "@sveltejs/adapter-static": "^2.0.1",

--- a/proxy/.npmrc
+++ b/proxy/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -12,6 +12,10 @@
   "bin": {
     "proxy": "./build/index.js"
   },
+  "engines" : {
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
# Motivation
Using an incompatible version of nodejs breaks builds, formatting and lockfiles.

# Changes
- Cause node to fail if an incompatible version of nodejs or npm is used.
  - Note: I have specified this individually in the .npmrc of each node project.  We may want to make a global entry, but must the n also remember to include it in docker builds that take just one directory and named other files.
- Specify the version of nodejs in CI.
  - Note: It would be nice to be able to read the node version from the package.json.  Ideally that should be done in both CI and in the dockerfile.  Should be possible, but in another PR.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
