### PR TITLE
Separate getting tool versions from tool installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
 # Note: This can be done in the builder but is slow because unrelated changes to dfx.json can cause a rebuild.
 #
 # Note: Here we play a bit with the idea of storing config in files, one file per parameter.
-from base as tool_versions
+FROM base as tool_versions
 SHELL ["bash", "-c"]
 RUN mkdir -p config
 COPY dfx.json dfx.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,43 +5,53 @@
 # docker cp $container_id:nns-dapp.wasm nns-dapp.wasm
 # docker rm --volumes $container_id
 
-# This is the "builder", i.e. the base image used later to build the final
-# code.
-FROM ubuntu:20.04 as builder
+# Operating system with basic tools
+FROM ubuntu:20.04 as base
 SHELL ["bash", "-c"]
-
-ARG rust_version=1.64.0
-ENV NODE_VERSION=16.17.1
-
 ENV TZ=UTC
-
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
         build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
         git jq npm
 
+# Gets tool versions.
+#
+# Note: This can be done in the builder but is slow because unrelated changes to dfx.json can cause a rebuild.
+#
+# Note: Here we play a bit with the idea of storing config in files, one file per parameter.
+from base as tool_versions
+SHELL ["bash", "-c"]
+RUN mkdir -p config
+COPY dfx.json dfx.json
+ARG rust_version=1.64.0
+ENV NODE_VERSION=16.17.1
+RUN jq -r .dfx dfx.json > config/dfx_version
+RUN printf "%s" "$NODE_VERSION" > config/node_version
+RUN printf "%s" "$rust_version" > config/rust_version
+RUN printf "%s" "0.3.1" > config/optimizer_version
+
+# This is the "builder", i.e. the base image used later to build the final code.
+FROM base as builder
+SHELL ["bash", "-c"]
+# Get tool versions
+COPY --from=tool_versions /config/*_version config/
 # Install node
 RUN npm install -g n
-RUN n "${NODE_VERSION}"
+RUN n "$(cat config/node_version)"
 RUN node --version
 RUN npm --version
-
 # Install Rust and Cargo in /opt
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
-
 RUN curl --fail https://sh.rustup.rs -sSf \
-        | sh -s -- -y --default-toolchain ${rust_version}-x86_64-unknown-linux-gnu --no-modify-path && \
-    rustup default ${rust_version}-x86_64-unknown-linux-gnu && \
+        | sh -s -- -y --default-toolchain "$(cat config/rust_version)-x86_64-unknown-linux-gnu" --no-modify-path && \
+    rustup default "$(cat config/rust_version)-x86_64-unknown-linux-gnu" && \
     rustup target add wasm32-unknown-unknown
-
 ENV PATH=/cargo/bin:$PATH
-
 # Install IC CDK optimizer
-RUN cargo install --version 0.3.1 ic-cdk-optimizer
-
+RUN cargo install --version "$(cat config/optimizer_version)" ic-cdk-optimizer
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty
 # `lib.rs`. Then we remove the dummy source files to make sure cargo rebuild
@@ -53,10 +63,10 @@ COPY Cargo.toml .
 COPY rs/backend/Cargo.toml rs/backend/Cargo.toml
 COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
 RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs && touch rs/sns_aggregator/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -rf rs/backend/src rs/sns_aggregator/src
-
 # Install dfx
-COPY dfx.json dfx.json
-RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+WORKDIR /
+RUN DFX_VERSION="$(cat config/dfx_version)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+RUN dfx --version
 
 FROM builder AS build_frontend
 ARG DFX_NETWORK=mainnet


### PR DESCRIPTION
# Broad context
I have rewritten the Dockerfile to address issues encountered recently, especially in the context of using docker builds on nns-dapp for testnets.  Docker builds play an important role for non-team members who want something that "just works" without too many knobs to configure.  That rewrite is broken down into small chunks.

# Motivation
There has been discussion about how we specify tool versions.  However changing _where_ we specify a tool version causes the tool installation to have to be rebuilt.

# Changes
- Separate getting tool versions from installing tools.

# Tests
- See CI
- I have verified that the result of `./scripts/docker-build` (with no further arguments or relevant env vars) is unaffected by this change.