### PR TITLE
Bump ic commit

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -54,8 +54,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Feb 21 with dfx 0.13.1
-          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
+          # Version from Thu Feb 23 with dfx 0.13.1
+          ref: '34133493140b01b14a07c1b9fa5e9aee7290ea6d'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -54,8 +54,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Fep 9 with dfx 0.13.xxx
-          ref: 'b78190b5617cd24a6e7bccf1b94dc1aa31137165'
+          # Version from Thu Feb 21 with dfx 0.13.1
+          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Feb 21 with dfx version 0.13.1
-          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
+          # Version from Thu Feb 23 with dfx version 0.13.1
+          ref: '34133493140b01b14a07c1b9fa5e9aee7290ea6d'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Thu Feb 9 with dfx version 0.13.xxx
-          ref: 'b78190b5617cd24a6e7bccf1b94dc1aa31137165'
+          # Version from Thu Feb 21 with dfx version 0.13.1
+          ref: 'd50f8826375aa6c9575ee6d20d1f7d46a21d6009'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -290,6 +290,7 @@ type NeuronParameters = record {
   dissolve_delay_seconds : opt nat64;
   source_nns_neuron_id : opt nat64;
   stake_e8s : opt nat64;
+  followees : vec NeuronId;
   hotkey : opt principal;
   neuron_id : opt NeuronId;
 };
@@ -319,6 +320,7 @@ type ProposalData = record {
   ballots : vec record { text; Ballot };
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
+  reward_event_end_timestamp_seconds : opt nat64;
   proposal_creation_timestamp_seconds : nat64;
   initial_voting_period_seconds : nat64;
   reject_cost_e8s : nat64;
@@ -342,6 +344,7 @@ type Result = variant { Error : GovernanceError; Neuron : Neuron };
 type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
 type RewardEvent = record {
   actual_timestamp_seconds : nat64;
+  end_timestamp_seconds : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -106,11 +106,16 @@ type ListSnsNeuronRecipesRequest = record {
 type ListSnsNeuronRecipesResponse = record {
   sns_neuron_recipes : vec SnsNeuronRecipe;
 };
-type NeuronAttributes = record { dissolve_delay_seconds : nat64; memo : nat64 };
+type NeuronAttributes = record {
+  dissolve_delay_seconds : nat64;
+  memo : nat64;
+  followees : vec NeuronId;
+};
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
+type NeuronId = record { id : vec nat8 };
 type NewSaleTicketRequest = record {
   subaccount : opt vec nat8;
   amount_icp_e8s : nat64;
@@ -167,11 +172,14 @@ type SnsNeuronRecipe = record {
 };
 type Swap = record {
   neuron_recipes : vec SnsNeuronRecipe;
+  next_ticket_id : opt nat64;
   decentralization_sale_open_timestamp_seconds : opt nat64;
   finalize_swap_in_progress : opt bool;
   cf_participants : vec CfParticipant;
   init : opt Init;
+  purge_old_tickets_last_completion_timestamp_nanoseconds : opt nat64;
   lifecycle : int32;
+  purge_old_tickets_next_principal : opt vec nat8;
   buyers : vec record { text; BuyerState };
   params : opt Params;
   open_sns_token_swap_proposal_id : opt nat64;
@@ -216,6 +224,7 @@ service : (Init) -> {
       ListSnsNeuronRecipesResponse,
     ) query;
   new_sale_ticket : (NewSaleTicketRequest) -> (NewSaleTicketResponse);
+  notify_payment_failure : (record {}) -> (Ok_1);
   open : (OpenRequest) -> (record {});
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.13.0-downgrade.1",
+  "dfx": "0.13.1",
   "canisters": {
     "nns-governance": {
       "type": "custom",

--- a/dfx.json
+++ b/dfx.json
@@ -1038,7 +1038,7 @@
       "config": {
         "RUSTC_VERSION": "1.64.0",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
-        "IC_COMMIT": "0a5b8387179d2dec8269cc48b907ab0b334fdac1"
+        "IC_COMMIT": "ced285287d5513832ba8c66fc3793e438c74b531"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -112,6 +112,7 @@ pub struct ProposalId { id: u64 }
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RewardEvent {
   pub  actual_timestamp_seconds: u64,
+  pub  end_timestamp_seconds: Option<u64>,
   pub  distributed_e8s_equivalent: u64,
   pub  round: u64,
   pub  settled_proposals: Vec<ProposalId>,
@@ -215,6 +216,7 @@ pub struct ProposalData {
   pub  ballots: Vec<(String,Ballot,)>,
   pub  reward_event_round: u64,
   pub  failed_timestamp_seconds: u64,
+  pub  reward_event_end_timestamp_seconds: Option<u64>,
   pub  proposal_creation_timestamp_seconds: u64,
   pub  initial_voting_period_seconds: u64,
   pub  reject_cost_e8s: u64,
@@ -393,6 +395,7 @@ pub struct NeuronParameters {
   pub  dissolve_delay_seconds: Option<u64>,
   pub  source_nns_neuron_id: Option<u64>,
   pub  stake_e8s: Option<u64>,
+  pub  followees: Vec<NeuronId>,
   pub  hotkey: Option<candid::Principal>,
   pub  neuron_id: Option<NeuronId>,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -235,7 +235,14 @@ pub struct GetSaleParametersResponse { params: Option<Params> }
 pub struct get_state_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronAttributes { dissolve_delay_seconds: u64, memo: u64 }
+pub struct NeuronId { id: Vec<u8> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct NeuronAttributes {
+  pub  dissolve_delay_seconds: u64,
+  pub  memo: u64,
+  pub  followees: Vec<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CfInvestment { hotkey_principal: String, nns_neuron_id: u64 }
@@ -263,11 +270,14 @@ pub struct CfParticipant { hotkey_principal: String, cf_neurons: Vec<CfNeuron> }
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Swap {
   pub  neuron_recipes: Vec<SnsNeuronRecipe>,
+  pub  next_ticket_id: Option<u64>,
   pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
   pub  finalize_swap_in_progress: Option<bool>,
   pub  cf_participants: Vec<CfParticipant>,
   pub  init: Option<Init>,
+  pub  purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
   pub  lifecycle: i32,
+  pub  purge_old_tickets_next_principal: Option<Vec<u8>>,
   pub  buyers: Vec<(String,BuyerState,)>,
   pub  params: Option<Params>,
   pub  open_sns_token_swap_proposal_id: Option<u64>,
@@ -329,6 +339,9 @@ pub enum Result_2 { Ok(Ok_1), Err(Err_2) }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NewSaleTicketResponse { result: Option<Result_2> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct notify_payment_failure_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct OpenRequest {
@@ -423,6 +436,12 @@ impl SERVICE{
   pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<
     (NewSaleTicketResponse,)
   > { ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await }
+  pub async fn notify_payment_failure(
+    &self,
+    arg0: notify_payment_failure_arg0,
+  ) -> CallResult<(Ok_1,)> {
+    ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
+  }
   pub async fn open(&self, arg0: OpenRequest) -> CallResult<(open_ret0,)> {
     ic_cdk::call(self.0, "open", (arg0,)).await
   }


### PR DESCRIPTION
# Motivation
We need to test against the latest SNS.

# Changes
- Advance the IC commit to `ced285287d5513832ba8c66fc3793e438c74b531`  (Wed Feb 22 23:25:09 2023 +0000)
 - Note: This was done with the update script.  No further changes or fixes were needed.
 
- Advance the snsdemo version used for testing to `34133493140b01b14a07c1b9fa5e9aee7290ea6d` (Thu Feb 23 04:22:12 2023 +0100)
 - Note: The snsdemo uses dfx version `0.13.1`, so this PR is stacked on top of the nns-dapp PR that introduces 0.13.1.

# Tests
## Local testnet
See CI
## Remote testnet
- Deployed snsdemo to small09.  Verifying a couple of canister IDs to ensure that the SNS wasms are as expected:
```
max@sinkpad:~/dfn/snsdemo (1:44:51)$ cat sns_ZUNAP_canister_ids.json
{
  "sns_governance": {
    "small09": "sbzkb-zqaaa-aaaaa-aaaiq-cai"
  },
  "sns_index": {
    "small09": "s24we-diaaa-aaaaa-aaaka-cai"
  },
  "sns_ledger": {
    "small09": "si2b5-pyaaa-aaaaa-aaaja-cai"
  },
  "sns_root": {
    "small09": "sgymv-uiaaa-aaaaa-aaaia-cai"
  },
  "sns_swap": {
    "small09": "sp3hj-caaaa-aaaaa-aaajq-cai"
  }
}
max@sinkpad:~/dfn/snsdemo (1:45:04)$ curl -s "https://download.dfinity.systems/ic/ced285287d5513832ba8c66fc3793e438c74b531/canisters/sns-governance-canister.wasm.gz" | gunzip | sha256sum 
be452d2d84cacd137986239df224a4c53f0e24231cdb9d88ebf4adc73a73d75f  -
max@sinkpad:~/dfn/snsdemo (1:45:10)$ dfx canister info sbzkb-zqaaa-aaaaa-aaaiq-cai --network small09
Controllers: sgymv-uiaaa-aaaaa-aaaia-cai
Module hash: 0xbe452d2d84cacd137986239df224a4c53f0e24231cdb9d88ebf4adc73a73d75f
max@sinkpad:~/dfn/snsdemo (1:45:21)$ 
max@sinkpad:~/dfn/snsdemo (1:45:23)$ 
max@sinkpad:~/dfn/snsdemo (1:45:24)$ curl -s "https://download.dfinity.systems/ic/ced285287d5513832ba8c66fc3793e438c74b531/canisters/sns-swap-canister.wasm.gz" | gunzip | sha256sum 
db3e6a586216b169fa3e1311be53cb19e1ddff9941018ec1bc38c33def78e540  -
max@sinkpad:~/dfn/snsdemo (1:45:46)$ dfx canister info sp3hj-caaaa-aaaaa-aaajq-cai --network small09
Controllers: r7inp-6aaaa-aaaaa-aaabq-cai
Module hash: 0xdb3e6a586216b169fa3e1311be53cb19e1ddff9941018ec1bc38c33def78e540
max@sinkpad:~/dfn/snsdemo (1:45:59)$ 
max@sinkpad:~/dfn/snsdemo (1:46:30)$ 
max@sinkpad:~/dfn/snsdemo (1:46:30)$ curl -s "https://download.dfinity.systems/ic/ced285287d5513832ba8c66fc3793e438c74b531/canisters/sns-root-canister.wasm.gz" | gunzip | sha256sum 
8ac197ef8873ad317db1ae30b42365b29045e650beaea8ea46e35f50816fbeff  -
max@sinkpad:~/dfn/snsdemo (1:46:36)$ dfx canister info sgymv-uiaaa-aaaaa-aaaia-cai --network small09
Controllers: sbzkb-zqaaa-aaaaa-aaaiq-cai
Module hash: 0x8ac197ef8873ad317db1ae30b42365b29045e650beaea8ea46e35f50816fbeff
max@sinkpad:~/dfn/snsdemo (1:46:50)$ 
```
Deployed the aggregator: https://q4eej-kyaaa-aaaaa-aaaha-cai.small09.testnet.dfinity.network/
Nnsdapp is deployed by snsdemo and is the main branch.  The nns-dapp is, I think, unaffected by this PR: https://qvhpv-4qaaa-aaaaa-aaagq-cai.small09.testnet.dfinity.network/launchpad/

