### PR TITLE
Docker friendly tests - DO NOT MERGE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,9 @@ screenshots
 target
 out
 web-assets
+frontend/src/tests/
+frontend/src/e2e-tests/
+frontend/node_modules/
 frontend/node_modules/
 frontend/public/build/
 frontend/public/assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,18 @@ ARG DFX_NETWORK=mainnet
 RUN mkdir -p frontend
 RUN ./config.sh
 
+# Title: Image to run unit tests against the frontend
+# Args: A file with env vars at frontend/.env created by config.sh
+FROM builder AS unit_test_frontend
+SHELL ["bash", "-c"]
+COPY ./frontend /build/frontend
+COPY --from=configurator /build/frontend/.env /build/frontend/.env
+COPY ./frontend/src/tests /build/frontend/src/tests
+COPY ./scripts/require-dfx-network.sh /build/scripts/
+WORKDIR /build
+RUN ( cd frontend && npm ci )
+RUN npm test
+
 # Title: Image to build the nns-dapp frontend.
 # Args: A file with env vars at frontend/.env created by config.sh
 FROM builder AS build_frontend

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -29,7 +29,7 @@ assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm)
 
 set -x
 DOCKER_BUILDKIT=1 docker build \
-  --target scratch \
+  --target unit_test_frontend \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
   -t "$image_name" \
   -o "$OUTDIR" . \


### PR DESCRIPTION
# Experiment 1
What happens if we ask .dockerignore to exclude tests, but explicitly ask for the tests to be included when we want them?

A: Fail:
```
 => CACHED [unit_test_frontend 2/7] COPY --from=configurator /build/frontend/.env /build/frontend/.env                                                                                                                                                                                                                                                                                                                      0.0s
 => ERROR [unit_test_frontend 3/7] COPY ./frontend/src/tests /build/frontend/src/tests                                                                                                                                                                                                                                                                                                                                      0.0s
------
 > [unit_test_frontend 3/7] COPY ./frontend/src/tests /build/frontend/src/tests:
------
failed to compute cache key: "/frontend/src/tests" not found: not found
```