### PR TITLE
Require PR approval from a GIX team member

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
 # For questions, reach out to: <gix@dfinity.org>
+* @dfinity/gix


### PR DESCRIPTION
# Motivation
At the moment, any two members of dfinity-core can collaborate to merge a PR into the nns-dapp codebase, even with no knowledge or approval by the GIX team.  This does not seem ideal.

## Bib
- Example from the sdk repo: https://github.com/dfinity/sdk/blob/master/.github/CODEOWNERS
- CODEOWNERS documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
- Note: Enforcement also requires this to be checked on the branch protections:  
![Screenshot from 2023-02-23 04-18-51](https://user-images.githubusercontent.com/5982633/220814361-053d3e2c-5f8a-4e8b-a592-b281288f64b7.png)


# Changes
- Add the gix team as the owners of everything in the CODEOWNERS file.

# Tests