### PR TITLE
Benchmark docker build

### DIFF
--- a/scripts/benchmark-docker-build
+++ b/scripts/benchmark-docker-build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+echo "Populate docker cache - time here is irrelevant"
+chronic ./scripts/docker-build
+
+echo "Time a change to the frontend"
+echo >>frontend/src/app.html
+time chronic ./scripts/docker-build
+
+echo "Time a change to the backend"
+echo >>rs/backend/src/main.rs
+time chronic ./scripts/docker-build
+
+echo "Time a change to the aggregator"
+echo >>rs/sns_aggregator/src/lib.rs
+time chronic ./scripts/docker-build

--- a/scripts/benchmark-docker-build
+++ b/scripts/benchmark-docker-build
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-echo "Populate docker cache - time here is irrelevant"
-chronic ./scripts/docker-build
+echo "Populate docker cache - time here is what end users feel when they want to verify your build."
+echo "For the full experience, wipe yor cache before you start."
+time chronic ./scripts/docker-build
+echo
 
 echo "Time a change to the frontend"
 echo >>frontend/src/app.html
 time chronic ./scripts/docker-build
+echo
 
 echo "Time a change to the backend"
 echo >>rs/backend/src/main.rs
 time chronic ./scripts/docker-build
+echo
 
 echo "Time a change to the aggregator"
 echo >>rs/sns_aggregator/src/lib.rs
 time chronic ./scripts/docker-build
+echo


### PR DESCRIPTION
# Motivation
When trying to make something faster, it helps to have a benchmark, even if it is a very simple one.

# Changes
- Add a script that measures how long it takes for docker build to complete with various changes.

# Tests
None.  This is purely for local use.  I am using this locally.