### PR TITLE
Downgrade/upgrade test for aggregator

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -164,6 +164,7 @@ jobs:
           }
       - name: Downgrade to prod and upgrade back again
         run: |
+          set -euxo pipefail
           git fetch --depth 1 origin tag aggregator-prod
           if git diff tags/aggregator-prod rs/sns_aggregator | grep -q .
           then ./scripts/sns/aggregator/downgrade-upgrade-test -w sns_aggregator.wasm

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -166,7 +166,8 @@ jobs:
         run: |
           set -euxo pipefail
           git fetch --depth 1 origin tag aggregator-prod
-          if git diff tags/aggregator-prod rs/sns_aggregator | grep -q .
+          diff="$(git diff tags/aggregator-prod rs/sns_aggregator)"
+          if test -n "${diff:-}"
           then ./scripts/sns/aggregator/downgrade-upgrade-test -w sns_aggregator.wasm
           else echo "Skipping test as there are no relevant code changes"
           fi

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -134,7 +134,7 @@ jobs:
             cat ,logs
             exit 1
           }
-      - name: Upgrade the aggregator with a slow refresh rate
+      - name: Upgrade the aggregator to self with a slow refresh rate
         run: dfx canister install --mode upgrade --wasm sns_aggregator.wasm --upgrade-unchanged sns_aggregator '(opt record { update_interval_ms = 1_000_000_000; fast_interval_ms = 1_000_000_000; })'
       - name: Expect the first page of data to be retained over the upgrade
         run: |
@@ -162,6 +162,13 @@ jobs:
           (( expect == actual ))  || {
             echo ERROR: Expected to have $expect SNS in the aggregator upstream data but found $actual.
           }
+      - name: Downgrade to prod and upgrade back again
+        run: |
+          git fetch --depth 1 origin tag aggregator-prod
+          if git diff tags/aggregator-prod rs/sns_aggregator | grep -q .
+          then ./scripts/sns/aggregator/downgrade-upgrade-test -w sns_aggregator.wasm
+          else echo "Skipping test as there are no relevant code changes"
+          fi
       - name: Stop replica
         run: dfx stop
   aggregator-pass:

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -168,7 +168,7 @@ jobs:
           git fetch --depth 1 origin tag aggregator-prod
           diff="$(git diff tags/aggregator-prod rs/sns_aggregator)"
           if test -n "${diff:-}"
-          then ./scripts/sns/aggregator/downgrade-upgrade-test -w sns_aggregator.wasm
+          then ./scripts/sns/aggregator/downgrade-upgrade-test -w sns_aggregator.wasm --verbose
           else echo "Skipping test as there are no relevant code changes"
           fi
       - name: Stop replica

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+help_text() {
+  cat <<-EOF
+	Tests the SNS aggregator:
+	  - downgrading the local build to prod.
+	  - upgrading prod to the local build.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../../clap.bash"
+# Define options
+clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
+clap.define short=p long=prod_wasm desc="The production wasm." variable=PROD_WASM default=""
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -euo pipefail
+
+verify_healthy() {
+  dfx canister call sns_aggregator get_canister_status
+}
+
+# Installs the current build of sns_aggregator
+upgrade_canister() {
+  dfx canister install --upgrade-unchanged sns_aggregator --wasm "$1" --mode upgrade
+}
+
+echo "Getting or building the local wasm..."
+test -n "${CURRENT_WASM:-}" || {
+  CURRENT_WASM="sns_aggregator_dev.wasm"
+  echo "Building $CURRENT_WASM..."
+  DFX_NETWORK=local ./scripts/docker-build
+}
+test -e "$CURRENT_WASM" || {
+  echo "ERROR: Wasm file not found at '$CURRENT_WASM'."
+  exit 1
+} >&2
+
+echo "Getting the prod wasm (if not supplied)..."
+test -n "${PROD_WASM:-}" || {
+  PROD_WASM="sns_aggregator_prod.wasm"
+  curl -sL https://github.com/dfinity/nns-dapp/releases/download/aggregator-prod/sns_aggregator.wasm >"$PROD_WASM"
+}
+test -e "$PROD_WASM" || {
+  echo "ERROR: Prod wasm file not found at '$PROD_WASM'."
+  exit 1
+} >&2
+
+echo "Installing $CURRENT_WASM..."
+if dfx canister id sns_aggregator >/dev/null 2>/dev/null; then
+  upgrade_canister "$CURRENT_WASM"
+else
+  dfx canister create sns_aggregator
+  dfx canister install sns_aggregator --wasm "$CURRENT_WASM"
+fi
+echo "Checking that the current wasm is healthy..."
+verify_healthy
+echo "Downgrading to the prod wasm..."
+upgrade_nnsdapp "$PROD_WASM"
+echo "Checking that the rollback is healthy..."
+verify_healthy
+echo "Rolling forwards..."
+upgrade_nnsdapp "$CURRENT_WASM"
+echo "Checking that the upgrade is healthy..."
+verify_healthy
+echo SUCCESS

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -30,7 +30,7 @@ upgrade_canister() {
 
 echo "Getting or building the local wasm..."
 test -n "${CURRENT_WASM:-}" || {
-  CURRENT_WASM="sns_aggregator_dev.wasm"
+  CURRENT_WASM="sns_aggregator.wasm"
   echo "Building $CURRENT_WASM..."
   DFX_NETWORK=local ./scripts/docker-build
 }

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -59,11 +59,11 @@ fi
 echo "Checking that the current wasm is healthy..."
 verify_healthy
 echo "Downgrading to the prod wasm..."
-upgrade_nnsdapp "$PROD_WASM"
+upgrade_canister "$PROD_WASM"
 echo "Checking that the rollback is healthy..."
 verify_healthy
 echo "Rolling forwards..."
-upgrade_nnsdapp "$CURRENT_WASM"
+upgrade_canister "$CURRENT_WASM"
 echo "Checking that the upgrade is healthy..."
 verify_healthy
 echo SUCCESS


### PR DESCRIPTION
# Motivation
Basic test that the canister can be downgraded and upgraded without bricking the canister.

Note: This does not catch subtle issues such as data corruption when deserializing and reserializing.  It just checks whether the canister can transition and is still alive after each transition.

Note: The test does a downgrade then an upgrade rather than the other way around as it is faster.  When testing, the new code is typically already installed and running, so downgrade+upgrade requires two installations, whereas upgrade downgrade needs four: downgrade-upgrade-downgrade-upgrade

# Changes
- Add a script to perform the downgrade-upgrade test
- Exercise the script in CI

# Tests
See the new tests in CI