### PR TITLE
Chore: Refactor getCommitment

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -92,11 +92,11 @@ export const loadSnsSwapCommitments = async (): Promise<void> => {
 export const loadSnsSwapCommitment = async ({
   rootCanisterId,
   onError,
-  forceFetch,
+  forceFetch = false,
 }: {
   rootCanisterId: string;
   onError?: () => void;
-  forceFetch: boolean;
+  forceFetch?: boolean;
 }) => {
   const swapCommitment = (get(snsSwapCommitmentsStore) ?? []).find(
     ({ swapCommitment }) =>

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -195,11 +195,21 @@ export const getSwapCanisterAccount = ({
   return accountIdentifier;
 };
 
+/**
+ * Returns `undefined` if commitment is not loaded yet.
+ * Returns `BigInt(0)` if commitment is loaded but there is no ICP amount.
+ * Returns commitment e8s if commitment is defined.
+ */
 export const getCommitmentE8s = (
   swapCommitment?: SnsSwapCommitment | null
-): bigint | undefined =>
-  fromNullable(swapCommitment?.myCommitment?.icp ?? [])?.amount_e8s ??
-  undefined;
+): bigint | undefined => {
+  if (isNullish(swapCommitment) || isNullish(swapCommitment.myCommitment)) {
+    return undefined;
+  }
+  return (
+    fromNullable(swapCommitment.myCommitment.icp ?? [])?.amount_e8s ?? BigInt(0)
+  );
+};
 
 /**
  * Tests the error message against `refresh_buyer_token` canister function.

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -245,7 +245,7 @@ describe("sns-utils", () => {
       expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
     });
 
-    it("returns commitment not loaded", () => {
+    it("returns undefined if commitment not loaded", () => {
       const noCommitment: SnsSwapCommitment = {
         rootCanisterId: mockPrincipal,
         myCommitment: undefined,

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -235,14 +235,24 @@ describe("sns-utils", () => {
       expect(getCommitmentE8s(commitment)).toEqual(commitmentE8s);
     });
 
-    it("returns undefined if no user commitment", () => {
+    it("returns 0 if no user commitment", () => {
       const commitment: SnsSwapCommitment = {
         rootCanisterId: mockPrincipal,
         myCommitment: {
           icp: [],
         },
       };
-      expect(getCommitmentE8s(commitment)).toBeUndefined();
+      expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
+    });
+
+    it("returns commitment not loaded", () => {
+      const noCommitment: SnsSwapCommitment = {
+        rootCanisterId: mockPrincipal,
+        myCommitment: undefined,
+      };
+      expect(getCommitmentE8s(noCommitment)).toBeUndefined();
+      expect(getCommitmentE8s(null)).toBeUndefined();
+      expect(getCommitmentE8s(undefined)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
# Motivation

Simplify and refactor to simplify the PR #2112 

# Changes

* Refactor sns util `getCommitment`.
* Make `forceFetch` optional in `loadSnsSwapCommitment`.

# Tests

* Test the new `getCommitment` functionality
