### PR TITLE
GIX-1335: Fix npm vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2028,25 +2028,25 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.5.6.tgz",
-      "integrity": "sha512-CHVeQpbcwSIUekF6WwevmExKXyfHnzM5nlCEUv13lGgfJ0zKA0ny5YwIe40vccrm5w5Caec7jMTt9Ih3McJr5g==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.3.tgz",
+      "integrity": "sha512-32tiLy5PPpt2lquK2p53/5wR+ghAXw0HymIBEezmwmwtzx7Xf36xw3RG3fDYQ9gyzon89T+JRweXgAv/qhhvSQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.3",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.18.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -2057,6 +2057,18 @@
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/kit/node_modules/magic-string": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -8518,9 +8530,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -10360,24 +10372,35 @@
       "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.5.6.tgz",
-      "integrity": "sha512-CHVeQpbcwSIUekF6WwevmExKXyfHnzM5nlCEUv13lGgfJ0zKA0ny5YwIe40vccrm5w5Caec7jMTt9Ih3McJr5g==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.3.tgz",
+      "integrity": "sha512-32tiLy5PPpt2lquK2p53/5wR+ghAXw0HymIBEezmwmwtzx7Xf36xw3RG3fDYQ9gyzon89T+JRweXgAv/qhhvSQ==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.3",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.18.0"
+        "undici": "5.20.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.29.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+          "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -15132,9 +15155,9 @@
       }
     },
     "undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "requires": {
         "busboy": "^1.6.0"

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -3,7 +3,6 @@
 import { createHash } from "crypto";
 import * as dotenv from "dotenv";
 import { readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
 import { findHtmlFiles } from "./build.utils.mjs";
 
 dotenv.config();
@@ -13,14 +12,10 @@ const isAggregatorCanisterUrlDefined = aggregatorCanisterUrl.length > 0;
 
 const buildCsp = (htmlFile) => {
   // 1. We extract the start script parsed by SvelteKit into the html file
-  const indexHTMLWithoutStartScript = extractStartScript(htmlFile);
-  // 2. We add our custom script loader - we inject it at build time because it would throw an error when developing locally if missing
-  const indexHTMLWithScriptLoader = injectScriptLoader(
-    indexHTMLWithoutStartScript
-  );
-  // 3. remove the content-security-policy tag injected by SvelteKit
-  const indexHTMLNoCSP = removeDefaultCspTag(indexHTMLWithScriptLoader);
-  // 4. We calculate the sha256 values for these scripts and update the CSP
+  const html = readFileSync(htmlFile, "utf-8");
+  // 2. remove the content-security-policy tag injected by SvelteKit
+  const indexHTMLNoCSP = removeDefaultCspTag(html);
+  // 3. We calculate the sha256 values for these scripts and update the CSP
   const indexHTMLWithCSP = updateCSP(indexHTMLNoCSP);
 
   writeFileSync(htmlFile, indexHTMLWithCSP);
@@ -31,51 +26,6 @@ const removeDefaultCspTag = (indexHtml) => {
     '<meta http-equiv="content-security-policy" content="">',
     ""
   );
-};
-
-/**
- * We need a script loader to implement a proper Content Security Policy. See `updateCSP` doc for more information.
- */
-const injectScriptLoader = (indexHtml) => {
-  return indexHtml.replace(
-    "<!-- SCRIPT_LOADER -->",
-    `<script>
-      const loader = document.createElement("script");
-      loader.type = "module";
-      loader.src = "main.js";
-      document.head.appendChild(loader);
-    </script>`
-  );
-};
-
-/**
- * Using a CSP with 'strict-dynamic' with SvelteKit breaks in Firefox.
- * Issue: https://github.com/sveltejs/kit/issues/3558
- *
- * As workaround:
- * 1. we extract the start script that is injected by SvelteKit in index.html into a separate main.js
- * 2. we remove the script content from index.html but, let the script tag as anchor
- * 3. we use our custom script loader to load the main.js script
- */
-const extractStartScript = (htmlFile) => {
-  const indexHtml = readFileSync(htmlFile, "utf-8");
-
-  const svelteKitStartScript =
-    /(<script type=\"module\" data-sveltekit-hydrate[\s\S]*?>)([\s\S]*?)(<\/script>)/gm;
-
-  // 1. extract SvelteKit start script to a separate main.js file
-  const [_script, _scriptStartTag, content, _scriptEndTag] =
-    svelteKitStartScript.exec(indexHtml);
-  const inlineScript = content.replace(/^\s*/gm, "");
-
-  // Each file needs its own main.js because the script that calls the SvelteKit start function contains information dedicated to the route
-  // i.e. the routeId and a particular id for the querySelector use to attach the content
-  const folderPath = dirname(htmlFile);
-
-  writeFileSync(join(folderPath, "main.js"), inlineScript, "utf-8");
-
-  // 2. replace SvelteKit script tag content with empty
-  return indexHtml.replace(svelteKitStartScript, "$1$3");
 };
 
 /**
@@ -102,6 +52,9 @@ const extractStartScript = (htmlFile) => {
  * - style-src 'unsafe-inline' is required because:
  * 1. svelte uses inline style for animation (scale, fly, fade, etc.)
  *    source: https://github.com/sveltejs/svelte/issues/6662
+ *
+ * - script-src and 'self':
+ * Svelte kit now adds script tags to the index.html file. We need to allow 'self' to load these scripts.
  */
 
 const updateCSP = (indexHtml) => {
@@ -127,7 +80,7 @@ const updateCSP = (indexHtml) => {
         };
         child-src 'self';
         manifest-src 'self';
-        script-src 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(
+        script-src 'self' 'unsafe-eval' 'unsafe-inline' ${indexHashes.join(
           " "
         )};
         base-uri 'self';

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -85,7 +85,8 @@
     <meta name="theme-color" content="#352652" />
 
     <!-- Init theme as fast as possible -->
-    <script>
+    <!-- We add an id to avoid moving it along with the svelte start script -->
+    <script id="theme-js">
       try {
         const isDarkPreferred = window.matchMedia(
           "(prefers-color-scheme: dark)"
@@ -107,11 +108,13 @@
       }
     </script>
 
-    <!-- SCRIPT_LOADER -->
-
     %sveltekit.head%
   </head>
   <body>
-    <div>%sveltekit.body%</div>
+    <div>
+      %sveltekit.body%
+      <!-- We need to set the script loader here because it needs to access the parent element -->
+      <!-- SCRIPT_LOADER -->
+    </div>
   </body>
 </html>

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -260,6 +260,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
         "html" => Some("text/html"),
         "xml" => Some("application/xml"),
         "js" => Some("application/javascript"),
+        "mjs" => Some("application/javascript"),
         "json" => Some("application/json"),
         "svg" => Some("image/svg+xml"),
         "png" => Some("image/png"),


### PR DESCRIPTION
# Motivation

`npm audit` found vulenrabilities and security requested to fix them.

# Changes

* Upgrade sveltekit.
* Change the build script. There is no need to create a custom start script.
* Add ".mjs" to the list of file extensions where the backends sets the "Content-Type" header.

# Tests

Only build step is changed.
