### PR TITLE
Update README to reflect the need to install docker-buildx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ The official build should ideally be reproducible, so that independent parties
 can validate that we really deploy what we claim to deploy.
 
 We try to achieve some level of reproducibility using a Dockerized build
-environment. The following steps _should_ build the official Wasm image
+environment. The following steps _should_ build the official Wasm image.
+
+We use `docker buildx` as a dependency, to install it please follow [the official guide](https://docs.docker.com/build/install-buildx/) or follow the steps here which walk you through installing the `0.10.4` version of
+`docker-buildx` on a x86-64 Linux machine.
+
+```sh
+wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
+mv buildx-v0.10.4.linux-amd64 docker-buildx
+chmod +x docker-buildx
+mkdir -p $HOME/.docker/cli-plugins/
+mv docker-buildx $HOME/.docker/cli-plugins/
+```
+
+Afterwards you can simply build the container with the following
 
 ```sh
 ./scripts/docker-build


### PR DESCRIPTION
# Motivation

A user could not build the Wasm image with `scripts/docker-build`, the command resulted in the following error 
```sh
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
```

# Changes

Added the steps necessary to install `docker-buildx`

