### PR TITLE
Feat: Don't watch not open projects

### DIFF
--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -31,11 +31,13 @@
     loadSnsMetrics,
     watchSnsMetrics,
   } from "$lib/services/sns-swap-metrics.services";
+  import { SnsSwapLifecycle } from "@dfinity/sns";
 
   export let rootCanisterId: string | undefined | null;
 
   let unsubscribeWatchCommitment: () => void | undefined;
   let unsubscribeWatchMetrics: () => void | undefined;
+  let enableWatchers = false;
 
   onDestroy(() => {
     unsubscribeWatchCommitment?.();
@@ -46,7 +48,7 @@
     loadCommitment({ rootCanisterId, forceFetch: false });
   }
 
-  $: if (nonNullish(rootCanisterId)) {
+  $: if (nonNullish(rootCanisterId) && enableWatchers) {
     unsubscribeWatchCommitment?.();
     unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
   }
@@ -93,7 +95,11 @@
   });
 
   let swapCanisterId: Principal | undefined;
-  $: if (nonNullish(swapCanisterId) && nonNullish(rootCanisterId)) {
+  $: if (
+    nonNullish(swapCanisterId) &&
+    nonNullish(rootCanisterId) &&
+    enableWatchers
+  ) {
     reloadSnsMetrics({ forceFetch: false });
     unsubscribeWatchMetrics?.();
     unsubscribeWatchMetrics = watchSnsMetrics({
@@ -127,6 +133,7 @@
     return goto(AppPath.Launchpad, { replaceState: true });
   };
 
+  // TODO: Change to a `let` that is recalculated when the store changes
   const setProjectStore = (rootCanisterId: string) => {
     // Check project summaries are loaded in store
     if ($snsSummariesStore.length === 0) {
@@ -174,14 +181,17 @@
 
       // TODO: Understand why this component doesn't subscribe to the store `projectDetailStore`.
       // Is it because it's created in this same component?
-      const newSwapCanisterId = $snsSummariesStore.find(
+      const summary = $snsSummariesStore.find(
         ({ rootCanisterId: rootCanister }) =>
           rootCanister?.toText() === rootCanisterId
-      )?.swapCanisterId;
+      );
+      const newSwapCanisterId = summary?.swapCanisterId;
 
       if (newSwapCanisterId?.toText() !== swapCanisterId?.toText()) {
         swapCanisterId = newSwapCanisterId;
       }
+
+      enableWatchers = summary?.swap.lifecycle === SnsSwapLifecycle.Open;
     })();
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -38,6 +38,11 @@
   let unsubscribeWatchCommitment: () => void | undefined;
   let unsubscribeWatchMetrics: () => void | undefined;
   let enableWatchers = false;
+  $: enableWatchers =
+    $snsSummariesStore.find(
+      ({ rootCanisterId: rootCanister }) =>
+        rootCanister?.toText() === rootCanisterId
+    )?.swap.lifecycle === SnsSwapLifecycle.Open;
 
   onDestroy(() => {
     unsubscribeWatchCommitment?.();
@@ -102,6 +107,7 @@
   ) {
     reloadSnsMetrics({ forceFetch: false });
     unsubscribeWatchMetrics?.();
+
     unsubscribeWatchMetrics = watchSnsMetrics({
       rootCanisterId: Principal.fromText(rootCanisterId),
       swapCanisterId: swapCanisterId,
@@ -190,8 +196,6 @@
       if (newSwapCanisterId?.toText() !== swapCanisterId?.toText()) {
         swapCanisterId = newSwapCanisterId;
       }
-
-      enableWatchers = summary?.swap.lifecycle === SnsSwapLifecycle.Open;
     })();
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -57,85 +57,113 @@ describe("ProjectDetail", () => {
       jest.clearAllMocks();
       snsQueryStore.reset();
       snsSwapCommitmentsStore.reset();
+    });
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
-          certified: true,
-        })
-      );
-      snsSwapCommitmentsStore.setSwapCommitment({
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        certified: true,
+    describe("Open project", () => {
+      beforeEach(() => {
+        snsQueryStore.setData(
+          snsResponsesForLifecycle({
+            lifecycles: [SnsSwapLifecycle.Open],
+            certified: true,
+          })
+        );
+        // snsSwapCommitmentsStore.setSwapCommitment({
+        //   swapCommitment:
+        //     mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+        //   certified: true,
+        // });
+      });
+
+      it("should start watching derived state", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
+      });
+
+      it("should clear watch commitments on unmount", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        expect(mockUnwatchCommitmentsCall).not.toBeCalled();
+
+        unmount();
+
+        await waitFor(() =>
+          expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
+        );
+      });
+
+      it("should start watching metrics", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(watchSnsMetrics).toBeCalled());
+      });
+
+      it("should clear watch metrics on unmount", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        expect(mockUnwatchMetricsCall).not.toBeCalled();
+
+        unmount();
+
+        await waitFor(() => expect(mockUnwatchMetricsCall).toBeCalledTimes(1));
+      });
+
+      it("should clear watch commitments on unmount", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        expect(mockUnwatchCommitmentsCall).not.toBeCalled();
+
+        unmount();
+
+        await waitFor(() =>
+          expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
+        );
+      });
+
+      it("should not load user's commitnemtn", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(loadSnsSwapCommitment).not.toBeCalled());
+      });
+
+      it("should render info section", async () => {
+        const { queryByTestId } = render(ProjectDetail, props);
+
+        await waitFor(() =>
+          expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument()
+        );
+      });
+
+      it("should render status section", async () => {
+        const { queryByTestId } = render(ProjectDetail, props);
+
+        await waitFor(() =>
+          expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument()
+        );
       });
     });
 
-    it("should start watching derived state", async () => {
-      render(ProjectDetail, props);
+    describe("Committed project project", () => {
+      beforeEach(() => {
+        snsQueryStore.setData(
+          snsResponsesForLifecycle({
+            lifecycles: [SnsSwapLifecycle.Committed],
+            certified: true,
+          })
+        );
+      });
 
-      await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
-    });
+      it("should not start watching derived state", async () => {
+        render(ProjectDetail, props);
 
-    it("should clear watch commitments on unmount", async () => {
-      const { unmount } = render(ProjectDetail, props);
+        await waitFor(() => expect(watchSnsTotalCommitment).not.toBeCalled());
+      });
 
-      expect(mockUnwatchCommitmentsCall).not.toBeCalled();
+      it("should not start watching metrics", async () => {
+        render(ProjectDetail, props);
 
-      unmount();
-
-      await waitFor(() =>
-        expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
-      );
-    });
-
-    it("should start watching metrics", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(watchSnsMetrics).toBeCalled());
-    });
-
-    it("should clear watch metrics on unmount", async () => {
-      const { unmount } = render(ProjectDetail, props);
-
-      expect(mockUnwatchMetricsCall).not.toBeCalled();
-
-      unmount();
-
-      await waitFor(() => expect(mockUnwatchMetricsCall).toBeCalledTimes(1));
-    });
-
-    it("should clear watch commitments on unmount", async () => {
-      const { unmount } = render(ProjectDetail, props);
-
-      expect(mockUnwatchCommitmentsCall).not.toBeCalled();
-
-      unmount();
-
-      await waitFor(() =>
-        expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
-      );
-    });
-
-    it("should not load user's commitnemtn", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(loadSnsSwapCommitment).not.toBeCalled());
-    });
-
-    it("should render info section", async () => {
-      const { queryByTestId } = render(ProjectDetail, props);
-
-      await waitFor(() =>
-        expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument()
-      );
-    });
-
-    it("should render status section", async () => {
-      const { queryByTestId } = render(ProjectDetail, props);
-
-      await waitFor(() =>
-        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument()
-      );
+        await waitFor(() => expect(watchSnsMetrics).not.toBeCalled());
+      });
     });
   });
 
@@ -147,57 +175,96 @@ describe("ProjectDetail", () => {
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
+    });
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
+    describe("Open project", () => {
+      beforeEach(() => {
+        snsQueryStore.setData(
+          snsResponsesForLifecycle({
+            lifecycles: [SnsSwapLifecycle.Open],
+            certified: true,
+          })
+        );
+        snsSwapCommitmentsStore.setSwapCommitment({
+          swapCommitment:
+            mockSnsFullProject.swapCommitment as SnsSwapCommitment,
           certified: true,
-        })
-      );
-      snsSwapCommitmentsStore.setSwapCommitment({
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        certified: true,
+        });
+      });
+
+      it("should start watching derived state", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
+      });
+
+      it("should clear watch on unmount", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        expect(mockUnwatchCommitmentsCall).not.toBeCalled();
+
+        unmount();
+
+        await waitFor(() =>
+          expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
+        );
+      });
+
+      it("should start watching metrics", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(watchSnsMetrics).toBeCalled());
+      });
+
+      it("should clear watch metrics on unmount", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        expect(mockUnwatchMetricsCall).not.toBeCalled();
+
+        unmount();
+
+        await waitFor(() => expect(mockUnwatchMetricsCall).toBeCalledTimes(1));
+      });
+
+      it("should load user's commitment", async () => {
+        render(ProjectDetail, props);
+
+        await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
       });
     });
 
-    it("should start watching derived state", async () => {
-      render(ProjectDetail, props);
+    describe("Committed project", () => {
+      beforeEach(() => {
+        snsQueryStore.setData(
+          snsResponsesForLifecycle({
+            lifecycles: [SnsSwapLifecycle.Committed],
+            certified: true,
+          })
+        );
+        snsSwapCommitmentsStore.setSwapCommitment({
+          swapCommitment:
+            mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+          certified: true,
+        });
+      });
 
-      await waitFor(() => expect(watchSnsTotalCommitment).toBeCalled());
-    });
+      it("should not start watching derived state", async () => {
+        render(ProjectDetail, props);
 
-    it("should clear watch on unmount", async () => {
-      const { unmount } = render(ProjectDetail, props);
+        await waitFor(() => expect(watchSnsTotalCommitment).not.toBeCalled());
+      });
 
-      expect(mockUnwatchCommitmentsCall).not.toBeCalled();
+      it("should not start watching metrics", async () => {
+        render(ProjectDetail, props);
 
-      unmount();
+        await waitFor(() => expect(watchSnsMetrics).not.toBeCalled());
+      });
 
-      await waitFor(() =>
-        expect(mockUnwatchCommitmentsCall).toBeCalledTimes(1)
-      );
-    });
+      it("should load user's commitment", async () => {
+        render(ProjectDetail, props);
 
-    it("should start watching metrics", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(watchSnsMetrics).toBeCalled());
-    });
-
-    it("should clear watch metrics on unmount", async () => {
-      const { unmount } = render(ProjectDetail, props);
-
-      expect(mockUnwatchMetricsCall).not.toBeCalled();
-
-      unmount();
-
-      await waitFor(() => expect(mockUnwatchMetricsCall).toBeCalledTimes(1));
-    });
-
-    it("should load user's commitment", async () => {
-      render(ProjectDetail, props);
-
-      await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
+        await waitFor(() => expect(loadSnsSwapCommitment).toBeCalled());
+      });
     });
   });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -12,7 +12,6 @@ import {
 } from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
-import type { SnsSwapCommitment } from "$lib/types/sns";
 import { page } from "$mocks/$app/stores";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -67,11 +66,6 @@ describe("ProjectDetail", () => {
             certified: true,
           })
         );
-        // snsSwapCommitmentsStore.setSwapCommitment({
-        //   swapCommitment:
-        //     mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        //   certified: true,
-        // });
       });
 
       it("should start watching derived state", async () => {
@@ -129,17 +123,13 @@ describe("ProjectDetail", () => {
       it("should render info section", async () => {
         const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() =>
-          expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument()
-        );
+        expect(queryByTestId("sns-project-detail-info")).toBeInTheDocument();
       });
 
       it("should render status section", async () => {
         const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() =>
-          expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument()
-        );
+        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
       });
     });
 
@@ -154,15 +144,17 @@ describe("ProjectDetail", () => {
       });
 
       it("should not start watching derived state", async () => {
-        render(ProjectDetail, props);
+        const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() => expect(watchSnsTotalCommitment).not.toBeCalled());
+        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+        expect(watchSnsTotalCommitment).not.toBeCalled();
       });
 
       it("should not start watching metrics", async () => {
-        render(ProjectDetail, props);
+        const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() => expect(watchSnsMetrics).not.toBeCalled());
+        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+        expect(watchSnsMetrics).not.toBeCalled();
       });
     });
   });
@@ -185,11 +177,6 @@ describe("ProjectDetail", () => {
             certified: true,
           })
         );
-        snsSwapCommitmentsStore.setSwapCommitment({
-          swapCommitment:
-            mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-          certified: true,
-        });
       });
 
       it("should start watching derived state", async () => {
@@ -241,23 +228,20 @@ describe("ProjectDetail", () => {
             certified: true,
           })
         );
-        snsSwapCommitmentsStore.setSwapCommitment({
-          swapCommitment:
-            mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-          certified: true,
-        });
       });
 
       it("should not start watching derived state", async () => {
-        render(ProjectDetail, props);
+        const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() => expect(watchSnsTotalCommitment).not.toBeCalled());
+        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+        expect(watchSnsTotalCommitment).not.toBeCalled();
       });
 
       it("should not start watching metrics", async () => {
-        render(ProjectDetail, props);
+        const { queryByTestId } = render(ProjectDetail, props);
 
-        await waitFor(() => expect(watchSnsMetrics).not.toBeCalled());
+        expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();
+        expect(watchSnsMetrics).not.toBeCalled();
       });
 
       it("should load user's commitment", async () => {


### PR DESCRIPTION
# Motivation

Avoid unnecessary calls from Project Detail page.

Do not watch the number of participants nor the total commitment if the project is not open.

# Changes

* In ProjectDetail.svelte, add a new variable `enableWatchers` and use it to call the watch services or not.

# Tests

* Add test for new scenario in ProjectDetail.svelte
