### PR TITLE
cleanup: Remove setLoading on snsQueryStore and snsProposalsStore

### DIFF
--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -3,8 +3,7 @@
   import ProjectCard from "./ProjectCard.svelte";
   import SkeletonProjectCard from "$lib/components/ui/SkeletonProjectCard.svelte";
   import { keyOf } from "$lib/utils/utils";
-  import { isNullish } from "@dfinity/utils";
-  import { snsQueryStore, snsSummariesStore } from "$lib/stores/sns.store";
+  import { snsQueryStoreIsLoading } from "$lib/stores/sns.store";
   import {
     snsProjectsActivePadStore,
     type SnsFullProject,
@@ -22,7 +21,7 @@
   });
 
   let loading = false;
-  $: loading = isNullish($snsSummariesStore) || isNullish($snsQueryStore);
+  $: loading = $snsQueryStoreIsLoading;
 
   const mapper: Record<SnsSwapLifecycle, string> = {
     [SnsSwapLifecycle.Open]: "no_open_projects",

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     openSnsProposalsStore,
-    snsProposalsStore,
+    snsProposalsStoreIsLoading,
   } from "$lib/stores/sns.store";
   import { isNullish } from "@dfinity/utils";
   import SkeletonProposalCard from "$lib/components/ui/SkeletonProposalCard.svelte";
@@ -11,10 +11,10 @@
   import { loadProposalsSnsCF } from "$lib/services/$public/sns.services";
 
   let loading = false;
-  $: loading = isNullish($snsProposalsStore);
+  $: loading = $snsProposalsStoreIsLoading;
 
   const load = () => {
-    if (isNullish($snsProposalsStore)) {
+    if ($snsProposalsStoreIsLoading) {
       loadProposalsSnsCF();
     }
   };

--- a/frontend/src/lib/components/launchpad/Proposals.svelte
+++ b/frontend/src/lib/components/launchpad/Proposals.svelte
@@ -5,7 +5,6 @@
     openSnsProposalsStore,
     snsProposalsStoreIsLoading,
   } from "$lib/stores/sns.store";
-  import { isNullish } from "@dfinity/utils";
   import SkeletonProposalCard from "$lib/components/ui/SkeletonProposalCard.svelte";
   import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
   import { loadProposalsSnsCF } from "$lib/services/$public/sns.services";

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -118,7 +118,7 @@ export const loadSnsProjects = async (): Promise<void> => {
 };
 
 export const loadSnsSummaries = (): Promise<void> => {
-  snsQueryStore.setLoadingState();
+  snsQueryStore.reset();
 
   return queryAndUpdate<[QuerySnsMetadata[], QuerySnsSwapState[]], unknown>({
     identityType: "anonymous",
@@ -137,7 +137,7 @@ export const loadSnsSummaries = (): Promise<void> => {
         identity.getPrincipal().isAnonymous() ||
         FORCE_CALL_STRATEGY === "query"
       ) {
-        snsQueryStore.setLoadingState();
+        snsQueryStore.reset();
 
         toastsError(
           toToastError({

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -152,7 +152,7 @@ export const loadSnsSummaries = (): Promise<void> => {
 };
 
 export const loadProposalsSnsCF = async (): Promise<void> => {
-  snsProposalsStore.setLoadingState();
+  snsProposalsStore.reset();
 
   return queryAndUpdate<ProposalInfo[], unknown>({
     identityType: "anonymous",
@@ -175,7 +175,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
         identity.getPrincipal().isAnonymous() ||
         FORCE_CALL_STRATEGY === "query"
       ) {
-        snsProposalsStore.setLoadingState();
+        snsProposalsStore.reset();
 
         toastsError(
           toToastError({

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -73,7 +73,6 @@ export type SnsQueryStoreData =
 
 export interface SnsQueryStore extends Readable<SnsQueryStoreData> {
   reset: () => void;
-  setLoadingState: () => void;
   setData: (data: [QuerySnsMetadata[], QuerySnsSwapState[]]) => void;
   updateData: (data: {
     data: [QuerySnsMetadata | undefined, QuerySnsSwapState | undefined];
@@ -98,7 +97,6 @@ export interface SnsQueryStore extends Readable<SnsQueryStoreData> {
  * Various derived stores will subscribe to this store to prepare, format and map the data in a way that can be use by the components.
  *
  * - reset: mark the store to not have been populated yet
- * - setLoadingState: explicitly set the store to not containing any data. useful to display various loading interaction while data are loaded
  * - setData: the function that initializes the store when the app starts
  * - updateData: a function to update the data of a particular root canister id - e.g. used to reload a particular sns project after user has participated to a sale
  */
@@ -110,10 +108,6 @@ const initSnsQueryStore = (): SnsQueryStore => {
 
     reset() {
       set(undefined);
-    },
-
-    setLoadingState() {
-      set(null);
     },
 
     setData([metadata, swaps]: [QuerySnsMetadata[], QuerySnsSwapState[]]) {
@@ -264,6 +258,11 @@ const initSnsQueryStore = (): SnsQueryStore => {
  * A store which contains the response of the queries performed against the backend to fetch summary and swap information of Snses.
  */
 export const snsQueryStore = initSnsQueryStore();
+
+export const snsQueryStoreIsLoading = derived<SnsQueryStore, boolean>(
+  snsQueryStore,
+  (data: SnsQueryStoreData) => isNullish(data)
+);
 
 /**
  * The response of the Snses about metadata and swap derived to data that can be used by NNS-dapp - i.e. it filters undefined and optional swap data, sort data for consistency

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -30,10 +30,6 @@ const initSnsProposalsStore = () => {
       set(undefined);
     },
 
-    setLoadingState() {
-      set(null);
-    },
-
     setProposals({
       proposals,
       certified,
@@ -60,6 +56,11 @@ const initOpenSnsProposalsStore = () =>
 
 export const snsProposalsStore = initSnsProposalsStore();
 export const openSnsProposalsStore = initOpenSnsProposalsStore();
+
+export const snsProposalsStoreIsLoading = derived<
+  Readable<SnsProposalsStore>,
+  boolean
+>(snsProposalsStore, (data: SnsProposalsStore) => isNullish(data));
 
 // ************** Sns summaries and swaps **************
 

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -19,7 +19,7 @@ jest.mock("$lib/services/$public/sns.services", () => {
 describe("Proposals", () => {
   const mockProposals = (proposals: ProposalInfo[] | null) =>
     proposals === null
-      ? snsProposalsStore.setLoadingState()
+      ? snsProposalsStore.reset()
       : snsProposalsStore.setProposals({ proposals, certified: true });
 
   beforeEach(snsProposalsStore.reset);

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -1,6 +1,7 @@
 import {
   openSnsProposalsStore,
   snsProposalsStore,
+  snsProposalsStoreIsLoading,
   snsQueryStore,
   snsQueryStoreIsLoading,
   snsSwapCommitmentsStore,
@@ -87,6 +88,19 @@ describe("sns.store", () => {
 
       expect($openSnsProposalsStore.length).toBe(1);
       expect($openSnsProposalsStore[0]).toEqual(proposals[1]);
+    });
+
+    it("should set the store as loading state", () => {
+      const proposals = {
+        proposals: [{ ...mockProposalInfo }],
+        certified: false,
+      };
+      snsProposalsStore.setProposals(proposals);
+
+      expect(get(snsProposalsStoreIsLoading)).toBe(false);
+
+      snsProposalsStore.reset();
+      expect(get(snsProposalsStoreIsLoading)).toBe(true);
     });
   });
 

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -2,6 +2,7 @@ import {
   openSnsProposalsStore,
   snsProposalsStore,
   snsQueryStore,
+  snsQueryStoreIsLoading,
   snsSwapCommitmentsStore,
   type SnsQueryStoreData,
 } from "$lib/stores/sns.store";
@@ -127,10 +128,10 @@ describe("sns.store", () => {
       });
 
       snsQueryStore.setData(data);
-      snsQueryStore.setLoadingState();
+      expect(get(snsQueryStoreIsLoading)).toBe(false);
 
-      const store = get(snsQueryStore);
-      expect(store).toBeNull();
+      snsQueryStore.reset();
+      expect(get(snsQueryStoreIsLoading)).toBe(true);
     });
 
     it("should update the data", () => {


### PR DESCRIPTION
# Motivation

snsQueryStore and snsProposalsStore use `undefined` to mean reset and `null` to mean loading. But then when checking whether they are loading we just use isNullish. This is confusing and it's also not super clear that setLoadingState actually resets all the data.

To make this obvious we use reset() instead of setLoadingState() and expose separate stores to check whether the store is loading via isNullish.

# Changes

1. Remove setLoading from snsQueryStore and snsProposalsStore.
2. Add snsQueryStoreIsLoading and snsProposalsStoreIsLoading
3. Use `.reset()` instead of `.setLoading()`.
4. Use `snsQueryStoreIsLoading` instead of `isNullish($snsSummariesStore) || isNullish($snsQueryStore)`. [snsSummariesStore](https://github.com/dfinity/nns-dapp/blob/4588644d282a9a3bbe4df3bac35215021f277361/frontend/src/lib/stores/sns.store.ts#L271) can't actually be non-nullish and `isNullish($snsQueryStore)` is what `snsQueryStoreIsLoading` does.
5. Use $snsProposalsStoreIsLoading instead of isNullish($snsProposalsStore)

# Tests

1. Changed an existing unit test for snsQueryStoreIsLoading and added a new test for snsProposalsStoreIsLoading.
2. Manual testing.