### PR TITLE
Remove attribute checking from page object constructors.

### DIFF
--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -5,10 +5,7 @@ export class AmountDisplayPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== AmountDisplayPo.tid) {
-      throw new Error(`${root} is not an Tooltip`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -1,10 +1,7 @@
 export class ButtonPo {
   root: Element;
 
-  constructor(root: Element) {
-    if (root.tagName !== "BUTTON") {
-      throw new Error(`${root} is not a button`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -5,10 +5,7 @@ export class HashPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== HashPo.tid) {
-      throw new Error(`${root} is not an Hash`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -7,10 +7,7 @@ export class NeuronDetailPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NeuronDetailPo.tid) {
-      throw new Error(`${root} is not a NeuronDetail`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -7,10 +7,7 @@ export class NeuronsPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NeuronsPo.tid) {
-      throw new Error(`${root} is not a Neurons`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -5,10 +5,7 @@ export class NnsNeuronCardPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NnsNeuronCardPo.tid) {
-      throw new Error(`${root} is not an NnsNeuronCard`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -3,10 +3,7 @@ export class NnsNeuronCardTitlePo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NnsNeuronCardTitlePo.tid) {
-      throw new Error(`${root} is not an NnsNeuronCardTitle`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -5,10 +5,7 @@ export class NnsNeuronDetailPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NnsNeuronDetailPo.tid) {
-      throw new Error(`${root} is not an NnsNeuronDetail`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -6,10 +6,7 @@ export class NnsNeuronsPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== NnsNeuronsPo.tid) {
-      throw new Error(`${root} is not an NnsNeurons`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -5,10 +5,7 @@ export class ProjectSwapDetailsPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== ProjectSwapDetailsPo.tid) {
-      throw new Error(`${root} is not a ProjectSwapDetailsPo`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -3,10 +3,7 @@ export class SkeletonCardPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SkeletonCardPo.tid) {
-      throw new Error(`${root} is not a SkeletonCard`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -5,10 +5,7 @@ export class SnsNeuronCardPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SnsNeuronCardPo.tid) {
-      throw new Error(`${root} is not an SnsNeuronCard`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -5,10 +5,7 @@ export class SnsNeuronCardTitlePo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SnsNeuronCardTitlePo.tid) {
-      throw new Error(`${root} is not an SnsNeuronCardTitle`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -5,10 +5,7 @@ export class SnsNeuronDetailPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SnsNeuronDetailPo.tid) {
-      throw new Error(`${root} is not an SnsNeuronDetail`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-obejct.ts
@@ -7,10 +7,7 @@ export class SnsNeuronInfoStakePo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SnsNeuronInfoStakePo.tid) {
-      throw new Error(`${root} is not an SnsNeuronInfoStakePo`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -6,10 +6,7 @@ export class SnsNeuronsPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== SnsNeuronsPo.tid) {
-      throw new Error(`${root} is not an SnsNeurons`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -5,10 +5,7 @@ export class TooltipPo {
 
   root: Element;
 
-  constructor(root: Element) {
-    if (root.getAttribute("data-tid") !== TooltipPo.tid) {
-      throw new Error(`${root} is not an Tooltip`);
-    }
+  private constructor(root: Element) {
     this.root = root;
   }
 


### PR DESCRIPTION
# Motivation

We want to reuse page objects for e2e tests.
Some things, such as getting element attributes, have to be async in e2e and so they will have to be async in shared page objects.
This means we can't do it in a constructor.
Currently, page objects check that the element has the expected data-tid in the constructor.

# Changes

1. Remove attribute checking in page object constructors.
2. Make constructors private to make sure page object classes still have full control over what can be used as their root elements.

# Tests

`npm run test`
