### PR TITLE
chore: fix webstorm resolution

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,11 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "paths": {
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"]
+    }
   },
   "exclude": [
     "**/*.spec.ts",


### PR DESCRIPTION
# Motivation

Webstorm does not resolve the path set by `.svelte-kit/tsconfig.json` and therefore we ends up with broken workspaces that cannot resolve dependencies and open imports.

This fix the issue providing the paths already in the `tsconfig.json` of the project.
