### PR TITLE
Remove use of non-existing user-drag property which causes a warning in svelte-check

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && vite build && npm run build:post-process",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run lint",
+    "check": "svelte-kit sync && svelte-check --fail-on-warnings --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint --max-warnings 0 .",
     "format": "prettier --plugin-search-dir . --write .",

--- a/frontend/src/lib/components/ui/Logo.svelte
+++ b/frontend/src/lib/components/ui/Logo.svelte
@@ -11,6 +11,7 @@
   {alt}
   role="presentation"
   loading="lazy"
+  draggable="false"
   data-tid={testId}
   class:huge={size === "huge"}
   class:big={size === "big"}

--- a/frontend/src/lib/components/ui/Logo.svelte
+++ b/frontend/src/lib/components/ui/Logo.svelte
@@ -25,7 +25,6 @@
 
     user-select: none;
     -webkit-user-drag: none;
-    user-drag: none;
   }
 
   .framed {


### PR DESCRIPTION
# Motivation

Running `svelte-check` which is part of `npm run check` currently gives 1 warning:
```
frontend/src/lib/components/ui/Logo.svelte:28:5
Warn: Unknown property: 'user-drag' (scss)
    -webkit-user-drag: none;
    user-drag: none;
  }
```

According to https://caniuse.com/webkit-user-drag:

> There is currently no unprefixed `user-drag` or other version of the property implemented in browsers or on a standards track as the HTML `draggable` attribute/property is the preferred solution.

# Changes

1. Remove `user-drag: none;` from Logo.svelte.
2. Add `draggable="false"` to the `<img>` tag in Logo.svelte.
3. Add `--fail-on-warnings` to `npm run check` to prevent new warnings.

# Tests

`npm run check`
Manually tried dragging an affected logo in both Chrome and Firefox and was not able to drag it.