### PR TITLE
Improve console log check during tests.

### DIFF
--- a/frontend/src/tests/utils/console.test-utils.ts
+++ b/frontend/src/tests/utils/console.test-utils.ts
@@ -1,34 +1,35 @@
-const realConsoleLog = console.log;
-const realConsoleDebug = console.debug;
-const realConsoleError = console.error;
+type LogType = "log" | "debug" | "warn" | "error";
+
+const logTypes: LogType[] = ["log", "debug", "warn", "error"];
+
+for (const logType of logTypes) {
+  replaceRealLogger(logType);
+}
 
 let gotLogs = false;
 let isLoggingAllowed = false;
 
+function replaceRealLogger(logType: LogType) {
+  const realLogger = console[logType];
+  console[logType] = function (...args) {
+    gotLogs = true;
+    realLogger(...args);
+  };
+}
+
 export const failTestsThatLogToConsole = () => {
   global.beforeEach(() => {
     gotLogs = false;
-    jest.spyOn(console, "log").mockImplementation((...args) => {
-      gotLogs = true;
-      realConsoleLog(...args);
-    });
-    jest.spyOn(console, "debug").mockImplementation((...args) => {
-      gotLogs = true;
-      realConsoleDebug(...args);
-    });
-    jest.spyOn(console, "error").mockImplementation((...args) => {
-      gotLogs = true;
-      realConsoleError(...args, new Error().stack);
-    });
   });
 
   global.afterEach(() => {
     if (!isLoggingAllowed && gotLogs) {
       throw new Error(
-        "Your test passed but produced console logs, which is not allowed.\n" +
+        "Your test produced console logs, which is not allowed.\n" +
           "If you need console output, mock and expect it in your test.\n" +
+          "This failure only happens after your test finishes so if your test had other failures, you can still see them and just ignore this.\n" +
           "If this is only for debugging, call allowLoggingInOneTest" +
-          "ForDebugging() from src/tests/utils/console.test-utils in your test."
+          "ForDebugging() from $tests/utils/console.test-utils in your test."
       );
     }
     isLoggingAllowed = false;


### PR DESCRIPTION
# Motivation

We don't want distracting logs in test output.

# Changes

1. Remove the message that says your test has passed because it may or may not have passed.
2. Explain that the log failure only happens after the test finished.
3. Don't use mocks to replace loggers because that breaks when a test does `jest.resetAllMocks()`.
4. Ban `console.warn` in addition to the other logs we ban.
5. Use `$tests` in the import path in the error message.

# Tests

`npm run test` with and without `console.warn`.