### PR TITLE
Remove it.only from SnsNeurons.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -98,7 +98,7 @@ describe("SnsNeurons", () => {
       );
     });
 
-    it.only("should render one grids", async () => {
+    it("should render one grids", async () => {
       const { container } = render(SnsNeurons);
 
       await waitFor(() =>


### PR DESCRIPTION
# Motivation

Having `it.only` merged was most likely a mistake.
The other tests pass with `.only` removed.

# Changes

Replace `it.only` with just `it` in SnsNeurons.spec.ts.

# Tests

pass
