### PR TITLE
Verbose docker build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -94,6 +94,17 @@ jobs:
           echo "WASM size:          $wasm_size"
           echo "Max supported size: $max_size"
           (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }
+
+  docker-build-cli-flags:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: docker-build prints help
+        run: ./scripts/docker-build --help | grep Usage
+      - name: docker-build complains about garbage
+        run: |
+                { ./scripts/docker-build safdashfdkj || true ; } |& grep 'ERROR: Unsupported flag:'
+
   docker-build:
     needs: assets
     runs-on: ubuntu-20.04
@@ -101,7 +112,7 @@ jobs:
       - name: Extract assets for verification
         run: echo TODO
   docker-build-passes:
-    needs: ["assets", "docker-build"]
+    needs: ["assets", "docker-build", "docker-build-cli-flags"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -94,7 +94,6 @@ jobs:
           echo "WASM size:          $wasm_size"
           echo "Max supported size: $max_size"
           (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }
-
   docker-build-cli-flags:
     runs-on: ubuntu-20.04
     steps:
@@ -103,8 +102,7 @@ jobs:
         run: ./scripts/docker-build --help | grep Usage
       - name: docker-build complains about garbage
         run: |
-                { ./scripts/docker-build safdashfdkj || true ; } |& grep 'ERROR: Unsupported flag:'
-
+          { ./scripts/docker-build safdashfdkj || true ; } |& grep 'ERROR: Unsupported flag:'
   docker-build:
     needs: assets
     runs-on: ubuntu-20.04

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -9,7 +9,42 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$SCRIPTS_DIR/.."
 
+# Note: This script is intended to be extremely robust and work on many platforms
+#       so we parse arguments manually rather than using a clever, feature-rich but
+#       fragile general purpose argument parser.
+print_help() {
+  cat <<-EOF
+	Builds the nns-dapp wasm and artifacts in docker.
+
+	Usage: $(basename "$0") [--network <network>] [--verbose] [--help]
+	EOF
+}
 DFX_NETWORK=${DFX_NETWORK:-mainnet}
+PROGRESS="--progress=auto"
+while (($# > 0)); do
+  arg="$1"
+  shift 1
+  case "$arg" in
+  --network)
+    DFX_NETWORK="$1"
+    shift 1
+    ;;
+  --verbose)
+    PROGRESS="--progress=plain"
+    ;;
+  --help)
+    print_help
+    exit 0
+    ;;
+  *)
+    {
+      echo "ERROR: Unsupported flag: '$arg'"
+      print_help
+    } >&2
+    exit 1
+    ;;
+  esac
+done
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"
@@ -30,6 +65,7 @@ assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm)
 set -x
 DOCKER_BUILDKIT=1 docker build \
   --target scratch \
+  "$PROGRESS" \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
   -t "$image_name" \
   -o "$OUTDIR" . \


### PR DESCRIPTION
# Motivation
Normally, when docker build runs it minimizes the output.  This is normally a nice user experience but it is unhelpful when debugging docker build issues, when the full printout would be helpful.

All `snsdemo` and many `nns-dapp` scripts support a `--verbose` option; it would be nice if docker-build did the same.

# Changes
- parse the docker-build command line arguments.
- Support these flags:
  - `--verbose`
  - `--help`
  - `--network`

# Tests
- I have used `--verbose` locally and am happy to report that the output has filled many screens with text.
- I have added tests for `--help` and garbage input to CI.  I have not added a test for `--network` or `--verbose` as it seems that the test run time would outweigh the benefit.
- I have checked that the docker build with no flags, as used for creating mainnet builds, is unaffected by this PR:
Main:
```
ea3ab3f9613c5b4bab4734c52360ed18cbe7f83e9290f1f029a700147c74eee8  assets.tar.xz
355c194be9d43378d8f079165c11ce3b585c1e0d4a5ac7f1517eff0c397fab8f  nns-dapp.wasm
d84a70cfd6ac7b59b0d9e537ca4f5f1f2085635f87a35e76e67603a15dc786d2  sns_aggregator.wasm
FIN
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (8:09)$ git rev-parse HEAD
ff7d09eb4ef2409e84645855614e40918bac0967
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (25:38)$ 
```
This PR:
```
ea3ab3f9613c5b4bab4734c52360ed18cbe7f83e9290f1f029a700147c74eee8  assets.tar.xz
355c194be9d43378d8f079165c11ce3b585c1e0d4a5ac7f1517eff0c397fab8f  nns-dapp.wasm
d84a70cfd6ac7b59b0d9e537ca4f5f1f2085635f87a35e76e67603a15dc786d2  sns_aggregator.wasm
FIN
max@sinkpad:~/dfn/nns-dapp/branches/verbose-docker-build (49:39)$ git rev-parse HEAD
358187b3bc877c3019e38ccea87571fbbd6a83a5
max@sinkpad:~/dfn/nns-dapp/branches/verbose-docker-build (51:46)$ 
```