### PR TITLE
Constrain clap errors

### DIFF
--- a/scripts/clap.bash
+++ b/scripts/clap.bash
@@ -57,13 +57,13 @@ function clap.define() {
 		clap.throw_error "You must give a variable for option: ($short/$long)"
 	fi
 
-	if [ "$val" = "" ]; then
+	if [ "${val:-}" = "" ]; then
 		val="\$OPTARG"
 	fi
 
 	# build OPTIONS and help
 	clap_usage="${clap_usage}#NL#TB${short} $(printf "%-25s %s" "${long}:" "${desc}")"
-	if [ "$default" != "" ] && [ "${nargs:-}" != "0" ]; then
+	if [ "${default:-}" != "" ] && [ "${nargs:-}" != "0" ]; then
 		clap_usage="${clap_usage} [default:$default]"
 	fi
 	if [ "${nargs:-}" == "" ]; then
@@ -73,11 +73,11 @@ function clap.define() {
 	else
 		clap_flags="${clap_flags}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
-	if [ "$default" != "" ]; then
+	if [ "${default:-}" != "" ]; then
 		clap_defaults="${clap_defaults}#NL${variable}=${default}"
 	fi
 	clap_arguments_string="${clap_arguments_string}${shortname}"
-	if [ "$val" = "\$OPTARG" ]; then
+	if [ "${val:-}" = "\$OPTARG" ]; then
 		clap_arguments_string="${clap_arguments_string}:"
 	fi
 }

--- a/scripts/deploy-snsdemo-testnet
+++ b/scripts/deploy-snsdemo-testnet
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -22,7 +23,6 @@ clap.define short=x long=ic_dir desc="Directory containing the ic source code" v
 clap.define short=y long=nd_dir desc="Directory containing the nns-dapp source code" variable=ND_REPO_DIR default="$HOME/dfn/nns-dapp"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 : Standard dfx sns demo, with standard canisters, not local nns-dapp, as compiling the local dapp takes time and the canister is not needed.
 dfx-sns-demo --network "$DFX_NETWORK" --ic_commit "$DFX_IC_COMMIT" --ic_dir "$IC_REPO_DIR" --nd_dir "$ND_REPO_DIR"

--- a/scripts/dfx-canister-check-wasm-hash
+++ b/scripts/dfx-canister-check-wasm-hash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -20,7 +21,6 @@ clap.define short=c long=canister desc="The canister name or ID" variable=DFX_CA
 clap.define short=w long=wasm desc="The path to the local wasm file" variable=DFX_WASM
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 # If the location of the wasm was not supplied, get the default location specified in dfx.json
 DFX_WASM="${DFX_WASM:-$(n="$DFX_CANISTER" jq -r '.canisters[env.n].wasm' dfx.json)}"

--- a/scripts/dfx-canister-set-id
+++ b/scripts/dfx-canister-set-id
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -10,7 +11,6 @@ clap.define short=i long=canister_id desc="The ID of the canister" variable=DFX_
 clap.define short=N long=canister_name desc="The name of the canister" variable=DFX_CANISTER_NAME
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 export DFX_NETWORK
 export DFX_CANISTER_NAME

--- a/scripts/dfx-nns-deploy-custom
+++ b/scripts/dfx-nns-deploy-custom
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -14,7 +15,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=f long=features desc="The feature set you would like in the test environment" variable=DFX_NETWORK_FEATURES default="nns"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 : "Make sure that old wasms are purged"
 rm -f nns-dapp.wasm nns-dapp_local.wasm

--- a/scripts/dfx-software-ii-cache
+++ b/scripts/dfx-software-ii-cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -16,7 +17,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=r long=release desc="The II release to get" variable=II_RELEASE default="use-dfx"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 WASMS_DIR="$(dfx cache show)/wasms"
 LOCAL_II_WASM="$(jq -r '.canisters.internet_identity.wasm' dfx.json)"

--- a/scripts/dfx-software-nd-cache
+++ b/scripts/dfx-software-nd-cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -15,7 +16,6 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 DFX_WASMS_DIR="$(dfx cache show)/wasms"
 LOCAL_ND_WASM="$(jq -r '.canisters["nns-dapp"].wasm' dfx.json)"

--- a/scripts/dfx-software-nns-dapp-latest
+++ b/scripts/dfx-software-nns-dapp-latest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 . "$SOURCE_DIR/versions.bash"
@@ -8,6 +9,5 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 gh release list --exclude-drafts --limit 20 --repo dfinity/nns-dapp | grep -m1 proposal | sed -E 's/.*\<(proposal-[0-9]+).*/\1/g'

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -18,7 +19,6 @@ source "$SOURCE_DIR/../clap.bash"
 clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 verify_healthy() {
   dfx canister call nns-dapp get_stats

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -17,7 +18,6 @@ clap.define short=w long=wasm desc="The wasm built from the local code." variabl
 clap.define short=p long=prod_wasm desc="The production wasm." variable=PROD_WASM default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 verify_healthy() {
   dfx canister call sns_aggregator get_canister_status

--- a/scripts/sns/aggregator/get_candid
+++ b/scripts/sns/aggregator/get_candid
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -12,6 +13,5 @@ source "$SOURCE_DIR/../../clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 dfx canister call sns_aggregator interface --network "$DFX_NETWORK" | idl2json | jq -r .

--- a/scripts/sns/aggregator/get_log
+++ b/scripts/sns/aggregator/get_log
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -12,7 +13,6 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=l long=lines desc="The number of lines of output" variable=DFX_LINES default="${LINES:-1000000}"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 dfx canister call sns_aggregator tail_log --network "$DFX_NETWORK" |
   idl2json | jq -r | tail -n "$DFX_LINES"

--- a/scripts/sns/aggregator/get_stable_data
+++ b/scripts/sns/aggregator/get_stable_data
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -11,7 +12,6 @@ source "$SOURCE_DIR/../../clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 dfx canister call sns_aggregator stable_data --network "$DFX_NETWORK" |
   tee stable_data.candid |

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
@@ -11,7 +12,6 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-set -euo pipefail
 
 : "Make sure that DFX_IC_COMMIT is defined"
 [[ "${DFX_IC_COMMIT:-}" != "" ]] || {


### PR DESCRIPTION
# Motivation
The bash argument parser may be close enough to be being clean that we can apply `set -euxo pipefail` before invoking it.

# Changes
- Move `set -euxo pipefail` to the beginning of files using the bash clap.
- Handle unset vars correctly in a couple of places in clap.

# Tests
Let's see CI

There may well be feedback from manual usage.