### PR TITLE
Feat: Allow neurons to follow themselves

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -793,13 +793,6 @@ export const addFollowee = async ({
   topic: Topic;
   followee: NeuronId;
 }): Promise<void> => {
-  // Do not allow a neuron to follow itself
-  if (followee === neuronId) {
-    toastsError({
-      labelKey: "new_followee.same_neuron",
-    });
-    return;
-  }
   const neuron = getNeuronFromStore(neuronId);
 
   const topicFollowees = followeesByTopic({ neuron, topic });

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -35,7 +35,6 @@ import {
   followeesByFunction,
   getSnsDissolveDelaySeconds,
   getSnsNeuronByHexId,
-  getSnsNeuronIdAsHexString,
   hasAutoStakeMaturityOn,
   isEnoughAmountToSplit,
   nextMemo,
@@ -597,14 +596,6 @@ export const addFollowee = async ({
   followeeHex: string;
   rootCanisterId: Principal;
 }): Promise<{ success: boolean }> => {
-  // Do not allow a neuron to follow itself
-  if (followeeHex === getSnsNeuronIdAsHexString(neuron)) {
-    toastsError({
-      labelKey: "new_followee.same_neuron",
-    });
-    return { success: false };
-  }
-
   const identity = await getSnsNeuronIdentity();
   const followee: SnsNeuronId = {
     id: arrayOfNumberToUint8Array(hexStringToBytes(followeeHex)),

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1147,7 +1147,7 @@ describe("neurons-services", () => {
       expect(spySetFollowees).toHaveBeenCalledWith(expectedArgument);
     });
 
-    it("should not call api if trying follow itself", async () => {
+    it("should call api if trying follow itself", async () => {
       neuronsStore.setNeurons({ neurons, certified: true });
       const topic = Topic.ExchangeRate;
 
@@ -1157,8 +1157,13 @@ describe("neurons-services", () => {
         followee: controlledNeuron.neuronId,
       });
 
-      expectToastError(en.new_followee.same_neuron);
-      expect(spySetFollowees).not.toHaveBeenCalled();
+      expect(spySetFollowees).toHaveBeenCalledWith({
+        neuronId: controlledNeuron.neuronId,
+        topic,
+        followees: [controlledNeuron.neuronId],
+        identity: mockIdentity,
+      });
+      expect(spySetFollowees).toHaveBeenCalledTimes(1);
     });
 
     it("should not call api if trying follow a neuron already added", async () => {

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -789,7 +789,7 @@ describe("sns-neurons-services", () => {
       expect(toastsError).toBeCalled();
     });
 
-    it("should not call sns api setFollowees when new followee is the same neuron", async () => {
+    it("should call sns api setFollowees when new followee is the same neuron", async () => {
       jest.spyOn(api, "querySnsNeuron").mockResolvedValue(mockSnsNeuron);
       const neuronIdHext = getSnsNeuronIdAsHexString(mockSnsNeuron);
       await addFollowee({
@@ -799,8 +799,14 @@ describe("sns-neurons-services", () => {
         followeeHex: neuronIdHext,
       });
 
-      expect(setFolloweesSpy).not.toBeCalled();
-      expect(toastsError).toBeCalled();
+      expect(setFolloweesSpy).toBeCalledWith({
+        neuronId: fromNullable(mockSnsNeuron.id),
+        identity: mockIdentity,
+        rootCanisterId,
+        followees: [mockSnsNeuron.id[0] as SnsNeuronId],
+        functionId,
+      });
+      expect(setFolloweesSpy).toBeCalledTimes(1);
     });
 
     it("should not call sns api setFollowees when new followee does not exist", async () => {


### PR DESCRIPTION
# Motivation

Allow SNS and NNS neurons to follow themselves.

# Changes

* Remove check in addFollowee for the same neuron id in sns-neurons and neurons services.

# Tests

* Change test to allow the behavior explicitly.
