### PR TITLE
refactor: validateAmount parameters

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -114,14 +114,13 @@
     await transferTokens($event);
   };
 
-  let userSelectedAccount: Account | undefined;
   let userAmount: number | undefined = undefined;
 
   let validateAmount: ValidateAmountFn;
-  $: validateAmount = (amount: number | undefined) => {
+  $: validateAmount = ({ amount, selectedAccount }) => {
     assertCkBTCUserInputAmount({
       networkBtc,
-      sourceAccount: userSelectedAccount,
+      sourceAccount: selectedAccount,
       amount,
       transactionFee: transactionFee.toE8s(),
       bitcoinEstimatedFee,
@@ -144,7 +143,6 @@
   bind:selectedNetwork
   {validateAmount}
   bind:amount={userAmount}
-  bind:selectedAccount={userSelectedAccount}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
   <p slot="description" class="value">

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -19,7 +19,10 @@
   import type { Principal } from "@dfinity/principal";
   import { translate } from "$lib/utils/i18n.utils";
   import SelectNetworkDropdown from "$lib/components/accounts/SelectNetworkDropdown.svelte";
-  import type { TransactionNetwork } from "$lib/types/transaction";
+  import type {
+    TransactionNetwork,
+    type ValidateAmountFn,
+  } from "$lib/types/transaction";
   import { isNullish } from "@dfinity/utils";
 
   // Tested in the TransactionModal
@@ -39,9 +42,7 @@
   export let mustSelectNetwork = false;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
 
-  export let validateAmount: (
-    amount: number | undefined
-  ) => string | undefined = () => undefined;
+  export let validateAmount: ValidateAmountFn = () => undefined;
 
   let filterDestinationAccounts: (account: Account) => boolean;
   $: filterDestinationAccounts = (account: Account) => {
@@ -85,7 +86,7 @@
         account: selectedAccount,
         amountE8s: tokens.toE8s() + transactionFee.toE8s(),
       });
-      errorMessage = validateAmount(amount);
+      errorMessage = validateAmount({ amount, selectedAccount });
     } catch (error: unknown) {
       if (error instanceof NotEnoughAmountError) {
         errorMessage = $i18n.error.insufficient_funds;

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionForm.svelte
@@ -21,7 +21,7 @@
   import SelectNetworkDropdown from "$lib/components/accounts/SelectNetworkDropdown.svelte";
   import type {
     TransactionNetwork,
-    type ValidateAmountFn,
+    ValidateAmountFn,
   } from "$lib/types/transaction";
   import { isNullish } from "@dfinity/utils";
 

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -8,7 +8,7 @@
   import type { Principal } from "@dfinity/principal";
   import type {
     TransactionNetwork,
-    type ValidateAmountFn,
+    ValidateAmountFn,
   } from "$lib/types/transaction";
 
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/NewTransaction/TransactionModal.svelte
@@ -6,7 +6,10 @@
   import TransactionReview from "./TransactionReview.svelte";
   import { ICPToken, TokenAmount, type Token } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
-  import type { TransactionNetwork } from "$lib/types/transaction";
+  import type {
+    TransactionNetwork,
+    type ValidateAmountFn,
+  } from "$lib/types/transaction";
 
   export let rootCanisterId: Principal;
   export let currentStep: WizardStep | undefined = undefined;
@@ -18,14 +21,11 @@
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
   export let mustSelectNetwork = false;
-  export let validateAmount: (
-    amount: number | undefined
-  ) => string | undefined = () => undefined;
+  export let validateAmount: ValidateAmountFn = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
   // User inputs
-  // TODO: do not export selectedAccount and path the value to `validateAmount({})`
-  export let selectedAccount: Account | undefined = sourceAccount;
+  let selectedAccount: Account | undefined = sourceAccount;
   export let destinationAddress: string | undefined = undefined;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
   export let amount: number | undefined = undefined;

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -49,7 +49,7 @@
         ) / E8S_PER_ICP
       : undefined;
   let checkMinimumStake: ValidateAmountFn;
-  $: checkMinimumStake = (amount: number | undefined) => {
+  $: checkMinimumStake = ({ amount }) => {
     if (
       nonNullish(amount) &&
       nonNullish(minimumStake) &&

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -157,7 +157,7 @@
 
   // Used for form inline validation
   let validateAmount: ValidateAmountFn;
-  $: validateAmount = (amount: number | undefined) => {
+  $: validateAmount = ({ amount }) => {
     if (
       swapCommitment !== undefined &&
       swapCommitment !== null &&

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -8,9 +8,10 @@ export type NewTransaction = {
   amount: number;
 };
 
-export type ValidateAmountFn = (
-  amount: number | undefined
-) => string | undefined;
+export type ValidateAmountFn = (params: {
+  amount: number | undefined;
+  selectedAccount: Account | undefined;
+}) => string | undefined;
 
 export interface IcrcTransactionData {
   toSelfTransaction: boolean;


### PR DESCRIPTION
# Motivation

Instead of exposing the selected account in the transaction modal we decided to pass it as a parameters of the validation function.

Follow-up of #2080.

