### PR TITLE
GIX-1328 Only select selectable universes.

### DIFF
--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -36,15 +36,10 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 
 export const selectedUniverseStore: Readable<Universe> = derived(
   [pageUniverseIdStore, selectableUniversesStore],
-  ([$pageUniverseIdStore, $selectableUniverses]) => {
-    //console.log('dskloetx selected-universe.derived.ts pageUniverseIdStore', $pageUniverseIdStore.toText());
-    //console.log('dskloetx selected-universe.derived.ts $selectableUniverses', $selectableUniverses);
-    return (
-      $selectableUniverses?.find(
-        ({ canisterId }) => canisterId === $pageUniverseIdStore.toText()
-      ) ?? NNS_UNIVERSE
-    );
-  }
+  ([$pageUniverseIdStore, $selectableUniverses]) =>
+    $selectableUniverses?.find(
+      ({ canisterId }) => canisterId === $pageUniverseIdStore.toText()
+    ) ?? NNS_UNIVERSE
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -43,9 +43,9 @@ export const selectedUniverseStore: Readable<Universe> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Universe>],
+  Readable<Universe>,
   Principal
->([selectedUniverseStore], ([universe]) =>
+>(selectedUniverseStore, (universe: Universe) =>
   Principal.fromText(universe.canisterId)
 );
 

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -158,7 +158,9 @@ describe("selected universe derived stores", () => {
       });
 
       it("returns CKBTC_UNIVERSE_CANISTER_ID", () => {
-        expect(get(selectedUniverseIdStore)).toEqual(CKBTC_UNIVERSE_CANISTER_ID);
+        expect(get(selectedUniverseIdStore)).toEqual(
+          CKBTC_UNIVERSE_CANISTER_ID
+        );
       });
 
       it("returns OWN_CANISTER_ID if universe is ckBTC but flag disabled", () => {

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -26,6 +26,7 @@ import {
 
 describe("selected universe derived stores", () => {
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockSnsCanisterId,

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -60,12 +60,27 @@ describe("selected universe derived stores", () => {
         data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
         routeId: AppPath.Accounts,
       });
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_LEDGER", true);
     });
 
     it("should be ckBTC inside ckBTC universe", () => {
       const $store = get(isCkBTCUniverseStore);
 
       expect($store).toEqual(true);
+    });
+
+    it("should not be ckBTC on unsupported path", () => {
+      page.mock({
+        data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
+        routeId: AppPath.Accounts,
+      });
+      expect(get(isCkBTCUniverseStore)).toEqual(true);
+
+      page.mock({
+        data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
+        routeId: AppPath.Neurons,
+      });
+      expect(get(isCkBTCUniverseStore)).toEqual(false);
     });
 
     it("should not be ckBTC outside ckBTC universe", () => {
@@ -129,6 +144,37 @@ describe("selected universe derived stores", () => {
 
       const $store2 = get(selectedUniverseIdStore);
       expect($store2.toText()).toEqual(OWN_CANISTER_ID.toText());
+    });
+
+    describe("in ckBTC universe", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_LEDGER", true);
+        page.mock({
+          data: {
+            universe: CKBTC_UNIVERSE_CANISTER_ID.toText(),
+          },
+          routeId: AppPath.Accounts,
+        });
+      });
+
+      it("returns CKBTC_UNIVERSE_CANISTER_ID", () => {
+        expect(get(selectedUniverseIdStore)).toEqual(CKBTC_UNIVERSE_CANISTER_ID);
+      });
+
+      it("returns OWN_CANISTER_ID if universe is ckBTC but flag disabled", () => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_LEDGER", false);
+        expect(get(selectedUniverseIdStore)).toEqual(OWN_CANISTER_ID);
+      });
+
+      it("returns OWN_CANISTER_ID if universe is ckBTC but path not supported", () => {
+        page.mock({
+          data: {
+            universe: CKBTC_UNIVERSE_CANISTER_ID.toText(),
+          },
+          routeId: AppPath.Neurons,
+        });
+        expect(get(selectedUniverseIdStore)).toEqual(OWN_CANISTER_ID);
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
@@ -7,16 +7,25 @@ import {
   snsProjectMainAccountStore,
 } from "$lib/derived/sns/sns-project-accounts.derived";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "../../../mocks/sns-accounts.mock";
+import { snsResponseFor } from "../../../mocks/sns-response.mock";
 
 describe("sns-project-accounts store", () => {
   beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
@@ -20,6 +20,7 @@ import { snsResponseFor } from "../../../mocks/sns-response.mock";
 
 describe("sns-project-accounts store", () => {
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockPrincipal,

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -26,6 +26,7 @@ describe("selected sns project derived stores", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
 
+      snsQueryStore.reset();
       snsQueryStore.setData(
         snsResponseFor({
           principal: mockSnsCanisterId,

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -12,13 +12,26 @@ import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 import { mockSnsSwapCommitment } from "../../../mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
-import { mockSnsCanisterIdText } from "../../../mocks/sns.api.mock";
+import {
+  snsResponseFor,
+  snsResponsesForLifecycle,
+} from "../../../mocks/sns-response.mock";
+import {
+  mockSnsCanisterId,
+  mockSnsCanisterIdText,
+} from "../../../mocks/sns.api.mock";
 
 describe("selected sns project derived stores", () => {
   describe("snsOnlyProjectStore", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+
+      snsQueryStore.setData(
+        snsResponseFor({
+          principal: mockSnsCanisterId,
+          lifecycle: SnsSwapLifecycle.Committed,
+        })
+      );
     });
 
     it("should be set by default undefined", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -15,7 +15,7 @@ import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
 describe("snsSelectedTransactionFeeStore", () => {
   const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Open],
+    lifecycles: [SnsSwapLifecycle.Committed],
     certified: true,
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -7,17 +7,30 @@ import {
   sortedSnsUserNeuronsStore,
 } from "$lib/derived/sns/sns-sorted-neurons.derived";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import { mockPrincipal } from "../../../mocks/auth.store.mock";
 import { createMockSnsNeuron } from "../../../mocks/sns-neurons.mock";
+import { snsResponsesFor } from "../../../mocks/sns-response.mock";
 
 describe("sortedSnsNeuronStore", () => {
+  const principal2 = Principal.fromText("aaaaa-aa");
+
   beforeEach(() => {
     snsNeuronsStore.reset();
+    snsQueryStore.reset();
+
+    snsQueryStore.setData(
+      snsResponsesFor([
+        { principal: mockPrincipal, lifecycle: SnsSwapLifecycle.Committed },
+        { principal: principal2, lifecycle: SnsSwapLifecycle.Committed },
+      ])
+    );
   });
 
   it("returns an empty array if no neurons", () => {
@@ -155,7 +168,6 @@ describe("sortedSnsNeuronStore", () => {
         created_timestamp_seconds: BigInt(3),
       },
     ];
-    const principal2 = Principal.fromText("aaaaa-aa");
     snsNeuronsStore.setNeurons({
       rootCanisterId: principal2,
       neurons: neurons2,

--- a/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-token-symbol-selected.store.spec.ts
@@ -13,7 +13,7 @@ import { snsResponsesForLifecycle } from "../../../mocks/sns-response.mock";
 
 describe("currentSnsTokenLabelStore", () => {
   const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Open],
+    lifecycles: [SnsSwapLifecycle.Committed],
     certified: true,
   });
 

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -8,10 +8,12 @@ import IncreaseSnsDissolveDelayModal from "$lib/modals/sns/neurons/IncreaseSnsDi
 import * as authServices from "$lib/services/auth.services";
 import { loadSnsParameters } from "$lib/services/sns-parameters.services";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
 import { page } from "$mocks/$app/stores";
 import { ICPToken } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fromDefinedNullable } from "@dfinity/utils";
 import { fireEvent } from "@testing-library/dom";
 import { waitFor, type RenderResult } from "@testing-library/svelte";
@@ -25,6 +27,7 @@ import {
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "../../../mocks/sns-neurons.mock";
+import { snsResponseFor } from "../../../mocks/sns-response.mock";
 
 jest.mock("$lib/api/sns-governance.api");
 jest.mock("$lib/services/sns-parameters.services");
@@ -70,6 +73,14 @@ describe("IncreaseSnsDissolveDelayModal", () => {
       rootCanisterId: mockPrincipal,
       parameters: snsNervousSystemParametersMock,
     });
+
+    snsQueryStore.reset();
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
 
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -3,22 +3,21 @@
  */
 
 import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
-import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Subscriber } from "svelte/store";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import { mockStoreSubscribe } from "../../mocks/commont.mock";
 import en from "../../mocks/i18n.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-} from "../../mocks/sns-projects.mock";
+import { mockSnsFullProject } from "../../mocks/sns-projects.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/services/sns-accounts.services");
 
@@ -26,6 +25,15 @@ describe("SnsAccounts", () => {
   const goToWallet = async () => {
     // Do nothing
   };
+
+  beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
+  });
 
   describe("when there are accounts in the store", () => {
     beforeEach(() => {
@@ -39,10 +47,6 @@ describe("SnsAccounts", () => {
       jest
         .spyOn(snsProjectSelectedStore, "subscribe")
         .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
-
-      jest
-        .spyOn(snsProjectsCommittedStore, "subscribe")
-        .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
 
       page.mock({ data: { universe: mockPrincipal.toText() } });
     });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -27,6 +27,7 @@ describe("SnsAccounts", () => {
   };
 
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockPrincipal,

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -2,6 +2,9 @@
  * @jest-environment jsdom
  */
 
+import { snsQueryStore } from "$lib/stores/sns.store";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import {
   sortedSnsCFNeuronsStore,
@@ -55,6 +58,13 @@ describe("SnsNeurons", () => {
     authStoreMock = jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: rootCanisterIdMock,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { snsQueryStore } from "$lib/stores/sns.store";
-import { snsResponseFor } from "../../mocks/sns-response.mock";
-import { SnsSwapLifecycle } from "@dfinity/sns";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import {
   sortedSnsCFNeuronsStore,
@@ -16,9 +13,11 @@ import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
 import { loadSnsParameters } from "$lib/services/sns-parameters.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { page } from "$mocks/$app/stores";
 import type { SnsNeuron } from "@dfinity/sns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { mockStoreSubscribe } from "../../mocks/commont.mock";
@@ -29,6 +28,7 @@ import {
   createMockSnsNeuron,
 } from "../../mocks/sns-neurons.mock";
 import { mockSnsFullProject } from "../../mocks/sns-projects.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
 
 jest.mock("$lib/services/sns-neurons.services", () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -43,6 +43,7 @@ describe("SnsProposals", () => {
     )[0];
 
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockPrincipal,

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -7,11 +7,14 @@ import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
 import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
 import { loadSnsFilters } from "$lib/services/sns-filters.services";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockSnsProposal } from "../../mocks/sns-proposals.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/services/$public/sns.services", () => {
   return {
@@ -38,6 +41,15 @@ describe("SnsProposals", () => {
     Array.from(container.querySelectorAll("p")).filter(
       (p) => p.textContent === en.voting.nothing_found
     )[0];
+
+  beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
+  });
 
   describe("logged in user", () => {
     beforeEach(() => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -6,14 +6,17 @@ import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-tr
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { Principal } from "@dfinity/principal";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   mockSnsAccountsStoreSubscribe,
   mockSnsMainAccount,
 } from "../../mocks/sns-accounts.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "../../mocks/transaction-fee.mock";
 
 jest.mock("$lib/services/sns-accounts.services", () => {
@@ -32,6 +35,15 @@ describe("SnsWallet", () => {
   const props = {
     accountIdentifier: mockSnsMainAccount.identifier,
   };
+
+  beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
+  });
 
   describe("accounts not loaded", () => {
     beforeEach(() => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -37,6 +37,7 @@ describe("SnsWallet", () => {
   };
 
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockPrincipal,

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -4,17 +4,16 @@
 
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import Neurons from "$lib/routes/Neurons.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-} from "../../mocks/sns-projects.mock";
+import { mockSnsFullProject } from "../../mocks/sns-projects.mock";
+import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/services/sns-neurons.services", () => {
   return {
@@ -43,16 +42,17 @@ describe("Neurons", () => {
       .mockImplementation(mockAuthStoreSubscribe)
   );
 
-  jest
-    .spyOn(snsProjectsStore, "subscribe")
-    .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
-
   beforeEach(() => {
     // Reset to default value
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Neurons,
     });
+
+    snsQueryStore.reset();
+    snsQueryStore.setData(
+      snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Committed] })
+    );
   });
 
   it("should render NnsNeurons by default", () => {

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -34,6 +34,7 @@ describe("ProposalDetail", () => {
   afterAll(jest.clearAllMocks);
 
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockSnsFullProject.rootCanisterId,

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -4,16 +4,15 @@
 
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import ProposalDetail from "$lib/routes/ProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-} from "../../mocks/sns-projects.mock";
+import { mockSnsFullProject } from "../../mocks/sns-projects.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/api/governance.api");
 
@@ -34,6 +33,15 @@ describe("ProposalDetail", () => {
 
   afterAll(jest.clearAllMocks);
 
+  beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
+  });
+
   it("should render NnsProposalDetail by default", () => {
     const { queryByTestId } = render(ProposalDetail, {
       props: {
@@ -46,10 +54,6 @@ describe("ProposalDetail", () => {
 
   describe("SnsProposalDetail", () => {
     beforeAll(() => {
-      jest
-        .spyOn(snsProjectsStore, "subscribe")
-        .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
-
       page.mock({
         data: { universe: mockSnsFullProject.rootCanisterId.toText() },
         routeId: AppPath.Proposal,

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -6,17 +6,15 @@ import {
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-  principal,
-} from "../../mocks/sns-projects.mock";
+import { mockSnsFullProject, principal } from "../../mocks/sns-projects.mock";
+import { snsResponseFor } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -37,6 +35,15 @@ jest.mock("$lib/services/ckbtc-transactions.services", () => {
 });
 
 describe("Wallet", () => {
+  beforeEach(() => {
+    snsQueryStore.setData(
+      snsResponseFor({
+        principal: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      })
+    );
+  });
+
   beforeAll(() =>
     jest
       .spyOn(authStore, "subscribe")
@@ -58,10 +65,6 @@ describe("Wallet", () => {
 
   describe("sns context", () => {
     beforeAll(() => {
-      jest
-        .spyOn(snsProjectsStore, "subscribe")
-        .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
-
       page.mock({
         data: { universe: mockSnsFullProject.rootCanisterId.toText() },
         routeId: AppPath.Wallet,

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -36,6 +36,7 @@ jest.mock("$lib/services/ckbtc-transactions.services", () => {
 
 describe("Wallet", () => {
   beforeEach(() => {
+    snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
         principal: mockSnsFullProject.rootCanisterId,

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -61,6 +61,15 @@ const mergeSnsResponses = (
   return [metadata, swapState];
 };
 
+export const snsResponsesFor = (
+  params: {
+    principal: Principal;
+    lifecycle: SnsSwapLifecycle;
+    certified?: boolean;
+  }[]
+): [QuerySnsMetadata[], QuerySnsSwapState[]] =>
+  mergeSnsResponses(params.map(snsResponseFor));
+
 export const snsResponsesForLifecycle = ({
   certified = false,
   lifecycles,


### PR DESCRIPTION
# Motivation

It's currently possible to see uncommitted sns neurons by deep linking the root canister id.
The issue seems to be that while `selectedUniverseStore` only gives a universe from `selectableUniversesStore`, `selectedUniverseIdStore` doesn't care whether the universe is in `selectableUniversesStore`.
The solution is to make both respect selectableUniversesStore by having one derive from the other.
As a side effect we no longer need to check if the selected universe is the ckBTC universe because selectableUniversesStore already does this check.

# Changes

frontend/src/lib/derived/selected-universe.derived.ts: Make sure selectedUniverseIdStore only holds a universe id from selectableUniversesStore.

Many tests had to change because they didn't set up the selectableUniversesStore to allow the selected universe they need for the test.

# Tests

1. Set up selectableUniversesStore correctly via snsQueryStore in many tests.
2. In selected-universe.derived.spec.ts, explicitly test that a universe has to be selectable to be selected.
3. Made sure the new test fails without the fix from this PR.
