### PR TITLE
build: web worker esm

### DIFF
--- a/frontend/src/lib/api/canisters.api.worker.ts
+++ b/frontend/src/lib/api/canisters.api.worker.ts
@@ -5,11 +5,15 @@ import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-man
 import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity, ManagementCanisterRecord } from "@dfinity/agent";
-/**
- * HTTP-Agent explicit CJS import for compatibility with web worker - avoid "window undefined" issues
- */
-import { getManagementCanister, HttpAgent } from "@dfinity/agent/lib/cjs/index";
+import { getManagementCanister, HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
+
+/**
+ * We still use a custom API for the worker because otherwise we face following error with `npm run build`:
+ * > Error [RollupError]: Unexpected token (Note that you need plugins to import files that are not JavaScript)
+ *
+ * Most probably linked with https://github.com/vitejs/vite/issues/9369#issuecomment-1196392031
+ */
 
 export const queryCanisterDetails = async ({
   identity,

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -1,7 +1,7 @@
 import { transactionFee as snsTransactionFee } from "$lib/api/sns-ledger.api";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import type { Principal } from "@dfinity/principal/lib/cjs";
+import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 

--- a/frontend/src/lib/workers/cycles.worker.ts
+++ b/frontend/src/lib/workers/cycles.worker.ts
@@ -1,4 +1,4 @@
-import { queryCanisterDetails } from "$lib/api/canisters.api.cjs";
+import { queryCanisterDetails } from "$lib/api/canisters.api.worker";
 import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
 import { SYNC_CYCLES_TIMER_INTERVAL } from "$lib/constants/canisters.constants";
 import type { CanisterSync } from "$lib/types/canister";

--- a/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
@@ -1,4 +1,4 @@
-import { queryCanisterDetails } from "$lib/api/canisters.api.cjs";
+import { queryCanisterDetails } from "$lib/api/canisters.api.worker";
 import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-management.types";
 import { mockIdentity } from "../../mocks/auth.store.mock";

--- a/frontend/src/tests/lib/api/canisters.api.worker.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.worker.spec.ts
@@ -4,7 +4,7 @@ import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-man
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import { mockCanisterDetails } from "../../mocks/canisters.mock";
 
-jest.mock("@dfinity/agent/lib/cjs/index", () => {
+jest.mock("@dfinity/agent", () => {
   class MockHttpAgent {}
 
   const response: CanisterStatusResponse = {
@@ -28,7 +28,7 @@ jest.mock("@dfinity/agent/lib/cjs/index", () => {
   };
 });
 
-describe("canisters-api.cjs", () => {
+describe("canisters-api.worker", () => {
   afterAll(() => jest.resetAllMocks());
 
   describe("queryCanisterDetails", () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -66,6 +66,9 @@ const config: UserConfig = {
       },
     },
   },
+  worker: {
+    format: "es",
+  },
 };
 
 export default config;


### PR DESCRIPTION
# Motivation

Use es modules to build web worker as well.

# Changes

- configure vite to use esm
- drop cjs for esm in few imports
