### PR TITLE
feat: reload balance

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -61,6 +61,7 @@
     "accounts_not_found": "An error occurred while loading the accounts information.",
     "accounts_not_found_poll": "An error occurred while loading the accounts information. The Internet Computer seems to be under high load, please try in a few minutes.",
     "account_not_found": "Sorry, the account \"$account_identifier\" was not found",
+    "account_not_reload": "Sorry, the account \"$account_identifier\" cannot be reloaded",
     "transactions_not_found": "An error occurred while loading the transactions.",
     "canister_not_found": "Sorry, the canister \"$canister_id\" was not found",
     "fail": "fail",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -65,6 +65,7 @@ interface I18nError {
   accounts_not_found: string;
   accounts_not_found_poll: string;
   account_not_found: string;
+  account_not_reload: string;
   transactions_not_found: string;
   canister_not_found: string;
   fail: string;

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -40,6 +40,7 @@ jest.mock("$lib/api/ledger.api");
 jest.mock("$lib/services/accounts.services", () => ({
   ...(jest.requireActual("$lib/services/accounts.services") as object),
   getAccountTransactions: jest.fn(),
+  syncAccounts: jest.fn(),
 }));
 
 describe("NnsWallet", () => {
@@ -199,7 +200,11 @@ describe("NnsWallet", () => {
     });
 
     it("should reload account after finish receiving tokens", async () => {
-      const spy = jest.spyOn(services, "getAccountTransactions");
+      const spyGetAccountTransactions = jest.spyOn(
+        services,
+        "getAccountTransactions"
+      );
+      const spySyncAccounts = jest.spyOn(services, "syncAccounts");
 
       const result = render(NnsWallet, props);
 
@@ -215,7 +220,8 @@ describe("NnsWallet", () => {
         getByTestId("reload-receive-account") as HTMLButtonElement
       );
 
-      await waitFor(() => expect(spy).toHaveBeenCalled());
+      await waitFor(() => expect(spySyncAccounts).toHaveBeenCalled());
+      expect(spyGetAccountTransactions).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -164,7 +164,10 @@ describe("SnsWallet", () => {
     });
 
     it("should reload account after finish receiving tokens", async () => {
-      const spy = jest.spyOn(services, "loadSnsAccountTransactions");
+      const spyLoadSnsAccountTransactions = jest.spyOn(
+        services,
+        "loadSnsAccountTransactions"
+      );
 
       const result = render(SnsWallet, props);
 
@@ -181,7 +184,8 @@ describe("SnsWallet", () => {
         getByTestId("reload-receive-account") as HTMLButtonElement
       );
 
-      await waitFor(() => expect(spy).toHaveBeenCalled());
+      await waitFor(() => expect(syncSnsAccounts).toHaveBeenCalled());
+      expect(spyLoadSnsAccountTransactions).toHaveBeenCalled();
     });
 
     it("should display receive modal information", async () => {


### PR DESCRIPTION
# Motivation

After "Finish" is executed in the new "Receive" modal the balance of the ICP and Sns wallet was not updated.

This PR adds reloading the account as well after suck operation is executed by the user.

# Changes

- sync accounts in callback `reloadAccount`
