### PR TITLE
Provide mainnet nns-canister ID to dfx

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -17,7 +17,13 @@
       "type": "custom",
       "candid": "rs/backend/nns-dapp.did",
       "wasm": "nns-dapp.wasm",
-      "build": "./build.sh"
+      "build": "./build.sh",
+      "remote": {
+        "id": {
+          "ic": "qoctq-giaaa-aaaaa-aaaea-cai",
+          "mainnet": "qoctq-giaaa-aaaaa-aaaea-cai"
+        }
+      }
     },
     "internet_identity": {
       "type": "custom",
@@ -138,7 +144,6 @@
         "FETCH_ROOT_KEY": false,
         "API_HOST": "https://icp-api.io",
         "STATIC_HOST": "https://icp0.io",
-        "OWN_CANISTER_ID": "qoctq-giaaa-aaaaa-aaaea-cai",
         "OWN_CANISTER_URL": "https://nns.internetcomputer.org",
         "IDENTITY_SERVICE_URL": "https://identity.internetcomputer.org/",
         "FEATURE_FLAGS": {


### PR DESCRIPTION
# Motivation
Out of the box, `dfx` commands such as `dfx canister call nns-dapp XXX --network ic` do not work.  Our `OWN_CANISTER_ID` predates the `dfx.json` remote entries.  Moving to the newer standard location for specifying a canister ID seems to break no flows and enable this use case.

Note: I have _not_ set a remote canister ID for `local` as we do deploy to local directly, not necessarily by proposal, and doing so would break related flows.

# Changes
- Remove the mainnet nns-dapp `OWN_CANISTER_ID`  in dfx.json.
- Add nns-dapp remotes for the ic and mainnet networks.

# Tests
- I have verified that the config output when building for mainnet is unchanged by this commit:
```
# Make config in this PR:
max@sinkpad:~/dfn/nns-dapp/branches/own-canister-id (11:20)$ DFX_NETWORK=mainnet ./config.sh 
~/dfn/nns-dapp/branches/own-canister-id ~/dfn/nns-dapp/branches/own-canister-id
VITE_DFX_NETWORK=mainnet
[SNIP]

# and then in main:
max@sinkpad:~/dfn/nns-dapp (4:28)$ DFX_NETWORK=mainnet ./config.sh
~/dfn/nns-dapp ~/dfn/nns-dapp
VITE_DFX_NETWORK=mainnet
[SNIP]
max@sinkpad:~/dfn/nns-dapp (18:28)$ diff deployment-config.json /home/max/dfn/nns-dapp/branches/own-canister-id/deployment-config.json

# Config is unchanged:
max@sinkpad:~/dfn/nns-dapp (18:28)$ diff deployment-config.json /home/max/dfn/nns-dapp/branches/own-canister-id/deployment-config.json
max@sinkpad:~/dfn/nns-dapp (18:31)$ diff frontend/.env /home/max/dfn/nns-dapp/branches/own-canister-id/frontend/.env 
max@sinkpad:~/dfn/nns-dapp (20:31)$ 
```
* I have verified that canister calls work out of the box with this change:
```
max@sinkpad:~/dfn/nns-dapp/branches/own-canister-id (21:46)$ dfx canister call nns-dapp get_stats --network ic
(
  record {
    latest_transaction_block_height = 5_709_934 : nat64;
    seconds_since_last_ledger_sync = 0 : nat64;
    sub_accounts_count = 32_756 : nat64;
    neurons_topped_up_count = 59_885 : nat64;
    transactions_to_process_queue_length = 0 : nat32;
    neurons_created_count = 39_393 : nat64;
    hardware_wallet_accounts_count = 8_548 : nat64;
    accounts_count = 161_530 : nat64;
    earliest_transaction_block_height = 16_153 : nat64;
    transactions_count = 519_474 : nat64;
    block_height_synced_up_to = opt (5_709_948 : nat64);
    latest_transaction_timestamp_nanos = 1_677_854_755_601_791_528 : nat64;
    earliest_transaction_timestamp_nanos = 1_620_569_306_110_018_152 : nat64;
  },
)
```