### PR TITLE
GIX-1328 Only show sns neurons for committed projects

### DIFF
--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -1,5 +1,6 @@
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import {
+  snsProjectsCommittedStore,
   snsProjectsStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
@@ -29,3 +30,14 @@ export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =
           rootCanisterId.toText() === $selectedUniverseIdStore.toText()
       )
   );
+
+export const snsCommittedProjectSelectedStore: Readable<
+  SnsFullProject | undefined
+> = derived(
+  [selectedUniverseIdStore, snsProjectsCommittedStore],
+  ([$selectedUniverseIdStore, $projectsStore]) =>
+    $projectsStore.find(
+      ({ rootCanisterId }) =>
+        rootCanisterId.toText() === $selectedUniverseIdStore.toText()
+    )
+);

--- a/frontend/src/lib/routes/Neurons.svelte
+++ b/frontend/src/lib/routes/Neurons.svelte
@@ -7,7 +7,7 @@
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import { nonNullish } from "@dfinity/utils";
-  import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
+  import { snsCommittedProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 </script>
 
 <TestIdWrapper testId="neurons-component">
@@ -16,7 +16,7 @@
 
     {#if $isNnsUniverseStore}
       <NnsNeurons />
-    {:else if nonNullish($snsProjectSelectedStore)}
+    {:else if nonNullish($snsCommittedProjectSelectedStore)}
       <SnsNeurons />
     {/if}
   </main>
@@ -24,7 +24,7 @@
   {#if $isNnsUniverseStore}
     <NnsNeuronsFooter />
     <!-- Staking SNS Neurons has not yet been reviewed by security -->
-  {:else if nonNullish($snsProjectSelectedStore)}
+  {:else if nonNullish($snsCommittedProjectSelectedStore)}
     <SnsNeuronsFooter />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -3,6 +3,7 @@
  */
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
+  snsCommittedProjectSelectedStore,
   snsOnlyProjectStore,
   snsProjectSelectedStore,
 } from "$lib/derived/sns/sns-selected-project.derived";
@@ -22,11 +23,14 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("selected sns project derived stores", () => {
+  beforeEach(() => {
+    snsQueryStore.reset();
+  });
+
   describe("snsOnlyProjectStore", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
 
-      snsQueryStore.reset();
       snsQueryStore.setData(
         snsResponseFor({
           principal: mockSnsCanisterId,
@@ -65,6 +69,7 @@ describe("selected sns project derived stores", () => {
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
     });
+
     it("returns the SNS project of the current universe", () => {
       const projectData = snsResponsesForLifecycle({
         lifecycles: [SnsSwapLifecycle.Committed],
@@ -86,8 +91,105 @@ describe("selected sns project derived stores", () => {
       expect(storeData.rootCanisterId.toText()).toEqual(rootCanisterIdText);
     });
 
+    it("returns undefined if the project doesn't exist", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+      const nonExistentProjectIdText = Principal.fromHex("123456").toText();
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(
+          Principal.fromText(rootCanisterIdText)
+        ),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: nonExistentProjectIdText } });
+
+      const storeData = get(snsProjectSelectedStore);
+      expect(storeData).toBeUndefined();
+    });
+
     it("returns undefined when nns", () => {
       const storeData = get(snsProjectSelectedStore);
+      expect(storeData).toBeUndefined();
+    });
+  });
+
+  describe("snsCommittedProjectSelectedStore", () => {
+    beforeEach(() => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+    });
+
+    it("returns the SNS project of the current universe", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(
+          Principal.fromText(rootCanisterIdText)
+        ),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: rootCanisterIdText } });
+
+      const storeData = get(snsCommittedProjectSelectedStore);
+      expect(storeData.rootCanisterId.toText()).toEqual(rootCanisterIdText);
+    });
+
+    it("returns undefined if the project doesn't exist", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Committed],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+      const nonExistentProjectIdText = Principal.fromHex("123456").toText();
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(
+          Principal.fromText(rootCanisterIdText)
+        ),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: nonExistentProjectIdText } });
+
+      const storeData = get(snsCommittedProjectSelectedStore);
+      expect(storeData).toBeUndefined();
+    });
+
+    it("returns undefined if the project isn't committed", () => {
+      const projectData = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+      });
+      const rootCanisterIdText = projectData[0][0].rootCanisterId;
+
+      snsSwapCommitmentsStore.setSwapCommitment({
+        swapCommitment: mockSnsSwapCommitment(
+          Principal.fromText(rootCanisterIdText)
+        ),
+        certified: true,
+      });
+
+      snsQueryStore.setData(projectData);
+
+      page.mock({ data: { universe: rootCanisterIdText } });
+
+      const storeData = get(snsCommittedProjectSelectedStore);
+      expect(storeData).toBeUndefined();
+    });
+
+    it("returns undefined when nns", () => {
+      const storeData = get(snsCommittedProjectSelectedStore);
       expect(storeData).toBeUndefined();
     });
   });

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -126,15 +126,6 @@ describe("Neurons", () => {
     const po = NeuronsPo.under(container);
 
     expect(po.hasNnsNeuronsPo()).toBe(false);
-    expect(po.hasSnsNeuronsPo()).toBe(true);
-    expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(false);
-    await waitFor(() => {
-      expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(true);
-    });
-
-    const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
-    // This should actually fail but doesn't because of
-    // https://dfinity.atlassian.net/browse/GIX-1328
-    expect(po.getSnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
+    expect(po.hasSnsNeuronsPo()).toBe(false);
   });
 });


### PR DESCRIPTION
# Motivation

Currently it's possible to see founder neurons before the sns project is committed by manually change a URL parameter.
The current code checks that the URL parameter represents an existing project but not that the project is committed.

# Changes

In Neurons.svelte, instead of only rendering SnsNeurons if the selected project exists, also check that it's committed.

# Tests

Unit tests and manual testing.