### PR TITLE
Add key event handler on theme toggle

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --plugin-search-dir . --check . && eslint --max-warnings 1 .",
+    "lint": "prettier --plugin-search-dir . --check . && eslint --max-warnings 0 .",
     "format": "prettier --plugin-search-dir . --write .",
     "test": "TZ=UTC jest",
     "update:next": "npm update @dfinity/utils @dfinity/ledger @dfinity/nns @dfinity/sns @dfinity/cmc @dfinity/ckbtc",

--- a/frontend/src/lib/components/login/LoginMenuItems.svelte
+++ b/frontend/src/lib/components/login/LoginMenuItems.svelte
@@ -26,7 +26,7 @@
   </MenuItem>
 </div>
 
-<div class="theme" on:click|stopPropagation>
+<div class="theme" on:click|stopPropagation on:keypress|stopPropagation>
   <span>{$i18n.theme.switch_theme}</span><ThemeToggle />
 </div>
 


### PR DESCRIPTION
# Motivation

This is the last remaining lint warning.
For a11y, lint wants every element with a click handler to also have a key handler.
Buttons etc. do this automatically but div/span/etc. not.
We have a div wrapping the theme toggle on the logged-out menu on mobile, which stops propagation on click to keep the menu open to allow toggling multiple times without having to reopen the menu each time.
It's currently not possible to use the toggle with the keyboard because it's not in the tab order (and only appears on mobile) but if it were possible, we'd probably want to keep the menu op in that case as well.
So for now, adding this handler just stops lint from complaining.

# Changes

1. Stop propagation of keyboard events from the theme toggle inside the logged-out menu.
2. Limit the allowed number of lint warnings to 0.

# Tests

Manually use the theme toggle.
Ran `npm run lint` and checked that there are no warnings.