### PR TITLE
GIX-1426: Use more modern ic command hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ checksum = "c98b304a2657bad15bcb547625a018e13cf596676d834cfd93023395a6e2e03a"
 dependencies = [
  "candid",
  "cfg-if 1.0.0",
- "ic-cdk-macros 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.6.10",
  "ic0 0.18.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_bytes",
@@ -1641,7 +1641,7 @@ dependencies = [
  "candid",
  "cfg-if 1.0.0",
  "futures",
- "ic-cdk-macros 0.6.8 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
+ "ic-cdk-macros 0.6.8",
  "ic0 0.18.9 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
  "serde",
  "serde_bytes",
@@ -1655,7 +1655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774b653cecdd15b6ae0731cce9e655b9cb2489b88458fd80a5b48aace55dfc1d"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.6.10",
  "ic0 0.18.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_bytes",
@@ -1664,8 +1664,7 @@ dependencies = [
 [[package]]
 name = "ic-cdk-macros"
 version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb423dab7c5bf19d4abccabd2ffe35e09b9dde611d478ea3afe0347b50fa727f"
+source = "git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a#58791941b72471e09e3d9e733f2a3d4d54e52b5a"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -1677,8 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.6.8"
-source = "git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a#58791941b72471e09e3d9e733f2a3d4d54e52b5a"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -2137,7 +2137,7 @@ dependencies = [
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-cdk 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.6.10",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-icrc1-ledger",
  "ic-metrics-encoder",
@@ -2159,7 +2159,7 @@ dependencies = [
  "ic-canister-log 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-cdk 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.6.10",
  "ic-crypto-tree-hash",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-icrc1-client",
@@ -3185,6 +3185,7 @@ dependencies = [
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-cdk 0.7.3",
+ "ic-cdk-macros 0.6.10",
  "ic-certified-map 0.3.4",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=21d3a113dc765b5e5803d9ad4dc68e14880ae6a0)",
@@ -4308,7 +4309,7 @@ dependencies = [
  "candid",
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",
  "ic-cdk 0.6.10 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
- "ic-cdk-macros 0.6.8 (git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a3d4d54e52b5a)",
+ "ic-cdk-macros 0.6.8",
  "ic-certified-map 0.3.2",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=d14361f9939baaeb899106b874851ad4a0ce928b)",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4.3"
 chrono = "=0.4.19"
 
 ic-cdk = "0.7.3"
+ic-cdk-macros = "0.6.10"
 cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 dfn_candid = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }
 dfn_core = { git = "https://github.com/dfinity/ic", rev = "21d3a113dc765b5e5803d9ad4dc68e14880ae6a0" }

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -37,7 +37,7 @@ fn init() {
 /// Redundant function, never called but reqired as this is main.rs.
 fn main() {}
 
-#[export_name = "canister_pre_upgrade"]
+#[pre_upgrade]
 fn pre_upgrade() {
     STATE.with(|s| {
         let bytes = s.encode();

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -70,12 +70,8 @@ pub fn http_request(req: assets::HttpRequest) -> assets::HttpResponse {
 /// The account details contain each of the AccountIdentifiers linked to the user's account. These
 /// include all accounts controlled by the user's principal directly and also any hardware wallet
 /// accounts they have registered.
-#[export_name = "canister_query get_account"]
-pub fn get_account() {
-    over(candid, |()| get_account_impl());
-}
-
-fn get_account_impl() -> GetAccountResponse {
+#[query]
+pub fn get_account() -> GetAccountResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| match s.accounts_store.borrow().get_account(principal) {
         Some(account) => GetAccountResponse::Ok(account),

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -165,12 +165,8 @@ pub async fn get_proposal_payload(proposal_id: u64) -> Result<String, String> {
     proposals::get_proposal_payload(proposal_id).await
 }
 
-#[export_name = "canister_update add_pending_notify_swap"]
-pub fn add_pending_notify_swap() {
-    over(candid_one, add_pending_notify_swap_impl);
-}
-
-fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPendingTransactionResponse {
+#[update]
+pub fn add_pending_notify_swap(request: AddPendingNotifySwapRequest) -> AddPendingTransactionResponse {
     let caller = dfn_core::api::caller();
     STATE.with(|s| {
         if s.accounts_store

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -8,8 +8,7 @@ use crate::assets::{hash_bytes, insert_asset, Asset};
 use crate::periodic_tasks_runner::run_periodic_tasks;
 use crate::state::{StableState, State, STATE};
 use candid::CandidType;
-use dfn_candid::{candid, candid_one};
-use dfn_core::{api::trap_with, over, over_async, stable};
+use dfn_core::{api::trap_with, stable};
 use ic_cdk_macros::{heartbeat, init, post_upgrade, pre_upgrade, query, update};
 use icp_ledger::AccountIdentifier;
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -83,12 +83,8 @@ pub fn get_account() -> GetAccountResponse {
 ///
 /// Returns true if the account was created, else false (which happens if the principal already has
 /// an account).
-#[export_name = "canister_update add_account"]
-fn add_account() {
-    over(candid, |()| add_account_impl());
-}
-
-fn add_account_impl() -> AccountIdentifier {
+#[query]
+fn add_account() -> AccountIdentifier {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().add_account(principal));
     AccountIdentifier::from(principal)
@@ -98,12 +94,8 @@ fn add_account_impl() -> AccountIdentifier {
 ///
 /// The AccountIdentifier must be linked to the caller's account, else an empty Vec will be
 /// returned.
-#[export_name = "canister_query get_transactions"]
-pub fn get_transactions() {
-    over(candid_one, get_transactions_impl);
-}
-
-fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResponse {
+#[query]
+pub fn get_transactions(request: GetTransactionsRequest) -> GetTransactionsResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow().get_transactions(principal, request))
 }
@@ -113,12 +105,8 @@ fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResp
 /// This newly created account can be used to send and receive ICP and is controlled only by the
 /// user's principal (the fact that it is controlled by the same principal as the user's other
 /// ledger accounts is not derivable externally).
-#[export_name = "canister_update create_sub_account"]
-pub fn create_sub_account() {
-    over(candid_one, create_sub_account_impl);
-}
-
-fn create_sub_account_impl(sub_account_name: String) -> CreateSubAccountResponse {
+#[query]
+pub fn create_sub_account(sub_account_name: String) -> CreateSubAccountResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| {
         s.accounts_store

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -209,29 +209,27 @@ pub fn canister_heartbeat() {
 /// Add an asset to be served by the canister.
 ///
 /// Only a whitelist of assets are accepted.
-#[export_name = "canister_update add_stable_asset"]
-pub fn add_stable_asset() {
-    over(candid_one, |asset_bytes: Vec<u8>| {
-        let hash_bytes = hash_bytes(&asset_bytes);
-        match hex::encode(hash_bytes).as_str() {
-            "933c135529499e2ed6b911feb8e8824068dc545298b61b93ae813358b306e7a6" => {
-                // Canvaskit wasm.
-                insert_asset(
-                    "/assets/canvaskit/canvaskit.wasm",
-                    Asset::new_stable(asset_bytes)
-                        .with_header("content-type", "application/wasm")
-                        .with_header("content-encoding", "gzip"),
-                );
-            }
-            "12729155ff56fce7be6bb93ab2666c99fd7ff844e6c4611d144808c942b50748" => {
-                // Canvaskit.js
-                insert_asset("/assets/canvaskit/canvaskit.js", Asset::new_stable(asset_bytes));
-            }
-            unknown_hash => {
-                dfn_core::api::trap_with(&format!("Unknown asset with hash {}", unknown_hash));
-            }
+#[update]
+pub fn add_stable_asset(asset_bytes: Vec<u8>) {
+    let hash_bytes = hash_bytes(&asset_bytes);
+    match hex::encode(hash_bytes).as_str() {
+        "933c135529499e2ed6b911feb8e8824068dc545298b61b93ae813358b306e7a6" => {
+            // Canvaskit wasm.
+            insert_asset(
+                "/assets/canvaskit/canvaskit.wasm",
+                Asset::new_stable(asset_bytes)
+                    .with_header("content-type", "application/wasm")
+                    .with_header("content-encoding", "gzip"),
+            );
         }
-    })
+        "12729155ff56fce7be6bb93ab2666c99fd7ff844e6c4611d144808c942b50748" => {
+            // Canvaskit.js
+            insert_asset("/assets/canvaskit/canvaskit.js", Asset::new_stable(asset_bytes));
+        }
+        unknown_hash => {
+            dfn_core::api::trap_with(&format!("Unknown asset with hash {}", unknown_hash));
+        }
+    }
 }
 
 #[derive(CandidType)]

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -7,11 +7,11 @@ use crate::accounts_store::{
 use crate::assets::{hash_bytes, insert_asset, Asset};
 use crate::periodic_tasks_runner::run_periodic_tasks;
 use crate::state::{StableState, State, STATE};
-use candid::{candid_method, CandidType};
+use candid::CandidType;
 use dfn_candid::{candid, candid_one};
 use dfn_core::{api::trap_with, over, over_async, stable};
+use ic_cdk_macros::{heartbeat, init, post_upgrade, pre_upgrade, query, update};
 use icp_ledger::AccountIdentifier;
-use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 
 mod accounts_store;
 mod assets;

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -199,7 +199,7 @@ pub fn get_stats() -> stats::Stats {
 /// - Sync transactions from the ledger
 /// - Process any queued 'multi-part' actions (eg. staking a neuron or topping up a canister)
 /// - Prune old transactions if memory usage is too high
-#[export_name = "canister_heartbeat"]
+#[heartbeat]
 pub fn canister_heartbeat() {
     let future = run_periodic_tasks();
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -37,7 +37,7 @@ fn init() {
 /// Redundant function, never called but reqired as this is main.rs.
 fn main() {}
 
-#[pre_upgrade]
+#[export_name = "canister_pre_upgrade"]
 fn pre_upgrade() {
     STATE.with(|s| {
         let bytes = s.encode();
@@ -45,7 +45,7 @@ fn pre_upgrade() {
     });
 }
 
-#[post_upgrade]
+#[export_name = "canister_post_upgrade"]
 fn post_upgrade() {
     STATE.with(|s| {
         let bytes = stable::get();
@@ -60,7 +60,7 @@ fn post_upgrade() {
     assets::init_assets();
 }
 
-#[query]
+#[export_name = "canister_query http_request"]
 pub fn http_request() {
     over(candid_one, assets::http_request);
 }
@@ -70,7 +70,7 @@ pub fn http_request() {
 /// The account details contain each of the AccountIdentifiers linked to the user's account. These
 /// include all accounts controlled by the user's principal directly and also any hardware wallet
 /// accounts they have registered.
-#[query]
+#[export_name = "canister_query get_account"]
 pub fn get_account() {
     over(candid, |()| get_account_impl());
 }
@@ -87,7 +87,7 @@ fn get_account_impl() -> GetAccountResponse {
 ///
 /// Returns true if the account was created, else false (which happens if the principal already has
 /// an account).
-#[query]
+#[export_name = "canister_update add_account"]
 fn add_account() {
     over(candid, |()| add_account_impl());
 }
@@ -102,7 +102,7 @@ fn add_account_impl() -> AccountIdentifier {
 ///
 /// The AccountIdentifier must be linked to the caller's account, else an empty Vec will be
 /// returned.
-#[query]
+#[export_name = "canister_query get_transactions"]
 pub fn get_transactions() {
     over(candid_one, get_transactions_impl);
 }
@@ -117,7 +117,7 @@ fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResp
 /// This newly created account can be used to send and receive ICP and is controlled only by the
 /// user's principal (the fact that it is controlled by the same principal as the user's other
 /// ledger accounts is not derivable externally).
-#[query]
+#[export_name = "canister_update create_sub_account"]
 pub fn create_sub_account() {
     over(candid_one, create_sub_account_impl);
 }
@@ -134,7 +134,7 @@ fn create_sub_account_impl(sub_account_name: String) -> CreateSubAccountResponse
 /// Changes the alias given to the chosen sub account.
 ///
 /// These aliases are not visible externally or to anyone else.
-#[query]
+#[export_name = "canister_update rename_sub_account"]
 pub fn rename_sub_account() {
     over(candid_one, rename_sub_account_impl);
 }
@@ -149,7 +149,7 @@ fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccount
 /// A single hardware wallet can be linked to multiple user accounts, but in order to make calls to
 /// the IC from the account, the user must use the hardware wallet to sign each request.
 /// Some readonly calls do not require signing, eg. viewing the account's ICP balance.
-#[query]
+#[export_name = "canister_update register_hardware_wallet"]
 pub fn register_hardware_wallet() {
     over(candid_one, register_hardware_wallet_impl);
 }
@@ -164,7 +164,7 @@ fn register_hardware_wallet_impl(request: RegisterHardwareWalletRequest) -> Regi
 }
 
 /// Returns the list of canisters which the user has attached to their account.
-#[query]
+#[export_name = "canister_query get_canisters"]
 pub fn get_canisters() {
     over(candid, |()| get_canisters_impl());
 }
@@ -175,7 +175,7 @@ fn get_canisters_impl() -> Vec<NamedCanister> {
 }
 
 /// Attaches a canister to the user's account.
-#[update]
+#[export_name = "canister_update attach_canister"]
 pub fn attach_canister() {
     over(candid_one, attach_canister_impl);
 }
@@ -186,7 +186,7 @@ fn attach_canister_impl(request: AttachCanisterRequest) -> AttachCanisterRespons
 }
 
 /// Detaches a canister from the user's account.
-#[update]
+#[export_name = "canister_update detach_canister"]
 pub fn detach_canister() {
     over(candid_one, detach_canister_impl);
 }
@@ -196,12 +196,12 @@ fn detach_canister_impl(request: DetachCanisterRequest) -> DetachCanisterRespons
     STATE.with(|s| s.accounts_store.borrow_mut().detach_canister(principal, request))
 }
 
-#[update]
+#[export_name = "canister_update get_proposal_payload"]
 pub fn get_proposal_payload() {
     over_async(candid_one, proposals::get_proposal_payload)
 }
 
-#[update]
+#[export_name = "canister_update add_pending_notify_swap"]
 pub fn add_pending_notify_swap() {
     over(candid_one, add_pending_notify_swap_impl);
 }
@@ -228,7 +228,7 @@ fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPend
 ///
 /// These stats include things such as the number of accounts registered, the memory usage, the
 /// number of neurons created, etc.
-#[query]
+#[export_name = "canister_query get_stats"]
 pub fn get_stats() {
     over(candid, |()| get_stats_impl());
 }
@@ -243,7 +243,7 @@ fn get_stats_impl() -> stats::Stats {
 /// - Sync transactions from the ledger
 /// - Process any queued 'multi-part' actions (eg. staking a neuron or topping up a canister)
 /// - Prune old transactions if memory usage is too high
-#[heartbeat]
+#[export_name = "canister_heartbeat"]
 pub fn canister_heartbeat() {
     let future = run_periodic_tasks();
 
@@ -253,7 +253,7 @@ pub fn canister_heartbeat() {
 /// Add an asset to be served by the canister.
 ///
 /// Only a whitelist of assets are accepted.
-#[update]
+#[export_name = "canister_update add_stable_asset"]
 pub fn add_stable_asset() {
     over(candid_one, |asset_bytes: Vec<u8>| {
         let hash_bytes = hash_bytes(&asset_bytes);

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -45,7 +45,7 @@ fn pre_upgrade() {
     });
 }
 
-#[export_name = "canister_post_upgrade"]
+#[post_upgrade]
 fn post_upgrade() {
     STATE.with(|s| {
         let bytes = stable::get();

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -60,9 +60,9 @@ fn post_upgrade() {
     assets::init_assets();
 }
 
-#[export_name = "canister_query http_request"]
-pub fn http_request() {
-    over(candid_one, assets::http_request);
+#[query]
+pub fn http_request(req: assets::HttpRequest) -> assets::HttpResponse {
+    assets::http_request(req)
 }
 
 /// Returns the user's account details if they have an account, else AccountNotFound.

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -228,12 +228,8 @@ fn add_pending_notify_swap_impl(request: AddPendingNotifySwapRequest) -> AddPend
 ///
 /// These stats include things such as the number of accounts registered, the memory usage, the
 /// number of neurons created, etc.
-#[export_name = "canister_query get_stats"]
-pub fn get_stats() {
-    over(candid, |()| get_stats_impl());
-}
-
-fn get_stats_impl() -> stats::Stats {
+#[query]
+pub fn get_stats() -> stats::Stats {
     STATE.with(stats::get_stats)
 }
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -160,9 +160,9 @@ pub fn detach_canister(request: DetachCanisterRequest) -> DetachCanisterResponse
     STATE.with(|s| s.accounts_store.borrow_mut().detach_canister(principal, request))
 }
 
-#[export_name = "canister_update get_proposal_payload"]
-pub fn get_proposal_payload() {
-    over_async(candid_one, proposals::get_proposal_payload)
+#[update]
+pub async fn get_proposal_payload(proposal_id: u64) -> Result<String, String> {
+    proposals::get_proposal_payload(proposal_id).await
 }
 
 #[export_name = "canister_update add_pending_notify_swap"]

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -105,7 +105,7 @@ pub fn get_transactions(request: GetTransactionsRequest) -> GetTransactionsRespo
 /// This newly created account can be used to send and receive ICP and is controlled only by the
 /// user's principal (the fact that it is controlled by the same principal as the user's other
 /// ledger accounts is not derivable externally).
-#[query]
+#[update]
 pub fn create_sub_account(sub_account_name: String) -> CreateSubAccountResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| {
@@ -118,12 +118,8 @@ pub fn create_sub_account(sub_account_name: String) -> CreateSubAccountResponse 
 /// Changes the alias given to the chosen sub account.
 ///
 /// These aliases are not visible externally or to anyone else.
-#[export_name = "canister_update rename_sub_account"]
-pub fn rename_sub_account() {
-    over(candid_one, rename_sub_account_impl);
-}
-
-fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccountResponse {
+#[update]
+pub fn rename_sub_account(request: RenameSubAccountRequest) -> RenameSubAccountResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().rename_sub_account(principal, request))
 }
@@ -133,12 +129,8 @@ fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccount
 /// A single hardware wallet can be linked to multiple user accounts, but in order to make calls to
 /// the IC from the account, the user must use the hardware wallet to sign each request.
 /// Some readonly calls do not require signing, eg. viewing the account's ICP balance.
-#[export_name = "canister_update register_hardware_wallet"]
-pub fn register_hardware_wallet() {
-    over(candid_one, register_hardware_wallet_impl);
-}
-
-fn register_hardware_wallet_impl(request: RegisterHardwareWalletRequest) -> RegisterHardwareWalletResponse {
+#[update]
+pub fn register_hardware_wallet(request: RegisterHardwareWalletRequest) -> RegisterHardwareWalletResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| {
         s.accounts_store
@@ -148,34 +140,22 @@ fn register_hardware_wallet_impl(request: RegisterHardwareWalletRequest) -> Regi
 }
 
 /// Returns the list of canisters which the user has attached to their account.
-#[export_name = "canister_query get_canisters"]
-pub fn get_canisters() {
-    over(candid, |()| get_canisters_impl());
-}
-
-fn get_canisters_impl() -> Vec<NamedCanister> {
+#[query]
+pub fn get_canisters() -> Vec<NamedCanister> {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().get_canisters(principal))
 }
 
 /// Attaches a canister to the user's account.
-#[export_name = "canister_update attach_canister"]
-pub fn attach_canister() {
-    over(candid_one, attach_canister_impl);
-}
-
-fn attach_canister_impl(request: AttachCanisterRequest) -> AttachCanisterResponse {
+#[update]
+pub fn attach_canister(request: AttachCanisterRequest) -> AttachCanisterResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().attach_canister(principal, request))
 }
 
 /// Detaches a canister from the user's account.
-#[export_name = "canister_update detach_canister"]
-pub fn detach_canister() {
-    over(candid_one, detach_canister_impl);
-}
-
-fn detach_canister_impl(request: DetachCanisterRequest) -> DetachCanisterResponse {
+#[update]
+pub fn detach_canister(request: DetachCanisterRequest) -> DetachCanisterResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().detach_canister(principal, request))
 }

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -7,7 +7,7 @@ use crate::accounts_store::{
 use crate::assets::{hash_bytes, insert_asset, Asset};
 use crate::periodic_tasks_runner::run_periodic_tasks;
 use crate::state::{StableState, State, STATE};
-use candid::CandidType;
+use candid::{candid_method, CandidType};
 use dfn_candid::{candid, candid_one};
 use dfn_core::{api::trap_with, over, over_async, stable};
 use icp_ledger::AccountIdentifier;
@@ -28,12 +28,16 @@ mod time;
 
 type Cycles = u128;
 
-#[export_name = "canister_init"]
-fn main() {
+#[ic_cdk_macros::init]
+#[candid_method(init)]
+fn init() {
     assets::init_assets();
 }
 
-#[export_name = "canister_pre_upgrade"]
+/// Redundant function, never called but reqired as this is main.rs.
+fn main() {}
+
+#[ic_cdk_macros::pre_upgrade]
 fn pre_upgrade() {
     STATE.with(|s| {
         let bytes = s.encode();
@@ -41,7 +45,7 @@ fn pre_upgrade() {
     });
 }
 
-#[export_name = "canister_post_upgrade"]
+#[ic_cdk_macros::post_upgrade]
 fn post_upgrade() {
     STATE.with(|s| {
         let bytes = stable::get();

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -22,6 +22,7 @@ set -euo pipefail
 
 verify_healthy() {
   dfx canister call nns-dapp get_stats
+  curl "http://$(dfx canister id nns-dapp).localhost:8080" | grep 'Network Nervous System frontend dapp'
 }
 
 get_current_wasm() {

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -22,7 +22,8 @@ set -euo pipefail
 
 verify_healthy() {
   dfx canister call nns-dapp get_stats
-  curl "http://$(dfx canister id nns-dapp).localhost:8080" | grep 'Network Nervous System frontend dapp'
+  bash -c 'curl "http://$(dfx canister id nns-dapp).localhost:8080" | gunzip | grep "Network Nervous System frontend dapp"'
+  echo Basic health check PASS
 }
 
 get_current_wasm() {


### PR DESCRIPTION
# Motivation
We are using very old IC macros and APIs.  This makes it harder to implement other features, such as stable memory management.  So let's update, a bit at a time.

# Changes
- Update the macros used for the cbackend API hooks.

# Tests
- CI tests
- Manula downgrade-upgrade test as in CI, repeatedly, just to be sure.
- As the e2e tests are incomplete, I have tested the API manually:
  - `http_request` - the site opens on localhost
  - `get_account` - main account shows up with balance, linked account shows up.
  - `add_account` - I can add a linked account
  - `get_transactions` - Selecting the main account, the main account transactions show up
  - `create_sub_account` - I can create a linked account
  - `rename_sub_account` - cool, I didn't play with this before.  I can rename, and the rename stays after refreshing.
  - `register_hardware_wallet` - not tested locally
  - `get_canisters` - Canisters I created before show up in the canisters tab
  - `attach_canister` - Unlinking and relinking a canister works
  - `detach_canister` - See `attach..`
  - `get_proposal_payload` - Proposals show up in the UI and I can see their details
  - `add_pending_notify_swap` - not tested, not sure I can do so easily, but it is a normal update so should work like the others that have been tested
  - `get_stats` - `dfx canister call nns-dapp get_stats` works
  - `add_stable_asset` - Not tested, not used for over a year and if the asset library comes in the next few weeks this will be deleted.