### PR TITLE
Chore: Query call in pollAccounts in participation

### DIFF
--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -37,7 +37,7 @@
   import { pollAccounts } from "$lib/services/accounts.services";
 
   onMount(() => {
-    pollAccounts();
+    pollAccounts(false);
   });
 
   const { store: projectDetailStore, reload } =

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -375,7 +375,7 @@ const pollLoadAccounts = async (params: {
  *
  * If the accounts are not certified or not present, it will poll the request until it succeeds.
  *
- * @param certified Whether the accounts should be requeted as certified or not.
+ * @param certified Whether the accounts should be requested as certified or not.
  */
 export const pollAccounts = async (certified = true) => {
   const accounts = get(accountsStore);

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -374,8 +374,10 @@ const pollLoadAccounts = async (params: {
  * If the accounts are already loaded and certified, it will skip the request.
  *
  * If the accounts are not certified or not present, it will poll the request until it succeeds.
+ *
+ * @param certified Whether the accounts should be requeted as certified or not.
  */
-export const pollAccounts = async () => {
+export const pollAccounts = async (certified = true) => {
   const accounts = get(accountsStore);
 
   // Skip if accounts are already loaded and certified
@@ -389,7 +391,7 @@ export const pollAccounts = async () => {
     const identity = await getAuthenticatedIdentity();
     const certifiedAccounts = await pollLoadAccounts({
       identity,
-      certified: true,
+      certified,
     });
     accountsStore.set(certifiedAccounts);
   } catch (err) {

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -705,6 +705,28 @@ describe("accounts-services", () => {
       expect(accounts).toEqual(mockAccounts);
     });
 
+    it("calls apis with certified param used", async () => {
+      const mainBalanceE8s = BigInt(10_000_000);
+      const queryAccountBalanceSpy = jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      const queryAccountSpy = jest
+        .spyOn(nnsdappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+
+      await pollAccounts(false);
+
+      expect(queryAccountSpy).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+      expect(queryAccountBalanceSpy).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        accountIdentifier: mockAccountDetails.account_identifier,
+        certified: false,
+      });
+    });
+
     it("polls if queryAccount fails", async () => {
       const mainBalanceE8s = BigInt(10_000_000);
 


### PR DESCRIPTION
# Motivation

Improve performance and handle more concurrent users.

# Changes

* Add `certified = true` param to `pollAccounts`.
* Pass `false` in `pollAccounts` call in ParticipateSwapModal.svelte.

# Tests

* Test that requests are query calls in ParticipateSwapModal.
* Test new functionality in `pollAccounts`.
