### PR TITLE
Feat: Do not poll twice

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -18,7 +18,7 @@
   import { goto } from "$app/navigation";
   import { onMount } from "svelte";
   import {
-    clearPollAccounts,
+    cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
 
@@ -29,7 +29,7 @@
   });
 
   onDestroy(() => {
-    clearPollAccounts();
+    cancelPollAccounts();
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -11,18 +11,25 @@
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { stopBusy } from "$lib/stores/busy.store";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onDestroy } from "svelte";
   import { disburse } from "$lib/services/neurons.services";
   import { neuronStake } from "$lib/utils/neuron.utils";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
   import { goto } from "$app/navigation";
   import { onMount } from "svelte";
-  import { pollAccounts } from "$lib/services/accounts.services";
+  import {
+    clearPollAccounts,
+    pollAccounts,
+  } from "$lib/services/accounts.services";
 
   export let neuron: NeuronInfo;
 
   onMount(() => {
     pollAccounts();
+  });
+
+  onDestroy(() => {
+    clearPollAccounts();
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
@@ -13,16 +13,23 @@
     type WizardStep,
   } from "@dfinity/gix-components";
   import { wizardStepIndex } from "@dfinity/gix-components";
-  import { createEventDispatcher, tick } from "svelte";
+  import { createEventDispatcher, onDestroy, tick } from "svelte";
   import { toastsError, toastsShow } from "$lib/stores/toasts.store";
   import AddUserToHotkeys from "$lib/components/neurons/AddUserToHotkeys.svelte";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
   import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import { onMount } from "svelte";
-  import { pollAccounts } from "$lib/services/accounts.services";
+  import {
+    clearPollAccounts,
+    pollAccounts,
+  } from "$lib/services/accounts.services";
 
   onMount(() => {
     pollAccounts();
+  });
+
+  onDestroy(() => {
+    clearPollAccounts();
   });
 
   const lastSteps: WizardSteps = [

--- a/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/StakeNeuronModal.svelte
@@ -20,7 +20,7 @@
   import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import { onMount } from "svelte";
   import {
-    clearPollAccounts,
+    cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
 
@@ -29,7 +29,7 @@
   });
 
   onDestroy(() => {
-    clearPollAccounts();
+    cancelPollAccounts();
   });
 
   const lastSteps: WizardSteps = [

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -40,7 +40,7 @@
   import SaleInProgress from "$lib/components/sale/SaleInProgress.svelte";
   import { SaleStep } from "$lib/types/sale";
   import {
-    clearPollAccounts,
+    cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
 
@@ -49,7 +49,7 @@
   });
 
   onDestroy(() => {
-    clearPollAccounts();
+    cancelPollAccounts();
   });
 
   const { store: projectDetailStore, reload } =

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { ICPToken, TokenAmount } from "@dfinity/nns";
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import {
+    createEventDispatcher,
+    getContext,
+    onDestroy,
+    onMount,
+  } from "svelte";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
@@ -34,10 +39,17 @@
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import SaleInProgress from "$lib/components/sale/SaleInProgress.svelte";
   import { SaleStep } from "$lib/types/sale";
-  import { pollAccounts } from "$lib/services/accounts.services";
+  import {
+    clearPollAccounts,
+    pollAccounts,
+  } from "$lib/services/accounts.services";
 
   onMount(() => {
     pollAccounts(false);
+  });
+
+  onDestroy(() => {
+    clearPollAccounts();
   });
 
   const { store: projectDetailStore, reload } =

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -7,7 +7,7 @@
   import type { Account } from "$lib/types/account";
   import { onDestroy, onMount } from "svelte";
   import {
-    clearPollAccounts,
+    cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
 
@@ -18,7 +18,7 @@
   });
 
   onDestroy(() => {
-    clearPollAccounts();
+    cancelPollAccounts();
   });
 </script>
 

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -6,8 +6,10 @@
   import { nonNullish } from "@dfinity/utils";
   import type { Account } from "$lib/types/account";
   import { onDestroy, onMount } from "svelte";
-  import { pollAccounts } from "$lib/services/accounts.services";
-  import { clearCurrentPolls } from "$lib/utils/utils";
+  import {
+    clearPollAccounts,
+    pollAccounts,
+  } from "$lib/services/accounts.services";
 
   export let goToWallet: (account: Account) => Promise<void>;
 
@@ -16,7 +18,7 @@
   });
 
   onDestroy(() => {
-    clearCurrentPolls();
+    clearPollAccounts();
   });
 </script>
 

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -5,13 +5,18 @@
   import { accountsStore } from "$lib/stores/accounts.store";
   import { nonNullish } from "@dfinity/utils";
   import type { Account } from "$lib/types/account";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { pollAccounts } from "$lib/services/accounts.services";
+  import { clearCurrentPolls } from "$lib/utils/utils";
 
   export let goToWallet: (account: Account) => Promise<void>;
 
   onMount(() => {
     pollAccounts();
+  });
+
+  onDestroy(() => {
+    clearCurrentPolls();
   });
 </script>
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
   import {
-    clearPollAccounts,
+    cancelPollAccounts,
     getAccountTransactions,
     pollAccounts,
   } from "$lib/services/accounts.services";
@@ -44,7 +44,7 @@
   });
 
   onDestroy(() => {
-    clearPollAccounts();
+    cancelPollAccounts();
   });
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { setContext, onMount } from "svelte";
+  import { setContext, onMount, onDestroy } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
   import {
+    clearPollAccounts,
     getAccountTransactions,
     pollAccounts,
   } from "$lib/services/accounts.services";
@@ -40,6 +41,10 @@
 
   onMount(() => {
     pollAccounts();
+  });
+
+  onDestroy(() => {
+    clearPollAccounts();
   });
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -29,9 +29,15 @@ import type { Account, AccountType } from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";
 import { findAccount, getAccountByPrincipal } from "$lib/utils/accounts.utils";
 import { toToastError } from "$lib/utils/error.utils";
-import { poll, pollingLimit } from "$lib/utils/utils";
+import {
+  cancelPoll,
+  poll,
+  pollingCancelled,
+  pollingLimit,
+} from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
@@ -358,14 +364,16 @@ const renameError = ({
 };
 
 const ACCOUNTS_RETRY_MILLIS = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
+const pollAccountsId = Symbol();
 const pollLoadAccounts = async (params: {
   identity: Identity;
   certified: boolean;
-}): Promise<AccountsStoreData> =>
+}): Promise<AccountsStoreData | undefined> =>
   poll({
     fn: () => loadAccounts(params),
     // Any error is an unknown error and worth a retry
     shouldExit: () => false,
+    pollId: pollAccountsId,
     useExponentialBackoff: true,
     maxAttempts: SYNC_ACCOUNTS_RETRY_MAX_ATTEMPTS,
     millisecondsToWait: ACCOUNTS_RETRY_MILLIS,
@@ -397,8 +405,14 @@ export const pollAccounts = async (certified = true) => {
       identity,
       certified: overriedCertified,
     });
-    accountsStore.set(certifiedAccounts);
+    if (nonNullish(certifiedAccounts)) {
+      accountsStore.set(certifiedAccounts);
+    }
   } catch (err) {
+    // Don't show error if polling was cancelled
+    if (pollingCancelled(err)) {
+      return;
+    }
     const errorKey = pollingLimit(err)
       ? "error.accounts_not_found_poll"
       : "error.accounts_not_found";
@@ -410,3 +424,5 @@ export const pollAccounts = async (certified = true) => {
     );
   }
 };
+
+export const clearPollAccounts = () => cancelPoll(pollAccountsId);

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -368,7 +368,7 @@ const pollAccountsId = Symbol();
 const pollLoadAccounts = async (params: {
   identity: Identity;
   certified: boolean;
-}): Promise<AccountsStoreData | undefined> =>
+}): Promise<AccountsStoreData> =>
   poll({
     fn: () => loadAccounts(params),
     // Any error is an unknown error and worth a retry
@@ -405,9 +405,7 @@ export const pollAccounts = async (certified = true) => {
       identity,
       certified: overriedCertified,
     });
-    if (nonNullish(certifiedAccounts)) {
-      accountsStore.set(certifiedAccounts);
-    }
+    accountsStore.set(certifiedAccounts);
   } catch (err) {
     // Don't show error if polling was cancelled
     if (pollingCancelled(err)) {
@@ -425,4 +423,4 @@ export const pollAccounts = async (certified = true) => {
   }
 };
 
-export const clearPollAccounts = () => cancelPoll(pollAccountsId);
+export const cancelPollAccounts = () => cancelPoll(pollAccountsId);

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -37,7 +37,6 @@ import {
 } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
-import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -249,6 +249,10 @@ export const poll = async <T>({
   pollId?: symbol;
 }): Promise<T> => {
   let highLoadToast: symbol | null = null;
+  // If we are already polling for this id, don't twice.
+  if (currentPolls.has(pollId)) {
+    throw new PollingCancelledError(pollId);
+  }
   // We'll never call `resolve`, therefore the type doesn't matter.
   // `T` just makes TS happy.
   const cancelPromise = new Promise<T>((_resolve, reject) => {

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -249,7 +249,7 @@ export const poll = async <T>({
   pollId?: symbol;
 }): Promise<T> => {
   let highLoadToast: symbol | null = null;
-  // If we are already polling for this id, don't twice.
+  // If we are already polling for this id, don't poll twice.
   if (currentPolls.has(pollId)) {
     throw new PollingCancelledError(pollId);
   }
@@ -257,7 +257,9 @@ export const poll = async <T>({
   // `T` just makes TS happy.
   const cancelPromise = new Promise<T>((_resolve, reject) => {
     if (nonNullish(pollId)) {
-      currentPolls[pollId] = reject;
+      currentPolls.set(pollId, (err) => {
+        reject(err);
+      });
     }
   });
   for (let counter = 0; counter < maxAttempts; counter++) {

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -196,6 +196,33 @@ export class PollingLimitExceededError extends Error {}
 export const DEFAULT_MAX_POLLING_ATTEMPTS = 10;
 const DEFAULT_WAIT_TIME_MS = 500;
 
+type Polls = Record<string, boolean>;
+const currentPolls: Polls = {};
+export const clearCurrentPolls = () => {
+  Object.keys(currentPolls).forEach((key: string) => {
+    clearTimeout(Number(key));
+    delete currentPolls[key];
+  });
+};
+/**
+ * Waits for a specific amount of milliseconds, and returns the id of the timeout.
+ *
+ * It loads the currentPolls object with the id of the timeout, so it can be cleared later.
+ *
+ * USED ONLY in `poll`
+ *
+ * @param milliseconds
+ * @returns {string} whether it waited or not
+ */
+const waitForMillisecondsPolling = (milliseconds: number): Promise<string> =>
+  new Promise((resolve) => {
+    const id = setTimeout(() => {
+      resolve(String(id));
+    }, milliseconds);
+    const idNumber = String(id);
+    currentPolls[idNumber] = true;
+  });
+
 /**
  * Function that polls a specific function, checking error with passed argument to recall or not.
  *
@@ -235,7 +262,11 @@ export const poll = async <T>({
           labelKey: "error.high_load_retrying",
         });
       }
-      await waitForMilliseconds(millisecondsToWait);
+      const id = await waitForMillisecondsPolling(millisecondsToWait);
+      // Exit polling if the timeout was cleared
+      if (!(id in currentPolls)) {
+        return undefined;
+      }
       if (useExponentialBackoff) {
         millisecondsToWait *= 2;
       }

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -250,7 +250,7 @@ export const poll = async <T>({
 }): Promise<T> => {
   let highLoadToast: symbol | null = null;
   // If we are already polling for this id, don't poll twice.
-  if (currentPolls.has(pollId)) {
+  if (nonNullish(pollId) && currentPolls.has(pollId)) {
     throw new PollingCancelledError(pollId);
   }
   // We'll never call `resolve`, therefore the type doesn't matter.

--- a/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
@@ -4,8 +4,10 @@
 
 import * as ledgerApi from "$lib/api/ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
+import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import StakeNeuronModal from "$lib/modals/neurons/StakeNeuronModal.svelte";
+import { cancelPollAccounts } from "$lib/services/accounts.services";
 import {
   addHotkeyForHardwareWalletNeuron,
   stakeNeuron,
@@ -78,6 +80,10 @@ jest.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("StakeNeuronModal", () => {
+  beforeEach(() => {
+    cancelPollAccounts();
+  });
+
   describe("main account selection", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
@@ -556,6 +562,62 @@ describe("StakeNeuronModal", () => {
       await waitFor(() =>
         expect(queryByTestId("account-card")).toBeInTheDocument()
       );
+    });
+  });
+
+  describe("when no accounts and user navigates away", () => {
+    let spyQueryAccount: jest.SpyInstance;
+    beforeEach(() => {
+      accountsStore.reset();
+      jest.clearAllTimers();
+      jest.clearAllMocks();
+      const now = Date.now();
+      jest.useFakeTimers().setSystemTime(now);
+      const mainBalanceE8s = BigInt(10_000_000);
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      spyQueryAccount = jest
+        .spyOn(nnsDappApi, "queryAccount")
+        .mockRejectedValue(new Error("connection error"));
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    it("should stop polling", async () => {
+      const { unmount } = await renderModal({
+        component: StakeNeuronModal,
+      });
+
+      let counter = 1;
+      let retryDelay = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
+      const retriesBeforeLeaving = 3;
+      const extraRetries = 4;
+      await waitFor(() => expect(spyQueryAccount).toBeCalledTimes(counter));
+      while (counter < retriesBeforeLeaving + extraRetries) {
+        expect(spyQueryAccount).toBeCalledTimes(
+          Math.min(counter, retriesBeforeLeaving)
+        );
+        counter += 1;
+        // Make sure the timers are set before we advance time.
+        await null;
+        await null;
+        await null;
+        jest.advanceTimersByTime(retryDelay);
+        retryDelay *= 2;
+        await waitFor(() =>
+          expect(spyQueryAccount).toBeCalledTimes(
+            Math.min(counter, retriesBeforeLeaving)
+          )
+        );
+
+        if (counter === retriesBeforeLeaving) {
+          unmount();
+        }
+      }
+
+      expect(counter).toBe(retriesBeforeLeaving + extraRetries);
+
+      expect(spyQueryAccount).toHaveBeenCalledTimes(retriesBeforeLeaving);
     });
   });
 });

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -773,5 +773,47 @@ describe("accounts-services", () => {
         return expect(accounts).toEqual(mockAccounts);
       });
     });
+
+    it("stops polling when cancelPollAccounts is called", async () => {
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(mainBalanceE8s);
+      const error = new Error("test");
+      const queryAccountSpy = jest
+        .spyOn(nnsdappApi, "queryAccount")
+        .mockRejectedValue(error);
+
+      pollAccounts();
+
+      let counter = 0;
+      let retryDelay = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
+      const retriesBeforeCancelPolling = 3;
+      const extraRetries = 4;
+      while (counter < retriesBeforeCancelPolling + extraRetries) {
+        expect(queryAccountSpy).toBeCalledTimes(
+          Math.min(counter, retriesBeforeCancelPolling)
+        );
+        counter += 1;
+        // Make sure the timers are set before we advance time.
+        await null;
+        await null;
+        await null;
+        jest.advanceTimersByTime(retryDelay);
+        retryDelay *= 2;
+        await waitFor(() =>
+          expect(queryAccountSpy).toBeCalledTimes(
+            Math.min(counter, retriesBeforeCancelPolling)
+          )
+        );
+
+        if (counter === retriesBeforeCancelPolling) {
+          cancelPollAccounts();
+        }
+      }
+
+      expect(counter).toBe(retriesBeforeCancelPolling + extraRetries);
+
+      expect(queryAccountSpy).toHaveBeenCalledTimes(retriesBeforeCancelPolling);
+    });
   });
 });

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -11,6 +11,7 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import {
   addSubAccount,
+  cancelPollAccounts,
   getAccountIdentity,
   getAccountIdentityByPrincipal,
   getAccountTransactions,
@@ -660,36 +661,36 @@ describe("accounts-services", () => {
   });
 
   describe("pollAccounts", () => {
+    const mainBalanceE8s = BigInt(10_000_000);
+    const mockAccounts = {
+      main: {
+        ...mockMainAccount,
+        balance: TokenAmount.fromE8s({
+          amount: mainBalanceE8s,
+          token: ICPToken,
+        }),
+      },
+      subAccounts: [],
+      hardwareWallets: [],
+      certified: true,
+    };
+
     beforeEach(() => {
       accountsStore.reset();
       jest.clearAllTimers();
       jest.clearAllMocks();
+      cancelPollAccounts();
       const now = Date.now();
       jest.useFakeTimers().setSystemTime(now);
     });
 
     it("calls apis and sets accountsStore", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
-
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
       const queryAccountSpy = jest
         .spyOn(nnsdappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
-
-      const mockAccounts = {
-        main: {
-          ...mockMainAccount,
-          balance: TokenAmount.fromE8s({
-            amount: mainBalanceE8s,
-            token: ICPToken,
-          }),
-        },
-        subAccounts: [],
-        hardwareWallets: [],
-        certified: true,
-      };
 
       await pollAccounts();
 
@@ -706,7 +707,6 @@ describe("accounts-services", () => {
     });
 
     it("calls apis with certified param used", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -716,6 +716,7 @@ describe("accounts-services", () => {
 
       await pollAccounts(false);
 
+      expect(queryAccountSpy).toHaveBeenCalledTimes(1);
       expect(queryAccountSpy).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
@@ -728,8 +729,6 @@ describe("accounts-services", () => {
     });
 
     it("polls if queryAccount fails", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
-
       jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -741,19 +740,6 @@ describe("accounts-services", () => {
         .mockRejectedValueOnce(error)
         .mockRejectedValueOnce(error)
         .mockResolvedValue(mockAccountDetails);
-
-      const mockAccounts = {
-        main: {
-          ...mockMainAccount,
-          balance: TokenAmount.fromE8s({
-            amount: mainBalanceE8s,
-            token: ICPToken,
-          }),
-        },
-        subAccounts: [],
-        hardwareWallets: [],
-        certified: true,
-      };
 
       pollAccounts();
 

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -768,6 +768,7 @@ describe("accounts-services", () => {
         // Make sure the timers are set before we advance time.
         await null;
         await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
         await waitFor(() =>

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -234,6 +234,10 @@ describe("sns-api", () => {
             Math.min(counter, retriesUntilSuccess)
           );
           counter += 1;
+          await null;
+          await null;
+          await null;
+          await null;
           jest.advanceTimersByTime(retryDelay);
           retryDelay *= 2;
 
@@ -267,6 +271,8 @@ describe("sns-api", () => {
         while (counter <= maxAttempts) {
           expect(spyOnGetOpenTicketApi).toBeCalledTimes(counter);
           counter += 1;
+          await null;
+          await null;
           jest.advanceTimersByTime(retryDelay);
           retryDelay *= 2;
 
@@ -400,6 +406,11 @@ describe("sns-api", () => {
     });
 
     describe("when disabling polling", () => {
+      beforeEach(() => {
+        jest.clearAllTimers();
+        const now = Date.now();
+        jest.useFakeTimers().setSystemTime(now);
+      });
       it("should stop retrying", async () => {
         snsTicketsStore.enablePolling(testSnsTicket.rootCanisterId);
         spyOnGetOpenTicketApi.mockRejectedValue(new Error("network error"));
@@ -414,15 +425,17 @@ describe("sns-api", () => {
         // We loop until 10 advancing time, but the polling should stop after `retriesBeforeStopPolling` + 1
         while (counter < DEFAULT_MAX_POLLING_ATTEMPTS) {
           expect(spyOnGetOpenTicketApi).toBeCalledTimes(
-            Math.min(counter, retriesBeforeStopPolling + 1)
+            Math.min(counter, retriesBeforeStopPolling)
           );
           counter += 1;
+          await null;
+          await null;
           jest.advanceTimersByTime(retryDelay);
           retryDelay *= 2;
 
           await waitFor(() =>
             expect(spyOnGetOpenTicketApi).toBeCalledTimes(
-              Math.min(counter, retriesBeforeStopPolling + 1)
+              Math.min(counter, retriesBeforeStopPolling)
             )
           );
 
@@ -434,7 +447,7 @@ describe("sns-api", () => {
 
         await waitFor(() =>
           expect(spyOnGetOpenTicketApi).toBeCalledTimes(
-            retriesBeforeStopPolling + 1
+            retriesBeforeStopPolling
           )
         );
       });
@@ -607,6 +620,8 @@ describe("sns-api", () => {
           Math.min(counter, extraRetries)
         );
         counter += 1;
+        await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
 
@@ -646,6 +661,8 @@ describe("sns-api", () => {
           Math.min(counter, extraRetries)
         );
         counter += 1;
+        await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
 
@@ -860,6 +877,8 @@ describe("sns-api", () => {
           Math.min(counter, retriesUntilSuccess)
         );
         counter += 1;
+        await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
 
@@ -912,6 +931,8 @@ describe("sns-api", () => {
           Math.min(expectedRetries, counter)
         );
         counter += 1;
+        await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
 
@@ -1021,6 +1042,8 @@ describe("sns-api", () => {
           Math.min(counter, retriesUntilSuccess)
         );
         counter += 1;
+        await null;
+        await null;
         jest.advanceTimersByTime(retryDelay);
         retryDelay *= 2;
 

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -9,8 +9,8 @@ import {
   isPngAsset,
   poll,
   pollingCancelled,
-  PollingLimitExceededError,
   PollingCancelledError,
+  PollingLimitExceededError,
   removeKeys,
   smallerVersion,
   stringifyJson,
@@ -526,14 +526,16 @@ describe("utils", () => {
           millisecondsToWait: 20 * 1000,
           useExponentialBackoff: false,
           pollId,
-        }).then((result) => {
-          throw new Error("This shouldn't happen");
-        }).catch((err) => {
-          expect(err).toBeInstanceOf(PollingCancelledError);
-          if (pollingCancelled(err)) {
-            cancelled = true;
-          }
-        });;
+        })
+          .then((result) => {
+            throw new Error("This shouldn't happen");
+          })
+          .catch((err) => {
+            expect(err).toBeInstanceOf(PollingCancelledError);
+            if (pollingCancelled(err)) {
+              cancelled = true;
+            }
+          });
         expect(fnSpy).toBeCalled();
         await advanceTime();
         expect(cancelled).toBe(false);
@@ -545,9 +547,11 @@ describe("utils", () => {
       it("should stop polling when cancelled during call", async () => {
         const pollId = Symbol();
         const fnSpy = jest.fn();
-        fnSpy.mockRejectedValue(new Promise(() => {
-          //never resolve
-        }));
+        fnSpy.mockRejectedValue(
+          new Promise(() => {
+            //never resolve
+          })
+        );
         let cancelled = false;
         poll({
           fn: fnSpy,
@@ -556,14 +560,16 @@ describe("utils", () => {
           millisecondsToWait: 20 * 1000,
           useExponentialBackoff: false,
           pollId,
-        }).then((result) => {
-          throw new Error("This shouldn't happen");
-        }).catch((err) => {
-          expect(err).toBeInstanceOf(PollingCancelledError);
-          if (pollingCancelled(err)) {
-            cancelled = true;
-          }
-        });;
+        })
+          .then((result) => {
+            throw new Error("This shouldn't happen");
+          })
+          .catch((err) => {
+            expect(err).toBeInstanceOf(PollingCancelledError);
+            if (pollingCancelled(err)) {
+              cancelled = true;
+            }
+          });
         expect(fnSpy).toBeCalled();
         await advanceTime();
         expect(cancelled).toBe(false);

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -381,7 +381,7 @@ describe("utils", () => {
         const t0 = Date.now();
         const timestamps = [];
 
-        const promise = poll({
+        poll({
           fn: async () => {
             timestamps.push(Date.now() - t0);
             throw new Error();
@@ -527,7 +527,7 @@ describe("utils", () => {
           useExponentialBackoff: false,
           pollId,
         })
-          .then((result) => {
+          .then(() => {
             throw new Error("This shouldn't happen");
           })
           .catch((err) => {
@@ -561,7 +561,7 @@ describe("utils", () => {
           useExponentialBackoff: false,
           pollId,
         })
-          .then((result) => {
+          .then(() => {
             throw new Error("This shouldn't happen");
           })
           .catch((err) => {

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   bytesToHexString,
+  cancelPoll,
   createChunks,
   expandObject,
   hexStringToBytes,
@@ -7,6 +8,7 @@ import {
   isHash,
   isPngAsset,
   poll,
+  pollingCancelled,
   PollingLimitExceededError,
   removeKeys,
   smallerVersion,
@@ -351,13 +353,18 @@ describe("utils", () => {
         },
       ];
 
+      let originalTimeout;
       beforeEach(() => {
+        jest.useRealTimers();
+        if (originalTimeout === undefined) {
+          originalTimeout = setTimeout;
+        }
         jest.useFakeTimers();
       });
 
       const advanceTime = async (): Promise<void> => {
         // Make sure the timers are set before we advance time.
-        await null;
+        await new Promise((resolve) => originalTimeout(resolve, 0));
         await jest.runOnlyPendingTimers();
       };
 
@@ -384,7 +391,7 @@ describe("utils", () => {
           useExponentialBackoff,
         });
 
-        for (let i = 0; i < maxAttempts; i++) {
+        for (let i = 0; i < maxAttempts - 1; i++) {
           await advanceTime();
         }
         expect(() => promise).rejects.toThrowError(PollingLimitExceededError);
@@ -451,6 +458,7 @@ describe("utils", () => {
         expect(calls).toBeLessThan(failuresBeforeHighLoadMessage);
         expect(get(toastsStore)).toEqual([]);
         await advanceTime();
+        await advanceTime();
         expect(calls).toBeGreaterThanOrEqual(failuresBeforeHighLoadMessage);
         expect(get(toastsStore)).toMatchObject(highLoadToast);
       });
@@ -500,6 +508,46 @@ describe("utils", () => {
         await advanceTime();
         // Still only 1 toast.
         expect(get(toastsStore)).toMatchObject(highLoadToast);
+      });
+
+      it.only("should stop polling when cancelled", async () => {
+        const pollId = Symbol();
+        const fnSpy = jest.fn();
+        let cancelled = false;
+        poll({
+          fn: fnSpy,
+          shouldExit: () => false,
+          maxAttempts: 10,
+          millisecondsToWait: 20 * 1000,
+          useExponentialBackoff: false,
+          pollId,
+        }).catch((err) => {
+          console.log("polling cancelled");
+          if (pollingCancelled(err)) {
+            cancelled = true;
+          }
+        });
+        expect(fnSpy).toBeCalled();
+        await advanceTime();
+        expect(cancelled).toBe(false);
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        cancelPoll(pollId);
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        await advanceTime();
+        expect(cancelled).toBe(true);
       });
     });
   });


### PR DESCRIPTION
# Motivation

Make sure the polling doesn't repeat and it lasts forever.

New functionality:
* Poll won't poll twice
* Cancel pollAccounts when navigating away.

# Changes

* Add a `pollId` parameter to the `poll` util.
* Add functionality to cancel poll by `pollId`.
* Don't poll twice with the same `pollId`.
* Use the new `pollId` in `pollAccounts`
* Add a service `cancelPollAccounts`.
* Use the new service `cancelPollAccounts` when the component that triggered the `pollAccounts` is destroyed.

# Tests

* Test new functionality in the `poll` util.
* Test `cancelPollAccounts`
* Test in each page where `pollAccounts` is started, that it's cancelled when component is unmounted.
