### PR TITLE
Feat: Retry new sale ticket

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -714,7 +714,7 @@
     "not_enough_amount": "Sorry, the amount is too small. You need a minimum of $amount ICP to participate in this sale.",
     "commitment_too_large": "Sorry, your new commitment of $newCommitment ICP is too high. You have already committed $currentCommitment ICP and the maximum is $maxCommitment ICP.",
     "commitment_exceeds_current_allowed": "Sorry, your commitment of $commitment ICP is too high. There is $remainingCommitment ICP left to reach maximum.",
-    "sns_sale_unexpected_error": "Sorry, There was an unexpected error while participating.",
+    "sns_sale_unexpected_error": "Sorry, There was an unexpected error while participating. Please refresh the page and try again.",
     "sns_sale_unexpected_and_refresh": "Sorry, There was an unexpected error while participating. Please refresh and try again",
     "sns_sale_final_error": "Sorry, there was an unexpected error connection with the SNS sale. Please reload the page and try again.",
     "sns_sale_proceed_with_existing_ticket": "Trying to complete the existing participation (Started at $time)",

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -219,6 +219,8 @@ describe("sns-api", () => {
       });
 
       it("should retry until gets an open ticket", async () => {
+        // Success in the fourth attempt
+        const retriesUntilSuccess = 4;
         spyOnGetOpenTicketApi
           .mockRejectedValueOnce(new Error("network error"))
           .mockRejectedValueOnce(new Error("network error"))
@@ -230,8 +232,7 @@ describe("sns-api", () => {
         });
 
         let counter = 0;
-        const retriesBeforeSuccess = 4;
-        while (counter < retriesBeforeSuccess) {
+        while (counter < retriesUntilSuccess) {
           expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
           counter += 1;
           jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
@@ -240,7 +241,7 @@ describe("sns-api", () => {
             expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter)
           );
         }
-        expect(counter).toBe(retriesBeforeSuccess);
+        expect(counter).toBe(retriesUntilSuccess);
 
         await waitFor(() =>
           expect(ticketFromStore(testSnsTicket.rootCanisterId).ticket).toEqual(
@@ -577,6 +578,8 @@ describe("sns-api", () => {
     });
 
     it("should retry unknown errors until successful", async () => {
+      // Success on the 4th try
+      const retriesUntilSuccess = 4;
       spyOnNewSaleTicketApi
         .mockRejectedValueOnce(new Error("connection error"))
         .mockRejectedValueOnce(new Error("connection error"))
@@ -589,8 +592,7 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      const retriesBeforeSuccess = 4;
-      while (counter < retriesBeforeSuccess) {
+      while (counter < retriesUntilSuccess) {
         expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
@@ -599,11 +601,13 @@ describe("sns-api", () => {
           expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter)
         );
       }
-      expect(counter).toBe(retriesBeforeSuccess);
+      expect(counter).toBe(retriesUntilSuccess);
       expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
     });
 
     it("should retry unknown errors until known error", async () => {
+      // Known error on the 4th try
+      const retriesUntilKnownError = 4;
       spyOnNewSaleTicketApi
         .mockRejectedValueOnce(new Error("connection error"))
         .mockRejectedValueOnce(new Error("connection error"))
@@ -620,8 +624,7 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      const retriesBeforeSuccess = 4;
-      while (counter < retriesBeforeSuccess) {
+      while (counter < retriesUntilKnownError) {
         expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
@@ -630,7 +633,7 @@ describe("sns-api", () => {
           expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter)
         );
       }
-      expect(counter).toBe(retriesBeforeSuccess);
+      expect(counter).toBe(retriesUntilKnownError);
       expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
     });
   });
@@ -795,6 +798,8 @@ describe("sns-api", () => {
     });
 
     it("should poll refresh_buyer_tokens until successful", async () => {
+      // Success on the fourth try
+      const retriesUntilSuccess = 4;
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
         ticket: testTicket,
@@ -821,8 +826,7 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      const retriesBeforeSuccess = 4;
-      while (counter < retriesBeforeSuccess) {
+      while (counter < retriesUntilSuccess) {
         expect(spyOnNotifyParticipation).toBeCalledTimes(counter);
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
@@ -831,7 +835,7 @@ describe("sns-api", () => {
           expect(spyOnNotifyParticipation).toBeCalledTimes(counter)
         );
       }
-      expect(counter).toBe(retriesBeforeSuccess);
+      expect(counter).toBe(retriesUntilSuccess);
 
       await waitFor(() => expect(ticketFromStore().ticket).toEqual(null));
 

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -232,22 +232,28 @@ describe("sns-api", () => {
         });
 
         let counter = 0;
-        while (counter < retriesUntilSuccess) {
-          expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
+        const extraRetries = 4;
+        while (counter < retriesUntilSuccess + extraRetries) {
+          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            Math.min(counter, retriesUntilSuccess)
+          );
           counter += 1;
           jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
 
           await waitFor(() =>
-            expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter)
+            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+              Math.min(counter, retriesUntilSuccess)
+            )
           );
         }
-        expect(counter).toBe(retriesUntilSuccess);
+        expect(counter).toBe(retriesUntilSuccess + extraRetries);
 
         await waitFor(() =>
           expect(ticketFromStore(testSnsTicket.rootCanisterId).ticket).toEqual(
             testTicket
           )
         );
+        expect(spyOnGetOpenTicketApi).toBeCalledTimes(retriesUntilSuccess);
       });
 
       it("should stop retrying after max attempts and set ticket to null", async () => {
@@ -592,17 +598,22 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      while (counter < retriesUntilSuccess) {
-        expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
+      const extraRetries = 4;
+      while (counter < retriesUntilSuccess + extraRetries) {
+        expect(spyOnNewSaleTicketApi).toBeCalledTimes(
+          Math.min(counter, extraRetries)
+        );
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
 
         await waitFor(() =>
-          expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter)
+          expect(spyOnNewSaleTicketApi).toBeCalledTimes(
+            Math.min(counter, extraRetries)
+          )
         );
       }
-      expect(counter).toBe(retriesUntilSuccess);
-      expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
+      expect(counter).toBe(retriesUntilSuccess + extraRetries);
+      expect(spyOnNewSaleTicketApi).toBeCalledTimes(retriesUntilSuccess);
     });
 
     it("should retry unknown errors until known error", async () => {
@@ -624,17 +635,22 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      while (counter < retriesUntilKnownError) {
-        expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
+      const extraRetries = 4;
+      while (counter < retriesUntilKnownError + extraRetries) {
+        expect(spyOnNewSaleTicketApi).toBeCalledTimes(
+          Math.min(counter, extraRetries)
+        );
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
 
         await waitFor(() =>
-          expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter)
+          expect(spyOnNewSaleTicketApi).toBeCalledTimes(
+            Math.min(counter, extraRetries)
+          )
         );
       }
-      expect(counter).toBe(retriesUntilKnownError);
-      expect(spyOnNewSaleTicketApi).toBeCalledTimes(counter);
+      expect(counter).toBe(retriesUntilKnownError + extraRetries);
+      expect(spyOnNewSaleTicketApi).toBeCalledTimes(retriesUntilKnownError);
     });
   });
 
@@ -826,21 +842,27 @@ describe("sns-api", () => {
       });
 
       let counter = 0;
-      while (counter < retriesUntilSuccess) {
-        expect(spyOnNotifyParticipation).toBeCalledTimes(counter);
+      // We add a few more times but it should not trigger more calls
+      const extraRetries = 4;
+      while (counter < retriesUntilSuccess + extraRetries) {
+        expect(spyOnNotifyParticipation).toBeCalledTimes(
+          Math.min(counter, retriesUntilSuccess)
+        );
         counter += 1;
         jest.advanceTimersByTime(SALE_PARTICIPATION_RETRY_SECONDS * 1000);
 
         await waitFor(() =>
-          expect(spyOnNotifyParticipation).toBeCalledTimes(counter)
+          expect(spyOnNotifyParticipation).toBeCalledTimes(
+            Math.min(counter, retriesUntilSuccess)
+          )
         );
       }
-      expect(counter).toBe(retriesUntilSuccess);
+      expect(counter).toBe(retriesUntilSuccess + extraRetries);
 
       await waitFor(() => expect(ticketFromStore().ticket).toEqual(null));
 
       expect(ledgerCanisterMock.transfer).toBeCalledTimes(1);
-      expect(spyOnNotifyParticipation).toBeCalledTimes(counter);
+      expect(spyOnNotifyParticipation).toBeCalledTimes(retriesUntilSuccess);
       expect(postprocessSpy).toBeCalledTimes(1);
     });
 


### PR DESCRIPTION
# Motivation

We want to retry and don't show error if creating the new sale ticket fails for unknown reasons. For example, replica is overloaded.

# Changes

* New helper `pollNewSaleTicket` in sns sale services.
* Use new helper `pollNewSaleTicket` instead of calling api function directly in sns service `newSaleTicket`

# Tests

* Change test that handles unknown errors and add a new one.
