### PR TITLE
GIX-1331: Manage TxTooOld error in Participation flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-02-20.tgz",
-      "integrity": "sha512-GeFKibVZo7qiHSIyVzlxsC39/zh91TZmnt0h+sO1uj21nPXUTay+nRzKSlnEoWzMM0ImGCkWOMGGt3aIGL+L+w==",
+      "version": "0.0.2-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-02-22.1.tgz",
+      "integrity": "sha512-ZzlhxK30JuIhXUKvvMHWrRpqBS3IAL3/wPzaBNw7WWT0wASd9r4QQ98OXjX46Bdeto5g2A4XbGZQ/3kiFI4CFQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.9-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-02-20.tgz",
-      "integrity": "sha512-fNNyJfPz5GsultY40dHiKq0IwQoedlj0ksdsH18P98PHncyVr0Wuk4FDWZre6NCPWFU0GMhPPVtqVCAOVte+EA==",
+      "version": "0.0.9-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-02-22.1.tgz",
+      "integrity": "sha512-Lj8Bc37dT0xZIe3tUUELy8O+7TIqCftVhAtQgiJBEoWmSXmtXG7XeBkumNjsO6FWynCmGRbuPAGc1LULCIvYLw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.6-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-02-20.tgz",
-      "integrity": "sha512-JhcfxhqH/x8GcgFkT2Inpn83Mycx3Die6GvcWkY7JLKCsx3nld1joaNn/IVoHfAZ87PqlgazFTsM71oxSmgkgw==",
+      "version": "0.0.6-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-02-22.1.tgz",
+      "integrity": "sha512-LcQv9wd00BclbX/zmafpIymlw2aMwp/xKYXYpJNuGEPLRSq0K2JtWWS6tcPzzV99NmgvUSacNNxLjEWKUaBfjQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.15.0-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-02-20.tgz",
-      "integrity": "sha512-hENOUBSZ769Rp75bK6atoeiCEOtN7k8gv7vNv2UIU3Y3uZnDwpwWl6OCdCSJkrmKfqTDKyXV9GTLjPmgBgk2dw==",
+      "version": "0.15.0-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-02-22.1.tgz",
+      "integrity": "sha512-w1yPie2+7qasnnwTogX3gI3TMAUGHrPmcxgCtLjlGBDvi5hupafoixOQCD7y+orhJa/ySQ7+BX7rCKiax7kyEg==",
       "dependencies": {
         "crc": "^4.3.2",
         "crc-32": "^1.2.2",
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.13-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-02-20.tgz",
-      "integrity": "sha512-q4crcwR7hpjlXBr5HqBvVYxyMje8monhMSbe9MyVk43zxAQ64gwp7YgsqdcuKK6eh5TX+UsQ5UgMOTyarHWFSQ==",
+      "version": "0.0.13-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-02-22.1.tgz",
+      "integrity": "sha512-Kq2TD0FrWTno7g5f1DFrZxPWCDJu2QMz2Z0vvyP9L42lq+ax/OVYuUIyaoDT3uNeBzXihSdy8VbKVIahkN+PEw==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.13-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-02-20.tgz",
-      "integrity": "sha512-t35SjVSSa9PwicUAmyBC/ycIbrbNSte+Jh5saHnwReBCDsEyBUFBRCi+ygjpxiS0fsPWbqTjaJVaGTwUgYg43g==",
+      "version": "0.0.13-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-02-22.1.tgz",
+      "integrity": "sha512-UvohBCixDqnGZ5Fez5e4aDozLmjGPeJAMFx/n0abkWKacwx1A3bUfm3rBmqhYTqAbnh9zeKdmRcrLrazH6PbHw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9490,15 +9490,15 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-02-20.tgz",
-      "integrity": "sha512-GeFKibVZo7qiHSIyVzlxsC39/zh91TZmnt0h+sO1uj21nPXUTay+nRzKSlnEoWzMM0ImGCkWOMGGt3aIGL+L+w==",
+      "version": "0.0.2-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-02-22.1.tgz",
+      "integrity": "sha512-ZzlhxK30JuIhXUKvvMHWrRpqBS3IAL3/wPzaBNw7WWT0wASd9r4QQ98OXjX46Bdeto5g2A4XbGZQ/3kiFI4CFQ==",
       "requires": {}
     },
     "@dfinity/cmc": {
-      "version": "0.0.9-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-02-20.tgz",
-      "integrity": "sha512-fNNyJfPz5GsultY40dHiKq0IwQoedlj0ksdsH18P98PHncyVr0Wuk4FDWZre6NCPWFU0GMhPPVtqVCAOVte+EA==",
+      "version": "0.0.9-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-02-22.1.tgz",
+      "integrity": "sha512-Lj8Bc37dT0xZIe3tUUELy8O+7TIqCftVhAtQgiJBEoWmSXmtXG7XeBkumNjsO6FWynCmGRbuPAGc1LULCIvYLw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -9521,15 +9521,15 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.6-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-02-20.tgz",
-      "integrity": "sha512-JhcfxhqH/x8GcgFkT2Inpn83Mycx3Die6GvcWkY7JLKCsx3nld1joaNn/IVoHfAZ87PqlgazFTsM71oxSmgkgw==",
+      "version": "0.0.6-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-02-22.1.tgz",
+      "integrity": "sha512-LcQv9wd00BclbX/zmafpIymlw2aMwp/xKYXYpJNuGEPLRSq0K2JtWWS6tcPzzV99NmgvUSacNNxLjEWKUaBfjQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.15.0-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-02-20.tgz",
-      "integrity": "sha512-hENOUBSZ769Rp75bK6atoeiCEOtN7k8gv7vNv2UIU3Y3uZnDwpwWl6OCdCSJkrmKfqTDKyXV9GTLjPmgBgk2dw==",
+      "version": "0.15.0-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-02-22.1.tgz",
+      "integrity": "sha512-w1yPie2+7qasnnwTogX3gI3TMAUGHrPmcxgCtLjlGBDvi5hupafoixOQCD7y+orhJa/ySQ7+BX7rCKiax7kyEg==",
       "requires": {
         "crc": "^4.3.2",
         "crc-32": "^1.2.2",
@@ -9548,17 +9548,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.13-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-02-20.tgz",
-      "integrity": "sha512-q4crcwR7hpjlXBr5HqBvVYxyMje8monhMSbe9MyVk43zxAQ64gwp7YgsqdcuKK6eh5TX+UsQ5UgMOTyarHWFSQ==",
+      "version": "0.0.13-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-02-22.1.tgz",
+      "integrity": "sha512-Kq2TD0FrWTno7g5f1DFrZxPWCDJu2QMz2Z0vvyP9L42lq+ax/OVYuUIyaoDT3uNeBzXihSdy8VbKVIahkN+PEw==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.13-next-2023-02-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-02-20.tgz",
-      "integrity": "sha512-t35SjVSSa9PwicUAmyBC/ycIbrbNSte+Jh5saHnwReBCDsEyBUFBRCi+ygjpxiS0fsPWbqTjaJVaGTwUgYg43g==",
+      "version": "0.0.13-next-2023-02-22.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-02-22.1.tgz",
+      "integrity": "sha512-UvohBCixDqnGZ5Fez5e4aDozLmjGPeJAMFx/n0abkWKacwx1A3bUfm3rBmqhYTqAbnh9zeKdmRcrLrazH6PbHw==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -178,6 +178,10 @@ const convertSwap = ({
   lifecycle,
   // TODO: Ask to Max, why isn't it there?
   neuron_recipes: [],
+  // TODO: extend when needed
+  next_ticket_id: [],
+  purge_old_tickets_last_completion_timestamp_nanoseconds: [],
+  purge_old_tickets_next_principal: [],
   // TODO: Ask to Max, why isn't it there?
   cf_participants: [],
   decentralization_sale_open_timestamp_seconds: toNullable(

--- a/frontend/src/lib/api/sns-sale.api.ts
+++ b/frontend/src/lib/api/sns-sale.api.ts
@@ -3,7 +3,6 @@ import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type { Ticket } from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
-import { fromNullable } from "@dfinity/utils";
 import { wrapper } from "./sns-wrapper.api";
 
 export const getOpenTicket = async ({
@@ -71,8 +70,7 @@ export const notifyPaymentFailure = async ({
     certified: true,
   });
 
-  const response = await notifyPaymentFailure();
-  const ticket = fromNullable(response?.ticket);
+  const ticket = await notifyPaymentFailure();
 
   logWithTimestamp(`[sale] notifyPaymentFailure complete.`);
 

--- a/frontend/src/lib/api/sns-sale.api.ts
+++ b/frontend/src/lib/api/sns-sale.api.ts
@@ -3,6 +3,7 @@ import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type { Ticket } from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
+import { fromNullable } from "@dfinity/utils";
 import { wrapper } from "./sns-wrapper.api";
 
 export const getOpenTicket = async ({
@@ -53,4 +54,27 @@ export const newSaleTicket = async ({
   logWithTimestamp(`[sale]newSaleTicket complete.`);
 
   return response;
+};
+
+export const notifyPaymentFailure = async ({
+  identity,
+  rootCanisterId,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+}): Promise<Ticket | undefined> => {
+  logWithTimestamp(`[sale] notifyPaymentFailure call...`);
+
+  const { notifyPaymentFailure } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  const response = await notifyPaymentFailure();
+  const ticket = fromNullable(response?.ticket);
+
+  logWithTimestamp(`[sale] notifyPaymentFailure complete.`);
+
+  return ticket;
 };

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -236,7 +236,7 @@
     "source": "Source",
     "transaction_fee": "Transaction Fee",
     "current_balance": "Current Balance",
-    "may_take_while": "This may take up to one minute",
+    "may_take_while": "This may take more than a minute",
     "create": "Create",
     "change_source": "Change Source Account",
     "community_fund": "Community fund",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -713,6 +713,7 @@
     "commitment_too_large": "Sorry, your new commitment of $newCommitment ICP is too high. You have already committed $currentCommitment ICP and the maximum is $maxCommitment ICP.",
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
     "sns_sale_unexpected_error": "Sorry, There was an unexpected error while participating.",
+    "sns_sale_unexpected_and_refresh": "Sorry, There was an unexpected error while participating. Please refresh and try again",
     "sns_sale_proceed_with_existing_ticket": "Trying to complete the existing participation (Started at $time)",
     "sns_sale_closed": "Sorry, the sale was already closed",
     "sns_sale_invalid_amount": "Can't participate with the selected amount. Please participate with a different amount ($min - $max).",

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -559,7 +559,8 @@ export const participateInSnsSale = async ({
   } catch (err) {
     console.error("[sale] on transfer", err);
 
-    // Frontend should wait until time reaches ledger_time before retrying
+    // Frontend should auto retry participation
+    // (in theory this error should be gone in a couple of seconds)
     if (err instanceof TxCreatedInFutureError) {
       const retryIn = SALE_PARTICIPATION_RETRY_SECONDS;
 

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -431,25 +431,16 @@ const notifyParticipationAndRemoveTicket = async ({
           console.error("[sale] notifyPaymentFailure", err);
         }
         // jump to unexpected_error
-      } else {
-        // unknown error: ask to refresh and stop the flow
-        toastsError({
-          labelKey: "error__sns.sns_sale_unexpected_and_refresh",
-          err,
-        });
-
-        return { success: false };
       }
     }
 
     // unexpected error (probably sale is closed)
+    // do not remove the ticket to not enable the button
+    // unknown error: ask to refresh and stop the flow
     toastsError({
-      labelKey: "error__sns.sns_sale_unexpected_error",
+      labelKey: "error__sns.sns_sale_unexpected_and_refresh",
       err,
     });
-
-    // enable participate button
-    snsTicketsStore.setNoTicket(rootCanisterId);
 
     return { success: false };
   }

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -413,6 +413,9 @@ const notifyParticipationAndRemoveTicket = async ({
         duration: DEFAULT_TOAST_DURATION_MILLIS,
       });
     }
+
+    // At this point the participation is done and the open ticket is removed
+    return { success: true };
   } catch (err) {
     console.error("[sale] notifyParticipation", err);
     const internalError = isInternalRefreshBuyerTokensError(err);
@@ -444,9 +447,6 @@ const notifyParticipationAndRemoveTicket = async ({
 
     return { success: false };
   }
-
-  // At this point the participation is done and the open ticket is removed
-  return { success: true };
 };
 
 /**

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -435,6 +435,7 @@ const notifyParticipationAndRemoveTicket = async ({
         // unknown error: ask to refresh and stop the flow
         toastsError({
           labelKey: "error__sns.sns_sale_unexpected_and_refresh",
+          err,
         });
 
         return { success: false };
@@ -444,6 +445,7 @@ const notifyParticipationAndRemoveTicket = async ({
     // unexpected error (probably sale is closed)
     toastsError({
       labelKey: "error__sns.sns_sale_unexpected_error",
+      err,
     });
 
     // enable participate button

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -414,10 +414,7 @@ const notifyParticipationAndRemoveTicket = async ({
   hasTooOldError: boolean;
   ticket: Ticket;
 }): Promise<{ success: boolean }> => {
-  const {
-    canisterIds: { swapCanisterId },
-    notifyParticipation: notifyParticipationApi,
-  } = await wrapper({
+  const { notifyParticipation: notifyParticipationApi } = await wrapper({
     identity,
     rootCanisterId: rootCanisterId.toText(),
     certified: true,
@@ -534,7 +531,6 @@ export const participateInSnsSale = async ({
   const { canister: nnsLedger } = await ledgerCanister({ identity });
   const {
     canisterIds: { swapCanisterId },
-    notifyParticipation,
   } = await wrapper({
     identity,
     rootCanisterId: rootCanisterId.toText(),

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -746,6 +746,7 @@ interface I18nError__sns {
   commitment_too_large: string;
   commitment_exceeds_current_allowed: string;
   sns_sale_unexpected_error: string;
+  sns_sale_unexpected_and_refresh: string;
   sns_sale_proceed_with_existing_ticket: string;
   sns_sale_closed: string;
   sns_sale_invalid_amount: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -748,6 +748,7 @@ interface I18nError__sns {
   commitment_too_large: string;
   commitment_exceeds_current_allowed: string;
   sns_sale_unexpected_error: string;
+  sns_sale_unexpected_and_refresh: string;
   sns_sale_final_error: string;
   sns_sale_proceed_with_existing_ticket: string;
   sns_sale_closed: string;

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -207,3 +207,31 @@ export const hasOpenTicketInProcess = (
   isNullish(rootCanisterId)
     ? true
     : get(snsTicketsStore)[rootCanisterId.toText()]?.ticket !== null;
+
+/**
+ * Tests the error message against `refresh_buyer_token` canister function.
+ * This is the workaround before the api call provides nice error details.
+ *
+ * @param err
+ */
+export const isInternalRefreshBuyerTokensError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const { message } = err;
+  return [
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs
+    "The token amount can only be refreshed when the canister is in the OPEN state",
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L611
+    "The ICP target for this token swap has already been reached.",
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L649
+    "The swap has already reached its target",
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L658
+    "Amount transferred:",
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L697
+    "New balance:",
+    // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L718
+    "The available balance to be topped up",
+  ].some((text) => message.startsWith(text));
+};

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -8,6 +8,7 @@ import {
   importSnsWasmCanister,
 } from "$lib/proxy/api.import.proxy";
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
+import { notifyPaymentFailure } from "../../../lib/api/sns-sale.api";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   deployedSnsMock,
@@ -28,8 +29,12 @@ describe("sns-sale.api", () => {
 
   const getOpenTicketSpy = jest.fn().mockResolvedValue(ticket.ticket);
   const newSaleTicketSpy = jest.fn().mockResolvedValue(ticket.ticket);
+  const notifyPaymentFailureSpy = jest.fn().mockResolvedValue(ticket.ticket);
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+
     (importSnsWasmCanister as jest.Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       create: (options: SnsWasmCanisterOptions) => ({
@@ -47,34 +52,40 @@ describe("sns-sale.api", () => {
         },
         getOpenTicket: getOpenTicketSpy,
         newSaleTicket: newSaleTicketSpy,
+        notifyPaymentFailure: notifyPaymentFailureSpy,
       })
     );
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
-
   it("should query open ticket", async () => {
-    const response = await getOpenTicket({
+    const result = await getOpenTicket({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
       certified: true,
     });
 
-    expect(response).not.toBeNull();
-    expect(response).toEqual(ticket.ticket);
+    expect(result).not.toBeNull();
+    expect(result).toEqual(ticket.ticket);
   });
 
   it("should create new sale ticket", async () => {
-    const response = await newSaleTicket({
+    const result = await newSaleTicket({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
       amount_icp_e8s: 123n,
     });
 
-    expect(response).not.toBeNull();
-    expect(response).toEqual(ticket.ticket);
+    expect(result).not.toBeNull();
+    expect(result).toEqual(ticket.ticket);
+  });
+
+  it("should notify payment failure", async () => {
+    const result = await notifyPaymentFailure({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual(ticket.ticket);
   });
 });

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -32,9 +32,6 @@ describe("sns-sale.api", () => {
   const notifyPaymentFailureSpy = jest.fn().mockResolvedValue(ticket.ticket);
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-
     (importSnsWasmCanister as jest.Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       create: (options: SnsWasmCanisterOptions) => ({
@@ -55,6 +52,11 @@ describe("sns-sale.api", () => {
         notifyPaymentFailure: notifyPaymentFailureSpy,
       })
     );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it("should query open ticket", async () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -93,9 +93,7 @@ describe("sns-api", () => {
     ],
   };
 
-  const spyOnNotifyParticipation = jest.fn().mockResolvedValue({
-    icp_accepted_participation_e8s: 666n,
-  });
+  const spyOnNotifyParticipation = jest.fn();
   const spyOnToastsShow = jest.spyOn(toastsStore, "toastsShow");
   const spyOnToastsSuccess = jest.spyOn(toastsStore, "toastsSuccess");
   const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
@@ -619,6 +617,7 @@ describe("sns-api", () => {
         });
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
+        expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
         expect(spyOnToastsError).not.toBeCalled();
         expect(spyOnToastsSuccess).toBeCalledTimes(1);
         expect(spyOnToastsSuccess).toBeCalledWith(
@@ -626,10 +625,11 @@ describe("sns-api", () => {
             labelKey: "sns_project_detail.participate_success",
           })
         );
+        // to enable the button/increase_participation
         expect(ticketFromStore().ticket).toEqual(null);
       });
 
-      it("should stop the error flow on unknown error", async () => {
+      it("should handle refresh_buyer_tokens unknown errors", async () => {
         snsTicketsStore.setTicket({
           rootCanisterId: rootCanisterIdMock,
           ticket: testTicket,
@@ -643,6 +643,7 @@ describe("sns-api", () => {
         });
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
+        expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
         expect(spyOnToastsError).toBeCalledTimes(1);
         expect(spyOnToastsError).toBeCalledWith(
           expect.objectContaining({
@@ -650,10 +651,11 @@ describe("sns-api", () => {
           })
         );
         expect(spyOnToastsSuccess).not.toBeCalled();
+        // the button/increase_participation should not be enabled
         expect(ticketFromStore().ticket).toEqual(testTicket);
       });
 
-      it("should manually remove the ticket on internal error", async () => {
+      it("should handle refresh_buyer_tokens internal errors and manually remove the ticket", async () => {
         snsTicketsStore.setTicket({
           rootCanisterId: rootCanisterIdMock,
           ticket: testTicket,
@@ -679,6 +681,7 @@ describe("sns-api", () => {
           })
         );
         expect(spyOnToastsSuccess).not.toBeCalled();
+        // the button/increase_participation should not be enabled
         expect(ticketFromStore().ticket).not.toBeNull();
       });
     });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -67,6 +67,7 @@ import {
   swapCanisterIdMock,
 } from "../../mocks/sns.api.mock";
 import { snsTicketMock } from "../../mocks/sns.mock";
+import {toastsSuccess} from "../../../lib/stores/toasts.store";
 
 jest.mock("$lib/proxy/api.import.proxy");
 jest.mock("$lib/api/agent.api", () => {
@@ -97,6 +98,7 @@ describe("sns-api", () => {
     icp_accepted_participation_e8s: 666n,
   });
   const spyOnToastsShow = jest.spyOn(toastsStore, "toastsShow");
+  const spyOnToastsSuccess = jest.spyOn(toastsStore, "toastsSuccess");
   const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
   const ledgerCanisterMock = mock<LedgerCanister>();
   const testRootCanisterId = rootCanisterIdMock;
@@ -113,6 +115,7 @@ describe("sns-api", () => {
   beforeEach(() => {
     spyOnToastsShow.mockClear();
     spyOnToastsError.mockClear();
+    spyOnToastsSuccess.mockClear();
     jest.clearAllMocks();
 
     snsTicketsStore.reset();
@@ -436,6 +439,10 @@ describe("sns-api", () => {
       expect(stopBusySpy).toBeCalledTimes(1);
       // null after ready
       expect(ticketFromStore().ticket).toEqual(null);
+      expect(spyOnToastsSuccess).toBeCalledTimes(1);
+      expect(spyOnToastsSuccess).toBeCalledWith(expect.objectContaining({
+        labelKey: "sns_project_detail.participate_success",
+      }));
       // no errors
       expect(spyOnToastsError).not.toBeCalled();
     });
@@ -591,7 +598,7 @@ describe("sns-api", () => {
       expect(ticketFromStore().ticket).toEqual(null);
     });
 
-    it("should display TooOldError errors", async () => {
+    it("should process TooOldError when notify participation succeed", async () => {
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
         ticket: testTicket,
@@ -603,12 +610,12 @@ describe("sns-api", () => {
         postprocess: jest.fn().mockResolvedValue(undefined),
       });
 
-      expect(spyOnNotifyParticipation).not.toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.ledger_too_old",
-        })
-      );
+      expect(spyOnNotifyParticipation).toBeCalledTimes(1);
+      expect(spyOnToastsError).not.toBeCalled();
+      expect(spyOnToastsSuccess).toBeCalledTimes(1);
+      expect(spyOnToastsSuccess).toBeCalledWith(expect.objectContaining({
+        labelKey: "sns_project_detail.participate_success",
+      }));
       expect(ticketFromStore().ticket).toEqual(null);
     });
 

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -8,7 +8,10 @@ import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { snsTicketsStore } from "../../../lib/stores/sns-tickets.store";
-import { hasOpenTicketInProcess } from "../../../lib/utils/sns.utils";
+import {
+  hasOpenTicketInProcess,
+  isInternalRefreshBuyerTokensError,
+} from "../../../lib/utils/sns.utils";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   createBuyersState,
@@ -274,6 +277,28 @@ describe("sns-utils", () => {
       });
 
       expect(hasOpenTicketInProcess(rootCanisterIdMock)).toBeFalsy();
+    });
+  });
+
+  describe("isInternalRefreshBuyerTokensError", () => {
+    it("returns true on known error", () => {
+      const error = new Error("The swap has already reached its target");
+      expect(isInternalRefreshBuyerTokensError(error)).toBeTruthy();
+    });
+
+    it("returns false on unknown error", () => {
+      const error = new Error("Fake the swap has already reached its target");
+      expect(isInternalRefreshBuyerTokensError(error)).toBeFalsy();
+    });
+
+    it("returns false on not error argument", () => {
+      expect(isInternalRefreshBuyerTokensError(null)).toBeFalsy();
+      expect(isInternalRefreshBuyerTokensError(undefined)).toBeFalsy();
+      expect(
+        isInternalRefreshBuyerTokensError(
+          "The swap has already reached its target"
+        )
+      ).toBeFalsy();
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -127,6 +127,9 @@ export const aggregatorSnsMock: CachedSns = {
         },
       ],
       open_sns_token_swap_proposal_id: [BigInt(120)],
+      next_ticket_id: [],
+      purge_old_tickets_last_completion_timestamp_nanoseconds: [],
+      purge_old_tickets_next_principal: [],
     },
     derived: {
       buyer_total_icp_e8s: BigInt(314100000000),

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -118,6 +118,9 @@ export const mockQuerySwap: SnsSwap = {
   open_sns_token_swap_proposal_id: [BigInt(1000)],
   buyers: [],
   params: [mockSnsParams],
+  next_ticket_id: [],
+  purge_old_tickets_last_completion_timestamp_nanoseconds: [],
+  purge_old_tickets_next_principal: [],
 };
 
 export const mockDerived: SnsSwapDerivedState = {

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -22,6 +22,10 @@ const swapToQuerySwap = (swap: SnsSummarySwap): [SnsSwap] => [
       swap.decentralization_sale_open_timestamp_seconds
     ),
     params: [{ ...swap.params }],
+
+    next_ticket_id: [],
+    purge_old_tickets_last_completion_timestamp_nanoseconds: [],
+    purge_old_tickets_next_principal: [],
   },
 ];
 


### PR DESCRIPTION
# Motivation

Handling of the `TransferError::TooOld`.

# Changes

- upgrade swap canister types (based on candid)
- upgrade `ic-js` to get `notifySwapFailure` api
- `notifySwapFailure` api
- `isInternalRefreshBuyerTokensError`
- update the sale flow
  - refactor `notifyParticipationAndRemoveTicket`
  - call `notifySwapFailure` to manually remove the ticket

# Tests

- notifyPaymentFailure api
- sale services update (notifyParticipationAndRemoveTicket)
- isInternalRefreshBuyerTokensError
