### PR TITLE
GIX-1333: Fix aggregator with localhost

### DIFF
--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -1,3 +1,5 @@
+import { addRawToUrl } from "$lib/utils/env.utils";
+
 export const DFX_NETWORK = import.meta.env.VITE_DFX_NETWORK;
 export const HOST = import.meta.env.VITE_HOST as string;
 export const DEV = import.meta.env.DEV;
@@ -6,13 +8,20 @@ export const FETCH_ROOT_KEY: boolean =
 
 export const HOST_IC0_APP = "https://ic0.app";
 
-// TODO: Add as env var https://dfinity.atlassian.net/browse/GIX-1245
-// Local development needs `.raw` to avoid CORS issues for now.
-// TODO: Fix CORS issues
+const snsAggregatorUrlEnv = import.meta.env
+  .VITE_AGGREGATOR_CANISTER_URL as string;
+/**
+ * If you are on a different domain from the canister that you are calling, the service worker will not be loaded for that domain.
+ * If the service worker is not loaded then it will make a request to the boundary node directly which will fail CORS.
+ *
+ * Therefore, we add `raw` to the URL to avoid CORS issues in local development.
+ */
 export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
-  (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string) === ""
+  snsAggregatorUrlEnv === ""
     ? undefined
-    : (import.meta.env.VITE_AGGREGATOR_CANISTER_URL as string);
+    : DEV
+    ? addRawToUrl(snsAggregatorUrlEnv)
+    : snsAggregatorUrlEnv;
 
 export interface FeatureFlags<T> {
   ENABLE_SNS_2: T;

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -10,6 +10,22 @@ export const HOST_IC0_APP = "https://ic0.app";
 
 const snsAggregatorUrlEnv = import.meta.env
   .VITE_AGGREGATOR_CANISTER_URL as string;
+const snsAggregatorUrl = (url: string) => {
+  if (url === "") {
+    return undefined;
+  }
+
+  if (url.includes("localhost")) {
+    return url;
+  }
+
+  if (DEV) {
+    return addRawToUrl(url);
+  }
+
+  return url;
+};
+
 /**
  * If you are on a different domain from the canister that you are calling, the service worker will not be loaded for that domain.
  * If the service worker is not loaded then it will make a request to the boundary node directly which will fail CORS.
@@ -17,11 +33,7 @@ const snsAggregatorUrlEnv = import.meta.env
  * Therefore, we add `raw` to the URL to avoid CORS issues in local development.
  */
 export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
-  snsAggregatorUrlEnv === ""
-    ? undefined
-    : DEV
-    ? addRawToUrl(snsAggregatorUrlEnv)
-    : snsAggregatorUrlEnv;
+  snsAggregatorUrl(snsAggregatorUrlEnv);
 
 export interface FeatureFlags<T> {
   ENABLE_SNS_2: T;

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -11,19 +11,21 @@ export const HOST_IC0_APP = "https://ic0.app";
 const snsAggregatorUrlEnv = import.meta.env
   .VITE_AGGREGATOR_CANISTER_URL as string;
 const snsAggregatorUrl = (url: string) => {
-  if (url === "") {
+  try {
+    const { hostname } = new URL(url);
+    if (["localhost", "127.0.0.1"].includes(hostname)) {
+      return url;
+    }
+
+    if (DEV) {
+      return addRawToUrl(url);
+    }
+
+    return url;
+  } catch (e) {
+    console.error(`Invalid URL for SNS aggregator: ${url}`, e);
     return undefined;
   }
-
-  if (url.includes("localhost")) {
-    return url;
-  }
-
-  if (DEV) {
-    return addRawToUrl(url);
-  }
-
-  return url;
 };
 
 /**

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -7,3 +7,24 @@ export const isNnsAlternativeOrigin = (): boolean => {
 
   return origin === NNS_IC_ORG_ALTERNATIVE_ORIGIN;
 };
+
+/**
+ * Sets `raw` in the URL to avoid CORS issues.
+ *
+ * Used for local development only.
+ *
+ * @param urlString
+ * @returns url with `raw` added
+ */
+export const addRawToUrl = (urlString: string): string => {
+  const hasTrailingSlash = urlString.endsWith("/");
+  const url = new URL(urlString);
+
+  const [canisterId, ...rest] = url.host.split(".");
+
+  const newHost = [canisterId, "raw", ...rest].join(".");
+
+  url.host = newHost;
+
+  return hasTrailingSlash ? url.toString() : url.toString().slice(0, -1);
+};

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -2,83 +2,125 @@
  * @jest-environment jsdom
  */
 
-import { isNnsAlternativeOrigin } from "$lib/utils/env.utils";
+import { addRawToUrl, isNnsAlternativeOrigin } from "$lib/utils/env.utils";
 
 describe("env-utils", () => {
-  let location;
+  describe("isNnsAlternativeOrigin", () => {
+    let location;
 
-  beforeAll(() => {
-    location = window.location;
-  });
+    beforeAll(() => {
+      location = window.location;
+    });
 
-  afterAll(() => {
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: { ...location },
+    afterAll(() => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: { ...location },
+      });
+    });
+
+    it("should be an alternative origin", () => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://nns.internetcomputer.org`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
+    });
+
+    it("should not be an alternative origin", () => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://nns.ic0.app`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeFalsy();
+
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://ic0.app`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeFalsy();
+
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://test.com`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeFalsy();
+
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://internetcomputer.org`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeFalsy();
+
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          ...location,
+          origin: `https://ii.internetcomputer.org`,
+        },
+      });
+
+      expect(isNnsAlternativeOrigin()).toBeFalsy();
     });
   });
 
-  it("should be an alternative origin", () => {
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://nns.internetcomputer.org`,
-      },
+  describe("addRawToUrl", () => {
+    it("adds raw to url", () => {
+      expect(
+        addRawToUrl(
+          "https://53zcu-tiaaa-aaaaa-qaaba-cai.medium09.testnet.dfinity.network"
+        )
+      ).toBe(
+        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.medium09.testnet.dfinity.network"
+      );
+
+      expect(
+        addRawToUrl(
+          "https://53zcu-tiaaa-aaaaa-qaaba-cai.nnsdapp.testnet.dfinity.network"
+        )
+      ).toBe(
+        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.nnsdapp.testnet.dfinity.network"
+      );
+
+      expect(
+        addRawToUrl(
+          "https://53zcu-tiaaa-aaaaa-qaaba-cai.nnsdapp.testnet.dfinity.network/"
+        )
+      ).toBe(
+        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.nnsdapp.testnet.dfinity.network/"
+      );
     });
 
-    expect(isNnsAlternativeOrigin()).toBeTruthy();
-  });
+    it("raises if url is not a valid url", () => {
+      const invalid1 = "http**://example.com";
+      expect(() => addRawToUrl(invalid1)).toThrow(
+        new TypeError(`Invalid URL: ${invalid1}`)
+      );
 
-  it("should not be an alternative origin", () => {
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://nns.ic0.app`,
-      },
+      const invalid2 = "";
+      expect(() => addRawToUrl(invalid2)).toThrow(
+        new TypeError(`Invalid URL: ${invalid2}`)
+      );
     });
-
-    expect(isNnsAlternativeOrigin()).toBeFalsy();
-
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://ic0.app`,
-      },
-    });
-
-    expect(isNnsAlternativeOrigin()).toBeFalsy();
-
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://test.com`,
-      },
-    });
-
-    expect(isNnsAlternativeOrigin()).toBeFalsy();
-
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://internetcomputer.org`,
-      },
-    });
-
-    expect(isNnsAlternativeOrigin()).toBeFalsy();
-
-    Object.defineProperty(window, "location", {
-      writable: true,
-      value: {
-        ...location,
-        origin: `https://ii.internetcomputer.org`,
-      },
-    });
-
-    expect(isNnsAlternativeOrigin()).toBeFalsy();
   });
 });


### PR DESCRIPTION
# Motivation

When we develop in localhost, we can't work with the data from the SNS aggregator because it fails.

After discussing with the trust team, the best way is to use `raw` when we're developing locally.

The problem is explained in a comment.

# Changes

* New env util `addRawToUrl` that adds `raw` to urls.
* Use `addRawToUrl` in environment constants when DEV is enabled.

# Tests

* Add tests for new util `addRawToUrl`.
