### PR TITLE
Bump downstream api to include sale time

### DIFF
--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -111,7 +111,7 @@ pub struct SlowSwap {
     /// to the outcome of the swap.
     pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
     /// The time at which the sale is expected to open.
-    pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
+    pub decentralization_sale_open_timestamp_seconds: Option<u64>,
 }
 
 impl From<&Swap> for SlowSwap {

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -110,6 +110,8 @@ pub struct SlowSwap {
     /// When the swap is committed, this field is initialized according
     /// to the outcome of the swap.
     pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
+    /// The time at which the sale is expected to open.
+    pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
 }
 
 impl From<&Swap> for SlowSwap {
@@ -119,6 +121,7 @@ impl From<&Swap> for SlowSwap {
             init: upstream.init.clone(),
             params: upstream.params.clone(),
             open_sns_token_swap_proposal_id: upstream.open_sns_token_swap_proposal_id,
+            decentralization_sale_open_timestamp_seconds: upstream.decentralization_sale_open_timestamp_seconds,
         }
     }
 }


### PR DESCRIPTION
# Motivation
The downstream API does not include the needed `decentralization_sale_open_timestamp_seconds`.

# Changes
* Add `decentralization_sale_open_timestamp_seconds` to the downstream fields.

# Tests
* Deployed to a testnet and verified that the field appears.