### PR TITLE
feat: cleanup before-unload and add guard to participate to sale

### DIFF
--- a/frontend/src/lib/components/sale/SaleInProgress.svelte
+++ b/frontend/src/lib/components/sale/SaleInProgress.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-  import { ProgressSteps, type ProgressStep } from "@dfinity/gix-components";
+  import {
+    IconWarning,
+    type ProgressStep,
+    ProgressSteps,
+  } from "@dfinity/gix-components";
   import { SaleStep } from "$lib/types/sale";
   import { ICON_SIZE_LARGE } from "$lib/constants/layout.constants";
-  import { IconWarning } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
+  import { saleInProgress } from "$lib/stores/sns-sale.store";
 
   export let progressStep: SaleStep;
 
@@ -50,6 +54,8 @@
   };
 
   $: progressStep, (() => updateSteps())();
+
+  $: saleInProgress.set(progressStep !== SaleStep.DONE);
 </script>
 
 <div class="warning" data-tid="sale-in-progress-warning">

--- a/frontend/src/lib/derived/before-unload.derived.ts
+++ b/frontend/src/lib/derived/before-unload.derived.ts
@@ -1,0 +1,15 @@
+import {derived, type Readable} from "svelte/store";
+import type {VoteRegistrationStoreData} from "$lib/stores/vote-registration.store";
+import {voteRegistrationStore} from "$lib/stores/vote-registration.store";
+import {saleInProgress} from "$lib/stores/sns-sale.store";
+import {voteRegistrationActive} from "$lib/utils/proposals.utils";
+
+export const confirmBeforeCloseStore = derived<
+    [Readable<VoteRegistrationStoreData>, Readable<boolean>],
+    boolean
+>(
+    [voteRegistrationStore, saleInProgress],
+    ([$voteRegistrationStore, $saleInProgress]) => voteRegistrationActive(
+        $voteRegistrationStore.registrations
+    ) || $saleInProgress
+);

--- a/frontend/src/lib/derived/before-unload.derived.ts
+++ b/frontend/src/lib/derived/before-unload.derived.ts
@@ -1,15 +1,15 @@
-import {derived, type Readable} from "svelte/store";
-import type {VoteRegistrationStoreData} from "$lib/stores/vote-registration.store";
-import {voteRegistrationStore} from "$lib/stores/vote-registration.store";
-import {saleInProgress} from "$lib/stores/sns-sale.store";
-import {voteRegistrationActive} from "$lib/utils/proposals.utils";
+import { saleInProgress } from "$lib/stores/sns-sale.store";
+import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
+import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
+import { voteRegistrationActive } from "$lib/utils/proposals.utils";
+import { derived, type Readable } from "svelte/store";
 
 export const confirmBeforeCloseStore = derived<
-    [Readable<VoteRegistrationStoreData>, Readable<boolean>],
-    boolean
+  [Readable<VoteRegistrationStoreData>, Readable<boolean>],
+  boolean
 >(
-    [voteRegistrationStore, saleInProgress],
-    ([$voteRegistrationStore, $saleInProgress]) => voteRegistrationActive(
-        $voteRegistrationStore.registrations
-    ) || $saleInProgress
+  [voteRegistrationStore, saleInProgress],
+  ([$voteRegistrationStore, $saleInProgress]) =>
+    voteRegistrationActive($voteRegistrationStore.registrations) ||
+    $saleInProgress
 );

--- a/frontend/src/lib/stores/sns-sale.store.ts
+++ b/frontend/src/lib/stores/sns-sale.store.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const saleInProgress = writable<boolean>(false);

--- a/frontend/src/lib/stores/vote-registration.store.ts
+++ b/frontend/src/lib/stores/vote-registration.store.ts
@@ -1,5 +1,5 @@
 import type { NeuronId, ProposalId, ProposalInfo, Vote } from "@dfinity/nns";
-import { writable } from "svelte/store";
+import { writable, type Readable } from "svelte/store";
 
 export type VoteRegistrationStatus =
   | "vote-registration"
@@ -14,8 +14,27 @@ export interface VoteRegistration {
   vote: Vote;
 }
 
-export interface VoteRegistrationStore {
+export interface VoteRegistrationStoreData {
   registrations: VoteRegistration[];
+}
+
+export interface VoteRegistrationStore
+  extends Readable<VoteRegistrationStoreData> {
+  add: (params: {
+    vote: Vote;
+    proposalInfo: ProposalInfo;
+    neuronIds: NeuronId[];
+  }) => VoteRegistration;
+  addSuccessfullyVotedNeuronId: (params: {
+    proposalId: ProposalId;
+    neuronId: NeuronId;
+  }) => void;
+  updateStatus: (params: {
+    proposalId: ProposalId;
+    status: VoteRegistrationStatus;
+  }) => void;
+  remove: (proposalId: ProposalId) => void;
+  reset: () => void;
 }
 
 // TODO: think about having an abstract store for the basic CRUD
@@ -24,8 +43,8 @@ export interface VoteRegistrationStore {
  * A store that contain votes in progress data (proposals and neurons that were not confirmed by `update` calls)
  * Is used for optimistic UI update
  */
-const initVoteRegistrationStore = () => {
-  const { subscribe, update, set } = writable<VoteRegistrationStore>({
+const initVoteRegistrationStore = (): VoteRegistrationStore => {
+  const { subscribe, update, set } = writable<VoteRegistrationStoreData>({
     registrations: [],
   });
 

--- a/frontend/src/lib/utils/before-unload.utils.ts
+++ b/frontend/src/lib/utils/before-unload.utils.ts
@@ -5,22 +5,22 @@ const onBeforeUnload = ($event: BeforeUnloadEvent) => {
   return ($event.returnValue = "Are you sure you want to exit?");
 };
 
-const addSyncBeforeUnload = () => {
+const addBeforeUnload = () => {
   window.addEventListener("beforeunload", onBeforeUnload, { capture: true });
 };
 
-const removeSyncBeforeUnload = () => {
+const removeBeforeUnload = () => {
   window.removeEventListener("beforeunload", onBeforeUnload, { capture: true });
 };
 
-export const syncBeforeUnload = (dirty: boolean) => {
+export const confirmToCloseBrowser = (dirty: boolean) => {
   if (!browser) {
     return;
   }
 
   if (dirty) {
-    addSyncBeforeUnload();
+    addBeforeUnload();
   } else {
-    removeSyncBeforeUnload();
+    removeBeforeUnload();
   }
 };

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -18,7 +18,7 @@ import {
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
 import type { AccountsStoreData } from "$lib/stores/accounts.store";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
-import type { VoteRegistrationStore } from "$lib/stores/vote-registration.store";
+import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";
 import type { Identity } from "@dfinity/agent";
 import type { WizardStep } from "@dfinity/gix-components";
@@ -800,7 +800,7 @@ export const neuronVoting = ({
   store: { registrations },
   neuronId,
 }: {
-  store: VoteRegistrationStore;
+  store: VoteRegistrationStoreData;
   neuronId: NeuronId;
 }): boolean =>
   registrations.find(

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -1,23 +1,17 @@
 <script lang="ts">
-  import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
-  import { syncBeforeUnload } from "$lib/utils/before-unload.utils";
-  import { voteRegistrationActive } from "$lib/utils/proposals.utils";
-  import { onDestroy, onMount } from "svelte";
+  import { confirmToCloseBrowser } from "$lib/utils/before-unload.utils";
+  import { onMount } from "svelte";
   import { Toasts, BusyScreen } from "@dfinity/gix-components";
   import {
     initAppAuth,
     initAppPublicData,
   } from "$lib/services/$public/app.services";
   import Warnings from "$lib/components/metrics/Warnings.svelte";
+  import {confirmBeforeCloseStore} from "$lib/derived/before-unload.derived";
 
   onMount(async () => await Promise.all([initAppAuth(), initAppPublicData()]));
 
-  const unsubscribeVoteInProgress = voteRegistrationStore.subscribe(
-    ({ registrations }) =>
-      syncBeforeUnload(voteRegistrationActive(registrations))
-  );
-
-  onDestroy(() => unsubscribeVoteInProgress());
+  $: confirmToCloseBrowser($confirmBeforeCloseStore);
 </script>
 
 <slot />

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -7,7 +7,7 @@
     initAppPublicData,
   } from "$lib/services/$public/app.services";
   import Warnings from "$lib/components/metrics/Warnings.svelte";
-  import {confirmBeforeCloseStore} from "$lib/derived/before-unload.derived";
+  import { confirmBeforeCloseStore } from "$lib/derived/before-unload.derived";
 
   onMount(async () => await Promise.all([initAppAuth(), initAppPublicData()]));
 


### PR DESCRIPTION
# Motivation

⚠️ DO NOT MERGE.

Not sure it is a good idea, to some extension yes but to some the browser freeze while displaying the popup so not sure what happens if user transfer icp, freeze browser for 5min, and continue during a sale.

That said, the PR also do a bit of clean-up, we might continue with that later.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
