### PR TITLE
Script to set up testnet development

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -12,7 +12,9 @@
 # with `dfx deploy nns-dapp` and it replace the provided canister.
 
 set -euo pipefail
-cd "$(dirname "$0")/.."
+
+top_dir=$(git rev-parse --show-toplevel)
+cd "$top_dir"
 
 bash_version=$(/usr/bin/env bash -c "echo \${BASH_VERSION}")
 bash_major_version=$(/usr/bin/env bash -c "echo \${BASH_VERSINFO[0]}")
@@ -36,6 +38,7 @@ need() {
 need dfx
 need jq
 need npm
+need node
 
 if ! pgrep icx-proxy >/dev/null; then
   echo "You need a local replica."

--- a/scripts/dev-testnet.sh
+++ b/scripts/dev-testnet.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Combine all the required steps and checks to develop against a testnet.
+# If npm dependencies and canister ids didn't change, it is faster to run
+# `npm run dev` from frontend/ but this script can be helpful to make sure
+# you don't forget anything.
+
+set -euo pipefail
+
+top_dir=$(git rev-parse --show-toplevel)
+ids_file="$top_dir/canister_ids.json"
+
+cd "$top_dir"
+
+if ! [ -f "$ids_file" ]; then
+  echo "You need a 'canister_ids.json' file in $top_dir."
+  echo "Ask a team member to send you theirs."
+  exit 1
+fi
+
+bash_version=$(/usr/bin/env bash -c "echo \${BASH_VERSION}")
+bash_major_version=$(/usr/bin/env bash -c "echo \${BASH_VERSINFO[0]}")
+
+if [ "$bash_major_version" -lt "4" ]; then
+  echo "Your bash version is very old. (${bash_version})"
+  echo "Install a newer version of bash."
+  exit 1
+fi
+
+need() {
+  tool="$1"
+  if ! command -v "$tool" >/dev/null; then
+    echo "You need $tool."
+    echo "Either it's not installed or it's not in your path."
+    echo "You can run ./scripts/setup to install necessary tools including $tool."
+    exit 1
+  fi
+}
+
+need dfx
+need jq
+need npm
+need node
+
+networks=$(jq -r '[.[]|keys[]]|unique|join(" ")' canister_ids.json)
+
+usage() {
+  echo "Usage: $0 <network>"
+  echo "Available networks are: $networks"
+}
+
+if [ "$#" != "1" ]; then
+  usage
+  exit 1
+fi
+
+network="$1"
+
+if ! echo "$networks" | grep "\\b$network\\b" >/dev/null; then
+  echo "'$network' is not a known network."
+  echo
+  usage
+  exit 1
+fi
+
+DFX_NETWORK="$network" ./config.sh >/dev/null
+
+if grep '=null$' frontend/.env; then
+  echo "Something is missing from your canister_ids.json."
+  exit 1
+fi
+
+cd frontend
+npm ci
+npm run dev


### PR DESCRIPTION
# Motivation

Running development against testnet requires several steps:
You need
1. a canister_ids.json file
2. several tools installed
3. to run `DFX_NETWORK=$network ./config.sh`
4. to run `npm ci` and `npm run dev` from `frontend/`

It's easy to forget something, especially if you're new to the team.
This scripts checks all the inputs and runs all the steps so you can't forget something.

# Changes

1. Add `dev-testnet.sh` analogous to `dev-local.sh`.
2. The script needs to be run from a git repo and will work from any directory inside the repo so you don't need to `cd` into or out of `frontend/`.
3. Change to `dev-local.sh` to make the previous point work for it as well.

<!-- List the changes that have been developed -->

# Tests

Tested manually with a new user account on my Mac.

<!-- Please provide any information or screenshots about the tests that have been done -->
