### PR TITLE
fix: error and back navigation after neuron staking

### DIFF
--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -65,6 +65,9 @@
     if (
       neuron === undefined &&
       $neuronsStore.neurons !== undefined &&
+      // After neuron staking the query (not certified) call can return the outdated neuron list
+      // so if the neuron is undefined it's more reliable to wait for the update call.
+      $neuronsStore.certified === true &&
       $pageStore.path === AppPath.Neuron
     ) {
       toastsError({


### PR DESCRIPTION
# Motivation

**Reprodusable not on all testnets**
After staking the neuron if user navigates fast to the neuron details
1. listNeurons query call returns no new neuron (update call does)
2. error message appears (screen 1)
3. User navigates back to the neuron list

# Changes

- skip the query result if there is no open neuron information. In the worst case scenario, when a user opens the neuron details page directly with unknown/wrong neuronId, the skeletons will be shown till the update call is done and only then the error message will be displayed + navigation to the list

# Screenshots

The Error
![image](https://user-images.githubusercontent.com/98811342/221491243-8d69113e-0744-40cb-854f-db7ad876a161.png)

After the fix
https://user-images.githubusercontent.com/98811342/221493098-b5767694-8f02-45e5-9495-c60b4f282de1.mp4

