### PR TITLE
Chore: Force query calls

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -58,6 +58,7 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
   SNS_AGGREGATOR_CANISTER_URL:
     "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network",
   STAKE_MATURITY: true,
+  FORCE_CALL_STRATEGY: undefined,
 }));
 
 global.localStorage = localStorageMock;

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -1,9 +1,6 @@
 import { createAgent } from "$lib/api/agent.api";
 import { WASM_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import {
-  FORCE_CALL_STRATEGY,
-  HOST,
-} from "$lib/constants/environment.constants";
+import { HOST } from "$lib/constants/environment.constants";
 import {
   importInitSnsWrapper,
   importSnsWasmCanister,
@@ -150,14 +147,13 @@ export const wrappers = async ({
   identity: Identity;
 }): Promise<Map<QueryRootCanisterId, SnsWrapper>> => {
   const principalText = identity.getPrincipal().toText();
-  const overriedCertified = FORCE_CALL_STRATEGY === "query" ? false : certified;
   if (certified) {
     if (identitiesCertifiedWrappers[principalText] === undefined) {
       // the initialization of the wrappers can be called mutliple times at the same time when the app loads.
       // We cache the promise so that if multiple calls are made then all will resolve when the first init resolve.
       identitiesCertifiedWrappers[principalText] = initWrappers({
         identity,
-        certified: overriedCertified,
+        certified,
       });
     }
     return identitiesCertifiedWrappers[principalText];
@@ -165,7 +161,7 @@ export const wrappers = async ({
     if (identitiesNotCertifiedWrappers[principalText] === undefined) {
       identitiesNotCertifiedWrappers[principalText] = initWrappers({
         identity,
-        certified: overriedCertified,
+        certified,
       });
     }
     return identitiesNotCertifiedWrappers[principalText];

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -1,6 +1,9 @@
 import { createAgent } from "$lib/api/agent.api";
 import { WASM_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { HOST } from "$lib/constants/environment.constants";
+import {
+  FORCE_CALL_STRATEGY,
+  HOST,
+} from "$lib/constants/environment.constants";
 import {
   importInitSnsWrapper,
   importSnsWasmCanister,
@@ -147,13 +150,14 @@ export const wrappers = async ({
   identity: Identity;
 }): Promise<Map<QueryRootCanisterId, SnsWrapper>> => {
   const principalText = identity.getPrincipal().toText();
+  const overriedCertified = FORCE_CALL_STRATEGY === "query" ? false : certified;
   if (certified) {
     if (identitiesCertifiedWrappers[principalText] === undefined) {
       // the initialization of the wrappers can be called mutliple times at the same time when the app loads.
       // We cache the promise so that if multiple calls are made then all will resolve when the first init resolve.
       identitiesCertifiedWrappers[principalText] = initWrappers({
         identity,
-        certified,
+        certified: overriedCertified,
       });
     }
     return identitiesCertifiedWrappers[principalText];
@@ -161,7 +165,7 @@ export const wrappers = async ({
     if (identitiesNotCertifiedWrappers[principalText] === undefined) {
       identitiesNotCertifiedWrappers[principalText] = initWrappers({
         identity,
-        certified,
+        certified: overriedCertified,
       });
     }
     return identitiesNotCertifiedWrappers[principalText];

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -45,3 +45,5 @@ export const IS_TESTNET: boolean =
 
 // TODO: disable TVL display locally until we use the XCR canister to fetch teh ICP<>USD exchange rate and a certified endpoint to fetch the TVL
 export const ENABLE_TVL = !DEV;
+
+export const FORCE_CALL_STRATEGY: "query" | undefined = "query";

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -43,7 +43,11 @@ const handleFindProposalsError = ({
   identity: Identity;
 }) => {
   console.error(err);
-  if (certified || identity.getPrincipal().isAnonymous()) {
+  if (
+    certified ||
+    identity.getPrincipal().isAnonymous() ||
+    FORCE_CALL_STRATEGY === "query"
+  ) {
     proposalsStore.setProposals({ proposals: [], certified });
 
     toastsError({
@@ -175,7 +179,7 @@ const findProposals = async ({
     request: ({ certified, identity }) =>
       queryProposals({ beforeProposal, identity, filters, certified }),
     onLoad: ({ response: proposals, certified }) => {
-      if (certified === false) {
+      if (!certified) {
         uncertifiedProposals = proposals;
         onLoad({ response: proposals, certified });
         return;

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -8,6 +8,7 @@ import {
   ProposalPayloadTooLargeError,
 } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import {
   proposalPayloadsStore,
   proposalsFiltersStore,
@@ -169,6 +170,7 @@ const findProposals = async ({
   let uncertifiedProposals: ProposalInfo[] | undefined;
 
   return queryAndUpdate<ProposalInfo[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     identityType: "current",
     request: ({ certified, identity }) =>
       queryProposals({ beforeProposal, identity, filters, certified }),

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -103,7 +103,11 @@ export const loadSnsSummaries = (): Promise<void> => {
     onError: ({ error: err, certified, identity }) => {
       console.error(err);
 
-      if (certified || identity.getPrincipal().isAnonymous()) {
+      if (
+        certified ||
+        identity.getPrincipal().isAnonymous() ||
+        FORCE_CALL_STRATEGY === "query"
+      ) {
         snsQueryStore.setLoadingState();
 
         toastsError(
@@ -137,7 +141,11 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
     onError: ({ error: err, certified, identity }) => {
       console.error(err);
 
-      if (certified || identity.getPrincipal().isAnonymous()) {
+      if (
+        certified ||
+        identity.getPrincipal().isAnonymous() ||
+        FORCE_CALL_STRATEGY === "query"
+      ) {
         snsProposalsStore.setLoadingState();
 
         toastsError(
@@ -193,7 +201,11 @@ export const loadSnsNervousSystemFunctions = async (
     onError: ({ certified, error, identity }) => {
       // If the user is not logged in, only a query is done.
       // Therefore, we want to show an error even if the error doesn't come from a certified call.
-      if (certified || identity.getPrincipal().isAnonymous()) {
+      if (
+        certified ||
+        identity.getPrincipal().isAnonymous() ||
+        FORCE_CALL_STRATEGY === "query"
+      ) {
         toastsError({
           labelKey: "error__sns.sns_load_functions",
           err: error,

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -1,6 +1,7 @@
 import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { queryAllSnsMetadata, querySnsSwapStates } from "$lib/api/sns.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
@@ -92,6 +93,7 @@ export const loadSnsSummaries = (): Promise<void> => {
 
   return queryAndUpdate<[QuerySnsMetadata[], QuerySnsSwapState[]], unknown>({
     identityType: "anonymous",
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       Promise.all([
         queryAllSnsMetadata({ certified, identity }),
@@ -121,6 +123,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
 
   return queryAndUpdate<ProposalInfo[], unknown>({
     identityType: "anonymous",
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified }) =>
       loadProposalsByTopic({
         certified,
@@ -160,6 +163,7 @@ export const loadSnsNervousSystemFunctions = async (
   }
 
   return queryAndUpdate<SnsNervousSystemFunction[], Error>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getNervousSystemFunctions({
         rootCanisterId,

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -381,6 +381,7 @@ const pollLoadAccounts = async (params: {
  * @param certified Whether the accounts should be requested as certified or not.
  */
 export const pollAccounts = async (certified = true) => {
+  const overriedCertified = FORCE_CALL_STRATEGY === "query" ? false : certified;
   const accounts = get(accountsStore);
 
   // Skip if accounts are already loaded and certified
@@ -394,7 +395,7 @@ export const pollAccounts = async (certified = true) => {
     const identity = await getAuthenticatedIdentity();
     const certifiedAccounts = await pollLoadAccounts({
       identity,
-      certified,
+      certified: overriedCertified,
     });
     accountsStore.set(certifiedAccounts);
   } catch (err) {

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -265,7 +265,7 @@ export const getAccountTransactions = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -18,6 +18,7 @@ import {
   SYNC_ACCOUNTS_RETRY_SECONDS,
 } from "$lib/constants/accounts.constants";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
@@ -158,6 +159,7 @@ export const syncAccounts = (
       errorHandler({ err, certified });
     },
     logMessage: "Syncing Accounts",
+    strategy: FORCE_CALL_STRATEGY,
   });
 };
 
@@ -249,6 +251,7 @@ export const getAccountTransactions = async ({
   }) => void;
 }): Promise<void> =>
   queryAndUpdate<Transaction[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getTransactions({
         identity,

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -13,6 +13,7 @@ import type {
   CanisterSettings,
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
@@ -40,6 +41,7 @@ export const listCanisters = async ({
 
   return queryAndUpdate<CanisterInfo[], unknown>({
     request: (options) => queryCanisters(options),
+    strategy: FORCE_CALL_STRATEGY,
     onLoad: ({ response: canisters, certified }) =>
       canistersStore.setCanisters({ canisters, certified }),
     onError: ({ error: err, certified }) => {

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -47,7 +47,7 @@ export const listCanisters = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -31,7 +31,7 @@ export const loadCkBTCAccounts = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -1,5 +1,6 @@
 import { ckBTCTransfer, getCkBTCAccounts } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
 import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
@@ -19,6 +20,7 @@ export const loadCkBTCAccounts = async ({
   handleError?: () => void;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getCkBTCAccounts({ identity, certified }),
     onLoad: ({ response: accounts, certified }) =>

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -33,7 +33,7 @@ export const loadCkBTCToken = async ({
         token,
       }),
     onError: ({ error: err, certified }) => {
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -1,5 +1,6 @@
 import { getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -19,6 +20,7 @@ export const loadCkBTCToken = async ({
   }
 
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getCkBTCToken({
         identity,

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -256,7 +256,7 @@ export const listNeurons = async ({
       callback?.(certified);
     },
     onError: ({ error, certified }) => {
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 
@@ -904,7 +904,7 @@ export const loadNeuron = ({
     onError: ({ error, certified }) => {
       console.error(error);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
       catchError(error);

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1,7 +1,10 @@
 import { neuronsApiService } from "$lib/api-services/neurons.api-service";
 import { makeDummyProposals as makeDummyProposalsApi } from "$lib/api/dev.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { IS_TESTNET } from "$lib/constants/environment.constants";
+import {
+  FORCE_CALL_STRATEGY,
+  IS_TESTNET,
+} from "$lib/constants/environment.constants";
 import {
   CANDID_PARSER_VERSION,
   MIN_VERSION_STAKE_MATURITY_WORKAROUND,
@@ -244,7 +247,7 @@ export const listNeurons = async ({
   strategy?: QueryAndUpdateStrategy;
 } = {}): Promise<void> => {
   return queryAndUpdate<NeuronInfo[], unknown>({
-    strategy,
+    strategy: strategy ?? FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       neuronsApiService.queryNeurons({ certified, identity }),
     onLoad: async ({ response: neurons, certified }) => {

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -1,5 +1,6 @@
 import type { IcrcTransferParams } from "$lib/api/icrc-ledger.api";
 import { getSnsAccounts, snsTransfer } from "$lib/api/sns-ledger.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
 import { loadSnsToken } from "$lib/services/sns-tokens.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
@@ -24,6 +25,7 @@ export const loadSnsAccounts = async ({
   handleError?: () => void;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getSnsAccounts({ rootCanisterId, identity, certified }),
     onLoad: ({ response: accounts, certified }) =>

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -19,6 +19,7 @@ import {
   querySnsNeurons,
   stakeNeuron as stakeNeuronApi,
 } from "$lib/api/sns.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import {
@@ -99,7 +100,7 @@ export const syncSnsNeurons = async (
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/sns-parameters.services.ts
+++ b/frontend/src/lib/services/sns-parameters.services.ts
@@ -1,4 +1,5 @@
 import { nervousSystemParameters } from "$lib/api/sns-governance.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
@@ -16,6 +17,7 @@ export const loadSnsParameters = async (
     return;
   }
   await queryAndUpdate<NervousSystemParameters, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       nervousSystemParameters({
         rootCanisterId,

--- a/frontend/src/lib/services/sns-parameters.services.ts
+++ b/frontend/src/lib/services/sns-parameters.services.ts
@@ -33,7 +33,11 @@ export const loadSnsParameters = async (
     onError: ({ error: err, certified, identity }) => {
       console.error(err);
 
-      if (certified || identity.getPrincipal().isAnonymous()) {
+      if (
+        certified ||
+        identity.getPrincipal().isAnonymous() ||
+        FORCE_CALL_STRATEGY === "query"
+      ) {
         snsParametersStore.resetProject(rootCanisterId);
 
         toastsError(

--- a/frontend/src/lib/services/sns-tokens.services.ts
+++ b/frontend/src/lib/services/sns-tokens.services.ts
@@ -1,4 +1,5 @@
 import { getSnsToken } from "$lib/api/sns-ledger.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -21,6 +22,7 @@ export const loadSnsToken = async ({
   }
 
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getSnsToken({
         identity,

--- a/frontend/src/lib/services/sns-tokens.services.ts
+++ b/frontend/src/lib/services/sns-tokens.services.ts
@@ -32,7 +32,7 @@ export const loadSnsToken = async ({
     onLoad: async ({ response: token, certified }) =>
       tokensStore.setToken({ certified, canisterId: rootCanisterId, token }),
     onError: ({ error: err, certified }) => {
-      if (certified) {
+      if (certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -69,7 +69,7 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 
@@ -107,7 +107,11 @@ export const loadSnsSwapCommitment = async ({
     onError: ({ error: err, certified, identity }) => {
       console.error(err);
 
-      if (certified || identity.getPrincipal().isAnonymous()) {
+      if (
+        certified ||
+        identity.getPrincipal().isAnonymous() ||
+        FORCE_CALL_STRATEGY === "query"
+      ) {
         toastsError(
           toToastError({
             err,

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -4,6 +4,7 @@ import {
   querySnsSwapCommitment,
   querySnsSwapCommitments,
 } from "$lib/api/sns.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import {
   snsQueryStore,
   snsSummariesStore,
@@ -54,6 +55,7 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
     return;
   }
   return queryAndUpdate<SnsSwapCommitment[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsSwapCommitments({ certified, identity }),
     onLoad: ({ response: swapCommitments, certified }) => {
@@ -93,6 +95,7 @@ export const loadSnsSwapCommitment = async ({
   onError?: () => void;
 }) =>
   queryAndUpdate<SnsSwapCommitment, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsSwapCommitment({
         rootCanisterId,

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -1,4 +1,5 @@
 import { transactionFee as snsTransactionFee } from "$lib/api/sns-ledger.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
 import { toastsError } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Principal } from "@dfinity/principal/lib/cjs";
@@ -18,6 +19,7 @@ export const loadSnsTransactionFee = async ({
     return;
   }
   return queryAndUpdate<bigint, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       snsTransactionFee({
         identity,

--- a/frontend/src/lib/services/transaction-fees.services.ts
+++ b/frontend/src/lib/services/transaction-fees.services.ts
@@ -30,7 +30,7 @@ export const loadSnsTransactionFee = async ({
       transactionsFeesStore.setFee({ certified, rootCanisterId, fee });
     },
     onError: ({ error: err, certified }) => {
-      if (certified !== true) {
+      if (!certified && FORCE_CALL_STRATEGY !== "query") {
         return;
       }
 


### PR DESCRIPTION
# Motivation

Improve performance of the nns dapp by dropping update calls.

# Changes

* Add a new constant FORCE_CALL_STRATEGY
* Use the new constant in all the `queryAndUpdate` calls reviewed by security and accepted to be query calls.

# Tests

* No tests were broken. Tests checked that calls were made, but not the number of them.
