### PR TITLE
GIX-1352: Init accounts service

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -106,13 +106,18 @@ export const loadAccounts = async ({
   };
 };
 
+type SyncAccontsErrorHandler = (params: {
+  err: unknown;
+  certified: boolean;
+}) => void;
+
 /**
  * Default error handler for syncAccounts.
  *
  * Ignores non-certified errors.
  * Resets accountsStore and shows toast for certified errors.
  */
-const defaultErrorHandlerAccounts = ({
+const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
   err,
   certified,
 }: {
@@ -137,7 +142,7 @@ const defaultErrorHandlerAccounts = ({
  * Loads the account data using the ledger and the nns dapp canister.
  */
 export const syncAccounts = (
-  errorHandler: typeof defaultErrorHandlerAccounts = defaultErrorHandlerAccounts
+  errorHandler: SyncAccontsErrorHandler = defaultErrorHandlerAccounts
 ): Promise<void> => {
   return queryAndUpdate<AccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),
@@ -151,7 +156,8 @@ export const syncAccounts = (
   });
 };
 
-const ignoreErrors = () => undefined;
+const ignoreErrors: SyncAccontsErrorHandler = () => undefined;
+
 /**
  * This function is called on app load to sync the accounts.
  *

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -119,11 +119,10 @@ const defaultErrorHandlerAccounts = ({
   err: unknown;
   certified: boolean;
 }) => {
-  if (certified !== true) {
+  if (!certified) {
     return;
   }
 
-  // Explicitly handle only UPDATE errors
   accountsStore.reset();
 
   toastsError(
@@ -134,18 +133,11 @@ const defaultErrorHandlerAccounts = ({
   );
 };
 
-type ErrorHanlder = ({
-  err,
-  certified,
-}: {
-  err: unknown;
-  certified: boolean;
-}) => void;
 /**
- * - sync: load the account data using the ledger and the nns dapp canister itself
+ * Loads the account data using the ledger and the nns dapp canister.
  */
 export const syncAccounts = (
-  errorHandler: ErrorHanlder = defaultErrorHandlerAccounts
+  errorHandler: typeof defaultErrorHandlerAccounts = defaultErrorHandlerAccounts
 ): Promise<void> => {
   return queryAndUpdate<AccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,9 +1,9 @@
-import { syncAccounts } from "./accounts.services";
+import { initAccounts } from "./accounts.services";
 
 export const initAppPrivateData = (): Promise<
   [PromiseSettledResult<void[]>]
 > => {
-  const initNns: Promise<void>[] = [syncAccounts()];
+  const initNns: Promise<void>[] = [initAccounts()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -276,10 +276,12 @@ describe("accounts-services", () => {
 
       await syncAccounts();
 
-      const toastsData = get(toastsStore);
-      const toast = toastsData[0];
-      expect(toast.text).toEqual(`${en.error.accounts_not_found} ${errorTest}`);
-      expect(toast.level).toEqual("error");
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: `${en.error.accounts_not_found} ${errorTest}`,
+        },
+      ]);
     });
 
     it("should use handler passed", async () => {

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -174,6 +174,7 @@ describe("accounts-services", () => {
     beforeEach(() => {
       toastsStore.reset();
     });
+
     it("should sync accounts", async () => {
       const mainBalanceE8s = BigInt(10_000_000);
       const queryAccountBalanceSpy = jest
@@ -282,22 +283,20 @@ describe("accounts-services", () => {
     });
 
     it("should use handler passed", async () => {
-      const errorTest = "test";
+      const errorTest = new Error("test");
       jest.spyOn(ledgerApi, "queryAccountBalance");
-      jest
-        .spyOn(nnsdappApi, "queryAccount")
-        .mockRejectedValue(new Error(errorTest));
+      jest.spyOn(nnsdappApi, "queryAccount").mockRejectedValue(errorTest);
 
       const handler = jest.fn();
       await syncAccounts(handler);
 
       expect(handler).toBeCalledTimes(2);
       expect(handler).toBeCalledWith({
-        err: new Error(errorTest),
+        err: errorTest,
         certified: false,
       });
       expect(handler).toBeCalledWith({
-        err: new Error(errorTest),
+        err: errorTest,
         certified: true,
       });
     });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -3,17 +3,19 @@
  */
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
-import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
+import { toastsStore } from "@dfinity/gix-components";
+import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
+import { get } from "svelte/store";
 import { mockAccountDetails } from "../../mocks/accounts.store.mock";
-import { mockNeuron } from "../../mocks/neurons.mock";
 
 describe("app-services", () => {
   const mockLedgerCanister = mock<LedgerCanister>();
   const mockNNSDappCanister = mock<NNSDappCanister>();
-  const mockGovernanceCanister = mock<GovernanceCanister>();
 
   beforeEach(() => {
+    toastsStore.reset();
+    jest.clearAllMocks();
     jest
       .spyOn(LedgerCanister, "create")
       .mockImplementation((): LedgerCanister => mockLedgerCanister);
@@ -22,24 +24,12 @@ describe("app-services", () => {
       .spyOn(NNSDappCanister, "create")
       .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
 
-    jest
-      .spyOn(GovernanceCanister, "create")
-      .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
-
-    mockCanisters();
-  });
-
-  const mockCanisters = () => {
-    mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
-    mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
-    mockGovernanceCanister.listNeurons.mockResolvedValue([mockNeuron]);
-  };
-
-  afterEach(() => {
-    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
   it("should init Nns", async () => {
+    mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
+    mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
     await initAppPrivateData();
 
     // query + update calls
@@ -52,5 +42,23 @@ describe("app-services", () => {
     await expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(
       numberOfCalls
     );
+  });
+
+  it("should not show errors if loading accounts fails", async () => {
+    mockNNSDappCanister.getAccount.mockRejectedValue(new Error("test"));
+    mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
+    await initAppPrivateData();
+
+    // query + update calls
+    const numberOfCalls = 2;
+
+    await expect(mockNNSDappCanister.getAccount).toHaveBeenCalledTimes(
+      numberOfCalls
+    );
+
+    await expect(mockLedgerCanister.accountBalance).not.toBeCalled();
+
+    const toastData = get(toastsStore);
+    expect(toastData).toHaveLength(0);
   });
 });


### PR DESCRIPTION
# Motivation

Do not show errors from loading accounts on init.

# Changes

* Add a parameter to `syncAccounts` which is an error handler.
* Extract the current logic on error to a default error handler for `syncAccounts`.
* New `initAccounts` service that uses `syncAccounts` with an empty function as error handler.

# Tests

* Test new functionality of `syncAccounts`.
* Test for new service `initAcconts`.
