### PR TITLE
GIX-1345: Change Select Universe navigation title

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
   import { Nav, BREAKPOINT_LARGE } from "@dfinity/gix-components";
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
+  import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
 
   let innerWidth = 0;
   let list = false;
@@ -14,7 +14,7 @@
 
 <Nav>
   <p class="title" slot="title" data-tid="select-universe-nav-title">
-    {$i18n.universe.select_token}
+    {$titleTokenSelectorStore}
   </p>
 
   {#if list}

--- a/frontend/src/lib/derived/title-token-selector.derived.ts
+++ b/frontend/src/lib/derived/title-token-selector.derived.ts
@@ -1,0 +1,16 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { i18n } from "$lib/stores/i18n";
+import { isSelectedPath } from "$lib/utils/navigation.utils";
+import { derived } from "svelte/store";
+import { pageStore } from "./page.derived";
+
+export const titleTokenSelectorStore = derived(
+  [i18n, pageStore],
+  ([$i18n, page]) =>
+    isSelectedPath({
+      currentPath: page.path,
+      paths: [AppPath.Neurons, AppPath.Neuron],
+    })
+      ? $i18n.universe.select_nervous_system
+      : $i18n.universe.select_token
+);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -763,6 +763,7 @@
   },
   "universe": {
     "select_token": "Select Token",
+    "select_nervous_system": "Select Nervous System",
     "select": "Select"
   },
   "sns_rewards_status": {

--- a/frontend/src/lib/modals/universe/SelectUniverseModal.svelte
+++ b/frontend/src/lib/modals/universe/SelectUniverseModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Modal } from "@dfinity/gix-components";
-  import { i18n } from "$lib/stores/i18n";
   import SelectUniverseList from "$lib/components/universe/SelectUniverseList.svelte";
   import { createEventDispatcher } from "svelte";
   import { goto } from "$app/navigation";
   import { buildSwitchUniverseUrl } from "$lib/utils/navigation.utils";
+  import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
 
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");
@@ -17,7 +17,7 @@
 
 <Modal testId="select-universe-modal" on:nnsClose>
   <span slot="title" data-tid="select-universe-modal-title"
-    >{$i18n.universe.select_token}</span
+    >{$titleTokenSelectorStore}</span
   >
 
   <SelectUniverseList

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -802,6 +802,7 @@ interface I18nAuth_sns {
 
 interface I18nUniverse {
   select_token: string;
+  select_nervous_system: string;
   select: string;
 }
 

--- a/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
@@ -33,7 +33,7 @@ describe("title token selector derived store", () => {
     expect($store3).toEqual(en.universe.select_token);
   });
 
-  it("should return select nervous system text if path is not related to neurons", () => {
+  it("should return select nervous system text if path is related to neurons", () => {
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Neuron,

--- a/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
+import { page } from "$mocks/$app/stores";
+import { get } from "svelte/store";
+import en from "../../mocks/i18n.mock";
+import { rootCanisterIdMock } from "../../mocks/sns.api.mock";
+
+describe("title token selector derived store", () => {
+  it("should return select token text if path is not related to neurons", () => {
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Accounts,
+    });
+    const $store1 = get(titleTokenSelectorStore);
+    expect($store1).toEqual(en.universe.select_token);
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Wallet,
+    });
+    const $store2 = get(titleTokenSelectorStore);
+    expect($store2).toEqual(en.universe.select_token);
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Proposals,
+    });
+    const $store3 = get(titleTokenSelectorStore);
+    expect($store3).toEqual(en.universe.select_token);
+  });
+
+  it("should return select nervous system text if path is not related to neurons", () => {
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Neuron,
+    });
+    const $store1 = get(titleTokenSelectorStore);
+    expect($store1).toEqual(en.universe.select_nervous_system);
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Neurons,
+    });
+    const $store2 = get(titleTokenSelectorStore);
+    expect($store2).toEqual(en.universe.select_nervous_system);
+  });
+
+  it("should change depending on page", () => {
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Accounts,
+    });
+    const $store1 = get(titleTokenSelectorStore);
+    expect($store1).toEqual(en.universe.select_token);
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Neurons,
+    });
+    const $store2 = get(titleTokenSelectorStore);
+    expect($store2).toEqual(en.universe.select_nervous_system);
+
+    page.mock({
+      data: {
+        universe: rootCanisterIdMock.toText(),
+      },
+      routeId: AppPath.Wallet,
+    });
+    const $store3 = get(titleTokenSelectorStore);
+    expect($store3).toEqual(en.universe.select_token);
+  });
+});


### PR DESCRIPTION
# Motivation

Change title of the universe selector depending on the page.

# Changes

* New derived store `titleTokenSelectorStore` that returns the title for the universe selector.
* Use `titleTokenSelectorStore` in the universe selector navbars.

# Tests

* Test new derived store.
