### PR TITLE
GIX-1336: Refactor restoring participation flow to project detail

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -76,6 +76,7 @@ jest.mock("./src/lib/constants/environment.constants.ts", () => ({
   ENABLE_METRICS: false,
   FORCE_CALL_STRATEGY: undefined,
   QR_CODE_RENDERED: true,
+  IS_TEST_ENV: true,
 }));
 
 global.localStorage = localStorageMock;

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import type { SnsSummary } from "$lib/types/sns";
-  import { getContext, onDestroy } from "svelte";
+  import { getContext } from "svelte";
   import { BottomSheet } from "@dfinity/gix-components";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -16,32 +16,19 @@
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
   import type { Principal } from "@dfinity/principal";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-  import {
-    cancelPollGetOpenTicket,
-    hidePollingToast,
-    restoreSnsSaleParticipation,
-  } from "$lib/services/sns-sale.services";
-  import { isSignedIn } from "$lib/utils/auth.utils";
-  import { authStore } from "$lib/stores/auth.store";
-  import {
-    getCommitmentE8s,
-    hasOpenTicketInProcess,
-  } from "$lib/utils/sns.utils";
+  import { hasOpenTicketInProcess } from "$lib/utils/sns.utils";
   import type { TicketStatus } from "$lib/types/sale";
-  import type { SaleStep } from "$lib/types/sale";
-  import SaleInProgressModal from "$lib/modals/sns/sale/SaleInProgressModal.svelte";
   import SpinnerText from "$lib/components/ui/SpinnerText.svelte";
 
-  const { store: projectDetailStore, reload } =
-    getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
+  const { store: projectDetailStore } = getContext<ProjectDetailContext>(
+    PROJECT_DETAIL_CONTEXT_KEY
+  );
 
   let lifecycle: number;
-  let swapCanisterId: Principal;
   $: ({
     swap: { lifecycle },
-    swapCanisterId,
   } =
     $projectDetailStore.summary ??
     ({
@@ -58,19 +45,12 @@
     swapCommitment: $projectDetailStore.swapCommitment,
   });
 
-  let userCommitment: undefined | bigint;
-  $: userCommitment =
-    // swapCommitment=null - not initialized yet
-    $projectDetailStore.swapCommitment === null
-      ? undefined
-      : getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
-
   let rootCanisterId: Principal | undefined;
   $: rootCanisterId = nonNullish($projectDetailStore?.summary?.rootCanisterId)
     ? $projectDetailStore?.summary?.rootCanisterId
     : undefined;
 
-  // busy if open ticket is available or not requested
+  // TODO: Receive this as props
   let status: TicketStatus = "unknown";
   $: ({ status } = hasOpenTicketInProcess({
     rootCanisterId,
@@ -80,71 +60,9 @@
   let busy = true;
   $: busy = status !== "none";
 
-  // Flag to avoid second getOpenTicket call on same page navigation
-  let loadingTicketRootCanisterId: string | undefined;
-
-  let progressStep: SaleStep | undefined = undefined;
-
-  const updateTicket = async (swapCanisterId: Principal) => {
-    // Avoid second call for the same rootCanisterId
-    if (
-      rootCanisterId === undefined ||
-      loadingTicketRootCanisterId === rootCanisterId.toText()
-    ) {
-      return;
-    }
-    if (isNullish(userCommitment)) {
-      // Typescript guard, user commitment cannot be undefined here
-      return;
-    }
-    loadingTicketRootCanisterId = rootCanisterId.toText();
-
-    const updateProgress = (step: SaleStep) => (progressStep = step);
-
-    await restoreSnsSaleParticipation({
-      rootCanisterId,
-      userCommitment,
-      swapCanisterId,
-      postprocess: reload,
-      updateProgress,
-    });
-  };
-
-  // skip ticket update if
-  // - the sns is not open
-  // - the user is not sign in
-  // - user commitment information is not loaded
-  // - project swap canister id is not loaded, needed for the ticket call
-  $: if (
-    lifecycle === SnsSwapLifecycle.Open &&
-    isSignedIn($authStore.identity) &&
-    nonNullish(userCommitment) &&
-    nonNullish(swapCanisterId)
-  ) {
-    updateTicket(swapCanisterId);
-  }
-
   let userHasParticipatedToSwap = false;
   $: userHasParticipatedToSwap = hasUserParticipatedToSwap({
     swapCommitment: $projectDetailStore.swapCommitment,
-  });
-
-  onDestroy(() => {
-    if (rootCanisterId === undefined) {
-      return;
-    }
-
-    // remove the ticket to stop sale-participation-retry from another pages because of the non-obvious UX
-    snsTicketsStore.setTicket({
-      rootCanisterId,
-      ticket: undefined,
-    });
-    // TODO: Improve cancellatoin of actions onDestroy
-    // The polling was triggered by `restoreSnsSaleParticipation` call and needs to be canceled explicitly.
-    cancelPollGetOpenTicket();
-
-    // Hide toasts when moving away from the page
-    hidePollingToast();
   });
 </script>
 
@@ -187,10 +105,6 @@
       </SignInGuard>
     </div>
   </BottomSheet>
-{/if}
-
-{#if status === "open" && nonNullish(progressStep)}
-  <SaleInProgressModal {progressStep} />
 {/if}
 
 {#if showModal}

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -70,7 +70,7 @@
     <div class="actions content-cell-details">
       {#if myCommitmentIcp !== undefined}
         <div>
-          <KeyValuePair>
+          <KeyValuePair testId="sns-user-commitment">
             <ProjectUserCommitmentLabel
               slot="key"
               summary={$projectDetailStore.summary}

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -75,3 +75,5 @@ export const FORCE_CALL_STRATEGY: "query" | undefined = undefined;
 // We use a constant / environment variable here because we set it to `true` for test purpose.
 // Indeed, we are running the jest suite as if the QR code would be rendered because Jest as trouble loading the QR-code dependency and because the QR-code content is anyway covered by e2e snapshot testing in gix-cmp.
 export const QR_CODE_RENDERED = false;
+
+export const IS_TEST_ENV = process.env.NODE_ENV === "test";

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -33,105 +33,17 @@
   } from "$lib/services/sns-swap-metrics.services";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
+  import SaleInProgressModal from "$lib/modals/sns/sale/SaleInProgressModal.svelte";
+  import {
+    cancelPollGetOpenTicket,
+    hidePollingToast,
+    restoreSnsSaleParticipation,
+  } from "$lib/services/sns-sale.services";
+  import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
+  import { SaleStep } from "$lib/types/sale";
+  import { getCommitmentE8s } from "$lib/utils/sns.utils";
 
   export let rootCanisterId: string | undefined | null;
-
-  let unsubscribeWatchCommitment: () => void | undefined;
-  let unsubscribeWatchMetrics: () => void | undefined;
-  let enableWatchers = false;
-  $: enableWatchers =
-    $snsSummariesStore.find(
-      ({ rootCanisterId: rootCanister }) =>
-        rootCanister?.toText() === rootCanisterId
-    )?.swap.lifecycle === SnsSwapLifecycle.Open;
-
-  onDestroy(() => {
-    unsubscribeWatchCommitment?.();
-    unsubscribeWatchMetrics?.();
-  });
-
-  $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
-    loadCommitment({ rootCanisterId, forceFetch: false });
-  }
-
-  $: if (nonNullish(rootCanisterId) && enableWatchers) {
-    unsubscribeWatchCommitment?.();
-    unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
-  }
-
-  const reloadSnsMetrics = async ({ forceFetch }: { forceFetch: boolean }) => {
-    const swapCanisterId = $projectDetailStore?.summary
-      ?.swapCanisterId as Principal;
-
-    if (isNullish(rootCanisterId) || isNullish(swapCanisterId)) {
-      return;
-    }
-
-    await loadSnsSwapMetrics({
-      rootCanisterId: Principal.fromText(rootCanisterId),
-      swapCanisterId,
-      forceFetch,
-    });
-  };
-
-  const reload = async () => {
-    if (rootCanisterId === undefined || rootCanisterId === null) {
-      // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
-      return;
-    }
-
-    await Promise.all([
-      loadSnsTotalCommitment({ rootCanisterId, strategy: "update" }),
-      loadSnsLifecycle({ rootCanisterId }),
-      loadCommitment({ rootCanisterId, forceFetch: true }),
-      reloadSnsMetrics({ forceFetch: true }),
-    ]);
-  };
-
-  const projectDetailStore = writable<ProjectDetailStore>({
-    summary: null,
-    swapCommitment: null,
-    totalTokensSupply: null,
-  });
-
-  debugSelectedProjectStore(projectDetailStore);
-
-  setContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY, {
-    store: projectDetailStore,
-    reload,
-  });
-
-  let swapCanisterId: Principal | undefined;
-  $: if (
-    nonNullish(swapCanisterId) &&
-    nonNullish(rootCanisterId) &&
-    enableWatchers
-  ) {
-    reloadSnsMetrics({ forceFetch: false });
-    unsubscribeWatchMetrics?.();
-
-    unsubscribeWatchMetrics = watchSnsMetrics({
-      rootCanisterId: Principal.fromText(rootCanisterId),
-      swapCanisterId: swapCanisterId,
-    });
-  }
-
-  const loadCommitment = ({
-    rootCanisterId,
-    forceFetch,
-  }: {
-    rootCanisterId: string;
-    forceFetch: boolean;
-  }) =>
-    loadSnsSwapCommitment({
-      rootCanisterId,
-      onError: () => {
-        // Set to not found
-        $projectDetailStore.swapCommitment = undefined;
-        goBack();
-      },
-      forceFetch,
-    });
 
   const goBack = async (): Promise<void> => {
     if (!browser) {
@@ -141,86 +53,221 @@
     return goto(AppPath.Launchpad, { replaceState: true });
   };
 
-  // TODO: Change to a `let` that is recalculated when the store changes
-  const setProjectStore = (rootCanisterId: string) => {
-    // Check project summaries are loaded in store
-    if ($snsSummariesStore.length === 0) {
+  /////////////////////////////////
+  // Set up and update the context
+  /////////////////////////////////
+
+  // Used to reload the data after a new swap participation
+  const reload = async () => {
+    if (isNullish(rootCanisterId) || isNullish(swapCanisterId)) {
+      // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
       return;
     }
-    // Check valid rootCanisterId
-    try {
-      if (rootCanisterId !== undefined) {
-        Principal.fromText(rootCanisterId);
-      }
-    } catch (error: unknown) {
-      // set values as not found
-      $projectDetailStore.summary = undefined;
-      $projectDetailStore.swapCommitment = undefined;
-      $projectDetailStore.totalTokensSupply = undefined;
-      return;
-    }
-    $projectDetailStore.summary =
-      rootCanisterId !== undefined
-        ? $snsSummariesStore.find(
-            ({ rootCanisterId: rootCanister }) =>
-              rootCanister?.toText() === rootCanisterId
-          )
-        : undefined;
 
-    $projectDetailStore.swapCommitment =
-      rootCanisterId !== undefined
-        ? $snsSwapCommitmentsStore?.find(
-            (item) =>
-              item?.swapCommitment?.rootCanisterId?.toText() === rootCanisterId
-          )?.swapCommitment
-        : undefined;
-
-    $projectDetailStore.totalTokensSupply =
-      rootCanisterId !== undefined
-        ? $snsTotalSupplyTokenAmountStore[rootCanisterId]
-        : undefined;
+    await Promise.all([
+      loadSnsTotalCommitment({ rootCanisterId, strategy: "update" }),
+      loadSnsLifecycle({ rootCanisterId }),
+      loadSnsSwapCommitment({
+        rootCanisterId,
+        onError: () => {
+          // Set to not found
+          $projectDetailStore.swapCommitment = undefined;
+        },
+        forceFetch: true,
+      }),
+      loadSnsSwapMetrics({
+        forceFetch: true,
+        rootCanisterId: Principal.fromText(rootCanisterId),
+        swapCanisterId,
+      }),
+    ]);
   };
 
+  const projectDetailStore = writable<ProjectDetailStore>({
+    summary: null,
+    swapCommitment: null,
+    totalTokensSupply: null,
+  });
+  debugSelectedProjectStore(projectDetailStore);
+  setContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY, {
+    store: projectDetailStore,
+    reload,
+  });
+
   /**
-   * We load all the sns summaries and swap commitments on the global scale of the app. That's why we subscribe to these stores - i.e. each times they change, we can try to find the current root canister id within these data.
+   * Set up the projectDetailStore that lives in the context.
+   *
+   * We load all the sns summaries and swap commitments on the global scale of the app.
+   * That's why we subscribe to these stores - i.e. each times they change, we can try to find the current root canister id within these data.
    */
   $: $snsSummariesStore,
     $snsSwapCommitmentsStore,
     $snsTotalSupplyTokenAmountStore,
     (async () => {
-      if (rootCanisterId === undefined || rootCanisterId === null) {
+      if (isNullish(rootCanisterId)) {
         await goBack();
         return;
       }
-      setProjectStore(rootCanisterId);
-
-      // TODO: Understand why this component doesn't subscribe to the store `projectDetailStore`.
-      // Is it because it's created in this same component?
-      const summary = $snsSummariesStore.find(
+      // Check project summaries are loaded in store
+      if ($snsSummariesStore.length === 0) {
+        return;
+      }
+      // Check valid rootCanisterId
+      try {
+        Principal.fromText(rootCanisterId);
+      } catch (error: unknown) {
+        // set values as not found
+        $projectDetailStore.summary = undefined;
+        $projectDetailStore.swapCommitment = undefined;
+        $projectDetailStore.totalTokensSupply = undefined;
+        return;
+      }
+      $projectDetailStore.summary = $snsSummariesStore.find(
         ({ rootCanisterId: rootCanister }) =>
           rootCanister?.toText() === rootCanisterId
       );
-      const newSwapCanisterId = summary?.swapCanisterId;
 
-      if (newSwapCanisterId?.toText() !== swapCanisterId?.toText()) {
-        swapCanisterId = newSwapCanisterId;
-      }
+      $projectDetailStore.swapCommitment = $snsSwapCommitmentsStore?.find(
+        (item) =>
+          item?.swapCommitment?.rootCanisterId?.toText() === rootCanisterId
+      )?.swapCommitment;
+
+      $projectDetailStore.totalTokensSupply =
+        $snsTotalSupplyTokenAmountStore[rootCanisterId];
     })();
+
+  /////////////////////////////////
+  // Set up watchers and load the data in stores
+  /////////////////////////////////
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
 
-  let notFound: boolean;
-  $: notFound = $projectDetailStore.summary === undefined;
+  let enableWatchers = false;
+  $: enableWatchers =
+    $projectDetailStore?.summary?.swap.lifecycle === SnsSwapLifecycle.Open;
 
-  $: (async () => {
+  let swapCanisterId: Principal | undefined;
+  $: swapCanisterId = $projectDetailStore.summary?.swapCanisterId;
+
+  $: if (nonNullish(rootCanisterId) && isSignedIn($authStore.identity)) {
+    loadSnsSwapCommitment({
+      rootCanisterId,
+      onError: () => {
+        // Set to not found
+        $projectDetailStore.swapCommitment = undefined;
+      },
+    });
+  }
+
+  let unsubscribeWatchCommitment: () => void | undefined;
+  let unsubscribeWatchMetrics: () => void | undefined;
+  $: if (
+    nonNullish(rootCanisterId) &&
+    enableWatchers &&
+    nonNullish(swapCanisterId)
+  ) {
+    unsubscribeWatchCommitment?.();
+    unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
+
+    // We load the metrics to have them initially available before setInterval starts
+    loadSnsSwapMetrics({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+      swapCanisterId,
+      forceFetch: false,
+    });
+    unsubscribeWatchMetrics?.();
+    unsubscribeWatchMetrics = watchSnsMetrics({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+      swapCanisterId: swapCanisterId,
+    });
+  }
+
+  /////////////////////////////////
+  // Restore participation
+  /////////////////////////////////
+
+  // Flag to avoid second getOpenTicket call on same page navigation
+  let loadingTicketRootCanisterIdText: string | undefined;
+  let userCommitment: undefined | bigint;
+  $: userCommitment = getCommitmentE8s($projectDetailStore.swapCommitment);
+  let progressStep: SaleStep | undefined = undefined;
+  $: {
+    if (nonNullish(progressStep) && progressStep === SaleStep.DONE) {
+      // Leave some time to the user to see the final step being done
+      setTimeout(() => {
+        progressStep = undefined;
+      }, 1000);
+    }
+  }
+
+  // skip ticket update if
+  // - the sns is not open
+  // - the user is not sign in
+  // - user commitment information is not loaded
+  // - project swap canister id is not loaded, needed for the ticket call
+  // - no root canister id
+  // - ticket already in progress for the same root canister id
+  $: if (
+    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Open &&
+    isSignedIn($authStore.identity) &&
+    nonNullish(userCommitment) &&
+    nonNullish(swapCanisterId) &&
+    nonNullish(rootCanisterId) &&
+    loadingTicketRootCanisterIdText !== rootCanisterId
+  ) {
+    loadingTicketRootCanisterIdText = rootCanisterId;
+
+    const updateProgress = (step: SaleStep) => (progressStep = step);
+
+    restoreSnsSaleParticipation({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+      userCommitment,
+      swapCanisterId,
+      postprocess: reload,
+      updateProgress,
+    });
+  }
+
+  /////////////////////////////////
+  // Clean up and checks
+  /////////////////////////////////
+
+  $: {
+    const notFound = $projectDetailStore.summary === undefined;
     if (notFound) {
       toastsError({
         labelKey: "error__sns.project_not_found",
       });
 
-      await goBack();
+      goBack();
     }
-  })();
+  }
+
+  onDestroy(() => {
+    unsubscribeWatchCommitment?.();
+    unsubscribeWatchMetrics?.();
+    if (isNullish(rootCanisterId)) {
+      return;
+    }
+
+    try {
+      // remove the ticket to stop sale-participation-retry from another pages because of the non-obvious UX
+      snsTicketsStore.setTicket({
+        rootCanisterId: Principal.fromText(rootCanisterId),
+        ticket: undefined,
+      });
+    } catch (error: unknown) {
+      // ignore error
+      // it can happen if the rootCanisterId is not valid
+    }
+
+    // TODO: Improve cancellatoin of actions onDestroy
+    // The polling was triggered by `restoreSnsSaleParticipation` call and needs to be canceled explicitly.
+    cancelPollGetOpenTicket();
+
+    // Hide toasts when moving away from the page
+    hidePollingToast();
+  });
 </script>
 
 <main>
@@ -239,6 +286,10 @@
     </div>
   </div>
 </main>
+
+{#if nonNullish(progressStep)}
+  <SaleInProgressModal {progressStep} />
+{/if}
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -48,6 +48,8 @@
 
   const goBack = async (): Promise<void> => {
     // We want `goto` to be called only in the browser or in the test environment
+    // Weirdly enough, the build step failed when I didn't have the `browser` check.
+    // TODO: Find out why and fix it. It should not be needed.
     if (browser || IS_TEST_ENV) {
       goto(AppPath.Launchpad, { replaceState: true });
     }
@@ -60,7 +62,7 @@
   // Used to reload the data after a new swap participation
   const reload = async () => {
     if (isNullish(rootCanisterId) || isNullish(swapCanisterId)) {
-      // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
+      // We cannot reload data for an undefined rootCanisterd or swapCanisterId but we silent the error here because it most probably means that the user has already navigated away of the detail route
       return;
     }
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -144,8 +144,8 @@
 
   $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
 
-  let enableWatchers = false;
-  $: enableWatchers =
+  let enableOpenProjectWatchers = false;
+  $: enableOpenProjectWatchers =
     $projectDetailStore?.summary?.swap.lifecycle === SnsSwapLifecycle.Open;
 
   let swapCanisterId: Principal | undefined;
@@ -171,7 +171,7 @@
       forceFetch: false,
     });
 
-    if (enableWatchers) {
+    if (enableOpenProjectWatchers) {
       unsubscribeWatchCommitment?.();
       unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
 
@@ -192,15 +192,12 @@
   let userCommitment: undefined | bigint;
   $: userCommitment = getCommitmentE8s($projectDetailStore.swapCommitment);
   let progressStep: SaleStep | undefined = undefined;
-  $: {
-    if (nonNullish(progressStep) && progressStep === SaleStep.DONE) {
-      // Leave some time to the user to see the final step being done
-      setTimeout(() => {
-        progressStep = undefined;
-      }, 1000);
-    }
+  $: if (nonNullish(progressStep) && progressStep === SaleStep.DONE) {
+    // Leave some time to the user to see the final step being done
+    setTimeout(() => {
+      progressStep = undefined;
+    }, 1000);
   }
-
   // skip ticket update if
   // - the sns is not open
   // - the user is not sign in

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -41,11 +41,16 @@
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
   import { SaleStep } from "$lib/types/sale";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
+  import { browser } from "$app/environment";
+  import { IS_TEST_ENV } from "$lib/constants/environment.constants";
 
   export let rootCanisterId: string | undefined | null;
 
   const goBack = async (): Promise<void> => {
-    return goto(AppPath.Launchpad, { replaceState: true });
+    // We want `goto` to be called only in the browser or in the test environment
+    if (browser || IS_TEST_ENV) {
+      goto(AppPath.Launchpad, { replaceState: true });
+    }
   };
 
   /////////////////////////////////

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -4,7 +4,7 @@
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
 import {
-  cancelPollGetOpenTicket,
+  cancelPollOpenTicket,
   restoreSnsSaleParticipation,
   type ParticipateInSnsSaleParameters,
 } from "$lib/services/sns-sale.services";
@@ -43,7 +43,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
       }
     ),
   hidePollingToast: jest.fn().mockResolvedValue(undefined),
-  cancelPollGetOpenTicket: jest.fn().mockResolvedValue(undefined),
+  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe("ParticipateButton", () => {
@@ -245,11 +245,11 @@ describe("ParticipateButton", () => {
         Component: ParticipateButton,
       });
 
-      expect(cancelPollGetOpenTicket).not.toBeCalled();
+      expect(cancelPollOpenTicket).not.toBeCalled();
 
       unmount();
 
-      expect(cancelPollGetOpenTicket).toBeCalled();
+      expect(cancelPollOpenTicket).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,15 +3,9 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
-import {
-  cancelPollOpenTicket,
-  restoreSnsSaleParticipation,
-  type ParticipateInSnsSaleParameters,
-} from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-import { SaleStep } from "$lib/types/sale";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
 import {
@@ -34,18 +28,6 @@ import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 
-jest.mock("$lib/services/sns-sale.services", () => ({
-  restoreSnsSaleParticipation: jest
-    .fn()
-    .mockImplementation(
-      ({ updateProgress }: ParticipateInSnsSaleParameters) => {
-        updateProgress(SaleStep.INITIALIZATION);
-      }
-    ),
-  hidePollingToast: jest.fn().mockResolvedValue(undefined),
-  cancelPollOpenTicket: jest.fn().mockResolvedValue(undefined),
-}));
-
 describe("ParticipateButton", () => {
   const { ticket: testTicket } = snsTicketMock({
     rootCanisterId: rootCanisterIdMock,
@@ -61,7 +43,6 @@ describe("ParticipateButton", () => {
       authStoreMock.next({
         identity: mockIdentity,
       });
-      (restoreSnsSaleParticipation as jest.Mock).mockClear();
       snsTicketsStore.reset();
       jest.clearAllMocks();
     });
@@ -146,8 +127,6 @@ describe("ParticipateButton", () => {
         Component: ParticipateButton,
       });
 
-      expect(restoreSnsSaleParticipation).toBeCalledTimes(1);
-
       await waitFor(() =>
         expect(getByTestId("connecting_sale_canister")).not.toBeNull()
       );
@@ -155,45 +134,13 @@ describe("ParticipateButton", () => {
       expect(queryByTestId("sns-project-participate-button")).toBeNull();
     });
 
-    it("should show progress modal if user has an open ticket", async () => {
-      snsTicketsStore.setTicket({
-        rootCanisterId: rootCanisterIdMock,
-        ticket: testTicket,
-      });
-
-      const { getByTestId } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ParticipateButton,
-      });
-
-      expect(restoreSnsSaleParticipation).toBeCalledTimes(1);
-
-      await waitFor(() =>
-        expect(getByTestId("sale-in-progress-modal")).not.toBeNull()
-      );
-    });
-
-    it("should not show progress modal if user has no no ticket", async () => {
-      snsTicketsStore.setNoTicket(rootCanisterIdMock);
-
-      const { getByTestId } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ParticipateButton,
-      });
-
-      expect(() => getByTestId("sale-in-progress-modal")).toThrow();
-    });
-
-    it("should display spinner and hide button when there is loading", async () => {
+    it("should display spinner and hide button when there is loading ticket", async () => {
       const { queryByTestId, getByTestId, container } = renderContextCmp({
         summary: summaryForLifecycle(SnsSwapLifecycle.Open),
         swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
         Component: ParticipateButton,
       });
 
-      expect(restoreSnsSaleParticipation).toBeCalledTimes(1);
       expect(container.querySelector("svg.small")).toBeInTheDocument();
       expect(getByTestId("connecting_sale_canister")).not.toBeNull();
       expect(queryByTestId("sns-project-participate-button")).toBeNull();
@@ -213,7 +160,6 @@ describe("ParticipateButton", () => {
       ) as HTMLButtonElement;
 
       await waitFor(() => expect(button.getAttribute("disabled")).toBeNull());
-      expect(restoreSnsSaleParticipation).toBeCalled();
     });
 
     it("should disable button if user has committed max already", () => {
@@ -236,20 +182,6 @@ describe("ParticipateButton", () => {
         "sns-project-participate-button"
       ) as HTMLButtonElement;
       expect(button.getAttribute("disabled")).not.toBeNull();
-    });
-
-    it("should cancel polling open ticket on destroy", async () => {
-      const { unmount } = renderContextCmp({
-        summary: mockSnsFullProject.summary,
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ParticipateButton,
-      });
-
-      expect(cancelPollOpenTicket).not.toBeCalled();
-
-      unmount();
-
-      expect(cancelPollOpenTicket).toBeCalled();
     });
   });
 


### PR DESCRIPTION
# Motivation

Move logic to restore participation from the button component to the page component.

There is no new functionality in this PR. This is just refactoring.

# Changes

Main changes
* Move logic to restore participation from ParticipateButton to ProjectDetail.
* Refactor and organize the code in ProjectDetail.svelte to make it more understandable.
* It's worth taking a look at the ProjectDetail.svelte alone instead of the changes to better understand the flow. I'd like to simplify a bit this, but that will come in another PR.

# Tests

* In ParticipateButton, I removed all the tests regarding the restoring participation flow.
* In ProjectDetail page, I mocked apis instead of service and adapted tests to it.
* Main and biggest test: make sure that the commitment is updated if there is an open ticket in ProjectDetail page.
