### PR TITLE
GIX-1363: Register Vote through GovernanceApiService

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -11,6 +11,7 @@ import {
   queryKnownNeurons,
   queryNeuron,
   queryNeurons,
+  registerVote,
   removeHotkey,
   setFollowees,
   spawnNeuron,
@@ -33,6 +34,7 @@ import {
   type ApiSplitNeuronParams,
   type ApiStakeMaturityParams,
   type ApiStakeNeuronParams,
+  type RegisterVoteParams,
 } from "$lib/api/governance.api";
 import { SECONDS_IN_MINUTE } from "$lib/constants/constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -136,6 +138,9 @@ export const governanceApiService = {
   },
   mergeNeurons(params: ApiMergeNeuronsParams) {
     return clearCacheAfter(mergeNeurons(params));
+  },
+  registerVote(params: RegisterVoteParams) {
+    return clearCacheAfter(registerVote(params));
   },
   removeHotkey(params: ApiManageHotkeyParams) {
     return clearCacheAfter(removeHotkey(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -12,7 +12,9 @@ import type {
   KnownNeuron,
   NeuronId,
   NeuronInfo,
+  ProposalId,
   Topic,
+  Vote,
 } from "@dfinity/nns";
 import { GovernanceCanister } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -432,6 +434,39 @@ export const claimOrRefreshNeuron = async ({
     `ClaimingOrRefreshing Neurons (${hashCode(neuronId)}) complete.`
   );
   return response;
+};
+
+export type RegisterVoteParams = {
+  neuronId: NeuronId;
+  proposalId: ProposalId;
+  vote: Vote;
+  identity: Identity;
+};
+export const registerVote = async ({
+  neuronId,
+  proposalId,
+  vote,
+  identity,
+}: RegisterVoteParams): Promise<void> => {
+  logWithTimestamp(
+    `Registering Vote (${hashCode(proposalId)}, ${hashCode(neuronId)}) call...`
+  );
+
+  const governance: GovernanceCanister = GovernanceCanister.create({
+    agent: await createAgent({ identity, host: HOST }),
+  });
+
+  await governance.registerVote({
+    neuronId,
+    vote,
+    proposalId,
+  });
+
+  logWithTimestamp(
+    `Registering Vote (${hashCode(proposalId)}, ${hashCode(
+      neuronId
+    )}) complete.`
+  );
 };
 
 /**

--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -7,10 +7,8 @@ import { enumsExclude } from "$lib/utils/enum.utils";
 import type { Identity } from "@dfinity/agent";
 import type {
   ListProposalsResponse,
-  NeuronId,
   ProposalId,
   ProposalInfo,
-  Vote,
 } from "@dfinity/nns";
 import { GovernanceCanister, Topic } from "@dfinity/nns";
 import { nnsDappCanister } from "./nns-dapp.api";
@@ -124,36 +122,4 @@ export const queryProposalPayload = async ({
   );
 
   return response;
-};
-
-export const registerVote = async ({
-  neuronId,
-  proposalId,
-  vote,
-  identity,
-}: {
-  neuronId: NeuronId;
-  proposalId: ProposalId;
-  vote: Vote;
-  identity: Identity;
-}): Promise<void> => {
-  logWithTimestamp(
-    `Registering Vote (${hashCode(proposalId)}, ${hashCode(neuronId)}) call...`
-  );
-
-  const governance: GovernanceCanister = GovernanceCanister.create({
-    agent: await createAgent({ identity, host: HOST }),
-  });
-
-  await governance.registerVote({
-    neuronId,
-    vote,
-    proposalId,
-  });
-
-  logWithTimestamp(
-    `Registering Vote (${hashCode(proposalId)}, ${hashCode(
-      neuronId
-    )}) complete.`
-  );
 };

--- a/frontend/src/lib/services/vote-registration.services.ts
+++ b/frontend/src/lib/services/vote-registration.services.ts
@@ -1,5 +1,4 @@
-import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
-import { registerVote } from "$lib/api/proposals.api";
+import { governanceApiService } from "$lib/api-services/governance.api-service";
 import { i18n } from "$lib/stores/i18n";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { proposalsStore } from "$lib/stores/proposals.store";
@@ -278,12 +277,13 @@ const registerNeuronsVote = async ({
   try {
     const requests = neuronIds.map(
       (neuronId: NeuronId): Promise<void> =>
-        registerVote({
-          neuronId,
-          vote,
-          proposalId,
-          identity,
-        })
+        governanceApiService
+          .registerVote({
+            neuronId,
+            vote,
+            proposalId,
+            identity,
+          })
           // call it only after successful registration
           .then(() =>
             neuronRegistrationComplete({
@@ -379,10 +379,6 @@ const updateAfterVoteRegistration = async (
         strategy: "update",
       })
     );
-
-  // TODO(JIRA-1975): improve quick fix
-  // We need to list the neurons with the very last ballots because the user just voted
-  resetNeuronsApiService();
 
   return Promise.all([
     listNeurons({

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -13,7 +13,8 @@ import {
   createMockKnownNeuron,
   createMockNeuron,
 } from "$tests/mocks/neurons.mock";
-import { Topic } from "@dfinity/nns";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { Topic, Vote } from "@dfinity/nns";
 
 jest.mock("$lib/api/governance.api");
 
@@ -894,6 +895,37 @@ describe("neurons api-service", () => {
       await shouldInvalidateCacheOnFailure({
         apiFunc: api.stopDissolving,
         apiServiceFunc: governanceApiService.stopDissolving,
+        params,
+      });
+    });
+  });
+
+  describe("registerVote", () => {
+    const params = {
+      neuronId,
+      identity: mockIdentity,
+      proposalId: mockProposalInfo.id,
+      vote: Vote.Yes,
+    };
+
+    it("should call stopDissolving api", () => {
+      governanceApiService.registerVote(params);
+      expect(api.registerVote).toHaveBeenCalledWith(params);
+      expect(api.registerVote).toHaveBeenCalledTimes(1);
+    });
+
+    it("should invalidate the cache", async () => {
+      await shouldInvalidateCache({
+        apiFunc: api.registerVote,
+        apiServiceFunc: governanceApiService.registerVote,
+        params,
+      });
+    });
+
+    it("should invalidate the cache on failure", async () => {
+      await shouldInvalidateCacheOnFailure({
+        apiFunc: api.registerVote,
+        apiServiceFunc: governanceApiService.registerVote,
         params,
       });
     });

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -908,7 +908,7 @@ describe("neurons api-service", () => {
       vote: Vote.Yes,
     };
 
-    it("should call stopDissolving api", () => {
+    it("should call registerVote api", () => {
       governanceApiService.registerVote(params);
       expect(api.registerVote).toHaveBeenCalledWith(params);
       expect(api.registerVote).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -633,13 +633,13 @@ describe("neurons-api", () => {
   });
 
   describe("registerVote", () => {
-    const neuronId = BigInt(0);
+    const neuronId = BigInt(110);
     const identity = mockIdentity;
-    const proposalId = BigInt(0);
+    const proposalId = BigInt(110);
 
     it("should call the canister to cast vote neuronIds count", async () => {
       await registerVote({
-        neuronId: neuronId,
+        neuronId,
         proposalId,
         vote: Vote.Yes,
         identity,

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -10,6 +10,7 @@ import {
   queryKnownNeurons,
   queryNeuron,
   queryNeurons,
+  registerVote,
   removeHotkey,
   setFollowees,
   spawnNeuron,
@@ -23,7 +24,7 @@ import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { HttpAgent } from "@dfinity/agent";
-import { GovernanceCanister, LedgerCanister, Topic } from "@dfinity/nns";
+import { GovernanceCanister, LedgerCanister, Topic, Vote } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 
@@ -48,6 +49,7 @@ describe("neurons-api", () => {
     mockGovernanceCanister.getNeuron.mockImplementation(
       jest.fn().mockResolvedValue(mockNeuron)
     );
+    mockGovernanceCanister.registerVote.mockResolvedValue(undefined);
     jest
       .spyOn(GovernanceCanister, "create")
       .mockImplementation(() => mockGovernanceCanister);
@@ -627,6 +629,27 @@ describe("neurons-api", () => {
         });
       expect(mockGovernanceCanister.splitNeuron).not.toBeCalled();
       await expect(call).rejects.toThrow(error);
+    });
+  });
+
+  describe("registerVote", () => {
+    const neuronId = BigInt(0);
+    const identity = mockIdentity;
+    const proposalId = BigInt(0);
+
+    it("should call the canister to cast vote neuronIds count", async () => {
+      await registerVote({
+        neuronId: neuronId,
+        proposalId,
+        vote: Vote.Yes,
+        identity,
+      });
+      expect(mockGovernanceCanister.registerVote).toHaveBeenCalledTimes(1);
+      expect(mockGovernanceCanister.registerVote).toHaveBeenCalledWith({
+        neuronId,
+        proposalId,
+        vote: Vote.Yes,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -2,14 +2,13 @@ import {
   queryProposal,
   queryProposalPayload,
   queryProposals,
-  registerVote,
 } from "$lib/api/proposals.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
-import { GovernanceCanister, Vote } from "@dfinity/nns";
+import { GovernanceCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 
 describe("proposals-api", () => {
@@ -17,7 +16,6 @@ describe("proposals-api", () => {
     new MockGovernanceCanister(mockProposals);
 
   let spyListProposals;
-  let spyRegisterVote;
 
   beforeEach(() => {
     jest
@@ -25,7 +23,6 @@ describe("proposals-api", () => {
       .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
 
     spyListProposals = jest.spyOn(mockGovernanceCanister, "listProposals");
-    spyRegisterVote = jest.spyOn(mockGovernanceCanister, "registerVote");
   });
 
   afterEach(() => spyListProposals.mockClear());
@@ -78,22 +75,6 @@ describe("proposals-api", () => {
           limit: 1,
         },
       });
-    });
-  });
-
-  describe("registerVote", () => {
-    const neuronId = BigInt(0);
-    const identity = mockIdentity;
-    const proposalId = BigInt(0);
-
-    it("should call the canister to cast vote neuronIds count", async () => {
-      await registerVote({
-        neuronId: neuronId,
-        proposalId,
-        vote: Vote.Yes,
-        identity,
-      });
-      expect(spyRegisterVote).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import * as neuronsServices from "$lib/services/neurons.services";
 import { registerVotes } from "$lib/services/vote-registration.services";
@@ -53,7 +54,7 @@ describe("vote-registration-services", () => {
     return Promise.resolve();
   };
   const spyRegisterVote = jest
-    .spyOn(proposalsApi, "registerVote")
+    .spyOn(governanceApi, "registerVote")
     .mockImplementation(mockRegisterVote);
 
   beforeAll(() => {
@@ -120,7 +121,7 @@ describe("vote-registration-services", () => {
           .mockImplementation(() => Promise.resolve(proposalInfo()));
 
         jest
-          .spyOn(proposalsApi, "registerVote")
+          .spyOn(governanceApi, "registerVote")
           .mockImplementation(() => waitForMilliseconds(10));
       });
 
@@ -340,7 +341,7 @@ describe("vote-registration-services", () => {
 
     beforeAll(() => {
       jest
-        .spyOn(proposalsApi, "registerVote")
+        .spyOn(governanceApi, "registerVote")
         .mockImplementation(mockRegisterVoteGovernanceAlreadyVotedError);
 
       jest
@@ -382,7 +383,7 @@ describe("vote-registration-services", () => {
     afterAll(() => {
       jest.clearAllMocks();
 
-      jest.spyOn(proposalsApi, "registerVote").mockClear();
+      jest.spyOn(governanceApi, "registerVote").mockClear();
     });
 
     it("should show error.register_vote_unknown on not nns-js-based error", async () => {
@@ -404,7 +405,7 @@ describe("vote-registration-services", () => {
 
     it("should show error.register_vote on nns-js-based errors", async () => {
       jest
-        .spyOn(proposalsApi, "registerVote")
+        .spyOn(governanceApi, "registerVote")
         .mockImplementation(mockRegisterVoteError);
 
       await registerVotes({
@@ -427,7 +428,7 @@ describe("vote-registration-services", () => {
     it("should display proopsalId in error detail", async () => {
       const proposal = proposalInfo();
       jest
-        .spyOn(proposalsApi, "registerVote")
+        .spyOn(governanceApi, "registerVote")
         .mockImplementation(mockRegisterVoteError);
 
       await registerVotes({
@@ -451,7 +452,7 @@ describe("vote-registration-services", () => {
 
     it("should show reason per neuron Error in detail", async () => {
       jest
-        .spyOn(proposalsApi, "registerVote")
+        .spyOn(governanceApi, "registerVote")
         .mockImplementation(mockRegisterVoteError);
 
       await registerVotes({
@@ -474,7 +475,7 @@ describe("vote-registration-services", () => {
 
     it("should show reason per neuron GovernanceError in detail", async () => {
       jest
-        .spyOn(proposalsApi, "registerVote")
+        .spyOn(governanceApi, "registerVote")
         .mockImplementation(mockRegisterVoteGovernanceError);
 
       await registerVotes({


### PR DESCRIPTION
# Motivation

The fix of the voting button used a test feature.

This is the fix we intended. Calls to governance canister should be done through the governance api service and this one decides when to reset or not the cache.

# Changes

* Add method "registerVote" in the GovernanceApiService. It clears the cache after it.
* Move "registerVote" api function to "governace.api". Slowly, start implementing the agreed pattern that api should be grouped by canister.
* Voting service uses governance api service instead of the api function directly. That means we can remove the call to `resetNeuronsApiService`.

# Tests

* Move test for the api function "registerVote" to the "governace.api.spec".
* Add test for registerVote in the governance api service.
* Change mocks due to moving api function to another file.
