### PR TITLE
GIX-1247: Add SNS Aggregator mainnet in config

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -190,7 +190,12 @@
       ],
       "candid": "rs/sns_aggregator/sns_aggregator.did",
       "wasm": "sns_aggregator.wasm",
-      "type": "custom"
+      "type": "custom",
+      "remote": {
+        "id": {
+          "mainnet": "3r4gx-wqaaa-aaaaq-aaaia-cai"
+        }
+      }
     },
     "ckbtc_ledger": {
       "build": [
@@ -223,7 +228,8 @@
     "mainnet": {
       "config": {
         "FETCH_ROOT_KEY": false,
-        "HOST": "https://icp-api.io",
+        "API_HOST": "https://icp-api.io",
+        "STATIC_HOST": "https://icp0.io",
         "OWN_CANISTER_ID": "qoctq-giaaa-aaaaa-aaaea-cai",
         "OWN_CANISTER_URL": "https://nns.internetcomputer.org",
         "IDENTITY_SERVICE_URL": "https://identity.internetcomputer.org/",


### PR DESCRIPTION
# Motivation

Allow mainnet nns-dapp to integrate with SNS Aggregator.

# Changes

* Add mainnet data for SNS aggregator in `dfx.json`.

# Tests

* Not applicable
