### PR TITLE
GIX-1340: Retry get open ticket

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -19,7 +19,7 @@ import { HOST } from "$lib/constants/environment.constants";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import { poll, PollingLimitExceededError } from "$lib/utils/utils";
+import { poll, pollingLimit } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { CMCCanister, ProcessingError, type Cycles } from "@dfinity/cmc";
 import { AccountIdentifier, SubAccount, TokenAmount } from "@dfinity/nns";
@@ -130,8 +130,6 @@ export const detachCanister = async ({
   logWithTimestamp("Detaching canister call complete.");
 };
 
-const pollingLimit = (error: unknown): boolean =>
-  error instanceof PollingLimitExceededError;
 const notProcessingError = (error: unknown): boolean =>
   !(error instanceof ProcessingError);
 

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -2,7 +2,7 @@
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import type { SnsSummary } from "$lib/types/sns";
   import { getContext, onDestroy } from "svelte";
-  import { BottomSheet, Spinner, toastsStore } from "@dfinity/gix-components";
+  import { BottomSheet, Spinner } from "@dfinity/gix-components";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -18,7 +18,10 @@
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-  import { restoreSnsSaleParticipation } from "$lib/services/sns-sale.services";
+  import {
+    hidePollingToast,
+    restoreSnsSaleParticipation,
+  } from "$lib/services/sns-sale.services";
   import { isSignedIn } from "$lib/utils/auth.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { hasOpenTicketInProcess } from "$lib/utils/sns.utils";
@@ -105,7 +108,7 @@
     });
 
     // Hide toasts when moving away from the page
-    toastsStore.reset();
+    hidePollingToast();
   });
 </script>
 

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -2,7 +2,7 @@
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import type { SnsSummary } from "$lib/types/sns";
   import { getContext, onDestroy } from "svelte";
-  import { BottomSheet, Spinner } from "@dfinity/gix-components";
+  import { BottomSheet, Spinner, toastsStore } from "@dfinity/gix-components";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
@@ -52,7 +52,10 @@
 
   // busy if open ticket is available or not requested
   let busy = true;
-  $: busy = hasOpenTicketInProcess(rootCanisterId);
+  $: busy = hasOpenTicketInProcess({
+    rootCanisterId,
+    ticketsStore: $snsTicketsStore,
+  });
 
   // TODO(sale): find a better solution
   let loadingTicketRootCanisterId: string | undefined;
@@ -65,6 +68,8 @@
     ) {
       return;
     }
+
+    snsTicketsStore.enablePolling(rootCanisterId);
 
     loadingTicketRootCanisterId = rootCanisterId.toText();
 
@@ -93,7 +98,14 @@
     }
 
     // remove the ticket to stop sale-participation-retry from another pages because of the non-obvious UX
-    snsTicketsStore.removeTicket(rootCanisterId);
+    snsTicketsStore.setTicket({
+      rootCanisterId,
+      ticket: undefined,
+      keepPolling: false,
+    });
+
+    // Hide toasts when moving away from the page
+    toastsStore.reset();
   });
 </script>
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -607,6 +607,7 @@
     "sale_end": "Sale End",
     "max_left": "max left",
     "max_user_commitment_reached": "Maximum commitment reached",
+    "getting_sns_open_ticket": "We're connecting with the SNS sale. This might take more than a minute.",
     "sign_in": "Sign in to participate"
   },
   "sns_neuron_detail": {
@@ -713,9 +714,11 @@
     "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
     "commitment_too_large": "Sorry, your new commitment of $newCommitment ICP is too high. You have already committed $currentCommitment ICP and the maximum is $maxCommitment ICP.",
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
-    "sns_sale_unexpected_error": "Sorry, There was an unexpected error while participating.",
+    "sns_sale_unexpected_error": "Sorry, there was an unexpected error while participating.",
+    "sns_sale_final_error": "Sorry, there was an unexpected error connection with the SNS sale. Please reload the page and try again.",
     "sns_sale_proceed_with_existing_ticket": "Trying to complete the existing participation (Started at $time)",
-    "sns_sale_closed": "Sorry, the sale was already closed",
+    "sns_sale_closed": "Sorry, the sale was already closed. Please reload the page.",
+    "sns_sale_not_open": "Sorry, the sale is not yet open. Please reload the page.",
     "sns_sale_invalid_amount": "Can't participate with the selected amount. Please participate with a different amount ($min - $max).",
     "sns_sale_invalid_subaccount": "Can't participate with the selected subaccount.",
     "sns_sale_try_later": "Sorry, there was an unexpected error while participating. Please try again later.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -101,6 +101,7 @@
     "not_canister_controller_to_update": "The current user is not the controller of the canister. Only controllers can change the settings.",
     "limit_exceeded_topping_up_canister": "Error topping up canister. ICP might have been transferred, refresh the page. Try again if not.",
     "limit_exceeded_creating_canister": "Error creating canister. Canister might be created, refresh the page. Try again if not.",
+    "limit_exceeded_getting_open_ticket": "There was an error connecting to the SNS sale. Please refresh the page.",
     "sns_loading_commited_projects": "Sorry, there was an error loading the projects.",
     "swap_not_loaded": "Sorry, there was an error loading the sale information.",
     "transaction_fee_not_found": "Sorry, there was an error loading the transaction fee.",

--- a/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/SwapModal/ParticipateSwapModal.svelte
@@ -28,6 +28,7 @@
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
   import { hasOpenTicketInProcess } from "$lib/utils/sns.utils";
+  import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 
   const { store: projectDetailStore, reload } =
     getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
@@ -86,9 +87,10 @@
   let accepted: boolean;
 
   let busy = true;
-  $: busy = hasOpenTicketInProcess(
-    $projectDetailStore?.summary?.rootCanisterId
-  );
+  $: busy = hasOpenTicketInProcess({
+    rootCanisterId: $projectDetailStore?.summary?.rootCanisterId,
+    ticketsStore: $snsTicketsStore,
+  });
 
   const dispatcher = createEventDispatcher();
   const participate = async ({

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -82,7 +82,7 @@ const shouldStopPollingTicket =
     return false;
   };
 
-const WAIT_FOR_TICKET_MILLIS = 1 * 1_000;
+const WAIT_FOR_TICKET_MILLIS = SALE_PARTICIPATION_RETRY_SECONDS * 1_000;
 const pollGetOpenTicket = async ({
   rootCanisterId,
   identity,

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -159,7 +159,6 @@ export const loadOpenTicket = async ({
     logWithTimestamp("[sale]loadOpenTicket:", ticket);
   } catch (err) {
     const store = get(snsTicketsStore)[rootCanisterId.toText()];
-
     // Do not show errors if the user has stopped polling.
     if (!store?.keepPolling) {
       // Reset toastId
@@ -170,7 +169,13 @@ export const loadOpenTicket = async ({
       return;
     }
 
-    snsTicketsStore.stopPolling(rootCanisterId);
+    // Set explicitly `null` to mark the ticket absence
+    // Stop polling
+    snsTicketsStore.setTicket({
+      rootCanisterId,
+      ticket: null,
+      keepPolling: false,
+    });
 
     if (err instanceof SnsSwapGetOpenTicketError) {
       // handle custom errors

--- a/frontend/src/lib/stores/sns-tickets.store.ts
+++ b/frontend/src/lib/stores/sns-tickets.store.ts
@@ -60,7 +60,9 @@ const initSnsTicketsStore = () => {
     },
 
     /**
-     * Enable polling for the ticket
+     * Disable polling for the ticket
+     *
+     * This is used for testing purposes only at the moment.
      *
      * @param rootCanisterId
      */

--- a/frontend/src/lib/stores/sns-tickets.store.ts
+++ b/frontend/src/lib/stores/sns-tickets.store.ts
@@ -64,7 +64,7 @@ const initSnsTicketsStore = () => {
      *
      * @param rootCanisterId
      */
-    stopPolling(rootCanisterId: Principal) {
+    disablePolling(rootCanisterId: Principal) {
       update((currentState: SnsTicketsStore) => ({
         ...currentState,
         [rootCanisterId.toText()]: {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -105,6 +105,7 @@ interface I18nError {
   not_canister_controller_to_update: string;
   limit_exceeded_topping_up_canister: string;
   limit_exceeded_creating_canister: string;
+  limit_exceeded_getting_open_ticket: string;
   sns_loading_commited_projects: string;
   swap_not_loaded: string;
   transaction_fee_not_found: string;
@@ -630,6 +631,7 @@ interface I18nSns_project_detail {
   sale_end: string;
   max_left: string;
   max_user_commitment_reached: string;
+  getting_sns_open_ticket: string;
   sign_in: string;
 }
 
@@ -746,8 +748,10 @@ interface I18nError__sns {
   commitment_too_large: string;
   commitment_exceeds_current_allowed: string;
   sns_sale_unexpected_error: string;
+  sns_sale_final_error: string;
   sns_sale_proceed_with_existing_ticket: string;
   sns_sale_closed: string;
+  sns_sale_not_open: string;
   sns_sale_invalid_amount: string;
   sns_sale_invalid_subaccount: string;
   sns_sale_try_later: string;

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -22,7 +22,7 @@ import type {
   SnsSwap,
   SnsSwapDerivedState,
 } from "@dfinity/sns";
-import { fromNullable, isNullish } from "@dfinity/utils";
+import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
 import { isPngAsset } from "./utils";
 
 type OptionalSnsSummarySwap = Omit<SnsSummarySwap, "params"> & {
@@ -216,7 +216,16 @@ export const hasOpenTicketInProcess = ({
     return true;
   }
 
-  return (
-    projectTicketData.ticket !== null && projectTicketData.keepPolling === true
-  );
+  // If we have a ticket, we have an open ticket in process.
+  if (nonNullish(projectTicketData.ticket)) {
+    return true;
+  }
+
+  // `null` means that the user has no open tickets.
+  if (projectTicketData.ticket === null) {
+    return false;
+  }
+
+  // `undefined` means that we could still be polling for the ticket.
+  return projectTicketData.keepPolling;
 };

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SNS_LOGO } from "$lib/constants/sns.constants";
-import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
+import type { SnsTicketsStore } from "$lib/stores/sns-tickets.store";
 import type { PngDataUrl } from "$lib/types/assets";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type {
@@ -23,7 +23,6 @@ import type {
   SnsSwapDerivedState,
 } from "@dfinity/sns";
 import { fromNullable, isNullish } from "@dfinity/utils";
-import { get } from "svelte/store";
 import { isPngAsset } from "./utils";
 
 type OptionalSnsSummarySwap = Omit<SnsSummarySwap, "params"> & {
@@ -201,9 +200,23 @@ export const getCommitmentE8s = (
   fromNullable(swapCommitment?.myCommitment?.icp ?? [])?.amount_e8s ??
   undefined;
 
-export const hasOpenTicketInProcess = (
-  rootCanisterId?: Principal | null
-): boolean =>
-  isNullish(rootCanisterId)
-    ? true
-    : get(snsTicketsStore)[rootCanisterId.toText()]?.ticket !== null;
+export const hasOpenTicketInProcess = ({
+  rootCanisterId,
+  ticketsStore,
+}: {
+  rootCanisterId?: Principal | null;
+  ticketsStore: SnsTicketsStore;
+}): boolean => {
+  if (isNullish(rootCanisterId)) {
+    return true;
+  }
+  const projectTicketData = ticketsStore[rootCanisterId.toText()];
+
+  if (isNullish(projectTicketData)) {
+    return true;
+  }
+
+  return (
+    projectTicketData.ticket !== null && projectTicketData.keepPolling === true
+  );
+};

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -234,6 +234,7 @@ export const poll = async <T>({
     shouldExit,
     maxAttempts,
     counter: counter + 1,
+    millisecondsToWait,
   });
 };
 

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -191,7 +191,8 @@ export const waitForMilliseconds = (milliseconds: number): Promise<void> =>
   });
 
 export class PollingLimitExceededError extends Error {}
-const DEFAUL_MAX_POLLING_ATTEMPTS = 10;
+// Exported for testing purposes
+export const DEFAULT_MAX_POLLING_ATTEMPTS = 10;
 /**
  * Function that polls a specific function, checking error with passed argument to recall or not.
  *
@@ -206,7 +207,7 @@ const DEFAUL_MAX_POLLING_ATTEMPTS = 10;
 export const poll = async <T>({
   fn,
   shouldExit,
-  maxAttempts = DEFAUL_MAX_POLLING_ATTEMPTS,
+  maxAttempts = DEFAULT_MAX_POLLING_ATTEMPTS,
   counter = 0,
   millisecondsToWait = 500,
 }: {

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -208,11 +208,13 @@ export const poll = async <T>({
   shouldExit,
   maxAttempts = DEFAUL_MAX_POLLING_ATTEMPTS,
   counter = 0,
+  millisecondsToWait = 500,
 }: {
   fn: () => Promise<T>;
   shouldExit: (err: unknown) => boolean;
   maxAttempts?: number;
   counter?: number;
+  millisecondsToWait?: number;
 }): Promise<T> => {
   if (counter >= maxAttempts) {
     throw new PollingLimitExceededError();
@@ -226,7 +228,7 @@ export const poll = async <T>({
     // Log swallowed errors
     console.error(`Error polling: ${errorToString(error)}`);
   }
-  await waitForMilliseconds(500);
+  await waitForMilliseconds(millisecondsToWait);
   return poll({
     fn,
     shouldExit,
@@ -234,6 +236,9 @@ export const poll = async <T>({
     counter: counter + 1,
   });
 };
+
+export const pollingLimit = (error: unknown): boolean =>
+  error instanceof PollingLimitExceededError;
 
 /**
  * Use to highlight a placeholder in a text rendered from i18n labels.

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -29,6 +29,7 @@ import { clickByTestId } from "../../../utils/utils.test-utils";
 
 jest.mock("$lib/services/sns-sale.services", () => ({
   restoreSnsSaleParticipation: jest.fn().mockResolvedValue(undefined),
+  hidePollingToast: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ParticipateButton", () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { SALE_PARTICIPATION_RETRY_SECONDS } from "$lib/constants/sns.constants";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import {
   importInitSnsWrapper,
@@ -13,6 +14,7 @@ import {
   loadOpenTicket,
   newSaleTicket,
   participateInSnsSale,
+  restoreSnsSaleParticipation,
 } from "$lib/services/sns-sale.services";
 import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
@@ -22,6 +24,7 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { DEFAULT_MAX_POLLING_ATTEMPTS } from "$lib/utils/utils";
 import type { HttpAgent, Identity } from "@dfinity/agent";
 import {
   ICPToken,
@@ -117,7 +120,6 @@ describe("sns-api", () => {
 
     snsTicketsStore.reset();
 
-    spyOnGetOpenTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     jest.spyOn(console, "error").mockReturnValue();
     snsQueryStore.reset();
@@ -186,54 +188,240 @@ describe("sns-api", () => {
   });
 
   describe("loadOpenTicket", () => {
-    it("Should load ticket in the store", async () => {
-      await loadOpenTicket({
-        rootCanisterId: testSnsTicket.rootCanisterId,
-        certified: true,
-      });
-
-      expect(spyOnGetOpenTicketApi).toBeCalled();
-      expect(ticketFromStore().ticket).toEqual(testTicket);
+    beforeEach(() => {
+      snsTicketsStore.reset();
     });
 
-    it("should display already closed error", async () => {
-      spyOnGetOpenTicketApi.mockRejectedValue(
-        new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
-      );
+    describe("when polling is enabled", () => {
+      beforeEach(() => {
+        jest.clearAllTimers();
+        snsTicketsStore.enablePolling(testSnsTicket.rootCanisterId);
+        const now = Date.now();
+        jest.useFakeTimers().setSystemTime(now);
+      });
+      it("should call api and load ticket in the store", async () => {
+        spyOnGetOpenTicketApi.mockResolvedValue(testSnsTicket.ticket);
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
 
-      await loadOpenTicket({
-        rootCanisterId: testSnsTicket.rootCanisterId,
-        certified: true,
+        expect(spyOnGetOpenTicketApi).toBeCalledTimes(1);
+        expect(ticketFromStore(testSnsTicket.rootCanisterId).ticket).toEqual(
+          testTicket
+        );
       });
 
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_closed",
-        })
-      );
-      expect(ticketFromStore()?.ticket).toBeNull();
+      it("should retry until gets an open ticket", async () => {
+        spyOnGetOpenTicketApi
+          .mockRejectedValueOnce(new Error("network error"))
+          .mockRejectedValueOnce(new Error("network error"))
+          .mockRejectedValueOnce(new Error("network error"))
+          .mockResolvedValue(testSnsTicket.ticket);
+        loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        let counter = 0;
+        const retriesBeforeSuccess = 4;
+        while (counter < retriesBeforeSuccess) {
+          expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
+          counter += 1;
+          jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
+
+          await waitFor(() =>
+            expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter)
+          );
+        }
+        expect(counter).toBe(retriesBeforeSuccess);
+
+        await waitFor(() =>
+          expect(ticketFromStore(testSnsTicket.rootCanisterId).ticket).toEqual(
+            testTicket
+          )
+        );
+      });
+
+      it("should stop retrying after max attempts and set ticket to null", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
+        loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        let counter = 0;
+        while (counter <= DEFAULT_MAX_POLLING_ATTEMPTS) {
+          expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
+          counter += 1;
+          jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
+
+          await waitFor(() =>
+            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+              Math.min(counter, DEFAULT_MAX_POLLING_ATTEMPTS)
+            )
+          );
+        }
+
+        expect(counter).toBe(DEFAULT_MAX_POLLING_ATTEMPTS + 1);
+        await waitFor(() =>
+          expect(
+            ticketFromStore(testSnsTicket.rootCanisterId).ticket
+          ).toBeNull()
+        );
+      });
+
+      it("should call api once if error is known", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(spyOnGetOpenTicketApi).toBeCalledTimes(1);
+      });
+
+      it("should set store to `null` on closed error", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(
+          ticketFromStore(testSnsTicket.rootCanisterId)?.ticket
+        ).toBeNull();
+      });
+
+      it("should show error on closed", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(spyOnToastsError).toBeCalledWith(
+          expect.objectContaining({
+            labelKey: "error__sns.sns_sale_closed",
+          })
+        );
+      });
+
+      it("should set store to `null` on unspecified type error", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(
+          ticketFromStore(testSnsTicket.rootCanisterId)?.ticket
+        ).toBeNull();
+      });
+
+      it("should show error on unspecified type error", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(spyOnToastsError).toBeCalledWith(
+          expect.objectContaining({
+            labelKey: "error__sns.sns_sale_final_error",
+          })
+        );
+      });
+
+      it("should set store to `null` on not open error", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(
+            GetOpenTicketErrorType.TYPE_SALE_NOT_OPEN
+          )
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(
+          ticketFromStore(testSnsTicket.rootCanisterId)?.ticket
+        ).toBeNull();
+      });
+
+      it("should show error on not open error", async () => {
+        spyOnGetOpenTicketApi.mockRejectedValue(
+          new SnsSwapGetOpenTicketError(
+            GetOpenTicketErrorType.TYPE_SALE_NOT_OPEN
+          )
+        );
+
+        await loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
+
+        expect(spyOnToastsError).toBeCalledWith(
+          expect.objectContaining({
+            labelKey: "error__sns.sns_sale_not_open",
+          })
+        );
+      });
     });
 
-    it("should display unexpected error on not_closed error", async () => {
-      spyOnGetOpenTicketApi.mockRejectedValue(
-        new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
-      );
+    describe("when disabling polling", () => {
+      it("should stop retrying", async () => {
+        snsTicketsStore.enablePolling(testSnsTicket.rootCanisterId);
+        spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
+        loadOpenTicket({
+          rootCanisterId: testSnsTicket.rootCanisterId,
+          certified: true,
+        });
 
-      spyOnGetOpenTicketApi.mockRejectedValue({
-        errorType: GetOpenTicketErrorType.TYPE_SALE_NOT_OPEN,
+        let counter = 0;
+        const retriesBeforeStopPolling = 4;
+        // We loop until 10 advancing time, but the polling should stop after `retriesBeforeStopPolling` + 1
+        while (counter < DEFAULT_MAX_POLLING_ATTEMPTS) {
+          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            Math.min(counter, retriesBeforeStopPolling + 1)
+          );
+          counter += 1;
+          jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
+
+          await waitFor(() =>
+            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+              Math.min(counter, retriesBeforeStopPolling + 1)
+            )
+          );
+
+          if (counter === retriesBeforeStopPolling) {
+            snsTicketsStore.disablePolling(testSnsTicket.rootCanisterId);
+          }
+        }
+        expect(counter).toBe(DEFAULT_MAX_POLLING_ATTEMPTS);
+
+        await waitFor(() =>
+          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            retriesBeforeStopPolling + 1
+          )
+        );
       });
-
-      await loadOpenTicket({
-        rootCanisterId: testSnsTicket.rootCanisterId,
-        certified: true,
-      });
-
-      expect(ticketFromStore()?.ticket).toBeNull();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_unexpected_error",
-        })
-      );
     });
   });
 
@@ -394,6 +582,51 @@ describe("sns-api", () => {
         })
       );
       expect(ticketFromStore()?.ticket).toEqual(null);
+    });
+  });
+
+  describe("restoreSnsSaleParticipation", () => {
+    it("should perform successful participation flow if open ticket", async () => {
+      spyOnGetOpenTicketApi.mockResolvedValue(testSnsTicket.ticket);
+      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
+      const startBusySpy = jest
+        .spyOn(busyStore, "startBusy")
+        .mockImplementation(jest.fn());
+      const stopBusySpy = jest
+        .spyOn(busyStore, "stopBusy")
+        .mockImplementation(jest.fn());
+
+      await restoreSnsSaleParticipation({
+        rootCanisterId: rootCanisterIdMock,
+        postprocess: postprocessSpy,
+      });
+
+      expect(startBusySpy).toBeCalledTimes(1);
+      expect(ledgerCanisterMock.transfer).toBeCalledTimes(1);
+      expect(postprocessSpy).toBeCalledTimes(1);
+      expect(stopBusySpy).toBeCalledTimes(1);
+      // null after ready
+      expect(ticketFromStore().ticket).toEqual(null);
+      // no errors
+      expect(spyOnToastsError).not.toBeCalled();
+    });
+
+    it("should not start flow if no open tickeet", async () => {
+      spyOnGetOpenTicketApi.mockResolvedValue(undefined);
+      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
+      const startBusySpy = jest
+        .spyOn(busyStore, "startBusy")
+        .mockImplementation(jest.fn());
+
+      await restoreSnsSaleParticipation({
+        rootCanisterId: rootCanisterIdMock,
+        postprocess: postprocessSpy,
+      });
+
+      expect(startBusySpy).not.toBeCalled();
+      expect(ledgerCanisterMock.transfer).not.toBeCalled();
+      expect(postprocessSpy).not.toBeCalled();
+      expect(ticketFromStore().ticket).toEqual(null);
     });
   });
 

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -244,26 +244,28 @@ describe("sns-api", () => {
       });
 
       it("should stop retrying after max attempts and set ticket to null", async () => {
+        const maxAttempts = 10;
         spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
         loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
           certified: true,
+          maxAttempts,
         });
 
         let counter = 0;
-        while (counter <= DEFAULT_MAX_POLLING_ATTEMPTS) {
+        while (counter <= maxAttempts) {
           expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
           counter += 1;
           jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
 
           await waitFor(() =>
             expect(spyOnGetOpenTicketApi).toBeCalledTimes(
-              Math.min(counter, DEFAULT_MAX_POLLING_ATTEMPTS)
+              Math.min(counter, maxAttempts)
             )
           );
         }
 
-        expect(counter).toBe(DEFAULT_MAX_POLLING_ATTEMPTS + 1);
+        expect(counter).toBe(maxAttempts + 1);
         await waitFor(() =>
           expect(
             ticketFromStore(testSnsTicket.rootCanisterId).ticket

--- a/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
@@ -11,7 +11,7 @@ describe("snsTicketsStore", () => {
     owner: mockPrincipal,
   });
 
-  afterEach(() => snsTicketsStore.reset());
+  beforeEach(() => snsTicketsStore.reset());
 
   it("should set ticket", () => {
     snsTicketsStore.setTicket({
@@ -23,6 +23,27 @@ describe("snsTicketsStore", () => {
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toEqual(ticket);
   });
 
+  it("should set ticket with polling disabled by default", () => {
+    snsTicketsStore.setTicket({
+      rootCanisterId: mockPrincipal,
+      ticket,
+    });
+
+    const $snsTicketsStore = get(snsTicketsStore);
+    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toEqual(false);
+  });
+
+  it("should set ticket with polling", () => {
+    snsTicketsStore.setTicket({
+      rootCanisterId: mockPrincipal,
+      ticket,
+      keepPolling: true,
+    });
+
+    const $snsTicketsStore = get(snsTicketsStore);
+    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toEqual(true);
+  });
+
   it("should set no-ticket for a project", () => {
     snsTicketsStore.setNoTicket(mockPrincipal);
 
@@ -30,15 +51,21 @@ describe("snsTicketsStore", () => {
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toBeNull();
   });
 
-  it("should remove ticket for a project", () => {
+  it("set no-ticket for a project keeps polling from before", () => {
     snsTicketsStore.setTicket({
       rootCanisterId: mockPrincipal,
       ticket,
+      keepPolling: true,
     });
-    snsTicketsStore.removeTicket(mockPrincipal);
+    const initStore = get(snsTicketsStore);
+    const initPolling = initStore[mockPrincipal.toText()].keepPolling;
+
+    snsTicketsStore.setNoTicket(mockPrincipal);
 
     const $snsTicketsStore = get(snsTicketsStore);
-    expect($snsTicketsStore[mockPrincipal.toText()]).toBeUndefined();
+    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toBe(
+      initPolling
+    );
   });
 
   it("should add ticket for another project", () => {
@@ -55,5 +82,38 @@ describe("snsTicketsStore", () => {
     const $snsTicketsStore = get(snsTicketsStore);
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toEqual(ticket);
     expect($snsTicketsStore[principal2.toText()].ticket).toEqual(null);
+  });
+
+  it("should enable polling for a project", () => {
+    snsTicketsStore.setTicket({
+      rootCanisterId: mockPrincipal,
+      ticket: ticket,
+    });
+    const initStore = get(snsTicketsStore);
+    expect(initStore[mockPrincipal.toText()].keepPolling).toEqual(false);
+
+    snsTicketsStore.enablePolling(mockPrincipal);
+
+    const finalStore = get(snsTicketsStore);
+    expect(finalStore[mockPrincipal.toText()].keepPolling).toEqual(true);
+  });
+
+  it("should disable polling for a project", () => {
+    snsTicketsStore.setTicket({
+      rootCanisterId: mockPrincipal,
+      ticket: ticket,
+    });
+    const initStore = get(snsTicketsStore);
+    expect(initStore[mockPrincipal.toText()].keepPolling).toEqual(false);
+
+    snsTicketsStore.enablePolling(mockPrincipal);
+
+    const midStore = get(snsTicketsStore);
+    expect(midStore[mockPrincipal.toText()].keepPolling).toEqual(true);
+
+    snsTicketsStore.disablePolling(mockPrincipal);
+
+    const finalStore = get(snsTicketsStore);
+    expect(finalStore[mockPrincipal.toText()].keepPolling).toEqual(false);
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -7,6 +7,7 @@ import {
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
 import { snsTicketsStore } from "../../../lib/stores/sns-tickets.store";
 import { hasOpenTicketInProcess } from "../../../lib/utils/sns.utils";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
@@ -244,18 +245,44 @@ describe("sns-utils", () => {
   });
 
   describe("hasOpenTicketInProcess", () => {
+    beforeEach(() => {
+      snsTicketsStore.reset();
+    });
     const testTicket = snsTicketMock({
       rootCanisterId: rootCanisterIdMock,
       owner: mockPrincipal,
     }).ticket;
 
-    it("returns true when the ticket is undefined", () => {
+    it("returns true when the ticket is undefined and we keep polling", () => {
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
         ticket: undefined,
+        keepPolling: true,
       });
+      const store = get(snsTicketsStore);
 
-      expect(hasOpenTicketInProcess(rootCanisterIdMock)).toBeTruthy();
+      expect(
+        hasOpenTicketInProcess({
+          rootCanisterId: rootCanisterIdMock,
+          ticketsStore: store,
+        })
+      ).toBeTruthy();
+    });
+
+    it("returns false when the ticket is undefined and we stopped keep polling", () => {
+      snsTicketsStore.setTicket({
+        rootCanisterId: rootCanisterIdMock,
+        ticket: undefined,
+        keepPolling: false,
+      });
+      const store = get(snsTicketsStore);
+
+      expect(
+        hasOpenTicketInProcess({
+          rootCanisterId: rootCanisterIdMock,
+          ticketsStore: store,
+        })
+      ).toBeFalsy();
     });
 
     it("returns true when there is an open ticket in the store", () => {
@@ -263,8 +290,14 @@ describe("sns-utils", () => {
         rootCanisterId: rootCanisterIdMock,
         ticket: testTicket,
       });
+      const store = get(snsTicketsStore);
 
-      expect(hasOpenTicketInProcess(rootCanisterIdMock)).toBeTruthy();
+      expect(
+        hasOpenTicketInProcess({
+          rootCanisterId: rootCanisterIdMock,
+          ticketsStore: store,
+        })
+      ).toBeTruthy();
     });
 
     it("returns false the open ticket is null (processed)", () => {
@@ -272,8 +305,14 @@ describe("sns-utils", () => {
         rootCanisterId: rootCanisterIdMock,
         ticket: null,
       });
+      const store = get(snsTicketsStore);
 
-      expect(hasOpenTicketInProcess(rootCanisterIdMock)).toBeFalsy();
+      expect(
+        hasOpenTicketInProcess({
+          rootCanisterId: rootCanisterIdMock,
+          ticketsStore: store,
+        })
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

Many users trying to participate at the same time might overload the sns sale canister.

We want to be the ones managing that experience, instead of showing errors.

Therefore, we retry getting the open ticket from the sale canister if we get a not identified error.

# Changes

Main changes to review:
* New helper `pollGetOpenTicket` used in `loadOpenTicket`.
* New property `keepPolling` in the SnsTicketsStore.
* New methods in `stopPolling` and `enablePolling` in SnsTicketsStore.

Other changes:
* Changes in error handling in `loadOpenTicket`.
* New parameter in `poll` util: `millisecondsToWait`
* Move `pollingLimit` next to the `poll` util.
* Changes in the onDestroy of the `ParticipateButton`.
* Refactor `hasOpenTicketInProcess` to pass the store so that it's recalculated when store changes.

# Tests

* More tests for `loadOpenTicket` service.
* Add missing test for `restoreSnsSaleParticipation`.
* New tests for snsTicketsStore
* Fix broken tests after changes.
