### PR TITLE
Use previous II

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -29,7 +29,7 @@
       "type": "custom",
       "wasm": "internet_identity_dev.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-02-23/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"


### PR DESCRIPTION
# Motivation
e2e tests have started failing.  It looks as if every test requiring login fails.  So, temporarily revert to an earlier II.

# Changes
- Specify the previous version of II

# Tests
- See CI