### PR TITLE
Introducing fake api modules for easier testing

### DIFF
--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -1,0 +1,79 @@
+import type { ApiQueryParams } from "$lib/api/governance.api";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
+import type { Identity } from "@dfinity/agent";
+import type { KnownNeuron, NeuronInfo } from "@dfinity/nns";
+import { isNullish } from "@dfinity/utils";
+
+const modulePath = "$lib/api/governance.api";
+const impl = {
+  queryNeurons,
+  queryKnownNeurons,
+};
+
+//////////////////////////////////////////////
+// State and helpers for fake implementations:
+//////////////////////////////////////////////
+
+const neurons: Map<string, NeuronInfo[]> = new Map();
+
+const mapKey = (identity: Identity) => identity.getPrincipal().toText();
+
+const getNeurons = (identity: Identity) => {
+  const key = mapKey(identity);
+  let neuronList = neurons.get(key);
+  if (isNullish(neuronList)) {
+    neuronList = [];
+    neurons.set(key, neuronList);
+  }
+  return neuronList;
+};
+
+////////////////////////
+// Fake implementations:
+////////////////////////
+
+async function queryNeurons({
+  identity,
+  certified: _,
+}: ApiQueryParams): Promise<NeuronInfo[]> {
+  return getNeurons(identity);
+}
+
+async function queryKnownNeurons({
+  identity: _,
+  certified: __,
+}: ApiQueryParams): Promise<KnownNeuron[]> {
+  return [];
+}
+
+/////////////////////////////////
+// Functions to control the fake:
+/////////////////////////////////
+
+const reset = () => {
+  neurons.clear();
+};
+
+export const addNeuronWith = ({
+  identity = mockIdentity,
+  ...neuronParams
+}: { identity?: Identity } & Partial<NeuronInfo>) => {
+  getNeurons(identity).push({
+    ...mockNeuron,
+    ...neuronParams,
+  });
+};
+
+// Call this inside a describe() block outside beforeEach() because it defines
+// its own beforeEach() and afterEach().
+export const install = () => {
+  beforeEach(() => {
+    reset();
+  });
+  installImplAndBlockRest({
+    modulePath,
+    impl,
+  });
+};

--- a/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
@@ -1,0 +1,55 @@
+import type { CachedSns } from "$lib/api/sns-aggregator.api";
+import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
+import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
+import type { SnsSwapLifecycle } from "@dfinity/sns";
+
+const modulePath = "$lib/api/sns-aggregator.api";
+const impl = {
+  querySnsProjects,
+};
+
+//////////////////////////////////////////////
+// State and helpers for fake implementations:
+//////////////////////////////////////////////
+
+const projects: CachedSns[] = [];
+
+////////////////////////
+// Fake implementations:
+////////////////////////
+
+async function querySnsProjects(): Promise<CachedSns[]> {
+  return projects;
+}
+
+/////////////////////////////////
+// Functions to control the fake:
+/////////////////////////////////
+
+const reset = () => {
+  projects.length = 0;
+};
+
+export const addProjectWith = ({
+  rootCanisterId,
+  lifecycle,
+}: {
+  rootCanisterId: string;
+  lifecycle: SnsSwapLifecycle;
+}): CachedSns => {
+  const project = aggregatorSnsMockWith({ rootCanisterId, lifecycle });
+  projects.push(project);
+  return project;
+};
+
+// Call this inside a describe() block outside beforeEach() because it defines
+// its own beforeEach() and afterEach().
+export const install = () => {
+  beforeEach(() => {
+    reset();
+  });
+  installImplAndBlockRest({
+    modulePath,
+    impl,
+  });
+};

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -1,0 +1,259 @@
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
+import { assertNonNullish } from "$tests/utils/utils.test-utils";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type {
+  NervousSystemParameters,
+  SnsNervousSystemFunction,
+  SnsNeuronId,
+} from "@dfinity/sns";
+import {
+  neuronSubaccount,
+  SnsGovernanceError,
+  type SnsNeuron,
+} from "@dfinity/sns";
+import { isNullish } from "@dfinity/utils";
+
+const modulePath = "$lib/api/sns-governance.api";
+
+const impl = {
+  nervousSystemParameters,
+  getNervousSystemFunctions,
+  getNeuronBalance,
+  refreshNeuron,
+  claimNeuron,
+};
+
+const snsApiPath = "$lib/api/sns.api";
+const snsApiImpl = {
+  // TODO: Move these functions to sns-governance.api.
+  querySnsNeurons,
+  getSnsNeuron,
+};
+
+//////////////////////////////////////////////
+// State and helpers for fake implementations:
+//////////////////////////////////////////////
+
+const neurons: Map<string, SnsNeuron[]> = new Map();
+
+type KeyParams = { identity: Identity; rootCanisterId: Principal };
+
+const mapKey = ({ identity, rootCanisterId }: KeyParams) =>
+  JSON.stringify([identity.getPrincipal().toText(), rootCanisterId.toText()]);
+
+const getNeurons = (keyParams: KeyParams) => {
+  const key = mapKey(keyParams);
+  let neuronList = neurons.get(key);
+  if (isNullish(neuronList)) {
+    neuronList = [];
+    neurons.set(key, neuronList);
+  }
+  return neuronList;
+};
+
+const snsNeuronIdToHexString = (id: SnsNeuronId): string =>
+  getSnsNeuronIdAsHexString({ ...mockSnsNeuron, id: [id] });
+
+const getNeuron = ({
+  neuronId,
+  ...keyParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  neuronId: SnsNeuronId;
+}): SnsNeuron | undefined => {
+  const neuronIdText = snsNeuronIdToHexString(neuronId);
+  return getNeurons(keyParams).find(
+    (neuron) => getSnsNeuronIdAsHexString(neuron) === neuronIdText
+  );
+};
+
+////////////////////////
+// Fake implementations:
+////////////////////////
+
+async function nervousSystemParameters({
+  rootCanisterId: _,
+  identity: __,
+  certified: ___,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+}): Promise<NervousSystemParameters> {
+  return snsNervousSystemParametersMock;
+}
+
+async function getNervousSystemFunctions({
+  rootCanisterId: _,
+  identity: __,
+  certified: ___,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+}): Promise<SnsNervousSystemFunction[]> {
+  return [];
+}
+
+async function getNeuronBalance({
+  neuronId,
+  rootCanisterId,
+  certified,
+  identity,
+}: {
+  neuronId: SnsNeuronId;
+  rootCanisterId: Principal;
+  certified: boolean;
+  identity: Identity;
+}): Promise<bigint> {
+  const neuron = await querySnsNeuron({
+    neuronId,
+    rootCanisterId,
+    certified,
+    identity,
+  });
+  if (neuron) {
+    // In reality the neuron balance can be different from the stake if
+    // the user has made a transaction to increase the stake and the
+    // neuron is not yet refreshed. But this is not yet implemented in
+    // the fake.
+    return neuron.cached_neuron_stake_e8s;
+  }
+  return BigInt(0);
+}
+
+async function refreshNeuron(params: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  neuronId: SnsNeuronId;
+}): Promise<void> {
+  assertNonNullish(getNeuron(params));
+}
+
+async function claimNeuron({
+  rootCanisterId: _1,
+  identity: _2,
+  memo: _3,
+  controller: _4,
+  subaccount,
+}: {
+  rootCanisterId: Principal;
+  identity: Identity;
+  memo: bigint;
+  controller: Principal;
+  subaccount: Uint8Array;
+}): Promise<SnsNeuronId> {
+  return { id: subaccount };
+}
+
+async function querySnsNeurons({
+  identity,
+  rootCanisterId,
+  certified: _,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+}): Promise<SnsNeuron[]> {
+  return neurons.get(mapKey({ identity, rootCanisterId })) || [];
+}
+
+async function querySnsNeuron({
+  certified: _,
+  neuronId,
+  ...keyParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+  neuronId: SnsNeuronId;
+}): Promise<SnsNeuron | undefined> {
+  return getNeuron({ ...keyParams, neuronId });
+}
+
+async function getSnsNeuron({
+  certified: _,
+  neuronId,
+  ...keyParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+  neuronId: SnsNeuronId;
+}): Promise<SnsNeuron> {
+  const neuron = getNeuron({ ...keyParams, neuronId });
+  if (isNullish(neuron)) {
+    throw new SnsGovernanceError("No neuron for given NeuronId.");
+  }
+  return neuron;
+}
+
+/////////////////////////////////
+// Functions to control the fake:
+/////////////////////////////////
+
+const reset = () => {
+  neurons.clear();
+};
+
+const createNeuronId = ({
+  identity,
+  index,
+}: {
+  identity: Identity;
+  index: number;
+}): SnsNeuronId => {
+  const controller = identity.getPrincipal();
+  const subaccount = neuronSubaccount({
+    controller,
+    index,
+  });
+  return { id: subaccount };
+};
+
+// This follows the same logic to determine neuron IDs as the real code because
+// the real code will look for neurons with these IDs without even knowing if
+// they exist.
+export const addNeuronWith = ({
+  identity = mockIdentity,
+  rootCanisterId,
+  ...neuronParams
+}: {
+  identity?: Identity;
+  rootCanisterId: Principal;
+} & Partial<SnsNeuron>): SnsNeuron => {
+  const neurons = getNeurons({ identity, rootCanisterId });
+  const index = neurons.length;
+  const defaultNeuronId = createNeuronId({ identity, index });
+  const neuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    id: [defaultNeuronId],
+    ...neuronParams,
+  };
+  neurons.push(neuron);
+  return neuron;
+};
+
+// Call this inside a describe() block outside beforeEach() because it defines
+// its own beforeEach() and afterEach().
+export const install = () => {
+  beforeEach(() => {
+    reset();
+  });
+  installImplAndBlockRest({
+    modulePath,
+    impl,
+  });
+  installImplAndBlockRest({
+    modulePath: snsApiPath,
+    impl: snsApiImpl,
+  });
+};

--- a/frontend/src/tests/fakes/sns-ledger-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-ledger-api.fake.ts
@@ -1,0 +1,79 @@
+import type { Account } from "$lib/types/account";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
+
+const modulePath = "$lib/api/sns-ledger.api";
+const impl = {
+  getSnsAccounts,
+};
+
+//////////////////////////////////////////////
+// State and helpers for fake implementations:
+//////////////////////////////////////////////
+
+const accounts: Map<string, Account[]> = new Map();
+
+type KeyParams = { identity: Identity; rootCanisterId: Principal };
+
+const mapKey = ({ identity, rootCanisterId }: KeyParams) =>
+  JSON.stringify([identity.getPrincipal().toText(), rootCanisterId.toText()]);
+
+////////////////////////
+// Fake implementations:
+////////////////////////
+
+async function getSnsAccounts({
+  identity,
+  rootCanisterId,
+  certified: _,
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  certified: boolean;
+}): Promise<Account[]> {
+  return accounts.get(mapKey({ identity, rootCanisterId })) || [];
+}
+
+/////////////////////////////////
+// Functions to control the fake:
+/////////////////////////////////
+
+const reset = () => {
+  accounts.clear();
+};
+
+export const addAccountWith = ({
+  identity = mockIdentity,
+  rootCanisterId,
+  ...account
+}: {
+  identity?: Identity;
+  rootCanisterId: Principal;
+} & Partial<Account>) => {
+  const key = mapKey({ identity, rootCanisterId });
+  let list = accounts.get(key);
+  if (isNullish(list)) {
+    list = [];
+    accounts.set(key, list);
+  }
+  list.push({
+    ...mockSnsMainAccount,
+    ...account,
+  });
+};
+
+// Call this inside a describe() block outside beforeEach() because it defines
+// its own beforeEach() and afterEach().
+export const install = () => {
+  beforeEach(() => {
+    reset();
+  });
+  installImplAndBlockRest({
+    modulePath,
+    impl,
+  });
+};

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -36,7 +36,6 @@ describe("Neurons", () => {
   fakeSnsAggregatorApi.install();
 
   let testCommittedSnsNeuron;
-  let testOpenSnsNeuron;
 
   beforeEach(async () => {
     snsQueryStore.reset();
@@ -45,7 +44,7 @@ describe("Neurons", () => {
     testCommittedSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({
       rootCanisterId: testCommittedSnsCanisterId,
     });
-    testOpenSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({
+    fakeSnsGovernanceApi.addNeuronWith({
       rootCanisterId: testOpenSnsCanisterId,
     });
     fakeSnsLedgerApi.addAccountWith({

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -2,11 +2,6 @@
  * @jest-environment jsdom
  */
 
-import * as governanceApi from "$lib/api/governance.api";
-import * as snsAggregatorApi from "$lib/api/sns-aggregator.api";
-import * as snsGovernanceApi from "$lib/api/sns-governance.api";
-import * as snsLedgerApi from "$lib/api/sns-ledger.api";
-import * as snsApi from "$lib/api/sns.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
@@ -14,16 +9,11 @@ import { loadSnsProjects } from "$lib/services/$public/sns.services";
 import { snsQueryStore } from "$lib/stores/sns.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
-import {
-  mockSnsNeuron,
-  snsNervousSystemParametersMock,
-} from "$tests/mocks/sns-neurons.mock";
-import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
+import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
+import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
+import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
@@ -35,45 +25,41 @@ jest.mock("$lib/api/sns-governance.api");
 jest.mock("$lib/api/sns-ledger.api");
 jest.mock("$lib/api/sns.api");
 
-const blockedApiPaths = [
-  "$lib/api/sns-aggregator.api",
-  "$lib/api/governance.api",
-  "$lib/api/sns.api",
-  "$lib/api/sns-ledger.api",
-  "$lib/api/sns-governance.api",
-];
-
 const testCommittedSnsCanisterId = Principal.fromHex("897654");
 const testOpenSnsCanisterId = Principal.fromHex("567812");
+const testNnsNeuronId = BigInt(543);
 
 describe("Neurons", () => {
-  blockAllCallsTo(blockedApiPaths);
+  fakeGovernanceApi.install();
+  fakeSnsGovernanceApi.install();
+  fakeSnsLedgerApi.install();
+  fakeSnsAggregatorApi.install();
+
+  let testCommittedSnsNeuron;
+  let testOpenSnsNeuron;
 
   beforeEach(async () => {
     snsQueryStore.reset();
 
-    jest.mocked(governanceApi.queryNeurons).mockResolvedValue([mockNeuron]);
-    jest
-      .mocked(snsGovernanceApi.nervousSystemParameters)
-      .mockResolvedValue(snsNervousSystemParametersMock);
-    jest.mocked(snsApi.querySnsNeurons).mockResolvedValue([mockSnsNeuron]);
-    jest.mocked(snsGovernanceApi.getNeuronBalance).mockResolvedValue(BigInt(0));
-    jest
-      .mocked(snsLedgerApi.getSnsAccounts)
-      .mockResolvedValue([mockSnsMainAccount]);
-    jest.mocked(snsGovernanceApi.refreshNeuron).mockResolvedValue(undefined);
-    jest.mocked(snsApi.getSnsNeuron).mockResolvedValue(mockSnsNeuron);
-    jest.mocked(snsLedgerApi.getSnsToken).mockResolvedValue(mockSnsToken);
-    jest.mocked(snsAggregatorApi.querySnsProjects).mockResolvedValue([
-      aggregatorSnsMockWith({
-        rootCanisterId: testCommittedSnsCanisterId.toText(),
-        lifecycle: SnsSwapLifecycle.Committed,
-      }),
-      aggregatorSnsMockWith({
-        rootCanisterId: testOpenSnsCanisterId.toText(),
-        lifecycle: SnsSwapLifecycle.Open,
-      }),
-    ]);
+    fakeGovernanceApi.addNeuronWith({ neuronId: testNnsNeuronId });
+    testCommittedSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({
+      rootCanisterId: testCommittedSnsCanisterId,
+    });
+    testOpenSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({
+      rootCanisterId: testOpenSnsCanisterId,
+    });
+    fakeSnsLedgerApi.addAccountWith({
+      rootCanisterId: testCommittedSnsCanisterId,
+    });
+
+    fakeSnsAggregatorApi.addProjectWith({
+      rootCanisterId: testCommittedSnsCanisterId.toText(),
+      lifecycle: SnsSwapLifecycle.Committed,
+    });
+    fakeSnsAggregatorApi.addProjectWith({
+      rootCanisterId: testOpenSnsCanisterId.toText(),
+      lifecycle: SnsSwapLifecycle.Open,
+    });
 
     await loadSnsProjects();
   });
@@ -94,7 +80,7 @@ describe("Neurons", () => {
       expect(po.getNnsNeuronsPo().isContentLoaded()).toBe(true);
     });
 
-    const neuronIdText = mockNeuron.neuronId.toString();
+    const neuronIdText = testNnsNeuronId.toString();
     expect(po.getNnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
   });
 
@@ -113,7 +99,7 @@ describe("Neurons", () => {
       expect(po.getSnsNeuronsPo().isContentLoaded()).toBe(true);
     });
 
-    const neuronIdText = getSnsNeuronIdAsHexString(mockSnsNeuron);
+    const neuronIdText = getSnsNeuronIdAsHexString(testCommittedSnsNeuron);
     expect(po.getSnsNeuronsPo().getNeuronIds()).toContain(neuronIdText);
   });
 

--- a/frontend/src/tests/utils/module.test-utils.ts
+++ b/frontend/src/tests/utils/module.test-utils.ts
@@ -4,55 +4,77 @@
  * to make sure each one is mocked in the test.
  */
 
-const blockedCalls: string[] = [];
-
-const failOnCall = ({
+/**
+ * Mock out all functions on a given module with, either a given
+ * implementation or, if not specified, a function that will throw
+ * and cause the test to fail.
+ *
+ * Call this inside a describe() block outside beforeEach() because it defines
+ * its own beforeEach() and afterEach().
+ */
+export const installImplAndBlockRest = ({
   modulePath,
-  fn,
-  args,
+  impl = {},
 }: {
   modulePath: string;
-  fn: string;
-  args: unknown;
-}): never => {
-  // Without this, JSON.stringify crashes on objects with bgint values.
-  const argsString = JSON.stringify(args, (_key, value) =>
-    typeof value === "bigint" ? value.toString() : value
-  );
-  const message = `"${modulePath}".${fn} is called (with ${argsString}) but not mocked.`;
-  blockedCalls.push(message);
-  throw new Error(message);
-};
+  impl: { [key: string]: (args: unknown) => unknown };
+}) => {
+  const blockedCalls: string[] = [];
 
-const blockModule = ({ module, modulePath }) => {
-  let hasMockFunction = false;
-  for (const fn in module) {
-    if (module[fn].mock) {
-      hasMockFunction = true;
-      module[fn].mockImplementation(async (args) => {
-        failOnCall({ modulePath, fn, args });
-      });
+  const failOnCall = (
+    {
+      modulePath,
+      fn,
+    }: {
+      modulePath: string;
+      fn: string;
+    },
+    ...args
+  ): never => {
+    // Without this, JSON.stringify crashes on objects with bgint values.
+    const argsString = JSON.stringify(args, (_key, value) =>
+      typeof value === "bigint" ? value.toString() : value
+    );
+    const message = `"${modulePath}".${fn} is called (with ${argsString}) but not mocked.`;
+    blockedCalls.push(message);
+    throw new Error(message);
+  };
+
+  const mockModule = async () => {
+    const module = await import(modulePath);
+    let hasMockFunction = false;
+    for (const fn in module) {
+      if (module[fn].mock) {
+        hasMockFunction = true;
+        const fnImpl = impl[fn] || failOnCall.bind(null, { modulePath, fn });
+        module[fn].mockImplementation(fnImpl);
+      }
     }
-  }
-  if (!hasMockFunction) {
-    // The module didn't have any mocked functions so it wasn't actually mocked.
-    // jest.mock() can't be done here because jest does some magic to move all
-    // those calls to the top of test to make sure they happen before any
-    // import.
-    throw new Error(`You must add 'jest.mock("${modulePath}");' to your test.`);
-  }
-};
+    if (!hasMockFunction) {
+      // The module didn't have any mocked functions so it wasn't actually mocked.
+      // jest.mock() can't be done here because jest does some magic to move all
+      // those calls to the top of test to make sure they happen before any
+      // import.
+      throw new Error(
+        `You must add 'jest.mock("${modulePath}");' to your test.`
+      );
+    }
+  };
 
-export const blockAllCallsTo = (modulePaths: string[]) => {
   beforeEach(async () => {
     blockedCalls.length = 0;
-    for (const modulePath of modulePaths) {
-      const module = await import(modulePath);
-      blockModule({ module, modulePath });
-    }
+    await mockModule();
   });
 
   afterEach(() => {
     expect(blockedCalls).toEqual([]);
   });
+};
+
+// Call this inside a describe() block outside beforeEach() because it defines
+// its own beforeEach() and afterEach().
+export const blockAllCallsTo = (modulePaths: string[]) => {
+  for (const modulePath of modulePaths) {
+    installImplAndBlockRest({ modulePath, impl: {} });
+  }
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,6 +18,7 @@
     "**/*.spec.ts",
     "jest.setup.ts",
     "**/*.mock.ts",
+    "**/*.fake.ts",
     "**/*.page-object.ts",
     "**/*Test.svelte",
     "**/*.test-utils.ts"


### PR DESCRIPTION
# Motivation

Setting up mocks for api calls during tests can be tedious and the result is often not easy to read.

A fake holds state and responds to calls in a consistent way based on the internal state, which is set up for the test.
It can also provide sane defaults for values that don't matter during the test.
This means the test can just set up the state it cares about and the fake will take care of the rest.

# Changes

1. Add partial fakes for governance.api, sns-aggregator.api and sns-ledger.api.
  * Meaning, not all of the functions on these apis are implemented and some just return empty or default values which can't yet be controlled by the test.
2. Add a fake for sns-governance.api which also fakes some functions on sns,api, which should really  be moved to sns-governance.api because they are backed by the same state.
3. Update NeuronDetail.spec.ts and Neurons.spec.ts to use the new fakes.
4. Update module.test-utils.ts to allow installing partial implementations of modules in addition to blocking calls to the functions for which no implementations are provided.
5. Update tsconfig.json to allow using "$tests" imports in fakes.
6. 
<!-- List the changes that have been developed -->

# Tests

Tests only.

<!-- Please provide any information or screenshots about the tests that have been done -->
