### PR TITLE
feat: toast resolve todo and bump gix-cmp

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -25,6 +25,8 @@ module.exports = {
     "^\\$lib(.*)$": "<rootDir>/src/lib$1",
     "^\\$routes(.*)$": "<rootDir>/src/routes$1",
     "^\\$mocks(.*)$": "<rootDir>/__mocks__$1",
+    "@dfinity/gix-components":
+      "<rootDir>/node_modules/@dfinity/gix-components/dist",
   },
   setupFiles: ["fake-indexeddb/auto"],
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -769,15 +769,15 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.3.0-next-2023-03-01.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.3.0-next-2023-03-01.2.tgz",
-      "integrity": "sha512-iuKx0NRUk5HmEEUJSNnCF+pqYs6rnNv45J/wYeJK9OAa3p1GnRRqMxhq+NUtdErVRLV2zDr5015hYbLALrpzoQ==",
+      "version": "2.4.0-next-2023-03-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.4.0-next-2023-03-03.1.tgz",
+      "integrity": "sha512-UjZVBayzApEVHZur/MKc7grN9bVRDm6CfwT5pn+4slaE3JkuSAW7SC/tiCIy2hSD1dqeUdzfar3uDdWwwTfSTg==",
       "dependencies": {
-        "dompurify": "^2.4.3",
+        "dompurify": "^3.0.1",
         "qr-creator": "^1.0.0"
       },
       "peerDependencies": {
-        "svelte": "^3.0.0"
+        "svelte": "^3.55.1"
       }
     },
     "node_modules/@dfinity/identity": {
@@ -3774,9 +3774,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
-      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
     },
     "node_modules/dotenv": {
       "version": "16.0.3",
@@ -9516,11 +9516,11 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.3.0-next-2023-03-01.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.3.0-next-2023-03-01.2.tgz",
-      "integrity": "sha512-iuKx0NRUk5HmEEUJSNnCF+pqYs6rnNv45J/wYeJK9OAa3p1GnRRqMxhq+NUtdErVRLV2zDr5015hYbLALrpzoQ==",
+      "version": "2.4.0-next-2023-03-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.4.0-next-2023-03-03.1.tgz",
+      "integrity": "sha512-UjZVBayzApEVHZur/MKc7grN9bVRDm6CfwT5pn+4slaE3JkuSAW7SC/tiCIy2hSD1dqeUdzfar3uDdWwwTfSTg==",
       "requires": {
-        "dompurify": "^2.4.3",
+        "dompurify": "^3.0.1",
         "qr-creator": "^1.0.0"
       }
     },
@@ -11666,9 +11666,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
-      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
     },
     "dotenv": {
       "version": "16.0.3",

--- a/frontend/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/src/lib/components/accounts/AccountCard.svelte
@@ -33,9 +33,9 @@
 </Card>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .title {
     @include card.stacked-title;

--- a/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
@@ -43,7 +43,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .table {
     display: grid;

--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -51,7 +51,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/form";
+  @use "@dfinity/gix-components/dist/styles/mixins/form";
   .select {
     @include form.input;
 

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -77,8 +77,8 @@
 </article>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   article {
     padding-bottom: var(--padding-2x);

--- a/frontend/src/lib/components/canister-detail/ControllersCard.svelte
+++ b/frontend/src/lib/components/canister-detail/ControllersCard.svelte
@@ -36,7 +36,7 @@
 </CardInfo>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   .actions {
     display: flex;

--- a/frontend/src/lib/components/canisters/CanisterCard.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCard.svelte
@@ -21,7 +21,7 @@
 </Card>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   .title {
     @include card.stacked-title;

--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -58,7 +58,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .wrapper {
     display: flex;

--- a/frontend/src/lib/components/common/Json.svelte
+++ b/frontend/src/lib/components/common/Json.svelte
@@ -111,7 +111,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/interaction";
+  @use "@dfinity/gix-components/dist/styles/mixins/interaction";
 
   .root,
   .root ~ ul,

--- a/frontend/src/lib/components/common/MenuMetrics.svelte
+++ b/frontend/src/lib/components/common/MenuMetrics.svelte
@@ -13,7 +13,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   div {
     display: flex;

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -38,8 +38,8 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/header";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/header";
 
   .info {
     width: 100%;

--- a/frontend/src/lib/components/header/Banner.svelte
+++ b/frontend/src/lib/components/header/Banner.svelte
@@ -53,7 +53,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
 
   div {
     position: fixed;

--- a/frontend/src/lib/components/header/LoginIconOnly.svelte
+++ b/frontend/src/lib/components/header/LoginIconOnly.svelte
@@ -28,7 +28,7 @@
 </button>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/header";
+  @use "@dfinity/gix-components/dist/styles/mixins/header";
 
   button {
     justify-self: flex-end;

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -36,8 +36,8 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   div {
     display: inline-grid;

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -119,7 +119,7 @@
 </Modal>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .open {
     display: flex;

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -61,7 +61,7 @@
 </Card>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
 
   .title {
     display: flex;

--- a/frontend/src/lib/components/launchpad/VotesProgress.svelte
+++ b/frontend/src/lib/components/launchpad/VotesProgress.svelte
@@ -38,7 +38,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .latest-tally {
     display: grid;

--- a/frontend/src/lib/components/layout/Footer.svelte
+++ b/frontend/src/lib/components/layout/Footer.svelte
@@ -11,8 +11,8 @@
 </footer>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
 
   footer {
     height: var(--footer-height);

--- a/frontend/src/lib/components/login/LoginBackground.svelte
+++ b/frontend/src/lib/components/login/LoginBackground.svelte
@@ -19,7 +19,7 @@
 </picture>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../themes/mixins/login";
 
   picture {

--- a/frontend/src/lib/components/login/LoginFooter.svelte
+++ b/frontend/src/lib/components/login/LoginFooter.svelte
@@ -50,9 +50,9 @@
 </footer>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
-  @use "@dfinity/gix-components/styles/mixins/text";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   a {
     display: flex;

--- a/frontend/src/lib/components/login/LoginHeader.svelte
+++ b/frontend/src/lib/components/login/LoginHeader.svelte
@@ -49,7 +49,7 @@
 </header>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   header {
     position: relative;

--- a/frontend/src/lib/components/login/LoginLinks.svelte
+++ b/frontend/src/lib/components/login/LoginLinks.svelte
@@ -54,8 +54,8 @@
 </ul>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
   @use "../../themes/mixins/login";
 
   ul {

--- a/frontend/src/lib/components/login/LoginTitle.svelte
+++ b/frontend/src/lib/components/login/LoginTitle.svelte
@@ -7,7 +7,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../themes/mixins/login";
 
   .title {

--- a/frontend/src/lib/components/metrics/TotalValueLocked.svelte
+++ b/frontend/src/lib/components/metrics/TotalValueLocked.svelte
@@ -30,8 +30,8 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .tvl {
     display: inline-block;

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -105,7 +105,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   h3 {
     line-height: var(--line-height-standard);

--- a/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -97,7 +97,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   h3 {
     margin: 0;

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -82,7 +82,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   ul {
     @include card.list;

--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -42,7 +42,7 @@
 </article>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/interaction";
+  @use "@dfinity/gix-components/dist/styles/mixins/interaction";
 
   article {
     :global(.collapsible-expand-icon) {

--- a/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
+++ b/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
@@ -20,7 +20,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .status {
     display: inline-flex;

--- a/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
@@ -39,7 +39,7 @@
 </NeuronCardContainer>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
   @use "../../themes/mixins/neuron";
 
   // TODO: avoid root global styling

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -34,8 +34,8 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .title {
     @include card.stacked-title;

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -197,7 +197,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .participate {
     display: flex;

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -87,7 +87,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .content {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -37,7 +37,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   ul {
     list-style: none;

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -66,7 +66,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   ul {
     list-style-type: none;

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -43,7 +43,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   @include media.min-width(medium) {
     // If this would be use elsewhere, we can extract some utility to gix-components

--- a/frontend/src/lib/components/proposal-detail/ProposalContentCell.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalContentCell.svelte
@@ -7,7 +7,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .content-cell-details:last-of-type {
     margin-bottom: 0;

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -21,8 +21,8 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .markdown {
     overflow-wrap: break-word;

--- a/frontend/src/lib/components/proposal-detail/VotesResults.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResults.svelte
@@ -39,7 +39,7 @@
 </ProposalContentCell>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .latest-tally {
     display: grid;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -125,7 +125,7 @@
 </BottomSheet>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .container:not(.signedIn) {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte
@@ -82,7 +82,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   [role="toolbar"] {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte
@@ -81,7 +81,7 @@
 </Collapsible>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .total {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectContainer.svelte
@@ -18,7 +18,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .neurons {
     padding: var(--padding-1_5x) var(--padding) 0;

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
@@ -57,7 +57,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   ul {
     list-style: none;

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -67,9 +67,9 @@
 </li>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/text";
-  @use "@dfinity/gix-components/styles/mixins/card";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   li.hidden {
     visibility: hidden;

--- a/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte
@@ -90,7 +90,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   ul {
     @include card.list;

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -164,7 +164,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
 
   .title {
     display: flex;

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCardTitle.svelte
@@ -44,9 +44,9 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/card";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/card";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .hash {
     @include fonts.standard(true);

--- a/frontend/src/lib/components/summary/PrincipalText.svelte
+++ b/frontend/src/lib/components/summary/PrincipalText.svelte
@@ -15,7 +15,7 @@
 </p>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .principal {
     display: flex;

--- a/frontend/src/lib/components/summary/Summary.svelte
+++ b/frontend/src/lib/components/summary/Summary.svelte
@@ -24,9 +24,9 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/text";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .summary {
     display: flex;

--- a/frontend/src/lib/components/summary/SummaryUniverse.svelte
+++ b/frontend/src/lib/components/summary/SummaryUniverse.svelte
@@ -7,7 +7,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .summary {
     display: none;

--- a/frontend/src/lib/components/ui/CardBlock.svelte
+++ b/frontend/src/lib/components/ui/CardBlock.svelte
@@ -27,8 +27,8 @@
 </article>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/interaction";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/interaction";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   article {
     text-decoration: none;

--- a/frontend/src/lib/components/ui/ColumnRow.svelte
+++ b/frontend/src/lib/components/ui/ColumnRow.svelte
@@ -8,8 +8,8 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/display";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/display";
 
   div {
     display: flex;

--- a/frontend/src/lib/components/ui/EmptyMessage.svelte
+++ b/frontend/src/lib/components/ui/EmptyMessage.svelte
@@ -1,7 +1,7 @@
 <p class="description empty"><slot /></p>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .empty {
     @include media.min-width(medium) {

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -54,7 +54,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .wrapper {
     position: relative;

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -56,9 +56,9 @@
 </Card>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
 
   .container {
     display: flex;

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -25,8 +25,8 @@
 </Nav>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/fonts";
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .title {
     margin: 0;

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -170,7 +170,7 @@
 </Modal>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .content {
     display: flex;

--- a/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
+++ b/frontend/src/lib/modals/proposals/VoteConfirmationModal.svelte
@@ -33,8 +33,8 @@
 </ConfirmationModal>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
 
   div {
     padding: var(--padding-2x) 0;

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -227,7 +227,7 @@
 <CanisterDetailModals />
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .actions {
     margin-bottom: var(--padding-3x);

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -117,7 +117,7 @@
 </Footer>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   main {
     padding-bottom: var(--footer-height);

--- a/frontend/src/lib/pages/Login.svelte
+++ b/frontend/src/lib/pages/Login.svelte
@@ -41,8 +41,8 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
-  @use "@dfinity/gix-components/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
   @use "../themes/mixins/login";
 
   .sign-in {

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -218,7 +218,7 @@
 </main>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
   .stretch-mobile {
     min-height: 100%;
 

--- a/frontend/src/lib/stores/toasts.store.ts
+++ b/frontend/src/lib/stores/toasts.store.ts
@@ -5,7 +5,6 @@ import { errorToString } from "$lib/utils/error.utils";
 import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
 import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
 import { toastsStore } from "@dfinity/gix-components";
-import { get } from "svelte/store";
 
 const mapToastText = ({ labelKey, substitutions, detail }: ToastMsg): string =>
   `${replacePlaceholders(translate({ labelKey }), substitutions ?? {})}${
@@ -19,7 +18,7 @@ const mapToastText = ({ labelKey, substitutions, detail }: ToastMsg): string =>
  * - toastsSuccess: display a message of type "success" - something went really well ;)
  * - toastsError: display an error and print the issue in the console as well
  * - toastsHide: remove the toast message with that timestamp or the first one.
- * - toastsReset: reset toasts
+ * - toastsClean: clean toasts with relatively low levels. Used after user sign-in.
  */
 
 export const toastsShow = (msg: ToastMsg): symbol => {
@@ -66,15 +65,10 @@ export const toastsError = ({
 
 export const toastsHide = (idToHide: symbol) => toastsStore.hide(idToHide);
 
-export const toastsReset = () => {
-  // TODO: Workaround, implement better solution
-  const toasts = [...get(toastsStore)];
-  const customToasts = toasts.filter(({ level }) => level === "custom");
-
-  toastsStore.reset();
-
-  customToasts.forEach((msg) => toastsStore.show(msg));
-};
+/**
+ * We keep error and custom (used for particular notifications such as high-load messages).
+ */
+export const toastsClean = () => toastsStore.reset(["success", "warn", "info"]);
 
 export const toastsUpdate = ({
   id,

--- a/frontend/src/lib/themes/legacy.scss
+++ b/frontend/src/lib/themes/legacy.scss
@@ -2,7 +2,7 @@
  * CSS styles that override gix-components preset for the "old ui"
  */
 
-@use "@dfinity/gix-components/styles/mixins/media";
+@use "@dfinity/gix-components/dist/styles/mixins/media";
 
 main.legacy {
   margin: inherit;

--- a/frontend/src/lib/themes/mixins/_neuron.scss
+++ b/frontend/src/lib/themes/mixins/_neuron.scss
@@ -1,4 +1,4 @@
-@use "@dfinity/gix-components/styles/mixins/media";
+@use "@dfinity/gix-components/dist/styles/mixins/media";
 
 @mixin maturity-card-info {
   h3 {

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -44,7 +44,7 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../lib/themes/mixins/login";
 
   .content {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import type { AuthStore } from "$lib/stores/auth.store";
   import { initAuthWorker } from "$lib/services/worker-auth.services";
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
-  import { toastsReset } from "$lib/stores/toasts.store";
+  import { toastsClean } from "$lib/stores/toasts.store";
 
   let ready = false;
 
@@ -29,7 +29,7 @@
     // We reset the toast to clear any previous messages.
     // This is notably user-friendly in case of the user would have been sign-out automatically - session duration expired.
     // That way user does not have to manually close previous message.
-    toastsReset();
+    toastsClean();
 
     // Load app global stores data
     await initAppPrivateDataProxy();
@@ -48,7 +48,7 @@
 <slot />
 
 <style lang="scss" global>
-  @import "@dfinity/gix-components/styles/global.scss";
+  @import "@dfinity/gix-components/dist/styles/global.scss";
   @import "../lib/themes/legacy";
   @import "../lib/themes/global";
   @import "../lib/themes/variables";

--- a/frontend/src/tests/lib/stores/toasts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/toasts.store.spec.ts
@@ -1,0 +1,49 @@
+import { toastsStore } from "@dfinity/gix-components";
+import { get } from "svelte/store";
+import { toastsClean } from "../../../lib/stores/toasts.store";
+
+describe("toast store", () => {
+  it("should clean toasts", () => {
+    toastsStore.show({
+      level: "success",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "success",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "warn",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "warn",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "error",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "info",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "custom",
+      text: "test",
+    });
+
+    toastsClean();
+
+    const msgs = get(toastsStore);
+
+    // Remain one error and one custom
+    expect(msgs.length).toEqual(2);
+  });
+});


### PR DESCRIPTION
# Motivation

Resolve yesterday evening todo (toast.reset -> toest.clean) and bump gix-cmp.

# Note

Because there were breaking changes in SvelteKit (adapted in gix-cmp in https://github.com/dfinity/gix-components/pull/166) this PR had to also adapt.

- gix-cmp is not flat but contains a sub-folder `dist` so Sass import and use needs to reference this sub-folder
- jest had a hard time finding the library so it needed an extra mapping configuration to find the components
