### PR TITLE
Chore: ckbtc scripts deploy to testnet

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -109,8 +109,8 @@
       "build": [
         "true"
       ],
-      "candid": "target/ic/ic-icrc1-ledger.did",
-      "wasm": "target/ic/ic-icrc1-ledger.wasm",
+      "candid": "tmp/ledger.did",
+      "wasm": "tmp/ledger_canister.wasm",
       "type": "custom",
       "remote": {
         "id": {
@@ -118,12 +118,20 @@
         }
       }
     },
+    "ckbtc_minter": {
+      "build": [
+        "true"
+      ],
+      "candid": "tmp/minter.did",
+      "wasm": "tmp/ckbtc_minter.wasm",
+      "type": "custom"
+    },
     "ckbtc_index": {
       "build": [
         "true"
       ],
-      "candid": "target/ic/ic-icrc1-index.did",
-      "wasm": "target/ic/ic-icrc1-index.wasm",
+      "candid": "tmp/index.did",
+      "wasm": "tmp/index_canister.wasm",
       "type": "custom",
       "remote": {
         "id": {
@@ -157,7 +165,7 @@
     "staging": {
       "config": {
         "FETCH_ROOT_KEY": true,
-        "HOST": "https://nnsdapp.testnet.dfinity.network",
+        "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": false,
           "ENABLE_SNS_VOTING": false,

--- a/dfx.json
+++ b/dfx.json
@@ -165,7 +165,7 @@
     "staging": {
       "config": {
         "FETCH_ROOT_KEY": true,
-        "HOST": "https://nnsdapp.dfinity.network",
+        "HOST": "https://nnsdapp.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": false,
           "ENABLE_SNS_VOTING": false,

--- a/dfx.json
+++ b/dfx.json
@@ -109,8 +109,8 @@
       "build": [
         "true"
       ],
-      "candid": "tmp/ledger.did",
-      "wasm": "tmp/ledger_canister.wasm",
+      "candid": "target/ic/ckbtc_ledger.did",
+      "wasm": "target/ic/ckbtc_ledger.wasm",
       "type": "custom",
       "remote": {
         "id": {
@@ -122,16 +122,16 @@
       "build": [
         "true"
       ],
-      "candid": "tmp/minter.did",
-      "wasm": "tmp/ckbtc_minter.wasm",
+      "candid": "target/ic/ckbtc_minter.did",
+      "wasm": "target/ic/ckbtc_minter.wasm",
       "type": "custom"
     },
     "ckbtc_index": {
       "build": [
         "true"
       ],
-      "candid": "tmp/index.did",
-      "wasm": "tmp/index_canister.wasm",
+      "candid": "target/ic/ckbtc_index.did",
+      "wasm": "target/ic/ckbtc_index.wasm",
       "type": "custom",
       "remote": {
         "id": {

--- a/scripts/ckbtc/deploy-ckbtc
+++ b/scripts/ckbtc/deploy-ckbtc
@@ -3,16 +3,16 @@
 # Original source
 # https://github.com/dfinity/ckBTC-Minter-Frontend/blob/master/local_deploy.sh
 
-dfx canister create ckbtc_test_ledger
-dfx canister create ckbtc_test_minter
+dfx canister create ckbtc_ledger --network "$DFX_NETWORK"
+dfx canister create ckbtc_minter --network "$DFX_NETWORK"
 
-MINTERID="$(dfx canister id ckbtc_test_minter)"
+MINTERID="$(dfx canister id ckbtc_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
-LEDGERID="$(dfx canister id ckbtc_test_ledger)"
+LEDGERID="$(dfx canister id ckbtc_ledger --network "$DFX_NETWORK")"
 echo "$LEDGERID"
 
-echo "Step 2: deploying minter canister..."
-dfx deploy ckbtc_test_minter --argument "(record {
+# echo "Step 2: deploying minter canister..."
+dfx deploy ckbtc_minter --network "$DFX_NETWORK" --argument "(record {
     btc_network = variant { Regtest };
     ledger_id = principal \"$LEDGERID\";
     ecdsa_key_name = \"dfx_test_key\";
@@ -24,7 +24,7 @@ dfx deploy ckbtc_test_minter --argument "(record {
 
 echo "Step 3: deploying ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy ckbtc_test_ledger --argument "(record {
+dfx deploy ckbtc_ledger --network "$DFX_NETWORK" --argument "(record {
     token_symbol = \"ckBTC\";
     token_name = \"Token ckBTC\";
     minting_account = record { owner = principal \"$MINTERID\" };
@@ -40,23 +40,23 @@ dfx deploy ckbtc_test_ledger --argument "(record {
 })" --mode=reinstall
 
 echo "Step 4: deploying index canister..."
-dfx deploy ckbtc_test_index --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode=reinstall
+dfx deploy ckbtc_index --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode=reinstall
 
 # Example to mint ckBTC
 
-# BTCADDRESS="$(dfx canister call ckbtc_test_minter get_btc_address '(record {subaccount=null;})')"
-# dfx canister call ckbtc_test_minter update_balance '(record {subaccount=null;})'
-# WITHDRAWALADDRESS="$(dfx canister call ckbtc_test_minter get_withdrawal_account)"
+# BTCADDRESS="$(dfx canister call ckbtc_minter get_btc_address '(record {subaccount=null;})')"
+# dfx canister call ckbtc_minter update_balance '(record {subaccount=null;})'
+# WITHDRAWALADDRESS="$(dfx canister call ckbtc_minter get_withdrawal_account)"
 # echo $BTCADDRESS
 # echo $WITHDRAWALADDRESS
 #
 # cleaned_output=$(echo $WITHDRAWALADDRESS | sed -re 's/^\(|, \)$//g')
 #
-# dfx canister call ckbtc_test_ledger icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+# dfx canister call ckbtc_ledger icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
 #
 # Execute the command to get the input string and save the result
-# dfx canister call ckbtc_test_minter retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
+# dfx canister call ckbtc_minter retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
 
 echo "Step 5: transfer ckBTC to principal..."
 # record { owner= principal “”;}
-dfx canister call ckbtc_test_ledger icrc1_transfer "(record {from=null; to=record { owner= principal \"zapga-qy4oi-6wufm-hyjvl-tgcuy-6jfcn-zcfeh-i7yap-aupxz-s2bj7-cae\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+dfx canister call ckbtc_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"zapga-qy4oi-6wufm-hyjvl-tgcuy-6jfcn-zcfeh-i7yap-aupxz-s2bj7-cae\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"

--- a/scripts/ckbtc/download-ckbtc
+++ b/scripts/ckbtc/download-ckbtc
@@ -2,7 +2,7 @@
 
 # Download
 
-DIR=tmp
+DIR=target/ic
 
 if [ ! -d "$DIR" ]; then
   mkdir "$DIR"
@@ -13,14 +13,14 @@ IC_COMMIT="fcef36254e620a39d6e801155c9af11ef612559a"
 curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz -o "$DIR"/ckbtc_minter.wasm.gz
 gunzip "$DIR"/ckbtc_minter.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz -o "$DIR"/ledger_canister.wasm.gz
-gunzip "$DIR"/ledger_canister.wasm.gz
+curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz -o "$DIR"/ckbtc_ledger.wasm.gz
+gunzip "$DIR"/ckbtc_ledger.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index.wasm.gz -o "$DIR"/index_canister.wasm.gz
-gunzip "$DIR"/index_canister.wasm.gz
+curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index.wasm.gz -o "$DIR"/ckbtc_index.wasm.gz
+gunzip "$DIR"/ckbtc_index.wasm.gz
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did -o "$DIR"/minter.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did -o "$DIR"/ckbtc_minter.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/ledger/icrc1.did -o "$DIR"/ledger.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/ledger/icrc1.did -o "$DIR"/ckbtc_ledger.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/index/index.did -o "$DIR"/index.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/index/index.did -o "$DIR"/ckbtc_index.did


### PR DESCRIPTION
# Motivation

Use ckbtc scripts to deploy ckbtc canisters to a testnet.

# Changes

* Change dfx.json with where the ckbtc related wasms and did files live once downloaded with script.
* Rename the canisters in the ckbtc file to match the ones in dfx.json

# Tests

Not applicable
