### PR TITLE
GIX-1346 Add exponential backoff option to poll

### DIFF
--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -201,6 +201,9 @@ const DEFAULT_WAIT_TIME_MS = 500;
  * @param {fn} params.fn Function to call
  * @param {shouldExit} params.shouldExit Function to check whether function should stop polling when it throws an error
  * @param {maxAttempts} params.maxAttempts Param to override the default number of times to poll.
+ * @param {counter} params.counter Param to check how many times it has polled.
+ * @param {millisecondsToWait} params.millisecondsToWait How long to wait between (the first 2, in case of exponential backoff) calls
+ * @param {useExponentialBackoff} params.useExponentialBackoff Whether to use exponential backoff instead of waiting the same time between retries
  *
  * @returns
  */

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -202,7 +202,7 @@ const DEFAULT_WAIT_TIME_MS = 500;
  * @param {shouldExit} params.shouldExit Function to check whether function should stop polling when it throws an error
  * @param {maxAttempts} params.maxAttempts Param to override the default number of times to poll.
  * @param {counter} params.counter Param to check how many times it has polled.
- * @param {millisecondsToWait} params.millisecondsToWait How long to wait between (the first 2, in case of exponential backoff) calls
+ * @param {millisecondsToWait} params.millisecondsToWait How long to wait between calls, or the base for the exponential backoff if that's enabled
  * @param {useExponentialBackoff} params.useExponentialBackoff Whether to use exponential backoff instead of waiting the same time between retries
  *
  * @returns

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -193,6 +193,7 @@ export const waitForMilliseconds = (milliseconds: number): Promise<void> =>
 export class PollingLimitExceededError extends Error {}
 // Exported for testing purposes
 export const DEFAULT_MAX_POLLING_ATTEMPTS = 10;
+const DEFAULT_WAIT_TIME_MS = 500;
 /**
  * Function that polls a specific function, checking error with passed argument to recall or not.
  *
@@ -200,7 +201,6 @@ export const DEFAULT_MAX_POLLING_ATTEMPTS = 10;
  * @param {fn} params.fn Function to call
  * @param {shouldExit} params.shouldExit Function to check whether function should stop polling when it throws an error
  * @param {maxAttempts} params.maxAttempts Param to override the default number of times to poll.
- * @param {counter} params.counter Param to check how many times it has polled.
  *
  * @returns
  */
@@ -209,13 +209,15 @@ export const poll = async <T>({
   shouldExit,
   maxAttempts = DEFAULT_MAX_POLLING_ATTEMPTS,
   counter = 0,
-  millisecondsToWait = 500,
+  millisecondsToWait = DEFAULT_WAIT_TIME_MS,
+  useExponentialBackoff = false,
 }: {
   fn: () => Promise<T>;
   shouldExit: (err: unknown) => boolean;
   maxAttempts?: number;
   counter?: number;
   millisecondsToWait?: number;
+  useExponentialBackoff?: boolean;
 }): Promise<T> => {
   if (counter >= maxAttempts) {
     throw new PollingLimitExceededError();
@@ -230,12 +232,16 @@ export const poll = async <T>({
     console.error(`Error polling: ${errorToString(error)}`);
   }
   await waitForMilliseconds(millisecondsToWait);
+  if (useExponentialBackoff) {
+    millisecondsToWait *= 2;
+  }
   return poll({
     fn,
     shouldExit,
     maxAttempts,
     counter: counter + 1,
     millisecondsToWait,
+    useExponentialBackoff,
   });
 };
 

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -264,80 +264,79 @@ describe("utils", () => {
 
   describe("poll", () => {
     describe("without timers", () => {
-    // TODO proper indent before merge. Left it like this for easy reviewing.
-    beforeEach(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
-      // Avoid to print errors during test
-      jest.spyOn(console, "log").mockImplementation(() => undefined);
-    });
-
-    it("should recall the function until `fn` succeeds", async () => {
-      const maxCalls = 3;
-      let calls = 0;
-      await poll({
-        fn: async () => {
-          calls += 1;
-          if (calls < maxCalls) {
-            throw new Error();
-          }
-          return calls;
-        },
-        shouldExit: () => false,
+      beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+        // Avoid to print errors during test
+        jest.spyOn(console, "log").mockImplementation(() => undefined);
       });
-      expect(calls).toBe(maxCalls);
-    });
 
-    it("should recall the function until `shouldExit` is true", async () => {
-      const maxCalls = 3;
-      let calls = 0;
-      const pollCall = () =>
-        poll({
+      it("should recall the function until `fn` succeeds", async () => {
+        const maxCalls = 3;
+        let calls = 0;
+        await poll({
           fn: async () => {
             calls += 1;
-            throw new Error("fn failed");
-          },
-          shouldExit: () => calls >= maxCalls,
-        });
-      await expect(pollCall).rejects.toThrow("fn failed");
-      expect(calls).toBe(maxCalls);
-    });
-
-    it("should return the value of `fn` when it doesn't throw", async () => {
-      const result = 10;
-      const expected = await poll({
-        fn: async () => result,
-        shouldExit: () => false,
-      });
-      expect(expected).toBe(result);
-    });
-
-    it("should throw when `shouldExit` returns true", async () => {
-      const result = 10;
-      const expected = await poll({
-        fn: async () => result,
-        shouldExit: () => true,
-      });
-      expect(expected).toBe(result);
-    });
-
-    it("should throw after `maxAttempts`", async () => {
-      let counter = 0;
-      const maxAttempts = 5;
-      const call = () =>
-        poll({
-          fn: async () => {
-            counter += 1;
-            throw new Error();
+            if (calls < maxCalls) {
+              throw new Error();
+            }
+            return calls;
           },
           shouldExit: () => false,
-          maxAttempts,
         });
-      // Without the `await`, the line didn't wait the `poll` to throw to
-      // move to the next line
-      await expect(call).rejects.toThrowError(PollingLimitExceededError);
-      expect(counter).toBe(maxAttempts);
-    });
+        expect(calls).toBe(maxCalls);
+      });
+
+      it("should recall the function until `shouldExit` is true", async () => {
+        const maxCalls = 3;
+        let calls = 0;
+        const pollCall = () =>
+          poll({
+            fn: async () => {
+              calls += 1;
+              throw new Error("fn failed");
+            },
+            shouldExit: () => calls >= maxCalls,
+          });
+        await expect(pollCall).rejects.toThrow("fn failed");
+        expect(calls).toBe(maxCalls);
+      });
+
+      it("should return the value of `fn` when it doesn't throw", async () => {
+        const result = 10;
+        const expected = await poll({
+          fn: async () => result,
+          shouldExit: () => false,
+        });
+        expect(expected).toBe(result);
+      });
+
+      it("should throw when `shouldExit` returns true", async () => {
+        const result = 10;
+        const expected = await poll({
+          fn: async () => result,
+          shouldExit: () => true,
+        });
+        expect(expected).toBe(result);
+      });
+
+      it("should throw after `maxAttempts`", async () => {
+        let counter = 0;
+        const maxAttempts = 5;
+        const call = () =>
+          poll({
+            fn: async () => {
+              counter += 1;
+              throw new Error();
+            },
+            shouldExit: () => false,
+            maxAttempts,
+          });
+        // Without the `await`, the line didn't wait the `poll` to throw to
+        // move to the next line
+        await expect(call).rejects.toThrowError(PollingLimitExceededError);
+        expect(counter).toBe(maxAttempts);
+      });
     });
 
     describe("with fake timers", () => {

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -264,79 +264,80 @@ describe("utils", () => {
 
   describe("poll", () => {
     describe("without timers", () => {
-      beforeEach(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
-        // Avoid to print errors during test
-        //jest.spyOn(console, "log").mockImplementation(() => undefined);
-      });
+    // TODO proper indent before merge. Left it like this for easy reviewing.
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+      // Avoid to print errors during test
+      jest.spyOn(console, "log").mockImplementation(() => undefined);
+    });
 
-      it("should recall the function until `fn` succeeds", async () => {
-        const maxCalls = 3;
-        let calls = 0;
-        await poll({
+    it("should recall the function until `fn` succeeds", async () => {
+      const maxCalls = 3;
+      let calls = 0;
+      await poll({
+        fn: async () => {
+          calls += 1;
+          if (calls < maxCalls) {
+            throw new Error();
+          }
+          return calls;
+        },
+        shouldExit: () => false,
+      });
+      expect(calls).toBe(maxCalls);
+    });
+
+    it("should recall the function until `shouldExit` is true", async () => {
+      const maxCalls = 3;
+      let calls = 0;
+      const pollCall = () =>
+        poll({
           fn: async () => {
             calls += 1;
-            if (calls < maxCalls) {
-              throw new Error();
-            }
-            return calls;
+            throw new Error("fn failed");
+          },
+          shouldExit: () => calls >= maxCalls,
+        });
+      await expect(pollCall).rejects.toThrow("fn failed");
+      expect(calls).toBe(maxCalls);
+    });
+
+    it("should return the value of `fn` when it doesn't throw", async () => {
+      const result = 10;
+      const expected = await poll({
+        fn: async () => result,
+        shouldExit: () => false,
+      });
+      expect(expected).toBe(result);
+    });
+
+    it("should throw when `shouldExit` returns true", async () => {
+      const result = 10;
+      const expected = await poll({
+        fn: async () => result,
+        shouldExit: () => true,
+      });
+      expect(expected).toBe(result);
+    });
+
+    it("should throw after `maxAttempts`", async () => {
+      let counter = 0;
+      const maxAttempts = 5;
+      const call = () =>
+        poll({
+          fn: async () => {
+            counter += 1;
+            throw new Error();
           },
           shouldExit: () => false,
+          maxAttempts,
         });
-        expect(calls).toBe(maxCalls);
-      });
-
-      it("should recall the function until `shouldExit` is true", async () => {
-        const maxCalls = 3;
-        let calls = 0;
-        const pollCall = () =>
-          poll({
-            fn: async () => {
-              calls += 1;
-              throw new Error("fn failed");
-            },
-            shouldExit: () => calls >= maxCalls,
-          });
-        await expect(pollCall).rejects.toThrow("fn failed");
-        expect(calls).toBe(maxCalls);
-      });
-
-      it("should return the value of `fn` when it doesn't throw", async () => {
-        const result = 10;
-        const expected = await poll({
-          fn: async () => result,
-          shouldExit: () => false,
-        });
-        expect(expected).toBe(result);
-      });
-
-      it("should throw when `shouldExit` returns true", async () => {
-        const result = 10;
-        const expected = await poll({
-          fn: async () => result,
-          shouldExit: () => true,
-        });
-        expect(expected).toBe(result);
-      });
-
-      it("should throw after `maxAttempts`", async () => {
-        let counter = 0;
-        const maxAttempts = 5;
-        const call = () =>
-          poll({
-            fn: async () => {
-              counter += 1;
-              throw new Error();
-            },
-            shouldExit: () => false,
-            maxAttempts,
-          });
-        // Without the `await`, the line didn't wait the `poll` to throw to
-        // move to the next line
-        await expect(call).rejects.toThrowError(PollingLimitExceededError);
-        expect(counter).toBe(maxAttempts);
-      });
+      // Without the `await`, the line didn't wait the `poll` to throw to
+      // move to the next line
+      await expect(call).rejects.toThrowError(PollingLimitExceededError);
+      expect(counter).toBe(maxAttempts);
+    });
     });
 
     describe("with fake timers", () => {

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -332,7 +332,8 @@ describe("utils", () => {
             shouldExit: () => false,
             maxAttempts,
           });
-        // Without the `await`, the line didn't wait the `poll` to throw to move to the next line
+        // Without the `await`, the line didn't wait the `poll` to throw to
+        // move to the next line
         await expect(call).rejects.toThrowError(PollingLimitExceededError);
         expect(counter).toBe(maxAttempts);
       });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -263,62 +263,146 @@ describe("utils", () => {
   });
 
   describe("poll", () => {
-    beforeEach(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
-      // Avoid to print errors during test
-      jest.spyOn(console, "log").mockImplementation(() => undefined);
-    });
-
-    it("should recall the function until `shouldExit` is true", async () => {
-      const maxCalls = 3;
-      let calls = 0;
-      await poll({
-        fn: async () => {
-          calls += 1;
-          if (calls < maxCalls) {
-            throw new Error();
-          }
-          return calls;
-        },
-        shouldExit: () => calls >= maxCalls,
+    describe("without timers", () => {
+      beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
+        // Avoid to print errors during test
+        //jest.spyOn(console, "log").mockImplementation(() => undefined);
       });
-      expect(calls).toBe(maxCalls);
-    });
 
-    it("should return the value of `fn` when it doesn't throw", async () => {
-      const result = 10;
-      const expected = await poll({
-        fn: async () => result,
-        shouldExit: () => false,
-      });
-      expect(expected).toBe(result);
-    });
-
-    it("should throw when `shuoldExit` returns trye", async () => {
-      const result = 10;
-      const expected = await poll({
-        fn: async () => result,
-        shouldExit: () => true,
-      });
-      expect(expected).toBe(result);
-    });
-
-    it("should throw after `maxAttempts`", async () => {
-      let counter = 0;
-      const maxAttempts = 5;
-      const call = () =>
-        poll({
+      it("should recall the function until `fn` succeeds", async () => {
+        const maxCalls = 3;
+        let calls = 0;
+        await poll({
           fn: async () => {
-            counter += 1;
+            calls += 1;
+            if (calls < maxCalls) {
+              throw new Error();
+            }
+            return calls;
+          },
+          shouldExit: () => false,
+        });
+        expect(calls).toBe(maxCalls);
+      });
+
+      it("should recall the function until `shouldExit` is true", async () => {
+        const maxCalls = 3;
+        let calls = 0;
+        const pollCall = () =>
+          poll({
+            fn: async () => {
+              calls += 1;
+              throw new Error("fn failed");
+            },
+            shouldExit: () => calls >= maxCalls,
+          });
+        await expect(pollCall).rejects.toThrow("fn failed");
+        expect(calls).toBe(maxCalls);
+      });
+
+      it("should return the value of `fn` when it doesn't throw", async () => {
+        const result = 10;
+        const expected = await poll({
+          fn: async () => result,
+          shouldExit: () => false,
+        });
+        expect(expected).toBe(result);
+      });
+
+      it("should throw when `shouldExit` returns true", async () => {
+        const result = 10;
+        const expected = await poll({
+          fn: async () => result,
+          shouldExit: () => true,
+        });
+        expect(expected).toBe(result);
+      });
+
+      it("should throw after `maxAttempts`", async () => {
+        let counter = 0;
+        const maxAttempts = 5;
+        const call = () =>
+          poll({
+            fn: async () => {
+              counter += 1;
+              throw new Error();
+            },
+            shouldExit: () => false,
+            maxAttempts,
+          });
+        // Without the `await`, the line didn't wait the `poll` to throw to move to the next line
+        await expect(call).rejects.toThrowError(PollingLimitExceededError);
+        expect(counter).toBe(maxAttempts);
+      });
+    });
+
+    describe("with fake timers", () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      const getTimestamps = async ({
+        maxAttempts,
+        millisecondsToWait,
+        useExponentialBackoff,
+      }: {
+        maxAttempts: number;
+        millisecondsToWait?: number;
+        useExponentialBackoff: boolean;
+      }): Promise<number[]> => {
+        const t0 = new Date().getTime();
+        const timestamps = [];
+
+        const promise = poll({
+          fn: async () => {
+            timestamps.push(new Date().getTime() - t0);
             throw new Error();
           },
           shouldExit: () => false,
           maxAttempts,
+          millisecondsToWait,
+          useExponentialBackoff,
         });
-      // Without the `await`, the line didn't wait the `poll` to throw to move to the next line
-      await expect(call).rejects.toThrowError(PollingLimitExceededError);
-      expect(counter).toBe(maxAttempts);
+
+        for (let i = 0; i < maxAttempts; i++) {
+          // Make sure the timers are set before we advance time.
+          await null;
+          await jest.runOnlyPendingTimers();
+        }
+        expect(() => promise).rejects.toThrowError(PollingLimitExceededError);
+        return timestamps;
+      };
+
+      it("should have a default wait time of 500ms", async () => {
+        expect(
+          await getTimestamps({
+            maxAttempts: 2,
+            useExponentialBackoff: false,
+          })
+        ).toEqual([0, 500]);
+      });
+
+      it("should wait the same amount between calls", async () => {
+        expect(
+          await getTimestamps({
+            maxAttempts: 5,
+            millisecondsToWait: 1000,
+            useExponentialBackoff: false,
+          })
+        ).toEqual([0, 1000, 2000, 3000, 4000]);
+      });
+
+      it("should do exponential backoff", async () => {
+        expect(
+          await getTimestamps({
+            maxAttempts: 5,
+            millisecondsToWait: 1000,
+            useExponentialBackoff: true,
+          })
+        ).toEqual([0, 1000, 3000, 7000, 15000]);
+      });
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to use exponential backoff for sns sale retries.
This PR only adds the optional functionality to the poll function which is used by the `sns-sale-services.ts`.

# Changes

1. Adds an optional `useExponentialBackoff` parameter to `poll()`.
2. Adds missing tests to test linear retry timestamps.
3. Adds tests to test exponential retry timestamps.

# Tests

1. Unit tests.
2. Manual test by adding a fail counter before `getOpenTicketApi()` in `sns-sale.services.ts`, both with and without exponential backoff.