### PR TITLE
Bump  dfx to 0.13.1

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -54,8 +54,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Fep 9 with dfx 0.13.xxx
-          ref: 'b78190b5617cd24a6e7bccf1b94dc1aa31137165'
+          # Version from Thu Feb 21 with dfx 0.13.1
+          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Feb 9 with dfx version 0.13.xxx
-          ref: 'b78190b5617cd24a6e7bccf1b94dc1aa31137165'
+          # Version from Thu Feb 21 with dfx version 0.13.1
+          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.13.0-downgrade.1",
+  "dfx": "0.13.1",
   "canisters": {
     "nns-governance": {
       "type": "custom",


### PR DESCRIPTION
# Motivation
We are currently on a non-standard release.  It _looks_, based on a cursory check, that v0.13.1 doesn't have the Linux issues seen on 0.13.0.

# Changes
- Change the ic commit to 0.13.1

# Tests
- See CI
- I have verified that dfx doesn't throw errors when run locally.