### PR TITLE
GIX-1401: Use loadBalance instead of syncAccounts

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -261,11 +261,9 @@ export const transferICP = async ({
     });
     await Promise.all([
       loadBalance({ accountIdentifier: identifier }),
-      ...[
-        nonNullish(toAccount)
-          ? loadBalance({ accountIdentifier: to })
-          : Promise.resolve(),
-      ],
+      nonNullish(toAccount)
+        ? loadBalance({ accountIdentifier: to })
+        : Promise.resolve(),
     ]);
 
     return { success: true };

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -26,7 +26,7 @@ import {
 } from "$lib/utils/error.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
-import { getAccountIdentity, syncAccounts } from "./accounts.services";
+import { getAccountIdentity, loadBalance } from "./accounts.services";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
@@ -84,9 +84,9 @@ export const createCanister = async ({
       fromSubAccount: account.subAccount,
     });
     await listCanisters({ clearBeforeQuery: false });
-    // We don't wait for `syncAccounts` to finish to give a better UX to the user.
-    // `syncAccounts` might be slow since it loads all accounts and balances.
-    syncAccounts();
+    // We don't wait for `loadBalance` to finish to give a better UX to the user.
+    // update calls might be slow.
+    loadBalance({ accountIdentifier: account.identifier });
     return canisterId;
   } catch (error: unknown) {
     toastsShow(
@@ -119,9 +119,9 @@ export const topUpCanister = async ({
       amount: icpAmount,
       fromSubAccount: account.subAccount,
     });
-    // We don't wait for `syncAccounts` to finish to give a better UX to the user.
-    // `syncAccounts` might be slow since it loads all accounts and balances.
-    syncAccounts();
+    // We don't wait for `loadBalance` to finish to give a better UX to the user.
+    // update calls might be slow.
+    loadBalance({ accountIdentifier: account.identifier });
     return { success: true };
   } catch (error: unknown) {
     toastsShow(

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -7,11 +7,12 @@ import {
 } from "$lib/api/sns-sale.api";
 import { wrapper } from "$lib/api/sns-wrapper.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import {
   snsProjectsStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
-import { syncAccounts } from "$lib/services/accounts.services";
+import { loadBalance } from "$lib/services/accounts.services";
 import { getCurrentIdentity } from "$lib/services/auth.services";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -22,6 +23,7 @@ import { SaleStep } from "$lib/types/sale";
 import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { validParticipation } from "$lib/utils/projects.utils";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import {
   getSwapCanisterAccount,
   isInternalRefreshBuyerTokensError,
@@ -660,7 +662,7 @@ const pollTransfer = ({
  *
  * 1. nnsLedger.transfer
  * 2. snsSale.notifyParticipation (refresh_buyer_tokens)
- * 3. syncAccounts
+ * 3. load new balance in store
  *
  * @param snsTicket
  * @param rootCanisterId
@@ -801,11 +803,27 @@ export const participateInSnsSale = async ({
   }
 
   // Step 4.
-  logWithTimestamp("[sale] 3. syncAccounts");
+  logWithTimestamp("[sale] 3. loadBalance");
 
   updateProgress(SaleStep.RELOAD);
 
-  await syncAccounts();
+  // Ticket return the account as ICRC. We can't compare identifiers directly.
+  // If there is no subaccount, then the account is the main account.
+  // Otherwise, we look for the matching subaccount.
+  const sourceAccount = get(nnsAccountsListStore).find((account) => {
+    if (isNullish(subaccount)) {
+      return account.type === "main";
+    }
+    if (nonNullish(account.subAccount)) {
+      return (
+        subaccountToHexString(subaccount) ===
+        subaccountToHexString(Uint8Array.from(account.subAccount))
+      );
+    }
+  });
+  if (nonNullish(sourceAccount)) {
+    await loadBalance({ accountIdentifier: sourceAccount.identifier });
+  }
 
   logWithTimestamp("[sale] done");
 

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -526,7 +526,16 @@ describe("accounts-services", () => {
         accountIdentifier: mockSubAccount.identifier,
         certified: true,
       });
-      // 2 times for source account, 2 times for destination account
+      expect(queryAccountBalanceSpy).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        accountIdentifier: sourceAccount.identifier,
+        certified: false,
+      });
+      expect(queryAccountBalanceSpy).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        accountIdentifier: sourceAccount.identifier,
+        certified: true,
+      });
       expect(queryAccountBalanceSpy).toHaveBeenCalledTimes(4);
     });
   });

--- a/frontend/src/tests/mocks/sns.mock.ts
+++ b/frontend/src/tests/mocks/sns.mock.ts
@@ -8,6 +8,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import type { Principal } from "@dfinity/principal";
+import { toNullable } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
@@ -15,9 +16,11 @@ import { writable } from "svelte/store";
 export const snsTicketMock = ({
   rootCanisterId,
   owner,
+  subaccount,
 }: {
   rootCanisterId: Principal;
   owner: Principal;
+  subaccount?: Uint8Array;
 }): SnsTicket => ({
   rootCanisterId,
   ticket: {
@@ -26,7 +29,7 @@ export const snsTicketMock = ({
     account: [
       {
         owner: [owner],
-        subaccount: [],
+        subaccount: toNullable(subaccount),
       },
     ],
     amount_icp_e8s: numberToE8s(10),


### PR DESCRIPTION
# Motivation

Continuing with the task of reducing the number of update calls by using `loadBalance` instead of `syncAccounts`.

# Changes

* Use `loadBalance` in the accounts service `transferICP`.
* Use `loadBalance` in the canister service `createCanister`.
* Use `loadBalance` in the canister service `topUpCanister`.
* Use `loadBalance` in the sns sale service `participateInSnsSale`.

# Tests

* Change expectations of calling `syncAccounts` service for only the `queryAccountBalance` api.
* Major change in `canister.services.spect.ts`. Mock only api layer.
* Use new `blockAllCallsTo` in canister and accounts services test files.
