### PR TITLE
feat: ckBTC to Btc validate amount

### DIFF
--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -59,6 +59,8 @@
   .wrapper {
     position: relative;
     width: 100%;
+
+    padding: var(--input-error-wrapper-padding);
   }
 
   .error {

--- a/frontend/src/lib/constants/bitcoin.constants.ts
+++ b/frontend/src/lib/constants/bitcoin.constants.ts
@@ -1,1 +1,6 @@
 export const BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC = 100_000_000;
+
+// The minimal amount of ckBTC that can be converted to BTC.
+// Reflects ckBTC minter state variable `retrieve_btc_min_amount`.
+// Value proposed and set with proposal https://dashboard.internetcomputer.org/proposal/111901.
+export const RETRIEVE_BTC_MIN_AMOUNT = 100_000n;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -80,7 +80,7 @@
     "split_neuron": "Sorry, there was an unexpected error splitting the neuron. Please try again later.",
     "not_authorized_neuron_action": "Sorry, none of your principals is the controller of the neuron.",
     "invalid_sender": "Sorry, you can't send funds from this account.",
-    "insufficient_funds": "Sorry, there are not enough funds in this account",
+    "insufficient_funds": "Sorry, there are not enough funds in this account.",
     "transfer_error": "Sorry, there was an error with the transaction. Please try again later.",
     "merge_neurons_same_id": "Two neurons with the same id can't be merged.",
     "merge_neurons_not_same_controller": "Two neurons need to have the same controller.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -860,7 +860,8 @@
     "amount_too_low": "Amount too low.",
     "insufficient_funds": "Insufficient funds.",
     "retrieve_btc_unknown": "Sorry, retrieving BTC failed for an unknown reason.",
-    "estimated_fee": "Sorry, the Bitcoin estimated fee cannot be fetched."
+    "estimated_fee": "Sorry, the Bitcoin estimated fee cannot be fetched.",
+    "retrieve_btc_min_amount": "The amount is below the $amount ckBTC minimum for converting to BTC."
   },
   "feature_flags_prompt": {
     "override_true": "Enter the number for the feature you want to enable.",

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -22,6 +22,10 @@
   import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
   import ConvertBtcInProgress from "$lib/components/accounts/ConvertBtcInProgress.svelte";
   import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
+  import { isNullish } from "@dfinity/utils";
+  import { RETRIEVE_BTC_MIN_AMOUNT } from "$lib/constants/bitcoin.constants";
+  import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+  import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
 
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
@@ -111,11 +115,48 @@
     await transferTokens($event);
   };
 
+  let userSelectedAccount: Account | undefined;
   let userAmount: number | undefined = undefined;
-  const validateAmount: ValidateAmountFn = (
-    amount: number | undefined
-  ): string | undefined => {
-    userAmount = amount;
+
+  let validateAmount: ValidateAmountFn;
+  $: validateAmount = (amount: number | undefined) => {
+    // No additional check for ckBTC network
+    if (!networkBtc) {
+      return undefined;
+    }
+
+    // No source account selected yet, we cannot check the available fund
+    if (isNullish(userSelectedAccount)) {
+      return undefined;
+    }
+
+    // No additional check if no amount is entered
+    if (isNullish(amount)) {
+      return undefined;
+    }
+
+    const amountE8s = numberToE8s(amount);
+
+    // No additional check if amount is zero because user might be entering a value such as 0.00000...
+    if (amountE8s === BigInt(0)) {
+      return undefined;
+    }
+
+    if (amountE8s < RETRIEVE_BTC_MIN_AMOUNT) {
+      return replacePlaceholders($i18n.error__ckbtc.retrieve_btc_min_amount, {
+        $amount: formatToken({
+          value: RETRIEVE_BTC_MIN_AMOUNT,
+          detailed: true,
+        }),
+      });
+    }
+
+    assertEnoughAccountFunds({
+      account: userSelectedAccount,
+      amountE8s:
+        amountE8s + transactionFee.toE8s() + (bitcoinEstimatedFee ?? BigInt(0)),
+    });
+
     return undefined;
   };
 </script>
@@ -132,6 +173,8 @@
   mustSelectNetwork={isUniverseCkTESTBTC(universeId)}
   bind:selectedNetwork
   {validateAmount}
+  bind:amount={userAmount}
+  bind:selectedAccount={userSelectedAccount}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
   <p slot="description" class="value">

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -200,6 +200,7 @@
 
   .amount {
     margin-top: var(--padding);
+    --input-error-wrapper-padding: 0 0 var(--padding-2x);
   }
 
   .account-identifier {

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -10,7 +10,6 @@
 
   export let rootCanisterId: Principal;
   export let currentStep: WizardStep | undefined = undefined;
-  export let destinationAddress: string | undefined = undefined;
   export let sourceAccount: Account | undefined = undefined;
   export let token: Token = ICPToken;
   export let transactionFee: TokenAmount;
@@ -19,11 +18,16 @@
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
   export let mustSelectNetwork = false;
-  export let selectedNetwork: TransactionNetwork | undefined = undefined;
   export let validateAmount: (
     amount: number | undefined
   ) => string | undefined = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
+
+  // User inputs
+  export let selectedAccount: Account | undefined = sourceAccount;
+  export let destinationAddress: string | undefined = undefined;
+  export let selectedNetwork: TransactionNetwork | undefined = undefined;
+  export let amount: number | undefined;
 
   const STEP_PROGRESS = "Progress";
 
@@ -49,9 +53,7 @@
   // This way we can identify whether to show a dropdown to select destination or source.
   let selectedDestinationAddress: string | undefined = destinationAddress;
   let canSelectDestination = destinationAddress === undefined;
-  let selectedAccount: Account | undefined = sourceAccount;
   let canSelectSource = sourceAccount === undefined;
-  let amount: number | undefined;
   let showManualAddress = true;
 
   const goNext = () => {

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -27,7 +27,7 @@
   export let selectedAccount: Account | undefined = sourceAccount;
   export let destinationAddress: string | undefined = undefined;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
-  export let amount: number | undefined;
+  export let amount: number | undefined = undefined;
 
   const STEP_PROGRESS = "Progress";
 

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -48,7 +48,7 @@
           mapNervousSystemParameters(parameters).neuron_minimum_stake_e8s
         ) / E8S_PER_ICP
       : undefined;
-  let checkMinimumStake: ValidateAmountFn = () => undefined;
+  let checkMinimumStake: ValidateAmountFn;
   $: checkMinimumStake = (amount: number | undefined) => {
     if (
       nonNullish(amount) &&

--- a/frontend/src/lib/types/ckbtc.errors.ts
+++ b/frontend/src/lib/types/ckbtc.errors.ts
@@ -1,1 +1,3 @@
 export class CkBTCErrorKey extends Error {}
+
+export class CkBTCErrorRetrieveBtcMinAmount extends Error {}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -909,6 +909,7 @@ interface I18nError__ckbtc {
   insufficient_funds: string;
   retrieve_btc_unknown: string;
   estimated_fee: string;
+  retrieve_btc_min_amount: string;
 }
 
 interface I18nFeature_flags_prompt {

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -1,0 +1,63 @@
+import { RETRIEVE_BTC_MIN_AMOUNT } from "$lib/constants/bitcoin.constants";
+import { i18n } from "$lib/stores/i18n";
+import type { Account } from "$lib/types/account";
+import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
+import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+import { isNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+export const assertCkBTCUserInputAmount = ({
+  networkBtc,
+  sourceAccount,
+  amount,
+  bitcoinEstimatedFee,
+  transactionFee,
+}: {
+  networkBtc: boolean;
+  sourceAccount: Account | undefined;
+  amount: number | undefined;
+  bitcoinEstimatedFee: bigint | undefined | null;
+  transactionFee: bigint;
+}) => {
+  if (!networkBtc) {
+    return;
+  }
+
+  // No source account selected yet, we cannot check the available fund
+  if (isNullish(sourceAccount)) {
+    return;
+  }
+
+  // No additional check if no amount is entered
+  if (isNullish(amount)) {
+    return;
+  }
+
+  const amountE8s = numberToE8s(amount);
+
+  // No additional check if amount is zero because user might be entering a value such as 0.00000...
+  if (amountE8s === BigInt(0)) {
+    return;
+  }
+
+  if (amountE8s < RETRIEVE_BTC_MIN_AMOUNT) {
+    const {
+      error__ckbtc: { retrieve_btc_min_amount },
+    } = get(i18n);
+    throw new CkBTCErrorRetrieveBtcMinAmount(
+      replacePlaceholders(retrieve_btc_min_amount, {
+        $amount: formatToken({
+          value: RETRIEVE_BTC_MIN_AMOUNT,
+          detailed: true,
+        }),
+      })
+    );
+  }
+
+  assertEnoughAccountFunds({
+    account: sourceAccount,
+    amountE8s: amountE8s + transactionFee + (bitcoinEstimatedFee ?? BigInt(0)),
+  });
+};


### PR DESCRIPTION
# Motivation

Add two validations regarding the amount the user input in the transaction wizard if ckBTC are converted to Btc.

"Continue" disabled if (one or the other):

- ckBTC fee + Btc estimated fee + amount > available funds
- amount is lower than minimal amount that can be converted by the minter

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
