### PR TITLE
GIX-1348: Retry transfer participation

### DIFF
--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -140,11 +140,6 @@ describe("sns-api", () => {
       ])
     );
 
-    // const ledgerMock = mock<LedgerCanister>();
-    // ledgerMock.accountBalance.mockResolvedValue(BigInt(100_000_000));
-    // jest.spyOn(LedgerCanister, "create").mockReturnValue(ledgerMock);
-
-    // sendICPSpy.mockResolvedValue(13n);
     sendICPSpy.mockResolvedValue(13n);
 
     snsQueryStore.setData(

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -30,7 +30,6 @@ import type { HttpAgent, Identity } from "@dfinity/agent";
 import {
   ICPToken,
   InsufficientFundsError,
-  LedgerCanister,
   TokenAmount,
   TransferError,
   TxCreatedInFutureError,
@@ -105,7 +104,6 @@ describe("sns-api", () => {
   const spyOnToastsShow = jest.spyOn(toastsStore, "toastsShow");
   const spyOnToastsSuccess = jest.spyOn(toastsStore, "toastsSuccess");
   const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
-  const ledgerCanisterMock = mock<LedgerCanister>();
   const testRootCanisterId = rootCanisterIdMock;
   const testSnsTicket = snsTicketMock({
     rootCanisterId: testRootCanisterId,


### PR DESCRIPTION
# Motivation

UI retries transfer in the sns participation flow during unkown errors.

# Changes

* New helper `pollTransfer` in sns-sale services.
* Use new helper `pollTransfer` in sns-sale services `participateInSnsSale`.

# Tests

* Test new functionality.
