### PR TITLE
GIX-1336: Refactor SNS Swap Participation

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -139,6 +139,8 @@
       rootCanisterId,
       ticket: undefined,
     });
+    // TODO: Improve cancellatoin of actions onDestroy
+    // The polling was triggered by `restoreSnsSaleParticipation` call and needs to be canceled explicitly.
     cancelPollGetOpenTicket();
 
     // Hide toasts when moving away from the page

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -19,6 +19,7 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import {
+    cancelPollOpenTicket,
     hidePollingToast,
     restoreSnsSaleParticipation,
   } from "$lib/services/sns-sale.services";
@@ -96,8 +97,6 @@
       // Typescript guard, user commitment cannot be undefined here
       return;
     }
-    snsTicketsStore.enablePolling(rootCanisterId);
-
     loadingTicketRootCanisterId = rootCanisterId.toText();
 
     const updateProgress = (step: SaleStep) => (progressStep = step);
@@ -139,8 +138,8 @@
     snsTicketsStore.setTicket({
       rootCanisterId,
       ticket: undefined,
-      keepPolling: false,
     });
+    cancelPollOpenTicket();
 
     // Hide toasts when moving away from the page
     hidePollingToast();

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -19,7 +19,7 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import {
-    cancelPollOpenTicket,
+    cancelPollGetOpenTicket,
     hidePollingToast,
     restoreSnsSaleParticipation,
   } from "$lib/services/sns-sale.services";
@@ -139,7 +139,7 @@
       rootCanisterId,
       ticket: undefined,
     });
-    cancelPollOpenTicket();
+    cancelPollGetOpenTicket();
 
     // Hide toasts when moving away from the page
     hidePollingToast();

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -190,7 +190,6 @@ export const loadOpenTicket = async ({
   } catch (err) {
     // Don't show error if polling was cancelled
     if (pollingCancelled(err)) {
-      hidePollingToast();
       return;
     }
 
@@ -218,7 +217,7 @@ export const loadOpenTicket = async ({
         err,
       });
     }
-
+  } finally {
     // There is an issue with toastStore.hide if we show a new toast right after.
     // The workaround was to show the error toast first and then hide the info toast.
     // TODO: solve the issue with toastStore.hide

--- a/frontend/src/lib/stores/sns-tickets.store.ts
+++ b/frontend/src/lib/stores/sns-tickets.store.ts
@@ -10,7 +10,6 @@ export interface SnsTicketsStoreEntry {
    * null: no ticket available
    */
   ticket: Ticket | undefined | null;
-  keepPolling: boolean;
 }
 
 export type SnsTicketsStoreData = Record<
@@ -22,10 +21,7 @@ export interface SnsTicketsStore extends Readable<SnsTicketsStoreData> {
   setTicket: (data: {
     rootCanisterId: Principal;
     ticket: Ticket | undefined | null;
-    keepPolling?: boolean;
   }) => void;
-  enablePolling: (rootCanisterId: Principal) => void;
-  disablePolling: (rootCanisterId: Principal) => void;
   setNoTicket: (rootCanisterId: Principal) => void;
   reset: () => void;
 }
@@ -43,49 +39,14 @@ const initSnsTicketsStore = (): SnsTicketsStore => {
     setTicket({
       rootCanisterId,
       ticket,
-      keepPolling,
     }: {
       rootCanisterId: Principal;
       ticket: Ticket | undefined | null;
-      keepPolling?: boolean;
     }) {
       update((currentState: SnsTicketsStoreData) => ({
         ...currentState,
         [rootCanisterId.toText()]: {
           ticket,
-          keepPolling: keepPolling || false,
-        },
-      }));
-    },
-
-    /**
-     * Enable polling for the ticket
-     *
-     * @param rootCanisterId
-     */
-    enablePolling(rootCanisterId: Principal) {
-      update((currentState: SnsTicketsStoreData) => ({
-        ...currentState,
-        [rootCanisterId.toText()]: {
-          ticket: currentState[rootCanisterId.toText()]?.ticket,
-          keepPolling: true,
-        },
-      }));
-    },
-
-    /**
-     * Disable polling for the ticket
-     *
-     * This is used for testing purposes only at the moment.
-     *
-     * @param rootCanisterId
-     */
-    disablePolling(rootCanisterId: Principal) {
-      update((currentState: SnsTicketsStoreData) => ({
-        ...currentState,
-        [rootCanisterId.toText()]: {
-          ticket: currentState[rootCanisterId.toText()]?.ticket,
-          keepPolling: false,
         },
       }));
     },
@@ -99,8 +60,6 @@ const initSnsTicketsStore = (): SnsTicketsStore => {
         ...currentState,
         [rootCanisterId.toText()]: {
           ticket: null,
-          keepPolling:
-            currentState[rootCanisterId.toText()]?.keepPolling ?? false,
         },
       }));
     },

--- a/frontend/src/lib/types/sale.ts
+++ b/frontend/src/lib/types/sale.ts
@@ -6,4 +6,4 @@ export enum SaleStep {
   DONE = "done",
 }
 
-export type TicketStatus = "unknown" | "open" | "none" | "polling";
+export type TicketStatus = "unknown" | "open" | "none" | "loading";

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -255,8 +255,8 @@ export const hasOpenTicketInProcess = ({
     return { status: "none" };
   }
 
-  // `undefined` means that we could still be polling for the ticket.
-  return { status: projectTicketData.keepPolling ? "polling" : "none" };
+  // As long as we don't have a known state, we assume we're fetching the data.
+  return { status: "loading" };
 };
 
 /**

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -4,7 +4,7 @@
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
 import {
-  cancelPollOpenTicket,
+  cancelPollGetOpenTicket,
   restoreSnsSaleParticipation,
   type ParticipateInSnsSaleParameters,
 } from "$lib/services/sns-sale.services";
@@ -43,7 +43,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
       }
     ),
   hidePollingToast: jest.fn().mockResolvedValue(undefined),
-  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
+  cancelPollGetOpenTicket: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ParticipateButton", () => {
@@ -245,11 +245,11 @@ describe("ParticipateButton", () => {
         Component: ParticipateButton,
       });
 
-      expect(cancelPollOpenTicket).not.toBeCalled();
+      expect(cancelPollGetOpenTicket).not.toBeCalled();
 
       unmount();
 
-      expect(cancelPollOpenTicket).toBeCalled();
+      expect(cancelPollGetOpenTicket).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,8 +3,11 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
-import type { ParticipateInSnsSaleParameters } from "$lib/services/sns-sale.services";
-import { restoreSnsSaleParticipation } from "$lib/services/sns-sale.services";
+import {
+  cancelPollOpenTicket,
+  restoreSnsSaleParticipation,
+  type ParticipateInSnsSaleParameters,
+} from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -40,6 +43,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
       }
     ),
   hidePollingToast: jest.fn().mockResolvedValue(undefined),
+  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ParticipateButton", () => {
@@ -53,15 +57,13 @@ describe("ParticipateButton", () => {
     .mockImplementation(mutableMockAuthStoreSubscribe);
 
   describe("signed in", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       authStoreMock.next({
         identity: mockIdentity,
       });
-    });
-
-    beforeEach(() => {
       (restoreSnsSaleParticipation as jest.Mock).mockClear();
       snsTicketsStore.reset();
+      jest.clearAllMocks();
     });
 
     it("should render a text to increase participation", () => {
@@ -234,6 +236,20 @@ describe("ParticipateButton", () => {
         "sns-project-participate-button"
       ) as HTMLButtonElement;
       expect(button.getAttribute("disabled")).not.toBeNull();
+    });
+
+    it("should cancel polling open ticket on destroy", async () => {
+      const { unmount } = renderContextCmp({
+        summary: mockSnsFullProject.summary,
+        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+        Component: ParticipateButton,
+      });
+
+      expect(cancelPollOpenTicket).not.toBeCalled();
+
+      unmount();
+
+      expect(cancelPollOpenTicket).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -51,6 +51,9 @@ describe("ProjectStatusSection", () => {
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatusSection,
     });
+    expect(
+      queryByTestId("sns-project-participate-button")
+    ).not.toBeInTheDocument();
     // Wait for the api call to return no ticket
     await waitFor(() => expect(snsSaleApiGetOpenTicketSpy).toBeCalled());
     expect(queryByTestId("sns-project-participate-button")).toBeInTheDocument();

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -13,14 +13,18 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+import { waitFor } from "@testing-library/svelte";
 
 describe("ProjectStatusSection", () => {
+  let snsSaleApiGetOpenTicketSpy: jest.SpyInstance;
   beforeEach(() => {
     jest.clearAllMocks();
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
-    jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
+    snsSaleApiGetOpenTicketSpy = jest
+      .spyOn(snsSaleApi, "getOpenTicket")
+      .mockResolvedValue(undefined);
   });
 
   it("should render subtitle", () => {
@@ -41,12 +45,14 @@ describe("ProjectStatusSection", () => {
     expect(queryByTestId("sns-project-current-commitment")).toBeInTheDocument();
   });
 
-  it("should render project participate button", () => {
+  it("should render project participate button", async () => {
     const { queryByTestId } = renderContextCmp({
       summary: mockSnsFullProject.summary,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatusSection,
     });
+    // Wait for the api call to return no ticket
+    await waitFor(() => expect(snsSaleApiGetOpenTicketSpy).toBeCalled());
     expect(queryByTestId("sns-project-participate-button")).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -42,7 +42,7 @@ jest.mock("$lib/services/sns-swap-metrics.services", () => {
 jest.mock("$lib/services/sns-sale.services", () => ({
   restoreSnsSaleParticipation: jest.fn().mockResolvedValue(undefined),
   hidePollingToast: jest.fn().mockResolvedValue(undefined),
-  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
+  cancelPollGetOpenTicket: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ProjectDetail", () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -42,6 +42,7 @@ jest.mock("$lib/services/sns-swap-metrics.services", () => {
 jest.mock("$lib/services/sns-sale.services", () => ({
   restoreSnsSaleParticipation: jest.fn().mockResolvedValue(undefined),
   hidePollingToast: jest.fn().mockResolvedValue(undefined),
+  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ProjectDetail", () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -531,8 +531,7 @@ describe("sns-api", () => {
         expect(spyOnToastsHide).not.toBeCalled();
         cancelPollGetOpenTicket();
 
-        await advanceTime(retryDelay);
-        retryDelay *= 2;
+        await runResolvedPromises();
         expect(spyOnToastsHide).toBeCalledTimes(1);
       });
     });

--- a/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-ticket.store.spec.ts
@@ -23,49 +23,11 @@ describe("snsTicketsStore", () => {
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toEqual(ticket);
   });
 
-  it("should set ticket with polling disabled by default", () => {
-    snsTicketsStore.setTicket({
-      rootCanisterId: mockPrincipal,
-      ticket,
-    });
-
-    const $snsTicketsStore = get(snsTicketsStore);
-    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toEqual(false);
-  });
-
-  it("should set ticket with polling", () => {
-    snsTicketsStore.setTicket({
-      rootCanisterId: mockPrincipal,
-      ticket,
-      keepPolling: true,
-    });
-
-    const $snsTicketsStore = get(snsTicketsStore);
-    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toEqual(true);
-  });
-
   it("should set no-ticket for a project", () => {
     snsTicketsStore.setNoTicket(mockPrincipal);
 
     const $snsTicketsStore = get(snsTicketsStore);
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toBeNull();
-  });
-
-  it("set no-ticket for a project keeps polling from before", () => {
-    snsTicketsStore.setTicket({
-      rootCanisterId: mockPrincipal,
-      ticket,
-      keepPolling: true,
-    });
-    const initStore = get(snsTicketsStore);
-    const initPolling = initStore[mockPrincipal.toText()].keepPolling;
-
-    snsTicketsStore.setNoTicket(mockPrincipal);
-
-    const $snsTicketsStore = get(snsTicketsStore);
-    expect($snsTicketsStore[mockPrincipal.toText()].keepPolling).toBe(
-      initPolling
-    );
   });
 
   it("should add ticket for another project", () => {
@@ -82,38 +44,5 @@ describe("snsTicketsStore", () => {
     const $snsTicketsStore = get(snsTicketsStore);
     expect($snsTicketsStore[mockPrincipal.toText()].ticket).toEqual(ticket);
     expect($snsTicketsStore[principal2.toText()].ticket).toEqual(null);
-  });
-
-  it("should enable polling for a project", () => {
-    snsTicketsStore.setTicket({
-      rootCanisterId: mockPrincipal,
-      ticket: ticket,
-    });
-    const initStore = get(snsTicketsStore);
-    expect(initStore[mockPrincipal.toText()].keepPolling).toEqual(false);
-
-    snsTicketsStore.enablePolling(mockPrincipal);
-
-    const finalStore = get(snsTicketsStore);
-    expect(finalStore[mockPrincipal.toText()].keepPolling).toEqual(true);
-  });
-
-  it("should disable polling for a project", () => {
-    snsTicketsStore.setTicket({
-      rootCanisterId: mockPrincipal,
-      ticket: ticket,
-    });
-    const initStore = get(snsTicketsStore);
-    expect(initStore[mockPrincipal.toText()].keepPolling).toEqual(false);
-
-    snsTicketsStore.enablePolling(mockPrincipal);
-
-    const midStore = get(snsTicketsStore);
-    expect(midStore[mockPrincipal.toText()].keepPolling).toEqual(true);
-
-    snsTicketsStore.disablePolling(mockPrincipal);
-
-    const finalStore = get(snsTicketsStore);
-    expect(finalStore[mockPrincipal.toText()].keepPolling).toEqual(false);
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -259,7 +259,6 @@ describe("sns-utils", () => {
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
         ticket: undefined,
-        keepPolling: true,
       });
       const store = get(snsTicketsStore);
 
@@ -285,11 +284,10 @@ describe("sns-utils", () => {
       ).toEqual({ status: "unknown" });
     });
 
-    it("returns polling when the ticket is undefined and we keep polling", () => {
+    it("returns polling when the ticket is undefined", () => {
       snsTicketsStore.setTicket({
         rootCanisterId: rootCanisterIdMock,
         ticket: undefined,
-        keepPolling: true,
       });
       const store = get(snsTicketsStore);
 
@@ -298,23 +296,7 @@ describe("sns-utils", () => {
           rootCanisterId: rootCanisterIdMock,
           ticketsStore: store,
         })
-      ).toEqual({ status: "polling" });
-    });
-
-    it("returns none when the ticket is undefined and we stopped keep polling", () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: undefined,
-        keepPolling: false,
-      });
-      const store = get(snsTicketsStore);
-
-      expect(
-        hasOpenTicketInProcess({
-          rootCanisterId: rootCanisterIdMock,
-          ticketsStore: store,
-        })
-      ).toEqual({ status: "none" });
+      ).toEqual({ status: "loading" });
     });
 
     it("returns open when there is an open ticket in the store", () => {


### PR DESCRIPTION
# Motivation

Simplify the flow to participate in SNS swap.

Remove the `keepPolling` state.

# Changes

* Add cancel `cancelPollOpenTicket` to the sns swap services.
* Use `cancelPollOpenTicket` on destroy of the ParticipateButton.
* Remove `keepPolling` from the snsTicketsStore.
* Remove all usages of `keepPolling` in different utils and services. It's not needed anymore.

# Tests

* Fix tests after refactor.
* Add a test to check that `cancelPollOpenTicket` is called on destroy of ParticipateButton.
