### PR TITLE
Don't use a mock for IntersectionObserverPassive

### DIFF
--- a/frontend/src/tests/mocks/infinitescroll.mock.ts
+++ b/frontend/src/tests/mocks/infinitescroll.mock.ts
@@ -1,12 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-nocheck
 
-export const IntersectionObserverPassive = jest.fn();
-IntersectionObserverPassive.mockReturnValue({
-  observe: () => null,
-  unobserve: () => null,
-  disconnect: () => null,
-});
+export class IntersectionObserverPassive implements IntersectionObserver {
+  public readonly root: Element | Document | null;
+  public readonly rootMargin: string;
+  public readonly thresholds: ReadonlyArray<number>;
+  public takeRecords: () => IntersectionObserverEntry[];
+  constructor() {}
+  observe = (element: HTMLElement) => null;
+  disconnect = () => null;
+  unobserve = () => null;
+}
 
 let isIntersecting = true;
 export const mockIntersectionObserverIsIntersecting = (intersecting: boolean) =>

--- a/frontend/src/tests/mocks/infinitescroll.mock.ts
+++ b/frontend/src/tests/mocks/infinitescroll.mock.ts
@@ -6,8 +6,7 @@ export class IntersectionObserverPassive implements IntersectionObserver {
   public readonly rootMargin: string;
   public readonly thresholds: ReadonlyArray<number>;
   public takeRecords: () => IntersectionObserverEntry[];
-  constructor() {}
-  observe = (element: HTMLElement) => null;
+  observe = () => null;
   disconnect = () => null;
   unobserve = () => null;
 }


### PR DESCRIPTION
# Motivation

IntersectionObserverPassive being a mock which is initialized once breaks with tests that do jest.resetAllMock() in beforeEach(). Doing a full cleanup in beforeEach is good practice in general.

# Changes

Provide a real stub implementation of IntersectionObserver as IntersectionObserverPassive.

# Tests

`npm run test`
