### PR TITLE
Fix date formatting tests for Node 18.13.0

### DIFF
--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -54,6 +54,3 @@ export const shortenWithMiddleEllipsis = (
     ? `${text.slice(0, splitLength)}...${text.slice(-1 * splitLength)}`
     : text;
 };
-
-export const normalizeWhitespace = (text: string): string =>
-  text.replace(/\s+/g, " ");

--- a/frontend/src/lib/utils/format.utils.ts
+++ b/frontend/src/lib/utils/format.utils.ts
@@ -54,3 +54,6 @@ export const shortenWithMiddleEllipsis = (
     ? `${text.slice(0, splitLength)}...${text.slice(-1 * splitLength)}`
     : text;
 };
+
+export const normalizeWhitespace = (text: string): string =>
+  text.replace(/\s+/g, " ");

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -4,6 +4,7 @@
 
 import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.svelte";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
+import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
@@ -128,7 +129,7 @@ describe("IcrcTransactionCard", () => {
     const div = getByTestId("transaction-date");
 
     expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(div?.textContent).toContain("12:00\u202FAM");
+    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -4,7 +4,6 @@
 
 import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.svelte";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
-import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
@@ -19,6 +18,7 @@ import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "../../../mocks/sns-projects.mock";
+import { normalizeWhitespace } from "../../../utils/utils.test-utils";
 
 describe("IcrcTransactionCard", () => {
   const renderTransactionCard = (

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -128,7 +128,7 @@ describe("IcrcTransactionCard", () => {
     const div = getByTestId("transaction-date");
 
     expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(div?.textContent).toContain("12:00 AM");
+    expect(div?.textContent).toContain("12:00\u202FAM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -85,7 +85,7 @@ describe("NnsTransactionCard", () => {
     const div = getByTestId("transaction-date");
 
     expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(div?.textContent).toContain("12:00 AM");
+    expect(div?.textContent).toContain("12:00\u202FAM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
+import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
@@ -85,7 +86,7 @@ describe("NnsTransactionCard", () => {
     const div = getByTestId("transaction-date");
 
     expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(div?.textContent).toContain("12:00\u202FAM");
+    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
-import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
@@ -18,6 +17,7 @@ import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,
 } from "../../../mocks/transaction.mock";
+import { normalizeWhitespace } from "../../../utils/utils.test-utils";
 
 describe("NnsTransactionCard", () => {
   const renderTransactionCard = (

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import TransactionCard from "$lib/components/accounts/TransactionCard.svelte";
+import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { ICPToken } from "@dfinity/nns";
@@ -79,8 +80,10 @@ describe("TransactionCard", () => {
 
     const div = getByTestId("transaction-date");
 
-    expect(div?.textContent).toContain("Mar 14, 2021 12:00\u202FAM");
-    expect(div?.textContent).toContain("12:00\u202FAM");
+    expect(normalizeWhitespace(div?.textContent)).toContain(
+      "Mar 14, 2021 12:00 AM"
+    );
+    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -79,8 +79,8 @@ describe("TransactionCard", () => {
 
     const div = getByTestId("transaction-date");
 
-    expect(div?.textContent).toContain("Mar 14, 2021 12:00 AM");
-    expect(div?.textContent).toContain("12:00 AM");
+    expect(div?.textContent).toContain("Mar 14, 2021 12:00\u202FAM");
+    expect(div?.textContent).toContain("12:00\u202FAM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -80,10 +80,9 @@ describe("TransactionCard", () => {
 
     const div = getByTestId("transaction-date");
 
-    expect(normalizeWhitespace(div?.textContent)).toContain(
-      "Mar 14, 2021 12:00 AM"
-    );
-    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
+    const textContent = normalizeWhitespace(div?.textContent);
+    expect(textContent).toContain("Mar 14, 2021 12:00 AM");
+    expect(textContent).toContain("12:00 AM");
   });
 
   it("displays identifier for received", () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import TransactionCard from "$lib/components/accounts/TransactionCard.svelte";
-import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { ICPToken } from "@dfinity/nns";
@@ -13,6 +12,7 @@ import {
   mockTransactionReceiveDataFromMain,
   mockTransactionSendDataFromMain,
 } from "../../../mocks/transaction.mock";
+import { normalizeWhitespace } from "../../../utils/utils.test-utils";
 
 describe("TransactionCard", () => {
   const renderTransactionCard = (

--- a/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
@@ -3,8 +3,8 @@
  */
 
 import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
-import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { render } from "@testing-library/svelte";
+import { normalizeWhitespace } from "../../../utils/utils.test-utils";
 
 describe("DateSeconds", () => {
   const seconds = Number(BigInt("0"));

--- a/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
@@ -19,7 +19,7 @@ describe("DateSeconds", () => {
       "Jan 1, 1970"
     );
     expect(container.querySelector(selector)?.textContent).toContain(
-      "12:00 AM"
+      "12:00\u202FAM"
     );
   };
 

--- a/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
+import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { render } from "@testing-library/svelte";
 
 describe("DateSeconds", () => {
@@ -15,12 +16,11 @@ describe("DateSeconds", () => {
     selector: "p" | "span";
     container: HTMLElement;
   }) => {
-    expect(container.querySelector(selector)?.textContent).toContain(
-      "Jan 1, 1970"
+    const textContent = normalizeWhitespace(
+      container.querySelector(selector)?.textContent
     );
-    expect(container.querySelector(selector)?.textContent).toContain(
-      "12:00\u202FAM"
-    );
+    expect(textContent).toContain("Jan 1, 1970");
+    expect(textContent).toContain("12:00 AM");
   };
 
   it("displays render date and time", () => {

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -7,9 +7,9 @@ import {
   secondsToDuration,
   secondsToTime,
 } from "$lib/utils/date.utils";
-import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { nanoSecondsToDateTime } from "../../../lib/utils/date.utils";
 import en from "../../mocks/i18n.mock";
+import { normalizeWhitespace } from "../../utils/utils.test-utils";
 
 describe("secondsToDuration", () => {
   it("should give year details", () => {

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -147,20 +147,22 @@ describe("secondsToDate", () => {
 
 describe("secondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(secondsToDateTime(BigInt(0))).toEqual("Jan 1, 1970 12:00 AM");
+    expect(secondsToDateTime(BigInt(0))).toEqual("Jan 1, 1970 12:00\u202FAM");
   });
 
   it("should return formatted date and time", () => {
     // We only support english for now
     const march25of2022InSeconds = Math.round(1648200639061 / 1000);
     const expectedDateText = secondsToDateTime(BigInt(march25of2022InSeconds));
-    expect(expectedDateText).toEqual("Mar 25, 2022 9:30 AM");
+    expect(expectedDateText).toEqual("Mar 25, 2022 9:30\u202FAM");
   });
 });
 
 describe("nanoSecondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(nanoSecondsToDateTime(BigInt(0))).toEqual("Jan 1, 1970 12:00 AM");
+    expect(nanoSecondsToDateTime(BigInt(0))).toEqual(
+      "Jan 1, 1970 12:00\u202FAM"
+    );
   });
 
   it("should return formatted date and time", () => {
@@ -169,7 +171,7 @@ describe("nanoSecondsToDateTime", () => {
     const expectedDateText = nanoSecondsToDateTime(
       BigInt(march25of2022InSeconds)
     );
-    expect(expectedDateText).toEqual("Mar 25, 2022 9:30 AM");
+    expect(expectedDateText).toEqual("Mar 25, 2022 9:30\u202FAM");
   });
 });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   secondsToDuration,
   secondsToTime,
 } from "$lib/utils/date.utils";
+import { normalizeWhitespace } from "$lib/utils/format.utils";
 import { nanoSecondsToDateTime } from "../../../lib/utils/date.utils";
 import en from "../../mocks/i18n.mock";
 
@@ -147,21 +148,25 @@ describe("secondsToDate", () => {
 
 describe("secondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(secondsToDateTime(BigInt(0))).toEqual("Jan 1, 1970 12:00\u202FAM");
+    expect(normalizeWhitespace(secondsToDateTime(BigInt(0)))).toEqual(
+      "Jan 1, 1970 12:00 AM"
+    );
   });
 
   it("should return formatted date and time", () => {
     // We only support english for now
     const march25of2022InSeconds = Math.round(1648200639061 / 1000);
     const expectedDateText = secondsToDateTime(BigInt(march25of2022InSeconds));
-    expect(expectedDateText).toEqual("Mar 25, 2022 9:30\u202FAM");
+    expect(normalizeWhitespace(expectedDateText)).toEqual(
+      "Mar 25, 2022 9:30 AM"
+    );
   });
 });
 
 describe("nanoSecondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(nanoSecondsToDateTime(BigInt(0))).toEqual(
-      "Jan 1, 1970 12:00\u202FAM"
+    expect(normalizeWhitespace(nanoSecondsToDateTime(BigInt(0)))).toEqual(
+      "Jan 1, 1970 12:00 AM"
     );
   });
 
@@ -171,7 +176,9 @@ describe("nanoSecondsToDateTime", () => {
     const expectedDateText = nanoSecondsToDateTime(
       BigInt(march25of2022InSeconds)
     );
-    expect(expectedDateText).toEqual("Mar 25, 2022 9:30\u202FAM");
+    expect(normalizeWhitespace(expectedDateText)).toEqual(
+      "Mar 25, 2022 9:30 AM"
+    );
   });
 });
 

--- a/frontend/src/tests/utils/utils.test-utils.ts
+++ b/frontend/src/tests/utils/utils.test-utils.ts
@@ -12,3 +12,7 @@ export const clickByTestId = async (
 
   element && fireEvent.click(element);
 };
+
+export const normalizeWhitespace = (
+  text: string | undefined
+): string | undefined => text && text.replace(/\s+/g, " ");


### PR DESCRIPTION
# Motivation

With Node 18.13.0 there was an update to ICU 72 which means date formatting has a slightly different output (whitespace only). This broke some tests which have expectations on formatted dates.
I originally just updated the expected values, but this breaks the test when using a Node version < 18.13.0.
My current solution is to normalize the whitespace before comparing. This allows the test to pass both with older and newer Node versions.

# Changes

Normalize whitespace in tests where ICU 72 introduced a different whitespace separator in front of AM/PM.

# Tests

Tests only
