### PR TITLE
Fix: SNS Wallet page infinite loading

### DIFF
--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -53,7 +53,8 @@
 
   export let accountIdentifier: string | undefined | null = undefined;
 
-  const load = () => {
+  let load: () => void;
+  $: load = () => {
     if (nonNullish(accountIdentifier)) {
       const selectedAccount = $snsProjectAccountsStore?.find(
         ({ identifier }) => identifier === accountIdentifier

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -53,8 +53,7 @@
 
   export let accountIdentifier: string | undefined | null = undefined;
 
-  let load: () => void;
-  $: load = () => {
+  const load = () => {
     if (nonNullish(accountIdentifier)) {
       const selectedAccount = $snsProjectAccountsStore?.find(
         ({ identifier }) => identifier === accountIdentifier
@@ -81,7 +80,7 @@
     });
   };
 
-  $: accountIdentifier, load();
+  $: accountIdentifier, $snsProjectAccountsStore, load();
 
   let disabled = false;
   $: disabled = isNullish($selectedAccountStore.account) || $busy;


### PR DESCRIPTION
# Motivation

Deep link to an SNS Wallet wasn't working.

The problem was that the `load` function that sets the context store was not called after the accounts were loaded in the store.

It was called only when the identifier was there.

It worked with normal navigation because the store was already filled with the accounts. But if the user arrives with the deep link, the accounts are loaded. Therefore, the `load` function was called before they were loaded, but not after they were in the store.

# Changes

* Call `load` function also when sns accounts store changes in SnsWallet.svelte page.

# Tests

* Upcoming in another PR along with other test for deep links.
