### PR TITLE
Feat: Use new and fewer endpoints after participation

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -12,6 +12,7 @@ import type { IcrcAccount } from "@dfinity/ledger";
 import { Principal } from "@dfinity/principal";
 import type {
   SnsGetDerivedStateResponse,
+  SnsGetLifecycleResponse,
   SnsNeuron,
   SnsNeuronId,
   SnsSwapBuyerState,
@@ -261,10 +262,39 @@ export const querySnsDerivedState = async ({
     await getDerivedState({});
 
   logWithTimestamp(
-    `Getting Sns ${rootCanisterId} swap commitment certified:${certified} done.`
+    `Getting Sns ${rootCanisterId} swap derived state certified:${certified} done.`
   );
 
   return derivedState;
+};
+
+export const querySnsLifecycle = async ({
+  rootCanisterId,
+  identity,
+  certified,
+}: {
+  rootCanisterId: QueryRootCanisterId;
+  identity: Identity;
+  certified: boolean;
+}): Promise<SnsGetLifecycleResponse | undefined> => {
+  logWithTimestamp(
+    `Getting Sns ${rootCanisterId} sale lifecycle certified:${certified} call...`
+  );
+
+  const { getLifecycle }: SnsWrapper = await wrapper({
+    rootCanisterId,
+    identity,
+    certified,
+  });
+
+  const lifecycleResponse: SnsGetLifecycleResponse | undefined =
+    await getLifecycle({});
+
+  logWithTimestamp(
+    `Getting Sns ${rootCanisterId} sale lifecycle certified:${certified} done.`
+  );
+
+  return lifecycleResponse;
 };
 
 export const querySnsNeurons = async ({

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -698,6 +698,7 @@
     "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
     "load_swap_commitment": "There was an unexpected error while loading the commitment of the project.",
     "load_sale_total_commitments": "There was an unexpected error while loading the commitments of the project.",
+    "load_sale_lifecycle": "There was an unexpected error while loading the status of the project.",
     "load_parameters": "There was an unexpected error while loading the parameters of the project.",
     "sns_remove_hotkey": "There was an error removing the hotkey.",
     "sns_split_neuron": "There was an error while splitting the neuron.",

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -6,7 +6,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import {
-    loadSnsSummary,
+    loadSnsLifecycle,
     loadSnsSwapCommitment,
     loadSnsTotalCommitment,
   } from "$lib/services/sns.services";
@@ -31,18 +31,7 @@
 
   $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
     loadCommitment(rootCanisterId);
-    loadTotalCommitments(rootCanisterId);
   }
-
-  const loadSummary = (rootCanisterId: string) =>
-    loadSnsSummary({
-      rootCanisterId,
-      onError: () => {
-        // Set to not found
-        $projectDetailStore.summary = undefined;
-        goBack();
-      },
-    });
 
   const loadCommitment = (rootCanisterId: string) =>
     loadSnsSwapCommitment({
@@ -54,9 +43,6 @@
       },
     });
 
-  const loadTotalCommitments = (rootCanisterId: string) =>
-    loadSnsTotalCommitment({ rootCanisterId });
-
   const reload = async () => {
     if (rootCanisterId === undefined || rootCanisterId === null) {
       // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
@@ -64,7 +50,8 @@
     }
 
     await Promise.all([
-      loadSummary(rootCanisterId),
+      loadSnsTotalCommitment({ rootCanisterId }),
+      loadSnsLifecycle({ rootCanisterId }),
       loadCommitment(rootCanisterId),
     ]);
   };

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -19,7 +19,7 @@ import type {
   SnsGetDerivedStateResponse,
   SnsGetLifecycleResponse,
 } from "@dfinity/sns";
-import { fromNullable } from "@dfinity/utils";
+import { fromNullable, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
@@ -164,7 +164,7 @@ export const loadSnsLifecycle = async ({
       }),
     onLoad: ({ response: lifecycleResponse }) => {
       const lifecycle = fromNullable(lifecycleResponse?.lifecycle ?? []);
-      if (lifecycle !== undefined) {
+      if (nonNullish(lifecycle)) {
         snsQueryStore.updateLifecycle({ lifecycle, rootCanisterId });
       }
     },

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -1,9 +1,8 @@
 import {
   querySnsDerivedState,
-  querySnsMetadata,
+  querySnsLifecycle,
   querySnsSwapCommitment,
   querySnsSwapCommitments,
-  querySnsSwapState,
 } from "$lib/api/sns.api";
 import {
   snsQueryStore,
@@ -12,12 +11,15 @@ import {
 } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
 import { toToastError } from "$lib/utils/error.utils";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import type { AccountIdentifier } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
-import type { SnsGetDerivedStateResponse } from "@dfinity/sns";
+import type {
+  SnsGetDerivedStateResponse,
+  SnsGetLifecycleResponse,
+} from "@dfinity/sns";
+import { fromNullable } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
@@ -83,45 +85,6 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
   });
 };
 
-/** Combined request: querySnsSummary + querySnsSwapState */
-export const loadSnsSummary = async ({
-  rootCanisterId,
-  onError,
-}: {
-  rootCanisterId: string;
-  onError: () => void;
-}) =>
-  queryAndUpdate<
-    [QuerySnsMetadata | undefined, QuerySnsSwapState | undefined],
-    unknown
-  >({
-    request: ({ certified, identity }) =>
-      Promise.all([
-        querySnsMetadata({
-          rootCanisterId,
-          identity,
-          certified,
-        }),
-        querySnsSwapState({ rootCanisterId, identity, certified }),
-      ]),
-    onLoad: ({ response: data }) =>
-      snsQueryStore.updateData({ data, rootCanisterId }),
-    onError: ({ error: err, certified, identity }) => {
-      console.error(err);
-      if (certified || identity.getPrincipal().isAnonymous()) {
-        toastsError(
-          toToastError({
-            err,
-            fallbackErrorLabelKey: "error__sns.load_summary",
-          })
-        );
-
-        onError();
-      }
-    },
-    logMessage: "Syncing Sns summary",
-  });
-
 export const loadSnsSwapCommitment = async ({
   rootCanisterId,
   onError,
@@ -185,6 +148,39 @@ export const loadSnsTotalCommitment = async ({
       }
     },
     logMessage: "Syncing Sns swap commitment",
+  });
+
+export const loadSnsLifecycle = async ({
+  rootCanisterId,
+}: {
+  rootCanisterId: string;
+}) =>
+  queryAndUpdate<SnsGetLifecycleResponse | undefined, unknown>({
+    request: ({ certified, identity }) =>
+      querySnsLifecycle({
+        rootCanisterId,
+        identity,
+        certified,
+      }),
+    onLoad: ({ response: lifecycleResponse }) => {
+      const lifecycle = fromNullable(lifecycleResponse?.lifecycle ?? []);
+      if (lifecycle !== undefined) {
+        snsQueryStore.updateLifecycle({ lifecycle, rootCanisterId });
+      }
+    },
+    onError: ({ error: err, certified }) => {
+      console.error(err);
+
+      if (certified) {
+        toastsError(
+          toToastError({
+            err,
+            fallbackErrorLabelKey: "error__sns.load_sale_lifecycle",
+          })
+        );
+      }
+    },
+    logMessage: "Syncing Sns lifecycle",
   });
 
 export const getSwapAccount = async (

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -187,7 +187,7 @@ const initSnsQueryStore = (): SnsQueryStore => {
      * Updates only the derived state of a sale.
      *
      * @param {Object} params
-     * @param {QuerySnsSwapState} params.swapData new swap data.
+     * @param {SnsGetDerivedStateResponse} params.derivedState new derived state.
      * @param {string} params.rootCanisterId canister id in text format.
      */
     updateDerivedState({
@@ -223,10 +223,10 @@ const initSnsQueryStore = (): SnsQueryStore => {
     },
 
     /**
-     * Updates only the derived state of a sale.
+     * Updates only the lifecycle of a sale.
      *
      * @param {Object} params
-     * @param {QuerySnsSwapState} params.swapData new swap data.
+     * @param {SnsSwapLifecycle} params.lifecycle new lifecycle.
      * @param {string} params.rootCanisterId canister id in text format.
      */
     updateLifecycle({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -731,6 +731,7 @@ interface I18nError__sns {
   list_swap_commitments: string;
   load_swap_commitment: string;
   load_sale_total_commitments: string;
+  load_sale_lifecycle: string;
   load_parameters: string;
   sns_remove_hotkey: string;
   sns_split_neuron: string;

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -19,7 +19,6 @@ import {
 
 jest.mock("$lib/services/sns.services", () => {
   return {
-    loadSnsSummary: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsSwapStateStore: jest.fn().mockResolvedValue(Promise.resolve()),
   };
 });

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -5,11 +5,7 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
-import {
-  loadSnsSummary,
-  loadSnsSwapCommitment,
-  loadSnsTotalCommitment,
-} from "$lib/services/sns.services";
+import { loadSnsSwapCommitment } from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
@@ -23,7 +19,6 @@ import { snsResponsesForLifecycle } from "../../mocks/sns-response.mock";
 
 jest.mock("$lib/services/sns.services", () => {
   return {
-    loadSnsSummary: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsSwapCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsTotalCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
   };
@@ -58,22 +53,10 @@ describe("ProjectDetail", () => {
       jest.clearAllMocks();
     });
 
-    it("should not load summary", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(loadSnsSummary).not.toBeCalled());
-    });
-
     it("should not load user's commitnemtn", async () => {
       render(ProjectDetail, props);
 
       await waitFor(() => expect(loadSnsSwapCommitment).not.toBeCalled());
-    });
-
-    it("should not load total commitments", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(loadSnsTotalCommitment).not.toBeCalled());
     });
 
     it("should render info section", async () => {
@@ -104,12 +87,6 @@ describe("ProjectDetail", () => {
       render(ProjectDetail, props);
 
       await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
-    });
-
-    it("should load total project's commitment", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(loadSnsTotalCommitment).toBeCalled());
     });
   });
 


### PR DESCRIPTION
# Motivation

Use new and fewer endpoints to load data after participation.

loadSnsSummary loaded data that didn't change after participation.

# Changes

* New sns api function `querySnsLifecycle`.
* Remove `loadSnsSummary`.
* New sns service `loadSnsLifecycle`.
* Use `loadSnsTotalCommitment` and `loadSnsLifecycle` instead of `loadSnsSummary` after participation.
* New method `updateLifecycle` in `snsQueryStore`.

# Tests

* Test for new sns api function `querySnsLifecycle`.
* Remove tests for `loadSnsSummary`.
* New test for sns service `loadSnsLifecycle`.
* Test new method `updateLifecycle` in `snsQueryStore`.
