### PR TITLE
GIX-1212: Filter SNS Proposals

### DIFF
--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -35,7 +35,7 @@
       {/if}
 
       {#if topic !== undefined}
-        <KeyValuePair>
+        <KeyValuePair testId="proposal-topic">
           <span slot="key">{$i18n.proposal_detail.topic_prefix}</span>
           <span slot="value" class="meta-data-value">{topic ?? ""}</span>
         </KeyValuePair>

--- a/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
@@ -1,0 +1,57 @@
+import {
+  snsSelectedFiltersStore,
+  type SnsFiltersStoreData,
+} from "$lib/stores/sns-filters.store";
+import {
+  snsProposalsStore,
+  type SnsProposalsStore,
+  type SnsProposalsStoreData,
+} from "$lib/stores/sns-proposals.store";
+import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
+import { isNullish } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+
+export const snsFilteredProposalsStore = derived<
+  [SnsProposalsStore, Readable<SnsFiltersStoreData>],
+  SnsProposalsStoreData
+>(
+  [snsProposalsStore, snsSelectedFiltersStore],
+  ([proposalsStore, selectedFilters]) => {
+    const filteredProposals = Object.entries(proposalsStore).reduce(
+      (acc, [rootCanisterIdText, projectProposals]) => {
+        const filteredProjectProposals = projectProposals.proposals.filter(
+          (proposal) => {
+            const projectSelectedFilters = selectedFilters[rootCanisterIdText];
+            // Do not filter until filters are loaded
+            if (isNullish(projectSelectedFilters)) {
+              return true;
+            }
+            const proposalData = mapProposalInfo({
+              proposalData: proposal,
+              nsFunctions: projectSelectedFilters.topics.map(
+                ({ value }) => value
+              ),
+            });
+            const statusMatch =
+              projectSelectedFilters.decisionStatus.length === 0 ||
+              projectSelectedFilters.decisionStatus
+                .map(({ value }) => value)
+                .includes(proposalData.status);
+            // TODO: Filter by reward status
+            // TODO: Filter by nervous functions
+            return statusMatch;
+          }
+        );
+        return {
+          ...acc,
+          [rootCanisterIdText]: {
+            proposals: filteredProjectProposals,
+            certified: projectProposals.certified,
+          },
+        };
+      },
+      {}
+    );
+    return filteredProposals;
+  }
+);

--- a/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
@@ -7,7 +7,7 @@ import {
   type SnsProposalsStore,
   type SnsProposalsStoreData,
 } from "$lib/stores/sns-proposals.store";
-import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
+import { snsDecisionStatus } from "$lib/utils/sns-proposals.utils";
 import { isNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
@@ -19,24 +19,18 @@ export const snsFilteredProposalsStore = derived<
   ([proposalsStore, selectedFilters]) => {
     const filteredProposals = Object.entries(proposalsStore).reduce(
       (acc, [rootCanisterIdText, projectProposals]) => {
+        const projectSelectedFilters = selectedFilters[rootCanisterIdText];
+        // Do not add proposals filters are loaded
+        if (isNullish(projectSelectedFilters)) {
+          return acc;
+        }
         const filteredProjectProposals = projectProposals.proposals.filter(
           (proposal) => {
-            const projectSelectedFilters = selectedFilters[rootCanisterIdText];
-            // Do not filter until filters are loaded
-            if (isNullish(projectSelectedFilters)) {
-              return true;
-            }
-            const proposalData = mapProposalInfo({
-              proposalData: proposal,
-              nsFunctions: projectSelectedFilters.topics.map(
-                ({ value }) => value
-              ),
-            });
             const statusMatch =
               projectSelectedFilters.decisionStatus.length === 0 ||
               projectSelectedFilters.decisionStatus
                 .map(({ value }) => value)
-                .includes(proposalData.status);
+                .includes(snsDecisionStatus(proposal));
             // TODO: Filter by reward status
             // TODO: Filter by nervous functions
             return statusMatch;

--- a/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-filtered-proposals.derived.ts
@@ -20,7 +20,8 @@ export const snsFilteredProposalsStore = derived<
     const filteredProposals = Object.entries(proposalsStore).reduce(
       (acc, [rootCanisterIdText, projectProposals]) => {
         const projectSelectedFilters = selectedFilters[rootCanisterIdText];
-        // Do not add proposals filters are loaded
+        // Skip the project if there are no filters for it.
+        // This will cause the proposals to be `undefined` for a specific project.
         if (isNullish(projectSelectedFilters)) {
           return acc;
         }

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -35,15 +35,11 @@
   let currentProjectCanisterId: Principal | undefined = undefined;
   const unsubscribeProjectIdStore: Unsubscriber = snsOnlyProjectStore.subscribe(
     async (selectedProjectCanisterId) => {
-      if (
-        nonNullish(selectedProjectCanisterId) &&
-        currentProjectCanisterId?.toText() !==
-          selectedProjectCanisterId.toText()
-      ) {
-        currentProjectCanisterId = selectedProjectCanisterId;
+      currentProjectCanisterId = selectedProjectCanisterId;
+      if (nonNullish(selectedProjectCanisterId)) {
         await Promise.all([
-          loadSnsNervousSystemFunctions(currentProjectCanisterId),
-          loadSnsFilters(currentProjectCanisterId),
+          loadSnsNervousSystemFunctions(selectedProjectCanisterId),
+          loadSnsFilters(selectedProjectCanisterId),
         ]);
       }
     }

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -18,6 +18,10 @@
   import { loadSnsFilters } from "$lib/services/sns-filters.services";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
+  import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+  import { nonNullish } from "@dfinity/utils";
+  import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposals.derived";
+  import type { Principal } from "@dfinity/principal";
 
   onMount(async () => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
@@ -28,19 +32,40 @@
     }
   });
 
-  const unsubscribe: Unsubscriber = snsOnlyProjectStore.subscribe(
+  let currentProjectCanisterId: Principal | undefined = undefined;
+  const unsubscribeProjectIdStore: Unsubscriber = snsOnlyProjectStore.subscribe(
     async (selectedProjectCanisterId) => {
-      if (selectedProjectCanisterId !== undefined) {
+      if (
+        nonNullish(selectedProjectCanisterId) &&
+        currentProjectCanisterId?.toText() !==
+          selectedProjectCanisterId.toText()
+      ) {
+        currentProjectCanisterId = selectedProjectCanisterId;
         await Promise.all([
-          loadSnsProposals({ rootCanisterId: selectedProjectCanisterId }),
-          loadSnsNervousSystemFunctions(selectedProjectCanisterId),
-          loadSnsFilters(selectedProjectCanisterId),
+          loadSnsNervousSystemFunctions(currentProjectCanisterId),
+          loadSnsFilters(currentProjectCanisterId),
         ]);
       }
     }
   );
 
-  onDestroy(unsubscribe);
+  const unsubscribeFiltersStore: Unsubscriber = snsFiltesStore.subscribe(
+    async (filters) => {
+      // First call will have `filters` as `undefined`.
+      // Once we have the initial filters, we load the proposals.
+      if (
+        nonNullish(currentProjectCanisterId) &&
+        nonNullish(filters[currentProjectCanisterId.toText()])
+      ) {
+        await loadSnsProposals({ rootCanisterId: currentProjectCanisterId });
+      }
+    }
+  );
+
+  onDestroy(() => {
+    unsubscribeProjectIdStore();
+    unsubscribeFiltersStore();
+  });
 
   let loadingNextPage = false;
   let loadNextPage: () => void;
@@ -60,24 +85,21 @@
 
   // `undefined` means that we haven't loaded the proposals yet.
   let proposals: SnsProposalData[] | undefined;
-  $: proposals =
-    $snsOnlyProjectStore !== undefined
-      ? sortSnsProposalsById(
-          $snsProposalsStore[$snsOnlyProjectStore.toText()]?.proposals
-        )
-      : undefined;
+  $: proposals = nonNullish(currentProjectCanisterId)
+    ? sortSnsProposalsById(
+        $snsFilteredProposalsStore[currentProjectCanisterId.toText()]?.proposals
+      )
+    : undefined;
 
   let nsFunctions: SnsNervousSystemFunction[] | undefined;
-  $: nsFunctions =
-    $snsOnlyProjectStore !== undefined
-      ? $snsFunctionsStore[$snsOnlyProjectStore.toText()]?.nsFunctions
-      : undefined;
+  $: nsFunctions = nonNullish(currentProjectCanisterId)
+    ? $snsFunctionsStore[currentProjectCanisterId.toText()]?.nsFunctions
+    : undefined;
 
   let disableInfiniteScroll: boolean;
-  $: disableInfiniteScroll =
-    $snsOnlyProjectStore !== undefined
-      ? $snsProposalsStore[$snsOnlyProjectStore.toText()]?.completed ?? false
-      : false;
+  $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)
+    ? $snsProposalsStore[currentProjectCanisterId.toText()]?.completed ?? false
+    : false;
 </script>
 
 <SnsProposalsList

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -10,6 +10,7 @@ import {
   syncSnsNeurons,
 } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
+import { snsSelectedFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import {
@@ -145,6 +146,7 @@ export const loadSnsProposals = async ({
   rootCanisterId: Principal;
   beforeProposalId?: SnsProposalId;
 }): Promise<void> => {
+  const filters = get(snsSelectedFiltersStore)[rootCanisterId.toText()];
   return queryAndUpdate<SnsProposalData[], unknown>({
     identityType: "current",
     request: ({ certified, identity }) =>
@@ -152,6 +154,10 @@ export const loadSnsProposals = async ({
         params: {
           limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
           beforeProposal: beforeProposalId,
+          includeStatus:
+            filters?.decisionStatus.map(({ value }) => value) ?? [],
+          // TODO: add filter by nervous function
+          // TODO: add filter by reward status
         },
         identity,
         certified,

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -3,12 +3,17 @@ import { snsFiltesStore } from "$lib/stores/sns-filters.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import type { Principal } from "@dfinity/principal";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 // TODO: Set default filters
 export const loadSnsFilters = async (rootCanisterId: Principal) => {
+  const filtersProjectStoreData = get(snsFiltesStore)[rootCanisterId.toText()];
+  if (nonNullish(filtersProjectStoreData)) {
+    return;
+  }
   const i18nKeys = get(i18n);
-  const filtersProjectData = get(snsFiltesStore)[rootCanisterId.toText()] ?? {
+  const filtersProjectData = {
     topics: [],
     rewardStatus: [],
     decisionStatus: [],

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -5,7 +5,7 @@ import type {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
 } from "@dfinity/sns";
-import { writable, type Readable } from "svelte/store";
+import { derived, writable, type Readable } from "svelte/store";
 
 export interface ProjectFiltersStoreData {
   topics: Filter<SnsNervousSystemFunction>[];
@@ -13,11 +13,11 @@ export interface ProjectFiltersStoreData {
   decisionStatus: Filter<SnsProposalDecisionStatus>[];
 }
 
-interface SnsFiltersStoreData {
+export interface SnsFiltersStoreData {
   [rootCanisterId: string]: ProjectFiltersStoreData;
 }
 
-interface ProjectFiltersStore extends Readable<SnsFiltersStoreData> {
+export interface SnsFiltersStore extends Readable<SnsFiltersStoreData> {
   setDecisionStatus: (data: {
     rootCanisterId: Principal;
     decisionStatus: Filter<SnsProposalDecisionStatus>[];
@@ -34,7 +34,7 @@ interface ProjectFiltersStore extends Readable<SnsFiltersStoreData> {
  *
  * TODO: persist to localstorage
  */
-export const initSnsFiltersStore = (): ProjectFiltersStore => {
+export const initSnsFiltersStore = (): SnsFiltersStore => {
   const { subscribe, set, update } = writable<SnsFiltersStoreData>({});
 
   return {
@@ -98,3 +98,20 @@ export const initSnsFiltersStore = (): ProjectFiltersStore => {
 };
 
 export const snsFiltesStore = initSnsFiltersStore();
+
+export const snsSelectedFiltersStore = derived<
+  Readable<SnsFiltersStoreData>,
+  SnsFiltersStoreData
+>(snsFiltesStore, ($snsFilters) =>
+  Object.entries($snsFilters).reduce(
+    (acc, [rootCanisterIdText, filters]) => ({
+      ...acc,
+      [rootCanisterIdText]: {
+        topics: filters.topics.filter(({ checked }) => checked),
+        rewardStatus: filters.rewardStatus.filter(({ checked }) => checked),
+        decisionStatus: filters.decisionStatus.filter(({ checked }) => checked),
+      },
+    }),
+    {}
+  )
+);

--- a/frontend/src/lib/stores/sns-proposals.store.ts
+++ b/frontend/src/lib/stores/sns-proposals.store.ts
@@ -1,19 +1,35 @@
 import type { Principal } from "@dfinity/principal";
 import type { SnsProposalData } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
-import { writable } from "svelte/store";
+import { writable, type Readable } from "svelte/store";
 
-export interface ProjectProposalStore {
+export interface ProjectProposalData {
   proposals: SnsProposalData[];
   // certified is an optimistic value - i.e. it represents the last value that has been pushed in store
   certified: boolean | undefined;
   // Whether all proposals have been loaded
   completed: boolean;
 }
-export interface SnsProposalsStore {
+export interface SnsProposalsStoreData {
   // Each SNS Project is an entry in this Store.
   // We use the root canister id as the key to identify the proposals for a specific project.
-  [rootCanisterId: string]: ProjectProposalStore;
+  [rootCanisterId: string]: ProjectProposalData;
+}
+
+export interface SnsProposalsStore extends Readable<SnsProposalsStoreData> {
+  setProposals: (data: {
+    rootCanisterId: Principal;
+    proposals: SnsProposalData[];
+    certified: boolean | undefined;
+    completed: boolean;
+  }) => void;
+  addProposals: (data: {
+    rootCanisterId: Principal;
+    proposals: SnsProposalData[];
+    certified: boolean | undefined;
+    completed: boolean;
+  }) => void;
+  reset: () => void;
 }
 
 /**
@@ -23,7 +39,7 @@ export interface SnsProposalsStore {
  * - addProposals: add new proposals to the list of proposals for a specific sns project
  */
 const initSnsProposalsStore = () => {
-  const { subscribe, update, set } = writable<SnsProposalsStore>({});
+  const { subscribe, update, set } = writable<SnsProposalsStoreData>({});
 
   return {
     subscribe,
@@ -39,7 +55,7 @@ const initSnsProposalsStore = () => {
       certified: boolean | undefined;
       completed: boolean;
     }) {
-      update((currentState: SnsProposalsStore) => ({
+      update((currentState: SnsProposalsStoreData) => ({
         ...currentState,
         [rootCanisterId.toText()]: {
           proposals: proposals,
@@ -60,7 +76,7 @@ const initSnsProposalsStore = () => {
       certified: boolean | undefined;
       completed: boolean;
     }) {
-      update((currentState: SnsProposalsStore) => {
+      update((currentState: SnsProposalsStoreData) => {
         const newIds = new Set(proposals.map(({ id }) => fromNullable(id)?.id));
         return {
           ...currentState,

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -41,8 +41,12 @@ const implementedFunctions = {
 // State and helpers for fake implementations:
 //////////////////////////////////////////////
 
+// Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of:
+// neurons
 const neurons: Map<string, SnsNeuron[]> = new Map();
+// proposals
 const proposals: Map<string, SnsProposalData[]> = new Map();
+// nervous functions
 const nervousFunctions: Map<string, SnsNervousSystemFunction[]> = new Map();
 
 type KeyParams = { identity: Identity; rootCanisterId: Principal };

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -41,12 +41,11 @@ const implementedFunctions = {
 // State and helpers for fake implementations:
 //////////////////////////////////////////////
 
-// Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of:
-// neurons
+// Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of neurons
 const neurons: Map<string, SnsNeuron[]> = new Map();
-// proposals
+// Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of proposals
 const proposals: Map<string, SnsProposalData[]> = new Map();
-// nervous functions
+// Maps a key representing rootCanisterId to a list of nervous system functions
 const nervousFunctions: Map<string, SnsNervousSystemFunction[]> = new Map();
 
 type KeyParams = { identity: Identity; rootCanisterId: Principal };

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -239,6 +239,7 @@ async function queryProposals({
 const reset = () => {
   neurons.clear();
   proposals.clear();
+  nervousFunctions.clear();
 };
 
 const createNeuronId = ({
@@ -299,7 +300,7 @@ export const addProposalWith = ({
   return proposal;
 };
 
-export const addNervousFunctionWith = ({
+export const addNervousSystemFunctionWith = ({
   identity = mockIdentity,
   rootCanisterId,
   ...functionParams

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -91,8 +91,8 @@ const getProposals = (keyParams: KeyParams) => {
   return proposalsList;
 };
 
-const getNervousFunctions = (keyParams: KeyParams) => {
-  const key = mapKey(keyParams);
+const getNervousFunctions = (rootCanisterId: Principal) => {
+  const key = rootCanisterId.toText();
   let nervousFunctionsList = nervousFunctions.get(key);
   if (isNullish(nervousFunctionsList)) {
     nervousFunctionsList = [];
@@ -119,14 +119,14 @@ async function nervousSystemParameters({
 
 async function getNervousSystemFunctions({
   rootCanisterId,
-  identity,
-  certified: _,
+  identity: _,
+  certified: __,
 }: {
   rootCanisterId: Principal;
   identity: Identity;
   certified: boolean;
 }): Promise<SnsNervousSystemFunction[]> {
-  return nervousFunctions.get(mapKey({ identity, rootCanisterId })) || [];
+  return nervousFunctions.get(rootCanisterId.toText()) || [];
 }
 
 async function getNeuronBalance({
@@ -305,14 +305,12 @@ export const addProposalWith = ({
 };
 
 export const addNervousSystemFunctionWith = ({
-  identity = mockIdentity,
   rootCanisterId,
   ...functionParams
 }: {
-  identity?: Identity;
   rootCanisterId: Principal;
 } & Partial<SnsNervousSystemFunction>): SnsNervousSystemFunction => {
-  const nervousFunctions = getNervousFunctions({ identity, rootCanisterId });
+  const nervousFunctions = getNervousFunctions(rootCanisterId);
   const index = nervousFunctions.length;
   const defaultFunctionId = BigInt(index + 1);
   const nervousFunction: SnsNervousSystemFunction = {

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
@@ -1,0 +1,134 @@
+import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposals.derived";
+import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import {
+  createSnsProposal,
+  mockSnsProposal,
+} from "$tests/mocks/sns-proposals.mock";
+import { SnsProposalDecisionStatus, type SnsProposalData } from "@dfinity/sns";
+import { get } from "svelte/store";
+
+describe("snsFilteredProposalsStore", () => {
+  const snsProposal1: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(2) }],
+  };
+  const snsProposal2: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(2) }],
+  };
+  const snsProposal3: SnsProposalData = {
+    ...mockSnsProposal,
+    id: [{ id: BigInt(3) }],
+  };
+
+  beforeEach(() => {
+    snsFiltesStore.reset();
+    snsProposalsStore.reset();
+  });
+  it("should return all proposals if filter store is not loaded", () => {
+    const rootCanisterId = mockPrincipal;
+    const proposals: SnsProposalData[] = [
+      snsProposal1,
+      snsProposal2,
+      snsProposal3,
+    ];
+    snsProposalsStore.setProposals({
+      rootCanisterId,
+      proposals,
+      certified: true,
+      completed: true,
+    });
+
+    expect(
+      get(snsFilteredProposalsStore)[rootCanisterId.toText()].proposals
+    ).toHaveLength(proposals.length);
+  });
+
+  it("should return all proposals if no decisions filter is checked", () => {
+    const rootCanisterId = mockPrincipal;
+    const proposals: SnsProposalData[] = [
+      snsProposal1,
+      snsProposal2,
+      snsProposal3,
+    ];
+    snsProposalsStore.setProposals({
+      rootCanisterId,
+      proposals,
+      certified: true,
+      completed: true,
+    });
+    const decisionStatus = [
+      {
+        id: "1",
+        name: "status-1",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        checked: false,
+      },
+      {
+        id: "2",
+        name: "status-2",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+        checked: false,
+      },
+    ];
+    snsFiltesStore.setDecisionStatus({
+      rootCanisterId,
+      decisionStatus,
+    });
+
+    expect(
+      get(snsFilteredProposalsStore)[rootCanisterId.toText()].proposals
+    ).toHaveLength(proposals.length);
+  });
+
+  it("should return open proposals if Open status is checked", () => {
+    const rootCanisterId = mockPrincipal;
+    const openProposal = createSnsProposal({
+      proposalId: BigInt(2),
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+    });
+    const failedProposal1 = createSnsProposal({
+      proposalId: BigInt(3),
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
+    });
+    const failedProposal2 = createSnsProposal({
+      proposalId: BigInt(4),
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
+    });
+    const proposals: SnsProposalData[] = [
+      failedProposal1,
+      openProposal,
+      failedProposal2,
+    ];
+    snsProposalsStore.setProposals({
+      rootCanisterId,
+      proposals,
+      certified: true,
+      completed: true,
+    });
+    const decisionStatus = [
+      {
+        id: "1",
+        name: "status-1",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        checked: true,
+      },
+      {
+        id: "2",
+        name: "status-2",
+        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+        checked: false,
+      },
+    ];
+    snsFiltesStore.setDecisionStatus({
+      rootCanisterId,
+      decisionStatus,
+    });
+
+    expect(
+      get(snsFilteredProposalsStore)[rootCanisterId.toText()].proposals
+    ).toHaveLength(1);
+  });
+});

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
@@ -27,7 +27,7 @@ describe("snsFilteredProposalsStore", () => {
     snsFiltesStore.reset();
     snsProposalsStore.reset();
   });
-  it("should return all proposals if filter store is not loaded", () => {
+  it("should return undefined if filter store is not loaded", () => {
     const rootCanisterId = mockPrincipal;
     const proposals: SnsProposalData[] = [
       snsProposal1,
@@ -42,8 +42,8 @@ describe("snsFilteredProposalsStore", () => {
     });
 
     expect(
-      get(snsFilteredProposalsStore)[rootCanisterId.toText()].proposals
-    ).toHaveLength(proposals.length);
+      get(snsFilteredProposalsStore)[rootCanisterId.toText()]
+    ).toBeUndefined();
   });
 
   it("should return all proposals if no decisions filter is checked", () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -2,39 +2,30 @@
  * @jest-environment jsdom
  */
 
+import * as governanceApi from "$lib/api/sns-governance.api";
 import SnsProposals from "$lib/pages/SnsProposals.svelte";
-import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
-import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
-import { loadSnsFilters } from "$lib/services/sns-filters.services";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
-import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
+import {
+  createSnsProposal,
+  mockSnsProposal,
+} from "$tests/mocks/sns-proposals.mock";
 import { snsResponseFor } from "$tests/mocks/sns-response.mock";
-import { SnsSwapLifecycle } from "@dfinity/sns";
-import { render, waitFor } from "@testing-library/svelte";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { SnsProposalDecisionStatus, SnsSwapLifecycle } from "@dfinity/sns";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
-jest.mock("$lib/services/$public/sns.services", () => {
-  return {
-    loadSnsNervousSystemFunctions: jest.fn().mockResolvedValue(undefined),
-  };
-});
+jest.mock("$lib/api/sns-governance.api");
 
-jest.mock("$lib/services/$public/sns-proposals.services", () => {
-  return {
-    loadSnsProposals: jest.fn().mockResolvedValue(undefined),
-  };
-});
-
-jest.mock("$lib/services/sns-filters.services", () => {
-  return {
-    loadSnsFilters: jest.fn().mockResolvedValue(undefined),
-  };
-});
+const blockedApiPaths = ["$lib/api/sns-governance.api"];
 
 describe("SnsProposals", () => {
+  blockAllCallsTo(blockedApiPaths);
+
   const nothingFound = (
     container: HTMLElement
   ): HTMLParagraphElement | undefined =>
@@ -42,35 +33,67 @@ describe("SnsProposals", () => {
       (p) => p.textContent === en.voting.nothing_found
     )[0];
 
+  const rootCanisterId = mockPrincipal;
+  const nervousFunction = nervousSystemFunctionMock;
+  const proposal = {
+    ...mockSnsProposal,
+    action: nervousFunction.id,
+  };
+
   beforeEach(() => {
+    jest.clearAllMocks();
+    snsProposalsStore.reset();
     snsQueryStore.reset();
     snsQueryStore.setData(
       snsResponseFor({
-        principal: mockPrincipal,
+        principal: rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
       })
     );
+    // Reset to default value
+    page.mock({ data: { universe: rootCanisterId.toText() } });
   });
 
   describe("logged in user", () => {
+    const proposals = [proposal];
     beforeEach(() => {
-      // Reset to default value
-      page.mock({ data: { universe: mockPrincipal.toText() } });
+      jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockResolvedValue([nervousFunction]);
     });
-
-    afterAll(() => jest.clearAllMocks());
 
     describe("Matching results", () => {
       beforeEach(() => {
-        snsProposalsStore.reset();
+        jest
+          .spyOn(governanceApi, "queryProposals")
+          .mockResolvedValue(proposals);
       });
 
-      it("should load proposals and nervous system functions functions", () => {
-        render(SnsProposals);
+      it("should load nervous system functions functions", async () => {
+        const { queryByTestId } = render(SnsProposals);
 
-        expect(loadSnsNervousSystemFunctions).toBeCalled();
-        expect(loadSnsProposals).toBeCalled();
-        expect(loadSnsFilters).toBeCalled();
+        await waitFor(() =>
+          expect(queryByTestId("proposal-card")).toBeInTheDocument()
+        );
+
+        expect(queryByTestId("proposal-topic").innerHTML).toMatch(
+          nervousFunction.name
+        );
+      });
+
+      it("should load decision status filters", async () => {
+        const { getByTestId, queryAllByTestId } = render(SnsProposals);
+
+        const decisionStatusButton = getByTestId("filters-by-status");
+        expect(decisionStatusButton).toBeInTheDocument();
+
+        fireEvent.click(decisionStatusButton);
+
+        await waitFor(() =>
+          expect(getByTestId("filter-modal")).toBeInTheDocument()
+        );
+
+        expect(queryAllByTestId("checkbox").length).toBeGreaterThan(0);
       });
 
       it("should render a spinner while searching proposals", async () => {
@@ -81,17 +104,12 @@ describe("SnsProposals", () => {
         );
       });
 
-      it("should render proposals", () => {
-        const proposals = [mockSnsProposal];
-        snsProposalsStore.setProposals({
-          rootCanisterId: mockPrincipal,
-          proposals,
-          certified: true,
-          completed: true,
-        });
+      it("should render proposals", async () => {
+        const { queryAllByTestId, queryByTestId } = render(SnsProposals);
 
-        const { queryAllByTestId } = render(SnsProposals);
-
+        await waitFor(() =>
+          expect(queryByTestId("proposals-loading")).not.toBeInTheDocument()
+        );
         expect(queryAllByTestId("proposal-card").length).toBe(proposals.length);
       });
 
@@ -106,47 +124,103 @@ describe("SnsProposals", () => {
 
     describe("No results", () => {
       beforeEach(() => {
-        // Reset to default value
-        page.mock({ data: { universe: mockPrincipal.toText() } });
+        jest.spyOn(governanceApi, "queryProposals").mockResolvedValue([]);
       });
 
       it("should render not found text", async () => {
-        snsProposalsStore.setProposals({
-          rootCanisterId: mockPrincipal,
-          proposals: [],
-          certified: true,
-          completed: true,
-        });
+        const { queryByTestId, container } = render(SnsProposals);
 
-        const { container } = render(SnsProposals);
+        await waitFor(() =>
+          expect(queryByTestId("proposals-loading")).not.toBeInTheDocument()
+        );
 
-        await waitFor(() => {
-          const p: HTMLParagraphElement | undefined = nothingFound(container);
-          expect(p).not.toBeUndefined();
-        });
+        const p: HTMLParagraphElement | undefined = nothingFound(container);
+        expect(p).not.toBeUndefined();
       });
     });
   });
 
   describe("when not logged in", () => {
-    afterAll(() => jest.clearAllMocks());
+    const proposals = [proposal];
+    beforeEach(() => {
+      jest.spyOn(governanceApi, "queryProposals").mockResolvedValue(proposals);
+      jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockResolvedValue([nervousFunction]);
+    });
 
     describe("Matching results", () => {
-      beforeEach(() => snsProposalsStore.reset());
+      it("should render proposals", async () => {
+        const { queryAllByTestId, queryByTestId } = render(SnsProposals);
 
-      it("should render proposals", () => {
-        const proposals = [mockSnsProposal];
-        snsProposalsStore.setProposals({
-          rootCanisterId: mockPrincipal,
-          proposals,
-          certified: true,
-          completed: true,
-        });
-
-        const { queryAllByTestId } = render(SnsProposals);
+        await waitFor(() =>
+          expect(queryByTestId("proposals-loading")).not.toBeInTheDocument()
+        );
 
         expect(queryAllByTestId("proposal-card").length).toBe(proposals.length);
       });
+    });
+  });
+
+  describe("filter proposals", () => {
+    const proposals = [
+      createSnsProposal({
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        proposalId: BigInt(1),
+      }),
+      createSnsProposal({
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED,
+        proposalId: BigInt(2),
+      }),
+    ];
+    beforeEach(() => {
+      jest.spyOn(governanceApi, "queryProposals").mockResolvedValue(proposals);
+      jest
+        .spyOn(governanceApi, "getNervousSystemFunctions")
+        .mockResolvedValue([nervousFunction]);
+    });
+
+    it("should filter by status", async () => {
+      const { getByTestId, queryAllByTestId, queryByTestId } =
+        render(SnsProposals);
+
+      await waitFor(() =>
+        expect(queryByTestId("proposals-loading")).not.toBeInTheDocument()
+      );
+
+      expect(queryAllByTestId("proposal-card").length).toBe(proposals.length);
+
+      const decisionStatusButton = getByTestId("filters-by-status");
+      expect(decisionStatusButton).toBeInTheDocument();
+
+      fireEvent.click(decisionStatusButton);
+
+      await waitFor(() =>
+        expect(queryByTestId("filter-modal")).toBeInTheDocument()
+      );
+
+      const checkBoxes = queryAllByTestId("checkbox");
+      expect(checkBoxes.length).toBeGreaterThan(0);
+
+      const openCheckbox = checkBoxes.find(
+        (element) =>
+          element.getAttribute("id") ===
+          String(SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN)
+      );
+      expect(openCheckbox).not.toBeUndefined();
+
+      // Select Open status checkbox
+      fireEvent.click(openCheckbox);
+
+      // Apply filters
+      fireEvent.click(getByTestId("apply-filters"));
+
+      // Wait for modal to close
+      await waitFor(() =>
+        expect(queryByTestId("filter-modal")).not.toBeInTheDocument()
+      );
+
+      expect(queryAllByTestId("proposal-card").length).toBe(1);
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -147,7 +147,6 @@ describe("SnsProposals", () => {
         rootCanisterId,
       });
       fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        identity: new AnonymousIdentity(),
         rootCanisterId,
       });
     });
@@ -194,7 +193,6 @@ describe("SnsProposals", () => {
         action: functionId,
       });
       fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        identity: new AnonymousIdentity(),
         rootCanisterId,
         id: functionId,
       });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -54,7 +54,7 @@ describe("SnsProposals", () => {
     const functionName = "test_function";
     const functionId = BigInt(3);
     beforeEach(() => {
-      fakeSnsGovernanceApi.addNervousFunctionWith({
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
         rootCanisterId,
         name: functionName,
         id: functionId,
@@ -146,7 +146,7 @@ describe("SnsProposals", () => {
         identity: new AnonymousIdentity(),
         rootCanisterId,
       });
-      fakeSnsGovernanceApi.addNervousFunctionWith({
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
       });
@@ -193,7 +193,7 @@ describe("SnsProposals", () => {
         ...proposals[1],
         action: functionId,
       });
-      fakeSnsGovernanceApi.addNervousFunctionWith({
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
         id: functionId,

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -24,5 +24,18 @@ describe("sns-filters services", () => {
         SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED
       );
     });
+
+    it("should not change filters if they are already present", async () => {
+      const decisionStatus = [];
+      snsFiltesStore.setDecisionStatus({
+        rootCanisterId: mockPrincipal,
+        decisionStatus,
+      });
+
+      await loadSnsFilters(mockPrincipal);
+
+      const projectStore = get(snsFiltesStore)[mockPrincipal.toText()];
+      expect(projectStore.decisionStatus).toHaveLength(decisionStatus.length);
+    });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
@@ -1,112 +1,162 @@
-import { snsFiltesStore } from "$lib/stores/sns-filters.store";
+import {
+  snsFiltesStore,
+  snsSelectedFiltersStore,
+} from "$lib/stores/sns-filters.store";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { Principal } from "@dfinity/principal";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-filters store", () => {
-  it("should setDecisionStatus in different projects", () => {
-    const rootCanisterId = mockPrincipal;
-    const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
-    const decisionStatus = [
-      {
-        id: "1",
-        name: "status-1",
-        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-        checked: true,
-      },
-      {
-        id: "2",
-        name: "status-2",
-        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-        checked: true,
-      },
-    ];
-    snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
-
-    const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
-    expect(projectStore.decisionStatus).toEqual(decisionStatus);
-
-    snsFiltesStore.setDecisionStatus({
-      rootCanisterId: rootCanisterId2,
-      decisionStatus,
+  describe("snsFiltersStore", () => {
+    beforeEach(() => {
+      snsFiltesStore.reset();
     });
-    const projectStore2 = get(snsFiltesStore)[rootCanisterId2.toText()];
-    expect(projectStore2.decisionStatus).toEqual(decisionStatus);
+
+    it("should setDecisionStatus in different projects", () => {
+      const rootCanisterId = mockPrincipal;
+      const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+      const decisionStatus = [
+        {
+          id: "1",
+          name: "status-1",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+          checked: true,
+        },
+        {
+          id: "2",
+          name: "status-2",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+          checked: true,
+        },
+      ];
+      snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+
+      const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
+      expect(projectStore.decisionStatus).toEqual(decisionStatus);
+
+      snsFiltesStore.setDecisionStatus({
+        rootCanisterId: rootCanisterId2,
+        decisionStatus,
+      });
+      const projectStore2 = get(snsFiltesStore)[rootCanisterId2.toText()];
+      expect(projectStore2.decisionStatus).toEqual(decisionStatus);
+    });
+
+    it("setCheckDecisionStatus should check filters in different projects", () => {
+      const rootCanisterId = mockPrincipal;
+      const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+      const decisionStatus = [
+        {
+          id: "1",
+          name: "status-1",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+          checked: false,
+        },
+        {
+          id: "2",
+          name: "status-2",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+          checked: false,
+        },
+      ];
+
+      // Project rootCanisterId
+      snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+      const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
+      expect(
+        projectStore.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(0);
+
+      const statuses = decisionStatus.map(({ value }) => value);
+      snsFiltesStore.setCheckDecisionStatus({
+        rootCanisterId,
+        checkedDecisionStatus: statuses,
+      });
+      const projectStore2 = get(snsFiltesStore)[rootCanisterId.toText()];
+      expect(
+        projectStore2.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(statuses.length);
+
+      // Project rootCanisterId2
+      snsFiltesStore.setDecisionStatus({
+        rootCanisterId: rootCanisterId2,
+        decisionStatus,
+      });
+      const projectStore3 = get(snsFiltesStore)[rootCanisterId2.toText()];
+      expect(
+        projectStore3.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(0);
+
+      snsFiltesStore.setCheckDecisionStatus({
+        rootCanisterId: rootCanisterId2,
+        checkedDecisionStatus: [
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        ],
+      });
+      const projectStore4 = get(snsFiltesStore)[rootCanisterId2.toText()];
+      expect(
+        projectStore4.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(1);
+
+      // Project 1 has not changed
+      const projectStore5 = get(snsFiltesStore)[rootCanisterId.toText()];
+      expect(
+        projectStore5.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(statuses.length);
+
+      // Uncheck from Project 2
+      snsFiltesStore.setCheckDecisionStatus({
+        rootCanisterId,
+        checkedDecisionStatus: [
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        ],
+      });
+      const projectStore6 = get(snsFiltesStore)[rootCanisterId.toText()];
+      expect(
+        projectStore6.decisionStatus.filter(({ checked }) => checked).length
+      ).toEqual(1);
+    });
   });
 
-  it("setCheckDecisionStatus should check filters in different projects", () => {
-    const rootCanisterId = mockPrincipal;
-    const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
-    const decisionStatus = [
-      {
-        id: "1",
-        name: "status-1",
-        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-        checked: false,
-      },
-      {
-        id: "2",
-        name: "status-2",
-        value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-        checked: false,
-      },
-    ];
-
-    // Project rootCanisterId
-    snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
-    const projectStore = get(snsFiltesStore)[rootCanisterId.toText()];
-    expect(
-      projectStore.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(0);
-
-    const statuses = decisionStatus.map(({ value }) => value);
-    snsFiltesStore.setCheckDecisionStatus({
-      rootCanisterId,
-      checkedDecisionStatus: statuses,
+  describe("snsSelectedFiltersStore", () => {
+    beforeEach(() => {
+      snsFiltesStore.reset();
     });
-    const projectStore2 = get(snsFiltesStore)[rootCanisterId2.toText()];
-    expect(
-      projectStore2.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(statuses.length);
+    it("should return the selected decision status filters", () => {
+      const rootCanisterId = mockPrincipal;
+      const decisionStatus = [
+        {
+          id: "1",
+          name: "status-1",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+          checked: false,
+        },
+        {
+          id: "2",
+          name: "status-2",
+          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+          checked: false,
+        },
+      ];
 
-    // Project rootCanisterId2
-    snsFiltesStore.setDecisionStatus({
-      rootCanisterId: rootCanisterId2,
-      decisionStatus,
+      // Project rootCanisterId
+      snsFiltesStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+
+      expect(
+        get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.decisionStatus
+      ).toHaveLength(0);
+
+      snsFiltesStore.setCheckDecisionStatus({
+        rootCanisterId,
+        checkedDecisionStatus: [
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+        ],
+      });
+
+      expect(
+        get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.decisionStatus
+      ).toHaveLength(1);
     });
-    const projectStore3 = get(snsFiltesStore)[rootCanisterId2.toText()];
-    expect(
-      projectStore3.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(0);
-
-    snsFiltesStore.setCheckDecisionStatus({
-      rootCanisterId: rootCanisterId2,
-      checkedDecisionStatus: [
-        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-      ],
-    });
-    const projectStore4 = get(snsFiltesStore)[rootCanisterId2.toText()];
-    expect(
-      projectStore4.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(1);
-
-    // Project 1 has not changed
-    const projectStore5 = get(snsFiltesStore)[rootCanisterId.toText()];
-    expect(
-      projectStore5.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(statuses.length);
-
-    // Uncheck from Project 2
-    snsFiltesStore.setCheckDecisionStatus({
-      rootCanisterId,
-      checkedDecisionStatus: [
-        SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-      ],
-    });
-    const projectStore6 = get(snsFiltesStore)[rootCanisterId.toText()];
-    expect(
-      projectStore6.decisionStatus.filter(({ checked }) => checked).length
-    ).toEqual(1);
   });
 });

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -1,4 +1,9 @@
-import type { SnsProposalData } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  type SnsProposalData,
+  type SnsProposalId,
+  type SnsTally,
+} from "@dfinity/sns";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 
 export const mockSnsProposal: SnsProposalData = {
@@ -43,4 +48,72 @@ export const mockSnsProposal: SnsProposalData = {
   is_eligible_for_rewards: true,
   executed_timestamp_seconds: BigInt(0),
   reward_event_end_timestamp_seconds: [],
+};
+
+const acceptedTally: SnsTally = {
+  no: BigInt(1),
+  yes: BigInt(10),
+  total: BigInt(11),
+  timestamp_seconds: BigInt(123455),
+};
+
+const rejectedTally: SnsTally = {
+  no: BigInt(10),
+  yes: BigInt(1),
+  total: BigInt(11),
+  timestamp_seconds: BigInt(123455),
+};
+
+export const createSnsProposal = ({
+  status,
+  proposalId,
+}: {
+  status: SnsProposalDecisionStatus;
+  proposalId: bigint;
+}): SnsProposalData => {
+  const id: [SnsProposalId] = [{ id: proposalId }];
+  switch (status) {
+    case SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN:
+      return {
+        ...mockSnsProposal,
+        id,
+        decided_timestamp_seconds: BigInt(0),
+      };
+    case SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED:
+      return {
+        ...mockSnsProposal,
+        id,
+        latest_tally: [acceptedTally],
+        decided_timestamp_seconds: BigInt(11223),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(0),
+      };
+    case SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED:
+      return {
+        ...mockSnsProposal,
+        id,
+        latest_tally: [acceptedTally],
+        decided_timestamp_seconds: BigInt(11223),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(112231320),
+      };
+    case SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED:
+      return {
+        ...mockSnsProposal,
+        id,
+        latest_tally: [acceptedTally],
+        decided_timestamp_seconds: BigInt(11223),
+        executed_timestamp_seconds: BigInt(112231320),
+        failed_timestamp_seconds: BigInt(0),
+      };
+    case SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_REJECTED:
+      return {
+        ...mockSnsProposal,
+        id,
+        latest_tally: [rejectedTally],
+        decided_timestamp_seconds: BigInt(11223),
+        executed_timestamp_seconds: BigInt(0),
+        failed_timestamp_seconds: BigInt(0),
+      };
+  }
 };

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -64,6 +64,12 @@ const rejectedTally: SnsTally = {
   timestamp_seconds: BigInt(123455),
 };
 
+/**
+ * Returns a proposal with the cusotmized parameters.
+ *
+ * For the status, the logic of the function is based on the code in `snsDecisionStatus` sns proposal util.
+ * Refecence: https://github.com/dfinity/ic/blob/226ab04e0984367da356bbe27c90447863d33a27/rs/sns/governance/src/proposal.rs#L717
+ */
 export const createSnsProposal = ({
   status,
   proposalId,


### PR DESCRIPTION
# Motivation

User can filter SNS proposal by decision status.

# Changes

* New derived store `snsFilteredProposalsStore` that combines the snsFiltersStore and snsProposals store to return the proposals that match the current filters.
* Change in how data is loaded in SnsProposals page. Filters and nervous functions are loaded when root canister id changes. Proposals when filters change.
* New simple derived store `snsSelectedFiltersStore` that returns the selected filters in snsFiltersStore.
* Changes in service `loadSnsProposals`. Now it reads the snsSelectedFiltersStore and applies the decision filters when asking for the proposals.

Minor change:
* Change type in snsProposals store to match current pattern.
* Service `loadSnsFilters` checks if filters are already loaded and skips if so.

# Tests

* Test new derived stores `snsFilteredProposalsStore` and `snsSelectedFiltersStore`.
* Test new logic in service `loadSnsProposals`.
* Changes in SnsProposals page test to mock only the api layer.
* New test in SnsProposals page test to test new filtering functionality.
* Test new logic in `loadSnsFilters`.
* New test helper `createSnsProposal`.