### PR TITLE
GIX-1329: Fetch derived state

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -11,6 +11,7 @@ import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount } from "@dfinity/ledger";
 import { Principal } from "@dfinity/principal";
 import type {
+  SnsGetDerivedStateResponse,
   SnsNeuron,
   SnsNeuronId,
   SnsSwapBuyerState,
@@ -235,6 +236,35 @@ export const querySnsSwapCommitment = async ({
     rootCanisterId: Principal.fromText(rootCanisterId),
     myCommitment: userCommitment,
   };
+};
+
+export const querySnsDerivedState = async ({
+  rootCanisterId,
+  identity,
+  certified,
+}: {
+  rootCanisterId: QueryRootCanisterId;
+  identity: Identity;
+  certified: boolean;
+}): Promise<SnsGetDerivedStateResponse | undefined> => {
+  logWithTimestamp(
+    `Getting Sns ${rootCanisterId} swap derived state certified:${certified} call...`
+  );
+
+  const { getDerivedState }: SnsWrapper = await wrapper({
+    rootCanisterId,
+    identity,
+    certified,
+  });
+
+  const derivedState: SnsGetDerivedStateResponse | undefined =
+    await getDerivedState({});
+
+  logWithTimestamp(
+    `Getting Sns ${rootCanisterId} swap commitment certified:${certified} done.`
+  );
+
+  return derivedState;
 };
 
 export const querySnsNeurons = async ({

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -690,6 +690,7 @@
     "load_summary": "There was an unexpected error while loading the project.",
     "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
     "load_swap_commitment": "There was an unexpected error while loading the commitment of the project.",
+    "load_sale_total_commitments": "There was an unexpected error while loading the commitments of the project.",
     "load_parameters": "There was an unexpected error while loading the parameters of the project.",
     "sns_remove_hotkey": "There was an error removing the hotkey.",
     "sns_split_neuron": "There was an error while splitting the neuron.",

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -8,6 +8,7 @@
   import {
     loadSnsSummary,
     loadSnsSwapCommitment,
+    loadSnsTotalCommitment,
   } from "$lib/services/sns.services";
   import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
   import {
@@ -30,6 +31,7 @@
 
   $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
     loadCommitment(rootCanisterId);
+    loadTotalCommitments(rootCanisterId);
   }
 
   const loadSummary = (rootCanisterId: string) =>
@@ -51,6 +53,9 @@
         goBack();
       },
     });
+
+  const loadTotalCommitments = (rootCanisterId: string) =>
+    loadSnsTotalCommitment({ rootCanisterId });
 
   const reload = async () => {
     if (rootCanisterId === undefined || rootCanisterId === null) {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -723,6 +723,7 @@ interface I18nError__sns {
   load_summary: string;
   list_swap_commitments: string;
   load_swap_commitment: string;
+  load_sale_total_commitments: string;
   load_parameters: string;
   sns_remove_hotkey: string;
   sns_split_neuron: string;

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -6,6 +6,7 @@ import {
   getSnsNeuron,
   increaseStakeNeuron,
   queryAllSnsMetadata,
+  querySnsDerivedState,
   querySnsMetadata,
   querySnsNeuron,
   querySnsNeurons,
@@ -58,9 +59,14 @@ describe("sns-api", () => {
     ],
   };
 
+  const derivedState = {
+    sns_tokens_per_icp: [1],
+    buyer_total_icp_e8s: [BigInt(1_000_000_000)],
+  };
   const notifyParticipationSpy = jest.fn().mockResolvedValue(undefined);
   const mockUserCommitment = createBuyersState(BigInt(100_000_000));
   const getUserCommitmentSpy = jest.fn().mockResolvedValue(mockUserCommitment);
+  const getDerivedStateSpy = jest.fn().mockResolvedValue(derivedState);
   const ledgerCanisterMock = mock<LedgerCanister>();
   const queryNeuronsSpy = jest.fn().mockResolvedValue([mockSnsNeuron]);
   const getNeuronSpy = jest.fn().mockResolvedValue(mockSnsNeuron);
@@ -98,6 +104,7 @@ describe("sns-api", () => {
         stakeNeuron: stakeNeuronSpy,
         queryNeuron: queryNeuronSpy,
         increaseStakeNeuron: increaseStakeNeuronSpy,
+        getDerivedState: getDerivedStateSpy,
       })
     );
   });
@@ -161,6 +168,16 @@ describe("sns-api", () => {
       rootCanisterId: rootCanisterIdMock,
       myCommitment: mockUserCommitment,
     });
+  });
+
+  it("should return derived state", async () => {
+    const receivedData = await querySnsDerivedState({
+      rootCanisterId: rootCanisterIdMock.toText(),
+      identity: mockIdentity,
+      certified: false,
+    });
+    expect(getDerivedStateSpy).toBeCalled();
+    expect(receivedData).toEqual(derivedState);
   });
 
   it("should query sns neurons", async () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -8,6 +8,7 @@ import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import {
   loadSnsSummary,
   loadSnsSwapCommitment,
+  loadSnsTotalCommitment,
 } from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
@@ -24,6 +25,7 @@ jest.mock("$lib/services/sns.services", () => {
   return {
     loadSnsSummary: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsSwapCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
+    loadSnsTotalCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
   };
 });
 
@@ -32,7 +34,7 @@ describe("ProjectDetail", () => {
     rootCanisterId: mockSnsFullProject.rootCanisterId.toText(),
   };
 
-  describe("present project in store", () => {
+  describe("not logged in user", () => {
     page.mock({ data: { universe: null } });
 
     beforeEach(() => {
@@ -68,6 +70,12 @@ describe("ProjectDetail", () => {
       await waitFor(() => expect(loadSnsSwapCommitment).not.toBeCalled());
     });
 
+    it("should not load total commitments", async () => {
+      render(ProjectDetail, props);
+
+      await waitFor(() => expect(loadSnsTotalCommitment).not.toBeCalled());
+    });
+
     it("should render info section", async () => {
       const { queryByTestId } = render(ProjectDetail, props);
 
@@ -96,6 +104,12 @@ describe("ProjectDetail", () => {
       render(ProjectDetail, props);
 
       await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
+    });
+
+    it("should load total project's commitment", async () => {
+      render(ProjectDetail, props);
+
+      await waitFor(() => expect(loadSnsTotalCommitment).toBeCalled());
     });
   });
 

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -5,6 +5,8 @@ import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+import type { GetDerivedStateResponse } from "@dfinity/sns/dist/candid/sns_swap";
+import { fromNullable } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import {
@@ -81,6 +83,58 @@ describe("sns-services", () => {
         .mockImplementation(() => Promise.resolve(commitments));
       await loadSnsSwapCommitments();
       expect(spy).not.toBeCalled();
+    });
+  });
+
+  describe("loadSnsTotalCommitment", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      snsSwapCommitmentsStore.reset();
+      snsQueryStore.reset();
+    });
+
+    it("should call api to get total commitments and load them in store", async () => {
+      const derivedState: GetDerivedStateResponse = {
+        sns_tokens_per_icp: [1],
+        buyer_total_icp_e8s: [BigInt(1_000_000_000)],
+      };
+      const [metadatas, swaps] = snsResponsesForLifecycle({
+        certified: true,
+        lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Open],
+      });
+      snsQueryStore.setData([metadatas, swaps]);
+      const canisterId = swaps[0].rootCanisterId;
+
+      const spy = jest
+        .spyOn(api, "querySnsDerivedState")
+        .mockImplementation(() => Promise.resolve(derivedState));
+
+      const initStore = get(snsQueryStore);
+      const initState = initStore?.swaps.find(
+        (swap) => swap.rootCanisterId === canisterId
+      )?.derived[0];
+      expect(initState?.buyer_total_icp_e8s).toEqual(
+        initState?.buyer_total_icp_e8s
+      );
+      expect(initState?.sns_tokens_per_icp).toEqual(
+        initState?.sns_tokens_per_icp
+      );
+
+      await services.loadSnsTotalCommitment({
+        rootCanisterId: canisterId,
+      });
+      expect(spy).toBeCalled();
+
+      const updatedStore = get(snsQueryStore);
+      const updatedState = updatedStore?.swaps.find(
+        (swap) => swap.rootCanisterId === canisterId
+      )?.derived[0];
+      expect(updatedState?.buyer_total_icp_e8s).toEqual(
+        fromNullable(derivedState.buyer_total_icp_e8s)
+      );
+      expect(updatedState?.sns_tokens_per_icp).toEqual(
+        fromNullable(derivedState.sns_tokens_per_icp)
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

Provide up to date data on how the sale is going.

SNS Aggregator takes a while to update. Therefore, for the total amount of commitments we shouldn't rely on it for users that want to participate.

# Changes

* New sns api function `querySnsDerivedState`.
* New sns service `loadSnsTotalCommitment` that loads the derived state in the summary.
* New method `updateDerivedState` in SnsQueryStore to update only the derived state.
* Use the new sns service in the ProjectDetail.

# Tests

* Test that ProjectDetail uses new service when appropiate.
* Test new sns api function.
* Test new method in SnsQueryStore.
* Test new sns service.
