### PR TITLE
Fix: Add CSP url

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,7 +24,7 @@ Every Pull Request needs unit tests.
 
 After installing the project, you can run the test suite:
 
-```
+```bash
 npm run test
 ```
 

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -156,6 +156,9 @@ const cspConnectSrc = () => {
     process.env.VITE_HOST,
     process.env.VITE_GOVERNANCE_CANISTER_URL,
     process.env.VITE_LEDGER_CANISTER_URL,
+    // TODO: solve with a worker
+    // Used for the metrics of OC launch
+    "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
   ];
 
   if (isAggregatorCanisterUrlDefined) {


### PR DESCRIPTION
# Motivation

Add OC swap canister URL to CSP rules.

# Changes

* Add url in CSP rules

# Tests

Not applicable
