### PR TITLE
feat: display BTC estimated amount received

### DIFF
--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
-  import {formatToken, numberToE8s} from "$lib/utils/token.utils";
+  import { formatToken, numberToE8s } from "$lib/utils/token.utils";
 
   export let amount: number | undefined = undefined;
   export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
@@ -18,7 +18,9 @@
 
 <p data-tid="bitcoin-estimated-amount" class="description">
   {$i18n.accounts.estimated_amount_received}:
-  <span class="value">{formatToken({ value: estimatedAmount, detailed: true})}</span>
+  <span class="value" data-tid="bitcoin-estimated-amount-value"
+    >{formatToken({ value: estimatedAmount, detailed: true })}</span
+  >
   <span class="label">{$i18n.ckbtc.btc}</span>
 </p>
 

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -6,10 +6,13 @@
   export let amount: number | undefined = undefined;
   export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
 
+  let amountE8s = BigInt(0);
+  $: amountE8s = nonNullish(amount) ? numberToE8s(amount) : BigInt(0);
+
   let estimatedAmount = BigInt(0);
   $: estimatedAmount =
-    nonNullish(bitcoinEstimatedFee) && nonNullish(amount) && amount > bitcoinEstimatedFee
-      ? numberToE8s(amount) - bitcoinEstimatedFee
+    nonNullish(bitcoinEstimatedFee) && amountE8s > bitcoinEstimatedFee
+      ? amountE8s - bitcoinEstimatedFee
       : BigInt(0);
 </script>
 

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { nonNullish } from "@dfinity/utils";
+  import { i18n } from "$lib/stores/i18n";
+  import {formatToken, numberToE8s} from "$lib/utils/token.utils";
+
+  export let amount: number | undefined = undefined;
+  export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
+
+  let estimatedAmount = BigInt(0);
+  $: estimatedAmount =
+    nonNullish(bitcoinEstimatedFee) && nonNullish(amount) && amount > bitcoinEstimatedFee
+      ? numberToE8s(amount) - bitcoinEstimatedFee
+      : BigInt(0);
+</script>
+
+<p data-tid="bitcoin-estimated-amount" class="description">
+  {$i18n.accounts.estimated_amount_received}:
+  <span class="value">{formatToken({ value: estimatedAmount, detailed: true})}</span>
+  <span class="label">{$i18n.ckbtc.btc}</span>
+</p>
+
+<style lang="scss">
+  p {
+    text-align: right;
+    padding-top: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -224,7 +224,8 @@
     "network_btc_mainnet": "Bitcoin (BTC)",
     "network_btc_testnet": "Bitcoin (Testnet BTC)",
     "select_network": "Select network",
-    "estimated_bitcoin_transaction_fee": "Estimated Bitcoin network transaction fee",
+    "estimated_bitcoin_transaction_fee": "Estimated Bitcoin network fee (deducted)",
+    "estimated_amount_received": "Estimated amount received",
     "receive_account": "Account"
   },
   "neurons": {

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -23,6 +23,7 @@
   import ConvertBtcInProgress from "$lib/components/accounts/ConvertBtcInProgress.svelte";
   import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
   import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
+  import BitcoinEstimatedAmountReceived from "$lib/components/accounts/BitcoinEstimatedAmountReceived.svelte";
 
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
@@ -156,13 +157,16 @@
       })}
     {/if}
   </p>
-  <BitcoinEstimatedFee
-    slot="additional-info-form"
-    {selectedNetwork}
-    amount={userAmount}
-    minterCanisterId={canisters.minterCanisterId}
-    bind:bitcoinEstimatedFee
-  />
+  <svelte:fragment slot="additional-info-form">
+    <BitcoinEstimatedFee
+      {selectedNetwork}
+      amount={userAmount}
+      minterCanisterId={canisters.minterCanisterId}
+      bind:bitcoinEstimatedFee
+    />
+
+    <BitcoinEstimatedAmountReceived {bitcoinEstimatedFee} amount={userAmount} />
+  </svelte:fragment>
   <svelte:fragment slot="additional-info-review">
     <BitcoinEstimatedFeeDisplay {bitcoinEstimatedFee} />
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -234,6 +234,7 @@ interface I18nAccounts {
   network_btc_testnet: string;
   select_network: string;
   estimated_bitcoin_transaction_fee: string;
+  estimated_amount_received: string;
   receive_account: string;
 }
 

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import BitcoinEstimatedAmountReceived from "$lib/components/accounts/BitcoinEstimatedAmountReceived.svelte";
+import { render } from "@testing-library/svelte";
+import en from "../../../mocks/i18n.mock";
+
+describe("BitcoinEstimatedAmountReceived", () => {
+  describe("should display zero as estimated received amount", () => {
+    it("both props undefined", () => {
+      const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
+        props: { amount: undefined, bitcoinEstimatedFee: undefined },
+      });
+
+      const element = getByTestId("bitcoin-estimated-amount-value");
+      expect(element?.textContent ?? "").toEqual("0");
+    });
+
+    it("amount undefined", () => {
+      const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
+        props: { amount: undefined, bitcoinEstimatedFee: 1_000n },
+      });
+
+      const element = getByTestId("bitcoin-estimated-amount-value");
+      expect(element?.textContent ?? "").toEqual("0");
+    });
+
+    it("fee undefined", () => {
+      const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
+        props: { amount: 10, bitcoinEstimatedFee: undefined },
+      });
+
+      const element = getByTestId("bitcoin-estimated-amount-value");
+      expect(element?.textContent ?? "").toEqual("0");
+    });
+
+    it("amount does not cover fee", () => {
+      const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
+        props: { amount: 0.0000099, bitcoinEstimatedFee: 1_000n },
+      });
+
+      const element = getByTestId("bitcoin-estimated-amount-value");
+      expect(element?.textContent ?? "").toEqual("0");
+    });
+  });
+
+  it("should display label estimated amount received", () => {
+    const { getByText } = render(BitcoinEstimatedAmountReceived, {
+      props: { amount: undefined, bitcoinEstimatedFee: undefined },
+    });
+
+    expect(
+      getByText(en.accounts.estimated_amount_received, { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it("should display btc label", () => {
+    const { getByText } = render(BitcoinEstimatedAmountReceived, {
+      props: { amount: undefined, bitcoinEstimatedFee: undefined },
+    });
+
+    expect(getByText(en.ckbtc.btc, { exact: false })).toBeInTheDocument();
+  });
+
+  it("should display estimated received amount", () => {
+    const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
+      props: { amount: 0.0099, bitcoinEstimatedFee: 1_000n },
+    });
+
+    const element = getByTestId("bitcoin-estimated-amount-value");
+    expect(element?.textContent ?? "").toEqual("0.00989");
+  });
+});

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -240,4 +240,20 @@ describe("CkBTCTransactionModal", () => {
       en.ckbtc.transaction_success_about_thirty_minutes
     );
   });
+
+  it("should render btc estimation info on first step", async () => {
+    const result = await renderTransactionModal();
+
+    await testTransferFormTokens({
+      result,
+      selectedNetwork: TransactionNetwork.BTC_TESTNET,
+      destinationAddress: mockBTCAddressTestnet,
+      amount: "0.002",
+    });
+
+    await waitFor(() =>
+      expect(result.getByTestId("bitcoin-estimated-fee")).not.toBeNull()
+    );
+    expect(result.getByTestId("bitcoin-estimated-amount")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
# Motivation

On transaction form, rename the deducted fee and display the estimated received BTC amount.

# Changes

- new cmp to display estimated bitcoin received amount
- display 0 to avoid layout shift and value otherwise
- rename deducted fee label

# Screenshots

<img width="1536" alt="Capture d’écran 2023-03-20 à 14 26 29" src="https://user-images.githubusercontent.com/16886711/226361149-c0b70b4d-c144-4f1a-a8d7-e15be75e0f1f.png">
<img width="1536" alt="Capture d’écran 2023-03-20 à 14 26 36" src="https://user-images.githubusercontent.com/16886711/226361172-10678099-d22a-4e2d-8c17-2024611b4684.png">
<img width="1536" alt="Capture d’écran 2023-03-20 à 14 26 43" src="https://user-images.githubusercontent.com/16886711/226361175-5532f777-248c-49de-86ea-dfafc665a00f.png">
<img width="1536" alt="Capture d’écran 2023-03-20 à 14 26 49" src="https://user-images.githubusercontent.com/16886711/226361182-cc1904f9-8f9f-4678-9b27-5bf0824cccaa.png">

