### PR TITLE
GIX-1353: Add pollAccounts to nns wallet and accounts

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -5,8 +5,14 @@
   import { accountsStore } from "$lib/stores/accounts.store";
   import { nonNullish } from "@dfinity/utils";
   import type { Account } from "$lib/types/account";
+  import { onMount } from "svelte";
+  import { pollAccounts } from "$lib/services/accounts.services";
 
   export let goToWallet: (account: Account) => Promise<void>;
+
+  onMount(() => {
+    pollAccounts();
+  });
 </script>
 
 <div class="card-grid" data-tid="accounts-body">

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-  import { setContext } from "svelte";
+  import { setContext, onMount } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
-  import { getAccountTransactions } from "$lib/services/accounts.services";
+  import {
+    getAccountTransactions,
+    pollAccounts,
+  } from "$lib/services/accounts.services";
   import { accountsStore } from "$lib/stores/accounts.store";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
@@ -34,6 +37,10 @@
   import { Island } from "@dfinity/gix-components";
   import WalletModals from "$lib/modals/accounts/WalletModals.svelte";
   import Summary from "$lib/components/summary/Summary.svelte";
+
+  onMount(() => {
+    pollAccounts();
+  });
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);
 

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -26,6 +26,8 @@
   import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
   import { ENABLE_CKBTC_LEDGER } from "$lib/stores/feature-flags.store";
 
+  // TODO: This component is mounted twice. Understand why and fix it.
+
   // Selected project ID on mount is excluded from load accounts balances. See documentation.
   let selectedUniverseId = $selectedUniverseIdStore;
 

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -2,20 +2,21 @@
  * @jest-environment jsdom
  */
 
+import * as ledgerApi from "$lib/api/ledger.api";
+import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
-import {
-  accountsStore,
-  type AccountsStoreData,
-} from "$lib/stores/accounts.store";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
-import type { Subscriber } from "svelte/store";
 import {
-  mockAccountsStoreSubscribe,
+  mockAccountDetails,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
 } from "../../mocks/accounts.store.mock";
+
+jest.mock("$lib/api/nns-dapp.api");
+jest.mock("$lib/api/ledger.api");
 
 describe("NnsAccounts", () => {
   const goToWallet = async () => {
@@ -25,12 +26,16 @@ describe("NnsAccounts", () => {
   afterEach(() => jest.clearAllMocks());
 
   describe("when there are accounts", () => {
-    let accountsStoreMock: jest.SpyInstance;
+    beforeEach(() => {
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [],
+        hardwareWallets: [],
+        certified: true,
+      });
+    });
 
     it("should render a main card", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe());
       const { container } = render(NnsAccounts, { props: { goToWallet } });
 
       const article = container.querySelector("article");
@@ -38,9 +43,6 @@ describe("NnsAccounts", () => {
     });
 
     it("should render account icp in card too", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe());
       const { container } = render(NnsAccounts, { props: { goToWallet } });
 
       const cardTitleRow = container.querySelector(
@@ -53,17 +55,17 @@ describe("NnsAccounts", () => {
     });
 
     it("should render account identifier", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe());
       const { getByText } = render(NnsAccounts, { props: { goToWallet } });
       getByText(mockMainAccount.identifier);
     });
 
     it("should render subaccount cards", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [],
+        certified: true,
+      });
       const { container } = render(NnsAccounts, { props: { goToWallet } });
 
       const articles = container.querySelectorAll("article");
@@ -73,11 +75,12 @@ describe("NnsAccounts", () => {
     });
 
     it("should render hardware wallet account cards", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(
-          mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
-        );
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [],
+        hardwareWallets: [mockHardwareWalletAccount],
+        certified: true,
+      });
       const { container } = render(NnsAccounts, { props: { goToWallet } });
 
       const articles = container.querySelectorAll("article");
@@ -85,30 +88,18 @@ describe("NnsAccounts", () => {
       expect(articles).not.toBeNull();
       expect(articles.length).toBe(2);
     });
-
-    it("should subscribe to store", () => {
-      accountsStoreMock = jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe());
-      render(NnsAccounts, { props: { goToWallet } });
-
-      expect(accountsStoreMock).toHaveBeenCalled();
-    });
   });
 
   describe("summary", () => {
-    beforeAll(() =>
-      jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(
-          mockAccountsStoreSubscribe(
-            [mockSubAccount],
-            [mockHardwareWalletAccount]
-          )
-        )
-    );
-
-    afterAll(jest.clearAllMocks);
+    beforeAll(() => {
+      jest.clearAllMocks();
+      accountsStore.set({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [mockHardwareWalletAccount],
+        certified: true,
+      });
+    });
 
     it("should contain a tooltip", () => {
       const { container } = render(NnsAccounts, { props: { goToWallet } });
@@ -119,19 +110,14 @@ describe("NnsAccounts", () => {
 
   describe("when no accounts", () => {
     beforeEach(() => {
+      accountsStore.reset();
+      const mainBalanceE8s = BigInt(10_000_000);
       jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(
-          (run: Subscriber<AccountsStoreData>): (() => void) => {
-            run({
-              main: undefined,
-              subAccounts: undefined,
-              hardwareWallets: undefined,
-            });
-
-            return () => undefined;
-          }
-        );
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      jest
+        .spyOn(nnsDappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
     });
     it("should not render a token amount component nor zero", () => {
       const { container } = render(NnsAccounts, { props: { goToWallet } });
@@ -140,6 +126,13 @@ describe("NnsAccounts", () => {
       expect(
         container.querySelector(".tooltip-wrapper")
       ).not.toBeInTheDocument();
+    });
+
+    it("should load accounts", () => {
+      const { container } = render(NnsAccounts, { props: { goToWallet } });
+
+      const article = container.querySelector("article");
+      expect(article).not.toBeNull();
     });
   });
 });

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -2,17 +2,23 @@
  * @jest-environment jsdom
  */
 
+import * as ledgerApi from "$lib/api/ledger.api";
+import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import {
-  mockAccountsStoreSubscribe,
+  mockAccountDetails,
+  mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
 } from "../../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
+
+jest.mock("$lib/api/nns-dapp.api");
+jest.mock("$lib/api/ledger.api");
 
 jest.mock("$lib/services/accounts.services", () => ({
   ...(jest.requireActual("$lib/services/accounts.services") as object),
@@ -41,7 +47,22 @@ describe("NnsWallet", () => {
     );
   };
 
-  describe("loading", () => {
+  describe("no accounts", () => {
+    beforeEach(() => {
+      accountsStore.reset();
+      const mainBalanceE8s = BigInt(10_000_000);
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      jest
+        .spyOn(nnsDappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+    });
+
+    const props = {
+      accountIdentifier: mockMainAccount.identifier,
+    };
+
     it("should render a spinner while loading", () => {
       const { getByTestId } = render(NnsWallet);
 
@@ -53,12 +74,6 @@ describe("NnsWallet", () => {
 
       testToolbarButton({ container, disabled: true });
     });
-  });
-
-  describe("no accounts", () => {
-    const props = {
-      accountIdentifier: mockMainAccount.identifier,
-    };
 
     it("new transaction should remain disabled if route is valid but store is not loaded", async () => {
       const { container } = render(NnsWallet, props);
@@ -71,16 +86,23 @@ describe("NnsWallet", () => {
       // route set triggers get account
       testToolbarButton({ container, disabled: true });
     });
+
+    it("should show new accounts after being loaded", async () => {
+      const { queryByTestId } = render(NnsWallet, props);
+
+      expect(queryByTestId("projects-summary")).toBeNull();
+
+      await waitFor(() =>
+        expect(queryByTestId("projects-summary")).toBeInTheDocument()
+      );
+    });
   });
 
   describe("accounts loaded", () => {
     beforeAll(() => {
-      jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(mockAccountsStoreSubscribe());
+      jest.clearAllMocks();
+      accountsStore.set(mockAccountsStoreData);
     });
-
-    afterAll(() => jest.clearAllMocks());
 
     const props = {
       accountIdentifier: mockMainAccount.identifier,
@@ -92,14 +114,6 @@ describe("NnsWallet", () => {
       const titleRow = getByTestId("projects-summary");
 
       expect(titleRow).not.toBeNull();
-    });
-
-    it("should hide spinner when selected account is loaded", async () => {
-      const { container } = render(NnsWallet, props);
-
-      await waitFor(() =>
-        expect(container.querySelector('[data-tid="spinner"]')).toBeNull()
-      );
     });
 
     it("should enable new transaction action for route and store", async () => {
@@ -143,12 +157,11 @@ describe("NnsWallet", () => {
   });
 
   describe("accounts loaded (Hardware Wallet)", () => {
-    beforeAll(() => {
-      jest
-        .spyOn(accountsStore, "subscribe")
-        .mockImplementation(
-          mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
-        );
+    beforeEach(() => {
+      accountsStore.set({
+        ...mockAccountsStoreData,
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
     });
 
     const props = {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -16,12 +16,14 @@ import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-tr
 import Accounts from "$lib/routes/Accounts.svelte";
 import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
 import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { page } from "$mocks/$app/stores";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { mockAccountsStoreData } from "../../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import en from "../../mocks/i18n.mock";
 import { mockSnsMainAccount } from "../../mocks/sns-accounts.mock";
@@ -87,6 +89,8 @@ describe("Accounts", () => {
       certified: true,
       accounts: [mockSnsMainAccount],
     });
+
+    accountsStore.set(mockAccountsStoreData);
   });
 
   it("should render NnsAccounts by default", () => {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -7,11 +7,13 @@ import {
 } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Wallet from "$lib/routes/Wallet.svelte";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
+import { mockAccountsStoreData } from "../../mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "../../mocks/auth.store.mock";
 import { mockSnsFullProject, principal } from "../../mocks/sns-projects.mock";
 import { snsResponseFor } from "../../mocks/sns-response.mock";
@@ -43,6 +45,7 @@ describe("Wallet", () => {
         lifecycle: SnsSwapLifecycle.Committed,
       })
     );
+    accountsStore.set(mockAccountsStoreData);
   });
 
   beforeAll(() =>


### PR DESCRIPTION
# Motivation

In case the accounts fail to load on init. Retry to fetch them in the nns wallet and accounts.

# Changes

* Add a call to `onMount` in NnsWallet.
* Add a call to `onMount` in NnsAccounts.

# Tests

* Add for NnsWallet and NnsAccounts tests.
* Fill accounts store in Wallet and Accounts tests.
