### PR TITLE
Remove unused fields from MultiPartTransactionsProcessor

### DIFF
--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::multi_part_transactions_processor::MultiPartTransactionToBeProcessed;
 use icp_ledger::Tokens;
 use std::str::FromStr;
 
@@ -1264,6 +1265,80 @@ fn get_stats() {
     store.mark_ledger_sync_complete();
     let stats = store.get_stats();
     assert!(stats.seconds_since_last_ledger_sync < 10);
+}
+
+fn assert_queue_item_eq_stake_neuron(
+    expected_block_index: BlockIndex,
+    expected_principal: PrincipalId,
+    expected_memo: Memo,
+    actual_queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
+) {
+    assert_eq!(actual_queue.len(), 1);
+    let actual_queue_item = actual_queue.get(0).unwrap();
+    assert_eq!(expected_block_index, actual_queue_item.0);
+    if let MultiPartTransactionToBeProcessed::StakeNeuron(actual_principal, actual_memo) = actual_queue_item.1 {
+        assert_eq!(expected_principal, actual_principal);
+        assert_eq!(expected_memo, actual_memo);
+    } else {
+        panic!("Queue item should be stake neuron transaction.");
+    }
+}
+
+#[test]
+fn decode_after_fields_removed_from_from_mptp() {
+    let mut mptp_old = MultiPartTransactionsProcessorWithRemovedFields::default();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let block_index = 123;
+    let memo = Memo(789);
+    let queue_item: (BlockIndex, MultiPartTransactionToBeProcessed) = (
+        block_index,
+        MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo),
+    );
+    mptp_old.queue.push_back(queue_item);
+
+    let bytes = Candid((&mptp_old,)).into_bytes().unwrap();
+    let (mptp_new,): (MultiPartTransactionsProcessor,) = Candid::from_bytes(bytes).map(|c| c.0).unwrap();
+
+    let decoded_queue = mptp_new.get_queue_for_testing();
+
+    assert_queue_item_eq_stake_neuron(block_index, principal, memo, decoded_queue);
+}
+
+#[test]
+fn decode_into_restored_fields_of_mptp_after_rollback() {
+    let new_mptp = MultiPartTransactionsProcessor::default();
+    let bytes = Candid((&new_mptp,)).into_bytes().unwrap();
+
+    let old_mptp_result: Result<(MultiPartTransactionsProcessorWithRemovedFields,), String> =
+        Candid::from_bytes(bytes).map(|c| c.0);
+
+    // This fails, showing that we need special logic to make rollbacks safe.
+    assert_eq!(old_mptp_result.err().unwrap().starts_with("Fail to decode"), true);
+}
+
+#[test]
+fn encode_decode_stable_state() {
+    let mut store = AccountsStore::default();
+    let block_index = 312;
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let memo = Memo(789);
+    let queue_item: (BlockIndex, MultiPartTransactionToBeProcessed) = (
+        block_index,
+        MultiPartTransactionToBeProcessed::StakeNeuron(principal, memo),
+    );
+    store
+        .multi_part_transactions_processor
+        .get_mut_queue_for_testing()
+        .push_back(queue_item);
+    let bytes = store.encode();
+    let decoded_store = AccountsStore::decode(bytes).unwrap();
+
+    assert_queue_item_eq_stake_neuron(
+        block_index,
+        principal,
+        memo,
+        decoded_store.multi_part_transactions_processor.get_queue_for_testing(),
+    );
 }
 
 fn setup_test_store() -> AccountsStore {

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1313,7 +1313,7 @@ fn decode_into_restored_fields_of_mptp_after_rollback() {
         Candid::from_bytes(bytes).map(|c| c.0);
 
     // This fails, showing that we need special logic to make rollbacks safe.
-    assert_eq!(old_mptp_result.err().unwrap().starts_with("Fail to decode"), true);
+    assert!(old_mptp_result.err().unwrap().starts_with("Fail to decode"));
 }
 
 #[test]

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -10,10 +10,26 @@ use std::collections::{BTreeMap, VecDeque};
 #[derive(Default, CandidType, Deserialize)]
 pub struct MultiPartTransactionsProcessor {
     queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
+}
+
+// We temporarily use this to encode stable state which can be
+// safely decoded even if we have to roll back to an earlier
+// version.
+#[derive(Default, CandidType, Deserialize)]
+pub struct MultiPartTransactionsProcessorWithRemovedFields {
+    pub queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
     // Unused but needs a migration to remove safely.
     statuses: BTreeMap<BlockIndex, (PrincipalId, MultiPartTransactionStatus)>,
     // Unused but needs a migration to remove safely.
     errors: VecDeque<MultiPartTransactionError>,
+}
+
+impl MultiPartTransactionsProcessorWithRemovedFields {
+    pub fn from(mptp: &MultiPartTransactionsProcessor) -> MultiPartTransactionsProcessorWithRemovedFields {
+        let mut result = MultiPartTransactionsProcessorWithRemovedFields::default();
+        result.queue = mptp.queue.clone();
+        result
+    }
 }
 
 #[derive(Clone, CandidType, Deserialize)]
@@ -59,6 +75,16 @@ impl MultiPartTransactionsProcessor {
 
     pub fn get_queue_length(&self) -> u32 {
         self.queue.len() as u32
+    }
+
+    #[cfg(test)]
+    pub fn get_queue_for_testing(&self) -> VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)> {
+        self.queue.clone()
+    }
+
+    #[cfg(test)]
+    pub fn get_mut_queue_for_testing(&mut self) -> &mut VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)> {
+        &mut self.queue
     }
 }
 

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -26,9 +26,11 @@ pub struct MultiPartTransactionsProcessorWithRemovedFields {
 
 impl MultiPartTransactionsProcessorWithRemovedFields {
     pub fn from(mptp: &MultiPartTransactionsProcessor) -> MultiPartTransactionsProcessorWithRemovedFields {
-        let mut result = MultiPartTransactionsProcessorWithRemovedFields::default();
-        result.queue = mptp.queue.clone();
-        result
+        MultiPartTransactionsProcessorWithRemovedFields {
+            queue: mptp.queue.clone(),
+            statuses: BTreeMap::default(),
+            errors: VecDeque::default(),
+        }
     }
 }
 


### PR DESCRIPTION
# Motivation

MultiPartTransactionsProcessor has 2 unused fields: `statuses` and `errors`.
We want to remove these fields but this has to be done carefully because there are part of stable state which is encode/decoded when the canister is upgraded.

Candid::from_bytes actually deals fine with additional data for removed fields, so removing the fields would be fine, but we want to be able to roll back to an earlier version of the canister, and in that case we would be adding the fields back.
And trying to decode bytes which do not include new fields does cause the decoding to fail.

My solution is to temporarily fork MultiPartTransactionsProcessor to have 2 versions: 1 with the unused fields removed and 1 with the unused fields intact.
We use the type with the extra fields for encoding and we use the type without the extra fields for decoding.
Let's assume we have the following 3 versions of the canister:
1. Built from current main branch with the unused fields still present.
2. Built after this PR is merged.
3. Built from current main branch with the unused fields removed and no additional code (so anything special from the PR removed again).

We can now safely go back and forth between versions 1 and 2 and we can go safely back and forth between versions 2 and 3. The only thing that fails is going straight from version 3 to version 1.

So if we stay with version 2 for one or two weeks, we should be safe to always have a rollback path to a good version.

# Changes

1. Forked MultiPartTransactionsProcessor to MultiPartTransactionsProcessorWithRemovedFields.
2. Removed `statuses` and `errors` from MultiPartTransactionsProcessor but kept them in MultiPartTransactionsProcessorWithRemovedFields.
3. When encoding AccountsStore to stable state, use MultiPartTransactionsProcessorWithRemovedFields instead of MultiPartTransactionsProcessor.
4. A test that shows that encoded MultiPartTransactionsProcessorWithRemovedFields can be decoded as MultiPartTransactionsProcessor.
5. A test that shows that encoded MultiPartTransactionsProcessor can not be decoded as MultiPartTransactionsProcessorWithRemovedFields.
6. A test that shows that AccountsStore can be encoded and decoded with the remaining field of MultiPartTransactionsProcessor (`queue`) intact.

# Tests

1. Added unit tests.
2. Deployed (on local replica) version 3 (described above) and then deployed version 1 to notice the failure.
3. Deployed version 3 and then deployed version 2 and then version 1 to notice that it works.
4. Deployed version 1 and then 2 and then 3 to make sure that works as well.