### PR TITLE
Chore: Add swapCanisterId ro `participateInSnsSale`

### DIFF
--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -58,6 +58,7 @@ import type {
 } from "@dfinity/sns/dist/candid/sns_swap";
 import type { E8s } from "@dfinity/sns/dist/types/types/common";
 import {
+  assertNonNullish,
   fromDefinedNullable,
   fromNullable,
   isNullish,
@@ -466,8 +467,10 @@ export const initiateSnsSaleParticipation = async ({
     });
 
     const swapCanisterId = project?.summary.swapCanisterId;
+    // Edge case: `initiateSnsSaleParticipation` can't be called if there is no swap canister id
+    assertNonNullish(swapCanisterId);
     const ticket = get(snsTicketsStore)[rootCanisterId?.toText()]?.ticket;
-    if (nonNullish(ticket) && nonNullish(swapCanisterId)) {
+    if (nonNullish(ticket)) {
       // Step 2. to finish
       const { success } = await participateInSnsSale({
         rootCanisterId,

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -115,6 +115,7 @@ describe("sns-api", () => {
   const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
   const spyOnToastsHide = jest.spyOn(toastsStore, "toastsHide");
   const testRootCanisterId = rootCanisterIdMock;
+  const swapCanisterId = swapCanisterIdMock;
   const testSnsTicket = snsTicketMock({
     rootCanisterId: testRootCanisterId,
     owner: mockPrincipal,
@@ -942,6 +943,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
@@ -972,6 +974,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
@@ -1000,6 +1003,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
@@ -1029,6 +1033,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
@@ -1072,6 +1077,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
@@ -1113,6 +1119,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1146,6 +1153,7 @@ describe("sns-api", () => {
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: updateProgressSpy,
@@ -1178,6 +1186,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1199,6 +1208,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1222,6 +1232,7 @@ describe("sns-api", () => {
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
+          swapCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1255,6 +1266,7 @@ describe("sns-api", () => {
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
+          swapCanisterId,
           userCommitment: 0n,
           postprocess: jest.fn().mockResolvedValue(undefined),
           updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1282,6 +1294,7 @@ describe("sns-api", () => {
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1303,6 +1316,7 @@ describe("sns-api", () => {
       });
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1328,6 +1342,7 @@ describe("sns-api", () => {
       });
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1351,6 +1366,7 @@ describe("sns-api", () => {
       });
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 7n,
         postprocess: jest.fn().mockResolvedValue(undefined),
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -1371,6 +1387,7 @@ describe("sns-api", () => {
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,
@@ -1409,6 +1426,7 @@ describe("sns-api", () => {
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
+        swapCanisterId,
         userCommitment: 0n,
         postprocess: postprocessSpy,
         updateProgress: upgradeProgressSpy,

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -44,7 +44,12 @@ import {
   mockSwap,
 } from "$tests/mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import { deployedSnsMock, swapCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import {
+  deployedSnsMock,
+  governanceCanisterIdMock,
+  ledgerCanisterIdMock,
+  swapCanisterIdMock,
+} from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import {
   advanceTime,
@@ -183,6 +188,12 @@ describe("sns-api", () => {
     });
     (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
       Promise.resolve({
+        canisterIds: {
+          rootCanisterId: rootCanisterIdMock,
+          ledgerCanisterId: ledgerCanisterIdMock,
+          governanceCanisterId: governanceCanisterIdMock,
+          swapCanisterId: swapCanisterIdMock,
+        },
         metadata: () =>
           Promise.resolve([mockQueryMetadataResponse, mockQueryTokenResponse]),
         swapState: () => Promise.resolve(mockQuerySwap),

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -44,12 +44,7 @@ import {
   mockSwap,
 } from "$tests/mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import {
-  deployedSnsMock,
-  governanceCanisterIdMock,
-  ledgerCanisterIdMock,
-  swapCanisterIdMock,
-} from "$tests/mocks/sns.api.mock";
+import { deployedSnsMock, swapCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import {
   advanceTime,
@@ -188,12 +183,6 @@ describe("sns-api", () => {
     });
     (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
       Promise.resolve({
-        canisterIds: {
-          rootCanisterId: rootCanisterIdMock,
-          ledgerCanisterId: ledgerCanisterIdMock,
-          governanceCanisterId: governanceCanisterIdMock,
-          swapCanisterId: swapCanisterIdMock,
-        },
         metadata: () =>
           Promise.resolve([mockQueryMetadataResponse, mockQueryTokenResponse]),
         swapState: () => Promise.resolve(mockQuerySwap),


### PR DESCRIPTION
# Motivation

Simplify the code in the Sns participation flow.

Add `swapCanisterId` as a parameter in swap service `participateInSnsSale`.

# Changes

* Add `swapCanisterId` param to `participateInSnsSale` sns swap service.
* Pass the new param where `participateInSnsSale` is used.

# Tests

* Fix tests after refactor.
