### PR TITLE
Create SNSs in parallel

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -89,11 +89,7 @@ jobs:
       - name: Create more SNSs
         run: |
           cd "$( dirname "$(command -v snsdemo)" )/.."
-          seq 11 | while read -r line ; do
-            dfx identity use snsdemo8 || true
-            dfx-sns-whitelist-me
-            dfx-sns-demo-mksns
-          done
+          ./bin/dfx-sns-demo-mksns-parallel --num_sns 11 --majority snsdemo8
       - name: Make the aggregator collect data quickly
         run: dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 1000; fast_interval_ms = 1_000_000_000; })'
       - name: Wait for the aggregator to get data

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -88,8 +88,7 @@ jobs:
         run: dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 1000000; fast_interval_ms = 1_000_000_000; })'
       - name: Create more SNSs
         run: |
-          cd "$( dirname "$(command -v snsdemo)" )/.."
-          ./bin/dfx-sns-demo-mksns-parallel --num_sns 11 --majority snsdemo8
+          dfx-sns-demo-mksns-parallel --num_sns 11 --majority snsdemo8
       - name: Make the aggregator collect data quickly
         run: dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 1000; fast_interval_ms = 1_000_000_000; })'
       - name: Wait for the aggregator to get data


### PR DESCRIPTION
# Motivation
Faster CI.  There are two things that take a lot of time in the current CI.  One of those is creating many SNS for the aggregator test.

# Changes
- Use the snsdemo command that creates SNSs in parallel

# Tests
This is a change to a test; see CI for the result...

In particular, at present the aggregator test currently takes between 18 and 21 minutes.  That includes several other steps but 7m of that is creating 11 SNSs.  If successful, this PR should take a few minutes off that.  It is hard to estimate how much less as the github runners are small single core VMs and that limits the value of running things in parallel.

Result: The aggregator test took 14 minutes, so the speedup is worthwhile.