### PR TITLE
GIX-1336: Refactor sns participation flow 1

### DIFF
--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -415,7 +415,7 @@ export const restoreSnsSaleParticipation = async ({
     return;
   }
 
-  await participateInSnsSsale({
+  await participateInSnsSale({
     rootCanisterId,
     userCommitment,
     postprocess,
@@ -474,7 +474,7 @@ export const initiateSnsSaleParticipation = async ({
     const ticket = get(snsTicketsStore)[rootCanisterId?.toText()]?.ticket;
     if (nonNullish(ticket)) {
       // Step 2. to finish
-      const { success } = await participateInSnsSsale({
+      const { success } = await participateInSnsSale({
         rootCanisterId,
         userCommitment,
         postprocess,
@@ -669,7 +669,7 @@ const pollTransfer = ({
  * @param snsTicket
  * @param rootCanisterId
  */
-export const participateInSnsSsale = async ({
+export const participateInSnsSale = async ({
   rootCanisterId,
   postprocess,
   userCommitment,
@@ -680,7 +680,7 @@ export const participateInSnsSsale = async ({
 }> => {
   let hasTooOldError = false;
   logWithTimestamp(
-    "[sale]participateInSnsSsale:",
+    "[sale]participateInSnsSale:",
     ticket,
     rootCanisterId?.toText()
   );

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -380,7 +380,7 @@ const getProjectFromStore = (
     ({ rootCanisterId: id }) => id.toText() === rootCanisterId.toText()
   );
 
-export interface ParticipateInSnsSwapParameters {
+export interface ParticipateInSnsSaleParameters {
   rootCanisterId: Principal;
   userCommitment: bigint;
   postprocess: () => Promise<void>;
@@ -393,7 +393,7 @@ export const restoreSnsSaleParticipation = async ({
   userCommitment,
   postprocess,
   updateProgress,
-}: ParticipateInSnsSwapParameters & {
+}: ParticipateInSnsSaleParameters & {
   swapCanisterId: Principal;
 }): Promise<void> => {
   // avoid concurrent restores
@@ -415,7 +415,7 @@ export const restoreSnsSaleParticipation = async ({
     return;
   }
 
-  await participateInSnsSwap({
+  await participateInSnsSsale({
     rootCanisterId,
     userCommitment,
     postprocess,
@@ -434,7 +434,7 @@ export const initiateSnsSaleParticipation = async ({
   userCommitment,
   postprocess,
   updateProgress,
-}: ParticipateInSnsSwapParameters & {
+}: ParticipateInSnsSaleParameters & {
   amount: TokenAmount;
   account: Account;
 }): Promise<{ success: boolean }> => {
@@ -474,7 +474,7 @@ export const initiateSnsSaleParticipation = async ({
     const ticket = get(snsTicketsStore)[rootCanisterId?.toText()]?.ticket;
     if (nonNullish(ticket)) {
       // Step 2. to finish
-      const { success } = await participateInSnsSwap({
+      const { success } = await participateInSnsSsale({
         rootCanisterId,
         userCommitment,
         postprocess,
@@ -669,18 +669,18 @@ const pollTransfer = ({
  * @param snsTicket
  * @param rootCanisterId
  */
-export const participateInSnsSwap = async ({
+export const participateInSnsSsale = async ({
   rootCanisterId,
   postprocess,
   userCommitment,
   updateProgress,
   ticket,
-}: ParticipateInSnsSwapParameters & { ticket: Ticket }): Promise<{
+}: ParticipateInSnsSaleParameters & { ticket: Ticket }): Promise<{
   success: boolean;
 }> => {
   let hasTooOldError = false;
   logWithTimestamp(
-    "[swap]participateInSnsSwap:",
+    "[sale]participateInSnsSsale:",
     ticket,
     rootCanisterId?.toText()
   );
@@ -701,7 +701,7 @@ export const participateInSnsSwap = async ({
 
   // TODO: add HW support
   if (identity.getPrincipal().toText() !== ownerPrincipal.toText()) {
-    console.error("[swap] identities don't match");
+    console.error("[sale] identities don't match");
     toastsError({
       labelKey: "error__sns.sns_sale_unexpected_error",
     });
@@ -723,7 +723,7 @@ export const participateInSnsSwap = async ({
       controller,
     });
 
-    logWithTimestamp("[swap] 1. transfer (time,id):", creationTime, ticketId);
+    logWithTimestamp("[sale] 1. transfer (time,id):", creationTime, ticketId);
 
     // Step 2.
     // Send amount to the ledger
@@ -738,7 +738,7 @@ export const participateInSnsSwap = async ({
       identity,
     });
   } catch (err) {
-    console.error("[swap] on transfer", err);
+    console.error("[sale] on transfer", err);
 
     switch ((err as object)?.constructor) {
       // if duplicated transfer, silently continue the flow
@@ -801,7 +801,7 @@ export const participateInSnsSwap = async ({
   }
 
   // Step 4.
-  logWithTimestamp("[swap] 3. loadBalance");
+  logWithTimestamp("[sale] 3. loadBalance");
 
   updateProgress(SaleStep.RELOAD);
 
@@ -823,7 +823,7 @@ export const participateInSnsSwap = async ({
     await loadBalance({ accountIdentifier: sourceAccount.identifier });
   }
 
-  logWithTimestamp("[swap] done");
+  logWithTimestamp("[sale] done");
 
   // reload
   await postprocess?.();

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
-import type { ParticipateInSnsSwapParameters } from "$lib/services/sns-sale.services";
+import type { ParticipateInSnsSaleParameters } from "$lib/services/sns-sale.services";
 import { restoreSnsSaleParticipation } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
@@ -35,7 +35,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
   restoreSnsSaleParticipation: jest
     .fn()
     .mockImplementation(
-      ({ updateProgress }: ParticipateInSnsSwapParameters) => {
+      ({ updateProgress }: ParticipateInSnsSaleParameters) => {
         updateProgress(SaleStep.INITIALIZATION);
       }
     ),

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
-import type { ParticipateInSnsSaleParameters } from "$lib/services/sns-sale.services";
+import type { ParticipateInSnsSwapParameters } from "$lib/services/sns-sale.services";
 import { restoreSnsSaleParticipation } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
@@ -35,7 +35,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
   restoreSnsSaleParticipation: jest
     .fn()
     .mockImplementation(
-      ({ updateProgress }: ParticipateInSnsSaleParameters) => {
+      ({ updateProgress }: ParticipateInSnsSwapParameters) => {
         updateProgress(SaleStep.INITIALIZATION);
       }
     ),

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -13,7 +13,7 @@ import {
   initiateSnsSaleParticipation,
   loadNewSaleTicket,
   loadOpenTicket,
-  participateInSnsSale,
+  participateInSnsSwap,
   restoreSnsSaleParticipation,
 } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
@@ -898,28 +898,25 @@ describe("sns-api", () => {
     });
   });
 
-  describe("participateInSnsSale", () => {
+  describe("participateInSnsSwap", () => {
     beforeEach(() => {
       jest.clearAllTimers();
       const now = Date.now();
       jest.useFakeTimers().setSystemTime(now);
     });
     it("should call postprocess and APIs", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       accountsStore.set({
         main: mockMainAccount,
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: testTicket,
       });
 
       expect(spyOnSendICP).toBeCalledTimes(1);
@@ -934,10 +931,6 @@ describe("sns-api", () => {
     });
 
     it("should update account's balance in the store", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       accountsStore.set({
         main: mockMainAccount,
       });
@@ -948,11 +941,12 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: testTicket,
       });
 
       expect(get(accountsStore).main.balance.toE8s()).toEqual(newBalanceE8s);
@@ -963,10 +957,6 @@ describe("sns-api", () => {
         rootCanisterId: rootCanisterIdMock,
         owner: mockIdentity.getPrincipal(),
         subaccount: arrayOfNumberToUint8Array(mockSubAccount.subAccount),
-      });
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: snsTicket.ticket,
       });
       accountsStore.set({
         main: mockMainAccount,
@@ -979,11 +969,12 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: snsTicket.ticket,
       });
 
       expect(get(accountsStore).subAccounts[0].balance.toE8s()).toEqual(
@@ -994,10 +985,6 @@ describe("sns-api", () => {
     it("should poll refresh_buyer_tokens until successful", async () => {
       // Success on the fourth try
       const callsUntilSuccess = 4;
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       const accountBalanceError = new Error(
         "Error calling method 'account_balance_pb'..."
       );
@@ -1011,11 +998,12 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSale({
+      participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: testTicket,
       });
 
       await runResolvedPromises();
@@ -1045,10 +1033,6 @@ describe("sns-api", () => {
     });
 
     it("should show error if known error is thrown", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnNotifyParticipation.mockRejectedValue(
         new Error(
           "The token amount can only be refreshed when the canister is in the OPEN state"
@@ -1057,11 +1041,12 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSale({
+      participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
+        ticket: testTicket,
       });
 
       await runResolvedPromises();
@@ -1081,26 +1066,6 @@ describe("sns-api", () => {
       expect(updateProgressSpy).toBeCalledTimes(2);
     });
 
-    it("should do nothing if there is no ticket (important for auto retry feature)", async () => {
-      snsTicketsStore.setNoTicket(rootCanisterIdMock);
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
-
-      await participateInSnsSale({
-        rootCanisterId: testRootCanisterId,
-        userCommitment: 0n,
-        postprocess: postprocessSpy,
-        updateProgress: updateProgressSpy,
-      });
-
-      expect(spyOnSendICP).not.toBeCalled();
-      expect(spyOnNotifyParticipation).not.toBeCalled();
-      expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
-      expect(spyOnQueryBalance).not.toBeCalled();
-      expect(postprocessSpy).not.toBeCalled();
-      expect(updateProgressSpy).not.toBeCalled();
-    });
-
     it("should display an error in case the ticket principal not equals to the current identity", async () => {
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
@@ -1117,11 +1082,12 @@ describe("sns-api", () => {
         return () => undefined;
       });
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket: testTicket,
       });
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
@@ -1136,10 +1102,6 @@ describe("sns-api", () => {
     });
 
     it("should poll transfer during unknown issues or TxCreatedInFutureError", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
 
@@ -1153,11 +1115,12 @@ describe("sns-api", () => {
         .mockRejectedValueOnce(new Error("Connection error"))
         .mockResolvedValue(13n);
 
-      participateInSnsSale({
+      participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
+        ticket: testTicket,
       });
 
       await runResolvedPromises();
@@ -1182,17 +1145,14 @@ describe("sns-api", () => {
     });
 
     it("should display transfer api unknown errors", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnSendICP.mockRejectedValue(new TransferError("test"));
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket: testTicket,
       });
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
@@ -1206,17 +1166,14 @@ describe("sns-api", () => {
     });
 
     it("should display InsufficientFundsError errors", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnSendICP.mockRejectedValue(new InsufficientFundsError(0n));
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket: testTicket,
       });
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
@@ -1232,17 +1189,14 @@ describe("sns-api", () => {
 
     describe("TooOldError", () => {
       it("should succeed when no errors on notify participation", async () => {
-        snsTicketsStore.setTicket({
-          rootCanisterId: rootCanisterIdMock,
-          ticket: testTicket,
-        });
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
 
-        await participateInSnsSale({
+        await participateInSnsSwap({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
+          ticket: testTicket,
         });
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
@@ -1259,10 +1213,6 @@ describe("sns-api", () => {
       });
 
       it("should handle refresh_buyer_tokens internal errors and manually remove the ticket", async () => {
-        snsTicketsStore.setTicket({
-          rootCanisterId: rootCanisterIdMock,
-          ticket: testTicket,
-        });
         spyOnNotifyParticipation.mockRejectedValue(
           new Error(
             "The token amount can only be refreshed when the canister is in the OPEN state"
@@ -1270,11 +1220,17 @@ describe("sns-api", () => {
         );
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
 
-        await participateInSnsSale({
+        snsTicketsStore.setTicket({
+          rootCanisterId: rootCanisterIdMock,
+          ticket: testTicket,
+        });
+
+        await participateInSnsSwap({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
+          ticket: testTicket,
         });
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
@@ -1292,19 +1248,16 @@ describe("sns-api", () => {
     });
 
     it("should ignore Duplicate error", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnSendICP.mockRejectedValue(new TxDuplicateError(0n));
 
       expect(spyOnToastsError).not.toBeCalled();
 
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket: testTicket,
       });
 
       expect(spyOnNotifyParticipation).toBeCalled();
@@ -1313,21 +1266,19 @@ describe("sns-api", () => {
     });
 
     it("should display a waring when current_committed ≠ ticket.amount", async () => {
+      const ticket = {
+        ...testTicket,
+        amount_icp_e8s: 1n,
+      };
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 100n,
       });
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: {
-          ...testTicket,
-          amount_icp_e8s: 1n,
-        },
-      });
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket,
       });
 
       expect(spyOnToastsShow).toBeCalledWith(
@@ -1340,21 +1291,19 @@ describe("sns-api", () => {
     });
 
     it("should not display a waring when current_committed = ticket.amount", async () => {
+      const ticket = {
+        ...testTicket,
+        amount_icp_e8s: 1n,
+      };
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 1n,
       });
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: {
-          ...testTicket,
-          amount_icp_e8s: 1n,
-        },
-      });
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket,
       });
 
       expect(spyOnToastsShow).not.toBeCalledWith(
@@ -1365,21 +1314,19 @@ describe("sns-api", () => {
     });
 
     it("should not display a waring when current_committed = ticket.amount for increase participation", async () => {
+      const ticket = {
+        ...testTicket,
+        amount_icp_e8s: 3n,
+      };
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 10n,
       });
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: {
-          ...testTicket,
-          amount_icp_e8s: 3n,
-        },
-      });
-      await participateInSnsSale({
+      await participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 7n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
+        ticket,
       });
 
       expect(spyOnToastsShow).not.toBeCalledWith(
@@ -1391,18 +1338,15 @@ describe("sns-api", () => {
 
     it("should show 'high load' toast after 6 failures", async () => {
       const expectFailuresBeforeToast = 6;
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnNotifyParticipation.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSale({
+      participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: testTicket,
       });
 
       await runResolvedPromises();
@@ -1432,18 +1376,15 @@ describe("sns-api", () => {
 
     it("transfer should show 'high load' toast after 6 failures", async () => {
       const expectFailuresBeforeToast = 6;
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
       spyOnSendICP.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSale({
+      participateInSnsSwap({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
+        ticket: testTicket,
       });
 
       await runResolvedPromises();

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -13,7 +13,7 @@ import {
   initiateSnsSaleParticipation,
   loadNewSaleTicket,
   loadOpenTicket,
-  participateInSnsSwap,
+  participateInSnsSsale,
   restoreSnsSaleParticipation,
 } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
@@ -898,7 +898,7 @@ describe("sns-api", () => {
     });
   });
 
-  describe("participateInSnsSwap", () => {
+  describe("participateInSnsSsale", () => {
     beforeEach(() => {
       jest.clearAllTimers();
       const now = Date.now();
@@ -911,7 +911,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -941,7 +941,7 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -969,7 +969,7 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -998,7 +998,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSwap({
+      participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1041,7 +1041,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSwap({
+      participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1082,7 +1082,7 @@ describe("sns-api", () => {
         return () => undefined;
       });
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1115,7 +1115,7 @@ describe("sns-api", () => {
         .mockRejectedValueOnce(new Error("Connection error"))
         .mockResolvedValue(13n);
 
-      participateInSnsSwap({
+      participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1147,7 +1147,7 @@ describe("sns-api", () => {
     it("should display transfer api unknown errors", async () => {
       spyOnSendICP.mockRejectedValue(new TransferError("test"));
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1168,7 +1168,7 @@ describe("sns-api", () => {
     it("should display InsufficientFundsError errors", async () => {
       spyOnSendICP.mockRejectedValue(new InsufficientFundsError(0n));
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1191,7 +1191,7 @@ describe("sns-api", () => {
       it("should succeed when no errors on notify participation", async () => {
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
 
-        await participateInSnsSwap({
+        await participateInSnsSsale({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1225,7 +1225,7 @@ describe("sns-api", () => {
           ticket: testTicket,
         });
 
-        await participateInSnsSwap({
+        await participateInSnsSsale({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1252,7 +1252,7 @@ describe("sns-api", () => {
 
       expect(spyOnToastsError).not.toBeCalled();
 
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1273,7 +1273,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 100n,
       });
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1298,7 +1298,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 1n,
       });
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1321,7 +1321,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 10n,
       });
-      await participateInSnsSwap({
+      await participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 7n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1341,7 +1341,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSwap({
+      participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1379,7 +1379,7 @@ describe("sns-api", () => {
       spyOnSendICP.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSwap({
+      participateInSnsSsale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -1213,17 +1213,16 @@ describe("sns-api", () => {
       });
 
       it("should handle refresh_buyer_tokens internal errors and manually remove the ticket", async () => {
+        snsTicketsStore.setTicket({
+          rootCanisterId: rootCanisterIdMock,
+          ticket: testTicket,
+        });
         spyOnNotifyParticipation.mockRejectedValue(
           new Error(
             "The token amount can only be refreshed when the canister is in the OPEN state"
           )
         );
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
-
-        snsTicketsStore.setTicket({
-          rootCanisterId: rootCanisterIdMock,
-          ticket: testTicket,
-        });
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -13,7 +13,7 @@ import {
   initiateSnsSaleParticipation,
   loadNewSaleTicket,
   loadOpenTicket,
-  participateInSnsSsale,
+  participateInSnsSale,
   restoreSnsSaleParticipation,
 } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
@@ -898,7 +898,7 @@ describe("sns-api", () => {
     });
   });
 
-  describe("participateInSnsSsale", () => {
+  describe("participateInSnsSale", () => {
     beforeEach(() => {
       jest.clearAllTimers();
       const now = Date.now();
@@ -911,7 +911,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -941,7 +941,7 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -969,7 +969,7 @@ describe("sns-api", () => {
         newBalanceE8s
       );
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -998,7 +998,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSsale({
+      participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1041,7 +1041,7 @@ describe("sns-api", () => {
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      participateInSnsSsale({
+      participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1082,7 +1082,7 @@ describe("sns-api", () => {
         return () => undefined;
       });
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1115,7 +1115,7 @@ describe("sns-api", () => {
         .mockRejectedValueOnce(new Error("Connection error"))
         .mockResolvedValue(13n);
 
-      participateInSnsSsale({
+      participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1147,7 +1147,7 @@ describe("sns-api", () => {
     it("should display transfer api unknown errors", async () => {
       spyOnSendICP.mockRejectedValue(new TransferError("test"));
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1168,7 +1168,7 @@ describe("sns-api", () => {
     it("should display InsufficientFundsError errors", async () => {
       spyOnSendICP.mockRejectedValue(new InsufficientFundsError(0n));
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1191,7 +1191,7 @@ describe("sns-api", () => {
       it("should succeed when no errors on notify participation", async () => {
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
 
-        await participateInSnsSsale({
+        await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1225,7 +1225,7 @@ describe("sns-api", () => {
           ticket: testTicket,
         });
 
-        await participateInSnsSsale({
+        await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1252,7 +1252,7 @@ describe("sns-api", () => {
 
       expect(spyOnToastsError).not.toBeCalled();
 
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1273,7 +1273,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 100n,
       });
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1298,7 +1298,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 1n,
       });
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1321,7 +1321,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 10n,
       });
-      await participateInSnsSsale({
+      await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 7n,
         postprocess: jest.fn().mockResolvedValue(undefined),
@@ -1341,7 +1341,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSsale({
+      participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
@@ -1379,7 +1379,7 @@ describe("sns-api", () => {
       spyOnSendICP.mockRejectedValue(new Error("network error"));
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
-      participateInSnsSsale({
+      participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,


### PR DESCRIPTION
# Motivation

Simplify the payment flow code to make it more maintainable.

# Changes

Main change
* Remove access to ticketStore in `participateInSnsSwap` and pass ticket as parameter.

Minor change
* Started some renaming from "Sale" to "Swap" for consistency.

# Tests

* Fixed tests after the refactor and rename
