### PR TITLE
Feat: Retry refresh_buyer_tokens

### DIFF
--- a/frontend/src/lib/api/sns-sale.api.ts
+++ b/frontend/src/lib/api/sns-sale.api.ts
@@ -1,7 +1,10 @@
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
-import type { Ticket } from "@dfinity/sns/dist/candid/sns_swap";
+import type {
+  RefreshBuyerTokensResponse,
+  Ticket,
+} from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
 import { wrapper } from "./sns-wrapper.api";
 
@@ -75,4 +78,28 @@ export const notifyPaymentFailure = async ({
   logWithTimestamp(`[sale] notifyPaymentFailure complete.`);
 
   return ticket;
+};
+
+export const notifyParticipation = async ({
+  identity,
+  rootCanisterId,
+  buyer,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  buyer: Principal;
+}): Promise<RefreshBuyerTokensResponse> => {
+  logWithTimestamp(`[sale] notifyParticipation call...`);
+
+  const { notifyParticipation: notifyParticipationApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  const response = await notifyParticipationApi({ buyer: buyer.toText() });
+
+  logWithTimestamp(`[sale] notifyParticipation complete.`);
+
+  return response;
 };

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -23,7 +23,6 @@ import { validParticipation } from "$lib/utils/projects.utils";
 import {
   getSwapCanisterAccount,
   isInternalRefreshBuyerTokensError,
-  isRetryRefreshBuyerToken,
 } from "$lib/utils/sns.utils";
 import { poll, pollingLimit } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
@@ -468,9 +467,6 @@ export const initiateSnsSaleParticipation = async ({
   stopBusy("project-participate");
 };
 
-const shouldStopPollingNotify = (err: unknown) =>
-  !isRetryRefreshBuyerToken(err);
-
 const pollNotifyParticipation = async ({
   buyer,
   identity,
@@ -484,7 +480,7 @@ const pollNotifyParticipation = async ({
     return await poll({
       fn: (): Promise<RefreshBuyerTokensResponse> =>
         notifyParticipation({ buyer, rootCanisterId, identity }),
-      shouldExit: shouldStopPollingNotify,
+      shouldExit: isInternalRefreshBuyerTokensError,
       millisecondsToWait: WAIT_FOR_TICKET_MILLIS / 10000,
     });
   } catch (error: unknown) {

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -481,7 +481,7 @@ const pollNotifyParticipation = async ({
       fn: (): Promise<RefreshBuyerTokensResponse> =>
         notifyParticipation({ buyer, rootCanisterId, identity }),
       shouldExit: isInternalRefreshBuyerTokensError,
-      millisecondsToWait: WAIT_FOR_TICKET_MILLIS / 10000,
+      millisecondsToWait: WAIT_FOR_TICKET_MILLIS,
     });
   } catch (error: unknown) {
     if (pollingLimit(error)) {

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -225,7 +225,7 @@ export const isInternalRefreshBuyerTokensError = (err: unknown): boolean => {
     "New balance:",
     // https://github.com/dfinity/ic/blob/c3f45aef7c2aa734c0451eaed682036879e54775/rs/sns/swap/src/swap.rs#L718
     "The available balance to be topped up",
-  ].some((text) => message.startsWith(text));
+  ].some((text) => message.includes(text));
 };
 
 export const isRetryRefreshBuyerToken = (err: unknown): boolean => {
@@ -237,7 +237,7 @@ export const isRetryRefreshBuyerToken = (err: unknown): boolean => {
   return [
     "Error calling method 'account_balance_pb'",
     "Failed to add buyer",
-  ].some((text) => message.startsWith(text));
+  ].some((text) => message.includes(text));
 };
 
 export const hasOpenTicketInProcess = ({

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -228,18 +228,6 @@ export const isInternalRefreshBuyerTokensError = (err: unknown): boolean => {
   ].some((text) => message.includes(text));
 };
 
-export const isRetryRefreshBuyerToken = (err: unknown): boolean => {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-
-  const { message } = err;
-  return [
-    "Error calling method 'account_balance_pb'",
-    "Failed to add buyer",
-  ].some((text) => message.includes(text));
-};
-
 export const hasOpenTicketInProcess = ({
   rootCanisterId,
   ticketsStore,

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -228,6 +228,18 @@ export const isInternalRefreshBuyerTokensError = (err: unknown): boolean => {
   ].some((text) => message.startsWith(text));
 };
 
+export const isRetryRefreshBuyerToken = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const { message } = err;
+  return [
+    "Error calling method 'account_balance_pb'",
+    "Failed to add buyer",
+  ].some((text) => message.startsWith(text));
+};
+
 export const hasOpenTicketInProcess = ({
   rootCanisterId,
   ticketsStore,

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { getOpenTicket, newSaleTicket } from "$lib/api/sns-sale.api";
+import {
+  getOpenTicket,
+  newSaleTicket,
+  notifyParticipation,
+} from "$lib/api/sns-sale.api";
 import {
   importInitSnsWrapper,
   importSnsWasmCanister,
@@ -30,6 +34,12 @@ describe("sns-sale.api", () => {
   const getOpenTicketSpy = jest.fn().mockResolvedValue(ticket.ticket);
   const newSaleTicketSpy = jest.fn().mockResolvedValue(ticket.ticket);
   const notifyPaymentFailureSpy = jest.fn().mockResolvedValue(ticket.ticket);
+  const participationResponse = {
+    icp_accepted_participation_e8s: 666n,
+  };
+  const notifyParticipationSpy = jest
+    .fn()
+    .mockResolvedValue(participationResponse);
 
   beforeEach(() => {
     (importSnsWasmCanister as jest.Mock).mockResolvedValue({
@@ -50,6 +60,7 @@ describe("sns-sale.api", () => {
         getOpenTicket: getOpenTicketSpy,
         newSaleTicket: newSaleTicketSpy,
         notifyPaymentFailure: notifyPaymentFailureSpy,
+        notifyParticipation: notifyParticipationSpy,
       })
     );
   });
@@ -89,5 +100,16 @@ describe("sns-sale.api", () => {
 
     expect(result).not.toBeNull();
     expect(result).toEqual(ticket.ticket);
+  });
+
+  it("should notify participation", async () => {
+    const result = await notifyParticipation({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      buyer: mockPrincipal,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual(participationResponse);
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -2,7 +2,6 @@ import type { SnsSwapCommitment } from "$lib/types/sns";
 import {
   getCommitmentE8s,
   getSwapCanisterAccount,
-  isRetryRefreshBuyerToken,
   mapAndSortSnsQueryToSummaries,
 } from "$lib/utils/sns.utils";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
@@ -326,6 +325,13 @@ describe("sns-utils", () => {
       expect(isInternalRefreshBuyerTokensError(error)).toBeTruthy();
     });
 
+    it("returns true on known error", () => {
+      const error = new Error(
+        "This is the beginning of the error. The swap has already reached its target ..."
+      );
+      expect(isInternalRefreshBuyerTokensError(error)).toBeTruthy();
+    });
+
     it("returns false on unknown error", () => {
       const error = new Error("Fake the swap has already reached its target");
       expect(isInternalRefreshBuyerTokensError(error)).toBeFalsy();
@@ -338,28 +344,6 @@ describe("sns-utils", () => {
         isInternalRefreshBuyerTokensError(
           "The swap has already reached its target"
         )
-      ).toBeFalsy();
-    });
-  });
-
-  describe("isRetryRefreshBuyerToken", () => {
-    it("returns true on known error", () => {
-      const error1 = new Error("Error calling method 'account_balance_pb'...");
-      expect(isRetryRefreshBuyerToken(error1)).toBeTruthy();
-      const error2 = new Error("Failed to add buyer...");
-      expect(isRetryRefreshBuyerToken(error2)).toBeTruthy();
-    });
-
-    it("returns false on unknown error", () => {
-      const error = new Error("Fake the swap has already reached its target");
-      expect(isRetryRefreshBuyerToken(error)).toBeFalsy();
-    });
-
-    it("returns false on not error argument", () => {
-      expect(isRetryRefreshBuyerToken(null)).toBeFalsy();
-      expect(isRetryRefreshBuyerToken(undefined)).toBeFalsy();
-      expect(
-        isRetryRefreshBuyerToken("The swap has already reached its target")
       ).toBeFalsy();
     });
   });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -2,6 +2,7 @@ import type { SnsSwapCommitment } from "$lib/types/sns";
 import {
   getCommitmentE8s,
   getSwapCanisterAccount,
+  isRetryRefreshBuyerToken,
   mapAndSortSnsQueryToSummaries,
 } from "$lib/utils/sns.utils";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
@@ -337,6 +338,28 @@ describe("sns-utils", () => {
         isInternalRefreshBuyerTokensError(
           "The swap has already reached its target"
         )
+      ).toBeFalsy();
+    });
+  });
+
+  describe("isRetryRefreshBuyerToken", () => {
+    it("returns true on known error", () => {
+      const error1 = new Error("Error calling method 'account_balance_pb'...");
+      expect(isRetryRefreshBuyerToken(error1)).toBeTruthy();
+      const error2 = new Error("Failed to add buyer...");
+      expect(isRetryRefreshBuyerToken(error2)).toBeTruthy();
+    });
+
+    it("returns false on unknown error", () => {
+      const error = new Error("Fake the swap has already reached its target");
+      expect(isRetryRefreshBuyerToken(error)).toBeFalsy();
+    });
+
+    it("returns false on not error argument", () => {
+      expect(isRetryRefreshBuyerToken(null)).toBeFalsy();
+      expect(isRetryRefreshBuyerToken(undefined)).toBeFalsy();
+      expect(
+        isRetryRefreshBuyerToken("The swap has already reached its target")
       ).toBeFalsy();
     });
   });


### PR DESCRIPTION
# Motivation

Retry on refresh_buyer_tokens for specific errors.

# Changes

Major changes:
* New helper `pollNotifyParticipation`.
* Use the new helper `pollNotifyParticipation` in `notifyParticipationAndRemoveTicket`.
* New util `isRetryRefreshBuyerToken` to identify errors that trigger a retry on `refresh_buyer_tokens`.

Minor changes:
* New sns api util `notifyParticipation` for easy mocking the error. It will also be easier for mocking. It shuold be the way to go.

# Tests

* Test new scenario in `participateInSnsSale`.
* Test new sns sale api `notifyParticipation`.
