### PR TITLE
Feat: get_open_ticket update call

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -902,7 +902,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC_LEDGER": false
         }
       },

--- a/frontend/src/lib/api/sns-sale.api.ts
+++ b/frontend/src/lib/api/sns-sale.api.ts
@@ -1,31 +1,37 @@
+import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
+import { SnsSwapCanister } from "@dfinity/sns";
 import type {
   RefreshBuyerTokensResponse,
   Ticket,
 } from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
+import { createAgent } from "./agent.api";
 import { wrapper } from "./sns-wrapper.api";
 
 export const getOpenTicket = async ({
   identity,
-  rootCanisterId,
+  swapCanisterId,
   certified,
 }: {
   identity: Identity;
-  rootCanisterId: Principal;
+  swapCanisterId: Principal;
   certified: boolean;
 }): Promise<Ticket | undefined> => {
   logWithTimestamp(`[sale] getOpenTicket call...`);
-
-  const { getOpenTicket } = await wrapper({
+  const agent = await createAgent({
     identity,
-    rootCanisterId: rootCanisterId.toText(),
-    certified,
+    host: HOST,
   });
 
-  const response = await getOpenTicket({});
+  const canister = SnsSwapCanister.create({
+    canisterId: swapCanisterId,
+    agent,
+  });
+
+  const response = await canister.getOpenTicket({ certified });
 
   logWithTimestamp(`[sale] getOpenTicket complete.`);
 

--- a/frontend/src/lib/api/sns-sale.api.ts
+++ b/frontend/src/lib/api/sns-sale.api.ts
@@ -1,3 +1,4 @@
+import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
@@ -8,7 +9,6 @@ import type {
   Ticket,
 } from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
-import { createAgent } from "./agent.api";
 import { wrapper } from "./sns-wrapper.api";
 
 export const getOpenTicket = async ({

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -25,8 +25,15 @@ import { nonNullish } from "@dfinity/utils";
 interface IdentityWrapper {
   [principal: string]: Promise<Map<QueryRootCanisterId, SnsWrapper>>;
 }
-const identitiesCertifiedWrappers: IdentityWrapper = {};
-const identitiesNotCertifiedWrappers: IdentityWrapper = {};
+
+let identitiesCertifiedWrappers: IdentityWrapper = {};
+let identitiesNotCertifiedWrappers: IdentityWrapper = {};
+
+// ONLY FOR TESTING PURPOSES
+export const clearWrapperCache = () => {
+  identitiesCertifiedWrappers = {};
+  identitiesNotCertifiedWrappers = {};
+};
 
 type CanisterIds = {
   rootCanisterId: Principal;

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -10,15 +10,75 @@ import { ApiErrorKey } from "$lib/types/api.errors";
 import type { QueryRootCanisterId } from "$lib/types/sns.query";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { HttpAgent, Identity } from "@dfinity/agent";
+import { IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger";
 import type { DeployedSns, SnsWasmCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import type { InitSnsWrapper, SnsWrapper } from "@dfinity/sns";
+import {
+  SnsGovernanceCanister,
+  SnsRootCanister,
+  SnsSwapCanister,
+  SnsWrapper,
+  type InitSnsWrapper,
+} from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 
 interface IdentityWrapper {
   [principal: string]: Promise<Map<QueryRootCanisterId, SnsWrapper>>;
 }
 const identitiesCertifiedWrappers: IdentityWrapper = {};
 const identitiesNotCertifiedWrappers: IdentityWrapper = {};
+
+type CanisterIds = {
+  rootCanisterId: Principal;
+  governanceCanisterId: Principal;
+  ledgerCanisterId: Principal;
+  swapCanisterId: Principal;
+  indexCanisterId: Principal;
+};
+export const buildAndStoreWrapper = async ({
+  identity,
+  certified,
+  canisterIds: {
+    rootCanisterId,
+    governanceCanisterId,
+    ledgerCanisterId,
+    swapCanisterId,
+    indexCanisterId,
+  },
+}: {
+  identity: Identity;
+  certified: boolean;
+  canisterIds: CanisterIds;
+}) => {
+  const agent = await createAgent({
+    identity,
+    host: HOST,
+  });
+  const wrapper = new SnsWrapper({
+    root: SnsRootCanister.create({ canisterId: rootCanisterId, agent }),
+    governance: SnsGovernanceCanister.create({
+      canisterId: governanceCanisterId,
+      agent,
+    }),
+    ledger: IcrcLedgerCanister.create({ canisterId: ledgerCanisterId, agent }),
+    swap: SnsSwapCanister.create({ canisterId: swapCanisterId, agent }),
+    index: IcrcIndexCanister.create({ canisterId: indexCanisterId, agent }),
+    certified,
+  });
+
+  const identitiesMap = certified
+    ? identitiesCertifiedWrappers
+    : identitiesNotCertifiedWrappers;
+
+  if (nonNullish(identitiesMap[identity.getPrincipal().toText()])) {
+    const wrappersMap = await identitiesMap[identity.getPrincipal().toText()];
+    wrappersMap.set(rootCanisterId.toText(), wrapper);
+  } else {
+    identitiesMap[identity.getPrincipal().toText()] = Promise.resolve(
+      new Map([[rootCanisterId.toText(), wrapper]])
+    );
+  }
+};
 
 /**
  * List all deployed Snses - i.e list all Sns projects

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -10,8 +10,24 @@
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import { goto } from "$app/navigation";
   import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
+  import { loadSnsSwapCommitment } from "$lib/services/sns.services";
+  import { isSignedIn } from "$lib/utils/auth.utils";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let project: SnsFullProject;
+
+  const loadSnsSale = async () => {
+    if (!isSignedIn($authStore.identity)) {
+      return;
+    }
+
+    await loadSnsSwapCommitment({
+      rootCanisterId: project.summary.rootCanisterId.toText(),
+      forceFetch: false,
+    });
+  };
+
+  $: $authStore.identity, loadSnsSale();
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -10,24 +10,8 @@
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import { goto } from "$app/navigation";
   import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
-  import { loadSnsSwapCommitment } from "$lib/services/sns.services";
-  import { isSignedIn } from "$lib/utils/auth.utils";
-  import { authStore } from "$lib/stores/auth.store";
 
   export let project: SnsFullProject;
-
-  const loadSnsSale = async () => {
-    if (!isSignedIn($authStore.identity)) {
-      return;
-    }
-
-    await loadSnsSwapCommitment({
-      rootCanisterId: project.summary.rootCanisterId.toText(),
-      forceFetch: false,
-    });
-  };
-
-  $: $authStore.identity, loadSnsSale();
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -37,8 +37,10 @@
     getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
 
   let lifecycle: number;
+  let swapCanisterId: Principal;
   $: ({
     swap: { lifecycle },
+    swapCanisterId,
   } =
     $projectDetailStore.summary ??
     ({
@@ -82,7 +84,7 @@
 
   let progressStep: SaleStep | undefined = undefined;
 
-  const updateTicket = async () => {
+  const updateTicket = async (swapCanisterId: Principal) => {
     // Avoid second call for the same rootCanisterId
     if (
       rootCanisterId === undefined ||
@@ -103,6 +105,7 @@
     await restoreSnsSaleParticipation({
       rootCanisterId,
       userCommitment,
+      swapCanisterId,
       postprocess: reload,
       updateProgress,
     });
@@ -112,14 +115,14 @@
   // - the sns is not open
   // - the user is not sign in
   // - user commitment information is not loaded
-  // - project summary is not loaded, to avoid building a wrapper instead of using a cached one
+  // - project swap canister id is not loaded, needed for the ticket call
   $: if (
     lifecycle === SnsSwapLifecycle.Open &&
     isSignedIn($authStore.identity) &&
     nonNullish(userCommitment) &&
-    nonNullish($projectDetailStore.summary)
+    nonNullish(swapCanisterId)
   ) {
-    updateTicket();
+    updateTicket(swapCanisterId);
   }
 
   let userHasParticipatedToSwap = false;

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -112,10 +112,12 @@
   // - the sns is not open
   // - the user is not sign in
   // - user commitment information is not loaded
+  // - project summary is not loaded, to avoid building a wrapper instead of using a cached one
   $: if (
     lifecycle === SnsSwapLifecycle.Open &&
     isSignedIn($authStore.identity) &&
-    nonNullish(userCommitment)
+    nonNullish(userCommitment) &&
+    nonNullish($projectDetailStore.summary)
   ) {
     updateTicket();
   }

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -7,19 +7,6 @@
     snsProjectsAdoptedStore,
     snsProjectsCommittedStore,
   } from "$lib/derived/sns/sns-projects.derived";
-  import { loadSnsSwapCommitments } from "$lib/services/sns.services";
-  import { authStore } from "$lib/stores/auth.store";
-  import { isSignedIn } from "$lib/utils/auth.utils";
-
-  const loadSnsSale = async () => {
-    if (!isSignedIn($authStore.identity)) {
-      return;
-    }
-
-    await loadSnsSwapCommitments();
-  };
-
-  $: $authStore.identity, (async () => await loadSnsSale())();
 
   let showCommitted = false;
   $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -7,6 +7,17 @@
     snsProjectsAdoptedStore,
     snsProjectsCommittedStore,
   } from "$lib/derived/sns/sns-projects.derived";
+  import { loadSnsSwapCommitments } from "$lib/services/sns.services";
+  import { authStore } from "$lib/stores/auth.store";
+  import { isSignedIn } from "$lib/utils/auth.utils";
+
+  const loadSnsSale = async () => {
+    if (!isSignedIn($authStore.identity)) {
+      return;
+    }
+    await loadSnsSwapCommitments();
+  };
+  $: $authStore.identity, (async () => await loadSnsSale())();
 
   let showCommitted = false;
   $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -29,13 +29,7 @@
 
   export let rootCanisterId: string | undefined | null;
 
-  // Wait until the project summary is loaded.
-  // This way the sns wrapper will be cached.
-  $: if (
-    nonNullish(rootCanisterId) &&
-    isSignedIn($authStore.identity) &&
-    nonNullish($projectDetailStore.summary)
-  ) {
+  $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
     loadCommitment({ rootCanisterId, forceFetch: false });
   }
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -29,11 +29,23 @@
 
   export let rootCanisterId: string | undefined | null;
 
-  $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
-    loadCommitment(rootCanisterId);
+  // Wait until the project summary is loaded.
+  // This way the sns wrapper will be cached.
+  $: if (
+    nonNullish(rootCanisterId) &&
+    isSignedIn($authStore.identity) &&
+    nonNullish($projectDetailStore.summary)
+  ) {
+    loadCommitment({ rootCanisterId, forceFetch: false });
   }
 
-  const loadCommitment = (rootCanisterId: string) =>
+  const loadCommitment = ({
+    rootCanisterId,
+    forceFetch,
+  }: {
+    rootCanisterId: string;
+    forceFetch: boolean;
+  }) =>
     loadSnsSwapCommitment({
       rootCanisterId,
       onError: () => {
@@ -41,6 +53,7 @@
         $projectDetailStore.swapCommitment = undefined;
         goBack();
       },
+      forceFetch,
     });
 
   const reload = async () => {
@@ -52,7 +65,7 @@
     await Promise.all([
       loadSnsTotalCommitment({ rootCanisterId }),
       loadSnsLifecycle({ rootCanisterId }),
-      loadCommitment(rootCanisterId),
+      loadCommitment({ rootCanisterId, forceFetch: true }),
     ]);
   };
 

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -26,36 +26,32 @@ export const loadSnsProjects = async (): Promise<void> => {
   try {
     const cachedSnses = await querySnsProjects();
     const identity = getCurrentIdentity();
-    if (!identity.getPrincipal().isAnonymous()) {
-      // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
-      // The SNS Aggregator gives us the canister ids of the SNS projects.
-      await Promise.all(
-        cachedSnses.map(async ({ canister_ids }) => {
-          const canisterIds = {
-            rootCanisterId: Principal.fromText(canister_ids.root_canister_id),
-            swapCanisterId: Principal.fromText(canister_ids.swap_canister_id),
-            governanceCanisterId: Principal.fromText(
-              canister_ids.governance_canister_id
-            ),
-            ledgerCanisterId: Principal.fromText(
-              canister_ids.ledger_canister_id
-            ),
-            indexCanisterId: Principal.fromText(canister_ids.index_canister_id),
-          };
-          // Build certified and uncertified wrappers because SNS aggregator gives certified data.
-          await buildAndStoreWrapper({
-            identity,
-            certified: true,
-            canisterIds,
-          });
-          await buildAndStoreWrapper({
-            identity,
-            certified: false,
-            canisterIds,
-          });
-        })
-      );
-    }
+    // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
+    // The SNS Aggregator gives us the canister ids of the SNS projects.
+    await Promise.all(
+      cachedSnses.map(async ({ canister_ids }) => {
+        const canisterIds = {
+          rootCanisterId: Principal.fromText(canister_ids.root_canister_id),
+          swapCanisterId: Principal.fromText(canister_ids.swap_canister_id),
+          governanceCanisterId: Principal.fromText(
+            canister_ids.governance_canister_id
+          ),
+          ledgerCanisterId: Principal.fromText(canister_ids.ledger_canister_id),
+          indexCanisterId: Principal.fromText(canister_ids.index_canister_id),
+        };
+        // Build certified and uncertified wrappers because SNS aggregator gives certified data.
+        await buildAndStoreWrapper({
+          identity,
+          certified: true,
+          canisterIds,
+        });
+        await buildAndStoreWrapper({
+          identity,
+          certified: false,
+          canisterIds,
+        });
+      })
+    );
     const snsQueryStoreData: [QuerySnsMetadata[], QuerySnsSwapState[]] = [
       cachedSnses.map((sns) => ({
         rootCanisterId: sns.canister_ids.root_canister_id,

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,12 +1,16 @@
+import { loadSnsProjects } from "./$public/sns.services";
 import { initAccounts } from "./accounts.services";
 
 export const initAppPrivateData = (): Promise<
-  [PromiseSettledResult<void[]>]
+  [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [initAccounts()];
+  // Reload the SNS projects even if they were loaded.
+  // Get latest data and create wrapper caches for the logged in identity.
+  const initSns: Promise<void>[] = [loadSnsProjects()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
-  return Promise.allSettled([Promise.all(initNns)]);
+  return Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
 };

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -106,11 +106,13 @@ const SALE_FAILURES_BEFORE_HIGHlOAD_MESSAGE = 6;
 // Export for testing purposes
 const pollGetOpenTicket = async ({
   rootCanisterId,
+  swapCanisterId,
   identity,
   certified,
   maxAttempts,
 }: {
   rootCanisterId: Principal;
+  swapCanisterId: Principal;
   identity: Identity;
   certified: boolean;
   maxAttempts?: number;
@@ -122,7 +124,7 @@ const pollGetOpenTicket = async ({
       fn: (): Promise<Ticket | undefined> =>
         getOpenTicketApi({
           identity,
-          rootCanisterId,
+          swapCanisterId,
           certified,
         }),
       shouldExit: shouldStopPollingTicket(rootCanisterId),
@@ -154,10 +156,12 @@ const getTicketErrorMapper: Record<GetOpenTicketErrorType, string> = {
  */
 export const loadOpenTicket = async ({
   rootCanisterId,
+  swapCanisterId,
   certified,
   maxAttempts = MAX_ATTEMPS_FOR_TICKET,
 }: {
   rootCanisterId: Principal;
+  swapCanisterId: Principal;
   certified: boolean;
   maxAttempts?: number;
 }): Promise<void> => {
@@ -165,6 +169,7 @@ export const loadOpenTicket = async ({
     const identity = await getCurrentIdentity();
     const ticket = await pollGetOpenTicket({
       identity,
+      swapCanisterId,
       rootCanisterId,
       certified,
       maxAttempts,
@@ -377,16 +382,20 @@ export interface ParticipateInSnsSaleParameters {
 
 export const restoreSnsSaleParticipation = async ({
   rootCanisterId,
+  swapCanisterId,
   userCommitment,
   postprocess,
   updateProgress,
-}: ParticipateInSnsSaleParameters): Promise<void> => {
+}: ParticipateInSnsSaleParameters & {
+  swapCanisterId: Principal;
+}): Promise<void> => {
   // avoid concurrent restores
   if (nonNullish(get(snsTicketsStore)[rootCanisterId?.toText()]?.ticket)) {
     return;
   }
 
   await loadOpenTicket({
+    swapCanisterId,
     rootCanisterId,
     certified: true,
   });

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -106,8 +106,9 @@ export const loadSnsSwapCommitment = async ({
     return;
   }
 
+  // We use update when we want to force fetch the data to make sure we have the latest data.
   queryAndUpdate<SnsSwapCommitment, unknown>({
-    strategy: FORCE_CALL_STRATEGY,
+    strategy: forceFetch ? "update" : FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsSwapCommitment({
         rootCanisterId,

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -54,6 +54,7 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
   ) {
     return;
   }
+
   return queryAndUpdate<SnsSwapCommitment[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
@@ -90,10 +91,21 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
 export const loadSnsSwapCommitment = async ({
   rootCanisterId,
   onError,
+  forceFetch,
 }: {
   rootCanisterId: string;
   onError?: () => void;
-}) =>
+  forceFetch: boolean;
+}) => {
+  const swapCommitment = (get(snsSwapCommitmentsStore) ?? []).find(
+    ({ swapCommitment }) =>
+      swapCommitment.rootCanisterId.toText() === rootCanisterId
+  );
+
+  if (nonNullish(swapCommitment) && !forceFetch) {
+    return;
+  }
+
   queryAndUpdate<SnsSwapCommitment, unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
@@ -124,6 +136,7 @@ export const loadSnsSwapCommitment = async ({
     },
     logMessage: "Syncing Sns swap commitment",
   });
+};
 
 export const loadSnsTotalCommitment = async ({
   rootCanisterId,

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -13,6 +13,8 @@ import {
   importSnsWasmCanister,
 } from "$lib/proxy/api.import.proxy";
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
+import { SnsSwapCanister } from "@dfinity/sns";
+import { mock } from "jest-mock-extended";
 import { mockIdentity, mockPrincipal } from "../../mocks/auth.store.mock";
 import {
   deployedSnsMock,
@@ -42,6 +44,7 @@ describe("sns-sale.api", () => {
     .mockResolvedValue(participationResponse);
 
   beforeEach(() => {
+    jest.clearAllMocks();
     (importSnsWasmCanister as jest.Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       create: (options: SnsWasmCanisterOptions) => ({
@@ -65,15 +68,20 @@ describe("sns-sale.api", () => {
     );
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
-
   it("should query open ticket", async () => {
+    const snsSwapCanister = mock<SnsSwapCanister>();
+    snsSwapCanister.getOpenTicket.mockResolvedValue(
+      snsTicketMock({
+        rootCanisterId: rootCanisterIdMock,
+        owner: mockIdentity.getPrincipal(),
+      }).ticket
+    );
+    jest
+      .spyOn(SnsSwapCanister, "create")
+      .mockImplementation((): SnsSwapCanister => snsSwapCanister);
     const result = await getOpenTicket({
       identity: mockIdentity,
-      rootCanisterId: rootCanisterIdMock,
+      swapCanisterId: swapCanisterIdMock,
       certified: true,
     });
 

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -1,10 +1,16 @@
-import { initSns, wrappers } from "$lib/api/sns-wrapper.api";
+import {
+  buildAndStoreWrapper,
+  clearWrapperCache,
+  initSns,
+  wrappers,
+} from "$lib/api/sns-wrapper.api";
 import type { HttpAgent } from "@dfinity/agent";
 import mock from "jest-mock-extended/lib/Mock";
 import { mockIdentity } from "../../mocks/auth.store.mock";
 import {
   deployedSnsMock,
   governanceCanisterIdMock,
+  indexCanisterIdMock,
   ledgerCanisterIdMock,
   rootCanisterIdMock,
   swapCanisterIdMock,
@@ -34,11 +40,24 @@ jest.mock("$lib/proxy/api.import.proxy", () => {
 });
 
 describe("sns-wrapper api", () => {
+  beforeEach(() => {
+    clearWrapperCache();
+    jest.clearAllMocks();
+  });
+
   describe("wrappers", () => {
     it("calls list to all Snses", async () => {
       await wrappers({ identity: mockIdentity, certified: false });
 
       expect(listSnsesSpy).toHaveBeenCalled();
+    });
+
+    it("caches wrappers", async () => {
+      await wrappers({ identity: mockIdentity, certified: false });
+      expect(listSnsesSpy).toHaveBeenCalledTimes(1);
+
+      await wrappers({ identity: mockIdentity, certified: false });
+      expect(listSnsesSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -52,6 +71,55 @@ describe("sns-wrapper api", () => {
       });
 
       expect(initSnsWrapperSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("buildAndStoreWrapper", () => {
+    const canisterIds = {
+      rootCanisterId: rootCanisterIdMock,
+      governanceCanisterId: governanceCanisterIdMock,
+      ledgerCanisterId: ledgerCanisterIdMock,
+      swapCanisterId: swapCanisterIdMock,
+      indexCanisterId: indexCanisterIdMock,
+    };
+
+    it("should build and cache certified wrapper", async () => {
+      const identity = mockIdentity;
+      const certified = true;
+      await buildAndStoreWrapper({
+        identity,
+        certified,
+        canisterIds,
+      });
+
+      expect(wrappers({ identity, certified })).resolves.not.toBeUndefined();
+    });
+
+    it("should build and cache uncertified wrapper", async () => {
+      const identity = mockIdentity;
+      const certified = false;
+      await buildAndStoreWrapper({
+        identity,
+        certified,
+        canisterIds,
+      });
+
+      expect(wrappers({ identity, certified })).resolves.not.toBeUndefined();
+    });
+
+    it("should not trigger listSnses when wrapper is cached", async () => {
+      const identity = mockIdentity;
+      const certified = false;
+      await buildAndStoreWrapper({
+        identity,
+        certified,
+        canisterIds,
+      });
+
+      await wrappers({ identity, certified });
+      await wrappers({ identity, certified });
+
+      expect(listSnsesSpy).not.toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
 import { toastsStore } from "@dfinity/gix-components";
@@ -8,6 +9,8 @@ import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 import { get } from "svelte/store";
 import { mockAccountDetails } from "../../mocks/accounts.store.mock";
+
+jest.mock("$lib/api/sns-aggregator.api");
 
 describe("app-services", () => {
   const mockLedgerCanister = mock<LedgerCanister>();
@@ -25,6 +28,8 @@ describe("app-services", () => {
       .mockImplementation((): NNSDappCanister => mockNNSDappCanister);
 
     jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    jest.spyOn(aggregatorApi, "querySnsProjects").mockResolvedValue([]);
   });
 
   it("should init Nns", async () => {
@@ -42,6 +47,12 @@ describe("app-services", () => {
     await expect(mockLedgerCanister.accountBalance).toHaveBeenCalledTimes(
       numberOfCalls
     );
+  });
+
+  it("shuold init SNS", async () => {
+    await initAppPrivateData();
+
+    await expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
   });
 
   it("should not show errors if loading accounts fails", async () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -41,6 +41,7 @@ import { Principal } from "@dfinity/principal";
 import {
   GetOpenTicketErrorType,
   NewSaleTicketResponseErrorType,
+  SnsSwapCanister,
   SnsSwapGetOpenTicketError,
   SnsSwapLifecycle,
   SnsSwapNewTicketError,
@@ -110,7 +111,7 @@ describe("sns-api", () => {
     owner: mockPrincipal,
   });
   const testTicket = testSnsTicket.ticket;
-  const spyOnGetOpenTicketApi = jest.fn();
+  const snsSwapCanister = mock<SnsSwapCanister>();
   const spyOnNewSaleTicketApi = jest.fn();
   const spyOnNotifyPaymentFailureApi = jest.fn();
   const ticketFromStore = (rootCanisterId = testRootCanisterId) =>
@@ -177,11 +178,15 @@ describe("sns-api", () => {
           Promise.resolve([mockQueryMetadataResponse, mockQueryTokenResponse]),
         swapState: () => Promise.resolve(mockQuerySwap),
         notifyParticipation: spyOnNotifyParticipation,
-        getOpenTicket: spyOnGetOpenTicketApi,
         newSaleTicket: spyOnNewSaleTicketApi,
         notifyPaymentFailure: spyOnNotifyPaymentFailureApi,
       })
     );
+
+    // `getOpenTicket` is mocked from the SnsSwapCanister not the wrapper
+    jest
+      .spyOn(SnsSwapCanister, "create")
+      .mockImplementation((): SnsSwapCanister => snsSwapCanister);
 
     jest
       .spyOn(authStore, "subscribe")
@@ -201,13 +206,14 @@ describe("sns-api", () => {
         jest.useFakeTimers().setSystemTime(now);
       });
       it("should call api and load ticket in the store", async () => {
-        spyOnGetOpenTicketApi.mockResolvedValue(testSnsTicket.ticket);
+        snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
-        expect(spyOnGetOpenTicketApi).toBeCalledTimes(1);
+        expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(1);
         expect(ticketFromStore(testSnsTicket.rootCanisterId).ticket).toEqual(
           testTicket
         );
@@ -216,13 +222,14 @@ describe("sns-api", () => {
       it("should retry until gets an open ticket", async () => {
         // Success in the fourth attempt
         const retriesUntilSuccess = 4;
-        spyOnGetOpenTicketApi
+        snsSwapCanister.getOpenTicket
           .mockRejectedValueOnce(new Error("network error"))
           .mockRejectedValueOnce(new Error("network error"))
           .mockRejectedValueOnce(new Error("network error"))
           .mockResolvedValue(testSnsTicket.ticket);
         loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -230,11 +237,10 @@ describe("sns-api", () => {
         let retryDelay = SALE_PARTICIPATION_RETRY_SECONDS * 1000;
         const extraRetries = 4;
         while (counter < retriesUntilSuccess + extraRetries) {
-          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+          expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
             Math.min(counter, retriesUntilSuccess)
           );
           counter += 1;
-          await null;
           await null;
           await null;
           await null;
@@ -242,7 +248,7 @@ describe("sns-api", () => {
           retryDelay *= 2;
 
           await waitFor(() =>
-            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
               Math.min(counter, retriesUntilSuccess)
             )
           );
@@ -254,14 +260,19 @@ describe("sns-api", () => {
             testTicket
           )
         );
-        expect(spyOnGetOpenTicketApi).toBeCalledTimes(retriesUntilSuccess);
+        expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
+          retriesUntilSuccess
+        );
       });
 
       it("should stop retrying after max attempts and set ticket to null", async () => {
         const maxAttempts = 10;
-        spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
+          new Error("network error")
+        );
         loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
           maxAttempts,
         });
@@ -269,7 +280,7 @@ describe("sns-api", () => {
         let counter = 0;
         let retryDelay = SALE_PARTICIPATION_RETRY_SECONDS * 1000;
         while (counter <= maxAttempts) {
-          expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
+          expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(counter);
           counter += 1;
           await null;
           await null;
@@ -277,7 +288,7 @@ describe("sns-api", () => {
           retryDelay *= 2;
 
           await waitFor(() =>
-            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
               Math.min(counter, maxAttempts)
             )
           );
@@ -292,25 +303,27 @@ describe("sns-api", () => {
       });
 
       it("should call api once if error is known", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
         );
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
-        expect(spyOnGetOpenTicketApi).toBeCalledTimes(1);
+        expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(1);
       });
 
       it("should set store to `null` on closed error", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
         );
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -320,12 +333,13 @@ describe("sns-api", () => {
       });
 
       it("should show error on closed", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
         );
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -337,12 +351,13 @@ describe("sns-api", () => {
       });
 
       it("should set store to `null` on unspecified type error", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
         );
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -352,12 +367,13 @@ describe("sns-api", () => {
       });
 
       it("should show error on unspecified type error", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
         );
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -369,7 +385,7 @@ describe("sns-api", () => {
       });
 
       it("should set store to `null` on not open error", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(
             GetOpenTicketErrorType.TYPE_SALE_NOT_OPEN
           )
@@ -377,6 +393,7 @@ describe("sns-api", () => {
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -386,7 +403,7 @@ describe("sns-api", () => {
       });
 
       it("should show error on not open error", async () => {
-        spyOnGetOpenTicketApi.mockRejectedValue(
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
           new SnsSwapGetOpenTicketError(
             GetOpenTicketErrorType.TYPE_SALE_NOT_OPEN
           )
@@ -394,6 +411,7 @@ describe("sns-api", () => {
 
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -413,9 +431,12 @@ describe("sns-api", () => {
       });
       it("should stop retrying", async () => {
         snsTicketsStore.enablePolling(testSnsTicket.rootCanisterId);
-        spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
+        snsSwapCanister.getOpenTicket.mockRejectedValue(
+          new Error("network error")
+        );
         loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
+          swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
@@ -424,17 +445,16 @@ describe("sns-api", () => {
         const retriesBeforeStopPolling = 4;
         // We loop until 10 advancing time, but the polling should stop after `retriesBeforeStopPolling` + 1
         while (counter < DEFAULT_MAX_POLLING_ATTEMPTS) {
-          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+          expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
             Math.min(counter, retriesBeforeStopPolling)
           );
           counter += 1;
-          await null;
           await null;
           jest.advanceTimersByTime(retryDelay);
           retryDelay *= 2;
 
           await waitFor(() =>
-            expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+            expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
               Math.min(counter, retriesBeforeStopPolling)
             )
           );
@@ -446,7 +466,7 @@ describe("sns-api", () => {
         expect(counter).toBe(DEFAULT_MAX_POLLING_ATTEMPTS);
 
         await waitFor(() =>
-          expect(spyOnGetOpenTicketApi).toBeCalledTimes(
+          expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
             retriesBeforeStopPolling
           )
         );
@@ -679,12 +699,13 @@ describe("sns-api", () => {
 
   describe("restoreSnsSaleParticipation", () => {
     it("should perform successful participation flow if open ticket", async () => {
-      spyOnGetOpenTicketApi.mockResolvedValue(testSnsTicket.ticket);
+      snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
+        swapCanisterId: swapCanisterIdMock,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
@@ -703,7 +724,7 @@ describe("sns-api", () => {
     });
 
     it("should not start flow if no open tickeet", async () => {
-      spyOnGetOpenTicketApi.mockResolvedValue(undefined);
+      snsSwapCanister.getOpenTicket.mockResolvedValue(undefined);
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
       const startBusySpy = jest
@@ -712,6 +733,7 @@ describe("sns-api", () => {
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
+        swapCanisterId: swapCanisterIdMock,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,

--- a/frontend/src/tests/mocks/sns.api.mock.ts
+++ b/frontend/src/tests/mocks/sns.api.mock.ts
@@ -37,6 +37,10 @@ export const swapCanisterIdMock: Principal = Principal.fromText(
   "kuwf5-5qaaa-aaaaa-aacqq-cai"
 );
 
+export const indexCanisterIdMock: Principal = Principal.fromText(
+  "pin7y-wyaaa-aaaaa-aacpa-cai"
+);
+
 export const snsMock: [string, Principal, SnsCanisterStatus][] = [
   ["root", rootCanisterIdMock, {} as unknown as SnsCanisterStatus],
   ["ledger", ledgerCanisterIdMock, {} as unknown as SnsCanisterStatus],


### PR DESCRIPTION
# Motivation

Avoid unnecessary update calls.

Our calls to SNS canisters use the sns wrapper. The sns wrapper calls the SNS-W and Root canister on initialization.

Yet, we don't really need to because the canister ids for each SNS project are already provided by the SNS Aggregator.

Therefore, this PR builds the wrappers after getting the data from SNS Aggregator and adds them to the cache.

Otherwise, there would be two extra update calls to SNS canisters when we get the open ticket with the update call.

# Changes

* New util `buildAndStoreWrapper` in `sns-wrapper.api`.
* Use the new util `buildAndStoreWrapper` after fetching the data from the SNS Aggregator.
* In ParticipateButton, wait until summary is present to load the ticket. This way the cached wrapper will be used.
* Changes in `loadSnsSwapCommitment`. Check whether we already have the user commitment to avoid getting it again.
* Change `rootCanisterId` for `swapCanisterId` in the `getOpenTicket` sns sale api to use the SnsSwapCanister directly instead of the wrapper.
* Fix calls to `getOpenTicket` and parent calls to add the `swapCanisterId` as param

# Tests

* Add test for `buildAndStoreWrapper`.
* Add test case for `wrappers`.
* Add missing test for `loadSnsSwapCommitment`.
* Fix tests after refactoring getOpenTicket to use SnsSwapCanister.
* Add test cases in app.services