### PR TITLE
GIX-1353: Poll accounts in neuron related modals

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -16,8 +16,14 @@
   import { neuronStake } from "$lib/utils/neuron.utils";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
   import { goto } from "$app/navigation";
+  import { onMount } from "svelte";
+  import { pollAccounts } from "$lib/services/accounts.services";
 
   export let neuron: NeuronInfo;
+
+  onMount(() => {
+    pollAccounts();
+  });
 
   const dispatcher = createEventDispatcher();
   const steps: WizardSteps = [

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -6,14 +6,19 @@
   import TransactionModal from "../accounts/NewTransaction/TransactionModal.svelte";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { WizardStep } from "@dfinity/gix-components";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
+  import { pollAccounts } from "$lib/services/accounts.services";
 
   export let neuron: NeuronInfo;
+
+  onMount(() => {
+    pollAccounts();
+  });
 
   let currentStep: WizardStep;
 

--- a/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
@@ -18,6 +18,12 @@
   import AddUserToHotkeys from "$lib/components/neurons/AddUserToHotkeys.svelte";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { definedNeuronsStore } from "$lib/stores/neurons.store";
+  import { onMount } from "svelte";
+  import { pollAccounts } from "$lib/services/accounts.services";
+
+  onMount(() => {
+    pollAccounts();
+  });
 
   const lastSteps: WizardSteps = [
     {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -3,7 +3,9 @@
  */
 
 import DisburseButton from "$lib/components/neuron-detail/actions/DisburseButton.svelte";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { fireEvent, render } from "@testing-library/svelte";
+import { mockAccountsStoreData } from "../../../../mocks/accounts.store.mock";
 import en from "../../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import NeuronContextTest from "../NeuronContextTest.svelte";
@@ -25,6 +27,8 @@ describe("DisburseButton", () => {
   });
 
   it("opens disburse nns neuron modal", async () => {
+    // To avoid that the modal requests the accounts
+    accountsStore.set(mockAccountsStoreData);
     const { container, queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -3,8 +3,10 @@
  */
 
 import NnsIncreaseStakeButton from "$lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { mockAccountsStoreData } from "../../../../mocks/accounts.store.mock";
 import en from "../../../../mocks/i18n.mock";
 import { mockNeuron } from "../../../../mocks/neurons.mock";
 import NeuronContextTest from "../NeuronContextTest.svelte";
@@ -26,6 +28,8 @@ describe("NnsIncreaseStakeButton", () => {
   });
 
   it("opens Increase Neuron Stake Modal", async () => {
+    // To avoid that the modal requests the accounts
+    accountsStore.set(mockAccountsStoreData);
     const { container } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
@@ -3,10 +3,12 @@
  */
 
 import NnsNeuronsFooter from "$lib/components/neurons/NnsNeuronsFooter.svelte";
+import { accountsStore } from "$lib/stores/accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { mockAccountsStoreData } from "../../../mocks/accounts.store.mock";
 import en from "../../../mocks/i18n.mock";
 import {
   buildMockNeuronsStoreSubscribe,
@@ -49,6 +51,8 @@ describe("NnsNeurons", () => {
     });
 
     it("should open the CreateNeuronModal on click to Stake Neurons", async () => {
+      // To avoid that the modal requests the accounts
+      accountsStore.set(mockAccountsStoreData);
       const { queryByTestId, queryByText } = render(NnsNeuronsFooter);
 
       const toolbarButton = queryByTestId("stake-neuron-button");

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import * as ledgerApi from "$lib/api/ledger.api";
+import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import DisburseNnsNeuronModal from "$lib/modals/neurons/DisburseNnsNeuronModal.svelte";
@@ -12,13 +14,16 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { get } from "svelte/store";
 import {
-  mockAccountsStoreSubscribe,
+  mockAccountDetails,
+  mockAccountsStoreData,
   mockMainAccount,
   mockSubAccount,
 } from "../../../mocks/accounts.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 import { mockNeuron } from "../../../mocks/neurons.mock";
 
+jest.mock("$lib/api/nns-dapp.api");
+jest.mock("$lib/api/ledger.api");
 jest.mock("$lib/services/neurons.services", () => {
   return {
     disburse: jest.fn().mockResolvedValue({ success: true }),
@@ -36,87 +41,116 @@ describe("DisburseNnsNeuronModal", () => {
     });
   };
 
-  beforeAll(() => {
-    jest
-      .spyOn(accountsStore, "subscribe")
-      .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
+  describe("when accounts are loaded", () => {
+    beforeEach(() => {
+      accountsStore.set({
+        ...mockAccountsStoreData,
+        subAccounts: [mockSubAccount],
+      });
+    });
+    it("should display modal", async () => {
+      const { container } = await renderDisburseModal(mockNeuron);
+
+      expect(container.querySelector("div.modal")).not.toBeNull();
+    });
+
+    it("should render accounts", async () => {
+      const { queryAllByTestId } = await renderDisburseModal(mockNeuron);
+
+      const accountCards = queryAllByTestId("account-card");
+      expect(accountCards.length).toBe(2);
+    });
+
+    it("should be able to select an account", async () => {
+      const { queryAllByTestId, queryByTestId } = await renderDisburseModal(
+        mockNeuron
+      );
+
+      const accountCards = queryAllByTestId("account-card");
+      expect(accountCards.length).toBe(2);
+
+      const firstAccount = accountCards[0];
+      await fireEvent.click(firstAccount);
+
+      const confirmScreen = queryByTestId("confirm-disburse-screen");
+      expect(confirmScreen).not.toBeNull();
+    });
+
+    it("should be able to add address in input", async () => {
+      const { container, queryByTestId } = await renderDisburseModal(
+        mockNeuron
+      );
+
+      const addressInput = container.querySelector("input[type='text']");
+      expect(addressInput).not.toBeNull();
+      const continueButton = queryByTestId("address-submit-button");
+      expect(continueButton).not.toBeNull();
+      expect(continueButton?.getAttribute("disabled")).not.toBeNull();
+
+      const address = mockMainAccount.identifier;
+      addressInput &&
+        (await fireEvent.input(addressInput, { target: { value: address } }));
+      expect(continueButton?.getAttribute("disabled")).toBeNull();
+
+      continueButton && (await fireEvent.click(continueButton));
+
+      const confirmScreen = queryByTestId("confirm-disburse-screen");
+      expect(confirmScreen).not.toBeNull();
+    });
+
+    it("should call disburse service", async () => {
+      const { container, queryByTestId } = await renderDisburseModal(
+        mockNeuron
+      );
+
+      const addressInput = container.querySelector("input[type='text']");
+      expect(addressInput).not.toBeNull();
+      const continueButton = queryByTestId("address-submit-button");
+      expect(continueButton).not.toBeNull();
+      expect(continueButton?.getAttribute("disabled")).not.toBeNull();
+
+      const address = mockMainAccount.identifier;
+      addressInput &&
+        (await fireEvent.input(addressInput, { target: { value: address } }));
+      expect(continueButton?.getAttribute("disabled")).toBeNull();
+
+      continueButton && (await fireEvent.click(continueButton));
+
+      const confirmScreen = queryByTestId("confirm-disburse-screen");
+      expect(confirmScreen).not.toBeNull();
+
+      const confirmButton = queryByTestId("disburse-neuron-button");
+      expect(confirmButton).not.toBeNull();
+
+      confirmButton && (await fireEvent.click(confirmButton));
+      expect(disburse).toBeCalled();
+      await waitFor(() => {
+        const { path } = get(pageStore);
+        expect(path).toEqual(AppPath.Neurons);
+      });
+    });
   });
 
-  it("should display modal", async () => {
-    const { container } = await renderDisburseModal(mockNeuron);
+  describe("when accounts store is empty", () => {
+    beforeEach(() => {
+      accountsStore.reset();
+    });
+    it("should fetch accounts and render account selector", async () => {
+      const mainBalanceE8s = BigInt(10_000_000);
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      jest
+        .spyOn(nnsDappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+      const { queryByTestId } = await renderDisburseModal(mockNeuron);
 
-    expect(container.querySelector("div.modal")).not.toBeNull();
-  });
+      expect(queryByTestId("account-card")).not.toBeInTheDocument();
 
-  it("should render accounts", async () => {
-    const { queryAllByTestId } = await renderDisburseModal(mockNeuron);
-
-    const accountCards = queryAllByTestId("account-card");
-    expect(accountCards.length).toBe(2);
-  });
-
-  it("should be able to select an account", async () => {
-    const { queryAllByTestId, queryByTestId } = await renderDisburseModal(
-      mockNeuron
-    );
-
-    const accountCards = queryAllByTestId("account-card");
-    expect(accountCards.length).toBe(2);
-
-    const firstAccount = accountCards[0];
-    await fireEvent.click(firstAccount);
-
-    const confirmScreen = queryByTestId("confirm-disburse-screen");
-    expect(confirmScreen).not.toBeNull();
-  });
-
-  it("should be able to add address in input", async () => {
-    const { container, queryByTestId } = await renderDisburseModal(mockNeuron);
-
-    const addressInput = container.querySelector("input[type='text']");
-    expect(addressInput).not.toBeNull();
-    const continueButton = queryByTestId("address-submit-button");
-    expect(continueButton).not.toBeNull();
-    expect(continueButton?.getAttribute("disabled")).not.toBeNull();
-
-    const address = mockMainAccount.identifier;
-    addressInput &&
-      (await fireEvent.input(addressInput, { target: { value: address } }));
-    expect(continueButton?.getAttribute("disabled")).toBeNull();
-
-    continueButton && (await fireEvent.click(continueButton));
-
-    const confirmScreen = queryByTestId("confirm-disburse-screen");
-    expect(confirmScreen).not.toBeNull();
-  });
-
-  it("should call disburse service", async () => {
-    const { container, queryByTestId } = await renderDisburseModal(mockNeuron);
-
-    const addressInput = container.querySelector("input[type='text']");
-    expect(addressInput).not.toBeNull();
-    const continueButton = queryByTestId("address-submit-button");
-    expect(continueButton).not.toBeNull();
-    expect(continueButton?.getAttribute("disabled")).not.toBeNull();
-
-    const address = mockMainAccount.identifier;
-    addressInput &&
-      (await fireEvent.input(addressInput, { target: { value: address } }));
-    expect(continueButton?.getAttribute("disabled")).toBeNull();
-
-    continueButton && (await fireEvent.click(continueButton));
-
-    const confirmScreen = queryByTestId("confirm-disburse-screen");
-    expect(confirmScreen).not.toBeNull();
-
-    const confirmButton = queryByTestId("disburse-neuron-button");
-    expect(confirmButton).not.toBeNull();
-
-    confirmButton && (await fireEvent.click(confirmButton));
-    expect(disburse).toBeCalled();
-    await waitFor(() => {
-      const { path } = get(pageStore);
-      expect(path).toEqual(AppPath.Neurons);
+      // Component is rendered after the accounts are loaded
+      await waitFor(() =>
+        expect(queryByTestId("account-card")).toBeInTheDocument()
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

Some nns neuron modals use the accounts: IncreaseStake, StakeNeuron, Disburse.

If initAccounts fail, use `pollAccoutns` to make sure the accounts are loaded.

# Changes

* Call `pollAccounts` on mount of DisburseNnsNeuronModal.svelte
* Call `pollAccounts` on mount of IncreaseNeuronStakeModal.svelte
* Call `pollAccounts` on mount of StakeNeuronModal.svelte

# Tests

* Load accounts store in tests that open the modals.
* Add scenario in each modal test that accounts are requested if they are not present in the store.
* Add a describe in the current tests for the modals with the acconts store loaded with accounts.
