### PR TITLE
Chore: Fail SNS aggregator with less than 2 SNSes

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -27,6 +27,10 @@ export const loadSnsProjects = async (): Promise<void> => {
   try {
     const cachedSnses = await querySnsProjects();
     const identity = getCurrentIdentity();
+    // TODO: Remove after SNS aggregator is upgraded and persists data after upgrades.
+    if (cachedSnses.length < 2) {
+      throw new Error("SNS aggregator did not return enough projects.");
+    }
     // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
     // The SNS Aggregator gives us the canister ids of the SNS projects.
     await Promise.all(

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -13,6 +13,7 @@ import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { Principal } from "@dfinity/principal";
@@ -72,6 +73,10 @@ describe("NeuronDetail", () => {
     beforeEach(() => {
       fakeSnsAggregatorApi.addProjectWith({
         rootCanisterId: testSnsCanisterId.toText(),
+        lifecycle: SnsSwapLifecycle.Committed,
+      });
+      fakeSnsAggregatorApi.addProjectWith({
+        rootCanisterId: mockPrincipal.toText(),
         lifecycle: SnsSwapLifecycle.Committed,
       });
 

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -115,7 +115,7 @@ describe("SNS public services", () => {
       const spyQuerySnsProjects = jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, { ...aggregatorSnsMock }])
+          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
         );
 
       await loadSnsProjects();
@@ -136,7 +136,7 @@ describe("SNS public services", () => {
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, { ...aggregatorSnsMock }])
+          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
         );
 
       await loadSnsProjects();
@@ -180,7 +180,7 @@ describe("SNS public services", () => {
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, { ...aggregatorSnsMock }])
+          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
         );
 
       await loadSnsProjects();

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -5,6 +5,7 @@ import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
 import { mockAccountDetails } from "$tests/mocks/accounts.store.mock";
+import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
@@ -29,7 +30,9 @@ describe("app-services", () => {
 
     jest.spyOn(console, "error").mockImplementation(() => undefined);
 
-    jest.spyOn(aggregatorApi, "querySnsProjects").mockResolvedValue([]);
+    jest
+      .spyOn(aggregatorApi, "querySnsProjects")
+      .mockResolvedValue([aggregatorSnsMock, aggregatorSnsMock]);
   });
 
   it("should init Nns", async () => {


### PR DESCRIPTION
# Motivation

Current SNS Aggregator doesn't persist data between upgrades. Therefore, it might be that for a few minutes the users of the NNS Dapp do not see OC and SNS-1 in the UI.

As a temporary solution, we'll revert to the fallback if the number of projects returned from the aggregator is less than 2.

# Changes

* Add a check after receiving the response from the aggregator. If less than 2 projects, raise an error to use the fallback.

# Tests

* Fix tests so that they don't run into the issue of less than 2.
* Add a test case to check that the fallback is used in case the number of SNSes is less than 2.
