### PR TITLE
Quick updates if start time has passed

### DIFF
--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -35,7 +35,7 @@ impl FastScheduler {
     /// Lifecycle states that need fast data collection either now or in the future.
     /// SNSs in other lifecycle states are ignored by this scheduler.
     const LIFECYCLES_TO_WATCH: [i32; 3] = [Self::LIFECYCLE_ADOPTED, Self::LIFECYCLE_PENDING, Self::LIFECYCLE_OPEN];
-    /// How long before an SNS starts, it i seligible for fast swap updates.
+    /// How long before an SNS starts, it is eligible for fast swap updates.
     const FAST_BEFORE_SECONDS: u64 = 60;
     /// Determines whether an SNS is eligible for an update
     fn needs_update(sns_swap_state: &GetStateResponse, time_now_seconds: u64) -> bool {


### PR DESCRIPTION
# Motivation
If the cached state of an SNS is approved and its sale start time has passed, assume that it is open and update the swap state rapidly.

Otherwise the rapid updates have to wait for the slow round robin, which would delay the sale by about 2 minutes.

This is how it looks like to a user waiting eagerly for a sale to start:

The user sees this and keeps hitting refresh, watching the countdown.
![Screenshot from 2023-03-02 16-15-41](https://user-images.githubusercontent.com/5982633/222470525-c5bfe724-6d14-4247-83ca-e6f305bbd3c9.png)

Then the countdown reaches zero, then the countdown value is blank, then the sale starts.  The blank period is undesirable. This PR reduces it from about 2 minutes (default settings) to a few seconds.


# Changes

<!-- List the changes that have been developed -->

# Tests
This is deployed on small09.  I have made several SNSs and verified the improvement.