### PR TITLE
Page object cleanups based on feedback from PR 2062

### DIFF
--- a/frontend/src/lib/components/common/TestIdWrapper.svelte
+++ b/frontend/src/lib/components/common/TestIdWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  export let testId: string;
+</script>
+
+<div class="contents" data-tid={testId}>
+  <slot />
+</div>
+
+<style lang="scss">
+  .contents {
+    display: contents;
+  }
+</style>

--- a/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import type { CardType } from "$lib/types/card";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronCardContainer from "./NeuronCardContainer.svelte";
   import NeuronStateInfo from "./NeuronStateInfo.svelte";
   import NnsNeuronCardTitle from "./NnsNeuronCardTitle.svelte";
@@ -17,7 +18,7 @@
   export let cardType: CardType = "card";
 </script>
 
-<div data-tid="nns-neuron-card-component" class="component">
+<TestIdWrapper testId="nns-neuron-card-component">
   <NeuronCardContainer
     {role}
     {selected}
@@ -38,7 +39,7 @@
 
     <slot />
   </NeuronCardContainer>
-</div>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/card";
@@ -55,9 +56,5 @@
 
   .content {
     @include neuron.neuron-card-content;
-  }
-
-  .component {
-    display: contents;
   }
 </style>

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronCard.svelte
@@ -3,6 +3,7 @@
   import type { SnsNeuron } from "@dfinity/sns";
   import type { CardType } from "$lib/types/card";
   import { getSnsNeuronState } from "$lib/utils/sns-neuron.utils";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronCardContainer from "$lib/components/neurons/NeuronCardContainer.svelte";
   import NeuronStateInfo from "$lib/components/neurons/NeuronStateInfo.svelte";
   import SnsNeuronCardTitle from "$lib/components/sns-neurons/SnsNeuronCardTitle.svelte";
@@ -18,7 +19,7 @@
   $: neuronState = getSnsNeuronState(neuron);
 </script>
 
-<div data-tid="sns-neuron-card-component" class="component">
+<TestIdWrapper testId="sns-neuron-card-component">
   <NeuronCardContainer on:click {role} {cardType} {ariaLabel}>
     <SnsNeuronCardTitle slot="start" {neuron} tagName="p" />
 
@@ -32,16 +33,12 @@
 
     <slot />
   </NeuronCardContainer>
-</div>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "../../themes/mixins/neuron";
 
   .content {
     @include neuron.neuron-card-content;
-  }
-
-  .component {
-    display: contents;
   }
 </style>

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
   import NnsNeuronHotkeysCard from "$lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte";
   import NnsNeuronMaturityCard from "$lib/components/neuron-detail/NnsNeuronMaturityCard.svelte";
@@ -132,7 +133,7 @@
   });
 </script>
 
-<div data-tid="nns-neuron-detail-component" class="component">
+<TestIdWrapper testId="nns-neuron-detail-component">
   <Island>
     <main class="legacy">
       <section data-tid="neuron-detail">
@@ -162,10 +163,4 @@
   </Island>
 
   <NnsNeuronModals />
-</div>
-
-<style lang="scss">
-  .component {
-    display: contents;
-  }
-</style>
+</TestIdWrapper>

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import type { NeuronId } from "@dfinity/nns";
   import { neuronsStore, sortedNeuronStore } from "$lib/stores/neurons.store";
@@ -29,7 +30,7 @@
     );
 </script>
 
-<div data-tid="nns-neurons-component" class="component">
+<TestIdWrapper testId="nns-neurons-component">
   <div class="card-grid" data-tid="neurons-body">
     {#if isLoading}
       <SkeletonCard />
@@ -62,10 +63,4 @@
   {#if !isLoading && $sortedNeuronStore.length === 0}
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
-</div>
-
-<style lang="scss">
-  .component {
-    display: contents;
-  }
-</style>
+</TestIdWrapper>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SnsNeuronHotkeysCard from "$lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte";
   import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
   import { getSnsNeuron } from "$lib/services/sns-neurons.services";
@@ -133,7 +134,7 @@
     transactionFee === undefined;
 </script>
 
-<div data-tid="sns-neuron-detail-component" class="component">
+<TestIdWrapper testId="sns-neuron-detail-component">
   <Island>
     <main class="legacy">
       <section data-tid="sns-neuron-detail-page">
@@ -166,10 +167,4 @@
   </Island>
 
   <SnsNeuronModals />
-</div>
-
-<style lang="scss">
-  .component {
-    display: contents;
-  }
-</style>
+</TestIdWrapper>

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import {
     sortedSnsCFNeuronsStore,
@@ -66,7 +67,7 @@
   $: summary = $snsProjectSelectedStore?.summary;
 </script>
 
-<div data-tid="sns-neurons-component" class="component">
+<TestIdWrapper testId="sns-neurons-component">
   {#if $sortedSnsUserNeuronsStore.length > 0 || loading}
     <div class="card-grid" data-tid="sns-neurons-body">
       {#if loading}
@@ -113,12 +114,9 @@
       })}</EmptyMessage
     >
   {/if}
-</div>
+</TestIdWrapper>
 
 <style lang="scss">
-  .component {
-    display: contents;
-  }
   .top-margin {
     margin-top: var(--padding-4x);
   }

--- a/frontend/src/lib/routes/NeuronDetail.svelte
+++ b/frontend/src/lib/routes/NeuronDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
   import NnsNeuronDetail from "$lib/pages/NnsNeuronDetail.svelte";
   import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
@@ -12,16 +13,10 @@
   layoutTitleStore.set($i18n.neuron_detail.title);
 </script>
 
-<div data-tid="neuron-detail-component" class="component">
+<TestIdWrapper testId="neuron-detail-component">
   {#if $isNnsUniverseStore}
     <NnsNeuronDetail neuronIdText={neuronId} />
   {:else if nonNullish($snsProjectSelectedStore)}
     <SnsNeuronDetail {neuronId} />
   {/if}
-</div>
-
-<style lang="scss">
-  .component {
-    display: contents;
-  }
-</style>
+</TestIdWrapper>

--- a/frontend/src/lib/routes/Neurons.svelte
+++ b/frontend/src/lib/routes/Neurons.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
   import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NnsNeuronsFooter from "$lib/components/neurons/NnsNeuronsFooter.svelte";
   import SnsNeuronsFooter from "$lib/components/sns-neurons/SnsNeuronsFooter.svelte";
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
@@ -9,7 +10,7 @@
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 </script>
 
-<div data-tid="neurons-component" class="component">
+<TestIdWrapper testId="neurons-component">
   <main>
     <SummaryUniverse />
 
@@ -26,12 +27,9 @@
   {:else if nonNullish($snsProjectSelectedStore)}
     <SnsNeuronsFooter />
   {/if}
-</div>
+</TestIdWrapper>
 
 <style lang="scss">
-  .component {
-    display: contents;
-  }
   main {
     padding-bottom: var(--footer-height);
   }

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -75,11 +75,11 @@ describe("NeuronDetail", () => {
       const { container } = render(NeuronDetail, nnsProps);
       const po = NeuronDetailPo.under(container);
 
-      expect(po.hasSnsNeuronDetail()).toBe(false);
-      expect(po.hasNnsNeuronDetail()).toBe(true);
-      expect(po.getNnsNeuronDetail().isContentLoaded()).toBe(false);
+      expect(po.hasSnsNeuronDetailPo()).toBe(false);
+      expect(po.hasNnsNeuronDetailPo()).toBe(true);
+      expect(po.getNnsNeuronDetailPo().isContentLoaded()).toBe(false);
       await waitFor(() => {
-        expect(po.getNnsNeuronDetail().isContentLoaded()).toBe(true);
+        expect(po.getNnsNeuronDetailPo().isContentLoaded()).toBe(true);
       });
     });
   });
@@ -120,9 +120,9 @@ describe("NeuronDetail", () => {
       await waitFor(() => {
         expect(po.isContentLoaded()).toBe(true);
       });
-      expect(po.hasNnsNeuronDetail()).toBe(false);
-      expect(po.hasSnsNeuronDetail()).toBe(true);
-      expect(po.getSnsNeuronDetail().isContentLoaded()).toBe(true);
+      expect(po.hasNnsNeuronDetailPo()).toBe(false);
+      expect(po.hasSnsNeuronDetailPo()).toBe(true);
+      expect(po.getSnsNeuronDetailPo().isContentLoaded()).toBe(true);
     });
 
     it("should load if sns projects are loaded after initial rendering", async () => {
@@ -137,9 +137,9 @@ describe("NeuronDetail", () => {
       await waitFor(() => {
         expect(po.isContentLoaded()).toBe(true);
       });
-      expect(po.hasNnsNeuronDetail()).toBe(false);
-      expect(po.hasSnsNeuronDetail()).toBe(true);
-      expect(po.getSnsNeuronDetail().isContentLoaded()).toBe(true);
+      expect(po.hasNnsNeuronDetailPo()).toBe(false);
+      expect(po.hasSnsNeuronDetailPo()).toBe(true);
+      expect(po.getSnsNeuronDetailPo().isContentLoaded()).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -87,15 +87,15 @@ describe("Neurons", () => {
     const { container } = render(Neurons);
     const po = NeuronsPo.under(container);
 
-    expect(po.hasSnsNeurons()).toBe(false);
-    expect(po.hasNnsNeurons()).toBe(true);
-    expect(po.getNnsNeurons().isContentLoaded()).toBe(false);
+    expect(po.hasSnsNeuronsPo()).toBe(false);
+    expect(po.hasNnsNeuronsPo()).toBe(true);
+    expect(po.getNnsNeuronsPo().isContentLoaded()).toBe(false);
     await waitFor(() => {
-      expect(po.getNnsNeurons().isContentLoaded()).toBe(true);
+      expect(po.getNnsNeuronsPo().isContentLoaded()).toBe(true);
     });
 
     const neuronIdText = mockNeuron.neuronId.toString();
-    expect(po.getNnsNeurons().getNeuronIds()).toContain(neuronIdText);
+    expect(po.getNnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
   });
 
   it("should render project page when a committed project is selected", async () => {
@@ -106,15 +106,15 @@ describe("Neurons", () => {
     const { container } = render(Neurons);
     const po = NeuronsPo.under(container);
 
-    expect(po.hasNnsNeurons()).toBe(false);
-    expect(po.hasSnsNeurons()).toBe(true);
-    expect(po.getSnsNeurons().isContentLoaded()).toBe(false);
+    expect(po.hasNnsNeuronsPo()).toBe(false);
+    expect(po.hasSnsNeuronsPo()).toBe(true);
+    expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(false);
     await waitFor(() => {
-      expect(po.getSnsNeurons().isContentLoaded()).toBe(true);
+      expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(true);
     });
 
     const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
-    expect(po.getSnsNeurons().getNeuronIds()).toContain(neuronIdText);
+    expect(po.getSnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
   });
 
   it("should not render neurons when an open project is selected", async () => {
@@ -125,16 +125,16 @@ describe("Neurons", () => {
     const { container } = render(Neurons);
     const po = NeuronsPo.under(container);
 
-    expect(po.hasNnsNeurons()).toBe(false);
-    expect(po.hasSnsNeurons()).toBe(true);
-    expect(po.getSnsNeurons().isContentLoaded()).toBe(false);
+    expect(po.hasNnsNeuronsPo()).toBe(false);
+    expect(po.hasSnsNeuronsPo()).toBe(true);
+    expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(false);
     await waitFor(() => {
-      expect(po.getSnsNeurons().isContentLoaded()).toBe(true);
+      expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(true);
     });
 
     const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
     // This should actually fail but doesn't because of
     // https://dfinity.atlassian.net/browse/GIX-1328
-    expect(po.getSnsNeurons().getNeuronIds()).toContain(neuronIdText);
+    expect(po.getSnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
   });
 });

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -17,11 +17,11 @@ export class HashPo {
     return el && new HashPo(el);
   }
 
-  getTooltip(): TooltipPo {
+  getTooltipPo(): TooltipPo {
     return TooltipPo.under(this.root);
   }
 
   getText(): string {
-    return this.getTooltip().getText();
+    return this.getTooltipPo().getText();
   }
 }

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -19,26 +19,26 @@ export class NeuronDetailPo {
     return el && new NeuronDetailPo(el);
   }
 
-  getNnsNeuronDetail(): NnsNeuronDetailPo | null {
+  getNnsNeuronDetailPo(): NnsNeuronDetailPo | null {
     return NnsNeuronDetailPo.under(this.root);
   }
 
-  getSnsNeuronDetail(): SnsNeuronDetailPo | null {
+  getSnsNeuronDetailPo(): SnsNeuronDetailPo | null {
     return SnsNeuronDetailPo.under(this.root);
   }
 
-  hasNnsNeuronDetail(): boolean {
-    return nonNullish(this.getNnsNeuronDetail());
+  hasNnsNeuronDetailPo(): boolean {
+    return nonNullish(this.getNnsNeuronDetailPo());
   }
 
-  hasSnsNeuronDetail(): boolean {
-    return nonNullish(this.getSnsNeuronDetail());
+  hasSnsNeuronDetailPo(): boolean {
+    return nonNullish(this.getSnsNeuronDetailPo());
   }
 
   isContentLoaded() {
     return (
-      this.getNnsNeuronDetail()?.isContentLoaded() ||
-      this.getSnsNeuronDetail()?.isContentLoaded() ||
+      this.getNnsNeuronDetailPo()?.isContentLoaded() ||
+      this.getSnsNeuronDetailPo()?.isContentLoaded() ||
       false
     );
   }

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -19,26 +19,26 @@ export class NeuronsPo {
     return el && new NeuronsPo(el);
   }
 
-  getNnsNeurons(): NnsNeuronsPo | null {
+  getNnsNeuronsPo(): NnsNeuronsPo | null {
     return NnsNeuronsPo.under(this.root);
   }
 
-  getSnsNeurons(): SnsNeuronsPo | null {
+  getSnsNeuronsPo(): SnsNeuronsPo | null {
     return SnsNeuronsPo.under(this.root);
   }
 
-  hasNnsNeurons(): boolean {
-    return nonNullish(this.getNnsNeurons());
+  hasNnsNeuronsPo(): boolean {
+    return nonNullish(this.getNnsNeuronsPo());
   }
 
-  hasSnsNeurons(): boolean {
-    return nonNullish(this.getSnsNeurons());
+  hasSnsNeuronsPo(): boolean {
+    return nonNullish(this.getSnsNeuronsPo());
   }
 
   isContentLoaded() {
     return (
-      this.getNnsNeurons()?.isContentLoaded() ||
-      this.getSnsNeurons()?.isContentLoaded() ||
+      this.getNnsNeuronsPo()?.isContentLoaded() ||
+      this.getSnsNeuronsPo()?.isContentLoaded() ||
       false
     );
   }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -18,11 +18,11 @@ export class NnsNeuronCardPo {
     ).map((el) => new NnsNeuronCardPo(el));
   }
 
-  getCardTitle(): NnsNeuronCardTitlePo {
+  getCardTitlePo(): NnsNeuronCardTitlePo {
     return NnsNeuronCardTitlePo.under(this.root);
   }
 
   getNeuronId(): string {
-    return this.getCardTitle().getNeuronId();
+    return this.getCardTitlePo().getNeuronId();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -17,11 +17,11 @@ export class NnsNeuronDetailPo {
     return el && new NnsNeuronDetailPo(el);
   }
 
-  getSkeletonCards(): SkeletonCardPo[] {
+  getSkeletonCardPos(): SkeletonCardPo[] {
     return SkeletonCardPo.allUnder(this.root);
   }
 
   isContentLoaded(): boolean {
-    return this.getSkeletonCards().length === 0;
+    return this.getSkeletonCardPos().length === 0;
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -18,20 +18,20 @@ export class NnsNeuronsPo {
     return el && new NnsNeuronsPo(el);
   }
 
-  getSkeletonCards(): SkeletonCardPo[] {
+  getSkeletonCardPos(): SkeletonCardPo[] {
     return SkeletonCardPo.allUnder(this.root);
   }
 
-  getNeuronCards(): NnsNeuronCardPo[] {
+  getNeuronCardPos(): NnsNeuronCardPo[] {
     return NnsNeuronCardPo.allUnder(this.root);
   }
 
   isContentLoaded(): boolean {
-    return this.getSkeletonCards().length === 0;
+    return this.getSkeletonCardPos().length === 0;
   }
 
   getNeuronIds(): string[] {
-    const cards = this.getNeuronCards();
+    const cards = this.getNeuronCardPos();
     return cards.map((card) => card.getNeuronId());
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -18,11 +18,11 @@ export class SnsNeuronCardPo {
     ).map((el) => new SnsNeuronCardPo(el));
   }
 
-  getCardTitle(): SnsNeuronCardTitlePo {
+  getCardTitlePo(): SnsNeuronCardTitlePo {
     return SnsNeuronCardTitlePo.under(this.root);
   }
 
   getNeuronId(): string {
-    return this.getCardTitle().getNeuronId();
+    return this.getCardTitlePo().getNeuronId();
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -17,11 +17,11 @@ export class SnsNeuronDetailPo {
     return el && new SnsNeuronDetailPo(el);
   }
 
-  getSkeletonCards(): SkeletonCardPo[] {
+  getSkeletonCardPos(): SkeletonCardPo[] {
     return SkeletonCardPo.allUnder(this.root);
   }
 
   isContentLoaded(): boolean {
-    return this.getSkeletonCards().length === 0;
+    return this.getSkeletonCardPos().length === 0;
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -18,20 +18,20 @@ export class SnsNeuronsPo {
     return el && new SnsNeuronsPo(el);
   }
 
-  getSkeletonCards(): SkeletonCardPo[] {
+  getSkeletonCardPos(): SkeletonCardPo[] {
     return SkeletonCardPo.allUnder(this.root);
   }
 
-  getNeuronCards(): SnsNeuronCardPo[] {
+  getNeuronCardPos(): SnsNeuronCardPo[] {
     return SnsNeuronCardPo.allUnder(this.root);
   }
 
   isContentLoaded(): boolean {
-    return this.getSkeletonCards().length === 0;
+    return this.getSkeletonCardPos().length === 0;
   }
 
   getNeuronIds(): string[] {
-    const cards = this.getNeuronCards();
+    const cards = this.getNeuronCardPos();
     return cards.map((card) => card.getNeuronId());
   }
 }


### PR DESCRIPTION
# Motivation

The getters on page objects that return page objects can be a bit confusing, especially then the component name is in plural. For example getNnsNeurons does not return multiple neurons but the page object for the component NnsNeurons.

We also had to add the same css to a number of different components just to be able to wrap it in an element with a test ID.

# Changes

1. For getters that return a page object, make the name end with "Po".
2. For getters that return a list of page objects, make the name end with "Pos".
3. For getters that return whether a page object is non-nullish, make the name end with "Po".
4. Add TestIdWrapper to wrap multiple element with a data-tid and apply display:contents.

# Tests

1. `npm run test`
2. Manual testing.