### PR TITLE
Feat: Hide Increase Stake for SNS CF neurons

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -22,7 +22,7 @@
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
   import SnsIncreaseStakeButton from "$lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte";
-  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import TestIdWrapper from "$lib/common/TestIdWrapper.svelte";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -14,6 +14,7 @@
     getSnsNeuronState,
     hasPermissionToDisburse,
     hasPermissionToDissolve,
+    isCommunityFund,
   } from "$lib/utils/sns-neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { NeuronState } from "@dfinity/nns";
@@ -21,6 +22,7 @@
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
   import SnsIncreaseStakeButton from "$lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -52,28 +54,37 @@
     nonNullish(neuronState) &&
     [NeuronState.Dissolving, NeuronState.Locked].includes(neuronState) &&
     allowedToDissolve;
+
+  let isCFNeuron = false;
+  $: isCFNeuron = nonNullish(neuron) ? isCommunityFund(neuron) : false;
 </script>
 
-{#if nonNullish(neuron) && nonNullish(neuronState)}
-  <KeyValuePair>
-    <h3 slot="key">{$i18n.neuron_detail.stake}</h3>
-    <SnsNeuronAmount {neuron} slot="value" />
-  </KeyValuePair>
+<TestIdWrapper testId="sns-neuron-info-stake">
+  {#if nonNullish(neuron) && nonNullish(neuronState)}
+    <KeyValuePair>
+      <h3 slot="key" data-tid="sns-neuron-stake">
+        {$i18n.neuron_detail.stake}
+      </h3>
+      <SnsNeuronAmount {neuron} slot="value" />
+    </KeyValuePair>
 
-  <div class="buttons">
-    {#if allowedToDissolve}
-      <IncreaseSnsDissolveDelayButton />
-    {/if}
-    <SnsIncreaseStakeButton />
-    {#if neuronState === NeuronState.Dissolved && allowedToDisburse}
-      <DisburseSnsButton />
-    {:else if canDissolve}
-      <DissolveSnsNeuronButton {neuronState} />
-    {/if}
-  </div>
+    <div class="buttons">
+      {#if allowedToDissolve}
+        <IncreaseSnsDissolveDelayButton />
+      {/if}
+      {#if !isCFNeuron}
+        <SnsIncreaseStakeButton />
+      {/if}
+      {#if neuronState === NeuronState.Dissolved && allowedToDisburse}
+        <DisburseSnsButton />
+      {:else if canDissolve}
+        <DissolveSnsNeuronButton {neuronState} />
+      {/if}
+    </div>
 
-  <Separator />
-{/if}
+    <Separator />
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   @use "../../themes/mixins/section";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -22,7 +22,7 @@
   import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte";
   import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
   import SnsIncreaseStakeButton from "$lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte";
-  import TestIdWrapper from "$lib/common/TestIdWrapper.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
@@ -34,20 +34,20 @@
   $: neuronState = isNullish(neuron) ? undefined : getSnsNeuronState(neuron);
 
   let allowedToDissolve: boolean;
-  $: allowedToDissolve = isNullish(neuron)
-    ? false
-    : hasPermissionToDissolve({
-        neuron,
-        identity: $authStore.identity,
-      });
+  $: allowedToDissolve =
+    nonNullish(neuron) &&
+    hasPermissionToDissolve({
+      neuron,
+      identity: $authStore.identity,
+    });
 
   let allowedToDisburse: boolean;
-  $: allowedToDisburse = isNullish(neuron)
-    ? false
-    : hasPermissionToDisburse({
-        neuron,
-        identity: $authStore.identity,
-      });
+  $: allowedToDisburse =
+    nonNullish(neuron) &&
+    hasPermissionToDisburse({
+      neuron,
+      identity: $authStore.identity,
+    });
 
   let canDissolve = false;
   $: canDissolve =
@@ -55,14 +55,14 @@
     [NeuronState.Dissolving, NeuronState.Locked].includes(neuronState) &&
     allowedToDissolve;
 
-  let isCFNeuron = false;
-  $: isCFNeuron = nonNullish(neuron) ? isCommunityFund(neuron) : false;
+  let isIncreaseStakeAllowed = false;
+  $: isIncreaseStakeAllowed = nonNullish(neuron) && !isCommunityFund(neuron);
 </script>
 
 <TestIdWrapper testId="sns-neuron-info-stake">
   {#if nonNullish(neuron) && nonNullish(neuronState)}
     <KeyValuePair>
-      <h3 slot="key" data-tid="sns-neuron-stake">
+      <h3 slot="key">
         {$i18n.neuron_detail.stake}
       </h3>
       <SnsNeuronAmount {neuron} slot="value" />
@@ -72,7 +72,7 @@
       {#if allowedToDissolve}
         <IncreaseSnsDissolveDelayButton />
       {/if}
-      {#if !isCFNeuron}
+      {#if isIncreaseStakeAllowed}
         <SnsIncreaseStakeButton />
       {/if}
       {#if neuronState === NeuronState.Dissolved && allowedToDisburse}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -22,8 +22,7 @@ import {
 
 describe("SnsNeuronInfoStake", () => {
   const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Open],
-    certified: true,
+    lifecycles: [SnsSwapLifecycle.Committed],
   });
   beforeEach(() => {
     const universe = data[0][0].rootCanisterId;

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -1,4 +1,4 @@
-import { assertNonNullish } from "$tests/utils/utils.test-utils";
+import { assertNonNullish } from "../utils/utils.test-utils";
 
 export class AmountDisplayPo {
   static readonly tid = "token-value-label";
@@ -17,7 +17,7 @@ export class AmountDisplayPo {
     return el && new AmountDisplayPo(el);
   }
 
-  getAmount(): string {
+  getAmount(): string | null {
     return assertNonNullish(this.root.querySelector(`[data-tid="token-value"]`))
       .textContent;
   }

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -1,0 +1,24 @@
+import { assertNonNullish } from "$tests/utils/utils.test-utils";
+
+export class AmountDisplayPo {
+  static readonly tid = "token-value-label";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== AmountDisplayPo.tid) {
+      throw new Error(`${root} is not an Tooltip`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): AmountDisplayPo | null {
+    const el = element.querySelector(`[data-tid=${AmountDisplayPo.tid}]`);
+    return el && new AmountDisplayPo(el);
+  }
+
+  getAmount(): string {
+    return assertNonNullish(this.root.querySelector(`[data-tid="token-value"]`))
+      .textContent;
+  }
+}

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -1,4 +1,4 @@
-export class Button {
+export class ButtonPo {
   root: Element;
 
   constructor(root: Element) {
@@ -14,8 +14,8 @@ export class Button {
   }: {
     element: Element;
     testId: string;
-  }): Button | null {
+  }): ButtonPo | null {
     const el = element.querySelector(`button[data-tid=${testId}]`);
-    return el && new Button(el);
+    return el && new ButtonPo(el);
   }
 }

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -1,0 +1,21 @@
+export class Button {
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.tagName !== "BUTTON") {
+      throw new Error(`${root} is not a button`);
+    }
+    this.root = root;
+  }
+
+  static under({
+    element,
+    testId,
+  }: {
+    element: Element;
+    testId: string;
+  }): Button | null {
+    const el = element.querySelector(`button[data-tid=${testId}]`);
+    return el && new Button(el);
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
@@ -1,5 +1,6 @@
 import { nonNullish } from "@dfinity/utils";
-import { Button } from "./Button.page-object";
+import { AmountDisplayPo } from "./AmountDisplay.page-object";
+import { ButtonPo } from "./Button.page-object";
 
 export class SnsNeuronInfoStakePo {
   static readonly tid = "sns-neuron-info-stake";
@@ -18,48 +19,47 @@ export class SnsNeuronInfoStakePo {
     return el && new SnsNeuronInfoStakePo(el);
   }
 
-  isContentLoaded() {
-    return nonNullish(this.root.querySelector(`[data-tid=sns-neuron-stake]`));
+  private getButton(testId: string): ButtonPo {
+    return ButtonPo.under({ element: this.root, testId });
   }
 
-  getDisburseButton() {
-    return Button.under({ element: this.root, testId: "disburse-button" });
+  isContentLoaded() {
+    return nonNullish(this.getStakeAmount());
+  }
+
+  getStakeAmount() {
+    return AmountDisplayPo.under(this.root)?.getAmount();
+  }
+
+  getDisburseButtonPo() {
+    return this.getButton("disburse-button");
   }
 
   hasDisburseButton() {
-    return nonNullish(this.getDisburseButton());
+    return nonNullish(this.getDisburseButtonPo());
   }
 
-  getIncreaseDissolveDelayButton() {
-    return Button.under({
-      element: this.root,
-      testId: "sns-increase-dissolve-delay",
-    });
+  getIncreaseDissolveDelayButtonPo() {
+    return this.getButton("sns-increase-dissolve-delay");
   }
 
   hasIncreaseDissolveDelayButton() {
-    return nonNullish(this.getIncreaseDissolveDelayButton());
+    return nonNullish(this.getIncreaseDissolveDelayButtonPo());
   }
 
-  getIncreaseStakeButton() {
-    return Button.under({
-      element: this.root,
-      testId: "sns-increase-stake",
-    });
+  getIncreaseStakeButtonPo() {
+    return this.getButton("sns-increase-stake");
   }
 
   hasIncreaseStakeButton() {
-    return nonNullish(this.getIncreaseStakeButton());
+    return nonNullish(this.getIncreaseStakeButtonPo());
   }
 
-  getDissolveButton() {
-    return Button.under({
-      element: this.root,
-      testId: "sns-dissolve-button",
-    });
+  getDissolveButtonPo() {
+    return this.getButton("sns-dissolve-button");
   }
 
   hasDissolveButton() {
-    return nonNullish(this.getDissolveButton());
+    return nonNullish(this.getDissolveButtonPo());
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
@@ -19,7 +19,7 @@ export class SnsNeuronInfoStakePo {
     return el && new SnsNeuronInfoStakePo(el);
   }
 
-  private getButton(testId: string): ButtonPo {
+  private getButton(testId: string): ButtonPo | null {
     return ButtonPo.under({ element: this.root, testId });
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
@@ -1,0 +1,65 @@
+import { nonNullish } from "@dfinity/utils";
+import { Button } from "./Button.page-object";
+
+export class SnsNeuronInfoStakePo {
+  static readonly tid = "sns-neuron-info-stake";
+
+  root: Element;
+
+  constructor(root: Element) {
+    if (root.getAttribute("data-tid") !== SnsNeuronInfoStakePo.tid) {
+      throw new Error(`${root} is not an SnsNeuronInfoStakePo`);
+    }
+    this.root = root;
+  }
+
+  static under(element: Element): SnsNeuronInfoStakePo | null {
+    const el = element.querySelector(`[data-tid=${SnsNeuronInfoStakePo.tid}]`);
+    return el && new SnsNeuronInfoStakePo(el);
+  }
+
+  isContentLoaded() {
+    return nonNullish(this.root.querySelector(`[data-tid=sns-neuron-stake]`));
+  }
+
+  getDisburseButton() {
+    return Button.under({ element: this.root, testId: "disburse-button" });
+  }
+
+  hasDisburseButton() {
+    return nonNullish(this.getDisburseButton());
+  }
+
+  getIncreaseDissolveDelayButton() {
+    return Button.under({
+      element: this.root,
+      testId: "sns-increase-dissolve-delay",
+    });
+  }
+
+  hasIncreaseDissolveDelayButton() {
+    return nonNullish(this.getIncreaseDissolveDelayButton());
+  }
+
+  getIncreaseStakeButton() {
+    return Button.under({
+      element: this.root,
+      testId: "sns-increase-stake",
+    });
+  }
+
+  hasIncreaseStakeButton() {
+    return nonNullish(this.getIncreaseStakeButton());
+  }
+
+  getDissolveButton() {
+    return Button.under({
+      element: this.root,
+      testId: "sns-dissolve-button",
+    });
+  }
+
+  hasDissolveButton() {
+    return nonNullish(this.getDissolveButton());
+  }
+}


### PR DESCRIPTION
# Motivation

User should not be able to increase the stake of a Community Fund owned SNS neuron.

NOTE: Functionality is permitted in the backend. But the fix for now is to disable it in the frontend.

# Changes

* Check whether neuron is part of the CF in SnsNeuroInfoStake.svelte to render the SnsIncreaseStakeButton.

# Tests

* New PO SnsNeuronInforStake.
* New PO Button
* Use new PO in SnsNeuronInfoStake test file.
* Add scenario for Incrase Stake neuron belonging and not belonging to CF.
