### PR TITLE
feat: nns.ic0.app is (still) main url of NNS-dapp

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -23,9 +23,9 @@
       property="og:description"
     />
     <meta content="website" property="og:type" />
-    <meta content="https://nns.internetcomputer.org/" property="og:url" />
+    <meta content="https://nns.ic0.app/" property="og:url" />
     <meta
-      content="https://nns.internetcomputer.org/assets/social-image.png"
+      content="https://nns.ic0.app/assets/social-image.png"
       property="og:image"
     />
     <meta content="summary_large_image" name="twitter:card" />
@@ -35,12 +35,12 @@
       name="twitter:description"
     />
     <meta
-      content="https://nns.internetcomputer.org/assets/social-image.png"
+      content="https://nns.ic0.app/assets/social-image.png"
       name="twitter:image"
     />
     <meta content="@dfinity" name="twitter:creator" />
 
-    <link href="https://nns.internetcomputer.org/" rel="canonical" />
+    <link href="https://nns.ic0.app/" rel="canonical" />
 
     <link rel="manifest" href="/manifest.json" crossorigin="anonymous" />
 

--- a/frontend/static/robots.txt
+++ b/frontend/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://nns.internetcomputer.org/sitemap.xml
-Host: https://nns.internetcomputer.org
+Sitemap: https://nns.ic0.app/sitemap.xml
+Host: https://nns.ic0.app

--- a/frontend/static/sitemap.xml
+++ b/frontend/static/sitemap.xml
@@ -7,27 +7,27 @@
         xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
 >
     <url>
-        <loc>https://nns.internetcomputer.org/</loc>
+        <loc>https://nns.ic0.app/</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://nns.internetcomputer.org/accounts/</loc>
+        <loc>https://nns.ic0.app/accounts/</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://nns.internetcomputer.org/neurons/</loc>
+        <loc>https://nns.ic0.app/neurons/</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://nns.internetcomputer.org/proposals/</loc>
+        <loc>https://nns.ic0.app/proposals/</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://nns.internetcomputer.org/canisters/</loc>
+        <loc>https://nns.ic0.app/canisters/</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>


### PR DESCRIPTION
# Motivation

`nns.ic0.app` is (still) main url of NNS-dapp therefore `robots.ts`, `sitemap.xml` and other static meta tags should still use it.
