### PR TITLE
Bump rust 68

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install rust formatter
-        run: rustup component add rustfmt
       - name: Install shfmt
         run: sudo snap install --classic shfmt
       - name: Install yq
@@ -37,7 +35,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.64.0"]
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
@@ -48,12 +45,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
-      - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup target add wasm32-unknown-unknown
-          rustup component add clippy
       - name: Lint rust code
         run: ./scripts/lint-rs
       - name: Run Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,14 @@ RUN n "$(cat config/node_version)"
 RUN node --version
 RUN npm --version
 # Install Rust and Cargo in /opt
+COPY rust-toolchain.toml .
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
 RUN curl --fail https://sh.rustup.rs -sSf \
         | sh -s -- -y --no-modify-path
 ENV PATH=/cargo/bin:$PATH
+RUN cargo --version
 # Install IC CDK optimizer
 RUN cargo install --version "$(cat config/optimizer_version)" ic-cdk-optimizer
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
@@ -54,6 +56,7 @@ RUN cargo install --version "$(cat config/optimizer_version)" ic-cdk-optimizer
 # everything once the actual source code is COPYed (and e.g. doesn't trip on
 # timestamps being older)
 WORKDIR /build
+COPY rust-toolchain.toml .
 COPY Cargo.lock .
 COPY Cargo.toml .
 COPY rs/backend/Cargo.toml rs/backend/Cargo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,9 @@ FROM base as tool_versions
 SHELL ["bash", "-c"]
 RUN mkdir -p config
 COPY dfx.json dfx.json
-ARG rust_version=1.64.0
 ENV NODE_VERSION=16.17.1
 RUN jq -r .dfx dfx.json > config/dfx_version
 RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
-RUN printf "%s" "$rust_version" > config/rust_version
 RUN printf "%s" "0.3.1" > config/optimizer_version
 
 # This is the "builder", i.e. the base image used later to build the final code.
@@ -46,9 +44,7 @@ ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH
 RUN curl --fail https://sh.rustup.rs -sSf \
-        | sh -s -- -y --default-toolchain "$(cat config/rust_version)-x86_64-unknown-linux-gnu" --no-modify-path && \
-    rustup default "$(cat config/rust_version)-x86_64-unknown-linux-gnu" && \
-    rustup target add wasm32-unknown-unknown
+        | sh -s -- -y --no-modify-path
 ENV PATH=/cargo/bin:$PATH
 # Install IC CDK optimizer
 RUN cargo install --version "$(cat config/optimizer_version)" ic-cdk-optimizer

--- a/dfx.json
+++ b/dfx.json
@@ -1027,7 +1027,6 @@
     },
     "build": {
       "config": {
-        "RUSTC_VERSION": "1.64.0",
         "NODE_VERSION": "18.14.2",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IC_COMMIT": "ced285287d5513832ba8c66fc3793e438c74b531"

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -959,7 +959,7 @@ impl AccountsStore {
             }
         }
 
-        count_to_prune as u32
+        count_to_prune
     }
 
     pub fn enqueue_multi_part_transaction(

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -318,8 +318,8 @@ fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -
         "IC-Certificate".to_string(),
         format!(
             "certificate=:{}:, tree=:{}:",
-            base64::encode(&certificate),
-            base64::encode(&serializer.into_inner())
+            base64::encode(certificate),
+            base64::encode(serializer.into_inner())
         ),
     )
 }

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -252,7 +252,7 @@ pub fn canister_heartbeat() {
 pub fn add_stable_asset() {
     over(candid_one, |asset_bytes: Vec<u8>| {
         let hash_bytes = hash_bytes(&asset_bytes);
-        match hex::encode(&hash_bytes).as_str() {
+        match hex::encode(hash_bytes).as_str() {
             "933c135529499e2ed6b911feb8e8824068dc545298b61b93ae813358b306e7a6" => {
                 // Canvaskit wasm.
                 insert_asset(

--- a/rs/backend/src/time.rs
+++ b/rs/backend/src/time.rs
@@ -5,5 +5,5 @@ pub fn time_millis() -> u64 {
 }
 
 pub fn time() -> u64 {
-    unsafe { ic0::time() as u64 }
+    unsafe { ic0::time() }
 }

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -176,8 +176,8 @@ fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -
         "IC-Certificate".to_string(),
         format!(
             "certificate=:{}:, tree=:{}:",
-            base64::encode(&certificate),
-            base64::encode(&serializer.into_inner())
+            base64::encode(certificate),
+            base64::encode(serializer.into_inner())
         ),
     ))
 }

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -58,7 +58,7 @@ async fn get_canister_status() -> ic_ic00_types::CanisterStatusResultV2 {
 #[allow(clippy::expect_used)] // This is a query call, no real damage can ensue to this canister.
 fn stable_data() -> String {
     STATE.with(|state| {
-        let to_serialize: &StableState = &(*state.stable.borrow());
+        let to_serialize: &StableState = &state.stable.borrow();
         serde_json::to_string(to_serialize).expect("Failed to serialize")
     })
 }
@@ -69,7 +69,7 @@ fn stable_data() -> String {
 fn tail_log(limit: Option<u16>) -> String {
     let limit = limit.unwrap_or(200) as usize;
     STATE.with(|state| {
-        let to_serialize: &VecDeque<String> = &(*state.log.borrow());
+        let to_serialize: &VecDeque<String> = &state.log.borrow();
         to_serialize
             .iter()
             .rev()
@@ -119,7 +119,7 @@ fn pre_upgrade() {
     //       seems to be to serialize with Serde, omitting asset hashes which can
     //       be serialized with neither.
     STATE.with(|state| {
-        let to_serialize: &StableState = &(*state.stable.borrow());
+        let to_serialize: &StableState = &state.stable.borrow();
         if let Ok(bytes) = to_serialize.to_bytes() {
             let bytes_summary = StableState::summarize_bytes(&bytes);
             match ic_cdk::storage::stable_save((bytes,)) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.64.0"
+# The channel should be updated regularly to stable, as advertised here: https://forge.rust-lang.org/
+channel = "1.68.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.64.0"
+# Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
+channel = "1.68.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-# The channel should be updated regularly to stable, as advertised here: https://forge.rust-lang.org/
-channel = "1.68.0"
+channel = "1.64.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -9,37 +9,7 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$SCRIPTS_DIR/.."
 
-# Note: This script is intended to be extremely robust and work on many platforms
-#       so we parse arguments manually rather than using a clever, feature-rich but
-#       fragile general purpose argument parser.
-print_help() {
-	cat <<-EOF
-	Builds the nns-dapp wasm and artifacts in docker.
-
-	Usage: $(basename "$0") [--network <network>] [--verbose] [--help]
-	EOF
-}
 DFX_NETWORK=${DFX_NETWORK:-mainnet}
-PROGRESS="--progress=auto"
-while (( $# > 0 )); do
-	arg="$1" ; shift 1
-	case "$arg" in
-		--network)
-			DFX_NETWORK="$1"
-			shift 1
-			;;
-		--verbose)
-			PROGRESS="--progress=plain"
-			;;
-		--help)
-			print_help
-			exit 0 ;;
-		*)
-			echo "ERROR: Unsupported flag: '$arg'"
-			print_help
-			exit 1 ;;
-	esac
-done
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"
@@ -60,7 +30,6 @@ assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm)
 set -x
 DOCKER_BUILDKIT=1 docker build \
   --target scratch \
-  "$PROGRESS" \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
   -t "$image_name" \
   -o "$OUTDIR" . \

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -9,7 +9,37 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$SCRIPTS_DIR/.."
 
+# Note: This script is intended to be extremely robust and work on many platforms
+#       so we parse arguments manually rather than using a clever, feature-rich but
+#       fragile general purpose argument parser.
+print_help() {
+	cat <<-EOF
+	Builds the nns-dapp wasm and artifacts in docker.
+
+	Usage: $(basename "$0") [--network <network>] [--verbose] [--help]
+	EOF
+}
 DFX_NETWORK=${DFX_NETWORK:-mainnet}
+PROGRESS="--progress=auto"
+while (( $# > 0 )); do
+	arg="$1" ; shift 1
+	case "$arg" in
+		--network)
+			DFX_NETWORK="$1"
+			shift 1
+			;;
+		--verbose)
+			PROGRESS="--progress=plain"
+			;;
+		--help)
+			print_help
+			exit 0 ;;
+		*)
+			echo "ERROR: Unsupported flag: '$arg'"
+			print_help
+			exit 1 ;;
+	esac
+done
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"
@@ -30,6 +60,7 @@ assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm)
 set -x
 DOCKER_BUILDKIT=1 docker build \
   --target scratch \
+  "$PROGRESS" \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
   -t "$image_name" \
   -o "$OUTDIR" . \


### PR DESCRIPTION
# Motivation
The latest cdk-rs requires Rust version `1.66` or later.  We currently use `1.64`

# Changes
- Bump Rust to the latest stable release, which is 1.48.0 at the time of writing.
- Fix lint issues.

# Tests
- There are no changes in functionality.  Existing tests _should_ suffice.