### PR TITLE
Feat: Watch derived state

### DIFF
--- a/frontend/src/lib/constants/sns.constants.ts
+++ b/frontend/src/lib/constants/sns.constants.ts
@@ -2,4 +2,4 @@ export const DEFAULT_SNS_LOGO = "/assets/sns-logo-default.svg";
 export const AGGREGATOR_CANISTER_VERSION = "v1";
 export const AGGREGATOR_CANISTER_PATH = "/sns/list/latest/slow.json";
 export const SALE_PARTICIPATION_RETRY_SECONDS = 2;
-export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 2000;
+export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 10_000;

--- a/frontend/src/lib/constants/sns.constants.ts
+++ b/frontend/src/lib/constants/sns.constants.ts
@@ -2,3 +2,4 @@ export const DEFAULT_SNS_LOGO = "/assets/sns-logo-default.svg";
 export const AGGREGATOR_CANISTER_VERSION = "v1";
 export const AGGREGATOR_CANISTER_PATH = "/sns/list/latest/slow.json";
 export const SALE_PARTICIPATION_RETRY_SECONDS = 2;
+export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 2000;

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -47,10 +47,7 @@
       return true;
     }
 
-    return (
-      $canistersStore.canisters !== undefined &&
-      $canistersStore.certified === true
-    );
+    return $canistersStore.canisters !== undefined;
   };
 
   let canistersReady = false;

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -47,6 +47,7 @@
       return true;
     }
 
+    // At the moment we load the stores with query only.
     return $canistersStore.canisters !== undefined;
   };
 

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -25,7 +25,7 @@
   $: if (isSignedIn($authStore.identity)) {
     // We only care for the update call.
     // The voting buttons are shown when the neurons are certified.
-    listNeurons({ strategy: "update" });
+    listNeurons({ strategy: "query_and_update" });
   }
 
   const mapProposalId = (

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -23,7 +23,9 @@
   export let referrerPath: AppPath | undefined = undefined;
 
   $: if (isSignedIn($authStore.identity)) {
-    listNeurons();
+    // We only care for the update call.
+    // The voting buttons are shown when the neurons are certified.
+    listNeurons({ strategy: "update" });
   }
 
   const mapProposalId = (

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -23,8 +23,8 @@
   export let referrerPath: AppPath | undefined = undefined;
 
   $: if (isSignedIn($authStore.identity)) {
-    // We only care for the update call.
-    // The voting buttons are shown when the neurons are certified.
+    // We want to force the strategy, otherwise uses `FORCE_CALL_STRATEGY` which is `query` for now.
+    // We want certified data for the neurons when voting.
     listNeurons({ strategy: "query_and_update" });
   }
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -117,7 +117,7 @@
     return goto(AppPath.Launchpad, { replaceState: true });
   };
 
-  const mapProjectDetail = (rootCanisterId: string) => {
+  const setProjectStore = (rootCanisterId: string) => {
     // Check project summaries are loaded in store
     if ($snsSummariesStore.length === 0) {
       return;
@@ -152,13 +152,15 @@
     // We need both of these here because this component does not "subscribe" to projectDetailStore
     // The store is created in this same component.
     reloadSnsMetrics({ forceFetch: false });
-
-    unsubscribeWatchMetrics?.();
-    unsubscribeWatchMetrics = watchSnsMetrics({
-      rootCanisterId: Principal.fromText(rootCanisterId),
-      // TS is not smart enought to understand the `nonNullish` before
-      swapCanisterId: $projectDetailStore.summary?.swapCanisterId as Principal,
-    });
+    if (nonNullish($projectDetailStore.summary?.swapCanisterId)) {
+      unsubscribeWatchMetrics?.();
+      unsubscribeWatchMetrics = watchSnsMetrics({
+        rootCanisterId: Principal.fromText(rootCanisterId),
+        // TS is not smart enought to understand the `nonNullish` before
+        swapCanisterId: $projectDetailStore.summary
+          ?.swapCanisterId as Principal,
+      });
+    }
   };
 
   /**
@@ -171,7 +173,7 @@
         await goBack();
         return;
       }
-      mapProjectDetail(rootCanisterId);
+      setProjectStore(rootCanisterId);
     })();
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -9,7 +9,7 @@
     loadSnsLifecycle,
     loadSnsSwapCommitment,
     loadSnsTotalCommitment,
-    watchDerivedState,
+    watchSnsTotalCommitment,
   } from "$lib/services/sns.services";
   import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
   import {
@@ -43,7 +43,7 @@
 
   $: if (nonNullish(rootCanisterId)) {
     unsubscribeWatch?.();
-    unsubscribeWatch = watchDerivedState({ rootCanisterId });
+    unsubscribeWatch = watchSnsTotalCommitment({ rootCanisterId });
   }
 
   const loadCommitment = ({

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -253,8 +253,8 @@ const handleNewSaleTicketError = ({
       case NewSaleTicketResponseErrorType.TYPE_TICKET_EXISTS: {
         const existingTicket = newSaleTicketError.existingTicket;
         if (nonNullish(existingTicket)) {
-          toastsShow({
-            level: "info",
+          // Show error so that it shows above the modal in case the user is participating and has the modal open
+          toastsError({
             labelKey: "error__sns.sns_sale_proceed_with_existing_ticket",
             substitutions: {
               $time: nanoSecondsToDateTime(existingTicket.creation_time),

--- a/frontend/src/lib/services/sns-swap-metrics.services.ts
+++ b/frontend/src/lib/services/sns-swap-metrics.services.ts
@@ -49,7 +49,7 @@ export const watchSnsMetrics = ({
 }): (() => void) => {
   const interval = setInterval(() => {
     loadSnsMetrics({ rootCanisterId, swapCanisterId, forceFetch: true });
-  }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
+  }, WATCH_SALE_STATE_EVERY_MILLISECONDS / 10);
 
   return () => {
     clearInterval(interval);
@@ -75,9 +75,8 @@ const querySnsMetrics = async ({
 
     const rawMetrics = await response.text();
     const saleBuyerCount = parseSnsSwapSaleBuyerCount(rawMetrics);
-    return saleBuyerCount === undefined ? undefined : { saleBuyerCount };
-
     logWithTimestamp("Loading SNS metrics completed");
+    return saleBuyerCount === undefined ? undefined : { saleBuyerCount };
   } catch (err) {
     logWithTimestamp("Error getting SNS metrics", err);
   }

--- a/frontend/src/lib/services/sns-swap-metrics.services.ts
+++ b/frontend/src/lib/services/sns-swap-metrics.services.ts
@@ -1,3 +1,4 @@
+import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Principal } from "@dfinity/principal";
@@ -37,6 +38,22 @@ export const loadSnsMetrics = async ({
     rootCanisterId,
     metrics: metrics ?? null,
   });
+};
+
+export const watchSnsMetrics = ({
+  rootCanisterId,
+  swapCanisterId,
+}: {
+  rootCanisterId: Principal;
+  swapCanisterId: Principal;
+}): (() => void) => {
+  const interval = setInterval(() => {
+    loadSnsMetrics({ rootCanisterId, swapCanisterId, forceFetch: true });
+  }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
+
+  return () => {
+    clearInterval(interval);
+  };
 };
 
 const querySnsMetrics = async ({

--- a/frontend/src/lib/services/sns-swap-metrics.services.ts
+++ b/frontend/src/lib/services/sns-swap-metrics.services.ts
@@ -49,7 +49,7 @@ export const watchSnsMetrics = ({
 }): (() => void) => {
   const interval = setInterval(() => {
     loadSnsMetrics({ rootCanisterId, swapCanisterId, forceFetch: true });
-  }, WATCH_SALE_STATE_EVERY_MILLISECONDS / 10);
+  }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
 
   return () => {
     clearInterval(interval);

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -176,7 +176,7 @@ export const loadSnsTotalCommitment = async ({
     logMessage: "Syncing Sns swap commitment",
   });
 
-export const watchDerivedState = ({
+export const watchSnsTotalCommitment = ({
   rootCanisterId,
 }: {
   rootCanisterId: string;

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -5,6 +5,7 @@ import {
   querySnsSwapCommitments,
 } from "$lib/api/sns.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/environment.constants";
+import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import {
   snsQueryStore,
   snsSummariesStore,
@@ -23,7 +24,7 @@ import type {
 import { fromNullable, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
-import { queryAndUpdate } from "./utils.services";
+import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 
 /**
  * Loads the user commitments for all projects.
@@ -141,10 +142,14 @@ export const loadSnsSwapCommitment = async ({
 
 export const loadSnsTotalCommitment = async ({
   rootCanisterId,
+  strategy,
 }: {
   rootCanisterId: string;
+  strategy?: QueryAndUpdateStrategy;
 }) =>
   queryAndUpdate<SnsGetDerivedStateResponse | undefined, unknown>({
+    strategy: strategy ?? FORCE_CALL_STRATEGY,
+    identityType: "current",
     request: ({ certified, identity }) =>
       querySnsDerivedState({
         rootCanisterId,
@@ -170,6 +175,20 @@ export const loadSnsTotalCommitment = async ({
     },
     logMessage: "Syncing Sns swap commitment",
   });
+
+export const watchDerivedState = ({
+  rootCanisterId,
+}: {
+  rootCanisterId: string;
+}) => {
+  const id = setInterval(() => {
+    loadSnsTotalCommitment({ rootCanisterId, strategy: "query" });
+  }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
+
+  return () => {
+    clearInterval(id);
+  };
+};
 
 export const loadSnsLifecycle = async ({
   rootCanisterId,

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -86,6 +86,21 @@ describe("CanisterDetail", () => {
     expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
   });
 
+  it("should render cards when not certified", async () => {
+    // Need to be the same that routePathCanisterId returns.
+    canistersStore.setCanisters({
+      canisters: [mockCanister],
+      certified: false,
+    });
+    const { queryByTestId } = render(CanisterDetail, props);
+
+    await waitFor(() =>
+      expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
+    );
+    // Waiting for the one above is enough
+    expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
+  });
+
   it("should not render cards if user is not the controller", async () => {
     setGetCanisterDetailReturn(Promise.reject(new UserNotTheControllerError()));
     // Need to be the same that routePathCanisterId returns.

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -87,7 +87,11 @@ describe("ProposalDetail", () => {
           certified: true,
         })
       );
-      expect(governanceApi.queryNeurons).toHaveBeenCalledTimes(1);
+      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+      });
+      expect(governanceApi.queryNeurons).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -87,6 +87,7 @@ describe("ProposalDetail", () => {
           certified: true,
         })
       );
+      expect(governanceApi.queryNeurons).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -87,10 +87,6 @@ describe("ProposalDetail", () => {
           certified: true,
         })
       );
-      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
-        identity: mockIdentity,
-        certified: false,
-      });
     });
   });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -7,7 +7,7 @@ import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import {
   loadSnsSwapCommitment,
-  watchDerivedState,
+  watchSnsTotalCommitment,
 } from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
@@ -25,7 +25,9 @@ jest.mock("$lib/services/sns.services", () => {
   return {
     loadSnsSwapCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsTotalCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
-    watchDerivedState: jest.fn().mockImplementation(() => mockUnwatchCall),
+    watchSnsTotalCommitment: jest
+      .fn()
+      .mockImplementation(() => mockUnwatchCall),
   };
 });
 
@@ -57,7 +59,7 @@ describe("ProjectDetail", () => {
     it("should start watching derived state", async () => {
       render(ProjectDetail, props);
 
-      await waitFor(() => expect(watchDerivedState).toBeCalled());
+      await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
     });
 
     it("should clear eatch on unmount", async () => {
@@ -106,7 +108,7 @@ describe("ProjectDetail", () => {
     it("should start watching derived state", async () => {
       render(ProjectDetail, props);
 
-      await waitFor(() => expect(watchDerivedState).toBeCalled());
+      await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
     });
 
     it("should clear eatch on unmount", async () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -5,7 +5,10 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
-import { loadSnsSwapCommitment } from "$lib/services/sns.services";
+import {
+  loadSnsSwapCommitment,
+  watchDerivedState,
+} from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
@@ -21,6 +24,7 @@ jest.mock("$lib/services/sns.services", () => {
   return {
     loadSnsSwapCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsTotalCommitment: jest.fn().mockResolvedValue(Promise.resolve()),
+    watchDerivedState: jest.fn().mockReturnValue(() => undefined),
   };
 });
 
@@ -53,6 +57,12 @@ describe("ProjectDetail", () => {
       jest.clearAllMocks();
     });
 
+    it("should start watching derived state", async () => {
+      render(ProjectDetail, props);
+
+      await waitFor(() => expect(watchDerivedState).toBeCalled());
+    });
+
     it("should not load user's commitnemtn", async () => {
       render(ProjectDetail, props);
 
@@ -81,6 +91,12 @@ describe("ProjectDetail", () => {
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
+    });
+
+    it("should start watching derived state", async () => {
+      render(ProjectDetail, props);
+
+      await waitFor(() => expect(watchDerivedState).toBeCalled());
     });
 
     it("should load user's commitment", async () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -533,7 +533,7 @@ describe("sns-api", () => {
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalled();
+      expect(spyOnToastsError).toBeCalledTimes(1);
       expect(spyOnToastsError).toBeCalledWith(
         expect.objectContaining({
           labelKey: "error__sns.sns_sale_proceed_with_existing_ticket",

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -533,8 +533,8 @@ describe("sns-api", () => {
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).not.toBeCalled();
-      expect(spyOnToastsShow).toBeCalledWith(
+      expect(spyOnToastsError).toBeCalled();
+      expect(spyOnToastsError).toBeCalledWith(
         expect.objectContaining({
           labelKey: "error__sns.sns_sale_proceed_with_existing_ticket",
           substitutions: {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -141,7 +141,7 @@ describe("sns-services", () => {
       expect(spy).toBeCalled();
 
       const updatedStore = get(snsQueryStore);
-      const updatedState = updatedStore?.swaps.find(
+      const updatedState = updatedStore.swaps.find(
         (swap) => swap.rootCanisterId === canisterId
       )?.derived[0];
       expect(updatedState?.buyer_total_icp_e8s).toEqual(
@@ -239,7 +239,7 @@ describe("sns-services", () => {
       expect(spy).toBeCalledTimes(retriesBeforeClearing);
 
       const updatedStore = get(snsQueryStore);
-      const updatedState = updatedStore?.swaps.find(
+      const updatedState = updatedStore.swaps.find(
         (swap) => swap.rootCanisterId === canisterId
       )?.derived[0];
       expect(updatedState?.buyer_total_icp_e8s).toEqual(


### PR DESCRIPTION
# Motivation

UI refreshes in real time the total committed for a project.

# Changes

* New services `watchDerivedState` that calls `loadSnsTotalCommitment` at intervals.
* Add new param to `loadSnsTotalCommitment` to specify the strategy.
* Allow `loadSnsTotalCommitment` to be called by non-logged in users.
* Render non-certified canister details.
* Force listNeurons in ProposalDetail to be `query_and_update`.
* New service `watchSnsMetrics` that calls `loadSnsMetrics` at intervals.
* ProjectDetail watches sns metrics and total commitments.
* Destroy watchers when ProjectDetail is unmounted.
* Show the toast while existing ticket as error.

# Tests

* Add test for `watchDerivedState`.
* Add test for new param in `loadSnsTotalCommitment`.
* Add test in ProjectDetail that watch is called and unsubscribed.
* Fix tests after changes in how data is loaded in CanisterDetail and NnsProposalDetail.
