### PR TITLE
Use docker as the standard build mechanism

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -17,7 +17,7 @@
       "type": "custom",
       "candid": "rs/backend/nns-dapp.did",
       "wasm": "nns-dapp.wasm",
-      "build": "./build.sh"
+      "build": "scripts/docker-build"
     },
     "internet_identity": {
       "type": "custom",
@@ -94,7 +94,7 @@
     },
     "sns_aggregator": {
       "build": [
-        "./build-sns-aggregator.sh"
+        "scripts/docker-build"
       ],
       "candid": "rs/sns_aggregator/sns_aggregator.did",
       "wasm": "sns_aggregator.wasm",

--- a/scripts/deploy-snsdemo-testnet
+++ b/scripts/deploy-snsdemo-testnet
@@ -52,4 +52,5 @@ dfx-canister-set-id --canister_name sns_aggregator --canister_id "$AGGREGATOR_CA
 dfx canister info sns_aggregator
 
 : Deploy the aggregator
-RUSTFLAGS="--cfg feature=\"reconfigurable\"" dfx deploy sns_aggregator --network "$DFX_NETWORK"
+./scripts/docker-build
+dfx canister install sns_aggregator --network "$DFX_NETWORK" --wasm sns_aggregator_dev.wasm


### PR DESCRIPTION
# Motivation
* Require only docker in order to deploy `nns-dapp` and `sns_aggregator` to a testnet.
  * Having docker and dfx installed (properly!) is now enough to run: `dfx deploy nns-dapp --network small09`
  * Deployments _may_ be faster if the local docker cache is warm.
* Align testnet deployments more closely with production.
  * The canonical way of building a production image is with docker.  It would be nice if testnet deployments were built in (almost) the same way.

# Changes
* Change the build command in dfx.json to `scripts/docker-build`.

Note: Deploying any of the wasms involves building all the wasms.  This is definitely a point that can be improved.  If the dockerfile is broken down into smaller chunks, this will be possible.

# Tests
- See CI for local builds.
- I have deployed sns_aggregator and nns-dapp to small09 using this code.