### PR TITLE
Fix PollingCancelledError appearing in the console

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -363,7 +363,7 @@ const renameError = ({
 };
 
 const ACCOUNTS_RETRY_MILLIS = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
-const pollAccountsId = Symbol();
+const pollAccountsId = Symbol("poll-accounts");
 const pollLoadAccounts = async (params: {
   identity: Identity;
   certified: boolean;

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -285,7 +285,7 @@ export const poll = async <T>({
         const result = await Promise.race([fn(), cancelPromise]);
         return result;
       } catch (error: unknown) {
-        if (shouldExit(error)) {
+        if (shouldExit(error) || pollingCancelled(error)) {
           throw error;
         }
         // Log swallowed errors

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -8,7 +8,6 @@ import {
   isHash,
   isPngAsset,
   poll,
-  pollingCancelled,
   PollingCancelledError,
   PollingLimitExceededError,
   removeKeys,
@@ -584,9 +583,7 @@ describe("utils", () => {
           })
           .catch((err) => {
             expect(err).toBeInstanceOf(PollingCancelledError);
-            if (pollingCancelled(err)) {
-              cancelled = true;
-            }
+            cancelled = true;
           });
         expect(fnSpy).toBeCalledTimes(1);
         await advanceTime();
@@ -623,9 +620,7 @@ describe("utils", () => {
           })
           .catch((err) => {
             expect(err).toBeInstanceOf(PollingCancelledError);
-            if (pollingCancelled(err)) {
-              cancelled = true;
-            }
+            cancelled = true;
           });
         rejectCall();
         await advanceTime();


### PR DESCRIPTION
# Motivation

If we move to a different view while polling for accounts, we cancel the polling.
This works through a mechanism which uses a race between 2 promises and we reject one of them when we cancel.
This is intended and the rejection should not cause any visible errors.
But if the rejection happened during the call rather than during the wait, it would be swallowed and logged if shouldExit returns falls.
Instead, we should rethrow it to really bail out of the polling.
This didn't cause anything to break because in the next round we would wait (also in a race with the same promise) not inside a try/catch block and there we would actually bail out of the polling. Except if it had been the last attempt and then we would throw PollingLimitedExceededError instead of the intended PollingCancelledError.

# Changes

1. Rethrow if we catch a PollingCancelledError.
2. Added a name in the Symbol used for cancelling so it's easier to identify in the future.
3. Removed `if (pollingCancelled` which is redundant after we just asserted the type of the error.

# Tests

1. Unit test that we can cancel on the last attempt and still get PollingCancelledError.
2. Manually test that the error no longer appears in the console.
