### PR TITLE
Fix: E2e tests failing

### DIFF
--- a/e2e-tests/components/ii-add-device-page.ts
+++ b/e2e-tests/components/ii-add-device-page.ts
@@ -1,5 +1,5 @@
 // Internet Identity "Add Device" page
 export class IIAddDevicePage {
-  static readonly REGISTER_ALIAS_INPUT_SELECTOR: string = "#registerAlias";
+  static readonly REGISTER_ALIAS_INPUT_SELECTOR: string = "#pickAliasInput";
   static readonly SUBMIT_BUTTON_SELECTOR: string = 'button[type="submit"]';
 }


### PR DESCRIPTION
# Motivation

E2e tests were failing; therefore, CI pipeline was failing.

# Changes

* Change the id of the element to register the alias in II.

# Tests

* Fix e2e test.
