### PR TITLE
Fix: Message on auto stake

### DIFF
--- a/frontend/src/lib/modals/neurons/NnsAutoStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsAutoStakeMaturityModal.svelte
@@ -14,14 +14,15 @@
 
   const autoStake = async () => {
     startBusy({ initiator: "auto-stake-maturity" });
+    const labelKey = `neuron_detail.auto_stake_maturity_${
+      hasAutoStakeOn ? "off" : "on"
+    }_success`;
 
     const { success } = await toggleAutoStakeMaturity(neuron);
 
     if (success) {
       toastsSuccess({
-        labelKey: `neuron_detail.auto_stake_maturity_${
-          hasAutoStakeOn ? "off" : "on"
-        }_success`,
+        labelKey,
       });
     }
 

--- a/frontend/src/lib/modals/neurons/NnsAutoStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsAutoStakeMaturityModal.svelte
@@ -20,7 +20,7 @@
     if (success) {
       toastsSuccess({
         labelKey: `neuron_detail.auto_stake_maturity_${
-          hasAutoStakeOn ? "on" : "off"
+          hasAutoStakeOn ? "off" : "on"
         }_success`,
       });
     }

--- a/frontend/src/lib/modals/sns/neurons/SnsAutoStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsAutoStakeMaturityModal.svelte
@@ -18,6 +18,9 @@
 
   const autoStake = async () => {
     startBusy({ initiator: "auto-stake-maturity" });
+    const labelKey = `neuron_detail.auto_stake_maturity_${
+      hasAutoStakeOn ? "off" : "on"
+    }_success`;
 
     const { success } = await toggleAutoStakeMaturity({
       neuron,
@@ -29,9 +32,7 @@
 
     if (success) {
       toastsSuccess({
-        labelKey: `neuron_detail.auto_stake_maturity_${
-          hasAutoStakeOn ? "off" : "on"
-        }_success`,
+        labelKey,
       });
     }
 

--- a/frontend/src/lib/modals/sns/neurons/SnsAutoStakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsAutoStakeMaturityModal.svelte
@@ -30,7 +30,7 @@
     if (success) {
       toastsSuccess({
         labelKey: `neuron_detail.auto_stake_maturity_${
-          hasAutoStakeOn ? "on" : "off"
+          hasAutoStakeOn ? "off" : "on"
         }_success`,
       });
     }

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -4,8 +4,11 @@
 
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
+import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 jest.mock("$lib/services/neurons.services", () => {
@@ -17,6 +20,7 @@ jest.mock("$lib/services/neurons.services", () => {
 describe("NnsAutoStakeMaturity", () => {
   afterEach(() => {
     jest.clearAllMocks();
+    toastsStore.reset();
   });
 
   it("renders checkbox", () => {
@@ -118,5 +122,21 @@ describe("NnsAutoStakeMaturity", () => {
   it("should call toggleAutoStakeMaturity neuron service on confirmation", async () => {
     await toggleAutoStake({ neuronAutoStakeMaturity: undefined });
     expect(toggleAutoStakeMaturity).toBeCalled();
+  });
+
+  it("should show success message when enabling", async () => {
+    await toggleAutoStake({ neuronAutoStakeMaturity: undefined });
+    expect(get(toastsStore)[0]).toMatchObject({
+      level: "success",
+      text: en.neuron_detail.auto_stake_maturity_on_success,
+    });
+  });
+
+  it("should show success message when disabling", async () => {
+    await toggleAutoStake({ neuronAutoStakeMaturity: true });
+    expect(get(toastsStore)[0]).toMatchObject({
+      level: "success",
+      text: en.neuron_detail.auto_stake_maturity_off_success,
+    });
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -6,9 +6,12 @@ import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsA
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { toggleAutoStakeMaturity } from "$lib/services/sns-neurons.services";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
+import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 jest.mock("$lib/services/sns-neurons.services", () => {
@@ -18,14 +21,12 @@ jest.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("SnsAutoStakeMaturity", () => {
-  beforeAll(() =>
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toastsStore.reset();
     jest
       .spyOn(snsTokenSymbolSelectedStore, "subscribe")
-      .mockImplementation(mockTokenStore)
-  );
-
-  afterEach(() => {
-    jest.clearAllMocks();
+      .mockImplementation(mockTokenStore);
   });
 
   it("renders checkbox", () => {
@@ -124,5 +125,21 @@ describe("SnsAutoStakeMaturity", () => {
   it("should call toggleAutoStakeMaturity neuron service on confirmation", async () => {
     await toggleAutoStake({ neuronAutoStakeMaturity: undefined });
     expect(toggleAutoStakeMaturity).toBeCalled();
+  });
+
+  it("should call toggleAutoStakeMaturity neuron service on confirmation", async () => {
+    await toggleAutoStake({ neuronAutoStakeMaturity: undefined });
+    expect(get(toastsStore)[0]).toMatchObject({
+      level: "success",
+      text: en.neuron_detail.auto_stake_maturity_on_success,
+    });
+  });
+
+  it("should show success message when disabling", async () => {
+    await toggleAutoStake({ neuronAutoStakeMaturity: true });
+    expect(get(toastsStore)[0]).toMatchObject({
+      level: "success",
+      text: en.neuron_detail.auto_stake_maturity_off_success,
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Success messages on enabling auto stake were the other way around.

It said: "Automatically staking new maturity." when disabling it.
And: "Stopped automatically staking new maturity." when enabling it.

# Changes

* Change which message to use in NnsAutoStakeMaturityModal and SnsAutoStakeMaturityModal.

# Tests

* Add tests that proper message is added to toastsStore.
