### PR TITLE
GIX-1328 Add a test that observes the bug

### DIFF
--- a/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
@@ -17,26 +17,28 @@
   export let cardType: CardType = "card";
 </script>
 
-<NeuronCardContainer
-  {role}
-  {selected}
-  {disabled}
-  {ariaLabel}
-  on:click
-  {cardType}
->
-  <NnsNeuronCardTitle {neuron} slot="start" />
+<div data-tid="nns-neuron-card-component" class="component">
+  <NeuronCardContainer
+    {role}
+    {selected}
+    {disabled}
+    {ariaLabel}
+    on:click
+    {cardType}
+  >
+    <NnsNeuronCardTitle {neuron} slot="start" />
 
-  <div class:disabled class="content">
-    <NnsNeuronAmount {neuron} {proposerNeuron} />
+    <div class:disabled class="content">
+      <NnsNeuronAmount {neuron} {proposerNeuron} />
 
-    <NeuronStateInfo state={neuron.state} />
-  </div>
+      <NeuronStateInfo state={neuron.state} />
+    </div>
 
-  <NnsNeuronRemainingTime {neuron} />
+    <NnsNeuronRemainingTime {neuron} />
 
-  <slot />
-</NeuronCardContainer>
+    <slot />
+  </NeuronCardContainer>
+</div>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/card";
@@ -53,5 +55,9 @@
 
   .content {
     @include neuron.neuron-card-content;
+  }
+
+  .component {
+    display: contents;
   }
 </style>

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -18,24 +18,30 @@
   $: neuronState = getSnsNeuronState(neuron);
 </script>
 
-<NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
-  <SnsNeuronCardTitle slot="start" {neuron} tagName="p" />
+<div data-tid="sns-neuron-card-component" class="component">
+  <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
+    <SnsNeuronCardTitle slot="start" {neuron} tagName="p" />
 
-  <div class="content">
-    <SnsNeuronAmount {neuron} />
+    <div class="content">
+      <SnsNeuronAmount {neuron} />
 
-    <NeuronStateInfo state={neuronState} />
-  </div>
+      <NeuronStateInfo state={neuronState} />
+    </div>
 
-  <SnsNeuronStateRemainingTime {neuron} />
+    <SnsNeuronStateRemainingTime {neuron} />
 
-  <slot />
-</NeuronCardContainer>
+    <slot />
+  </NeuronCardContainer>
+</div>
 
 <style lang="scss">
   @use "../../themes/mixins/neuron";
 
   .content {
     @include neuron.neuron-card-content;
+  }
+
+  .component {
+    display: contents;
   }
 </style>

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -13,7 +13,7 @@
   $: shortenText = shortenWithMiddleEllipsis(text);
 </script>
 
-<span>
+<span data-tid="hash-component">
   <Tooltip {id} {text}>
     <svelte:element this={tagName} data-tid={testId}>
       {shortenText}</svelte:element

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -75,7 +75,7 @@
 
 <svelte:window bind:innerWidth />
 
-<div class="tooltip-wrapper">
+<div class="tooltip-wrapper" data-tid="tooltip-component">
   <div class="tooltip-target" aria-describedby={id} bind:this={target}>
     <slot />
   </div>

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -29,35 +29,43 @@
     );
 </script>
 
-<div class="card-grid" data-tid="neurons-body">
-  {#if isLoading}
-    <SkeletonCard />
-    <SkeletonCard />
-  {:else}
-    {#each $sortedNeuronStore as neuron}
-      {#if isSpawning(neuron)}
-        <Tooltip
-          id="spawning-neuron-card"
-          text={$i18n.neuron_detail.spawning_neuron_info}
-        >
+<div data-tid="nns-neurons-component" class="component">
+  <div class="card-grid" data-tid="neurons-body">
+    {#if isLoading}
+      <SkeletonCard />
+      <SkeletonCard />
+    {:else}
+      {#each $sortedNeuronStore as neuron}
+        {#if isSpawning(neuron)}
+          <Tooltip
+            id="spawning-neuron-card"
+            text={$i18n.neuron_detail.spawning_neuron_info}
+          >
+            <NnsNeuronCard
+              disabled
+              ariaLabel={$i18n.neurons.aria_label_neuron_card}
+              {neuron}
+            />
+          </Tooltip>
+        {:else}
           <NnsNeuronCard
-            disabled
+            role="link"
             ariaLabel={$i18n.neurons.aria_label_neuron_card}
+            on:click={async () => await goToNeuronDetails(neuron.neuronId)}
             {neuron}
           />
-        </Tooltip>
-      {:else}
-        <NnsNeuronCard
-          role="link"
-          ariaLabel={$i18n.neurons.aria_label_neuron_card}
-          on:click={async () => await goToNeuronDetails(neuron.neuronId)}
-          {neuron}
-        />
-      {/if}
-    {/each}
+        {/if}
+      {/each}
+    {/if}
+  </div>
+
+  {#if !isLoading && $sortedNeuronStore.length === 0}
+    <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
 </div>
 
-{#if !isLoading && $sortedNeuronStore.length === 0}
-  <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
-{/if}
+<style lang="scss">
+  .component {
+    display: contents;
+  }
+</style>

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -66,13 +66,36 @@
   $: summary = $snsProjectSelectedStore?.summary;
 </script>
 
-{#if $sortedSnsUserNeuronsStore.length > 0 || loading}
-  <div class="card-grid" data-tid="sns-neurons-body">
-    {#if loading}
-      <SkeletonCard />
-      <SkeletonCard />
-    {:else}
-      {#each $sortedSnsUserNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
+<div data-tid="sns-neurons-component" class="component">
+  {#if $sortedSnsUserNeuronsStore.length > 0 || loading}
+    <div class="card-grid" data-tid="sns-neurons-body">
+      {#if loading}
+        <SkeletonCard />
+        <SkeletonCard />
+      {:else}
+        {#each $sortedSnsUserNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
+          <SnsNeuronCard
+            role="link"
+            {neuron}
+            ariaLabel={$i18n.neurons.aria_label_neuron_card}
+            on:click={async () => await goToNeuronDetails(neuron)}
+          />
+        {/each}
+      {/if}
+    </div>
+  {/if}
+
+  {#if $sortedSnsCFNeuronsStore.length > 0}
+    <h2
+      data-tid="community-fund-title"
+      class={`bottom-margin ${
+        $sortedSnsUserNeuronsStore.length > 0 ? "top-margin" : ""
+      }`}
+    >
+      {$i18n.sns_neuron_detail.community_fund_section}
+    </h2>
+    <div class="card-grid">
+      {#each $sortedSnsCFNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
         <SnsNeuronCard
           role="link"
           {neuron}
@@ -80,40 +103,22 @@
           on:click={async () => await goToNeuronDetails(neuron)}
         />
       {/each}
-    {/if}
-  </div>
-{/if}
+    </div>
+  {/if}
 
-{#if $sortedSnsCFNeuronsStore.length > 0}
-  <h2
-    data-tid="community-fund-title"
-    class={`bottom-margin ${
-      $sortedSnsUserNeuronsStore.length > 0 ? "top-margin" : ""
-    }`}
-  >
-    {$i18n.sns_neuron_detail.community_fund_section}
-  </h2>
-  <div class="card-grid">
-    {#each $sortedSnsCFNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
-      <SnsNeuronCard
-        role="link"
-        {neuron}
-        ariaLabel={$i18n.neurons.aria_label_neuron_card}
-        on:click={async () => await goToNeuronDetails(neuron)}
-      />
-    {/each}
-  </div>
-{/if}
-
-{#if !loading && empty && nonNullish(summary)}
-  <EmptyMessage
-    >{replacePlaceholders($i18n.sns_neurons.text, {
-      $project: summary.metadata.name,
-    })}</EmptyMessage
-  >
-{/if}
+  {#if !loading && empty && nonNullish(summary)}
+    <EmptyMessage
+      >{replacePlaceholders($i18n.sns_neurons.text, {
+        $project: summary.metadata.name,
+      })}</EmptyMessage
+    >
+  {/if}
+</div>
 
 <style lang="scss">
+  .component {
+    display: contents;
+  }
   .top-margin {
     margin-top: var(--padding-4x);
   }

--- a/frontend/src/lib/routes/Neurons.svelte
+++ b/frontend/src/lib/routes/Neurons.svelte
@@ -9,24 +9,29 @@
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 </script>
 
-<main>
-  <SummaryUniverse />
+<div data-tid="neurons-component" class="component">
+  <main>
+    <SummaryUniverse />
+
+    {#if $isNnsUniverseStore}
+      <NnsNeurons />
+    {:else if nonNullish($snsProjectSelectedStore)}
+      <SnsNeurons />
+    {/if}
+  </main>
 
   {#if $isNnsUniverseStore}
-    <NnsNeurons />
+    <NnsNeuronsFooter />
+    <!-- Staking SNS Neurons has not yet been reviewed by security -->
   {:else if nonNullish($snsProjectSelectedStore)}
-    <SnsNeurons />
+    <SnsNeuronsFooter />
   {/if}
-</main>
-
-{#if $isNnsUniverseStore}
-  <NnsNeuronsFooter />
-  <!-- Staking SNS Neurons has not yet been reviewed by security -->
-{:else if nonNullish($snsProjectSelectedStore)}
-  <SnsNeuronsFooter />
-{/if}
+</div>
 
 <style lang="scss">
+  .component {
+    display: contents;
+  }
   main {
     padding-bottom: var(--footer-height);
   }

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -2,73 +2,141 @@
  * @jest-environment jsdom
  */
 
+import * as governanceApi from "$lib/api/governance.api";
+import * as snsAggregatorApi from "$lib/api/sns-aggregator.api";
+import * as snsGovernanceApi from "$lib/api/sns-governance.api";
+import * as snsLedgerApi from "$lib/api/sns-ledger.api";
+import * as snsApi from "$lib/api/sns.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
-import { authStore } from "$lib/stores/auth.store";
+import { loadSnsProjects } from "$lib/services/$public/sns.services";
 import { snsQueryStore } from "$lib/stores/sns.store";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
-import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
+import {
+  mockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 
-jest.mock("$lib/services/sns-neurons.services", () => {
-  return {
-    syncSnsNeurons: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("$lib/services/sns-accounts.services", () => {
-  return {
-    syncSnsAccounts: jest.fn().mockReturnValue(undefined),
-  };
-});
-
-jest.mock("$lib/services/sns-parameters.services", () => {
-  return {
-    loadSnsParameters: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
 jest.mock("$lib/api/governance.api");
+jest.mock("$lib/api/sns-aggregator.api");
+jest.mock("$lib/api/sns-governance.api");
+jest.mock("$lib/api/sns-ledger.api");
+jest.mock("$lib/api/sns.api");
+
+const blockedApiPaths = [
+  "$lib/api/sns-aggregator.api",
+  "$lib/api/governance.api",
+  "$lib/api/sns.api",
+  "$lib/api/sns-ledger.api",
+  "$lib/api/sns-governance.api",
+];
+
+const testCommittedSnsCanisterId = Principal.fromHex("897654");
+const testOpenSnsCanisterId = Principal.fromHex("567812");
+
+const testFee = BigInt(25000);
 
 describe("Neurons", () => {
-  beforeAll(() =>
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe)
-  );
+  blockAllCallsTo(blockedApiPaths);
 
-  beforeEach(() => {
-    // Reset to default value
+  beforeEach(async () => {
+    snsQueryStore.reset();
+
+    jest.mocked(governanceApi.queryNeurons).mockResolvedValue([mockNeuron]);
+    jest
+      .mocked(snsGovernanceApi.nervousSystemParameters)
+      .mockResolvedValue(snsNervousSystemParametersMock);
+    jest.mocked(snsApi.querySnsNeurons).mockResolvedValue([mockSnsNeuron]);
+    jest.mocked(snsGovernanceApi.getNeuronBalance).mockResolvedValue(BigInt(0));
+    jest
+      .mocked(snsLedgerApi.getSnsAccounts)
+      .mockResolvedValue([mockSnsMainAccount]);
+    jest.mocked(snsGovernanceApi.refreshNeuron).mockResolvedValue(undefined);
+    jest.mocked(snsApi.getSnsNeuron).mockResolvedValue(mockSnsNeuron);
+    jest.mocked(snsLedgerApi.getSnsToken).mockResolvedValue(mockSnsToken);
+    jest.mocked(snsAggregatorApi.querySnsProjects).mockResolvedValue([
+      aggregatorSnsMockWith({
+        rootCanisterId: testCommittedSnsCanisterId.toText(),
+        lifecycle: SnsSwapLifecycle.Committed,
+      }),
+      aggregatorSnsMockWith({
+        rootCanisterId: testOpenSnsCanisterId.toText(),
+        lifecycle: SnsSwapLifecycle.Open,
+      }),
+    ]);
+
+    await loadSnsProjects();
+  });
+
+  it("should render NnsNeurons by default", async () => {
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Neurons,
     });
 
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Committed] })
-    );
-  });
+    const { container } = render(Neurons);
+    const po = NeuronsPo.under(container);
 
-  it("should render NnsNeurons by default", () => {
-    const { queryByTestId } = render(Neurons);
-    expect(queryByTestId("neurons-body")).toBeInTheDocument();
-  });
-
-  it("should render project page when a project is selected", async () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
+    expect(po.hasSnsNeurons()).toBe(false);
+    expect(po.hasNnsNeurons()).toBe(true);
+    expect(po.getNnsNeurons().isContentLoaded()).toBe(false);
+    await waitFor(() => {
+      expect(po.getNnsNeurons().isContentLoaded()).toBe(true);
     });
 
-    const { queryByTestId } = render(Neurons);
+    const neuronIdText = mockNeuron.neuronId.toString();
+    expect(po.getNnsNeurons().getNeuronIds()).toContain(neuronIdText);
+  });
 
-    await waitFor(() =>
-      expect(queryByTestId("sns-neurons-body")).toBeInTheDocument()
-    );
+  it("should render project page when a committed project is selected", async () => {
+    page.mock({
+      data: { universe: testCommittedSnsCanisterId.toText() },
+    });
+
+    const { container } = render(Neurons);
+    const po = NeuronsPo.under(container);
+
+    expect(po.hasNnsNeurons()).toBe(false);
+    expect(po.hasSnsNeurons()).toBe(true);
+    expect(po.getSnsNeurons().isContentLoaded()).toBe(false);
+    await waitFor(() => {
+      expect(po.getSnsNeurons().isContentLoaded()).toBe(true);
+    });
+
+    const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
+    expect(po.getSnsNeurons().getNeuronIds()).toContain(neuronIdText);
+  });
+
+  it("should not render neurons when an open project is selected", async () => {
+    page.mock({
+      data: { universe: testOpenSnsCanisterId.toText() },
+    });
+
+    const { container } = render(Neurons);
+    const po = NeuronsPo.under(container);
+
+    expect(po.hasNnsNeurons()).toBe(false);
+    expect(po.hasSnsNeurons()).toBe(true);
+    expect(po.getSnsNeurons().isContentLoaded()).toBe(false);
+    await waitFor(() => {
+      expect(po.getSnsNeurons().isContentLoaded()).toBe(true);
+    });
+
+    const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
+    // This should actually fail but doesn't because of
+    // https://dfinity.atlassian.net/browse/GIX-1328
+    expect(po.getSnsNeurons().getNeuronIds()).toContain(neuronIdText);
   });
 });

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -1,0 +1,27 @@
+import { TooltipPo } from "./Tooltip.page-object";
+
+export class HashPo {
+  static readonly tid = "hash-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== HashPo.tid) {
+      throw new Error(`${root} is not an Hash`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): HashPo | null {
+    const el = element.querySelector(`[data-tid=${HashPo.tid}]`);
+    return el && new HashPo(el);
+  }
+
+  getTooltip(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+
+  getText(): string {
+    return this.getTooltip().getText();
+  }
+}

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -1,0 +1,45 @@
+import { nonNullish } from "@dfinity/utils";
+import { NnsNeuronsPo } from "./NnsNeurons.page-object";
+import { SnsNeuronsPo } from "./SnsNeurons.page-object";
+
+export class NeuronsPo {
+  static readonly tid = "neurons-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== NeuronsPo.tid) {
+      throw new Error(`${root} is not a Neurons`);
+    }
+    this.root = root;
+  }
+
+  static under(element: HTMLElement): NeuronsPo | null {
+    const el = element.querySelector(`[data-tid=${NeuronsPo.tid}]`);
+    return el && new NeuronsPo(el);
+  }
+
+  getNnsNeurons(): NnsNeuronsPo | null {
+    return NnsNeuronsPo.under(this.root);
+  }
+
+  getSnsNeurons(): SnsNeuronsPo | null {
+    return SnsNeuronsPo.under(this.root);
+  }
+
+  hasNnsNeurons(): boolean {
+    return nonNullish(this.getNnsNeurons());
+  }
+
+  hasSnsNeurons(): boolean {
+    return nonNullish(this.getSnsNeurons());
+  }
+
+  isContentLoaded() {
+    return (
+      this.getNnsNeurons()?.isContentLoaded() ||
+      this.getSnsNeurons()?.isContentLoaded() ||
+      false
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -1,0 +1,28 @@
+import { NnsNeuronCardTitlePo } from "./NnsNeuronCardTitle.page-object";
+
+export class NnsNeuronCardPo {
+  static readonly tid = "nns-neuron-card-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== NnsNeuronCardPo.tid) {
+      throw new Error(`${root} is not an NnsNeuronCard`);
+    }
+    this.root = root;
+  }
+
+  static allUnder(element: Element): NnsNeuronCardPo[] {
+    return Array.from(
+      element.querySelectorAll(`[data-tid=${NnsNeuronCardPo.tid}]`)
+    ).map((el) => new NnsNeuronCardPo(el));
+  }
+
+  getCardTitle(): NnsNeuronCardTitlePo {
+    return NnsNeuronCardTitlePo.under(this.root);
+  }
+
+  getNeuronId(): string {
+    return this.getCardTitle().getNeuronId();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,0 +1,21 @@
+export class NnsNeuronCardTitlePo {
+  static readonly tid = "neuron-card-title";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== NnsNeuronCardTitlePo.tid) {
+      throw new Error(`${root} is not an NnsNeuronCardTitle`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): NnsNeuronCardTitlePo | null {
+    const el = element.querySelector(`[data-tid=${NnsNeuronCardTitlePo.tid}]`);
+    return el && new NnsNeuronCardTitlePo(el);
+  }
+
+  getNeuronId(): string {
+    return this.root.querySelector("[data-tid=neuron-id]").textContent;
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,0 +1,37 @@
+import { NnsNeuronCardPo } from "./NnsNeuronCard.page-object";
+import { SkeletonCardPo } from "./SkeletonCard.page-object";
+
+export class NnsNeuronsPo {
+  static readonly tid = "nns-neurons-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== NnsNeuronsPo.tid) {
+      throw new Error(`${root} is not an NnsNeurons`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): NnsNeuronsPo | null {
+    const el = element.querySelector(`[data-tid=${NnsNeuronsPo.tid}]`);
+    return el && new NnsNeuronsPo(el);
+  }
+
+  getSkeletonCards(): SkeletonCardPo[] {
+    return SkeletonCardPo.allUnder(this.root);
+  }
+
+  getNeuronCards(): NnsNeuronCardPo[] {
+    return NnsNeuronCardPo.allUnder(this.root);
+  }
+
+  isContentLoaded(): boolean {
+    return this.getSkeletonCards().length === 0;
+  }
+
+  getNeuronIds(): string[] {
+    const cards = this.getNeuronCards();
+    return cards.map((card) => card.getNeuronId());
+  }
+}

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -4,7 +4,7 @@ export class SkeletonCardPo {
   root: Element;
 
   constructor(root: Element) {
-    if (root.getAttribute("testId") !== SkeletonCardPo.tid) {
+    if (root.getAttribute("data-tid") !== SkeletonCardPo.tid) {
       throw new Error(`${root} is not a SkeletonCard`);
     }
     this.root = root;
@@ -12,7 +12,7 @@ export class SkeletonCardPo {
 
   static allUnder(element: Element): SkeletonCardPo[] {
     return Array.from(
-      element.querySelectorAll(`[testId=${SkeletonCardPo.tid}]`)
+      element.querySelectorAll(`[data-tid=${SkeletonCardPo.tid}]`)
     ).map((el) => new SkeletonCardPo(el));
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -1,0 +1,28 @@
+import { SnsNeuronCardTitlePo } from "./SnsNeuronCardTitle.page-object";
+
+export class SnsNeuronCardPo {
+  static readonly tid = "sns-neuron-card-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== SnsNeuronCardPo.tid) {
+      throw new Error(`${root} is not an SnsNeuronCard`);
+    }
+    this.root = root;
+  }
+
+  static allUnder(element: Element): SnsNeuronCardPo[] {
+    return Array.from(
+      element.querySelectorAll(`[data-tid=${SnsNeuronCardPo.tid}]`)
+    ).map((el) => new SnsNeuronCardPo(el));
+  }
+
+  getCardTitle(): SnsNeuronCardTitlePo {
+    return SnsNeuronCardTitlePo.under(this.root);
+  }
+
+  getNeuronId(): string {
+    return this.getCardTitle().getNeuronId();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -1,0 +1,25 @@
+import { HashPo } from "./Hash.page-object";
+
+export class SnsNeuronCardTitlePo {
+  static readonly tid = "sns-neuron-card-title";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== SnsNeuronCardTitlePo.tid) {
+      throw new Error(`${root} is not an SnsNeuronCardTitle`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): SnsNeuronCardTitlePo | null {
+    const el = element.querySelector(`[data-tid=${SnsNeuronCardTitlePo.tid}]`);
+    return el && new SnsNeuronCardTitlePo(el);
+  }
+
+  getNeuronId(): string {
+    return HashPo.under(
+      this.root.querySelector("[data-tid=neuron-id-container]")
+    ).getText();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,0 +1,37 @@
+import { SkeletonCardPo } from "./SkeletonCard.page-object";
+import { SnsNeuronCardPo } from "./SnsNeuronCard.page-object";
+
+export class SnsNeuronsPo {
+  static readonly tid = "sns-neurons-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== SnsNeuronsPo.tid) {
+      throw new Error(`${root} is not an SnsNeurons`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): SnsNeuronsPo | null {
+    const el = element.querySelector(`[data-tid=${SnsNeuronsPo.tid}]`);
+    return el && new SnsNeuronsPo(el);
+  }
+
+  getSkeletonCards(): SkeletonCardPo[] {
+    return SkeletonCardPo.allUnder(this.root);
+  }
+
+  getNeuronCards(): SnsNeuronCardPo[] {
+    return SnsNeuronCardPo.allUnder(this.root);
+  }
+
+  isContentLoaded(): boolean {
+    return this.getSkeletonCards().length === 0;
+  }
+
+  getNeuronIds(): string[] {
+    const cards = this.getNeuronCards();
+    return cards.map((card) => card.getNeuronId());
+  }
+}

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -1,0 +1,21 @@
+export class TooltipPo {
+  static readonly tid = "tooltip-component";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== TooltipPo.tid) {
+      throw new Error(`${root} is not an Tooltip`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): TooltipPo | null {
+    const el = element.querySelector(`[data-tid=${TooltipPo.tid}]`);
+    return el && new TooltipPo(el);
+  }
+
+  getText(): string {
+    return this.root.querySelector(".tooltip").textContent;
+  }
+}

--- a/frontend/src/tests/utils/module.test-utils.ts
+++ b/frontend/src/tests/utils/module.test-utils.ts
@@ -15,9 +15,11 @@ const failOnCall = ({
   fn: string;
   args: unknown;
 }): never => {
-  const message = `"${modulePath}".${fn} is called (with ${JSON.stringify(
-    args
-  )}) but not mocked.`;
+  // Without this, JSON.stringify crashes on objects with bgint values.
+  const argsString = JSON.stringify(args, (_key, value) =>
+    typeof value === "bigint" ? value.toString() : value
+  );
+  const message = `"${modulePath}".${fn} is called (with ${argsString}) but not mocked.`;
   blockedCalls.push(message);
   throw new Error(message);
 };


### PR DESCRIPTION
# Motivation

There is a bug where you can see neurons on not yet committed SNS projects by manually changing the URL on the neurons tab.
This PR puts `frontend/src/tests/lib/routes/Neurons.spec.ts` in a good state to properly test the fix when we fix the bug in the next PR.

# Changes

Changes to Neurons.spec.ts:
1. Mocked API instead of service.
2. Blocked additional API calls to make sure we know about all the API calls.
3. Added and used page objects.
4. Verified that content is loaded and neurons are displayed.
5. Added an additional test with an open SNS project to observe the bug from https://dfinity.atlassian.net/browse/GIX-1328. This will be fixed in another PR.

Additional changes:
1. Added wrapper div with data-tid (and display: contents) to components.
2. Fixed using [data-tid] attribute in SkeletonCard page-object. Apparently we previously only checked that skeleton cards were not present.
3. Fixed displaying bigint parameters to blocked API calls.

# Tests

1. `npm run test`
2. Checked manually that the nns and sns neurons tabs still look fine.