### PR TITLE
Make e2e-tests/scripts/update-chromedriver work on Mac.

### DIFF
--- a/e2e-tests/scripts/update-chromedriver
+++ b/e2e-tests/scripts/update-chromedriver
@@ -4,10 +4,10 @@ set -euxo pipefail
 if command -v google-chrome; then
   chrome_version=$(google-chrome --version)
 else
-  chrome_version=$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version)
+  chrome_version="$(osascript -e 'get version of application "Google Chrome"')"
 fi
 
-chrome_major_version="$(echo "$chrome_version" | sed -E 's/.*[[:space:]]([0-9]+).*/\1/g')"
+chrome_major_version="$(echo "$chrome_version" | sed -E 's/[^0-9]*([0-9]+).*/\1/g')"
 
 cd "$(dirname "$0")/.."
 npm install "chromedriver@$chrome_major_version"

--- a/e2e-tests/scripts/update-chromedriver
+++ b/e2e-tests/scripts/update-chromedriver
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 set -euxo pipefail
+
+if command -v google-chrome; then
+  chrome_version=$(google-chrome --version)
+else
+  chrome_version=$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version)
+fi
+
+chrome_major_version="$(echo "$chrome_version" | sed -E 's/.*[[:space:]]([0-9]+).*/\1/g')"
+
 cd "$(dirname "$0")/.."
-npm install "chromedriver@$(google-chrome --version | sed -E 's/.*\s([0-9]+).*/\1/g')"
+npm install "chromedriver@$chrome_major_version"


### PR DESCRIPTION
# Motivation

e2e-tests/scripts/update-chromedriver currently doesn't work on Mac.

# Changes

1. Call `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version` if `google-chrome` doesn't exist.
2. Use `[[:space:]]` in sed instead of `\s`. Supposedly the latter only work on GNU sed.

# Tests

1. Used it manually on Mac.
2. Tested the part to determine chrome_major_version on my personal Linux laptop.