### PR TITLE
Refactor: Move stats out of the accounts store

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1,11 +1,10 @@
 use crate::constants::{MEMO_CREATE_CANISTER, MEMO_TOP_UP_CANISTER};
-use crate::metrics_encoder::MetricsEncoder;
 use crate::multi_part_transactions_processor::{
     MultiPartTransactionToBeProcessed, MultiPartTransactionsProcessor, MultiPartTransactionsProcessorWithRemovedFields,
 };
 use crate::state::StableState;
+use crate::stats::Stats;
 use crate::time::time_millis;
-use crate::STATE;
 use candid::CandidType;
 use dfn_candid::Candid;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -851,7 +850,7 @@ impl AccountsStore {
         self.multi_part_transactions_processor.push(block_height, transaction);
     }
 
-    pub fn get_stats(&self) -> Stats {
+    pub fn get_stats(&self, stats: &mut Stats) {
         let earliest_transaction = self.transactions.front();
         let latest_transaction = self.transactions.back();
         let timestamp_now_nanos = dfn_core::api::now()
@@ -861,23 +860,21 @@ impl AccountsStore {
         let duration_since_last_sync =
             Duration::from_nanos(timestamp_now_nanos - self.last_ledger_sync_timestamp_nanos);
 
-        Stats {
-            accounts_count: self.accounts.len() as u64,
-            sub_accounts_count: self.sub_accounts_count,
-            hardware_wallet_accounts_count: self.hardware_wallet_accounts_count,
-            transactions_count: self.transactions.len() as u64,
-            block_height_synced_up_to: self.block_height_synced_up_to,
-            earliest_transaction_timestamp_nanos: earliest_transaction
-                .map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch()),
-            earliest_transaction_block_height: earliest_transaction.map_or(0, |t| t.block_height),
-            latest_transaction_timestamp_nanos: latest_transaction
-                .map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch()),
-            latest_transaction_block_height: latest_transaction.map_or(0, |t| t.block_height),
-            seconds_since_last_ledger_sync: duration_since_last_sync.as_secs(),
-            neurons_created_count: self.neuron_accounts.len() as u64,
-            neurons_topped_up_count: self.neurons_topped_up_count,
-            transactions_to_process_queue_length: self.multi_part_transactions_processor.get_queue_length(),
-        }
+        stats.accounts_count = self.accounts.len() as u64;
+        stats.sub_accounts_count = self.sub_accounts_count;
+        stats.hardware_wallet_accounts_count = self.hardware_wallet_accounts_count;
+        stats.transactions_count = self.transactions.len() as u64;
+        stats.block_height_synced_up_to = self.block_height_synced_up_to;
+        stats.earliest_transaction_timestamp_nanos =
+            earliest_transaction.map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch());
+        stats.earliest_transaction_block_height = earliest_transaction.map_or(0, |t| t.block_height);
+        stats.latest_transaction_timestamp_nanos =
+            latest_transaction.map_or(0, |t| t.timestamp.as_nanos_since_unix_epoch());
+        stats.latest_transaction_block_height = latest_transaction.map_or(0, |t| t.block_height);
+        stats.seconds_since_last_ledger_sync = duration_since_last_sync.as_secs();
+        stats.neurons_created_count = self.neuron_accounts.len() as u64;
+        stats.neurons_topped_up_count = self.neurons_topped_up_count;
+        stats.transactions_to_process_queue_length = self.multi_part_transactions_processor.get_queue_length();
     }
 
     fn try_add_transaction_to_account(
@@ -1506,65 +1503,6 @@ pub enum TransferResult {
         amount: Tokens,
         fee: Tokens,
     },
-}
-
-pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
-    STATE.with(|s| {
-        let stats = s.accounts_store.borrow().get_stats();
-        w.encode_gauge(
-            "neurons_created_count",
-            stats.neurons_created_count as f64,
-            "Number of neurons created.",
-        )?;
-        w.encode_gauge(
-            "neurons_topped_up_count",
-            stats.neurons_topped_up_count as f64,
-            "Number of neurons topped up by the canister.",
-        )?;
-        w.encode_gauge(
-            "transactions_count",
-            stats.transactions_count as f64,
-            "Number of transactions processed by the canister.",
-        )?;
-        w.encode_gauge(
-            "accounts_count",
-            stats.accounts_count as f64,
-            "Number of accounts created.",
-        )?;
-        w.encode_gauge(
-            "sub_accounts_count",
-            stats.sub_accounts_count as f64,
-            "Number of sub accounts created.",
-        )?;
-        w.encode_gauge(
-            "hardware_wallet_accounts_count",
-            stats.hardware_wallet_accounts_count as f64,
-            "Number of hardware wallet accounts created.",
-        )?;
-        w.encode_gauge(
-            "seconds_since_last_ledger_sync",
-            stats.seconds_since_last_ledger_sync as f64,
-            "Number of seconds since last ledger sync.",
-        )?;
-        Ok(())
-    })
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct Stats {
-    accounts_count: u64,
-    sub_accounts_count: u64,
-    hardware_wallet_accounts_count: u64,
-    transactions_count: u64,
-    block_height_synced_up_to: Option<u64>,
-    earliest_transaction_timestamp_nanos: u64,
-    earliest_transaction_block_height: BlockIndex,
-    latest_transaction_timestamp_nanos: u64,
-    latest_transaction_block_height: BlockIndex,
-    seconds_since_last_ledger_sync: u64,
-    neurons_created_count: u64,
-    neurons_topped_up_count: u64,
-    transactions_to_process_queue_length: u32,
 }
 
 #[cfg(test)]

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1506,4 +1506,4 @@ pub enum TransferResult {
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1216,7 +1216,9 @@ fn hardware_wallet_account_name_too_long() {
 fn get_stats() {
     let mut store = setup_test_store();
 
-    let stats = store.get_stats();
+    let mut stats = crate::stats::Stats::default();
+    store.get_stats(&mut stats);
+
     assert_eq!(2, stats.accounts_count);
     assert_eq!(0, stats.sub_accounts_count);
     assert_eq!(0, stats.hardware_wallet_accounts_count);
@@ -1232,13 +1234,13 @@ fn get_stats() {
     store.add_account(principal3);
     store.add_account(principal4);
 
-    let stats = store.get_stats();
+    store.get_stats(&mut stats);
 
     assert_eq!(4, stats.accounts_count);
 
     for i in 1..10 {
         store.create_sub_account(principal3, i.to_string());
-        let stats = store.get_stats();
+        store.get_stats(&mut stats);
         assert_eq!(i, stats.sub_accounts_count);
     }
 
@@ -1259,11 +1261,11 @@ fn get_stats() {
         },
     );
 
-    let stats = store.get_stats();
+    store.get_stats(&mut stats);
     assert_eq!(2, stats.hardware_wallet_accounts_count);
 
     store.mark_ledger_sync_complete();
-    let stats = store.get_stats();
+    store.get_stats(&mut stats);
     assert!(stats.seconds_since_last_ledger_sync < 10);
 }
 

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1212,13 +1212,8 @@ fn hardware_wallet_account_name_too_long() {
     assert!(matches!(res2, RegisterHardwareWalletResponse::NameTooLong));
 }
 
-#[test]
-fn get_stats() {
-    let mut store = setup_test_store();
-
-    let mut stats = crate::stats::Stats::default();
-    store.get_stats(&mut stats);
-
+/// Test that the stats are as expected for a new test store.
+pub(crate) fn assert_initial_test_store_stats_are_correct(stats: &Stats) {
     assert_eq!(2, stats.accounts_count);
     assert_eq!(0, stats.sub_accounts_count);
     assert_eq!(0, stats.hardware_wallet_accounts_count);
@@ -1227,6 +1222,23 @@ fn get_stats() {
     assert_eq!(0, stats.earliest_transaction_block_height);
     assert_eq!(3, stats.latest_transaction_block_height);
     assert!(stats.seconds_since_last_ledger_sync > 1_000_000_000);
+}
+
+/// The stats test should reject an empty response when we know that there is data in the accounts store.
+#[test]
+#[should_panic]
+fn stats_test_should_fail_for_default_fill() {
+    let stats = Stats::default();
+    assert_initial_test_store_stats_are_correct(&stats);
+}
+
+#[test]
+fn get_stats() {
+    let mut store = setup_test_store();
+
+    let mut stats = crate::stats::Stats::default();
+    store.get_stats(&mut stats);
+    assert_initial_test_store_stats_are_correct(&stats);
 
     let principal3 = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
     let principal4 = PrincipalId::from_str(TEST_ACCOUNT_4).unwrap();
@@ -1343,7 +1355,7 @@ fn encode_decode_stable_state() {
     );
 }
 
-fn setup_test_store() -> AccountsStore {
+pub(crate) fn setup_test_store() -> AccountsStore {
     let principal1 = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
     let principal2 = PrincipalId::from_str(TEST_ACCOUNT_2).unwrap();
     let account_identifier1 = AccountIdentifier::from(principal1);

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -1,6 +1,6 @@
-use crate::accounts_store::encode_metrics;
 use crate::metrics_encoder::MetricsEncoder;
 use crate::state::{State, STATE};
+use crate::stats::encode_metrics;
 use crate::StableState;
 use candid::{CandidType, Decode, Encode};
 use dfn_core::api::ic0::time;

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -2,7 +2,7 @@ use crate::accounts_store::{
     AccountDetails, AddPendingNotifySwapRequest, AddPendingTransactionResponse, AttachCanisterRequest,
     AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest, DetachCanisterResponse,
     GetTransactionsRequest, GetTransactionsResponse, NamedCanister, RegisterHardwareWalletRequest,
-    RegisterHardwareWalletResponse, RenameSubAccountRequest, RenameSubAccountResponse, Stats, TransactionType,
+    RegisterHardwareWalletResponse, RenameSubAccountRequest, RenameSubAccountResponse, TransactionType,
 };
 use crate::assets::{hash_bytes, insert_asset, Asset};
 use crate::periodic_tasks_runner::run_periodic_tasks;
@@ -22,6 +22,7 @@ mod multi_part_transactions_processor;
 mod periodic_tasks_runner;
 mod proposals;
 mod state;
+mod stats;
 mod time;
 
 type Cycles = u128;
@@ -227,8 +228,8 @@ pub fn get_stats() {
     over(candid, |()| get_stats_impl());
 }
 
-fn get_stats_impl() -> Stats {
-    STATE.with(|s| s.accounts_store.borrow().get_stats())
+fn get_stats_impl() -> stats::Stats {
+    STATE.with(stats::get_stats)
 }
 
 /// Executes on every block height and is used to run background processes.

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -1,0 +1,71 @@
+use crate::metrics_encoder::MetricsEncoder;
+use crate::state::State;
+use crate::STATE;
+use candid::CandidType;
+use icp_ledger::BlockIndex;
+use serde::Deserialize;
+
+pub fn get_stats(state: &State) -> Stats {
+    let mut ans = Stats::default();
+    // Collect values from various subcomponents
+    state.accounts_store.borrow().get_stats(&mut ans);
+    // Return all the values
+    ans
+}
+
+#[derive(CandidType, Deserialize, Default)]
+pub struct Stats {
+    pub accounts_count: u64,
+    pub sub_accounts_count: u64,
+    pub hardware_wallet_accounts_count: u64,
+    pub transactions_count: u64,
+    pub block_height_synced_up_to: Option<u64>,
+    pub earliest_transaction_timestamp_nanos: u64,
+    pub earliest_transaction_block_height: BlockIndex,
+    pub latest_transaction_timestamp_nanos: u64,
+    pub latest_transaction_block_height: BlockIndex,
+    pub seconds_since_last_ledger_sync: u64,
+    pub neurons_created_count: u64,
+    pub neurons_topped_up_count: u64,
+    pub transactions_to_process_queue_length: u32,
+}
+
+pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+    let stats = STATE.with(get_stats);
+    w.encode_gauge(
+        "neurons_created_count",
+        stats.neurons_created_count as f64,
+        "Number of neurons created.",
+    )?;
+    w.encode_gauge(
+        "neurons_topped_up_count",
+        stats.neurons_topped_up_count as f64,
+        "Number of neurons topped up by the canister.",
+    )?;
+    w.encode_gauge(
+        "transactions_count",
+        stats.transactions_count as f64,
+        "Number of transactions processed by the canister.",
+    )?;
+    w.encode_gauge(
+        "accounts_count",
+        stats.accounts_count as f64,
+        "Number of accounts created.",
+    )?;
+    w.encode_gauge(
+        "sub_accounts_count",
+        stats.sub_accounts_count as f64,
+        "Number of sub accounts created.",
+    )?;
+    w.encode_gauge(
+        "hardware_wallet_accounts_count",
+        stats.hardware_wallet_accounts_count as f64,
+        "Number of hardware wallet accounts created.",
+    )?;
+    w.encode_gauge(
+        "seconds_since_last_ledger_sync",
+        stats.seconds_since_last_ledger_sync as f64,
+        "Number of seconds since last ledger sync.",
+    )?;
+    Ok(())
+}

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -4,6 +4,8 @@ use crate::STATE;
 use candid::CandidType;
 use icp_ledger::BlockIndex;
 use serde::Deserialize;
+#[cfg(test)]
+mod tests;
 
 pub fn get_stats(state: &State) -> Stats {
     let mut ans = Stats::default();
@@ -13,7 +15,7 @@ pub fn get_stats(state: &State) -> Stats {
     ans
 }
 
-#[derive(CandidType, Deserialize, Default)]
+#[derive(CandidType, Deserialize, Default, Debug, Eq, PartialEq)]
 pub struct Stats {
     pub accounts_count: u64,
     pub sub_accounts_count: u64,

--- a/rs/backend/src/stats/tests.rs
+++ b/rs/backend/src/stats/tests.rs
@@ -1,0 +1,22 @@
+/// Tests that the stats data collection is as expected
+use super::get_stats;
+use crate::assets::{AssetHashes, Assets};
+use crate::State;
+use core::cell::RefCell;
+
+/// Creates a populated test state for testing.
+fn setup_test_state() -> State {
+    State {
+        accounts_store: RefCell::new(crate::accounts_store::tests::setup_test_store()),
+        assets: RefCell::new(Assets::default()),
+        asset_hashes: RefCell::new(AssetHashes::default()),
+    }
+}
+
+/// Verifies that the stats match the state.
+#[test]
+fn populated_state_should_have_populated_stats() {
+    let state = setup_test_state();
+    let stats = get_stats(&state);
+    crate::accounts_store::tests::assert_initial_test_store_stats_are_correct(&stats);
+}


### PR DESCRIPTION
# Motivation
Stats and metrics are currently calculated inside the accounts store.  This is limiting, given that there are interesting statistics to be had from other parts of the canister.

# Changes
* Move the stats code out of the accounts store, leaving behind just the part that populates account stats.

# Tests
This changes no externally functionality so no new tests are required.