### PR TITLE
Factor out the wasm comparison test

### DIFF
--- a/scripts/dfx-canister-check-wasm-hash
+++ b/scripts/dfx-canister-check-wasm-hash
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Checks that a deployed canister's hash matches a local WASM.
+	If a deployment succeeded, the wasms must match.
+
+	This will not detect whether the canister arguments were as expected.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=c long=canister desc="The canister name or ID" variable=DFX_CANISTER
+clap.define short=w long=wasm desc="The path to the local wasm file" variable=DFX_WASM
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+set -euo pipefail
+
+# If the location of the wasm was not supplied, get the default location specified in dfx.json
+DFX_WASM="${DFX_WASM:-$(n="$DFX_CANISTER" jq -r '.canisters[env.n].wasm' dfx.json)}"
+test -e "${DFX_WASM:-}" || {
+  echo "ERROR:  Wasm not found at '${DFX_WASM:-}'"
+  echo "        Please check and specify the correct path."
+  exit 1
+} >&2
+
+build_hash="$(sha256sum "$DFX_WASM" | awk '{print $1}')"
+deployed_hash="$(dfx canister info "$DFX_CANISTER" --network "$DFX_NETWORK" | awk '/Module hash/{print $3}')"
+if [[ "0x$build_hash" == "$deployed_hash" ]]; then
+  echo "Check passed: Installed $DFX_CANISTER matches local wasm."
+else
+  {
+    echo "ERROR: Deployed $DFX_CANISTER hash does not match."
+    echo "Local build: 0x$build_hash"
+    echo "Deployed:    $deployed_hash"
+    exit 1
+  } >&2
+fi

--- a/scripts/dfx-nns-deploy-custom
+++ b/scripts/dfx-nns-deploy-custom
@@ -46,17 +46,5 @@ esac
 
 : "Verify that deployment has the expected canisters"
 for canister_name in nns-dapp internet_identity; do
-  wasm="$(n="$canister_name" jq -r '.canisters[env.n].wasm' dfx.json)"
-  build_hash="$(sha256sum "$wasm" | awk '{print $1}')"
-  deployed_hash="$(dfx canister info "$canister_name" | awk '/Module hash/{print $3}')"
-  if [[ "0x$build_hash" == "$deployed_hash" ]]; then
-    echo "Check passed: Installed $canister_name matches local wasm."
-  else
-    {
-      echo "ERROR: Deployed $canister_name hash does not match."
-      echo "Local build: 0x$build_hash"
-      echo "Deployed:    $deployed_hash"
-      exit 1
-    } >&2
-  fi
+  "$SOURCE_DIR/dfx-canister-check-wasm-hash" --canister "$canister_name"
 done

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -35,6 +35,7 @@ get_prod_wasm() {
 # Installs the current build of nns-dapp
 upgrade_nnsdapp() {
   dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade
+  scripts/dfx-canister-check-wasm-hash --wasm "$1" --canister nns-dapp
 }
 
 echo "Getting or building the wasm..."


### PR DESCRIPTION
# Motivation
Whenever deploying, it is useful, and sometimes important, to verify that the deployment succeeded in updating the wasm.  The testnet deployment script performs this check.  Why not make the test more generally available?

# Changes
- Factor out the wasm hash comparison check into a standalone script.
- Call the script in the downgrade-upgrade test.
  - It can probably be used profitably in many more places, I have looked only in the places that seemed most important to me.  Further suggestions are welcome but may be implemented in later PRs.

# Tests
- Test in production, of course:
  - Check out tags/prod
  - `./scripts/docker-build`
  - Verify that mainnet has the same wasm:
```
1e3e3bc28177e8665fc3b87f7fe143fae784dd5a99660f8c143aeb80f0ed820d  assets.tar.xz
87743bc2e1ed4c1739bd2073fcb54674ed2db2fe1022e3e7a945fb803bfaf72f  nns-dapp.wasm
4e3cbfdb8377bd2e4d6a43b622d74b97a39c394ebd3c454664c390676cb528fa  sns_aggregator.wasm
FIN
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (2:21)$ /home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash --canister nns-dapp --network ic
/home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash: line 26: canister_name: unbound variable
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (3:45)$ /home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash --canister nns-dapp --network ic
Error: Failed to determine id for canister 'nns-dapp'.
Caused by: Failed to determine id for canister 'nns-dapp'.
  Cannot find canister id. Please issue 'dfx canister create nns-dapp'.
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (4:20)$ /home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash --canister nns-dapp --network mainnet
Error: Failed to determine id for canister 'nns-dapp'.
Caused by: Failed to determine id for canister 'nns-dapp'.
  Cannot find canister id. Please issue 'dfx canister create nns-dapp'.
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (4:30)$ /home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash --canister nns-dapp --network mainnet
Check passed: Installed nns-dapp matches local wasm.
max@sinkpad:~/dfn/nns-dapp/branches/release-tesing (5:00)$ 
```

However the same test fails, as expected, if run on head of main:
```
80308f4886960983dab67e7cb5fce39da9ad3b3a8f053df5970fcd0efd356ad1  assets.tar.xz
d8595e1791dd43a485e90a52516c7c66c97a1b732fac51f238ad17ea2ba28ec3  nns-dapp.wasm
db7870f326cefb2af5e0bca05255050b0e4a6f0374cdc4a69d9f29ebbe450bac  sns_aggregator.wasm
FIN
max@sinkpad:~/dfn/nns-dapp (1:58)$ /home/max/dfn/nns-dapp/branches/upgrade-cycle-counter/scripts/dfx-canister-check-wasm-hash --canister nns-dapp --network mainnet
ERROR: Deployed nns-dapp hash does not match.
Local build: 0xd8595e1791dd43a485e90a52516c7c66c97a1b732fac51f238ad17ea2ba28ec3
Deployed:    0x87743bc2e1ed4c1739bd2073fcb54674ed2db2fe1022e3e7a945fb803bfaf72f
max@sinkpad:~/dfn/nns-dapp (8:00)$ 
```