### PR TITLE
Chore: Add flags dfx json

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -191,8 +191,8 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
-          "ENABLE_CKBTC": false,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -208,8 +208,8 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": false,
           "ENABLE_SNS_VOTING": false,
-          "ENABLE_SNS_AGGREGATOR": false,
-          "ENABLE_CKBTC": false,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -225,7 +225,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -242,7 +242,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -259,7 +259,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -276,7 +276,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -293,7 +293,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -317,7 +317,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -334,7 +334,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
@@ -352,7 +352,7 @@
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
-          "ENABLE_SNS_AGGREGATOR": false,
+          "ENABLE_SNS_AGGREGATOR": true,
           "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }

--- a/dfx.json
+++ b/dfx.json
@@ -226,7 +226,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -243,7 +243,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -260,7 +260,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -277,7 +277,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -294,7 +294,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -318,7 +318,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -335,7 +335,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -353,7 +353,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -536,7 +536,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -560,7 +560,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -584,7 +584,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -608,7 +608,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -632,7 +632,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -652,7 +652,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -672,7 +672,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -692,7 +692,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -712,7 +712,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -732,7 +732,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -752,7 +752,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -772,7 +772,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -792,7 +792,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -812,7 +812,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -832,7 +832,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -849,7 +849,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -866,7 +866,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -883,7 +883,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -900,7 +900,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -917,7 +917,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -934,7 +934,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -951,7 +951,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -968,7 +968,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },
@@ -985,7 +985,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": false,
+          "ENABLE_CKBTC": true,
           "ENABLE_CKTESTBTC": false
         }
       },

--- a/dfx.json
+++ b/dfx.json
@@ -534,7 +534,10 @@
         "HOST": "https://large01.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -555,7 +558,10 @@
         "HOST": "https://large03.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -576,7 +582,10 @@
         "HOST": "https://large04.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -597,7 +606,10 @@
         "HOST": "https://large05.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -618,7 +630,10 @@
         "HOST": "https://medium01.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -635,7 +650,10 @@
         "HOST": "https://medium02.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -652,7 +670,10 @@
         "HOST": "https://medium03.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -669,7 +690,10 @@
         "HOST": "https://medium04.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -686,7 +710,10 @@
         "HOST": "https://medium05.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -703,7 +730,10 @@
         "HOST": "https://medium06.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -720,7 +750,10 @@
         "HOST": "https://medium07.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -737,7 +770,10 @@
         "HOST": "https://medium08.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -754,7 +790,10 @@
         "HOST": "https://medium09.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -771,7 +810,10 @@
         "HOST": "https://medium10.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -788,7 +830,10 @@
         "HOST": "https://small01.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -802,7 +847,10 @@
         "HOST": "https://small02.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -816,7 +864,10 @@
         "HOST": "https://small03.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -830,7 +881,10 @@
         "HOST": "https://small04.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -844,7 +898,10 @@
         "HOST": "https://small05.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -858,7 +915,10 @@
         "HOST": "https://small07.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -872,7 +932,10 @@
         "HOST": "https://small08.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -886,7 +949,10 @@
         "HOST": "https://small10.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [
@@ -900,7 +966,10 @@
         "HOST": "https://small15.testnet.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
-          "ENABLE_SNS_VOTING": true
+          "ENABLE_SNS_VOTING": true,
+          "ENABLE_SNS_AGGREGATOR": true,
+          "ENABLE_CKBTC": false,
+          "ENABLE_CKTESTBTC": false
         }
       },
       "providers": [

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -57,7 +57,7 @@ export type FeatureKey = keyof FeatureFlags<boolean>;
  */
 export const FEATURE_FLAG_ENVIRONMENT: FeatureFlags<boolean> = JSON.parse(
   import.meta.env.VITE_FEATURE_FLAGS.replace(/\\"/g, '"') ??
-    '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": false, "ENABLE_CKBTC": true, "ENABLE_CKTESTBTC": false}'
+    '{"ENABLE_SNS_2":false, "ENABLE_SNS_VOTING": false, "ENABLE_SNS_AGGREGATOR": true, "ENABLE_CKBTC": true, "ENABLE_CKTESTBTC": false}'
 );
 
 export const IS_TESTNET: boolean =


### PR DESCRIPTION
# Motivation

Set features flags of testnets at last as restrictive as mainnet, but not less.

Except the environments used for sns-testing `https___<network>_testnet_dfinity_network`, which require ckbtc to be disabled by default.

# Changes

* Changes in the flags in dfx.json

# Tests

Only config changes
