### PR TITLE
GIX-1219: Fetch SNS proposal and load it in component

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -45,6 +45,8 @@
     "sns_accounts_balance_load": "An error occurred while loading the balance of the accounts.",
     "icrc_token_load": "An error occurred while loading the token balance or metadata.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
+    "get_proposal": "There was an unexpected issue while fetching the proposal $proposalId.",
+    "wrong_proposal_id": "The $proposalId is not a valid proposal id.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",
     "missing_identity": "The operation cannot be executed without any identity.",
     "rename_subaccount": "An error occurred while renaming your linked account.",

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -4,8 +4,15 @@
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { buildProposalsUrl } from "$lib/utils/navigation.utils";
   import { ENABLE_SNS_VOTING } from "$lib/stores/feature-flags.store";
+  import { nonNullish } from "@dfinity/utils";
+  import { getSnsProposalById } from "$lib/services/$public/sns-proposals.services";
+  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
+  import type { SnsProposalData } from "@dfinity/sns";
+  import { toastsError } from "$lib/stores/toasts.store";
 
   export let proposalIdText: string | undefined | null = undefined;
+
+  let proposal: SnsProposalData | "loading" | "error" = "loading";
 
   onMount(() => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
@@ -15,6 +22,44 @@
       });
     }
   });
+
+  // By setting a local variable, we avoid calling the below text when the whole store is changes.
+  let rootCanisterId = $snsOnlyProjectStore;
+
+  // TODO: Fix race condition in case the user changes the proposal before the first one hasn't loaded yet.
+  $: {
+    if (nonNullish(proposalIdText) && nonNullish(rootCanisterId)) {
+      // We can't be sure that `snsOnlyProjectStore` is the same when `handleError` is called.
+      const rootCanisterIdText = rootCanisterId.toText();
+      try {
+        const proposalId = BigInt(proposalIdText);
+        proposal = "loading";
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId: { id: proposalId },
+          setProposal: ({ proposal: proposalData }) => {
+            proposal = proposalData;
+          },
+          handleError: () => {
+            goto(buildProposalsUrl({ universe: rootCanisterIdText }), {
+              replaceState: true,
+            });
+          },
+        });
+      } catch (error) {
+        proposal = "error";
+        toastsError({
+          labelKey: "error.wrong_proposal_id",
+          substitutions: {
+            $proposalId: proposalIdText,
+          },
+        });
+        goto(buildProposalsUrl({ universe: rootCanisterIdText }), {
+          replaceState: true,
+        });
+      }
+    }
+  }
 </script>
 
 <div class="content-grid" data-tid="sns-proposal-details-grid">

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -49,6 +49,8 @@ interface I18nError {
   sns_accounts_balance_load: string;
   icrc_token_load: string;
   list_proposals: string;
+  get_proposal: string;
+  wrong_proposal_id: string;
   list_canisters: string;
   missing_identity: string;
   rename_subaccount: string;

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
+import { authStore } from "$lib/stores/auth.store";
+import { page } from "$mocks/$app/stores";
+import * as snsGovernanceFake from "$tests/fakes/sns-governance-api.fake";
+import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+jest.mock("$lib/api/sns-governance.api");
+
+const blockedApiPaths = ["$lib/api/sns-governance.api"];
+
+describe("SnsProposalDetail", () => {
+  blockAllCallsTo(blockedApiPaths);
+  snsGovernanceFake.install();
+
+  describe("not logged in", () => {
+    const rootCanisterId = mockCanisterId;
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreNoIdentitySubscribe);
+      page.mock({ data: { universe: rootCanisterId.toText() } });
+    });
+
+    it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {
+      render(SnsProposalDetail, {
+        props: {
+          proposalIdText: "invalid",
+        },
+      });
+      await waitFor(() => {
+        const { path } = get(pageStore);
+        return expect(path).toEqual(AppPath.Proposals);
+      });
+    });
+
+    it("should redirect to the list of sns proposals if proposal is not found", async () => {
+      snsGovernanceFake.setQueryProposalError(new Error("Some error"));
+      render(SnsProposalDetail, {
+        props: {
+          proposalIdText: "2",
+        },
+      });
+      await waitFor(() => {
+        const { path } = get(pageStore);
+        return expect(path).toEqual(AppPath.Proposals);
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -5,6 +5,7 @@
 import * as api from "$lib/api/sns-governance.api";
 import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
 import {
+  getSnsProposalById,
   loadSnsProposals,
   registerVote,
 } from "$lib/services/$public/sns-proposals.services";
@@ -12,14 +13,17 @@ import { authStore } from "$lib/stores/auth.store";
 import { snsFiltesStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import * as toastsFunctions from "$lib/stores/toasts.store";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
   mockAuthStoreNoIdentitySubscribe,
   mockAuthStoreSubscribe,
   mockIdentity,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
+import { toastsStore } from "@dfinity/gix-components";
 import {
   SnsProposalDecisionStatus,
   SnsVote,
@@ -30,6 +34,12 @@ import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-proposals services", () => {
+  beforeEach(() => {
+    snsFiltesStore.reset();
+    snsProposalsStore.reset();
+    toastsStore.reset();
+    jest.clearAllMocks();
+  });
   const proposal1: SnsProposalData = {
     ...mockSnsProposal,
     id: [{ id: BigInt(1) }],
@@ -50,9 +60,6 @@ describe("sns-proposals services", () => {
 
     describe("not logged in", () => {
       beforeEach(() => {
-        snsFiltesStore.reset();
-        snsProposalsStore.reset();
-        jest.clearAllMocks();
         jest
           .spyOn(authStore, "subscribe")
           .mockImplementation(mockAuthStoreNoIdentitySubscribe);
@@ -237,6 +244,216 @@ describe("sns-proposals services", () => {
           labelKey: "error__sns.sns_register_vote",
         })
       );
+    });
+  });
+
+  describe("getSnsProposalById", () => {
+    const rootCanisterId = mockPrincipal;
+    const proposalId = mockSnsProposal.id[0];
+
+    describe("not logged in", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(authStore, "subscribe")
+          .mockImplementation(mockAuthStoreNoIdentitySubscribe);
+      });
+
+      it("should use the proposal in store if certified and not call api", (done) => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        snsProposalsStore.setProposals({
+          rootCanisterId,
+          proposals: [mockSnsProposal],
+          certified: true,
+          completed: true,
+        });
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: ({ proposal }) => {
+            expect(queryProposalSpy).not.toBeCalledTimes(1);
+            expect(proposal).toEqual(mockSnsProposal);
+            done();
+          },
+        });
+      });
+
+      it("should not use the proposal in store if not certified and call api", (done) => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        snsProposalsStore.setProposals({
+          rootCanisterId,
+          proposals: [mockSnsProposal],
+          certified: false,
+          completed: true,
+        });
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: () => {
+            expect(queryProposalSpy).toBeCalledWith({
+              identity: new AnonymousIdentity(),
+              certified: false,
+              rootCanisterId,
+              proposalId,
+            });
+            expect(queryProposalSpy).toBeCalledTimes(1);
+            done();
+          },
+        });
+      });
+
+      it("should call api if store is empty", (done) => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: () => {
+            expect(queryProposalSpy).toBeCalledWith({
+              identity: new AnonymousIdentity(),
+              certified: false,
+              rootCanisterId,
+              proposalId,
+            });
+            expect(queryProposalSpy).toBeCalledTimes(1);
+            done();
+          },
+        });
+      });
+    });
+
+    describe("logged in", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(authStore, "subscribe")
+          .mockImplementation(mockAuthStoreSubscribe);
+      });
+
+      it("should use the proposal in store if certified and not call api", (done) => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        snsProposalsStore.setProposals({
+          rootCanisterId,
+          proposals: [mockSnsProposal],
+          certified: true,
+          completed: true,
+        });
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: ({ proposal }) => {
+            expect(queryProposalSpy).not.toBeCalledTimes(1);
+            expect(proposal).toEqual(mockSnsProposal);
+            done();
+          },
+        });
+      });
+
+      it("should not use the proposal in store if not certified and call api", async () => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        snsProposalsStore.setProposals({
+          rootCanisterId,
+          proposals: [mockSnsProposal],
+          certified: false,
+          completed: true,
+        });
+        let dataCertified = false;
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: ({ certified }) => {
+            if (certified) {
+              dataCertified = true;
+            }
+          },
+        });
+
+        await waitFor(() => expect(dataCertified).toBe(true));
+        expect(queryProposalSpy).toBeCalledWith({
+          identity: mockIdentity,
+          certified: false,
+          rootCanisterId,
+          proposalId,
+        });
+        expect(queryProposalSpy).toBeCalledWith({
+          identity: mockIdentity,
+          certified: true,
+          rootCanisterId,
+          proposalId,
+        });
+        expect(queryProposalSpy).toBeCalledTimes(2);
+      });
+
+      it("should call api if store is empty", async () => {
+        const queryProposalSpy = jest
+          .spyOn(api, "queryProposal")
+          .mockResolvedValue(mockSnsProposal);
+        let dataCertified = false;
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: ({ certified }) => {
+            if (certified) {
+              dataCertified = true;
+            }
+          },
+        });
+        await waitFor(() => expect(dataCertified).toBe(true));
+        expect(queryProposalSpy).toBeCalledWith({
+          identity: mockIdentity,
+          certified: false,
+          rootCanisterId,
+          proposalId,
+        });
+        expect(queryProposalSpy).toBeCalledWith({
+          identity: mockIdentity,
+          certified: true,
+          rootCanisterId,
+          proposalId,
+        });
+        expect(queryProposalSpy).toBeCalledTimes(2);
+      });
+
+      it("should call handle error if api call fails", async () => {
+        jest.spyOn(api, "queryProposal").mockRejectedValue(new Error("error"));
+        const handleErrorSpy = jest.fn();
+        const setProposalSpy = jest.fn();
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: setProposalSpy,
+          handleError: handleErrorSpy,
+        });
+
+        await waitFor(() => expect(handleErrorSpy).toBeCalledTimes(2));
+      });
+
+      it("should show error if api call fails", async () => {
+        jest.spyOn(api, "queryProposal").mockRejectedValue(new Error("error"));
+        const handleErrorSpy = jest.fn();
+        const setProposalSpy = jest.fn();
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId,
+          setProposal: setProposalSpy,
+          handleError: handleErrorSpy,
+        });
+
+        await waitFor(() => expect(handleErrorSpy).toBeCalledTimes(2));
+        expect(get(toastsStore)[0]).toMatchObject({
+          level: "error",
+          text: replacePlaceholders(en.error.get_proposal, {
+            $proposalId: proposalId.id.toString(),
+          }),
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

User should see the data of an SNS proposal.

This PR: Load the proposal in the component.

# Changes

* New sns proposal service `getSnsProposalById`.
* Use the new service in page `SnsProposalDetail.svelte` to load the proposal in a local variable.
* Redirect the user if there is an error loading the proposal.

# Tests

* Test new sns proposal service.
* Add test for page SnsProposalDetail and test that user is redirected in the different scenarios.
* Add an errors map in the sns governace api fake and a function to set an error for the queryProposal api function.
