### PR TITLE
Enforce === and !==

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -17,6 +17,7 @@ module.exports = {
     ecmaVersion: 2020,
   },
   rules: {
+    eqeqeq: ["error"],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -41,7 +41,7 @@ export const secondsToDuration = (seconds: bigint): string => {
     .map(
       (labelInfo) =>
         `${labelInfo.amount} ${
-          labelInfo.amount == 1
+          labelInfo.amount === 1
             ? i18nObj.time[labelInfo.labelKey]
             : i18nObj.time[`${labelInfo.labelKey}_plural`]
         }`
@@ -83,7 +83,7 @@ export const daysToDuration = (days: number): string => {
     .map(
       (labelInfo) =>
         `${labelInfo.amount} ${
-          labelInfo.amount == 1
+          labelInfo.amount === 1
             ? i18nObj.time[labelInfo.labelKey]
             : i18nObj.time[`${labelInfo.labelKey}_plural`]
         }`
@@ -119,7 +119,7 @@ export const secondsToDissolveDelayDuration = (seconds: bigint): string => {
     .map(
       (labelInfo) =>
         `${labelInfo.amount} ${
-          labelInfo.amount == 1
+          labelInfo.amount === 1
             ? i18nObj.time[labelInfo.labelKey]
             : i18nObj.time[`${labelInfo.labelKey}_plural`]
         }`

--- a/frontend/src/lib/utils/dev.utils.ts
+++ b/frontend/src/lib/utils/dev.utils.ts
@@ -1,7 +1,7 @@
+import { nonNullish } from "@dfinity/utils";
+
 export const isNode = (): boolean =>
-  typeof process !== "undefined" &&
-  process.versions != null &&
-  process.versions.node != null;
+  typeof process !== "undefined" && nonNullish(process.versions?.node);
 
 /**
  *

--- a/frontend/src/lib/utils/ledger.utils.ts
+++ b/frontend/src/lib/utils/ledger.utils.ts
@@ -25,7 +25,7 @@ export const decodePublicKey = ({
     throw new LedgerErrorKey("error__ledger.please_open");
   }
 
-  if (code == LedgerError.TransactionRejected) {
+  if (code === LedgerError.TransactionRejected) {
     throw new LedgerErrorKey("error__ledger.locked");
   }
 

--- a/frontend/src/lib/utils/route.utils.ts
+++ b/frontend/src/lib/utils/route.utils.ts
@@ -17,4 +17,4 @@ export const replaceHistory = (url: URL) => {
 const supportsHistory = (): boolean =>
   window.history !== undefined &&
   "pushState" in window.history &&
-  typeof window.history.pushState != "undefined";
+  typeof window.history.pushState !== "undefined";


### PR DESCRIPTION
# Motivation

`===` and `!==` express more explicit intent than `==` and `!=` and it's good practice to avoid the latter.

# Changes

1. Enable lint to enforce `===` and `!==`.
2. Fix existing violations.

# Tests

`npm run lint` and `npm run test`