### PR TITLE
Script to share canister ids.

### DIFF
--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -26,8 +26,8 @@ if [ "$command" = "export" ]; then
 		exit 1
 	fi
 
-	# This whole block can be done in a single line of jq script but it woudn't
-	# be readable.
+        # This whole block can be done in a single line of jq script but it
+        # woudn't be readable.
 	canisters=$(jq -r 'keys|join(" ")' "$ids_file")
 	output="{}"
 	for canister in $canisters; do

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -3,48 +3,48 @@
 set -euo pipefail
 
 usage() {
-	echo "Usage: $0 export <network> (outputs to stdout)"
-	echo "       $0 import           (reads from stdin)"
+  echo "Usage: $0 export <network> (outputs to stdout)"
+  echo "       $0 import           (reads from stdin)"
 }
 
 top_dir=$(git rev-parse --show-toplevel)
 ids_file="$top_dir/canister_ids.json"
 
 if ! [ -f "$ids_file" ]; then
-	echo "$ids_file is missing."
-	exit 1
+  echo "$ids_file is missing."
+  exit 1
 fi
 
 command="${1-}"
 
 if [ "$command" = "export" ]; then
-	network="${2-}"
-	if [ -z "$network" ]; then
-		usage
-		exit 1
-	fi
+  network="${2-}"
+  if [ -z "$network" ]; then
+    usage
+    exit 1
+  fi
 
-        # This whole block can be done in a single line of jq script but it
-        # woudn't be readable.
-	canisters=$(jq -r 'keys|join(" ")' "$ids_file")
-	output="{}"
-	for canister in $canisters; do
-		id=$(jq -r ".[\"$canister\"][\"$network\"]?" "$ids_file")
-		if [ "$id" != "null" ]; then
-			new_output=$(echo "$output" | jq ".[\"$canister\"][\"$network\"]=\"$id\"")
-			output="$new_output"
-		fi
-	done
-	echo "$output"
-	exit
+  # This whole block can be done in a single line of jq script but it woudn't
+  # be readable.
+  canisters=$(jq -r 'keys|join(" ")' "$ids_file")
+  output="{}"
+  for canister in $canisters; do
+    id=$(jq -r ".[\"$canister\"][\"$network\"]?" "$ids_file")
+    if [ "$id" != "null" ]; then
+      new_output=$(echo "$output" | jq ".[\"$canister\"][\"$network\"]=\"$id\"")
+      output="$new_output"
+    fi
+  done
+  echo "$output"
+  exit
 fi
 
 if [ "$command" = "import" ]; then
-	echo "Reading from stdin..."
-	input="$(cat)"
-	output="$(jq --argjson input "$input" '. * $input' "$ids_file")"
-	echo "$output" >"$ids_file"
-	exit
+  echo "Reading from stdin..."
+  input="$(cat)"
+  output="$(jq --argjson input "$input" '. * $input' "$ids_file")"
+  echo "$output" >"$ids_file"
+  exit
 fi
 
 usage

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: $0 export <network> (outputs to stdout)"
+	echo "       $0 import           (reads from stdin)"
+}
+
+top_dir=$(git rev-parse --show-toplevel)
+ids_file="$top_dir/canister_ids.json"
+
+if ! [ -f "$ids_file" ]; then
+	echo "$ids_file is missing."
+	exit 1
+fi
+
+canisters=$(jq -r 'keys|join(" ")' "$ids_file")
+
+command="${1-}"
+
+if [ "$command" = "export" ]; then
+	network="${2-}"
+	if [ -z "$network" ]; then
+		usage
+		exit 1
+	fi
+
+	# This whole block can be done in a single line of jq script but it woudn't
+	# be readable.
+	canisters=$(jq -r 'keys|join(" ")' "$ids_file")
+	output="{}"
+	for canister in $canisters; do
+		id=$(jq -r ".[\"$canister\"][\"$network\"]?" "$ids_file")
+		if [ "$id" != "null" ]; then
+			new_output=$(echo "$output" | jq ".[\"$canister\"][\"$network\"]=\"$id\"")
+			output="$new_output"
+		fi
+	done
+
+	echo "$output"
+
+	exit
+fi
+
+if [ "$command" = "import" ]; then
+	echo "Reading from stdin..."
+	input="$(cat)"
+	output="$(jq --argjson input "$input" '. * $input' "$ids_file")"
+	echo "$output" >"$ids_file"
+	exit
+fi
+
+usage

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -15,8 +15,6 @@ if ! [ -f "$ids_file" ]; then
 	exit 1
 fi
 
-canisters=$(jq -r 'keys|join(" ")' "$ids_file")
-
 command="${1-}"
 
 if [ "$command" = "export" ]; then

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -35,9 +35,7 @@ if [ "$command" = "export" ]; then
 			output="$new_output"
 		fi
 	done
-
 	echo "$output"
-
 	exit
 fi
 


### PR DESCRIPTION
# Motivation

When we deploy new canisters to testnets, it's sometimes useful to share ids of multiple canisters to add to canister_ids.json.
This script lets one person do `scripts/canister_ids export medium06` and it will output something like:
```
{
  "internet_identity": {
    "medium06": "qhbym-qaaaa-aaaaa-aaafq-cai"
  },
  "nns-dapp": {
    "medium06": "qsgjb-riaaa-aaaaa-aaaga-cai"
  },
  "sns_aggregator": {
    "medium06": "5v3p4-iyaaa-aaaaa-qaaaa-cai"
  }
}
```
This can then be shared and then other people can do `scripts/canister_ids import` and paste the shared partial config to apply it to their own `canister_ids.json`.

# Changes

Add new script.

# Tests

Tested export and import manually.