### PR TITLE
Reduce inputs to build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,25 +58,37 @@ RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs
 COPY dfx.json dfx.json
 RUN DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
-FROM builder AS build_frontend
+# Title: Gets the deployment configuration
+# Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.
+FROM builder AS configurator
+SHELL ["bash", "-c"]
+COPY dfx.json config.sh .df[x] canister_ids.jso[n] /build/
+WORKDIR /build
 ARG DFX_NETWORK=mainnet
-RUN echo "DFX_NETWORK: '$DFX_NETWORK'"
+RUN mkdir -p frontend
+RUN ./config.sh
+
+# Title: Image to build the nns-dapp frontend.
+# Args: A file with env vars at frontend/.env created by config.sh
+FROM builder AS build_frontend
 SHELL ["bash", "-c"]
 COPY ./frontend /build/frontend
-COPY ./config.sh /build/
+COPY --from=configurator /build/frontend/.env /build/frontend/.env
 COPY ./build-frontend.sh /build/
-COPY ./dfx.json /build/
 COPY ./scripts/require-dfx-network.sh /build/scripts/
 WORKDIR /build
 RUN ( cd frontend && npm ci )
-RUN export DFX_NETWORK && . config.sh && ./build-frontend.sh
+RUN ./build-frontend.sh
 
+# Title: Image to build the nns-dapp backend.
+# Args: DFX_NETWORK env var for enabling/disabling features.
+#       Note:  Better would probably be to take a config so
+#       that prod-like config can be used in another deployment.
 FROM builder AS build_nnsdapp
 ARG DFX_NETWORK=mainnet
 RUN echo "DFX_NETWORK: '$DFX_NETWORK'"
 SHELL ["bash", "-c"]
 COPY ./rs /build/rs
-COPY ./config.sh /build/
 COPY ./build-backend.sh /build/
 COPY ./build-rs.sh /build/
 COPY ./Cargo.toml /build/
@@ -84,8 +96,13 @@ COPY ./Cargo.lock /build/
 COPY ./dfx.json /build/
 COPY --from=build_frontend /build/assets.tar.xz /build/
 WORKDIR /build
-RUN export DFX_NETWORK && ./build-backend.sh
+RUN ./build-backend.sh
 
+# Title: Image to build the sns aggregator, used to increase performance and reduce load.
+# Args: None.
+#       The SNS aggregator needs to know the canister ID of the
+#       NNS-SNS-wasm canister.  That is hard-wired but should be
+#       configurable
 FROM builder AS build_aggregate
 SHELL ["bash", "-c"]
 COPY ./rs /build/rs
@@ -99,10 +116,11 @@ RUN RUSTFLAGS="--cfg feature=\"reconfigurable\"" ./build-sns-aggregator.sh
 RUN mv sns_aggregator.wasm sns_aggregator_dev.wasm
 RUN ./build-sns-aggregator.sh
 
+# Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch
+COPY --from=configurator /build/deployment-config.json /
 COPY --from=build_nnsdapp /build/nns-dapp.wasm /
 COPY --from=build_nnsdapp /build/assets.tar.xz /
-COPY --from=build_frontend /build/deployment-config.json /
 COPY --from=build_frontend /build/frontend/.env /frontend-config.sh
 COPY --from=build_aggregate /build/sns_aggregator.wasm /
 COPY --from=build_aggregate /build/sns_aggregator_dev.wasm /

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 TOPLEVEL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Need to know which deployment we are building for:
-. "$TOPLEVEL/scripts/require-dfx-network.sh"
-
-# Should we skip this if we can detect that it's already run from build.sh?
-
-# Assemble the configuration
-. config.sh
+# Verify that we have the configuration
+test -e frontend/.env || {
+  echo "ERROR: Building the frontend requires a config file."
+  echo "       Please create the config file by running config.sh."
+  exit 1
+} >&2
 
 ###################
 # frontend # (output: frontend/public/)

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ TOPLEVEL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Or do we need the exports for the backend as well?
 
 # Assemble the configuration
-. config.sh
+./config.sh
 
 set -x
 

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -10,6 +10,8 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPTS_DIR/.."
 
 DFX_NETWORK=${DFX_NETWORK:-mainnet}
+export DFX_NETWORK
+./config.sh
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -10,8 +10,6 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPTS_DIR/.."
 
 DFX_NETWORK=${DFX_NETWORK:-mainnet}
-export DFX_NETWORK
-./config.sh
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"


### PR DESCRIPTION
# Motivation
The build steps for the nns-dapp  frontend and backend currently run ./config.sh.  For config.sh to work properly for environments other than hard-wired entries such as mainnet, it needs access to the environment such as `.dfx/`.  The environment contains a huge amount of information that is not relevant and that makes it harder to reason about the build and breaks caches.  If we put this "config extraction" into a separate step, the inputs to the build can stay small.

# Changes
- Add a separate docker stage to get build configuration
- Move ./config.sh out of the frontend build command.
- Minimize inputs to the build commands, e.g. removing env vars.