### PR TITLE
Downgrade upgrade test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,13 @@ jobs:
           # - The II version specified in dfx.json
           # - Functional SNS canisters
           ./scripts/dfx-nns-deploy-custom --features sns
+      - name: Basic downgrade-upgrade test
+        run: |
+          git fetch --depth 1 origin tag prod
+          if git diff tags/prod rs/backend | grep -q .
+          then ./scripts/nns-dapp/downgrade-upgrade-test
+          else echo "Skipping test as there are no relevant code changes"
+          fi
       - name: 'Upload nns-dapp_local wasm module'
         uses: actions/upload-artifact@v3
         with:
@@ -110,12 +117,6 @@ jobs:
           rm -rf screenshots
           set -o pipefail
           SCREENSHOT=1 npm run test | tee -a wdio.log
-      - name: Basic downgrade-upgrade test
-        run: |
-          if git diff tags/prod rs/backend | grep -q .
-          then ./scripts/nns-dapp/downgrade-upgrade-test
-          esle echo "Skipping test as there are no relevant code changes"
-          fi
       - name: Stop replica
         run: dfx stop
       - name: Archive wdio logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Generate .env configuration for e2e-tests
         run: |
           DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
+      - name: Basic downgrade-upgrade test
+        run: |
+          if git diff tags/prod rs/backend | grep -q .
+          then ./scripts/nns-dapp/downgrade-upgrade-test
+          fi
       - name: prepare and run the test suite
         working-directory: e2e-tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
         run: |
           if git diff tags/prod rs/backend | grep -q .
           then ./scripts/nns-dapp/downgrade-upgrade-test
+          esle echo "Skipping test as there are no relevant code changes"
           fi
       - name: Stop replica
         run: dfx stop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           git fetch --depth 1 origin tag prod
           if git diff tags/prod rs/backend | grep -q .
-          then ./scripts/nns-dapp/downgrade-upgrade-test
+          then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp.wasm
           else echo "Skipping test as there are no relevant code changes"
           fi
       - name: 'Upload nns-dapp_local wasm module'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,11 +102,6 @@ jobs:
       - name: Generate .env configuration for e2e-tests
         run: |
           DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
-      - name: Basic downgrade-upgrade test
-        run: |
-          if git diff tags/prod rs/backend | grep -q .
-          then ./scripts/nns-dapp/downgrade-upgrade-test
-          fi
       - name: prepare and run the test suite
         working-directory: e2e-tests
         run: |
@@ -115,6 +110,11 @@ jobs:
           rm -rf screenshots
           set -o pipefail
           SCREENSHOT=1 npm run test | tee -a wdio.log
+      - name: Basic downgrade-upgrade test
+        run: |
+          if git diff tags/prod rs/backend | grep -q .
+          then ./scripts/nns-dapp/downgrade-upgrade-test
+          fi
       - name: Stop replica
         run: dfx stop
       - name: Archive wdio logs

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -3,7 +3,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 help_text() {
-	cat <<-EOF
+  cat <<-EOF
 	Downgrade and then upgrade a local deployment.
 
 	Note: This deploys nns-dapp_local.wasm for the upgrade.
@@ -29,38 +29,38 @@ PROD_WASM="nns-dapp-prod_local.wasm"
 CURRENT_WASM="nns-dapp.wasm"
 
 verify_healthy() {
-	dfx canister call nns-dapp get_stats
+  dfx canister call nns-dapp get_stats
 }
 
 get_current_wasm() {
-	DFX_NETWORK=local ./scripts/docker-build
+  DFX_NETWORK=local ./scripts/docker-build
 }
 
 get_prod_wasm() {
-	curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_local.wasm > "$PROD_WASM"
+  curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_local.wasm >"$PROD_WASM"
 }
 
 # Installs the current build of nns-dapp
 upgrade_nnsdapp() {
-	dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
+  dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
 }
 
-
 test -e "$CURRENT_WASM" || {
-	echo "Please build '$CURRENT_WASM' before running this test."
-	exit 1
+  echo "Please build '$CURRENT_WASM' before running this test."
+  exit 1
 } >&2
 
 echo "Build the wasm, if it doesn't exist yet."
 test -e "$CURRENT_WASM" || {
-	echo "Building $CURRENT_WASM..."
-	DFX_NETWORK=local ./scripts/docker-build
+  echo "Building $CURRENT_WASM..."
+  DFX_NETWORK=local ./scripts/docker-build
 }
 echo "Make sure that the current wasm is the one currently installed"
-if dfx canister id nns-dapp >/dev/null 2>/dev/null
-then upgrade_nnsdapp "$CURRENT_WASM"
-else dfx canister create nns-dapp
-     dfx canister install nns-dapp --wasm "$CURRENT_WASM"
+if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
+  upgrade_nnsdapp "$CURRENT_WASM"
+else
+  dfx canister create nns-dapp
+  dfx canister install nns-dapp --wasm "$CURRENT_WASM"
 fi
 echo "Make sure that the current wasm is running healthily..."
 verify_healthy

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+help_text() {
+	cat <<-EOF
+	Downgrade and then upgrade a local deployment.
+
+	Note: This deploys nns-dapp_local.wasm for the upgrade.
+	      If the wasm is already present, it will be used.
+	      Please make sure that hte wasm is up to date.
+	      If the wasm is absent, it will be built.
+
+	Note: If the nns-dapp is already deployed, the deployment
+	      will be used in the downgrade and upgrade.  You may
+	      find it useful to verify that the state has been preserved.
+	      If the existing deployment is unhealthy, upgrades may fail.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -euo pipefail
+
+PROD_WASM="nns-dapp-prod_local.wasm"
+CURRENT_WASM="nns-dapp.wasm"
+
+verify_healthy() {
+	dfx canister id nns-dapp || {
+		echo "ERROR: Canister ID not defined."
+		exit 1	
+	} >&2
+}
+
+get_current_wasm() {
+	DFX_NETWORK=local ./scripts/docker-build
+}
+
+get_prod_wasm() {
+	curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_local.wasm > "$PROD_WASM"
+}
+
+# Installs the current build of nns-dapp
+upgrade_nnsdapp() {
+	dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
+}
+
+
+test -e "$CURRENT_WASM" || {
+	echo "Please build '$CURRENT_WASM' before running this test."
+	exit 1
+} >&2
+
+# Build the wasm, if it doesn't exist yet.
+test -e "$CURRENT_WASM" || {
+	echo "Building $CURRENT_WASM..."
+	DFX_NETWORK=local ./scripts/docker-build
+}
+# Make sure that the current wasm is the one currently installed
+if dfx canister id nns-dapp >/dev/null 2>/dev/null
+then upgrade_nnsdapp "$CURRENT_WASM"
+else dfx canister create nns-dapp
+     dfx canister install nns-dapp --wasm "$CURRENT_WASM"
+fi
+# Make sure that the current wasm is running healthily.
+verify_healthy
+# Downlaod and install the prod wasm
+get_prod_wasm
+upgrade_nnsdapp "$PROD_WASM"
+# Verify that the rollback is healthy
+verify_healthy
+# Roll forwards and test again
+upgrade_nnsdapp "$CURRENT_WASM"
+verify_healthy
+echo SUCCESS

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -7,8 +7,8 @@ PROD_WASM="nns-dapp-prod_local.wasm"
 help_text() {
   cat <<-EOF
 	Tests:
-	  - downgrading the current build to the prod build.
-	  - upgrading the prod build to the current build.
+	  - downgrading the local build to prod.
+	  - upgrading prod to the local build.
 	EOF
   # Note: If the code changes, please update the summary above to match.
 }

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -8,7 +8,7 @@ help_text() {
 
 	Note: This deploys nns-dapp_local.wasm for the upgrade.
 	      If the wasm is already present, it will be used.
-	      Please make sure that hte wasm is up to date.
+	      Please make sure that the wasm is up to date.
 	      If the wasm is absent, it will be built.
 
 	Note: If the nns-dapp is already deployed, the deployment

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -3,28 +3,12 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 PROD_WASM="nns-dapp-prod_local.wasm"
-CURRENT_WASM="nns-dapp.wasm"
 
 help_text() {
   cat <<-EOF
-	Downgrade and then upgrade a local deployment.
-
-	1) Prepare:
-	  1.1) Make sure that $CURRENT_WASM exists:
-	       - If it does not exist, build it.
-	       - If it does exits, it is the caller's responsibility
-	         to make sure that it is the wasm that is to be tested.
-	  1.2) Make sure that $CURRENT_WASM is deployed:
-	       - If the nns-dapp has already been created, upgrade the wasm
-	         to $CURRENT_WASM.  If successful, this will preserve
-	         existing state.
-	       - If nns-dapp has NOT been created, deploy it.
-	2) Test:
-	  2.1) Perform a basic health check.
-	  2.2) Downgrade to the prod release.
-	  2.3) Perform a basic health check.
-	  2.4) Upgrade to $CURRENT_WASM
-	  2.5) Perform a basic health check.
+	Tests:
+	  - downgrading the current build to the prod build.
+	  - upgrading the prod build to the current build.
 	EOF
   # Note: If the code changes, please update the summary above to match.
 }
@@ -32,6 +16,7 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
+clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -euo pipefail
@@ -53,11 +38,16 @@ upgrade_nnsdapp() {
   dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
 }
 
-echo "Ensuring that $CURRENT_WASM exists..."
-test -e "$CURRENT_WASM" || {
+echo "Getting or building the wasm..."
+test -n "${CURRENT_WASM:-}" || {
+  CURRENT_WASM="nns-dapp.wasm"
   echo "Building $CURRENT_WASM..."
   DFX_NETWORK=local ./scripts/docker-build
 }
+test -e "$CURRENT_WASM" || {
+  echo "ERROR: Wasm file not found at '$CURRENT_WASM'."
+  exit 1
+} >&2
 echo "Installing $CURRENT_WASM..."
 if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
   upgrade_nnsdapp "$CURRENT_WASM"

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -2,20 +2,31 @@
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
+PROD_WASM="nns-dapp-prod_local.wasm"
+CURRENT_WASM="nns-dapp.wasm"
+
 help_text() {
   cat <<-EOF
 	Downgrade and then upgrade a local deployment.
 
-	Note: This deploys nns-dapp_local.wasm for the upgrade.
-	      If the wasm is already present, it will be used.
-	      Please make sure that the wasm is up to date.
-	      If the wasm is absent, it will be built.
-
-	Note: If the nns-dapp is already deployed, the deployment
-	      will be used in the downgrade and upgrade.  You may
-	      find it useful to verify that the state has been preserved.
-	      If the existing deployment is unhealthy, upgrades may fail.
+	1) Prepare:
+	  1.1) Make sure that $CURRENT_WASM exists:
+	       - If it does not exist, build it.
+	       - If it does exits, it is the caller's responsibility
+	         to make sure that it is the wasm that is to be tested.
+	  1.2) Make sure that $CURRENT_WASM is deployed:
+	       - If the nns-dapp has already been created, upgrade the wasm
+	         to $CURRENT_WASM.  If successful, this will preserve
+	         existing state.
+	       - If nns-dapp has NOT been created, deploy it.
+	2) Test:
+	  2.1) Perform a basic health check.
+	  2.2) Downgrade to the prod release.
+	  2.3) Perform a basic health check.
+	  2.4) Upgrade to $CURRENT_WASM
+	  2.5) Perform a basic health check.
 	EOF
+	# Note: If the code changes, please update the summary above to match.
 }
 
 # Source the clap.bash file ---------------------------------------------------
@@ -24,9 +35,6 @@ source "$SOURCE_DIR/../clap.bash"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 set -euo pipefail
-
-PROD_WASM="nns-dapp-prod_local.wasm"
-CURRENT_WASM="nns-dapp.wasm"
 
 verify_healthy() {
   dfx canister call nns-dapp get_stats
@@ -45,31 +53,27 @@ upgrade_nnsdapp() {
   dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
 }
 
-test -e "$CURRENT_WASM" || {
-  echo "Please build '$CURRENT_WASM' before running this test."
-  exit 1
-} >&2
-
-echo "Build the wasm, if it doesn't exist yet."
+echo "Ensuring that $CURRENT_WASM exists..."
 test -e "$CURRENT_WASM" || {
   echo "Building $CURRENT_WASM..."
   DFX_NETWORK=local ./scripts/docker-build
 }
-echo "Make sure that the current wasm is the one currently installed"
+echo "Installing $CURRENT_WASM..."
 if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
   upgrade_nnsdapp "$CURRENT_WASM"
 else
   dfx canister create nns-dapp
   dfx canister install nns-dapp --wasm "$CURRENT_WASM"
 fi
-echo "Make sure that the current wasm is running healthily..."
+echo "Checking that the current wasm is healthy..."
 verify_healthy
-echo "Download and install the prod wasm..."
+echo "Downloading and installing the prod wasm..."
 get_prod_wasm
 upgrade_nnsdapp "$PROD_WASM"
-echo "Verify that the rollback is healthy..."
+echo "Checking that the rollback is healthy..."
 verify_healthy
-echo "Roll forwards and test again"
+echo "Rolling forwards..."
 upgrade_nnsdapp "$CURRENT_WASM"
+echo "Checking that the upgrade is healthy..."
 verify_healthy
 echo SUCCESS

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -10,7 +10,6 @@ help_text() {
 	  - downgrading the local build to prod.
 	  - upgrading prod to the local build.
 	EOF
-  # Note: If the code changes, please update the summary above to match.
 }
 
 # Source the clap.bash file ---------------------------------------------------

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -26,7 +26,7 @@ help_text() {
 	  2.4) Upgrade to $CURRENT_WASM
 	  2.5) Perform a basic health check.
 	EOF
-	# Note: If the code changes, please update the summary above to match.
+  # Note: If the code changes, please update the summary above to match.
 }
 
 # Source the clap.bash file ---------------------------------------------------

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -29,10 +29,7 @@ PROD_WASM="nns-dapp-prod_local.wasm"
 CURRENT_WASM="nns-dapp.wasm"
 
 verify_healthy() {
-	dfx canister id nns-dapp || {
-		echo "ERROR: Canister ID not defined."
-		exit 1	
-	} >&2
+	dfx canister call nns-dapp get_stats
 }
 
 get_current_wasm() {
@@ -54,25 +51,25 @@ test -e "$CURRENT_WASM" || {
 	exit 1
 } >&2
 
-# Build the wasm, if it doesn't exist yet.
+echo "Build the wasm, if it doesn't exist yet."
 test -e "$CURRENT_WASM" || {
 	echo "Building $CURRENT_WASM..."
 	DFX_NETWORK=local ./scripts/docker-build
 }
-# Make sure that the current wasm is the one currently installed
+echo "Make sure that the current wasm is the one currently installed"
 if dfx canister id nns-dapp >/dev/null 2>/dev/null
 then upgrade_nnsdapp "$CURRENT_WASM"
 else dfx canister create nns-dapp
      dfx canister install nns-dapp --wasm "$CURRENT_WASM"
 fi
-# Make sure that the current wasm is running healthily.
+echo "Make sure that the current wasm is running healthily..."
 verify_healthy
-# Downlaod and install the prod wasm
+echo "Download and install the prod wasm..."
 get_prod_wasm
 upgrade_nnsdapp "$PROD_WASM"
-# Verify that the rollback is healthy
+echo "Verify that the rollback is healthy..."
 verify_healthy
-# Roll forwards and test again
+echo "Roll forwards and test again"
 upgrade_nnsdapp "$CURRENT_WASM"
 verify_healthy
 echo SUCCESS


### PR DESCRIPTION
# Motivation
We are making more changes to the nns-dapp  backend and in particular to the stable memory.  It would be good to have at least a very basic downgrade-upgrade test in CI.

Requirements:
- Fast; should not slow down CI significantly.
- Verify that there are no panics in the pre and post-upgrade hooks.

Not covered:
- Detailed checks that might be applicable to a specific upgrade, e.g. making sure that stable data is preserved or manipulated in a  certain way.

# Changes
- Add a script that performs a downgrade and then an upgrade.  Given that the current code is usually deployed when testing, a downgrade-upgrade test is quicker to implement than an upgrade-downgrade test, which would really be a downgrade-upgrade-downgrade-upgrade test.
- Perform a health check by calling the stats endpoint.  This is much faster than an e2e test.

# Tests
- No change to rust code: See how these tests perform in CI.
- Change to Rust code:  I have run the script in this PR on code that breaks that stable memory and indeed, the script fails.