### PR TITLE
Debug commands to enable feature flags.

### DIFF
--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -339,7 +339,7 @@ const promptFeatureFlag = (question: string): FeatureKey | null => {
     question,
     ...editableNonTestFlags.map((flag, index) => index + 1 + ": " + flag),
   ].join("\n");
-  const choice: number = prompt(message);
+  const choice: number = +prompt(message);
   if (choice >= 1 && choice <= editableNonTestFlags.length) {
     return editableNonTestFlags[choice - 1];
   }

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -100,21 +100,21 @@ export function triggerDebugReport(node: HTMLElement) {
         }
 
         if (LogType.FeatureFlagsOverrideTrue === logType) {
-          const flag: FeatureKey = promptFeatureFlag(
+          const flag = promptFeatureFlag(
             get(i18n).feature_flags_prompt.override_true
           );
           flag && overrideFeatureFlagsStore.setFlag(flag, true);
         }
 
         if (LogType.FeatureFlagsOverrideFalse === logType) {
-          const flag: FeatureKey = promptFeatureFlag(
+          const flag = promptFeatureFlag(
             get(i18n).feature_flags_prompt.override_false
           );
           flag && overrideFeatureFlagsStore.setFlag(flag, false);
         }
 
         if (LogType.FeatureFlagsOverrideRemove === logType) {
-          const flag: FeatureKey = promptFeatureFlag(
+          const flag = promptFeatureFlag(
             get(i18n).feature_flags_prompt.remove_override
           );
           flag && overrideFeatureFlagsStore.removeFlag(flag);
@@ -339,7 +339,9 @@ const promptFeatureFlag = (question: string): FeatureKey | null => {
     question,
     ...editableNonTestFlags.map((flag, index) => index + 1 + ": " + flag),
   ].join("\n");
-  const choice: number = +prompt(message);
+
+  const choice = Number(prompt(message));
+
   if (choice >= 1 && choice <= editableNonTestFlags.length) {
     return editableNonTestFlags[choice - 1];
   }

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -1,6 +1,11 @@
 import { addHotkey } from "$lib/api/governance.api";
+import type { FeatureKey } from "$lib/constants/environment.constants";
 import { initDebugStore } from "$lib/derived/debug.derived";
 import { listNeurons, removeFollowee } from "$lib/services/neurons.services";
+import {
+  EDITABLE_FEATURE_FLAGS,
+  overrideFeatureFlagsStore,
+} from "$lib/stores/feature-flags.store";
 import { i18n } from "$lib/stores/i18n";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
@@ -47,6 +52,9 @@ export enum LogType {
   ClaimNeurons = "cn",
   AddHotkey = "ah",
   RemoveFolloweesDecentralizedSale = "rfds",
+  FeatureFlagsOverrideTrue = "fft",
+  FeatureFlagsOverrideFalse = "fff",
+  FeatureFlagsOverrideRemove = "ffr",
 }
 
 /**
@@ -89,6 +97,27 @@ export function triggerDebugReport(node: HTMLElement) {
         if (LogType.RemoveFolloweesDecentralizedSale === logType) {
           removeFolloweesDecentralizedSale();
           return;
+        }
+
+        if (LogType.FeatureFlagsOverrideTrue === logType) {
+          const flag: FeatureKey = promptFeatureFlag(
+            get(i18n).feature_flags_prompt.override_true
+          );
+          flag && overrideFeatureFlagsStore.setFlag(flag, true);
+        }
+
+        if (LogType.FeatureFlagsOverrideFalse === logType) {
+          const flag: FeatureKey = promptFeatureFlag(
+            get(i18n).feature_flags_prompt.override_false
+          );
+          flag && overrideFeatureFlagsStore.setFlag(flag, false);
+        }
+
+        if (LogType.FeatureFlagsOverrideRemove === logType) {
+          const flag: FeatureKey = promptFeatureFlag(
+            get(i18n).feature_flags_prompt.remove_override
+          );
+          flag && overrideFeatureFlagsStore.removeFlag(flag);
         }
 
         generateDebugLog(logType);
@@ -300,4 +329,19 @@ const generateDebugLog = async (logType: LogType) => {
   } else {
     logWithTimestamp(stringifiedState);
   }
+};
+
+const promptFeatureFlag = (question: string): FeatureKey | null => {
+  const editableNonTestFlags = EDITABLE_FEATURE_FLAGS.filter(
+    (f) => !f.startsWith("TEST_")
+  );
+  const message = [
+    question,
+    ...editableNonTestFlags.map((flag, index) => index + 1 + ": " + flag),
+  ].join("\n");
+  const choice: number = prompt(message);
+  if (choice >= 1 && choice <= editableNonTestFlags.length) {
+    return editableNonTestFlags[choice - 1];
+  }
+  return null;
 };

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -104,6 +104,7 @@ export function triggerDebugReport(node: HTMLElement) {
             get(i18n).feature_flags_prompt.override_true
           );
           flag && overrideFeatureFlagsStore.setFlag(flag, true);
+          return;
         }
 
         if (LogType.FeatureFlagsOverrideFalse === logType) {
@@ -111,6 +112,7 @@ export function triggerDebugReport(node: HTMLElement) {
             get(i18n).feature_flags_prompt.override_false
           );
           flag && overrideFeatureFlagsStore.setFlag(flag, false);
+          return;
         }
 
         if (LogType.FeatureFlagsOverrideRemove === logType) {
@@ -118,6 +120,7 @@ export function triggerDebugReport(node: HTMLElement) {
             get(i18n).feature_flags_prompt.remove_override
           );
           flag && overrideFeatureFlagsStore.removeFlag(flag);
+          return;
         }
 
         generateDebugLog(logType);
@@ -333,11 +336,11 @@ const generateDebugLog = async (logType: LogType) => {
 
 const promptFeatureFlag = (question: string): FeatureKey | null => {
   const editableNonTestFlags = EDITABLE_FEATURE_FLAGS.filter(
-    (f) => !f.startsWith("TEST_")
+    (flag) => !flag.startsWith("TEST_")
   );
   const message = [
     question,
-    ...editableNonTestFlags.map((flag, index) => index + 1 + ": " + flag),
+    ...editableNonTestFlags.map((flag, index) => `${index + 1}: ${flag}`),
   ].join("\n");
 
   const choice = Number(prompt(message));

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -844,5 +844,10 @@
     "insufficient_funds": "Insufficient funds.",
     "retrieve_btc_unknown": "Sorry, retrieving BTC failed for an unknown reason.",
     "estimated_fee": "Sorry, the Bitcoin estimated fee cannot be fetched."
+  },
+  "feature_flags_prompt" : {
+    "override_true": "Enter the number for the feature you want to enable.",
+    "override_false": "Enter the number for the feature you want to disabled.",
+    "remove_override": "Enter the number for the feature you want to set back to its default value."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -845,7 +845,7 @@
     "retrieve_btc_unknown": "Sorry, retrieving BTC failed for an unknown reason.",
     "estimated_fee": "Sorry, the Bitcoin estimated fee cannot be fetched."
   },
-  "feature_flags_prompt" : {
+  "feature_flags_prompt": {
     "override_true": "Enter the number for the feature you want to enable.",
     "override_false": "Enter the number for the feature you want to disabled.",
     "remove_override": "Enter the number for the feature you want to set back to its default value."

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -29,7 +29,7 @@ const assertEditableFeatureFlag = (flag: FeatureKey) => {
   }
 };
 
-const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
+export const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
   "ENABLE_SNS_AGGREGATOR",
   "ENABLE_SNS_2",
   "TEST_FLAG_EDITABLE",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -893,6 +893,12 @@ interface I18nError__ckbtc {
   estimated_fee: string;
 }
 
+interface I18nFeature_flags_prompt {
+  override_true: string;
+  override_false: string;
+  remove_override: string;
+}
+
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -1129,6 +1135,7 @@ interface I18n {
   metrics: I18nMetrics;
   ckbtc: I18nCkbtc;
   error__ckbtc: I18nError__ckbtc;
+  feature_flags_prompt: I18nFeature_flags_prompt;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;


### PR DESCRIPTION
# Motivation

We want to be able to enable feature flag on mobile where we can't open the JS console.

https://user-images.githubusercontent.com/122978264/223469577-0c34374d-ed90-40cf-914f-a0d3c77e0552.mov

# Changes

In the 6-click debug directive add 3 new commands:
1. "fft" for "feature-flag true" to override a feature flag to true.
2. "fff" for "feature-flag false" to override a feature flag to false.
3. "ffr" to remove a feature flag override.

# Tests

Tested manually on testnet.