### PR TITLE
fix: input address field value blocked (edge case)

### DIFF
--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -12,6 +12,7 @@
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
   import type { TransactionNetwork } from "$lib/types/transaction";
+  import {nonNullish} from "@dfinity/utils";
 
   export let rootCanisterId: Principal;
   export let selectedDestinationAddress: string | undefined = undefined;
@@ -31,7 +32,7 @@
       selectedDestinationAddress = address;
     }
     // Keep in sync the selected destination address
-    if (selectedAccount !== undefined) {
+    if (nonNullish(selectedAccount) && !showManualAddress) {
       selectedDestinationAddress = selectedAccount.identifier;
     }
   }

--- a/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/SelectDestinationAddress.svelte
@@ -12,7 +12,7 @@
   import SelectAccountDropdown from "./SelectAccountDropdown.svelte";
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
   import type { TransactionNetwork } from "$lib/types/transaction";
-  import {nonNullish} from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rootCanisterId: Principal;
   export let selectedDestinationAddress: string | undefined = undefined;


### PR DESCRIPTION
# Motivation

Edge case: if user enters the address from one of his/her account in the input field, go to review step and come back to the form, the input field will be blocked.

Happens on mainnet as well.

# Changes

- overwrite input address with account address on in manual mode

# Screenshots

Issue:

![a](https://user-images.githubusercontent.com/16886711/223723734-f0f5a3b9-7636-4e56-9c59-9688c83bce87.gif)

Afterwards:

![b](https://user-images.githubusercontent.com/16886711/223723817-db21dd61-1a4b-4a36-a1d0-5d244c603791.gif)

