### PR TITLE
cleanup: Remove impossible return type undefined

### DIFF
--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -52,7 +52,7 @@
   });
 
   let governanceCanisterId: Principal | undefined;
-  $: governanceCanisterId = $snsProjectsStore?.find(
+  $: governanceCanisterId = $snsProjectsStore.find(
     ({ rootCanisterId: currentId }) =>
       currentId.toText() === rootCanisterId.toText()
   )?.summary.governanceCanisterId;

--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -15,7 +15,7 @@
 
   export let status: SnsSwapLifecycle;
 
-  let projects: SnsFullProject[] | undefined;
+  let projects: SnsFullProject[];
   $: projects = filterProjectsStatus({
     swapLifecycle: status,
     projects: $snsProjectsActivePadStore,
@@ -39,7 +39,7 @@
   });
 </script>
 
-{#if loading || projects === undefined}
+{#if loading}
   <div class="card-grid">
     <SkeletonProjectCard />
     <SkeletonProjectCard />

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -14,14 +14,14 @@ export const NNS_UNIVERSE: Universe = {
 };
 
 const universesStore = derived<
-  [Readable<SnsFullProject[] | undefined>, Readable<Universe[]>],
+  [Readable<SnsFullProject[]>, Readable<Universe[]>],
   Universe[]
 >(
   [snsProjectsCommittedStore, ckBTCUniversesStore],
-  ([projects, ckBTCUniverses]: [SnsFullProject[] | undefined, Universe[]]) => [
+  ([projects, ckBTCUniverses]: [SnsFullProject[], Universe[]]) => [
     NNS_UNIVERSE,
     ...ckBTCUniverses,
-    ...(projects?.map(({ rootCanisterId, summary }) => ({
+    ...(projects.map(({ rootCanisterId, summary }) => ({
       canisterId: rootCanisterId.toText(),
       summary,
     })) ?? []),

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -51,7 +51,7 @@ export const snsProjectsStore = derived<
 
 export const snsProjectsActivePadStore = derived<
   Readable<SnsFullProject[]>,
-  SnsFullProject[] | undefined
+  SnsFullProject[]
 >(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterActiveProjects(projects)
 );

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -65,7 +65,7 @@ export const snsProjectsCommittedStore = derived<
 
 export const snsProjectsAdoptedStore = derived<
   Readable<SnsFullProject[]>,
-  SnsFullProject[] | undefined
+  SnsFullProject[]
 >(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterProjectsStatus({ swapLifecycle: SnsSwapLifecycle.Adopted, projects })
 );

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -29,11 +29,11 @@ export interface SnsFullProject {
  */
 export const snsProjectsStore = derived<
   [Readable<SnsSummary[]>, SnsSwapCommitmentsStore],
-  SnsFullProject[] | undefined
+  SnsFullProject[]
 >(
   [snsSummariesStore, snsSwapCommitmentsStore],
-  ([summaries, $snsSwapStatesStore]): SnsFullProject[] | undefined =>
-    summaries?.map((summary) => {
+  ([summaries, $snsSwapStatesStore]): SnsFullProject[] =>
+    summaries.map((summary) => {
       const { rootCanisterId } = summary;
       const summaryPrincipalAsText = rootCanisterId.toText();
       const swapCommitmentStoreEntry = $snsSwapStatesStore?.find(
@@ -50,22 +50,22 @@ export const snsProjectsStore = derived<
 );
 
 export const snsProjectsActivePadStore = derived<
-  Readable<SnsFullProject[] | undefined>,
+  Readable<SnsFullProject[]>,
   SnsFullProject[] | undefined
->(snsProjectsStore, (projects: SnsFullProject[] | undefined) =>
+>(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterActiveProjects(projects)
 );
 
 export const snsProjectsCommittedStore = derived<
-  Readable<SnsFullProject[] | undefined>,
+  Readable<SnsFullProject[]>,
   SnsFullProject[] | undefined
->(snsProjectsStore, (projects: SnsFullProject[] | undefined) =>
+>(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterCommittedProjects(projects)
 );
 
 export const snsProjectsAdoptedStore = derived<
-  Readable<SnsFullProject[] | undefined>,
+  Readable<SnsFullProject[]>,
   SnsFullProject[] | undefined
->(snsProjectsStore, (projects: SnsFullProject[] | undefined) =>
+>(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterProjectsStatus({ swapLifecycle: SnsSwapLifecycle.Adopted, projects })
 );

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -58,7 +58,7 @@ export const snsProjectsActivePadStore = derived<
 
 export const snsProjectsCommittedStore = derived<
   Readable<SnsFullProject[]>,
-  SnsFullProject[] | undefined
+  SnsFullProject[]
 >(snsProjectsStore, (projects: SnsFullProject[]) =>
   filterCommittedProjects(projects)
 );

--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -24,7 +24,7 @@ export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =
   derived(
     [selectedUniverseIdStore, snsProjectsStore],
     ([$selectedUniverseIdStore, $projectsStore]) =>
-      $projectsStore?.find(
+      $projectsStore.find(
         ({ rootCanisterId }) =>
           rootCanisterId.toText() === $selectedUniverseIdStore.toText()
       )

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -20,7 +20,7 @@
   $: $authStore.identity, (async () => await loadSnsSale())();
 
   let showCommitted = false;
-  $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;
+  $: showCommitted = $snsProjectsCommittedStore.length > 0;
 
   let showAdopted = false;
   $: showAdopted = $snsProjectsAdoptedStore.length > 0;

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -23,7 +23,7 @@
   $: showCommitted = ($snsProjectsCommittedStore?.length ?? []) > 0;
 
   let showAdopted = false;
-  $: showAdopted = ($snsProjectsAdoptedStore?.length ?? []) > 0;
+  $: showAdopted = $snsProjectsAdoptedStore.length > 0;
 </script>
 
 <main>

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -13,7 +13,7 @@
     snsProjectsCommittedStore,
     type SnsFullProject,
   } from "$lib/derived/sns/sns-projects.derived";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
   import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
@@ -35,11 +35,9 @@
   let loadSnsAccountsBalancesRequested = false;
   let loadCkBTCAccountsBalancesRequested = false;
 
-  const loadSnsAccountsBalances = async (
-    projects: SnsFullProject[] | undefined
-  ) => {
+  const loadSnsAccountsBalances = async (projects: SnsFullProject[]) => {
     // We start when the projects are fetched
-    if (isNullish(projects) || projects.length === 0) {
+    if (projects.length === 0) {
       return;
     }
 

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -369,7 +369,7 @@ export const newSaleTicket = async ({
 const getProjectFromStore = (
   rootCanisterId: Principal
 ): SnsFullProject | undefined =>
-  get(snsProjectsStore)?.find(
+  get(snsProjectsStore).find(
     ({ rootCanisterId: id }) => id.toText() === rootCanisterId.toText()
   );
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -41,7 +41,9 @@ export const filterCommittedProjects = (
  * - complete - we display completed project for a while to make the screen user-friendly
  * @param projects
  */
-export const filterActiveProjects = (projects: SnsFullProject[] | undefined) =>
+export const filterActiveProjects = (
+  projects: SnsFullProject[]
+): SnsFullProject[] =>
   projects?.filter(
     ({
       summary: {

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -16,9 +16,9 @@ export const filterProjectsStatus = ({
   projects,
 }: {
   swapLifecycle: SnsSwapLifecycle;
-  projects: SnsFullProject[] | undefined;
-}): SnsFullProject[] | undefined =>
-  projects?.filter(
+  projects: SnsFullProject[];
+}): SnsFullProject[] =>
+  projects.filter(
     ({
       summary: {
         swap: { lifecycle },

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -28,7 +28,7 @@ export const filterProjectsStatus = ({
 
 export const filterCommittedProjects = (
   projects: SnsFullProject[]
-): SnsFullProject[] | undefined =>
+): SnsFullProject[] =>
   filterProjectsStatus({
     swapLifecycle: SnsSwapLifecycle.Committed,
     projects,

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -27,7 +27,7 @@ export const filterProjectsStatus = ({
   );
 
 export const filterCommittedProjects = (
-  projects: SnsFullProject[] | undefined
+  projects: SnsFullProject[]
 ): SnsFullProject[] | undefined =>
   filterProjectsStatus({
     swapLifecycle: SnsSwapLifecycle.Committed,

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -84,13 +84,13 @@ describe("projects.derived", () => {
       );
 
       const committed = get(snsProjectsCommittedStore);
-      expect(committed?.length).toEqual(1);
+      expect(committed.length).toEqual(1);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
       const noCommitted = get(snsProjectsCommittedStore);
-      expect(noCommitted?.length).toEqual(0);
+      expect(noCommitted.length).toEqual(0);
     });
 
     it("should filter projects that are adopted only", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -99,13 +99,13 @@ describe("projects.derived", () => {
       );
 
       const adopted = get(snsProjectsAdoptedStore);
-      expect(adopted?.length).toEqual(1);
+      expect(adopted.length).toEqual(1);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
       const noAdopted = get(snsProjectsAdoptedStore);
-      expect(noAdopted?.length).toEqual(0);
+      expect(noAdopted.length).toEqual(0);
     });
   });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -61,7 +61,7 @@ describe("projects.derived", () => {
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
       );
       const open = get(snsProjectsActivePadStore);
-      expect(open?.length).toEqual(1);
+      expect(open.length).toEqual(1);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({
@@ -69,13 +69,13 @@ describe("projects.derived", () => {
         })
       );
       const open2 = get(snsProjectsActivePadStore);
-      expect(open2?.length).toEqual(2);
+      expect(open2.length).toEqual(2);
 
       snsQueryStore.setData(
         snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Unspecified] })
       );
       const noOpen = get(snsProjectsActivePadStore);
-      expect(noOpen?.length).toEqual(0);
+      expect(noOpen.length).toEqual(0);
     });
 
     it("should filter projects that are committed only", () => {


### PR DESCRIPTION
# Motivation

snsSummariesStore is declared to hold SnsSummary[] so snsProjectsStore can't hold undefined. As a result a number of other things can't be undefined either and declare them as potentially undefined is confusing.

I recommend reviewing this PR 1 commit at a time.

# Changes

Commits:
1. snsSummariesStore is declared to hold SnsSummary[] so snsProjectsStore can't hold undefined.
2. snsProjectsStore never holds undefined, so filterActiveProjects is never called with undefined, so declare it to not take nor return undefined.
3. filterActiveProjects can't return undefined so snsProjectsActivePadStore can't hold undefined.
4. filterCommittedProjects is never called with undefined so declare it to not accept undefined.
5. filterProjectsStatus is never called with undefined so declare it to not accept and not return undefined.
6. filterProjectsStatus doesn't return undefined so filterCommittedProjects doesn't return undefined.
7. filterProjectsStatus doesn't return undefined so snsProjectsAdoptedStore can't hold undefined.
8. filterCommittedProjects doesn't return undefined so snsProjectsCommittedStore can't hold undefined.

# Tests

`npm run check` between every commit.
`npm run test`
Manual testing.