### PR TITLE
npm install --save-dev @types/jest-expect-message

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/svelte": "^3.2.2",
         "@types/jest": "^29.4.0",
+        "@types/jest-expect-message": "^1.1.0",
         "@types/marked": "^4.0.8",
         "@types/wicg-file-system-access": "^2020.9.5",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
@@ -2281,6 +2282,16 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest-expect-message": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jest-expect-message/-/jest-expect-message-1.1.0.tgz",
+      "integrity": "sha512-PbmZ6pTBpJTzj7KdGP8l8qTyf6RA5BVWg0C51XjCb0GuifXVcu3jAR6+U/W47nmE5S3tLPPEo70UcuhSlSS1hg==",
+      "deprecated": "This is a stub types definition. jest-expect-message provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "jest-expect-message": "*"
       }
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
@@ -10599,6 +10610,15 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
+      }
+    },
+    "@types/jest-expect-message": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jest-expect-message/-/jest-expect-message-1.1.0.tgz",
+      "integrity": "sha512-PbmZ6pTBpJTzj7KdGP8l8qTyf6RA5BVWg0C51XjCb0GuifXVcu3jAR6+U/W47nmE5S3tLPPEo70UcuhSlSS1hg==",
+      "dev": true,
+      "requires": {
+        "jest-expect-message": "*"
       }
     },
     "@types/jsdom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/svelte": "^3.2.2",
     "@types/jest": "^29.4.0",
+    "@types/jest-expect-message": "^1.1.0",
     "@types/marked": "^4.0.8",
     "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^5.51.0",


### PR DESCRIPTION
# Motivation

Package jest-expect-message allows passing a message to expect calls.
We were sometimes getting errors such as `Expected 1 arguments, but got 2.` which surprisingly went away after running `npm run test -- --clearCache` but would reappear after some time.
After installing the types package for jest-expect-message, the errors no longer seem to appear.
The [package](https://www.npmjs.com/package/@types/jest-expect-message) is supposedly deprecated because it shouldn't be necessary but it does appear to be necessary for us.

# Changes

Ran `npm install --save-dev @types/jest-expect-message`

# Tests

I found out that after running `npm run test -- --clearCache`, the error would reappear after running `npm run test -- feature-flags.store.spec.ts` twice while making changes to the test in between.
After installing the additional package, I was no longer able to reproduce the error in this way.

I tried several other things mentioned on https://www.npmjs.com/package/jest-expect-message but none of the other things made the errors go away.
