### PR TITLE
fix: close ckBTC to BTC modal on error

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -92,7 +92,11 @@
     if (success) {
       toastsSuccess({ labelKey: "accounts.transaction_success" });
       dispatcher("nnsTransfer");
+      return;
     }
+
+    // Unlike "send ckBTC" we close the modal in case of error because the issue can potentially happen after a successful transfer
+    dispatcher("nnsClose");
   };
 
   let networkBtc = false;


### PR DESCRIPTION
# Motivation

On ckBTC to BTC conversion error the user got stuck on the "Progress" step. The modal should be close if such error happens.
