### PR TITLE
test: missing params lead to warning

### DIFF
--- a/frontend/src/tests/lib/modals/accounts/TransactionModalTest.svelte
+++ b/frontend/src/tests/lib/modals/accounts/TransactionModalTest.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
   import TransactionModal from "$lib/modals/accounts/NewTransaction/TransactionModal.svelte";
   import type { WizardStep } from "@dfinity/gix-components";
+  import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 
   export let currentStep: WizardStep;
 
   let modal: TransactionModal;
 
   $: modal, (() => modal?.goProgress())();
+
+  const rootCanisterId = OWN_CANISTER_ID;
+  const transactionFee = TokenAmount.fromE8s({
+    amount: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+    token: ICPToken,
+  });
 </script>
 
-<TransactionModal bind:currentStep bind:this={modal} />
+<TransactionModal
+  bind:currentStep
+  bind:this={modal}
+  {rootCanisterId}
+  {transactionFee}
+/>


### PR DESCRIPTION
# Motivation

Solve test warn

> console.warn
>    <TransactionModal> was created without expected prop 'rootCanisterId'

# Changes

- add constant to test cmp