### PR TITLE
nvm -> n

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,11 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
         build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
-        git jq
+        git jq npm
 
 # Install node
-RUN curl --fail -sSf https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
-ENV NVM_DIR=/root/.nvm
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN npm install -g n
+RUN n "${NODE_VERSION}"
 RUN node --version
 RUN npm --version
 


### PR DESCRIPTION
# Broad context
I have rewritten the Dockerfile to address issues encountered recently, especially in the context of using docker builds on nns-dapp for testnets.  Docker builds play an important role for non-team members who want something that "just works" without too many knobs to configure.  That rewrite is broken down into small chunks.

# Motivation
Using nvm to install a specific node also requires changing the path.  This introduces complexity, especially in Docker, where every downstream image then also needs to use that path, and docker ENV vars cannot be set dynamically, so there is also pain or complexity if we try to set the node version in one central place.

`n` also installs specific versions of node and npm but puts them into the default path.  So while `nvm` _can_ be made to work, `n` is significantly simpler to work with.

# Changes
* Switch `nvm` to `n`.
* Install an `npm` for bootstrapping; `n` then switches the `npm` in the path to a version matching the given node.

# Tests
* See CI
* Running `./scriupts/docker-build` to create the production wasms produces the same output in this PR and in main:
```
3ce0b751e5ce6e8d5a7f25ef5b68f6e9dccd49f36e74fe8beb81266863e5f6ad  assets.tar.xz
3cd97e07d3a73acb8b240627a682adc5e5766015791b2ffcf395eae67ea856ff  nns-dapp.wasm
548f70ad955dd520b0df38e5bec148cb47c6ec328cd8f830170ed576703677e9  sns_aggregator.wasm
```
Commits compared:
* Main commit: 00530876f950f43c9c64c091a519af56fef0230e
* This MR: c91a67923a7b3fc02fe1aca9472343e79bfbba1a