### PR TITLE
GIX-1328 Small test cleanups

### DIFF
--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -18,10 +18,12 @@ describe("snsSelectedTransactionFeeStore", () => {
     lifecycles: [SnsSwapLifecycle.Open],
     certified: true,
   });
-  afterEach(() => {
+
+  beforeEach(() => {
     snsQueryStore.reset();
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
+
   it("returns transaction fee of current selected sns project", () => {
     snsQueryStore.setData(data);
     const [metadatas] = data;

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -16,7 +16,10 @@ import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { createMockSnsNeuron } from "../../../mocks/sns-neurons.mock";
 
 describe("sortedSnsNeuronStore", () => {
-  afterEach(() => snsNeuronsStore.reset());
+  beforeEach(() => {
+    snsNeuronsStore.reset();
+  });
+
   it("returns an empty array if no neurons", () => {
     expect(get(snsSortedNeuronStore).length).toBe(0);
   });

--- a/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
@@ -16,10 +16,12 @@ describe("currentSnsTokenLabelStore", () => {
     lifecycles: [SnsSwapLifecycle.Open],
     certified: true,
   });
-  afterEach(() => {
+
+  beforeEach(() => {
     snsQueryStore.reset();
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
   });
+
   it("returns token symbol of current selected sns project", () => {
     snsQueryStore.setData(data);
     const [metadatas] = data;

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -14,17 +14,13 @@ import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockStoreSubscribe } from "../../mocks/commont.mock";
 import en from "../../mocks/i18n.mock";
-import { mockSnsAccountsStoreSubscribe } from "../../mocks/sns-accounts.mock";
+import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "../../mocks/sns-projects.mock";
 
-jest.mock("$lib/services/sns-accounts.services", () => {
-  return {
-    syncSnsAccounts: jest.fn().mockResolvedValue(undefined),
-  };
-});
+jest.mock("$lib/services/sns-accounts.services");
 
 describe("SnsAccounts", () => {
   const goToWallet = async () => {
@@ -32,10 +28,12 @@ describe("SnsAccounts", () => {
   };
 
   describe("when there are accounts in the store", () => {
-    beforeAll(() => {
-      jest
-        .spyOn(snsAccountsStore, "subscribe")
-        .mockImplementation(mockSnsAccountsStoreSubscribe(mockPrincipal));
+    beforeEach(() => {
+      snsAccountsStore.setAccounts({
+        rootCanisterId: mockPrincipal,
+        accounts: [mockSnsMainAccount],
+        certified: true,
+      });
 
       jest
         .spyOn(snsProjectSelectedStore, "subscribe")
@@ -88,6 +86,9 @@ describe("SnsAccounts", () => {
           return () => undefined;
         });
     });
+
+    // This test seems wrong. I would expect that moving it to the group above
+    // should cause it to fail but it doesn't.
     it("should not render a token amount component nor zero", () => {
       const { container } = render(SnsAccounts, { props: { goToWallet } });
 

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -29,6 +29,7 @@ describe("SnsAccounts", () => {
 
   describe("when there are accounts in the store", () => {
     beforeEach(() => {
+      snsAccountsStore.reset();
       snsAccountsStore.setAccounts({
         rootCanisterId: mockPrincipal,
         accounts: [mockSnsMainAccount],


### PR DESCRIPTION
# Motivation

My solution to GIX-1328 requires changes to these tests (among others) otherwise the SNS neuron won't be available.
I decided to do a separate cleanup of the tests to keep the PR that fixes GIX-1328 more readable.

# Changes

1. beforeEach instead of afterEach.
2. Use real snsAccountsStore instead of mock.

# Tests

Tests only