### PR TITLE
In scripts/dev-local.sh make sure .dfx/local/ exists.

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -70,6 +70,7 @@ sed -e "s@null@${nns_dapp_canister_id}@" frontend/.env-with-null >frontend/.env
 rm frontend/.env-with-null
 
 local_ids=".dfx/local/canister_ids.json"
+mkdir -p $(dirname "$local_ids")
 if ! [ -f "$local_ids" ]; then
   echo "{
   \"nns-dapp\": {

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -70,7 +70,7 @@ sed -e "s@null@${nns_dapp_canister_id}@" frontend/.env-with-null >frontend/.env
 rm frontend/.env-with-null
 
 local_ids=".dfx/local/canister_ids.json"
-mkdir -p $(dirname "$local_ids")
+mkdir -p "$(dirname "$local_ids")"
 if ! [ -f "$local_ids" ]; then
   echo "{
   \"nns-dapp\": {


### PR DESCRIPTION
# Motivation

`dfx start --clean` has started deleting `.dfx/local/`, causing `scripts/dev-local.sh` to fail when it tries to create `.dfx/local/canister_ids.json`.

# Changes

Make sure the directory exists before we try to write a file to it.

# Tests

Manually ran the script.