### PR TITLE
Chore: Enable stake maturity

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
@@ -19,7 +19,6 @@
   import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte";
   import { isNullish } from "@dfinity/utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_SNS_2 } from "$lib/stores/feature-flags.store";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -42,7 +41,7 @@
     <h3 slot="value">{formattedTotalMaturity(neuron)}</h3>
   </KeyValuePair>
 
-  {#if hasStakedMaturity(neuron) && $ENABLE_SNS_2}
+  {#if hasStakedMaturity(neuron)}
     <KeyValuePair testId="staked-maturity">
       <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
 
@@ -52,15 +51,13 @@
     </KeyValuePair>
   {/if}
 
-  {#if allowedToStakeMaturity && $ENABLE_SNS_2}
+  {#if allowedToStakeMaturity}
     <div class="actions" data-tid="stake-maturity-actions">
       <SnsStakeMaturityButton />
     </div>
   {/if}
 
-  {#if $ENABLE_SNS_2}
-    <SnsAutoStakeMaturity />
-  {/if}
+  <SnsAutoStakeMaturity />
 </CardInfo>
 
 <Separator />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.spec.ts
@@ -4,7 +4,6 @@
 
 import SnsNeuronMaturityCard from "$lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import {
   SELECTED_SNS_NEURON_CONTEXT_KEY,
   type SelectedSnsNeuronContext,
@@ -16,7 +15,7 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsNeuronPermissionType } from "@dfinity/sns";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 import {
   mockAuthStoreSubscribe,
@@ -103,30 +102,5 @@ describe("SnsNeuronMaturityCard", () => {
     );
 
     expect(getByTestId("stake-maturity-actions")).toBeInTheDocument();
-  });
-
-  it("should hide stake maturity actions feature flag is disabled", async () => {
-    const neuron = {
-      ...mockSnsNeuron,
-      permissions: [
-        {
-          principal: [mockIdentity.getPrincipal()],
-          permission_type: [
-            SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_STAKE_MATURITY,
-          ],
-        },
-      ],
-    };
-    const { queryByTestId } = renderSnsNeuronMaturityCard(
-      neuron as unknown as SnsNeuron
-    );
-
-    expect(queryByTestId("stake-maturity-actions")).toBeInTheDocument();
-
-    overrideFeatureFlagsStore.setFlag("ENABLE_SNS_2", false);
-
-    await waitFor(() =>
-      expect(queryByTestId("stake-maturity-actions")).not.toBeInTheDocument()
-    );
   });
 });


### PR DESCRIPTION
# Motivation

Enable staking maturity for SNS neurons.

I haven't removed nor changed the feature flag ENABLE_SNS_2. We might use it for upcoming functionality like disbursing maturity and voting history.

# Changes

* Remove usage of ENABLE_SNS_2 for staking maturity.

# Tests

* Remove test that showed or hid Stake Maturity button when ENABLE_SNS_2 changed.
