### PR TITLE
Fix not equal to amount warning

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -57,6 +57,7 @@
 
   let userCommitment: undefined | bigint;
   $: userCommitment =
+    // swapCommitment=null - not initialized yet
     $projectDetailStore.swapCommitment === null
       ? undefined
       : getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
@@ -90,8 +91,6 @@
       return;
     }
 
-    assertNonNullish(userCommitment);
-
     snsTicketsStore.enablePolling(rootCanisterId);
 
     loadingTicketRootCanisterId = rootCanisterId.toText();
@@ -100,7 +99,7 @@
 
     await restoreSnsSaleParticipation({
       rootCanisterId,
-      userCommitment,
+      userCommitment: userCommitment!,
       postprocess: reload,
       updateProgress,
     });
@@ -113,7 +112,7 @@
   $: if (
     lifecycle === SnsSwapLifecycle.Open &&
     isSignedIn($authStore.identity) &&
-    userCommitment !== undefined
+    nonNullish(userCommitment)
   ) {
     updateTicket();
   }

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -106,7 +106,10 @@
     });
   };
 
-  // skip ticket update if the sns is not open
+  // skip ticket update if
+  // - the sns is not open
+  // - the user is not sign in
+  // - user commitment information is not loaded
   $: if (
     lifecycle === SnsSwapLifecycle.Open &&
     isSignedIn($authStore.identity) &&

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -16,7 +16,7 @@
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
   import type { Principal } from "@dfinity/principal";
-  import { assertNonNullish, nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import {
     hidePollingToast,
@@ -90,7 +90,10 @@
     ) {
       return;
     }
-
+    if (isNullish(userCommitment)) {
+      // Typescript guard, user commitment cannot be undefined here
+      return;
+    }
     snsTicketsStore.enablePolling(rootCanisterId);
 
     loadingTicketRootCanisterId = rootCanisterId.toText();
@@ -99,7 +102,7 @@
 
     await restoreSnsSaleParticipation({
       rootCanisterId,
-      userCommitment: userCommitment!,
+      userCommitment,
       postprocess: reload,
       updateProgress,
     });

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -16,7 +16,7 @@
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
   import type { Principal } from "@dfinity/principal";
-  import { nonNullish } from "@dfinity/utils";
+  import { assertNonNullish, nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import {
     hidePollingToast,
@@ -88,6 +88,8 @@
     ) {
       return;
     }
+
+    assertNonNullish(userCommitment);
 
     snsTicketsStore.enablePolling(rootCanisterId);
 

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -27,7 +27,7 @@
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
-  import { hasOpenTicketInProcess } from "$lib/utils/sns.utils";
+  import {getCommitmentE8s, hasOpenTicketInProcess} from "$lib/utils/sns.utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import SaleInProgress from "$lib/components/sale/SaleInProgress.svelte";
   import { SaleStep } from "$lib/types/sale";
@@ -113,11 +113,14 @@
       modal?.goProgress();
 
       const updateProgress = (step: SaleStep) => (progressStep = step);
+      const userCommitment = getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
+
 
       const { success } = await initiateSnsSaleParticipation({
         account: sourceAccount,
         amount: TokenAmount.fromNumber({ amount, token: ICPToken }),
         rootCanisterId: $projectDetailStore.summary.rootCanisterId,
+        userCommitment,
         postprocess: async () => {
           await reload();
         },

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -27,7 +27,10 @@
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
-  import {getCommitmentE8s, hasOpenTicketInProcess} from "$lib/utils/sns.utils";
+  import {
+    getCommitmentE8s,
+    hasOpenTicketInProcess,
+  } from "$lib/utils/sns.utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import SaleInProgress from "$lib/components/sale/SaleInProgress.svelte";
   import { SaleStep } from "$lib/types/sale";
@@ -113,8 +116,8 @@
       modal?.goProgress();
 
       const updateProgress = (step: SaleStep) => (progressStep = step);
-      const userCommitment = getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
-
+      const userCommitment =
+        getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
 
       const { success } = await initiateSnsSaleParticipation({
         account: sourceAccount,

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -368,7 +368,7 @@ const getProjectFromStore = (
 
 export interface ParticipateInSnsSaleParameters {
   rootCanisterId: Principal;
-  userCommitment: bigint | undefined;
+  userCommitment: bigint;
   postprocess: () => Promise<void>;
   updateProgress: (step: SaleStep) => void;
 }
@@ -538,7 +538,7 @@ const notifyParticipationAndRemoveTicket = async ({
   identity,
   hasTooOldError,
   ticket,
-                                                    userCommitment,
+  userCommitment,
 }: {
   rootCanisterId: Principal;
   identity: Identity;
@@ -557,7 +557,10 @@ const notifyParticipationAndRemoveTicket = async ({
     });
 
     // current_committed (the sum of all) ≠ ticket.amount + previous commitment
-    if (icp_accepted_participation_e8s !== ticket.amount_icp_e8s + userCommitment) {
+    if (
+      icp_accepted_participation_e8s !==
+      ticket.amount_icp_e8s + userCommitment
+    ) {
       toastsShow({
         level: "warn",
         labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -7,7 +7,15 @@ import type { SnsSummary, SnsSwapCommitment } from "./sns";
  * SnsSummary or SnsSwapCommitment is a valid project
  */
 export type ProjectDetailStore = {
+  /**
+   * `null` - not initialized<br>
+   * `undefined` - not found
+   */
   summary: SnsSummary | undefined | null;
+  /**
+   * `null` - not initialized<br>
+   * `undefined` - not found
+   */
   swapCommitment: SnsSwapCommitment | undefined | null;
 };
 

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -667,6 +667,7 @@ describe("sns-api", () => {
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -693,6 +694,7 @@ describe("sns-api", () => {
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -724,6 +726,7 @@ describe("sns-api", () => {
           token: ICPToken,
         }),
         account,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -771,6 +774,7 @@ describe("sns-api", () => {
           token: ICPToken,
         }),
         account,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -799,6 +803,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
       });
@@ -840,6 +845,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
       });
@@ -891,6 +897,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -931,6 +938,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -961,6 +969,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -997,6 +1006,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
       });
@@ -1038,6 +1048,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -1061,6 +1072,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -1085,6 +1097,7 @@ describe("sns-api", () => {
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
+          userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
         });
@@ -1116,6 +1129,7 @@ describe("sns-api", () => {
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
+          userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
         });
@@ -1145,6 +1159,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -1155,12 +1170,19 @@ describe("sns-api", () => {
     });
 
     it("should display a waring when current_committed ≠ ticket.amount", async () => {
+      spyOnNotifyParticipation.mockResolvedValue({
+        icp_accepted_participation_e8s: 100n,
+      });
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
+        ticket: {
+          ...testTicket,
+          amount_icp_e8s: 1n,
+        },
       });
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
       });
@@ -1172,6 +1194,56 @@ describe("sns-api", () => {
         })
       );
       expect(ticketFromStore().ticket).toEqual(null);
+    });
+
+    it("should not display a waring when current_committed = ticket.amount", async () => {
+      spyOnNotifyParticipation.mockResolvedValue({
+        icp_accepted_participation_e8s: 1n,
+      });
+      snsTicketsStore.setTicket({
+        rootCanisterId: rootCanisterIdMock,
+        ticket: {
+          ...testTicket,
+          amount_icp_e8s: 1n,
+        },
+      });
+      await participateInSnsSale({
+        rootCanisterId: testRootCanisterId,
+        userCommitment: 0n,
+        postprocess: jest.fn().mockResolvedValue(undefined),
+        updateProgress: jest.fn().mockResolvedValue(undefined),
+      });
+
+      expect(spyOnToastsShow).not.toBeCalledWith(
+        expect.objectContaining({
+          labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
+        })
+      );
+    });
+
+    it("should not display a waring when current_committed = ticket.amount for increase participation", async () => {
+      spyOnNotifyParticipation.mockResolvedValue({
+        icp_accepted_participation_e8s: 10n,
+      });
+      snsTicketsStore.setTicket({
+        rootCanisterId: rootCanisterIdMock,
+        ticket: {
+          ...testTicket,
+          amount_icp_e8s: 3n,
+        },
+      });
+      await participateInSnsSale({
+        rootCanisterId: testRootCanisterId,
+        userCommitment: 7n,
+        postprocess: jest.fn().mockResolvedValue(undefined),
+        updateProgress: jest.fn().mockResolvedValue(undefined),
+      });
+
+      expect(spyOnToastsShow).not.toBeCalledWith(
+        expect.objectContaining({
+          labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

Fix visibility logic of the "actual commitment not equals to ticket amount" warning to work not only for the first participation.

# Changes

- replace (ticket.amount != finalCommitment) with (ticket.amount + userCommitment != finalCommitment)

# Tests

- updated tests for warning visibility

# Screenshots

**Increasing participation w/o warning**
![Screen Recording 2023-02-28 at 23 10 17](https://user-images.githubusercontent.com/98811342/221993259-87cf0702-b433-4238-a671-9ad3bc3723d8.gif)



