### PR TITLE
fix: remove redundant error on TYPE_TICKET_EXISTS

### DIFF
--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -262,8 +262,7 @@ const handleNewSaleTicketError = ({
             ticket: existingTicket,
           });
         }
-        // break to jump to the generic error message
-        break;
+        return;
       }
       case NewSaleTicketResponseErrorType.TYPE_INVALID_USER_AMOUNT: {
         const { min_amount_icp_e8s_included, max_amount_icp_e8s_included } =

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -500,6 +500,7 @@ describe("sns-api", () => {
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
+      expect(spyOnToastsError).not.toBeCalled();
       expect(spyOnToastsShow).toBeCalledWith(
         expect.objectContaining({
           labelKey: "error__sns.sns_sale_proceed_with_existing_ticket",


### PR DESCRIPTION
# Motivation

Fix wrong `TYPE_TICKET_EXISTS` handling.

# Changes

- return after notification on `TYPE_TICKET_EXISTS`

# Tests

- updated to not display an error


![Untitled](https://user-images.githubusercontent.com/98811342/222134706-223fbe1b-20bb-44f5-b2c1-01f537f00f08.gif)

