### PR TITLE
Cache rs projects separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY Cargo.lock .
 COPY Cargo.toml .
 COPY rs/backend/Cargo.toml rs/backend/Cargo.toml
 COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
-RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs && touch rs/sns_aggregator/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -rf rs/backend/src rs/sns_aggregator/src
+RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs && touch rs/sns_aggregator/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp
 # Install dfx
 WORKDIR /
 RUN DFX_VERSION="$(cat config/dfx_version)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
@@ -97,7 +97,7 @@ FROM builder AS build_nnsdapp
 ARG DFX_NETWORK=mainnet
 RUN echo "DFX_NETWORK: '$DFX_NETWORK'"
 SHELL ["bash", "-c"]
-COPY ./rs /build/rs
+COPY ./rs/backend /build/rs/backend
 COPY ./build-backend.sh /build/
 COPY ./build-rs.sh /build/
 COPY ./Cargo.toml /build/
@@ -114,7 +114,7 @@ RUN ./build-backend.sh
 #       configurable
 FROM builder AS build_aggregate
 SHELL ["bash", "-c"]
-COPY ./rs /build/rs
+COPY ./rs/sns_aggregator /build/rs/sns_aggregator
 COPY ./build-sns-aggregator.sh /build/build-sns-aggregator.sh
 COPY ./build-rs.sh /build/build-rs.sh
 COPY ./Cargo.toml /build/Cargo.toml


### PR DESCRIPTION
# Motivation
If any rust code is changed, all rust code is recompiled in Docker.  Changes in the `nns-dapp` cause the aggregator to be rebuilt and vice versa.  This is unnecessary work.

# Changes
- Keep the toy implementation of every rust project created in builder to warm the cache.
- When building a rust project, copy in only the code for that project and use the placeholder for the other project.

# Tests
See docker builds in CI