### PR TITLE
Eq trait for state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
  "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
- "ic-certified-map 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certified-map 0.3.4",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-tree-hash",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
@@ -1677,19 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ic-certified-map"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/cdk-rs?rev=7676e7f#7676e7f47e0d7505d97d4dda1032fbce2d798527"
-dependencies = [
- "serde",
- "serde_bytes",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "ic-certified-map"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c301b1d4fc0b8ec0ee9bc558f702a2480c821e1fe647bf0d75fda46b3efa5602"
+source = "git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a#58791941b72471e09e3d9e733f2a3d4d54e52b5a"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -1698,8 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certified-map"
-version = "0.3.2"
-source = "git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a#58791941b72471e09e3d9e733f2a3d4d54e52b5a"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adc65afeffc619a7cd19553c66c79820908c12f42191af90cfb39e2e93c4431"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -3181,7 +3171,7 @@ dependencies = [
  "futures",
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
- "ic-certified-map 0.1.0",
+ "ic-certified-map 0.3.4",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
@@ -3927,7 +3917,7 @@ dependencies = [
  "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "futures",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
- "ic-certified-map 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-crypto-utils-basic-sig",
@@ -4305,7 +4295,7 @@ dependencies = [
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",
  "ic-cdk 0.6.10 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
  "ic-cdk-macros 0.6.8 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
- "ic-certified-map 0.3.2 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
+ "ic-certified-map 0.3.2",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",
  "lazy_static",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -33,7 +33,7 @@ dfn_json = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d
 dfn_macro = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
-ic-certified-map = { git = "https://github.com/dfinity/cdk-rs", rev = "7676e7f"}
+ic-certified-map = "0.3.4" # == https://github.com/dfinity/cdk-rs 6a15aa1616bcfdfdc4c120d17d37a089f5700c36
 ic-crypto-sha = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, SystemTime};
 
 type TransactionIndex = u64;
 
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq)]
 pub struct AccountsStore {
     // TODO(NNS1-720): Use AccountIdentifier directly as the key for this HashMap
     accounts: HashMap<Vec<u8>, Account>,
@@ -44,13 +44,13 @@ pub struct AccountsStore {
     neurons_topped_up_count: u64,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Eq, PartialEq)]
 enum AccountWrapper {
     SubAccount(AccountIdentifier, u8),      // Account Identifier + Sub Account Identifier
     HardwareWallet(Vec<AccountIdentifier>), // Vec of Account Identifiers since a hardware wallet could theoretically be shared between multiple accounts
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Eq, PartialEq)]
 struct Account {
     principal: Option<PrincipalId>,
     account_identifier: AccountIdentifier,
@@ -60,14 +60,14 @@ struct Account {
     canisters: Vec<NamedCanister>,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Eq, PartialEq)]
 struct NamedSubAccount {
     name: String,
     account_identifier: AccountIdentifier,
     transactions: Vec<TransactionIndex>,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Eq, PartialEq)]
 struct NamedHardwareWalletAccount {
     name: String,
     principal: PrincipalId,
@@ -100,7 +100,7 @@ pub enum OldOperation {
     },
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Eq, PartialEq)]
 struct Transaction {
     transaction_index: TransactionIndex,
     block_height: BlockIndex,
@@ -122,20 +122,20 @@ struct OldTransaction {
     transaction_type: Option<OldTransactionType>,
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize)]
+#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub enum TransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
     TopUpNeuron(PrincipalId, Memo),
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize)]
+#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub struct CreateCanisterArgs {
     pub controller: PrincipalId,
     pub amount: Tokens,
     pub refund_address: AccountIdentifier,
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize)]
+#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub struct TopUpCanisterArgs {
     pub principal: PrincipalId,
     pub canister_id: CanisterId,
@@ -143,7 +143,7 @@ pub struct TopUpCanisterArgs {
     pub refund_address: AccountIdentifier,
 }
 
-#[derive(Clone, CandidType, Deserialize)]
+#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub struct RefundTransactionArgs {
     pub recipient_principal: PrincipalId,
     pub from_sub_account: Subaccount,
@@ -183,7 +183,7 @@ pub enum OldTransactionType {
     ParticipateSwap(CanisterId),
 }
 
-#[derive(Clone, CandidType, Deserialize)]
+#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub struct NeuronDetails {
     account_identifier: AccountIdentifier,
     principal: PrincipalId,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, SystemTime};
 
 type TransactionIndex = u64;
 
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct AccountsStore {
     // TODO(NNS1-720): Use AccountIdentifier directly as the key for this HashMap
     accounts: HashMap<Vec<u8>, Account>,
@@ -44,13 +44,13 @@ pub struct AccountsStore {
     neurons_topped_up_count: u64,
 }
 
-#[derive(CandidType, Deserialize, Eq, PartialEq)]
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
 enum AccountWrapper {
     SubAccount(AccountIdentifier, u8),      // Account Identifier + Sub Account Identifier
     HardwareWallet(Vec<AccountIdentifier>), // Vec of Account Identifiers since a hardware wallet could theoretically be shared between multiple accounts
 }
 
-#[derive(CandidType, Deserialize, Eq, PartialEq)]
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
 struct Account {
     principal: Option<PrincipalId>,
     account_identifier: AccountIdentifier,
@@ -60,14 +60,14 @@ struct Account {
     canisters: Vec<NamedCanister>,
 }
 
-#[derive(CandidType, Deserialize, Eq, PartialEq)]
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
 struct NamedSubAccount {
     name: String,
     account_identifier: AccountIdentifier,
     transactions: Vec<TransactionIndex>,
 }
 
-#[derive(CandidType, Deserialize, Eq, PartialEq)]
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
 struct NamedHardwareWalletAccount {
     name: String,
     principal: PrincipalId,
@@ -100,7 +100,7 @@ pub enum OldOperation {
     },
 }
 
-#[derive(CandidType, Deserialize, Eq, PartialEq)]
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
 struct Transaction {
     transaction_index: TransactionIndex,
     block_height: BlockIndex,
@@ -122,20 +122,20 @@ struct OldTransaction {
     transaction_type: Option<OldTransactionType>,
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum TransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
     TopUpNeuron(PrincipalId, Memo),
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct CreateCanisterArgs {
     pub controller: PrincipalId,
     pub amount: Tokens,
     pub refund_address: AccountIdentifier,
 }
 
-#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct TopUpCanisterArgs {
     pub principal: PrincipalId,
     pub canister_id: CanisterId,
@@ -143,7 +143,7 @@ pub struct TopUpCanisterArgs {
     pub refund_address: AccountIdentifier,
 }
 
-#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct RefundTransactionArgs {
     pub recipient_principal: PrincipalId,
     pub from_sub_account: Subaccount,
@@ -183,7 +183,7 @@ pub enum OldTransactionType {
     ParticipateSwap(CanisterId),
 }
 
-#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct NeuronDetails {
     account_identifier: AccountIdentifier,
     principal: PrincipalId,

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -52,7 +52,7 @@ impl ContentEncoding {
 
 const LABEL_ASSETS: &[u8] = b"http_assets";
 
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq)]
 pub struct AssetHashes(RbTree<Vec<u8>, Hash>);
 
 impl From<&Assets> for AssetHashes {

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -52,7 +52,7 @@ impl ContentEncoding {
 
 const LABEL_ASSETS: &[u8] = b"http_assets";
 
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct AssetHashes(RbTree<Vec<u8>, Hash>);
 
 impl From<&Assets> for AssetHashes {

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -7,7 +7,7 @@ use icp_ledger::{BlockIndex, Memo};
 use serde::Deserialize;
 use std::collections::{BTreeMap, VecDeque};
 
-#[derive(Default, CandidType, Deserialize)]
+#[derive(Default, CandidType, Deserialize, Eq, PartialEq)]
 pub struct MultiPartTransactionsProcessor {
     queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
 }
@@ -34,7 +34,7 @@ impl MultiPartTransactionsProcessorWithRemovedFields {
     }
 }
 
-#[derive(Clone, CandidType, Deserialize)]
+#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
     TopUpNeuron(PrincipalId, Memo),

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -7,7 +7,7 @@ use icp_ledger::{BlockIndex, Memo};
 use serde::Deserialize;
 use std::collections::{BTreeMap, VecDeque};
 
-#[derive(Default, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Default, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct MultiPartTransactionsProcessor {
     queue: VecDeque<(BlockIndex, MultiPartTransactionToBeProcessed)>,
 }
@@ -34,7 +34,7 @@ impl MultiPartTransactionsProcessorWithRemovedFields {
     }
 }
 
-#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum MultiPartTransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
     TopUpNeuron(PrincipalId, Memo),

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -5,7 +5,7 @@ use dfn_candid::Candid;
 use on_wire::{FromWire, IntoWire};
 use std::cell::RefCell;
 
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct State {
     // NOTE: When adding new persistent fields here, ensure that these fields
     // are being persisted in the `replace` method below.

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -5,7 +5,7 @@ use dfn_candid::Candid;
 use on_wire::{FromWire, IntoWire};
 use std::cell::RefCell;
 
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq)]
 pub struct State {
     // NOTE: When adding new persistent fields here, ensure that these fields
     // are being persisted in the `replace` method below.


### PR DESCRIPTION
# Motivation
Testing state transition requires being able to compare state.  That is hard when most of the structures in state don't implement the Eq trait.

Adding this trait touches many files in many places, so it makes sense to isolate this in a separate PR.

# Changes
* Bump RbTree to a version that implements the Eq trait.
* Add the Eq and PartialEq traits to the backend State and all the structures in it.
* Add the Debug trait as required for `assert_eq(...)`

# Tests