### PR TITLE
fix: take transfer errors into consideration for modal close waiting

### DIFF
--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -1085,6 +1085,7 @@ describe("sns-api", () => {
         })
       );
       expect(ticketFromStore().ticket).toEqual(null);
+      expect(spyOnToastsSuccess).not.toBeCalled();
     });
 
     describe("TooOldError", () => {


### PR DESCRIPTION
# Motivation

A tiny adjustment to take transfer errors into consideration for modal close waiting time.

# Changes

- return the error state of the transfer

# Tests

- not provided
