### PR TITLE
feat: make ckBTC default segment of receive modal with Bitcoin

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -44,7 +44,7 @@
   let bitcoinSegmentId = Symbol("bitcoin");
   let ckBTCSegmentId = Symbol("ckBTC");
   let selectedSegmentId: symbol;
-  $: selectedSegmentId = displayBtcAddress ? bitcoinSegmentId : ckBTCSegmentId;
+  $: selectedSegmentId = ckBTCSegmentId;
 
   let modalRendered = false;
   let segment: Segment;
@@ -151,10 +151,10 @@
   {#if displayBtcAddress}
     <div class="receive">
       <Segment bind:selectedSegmentId bind:this={segment}>
+        <SegmentButton segmentId={ckBTCSegmentId}>{segmentLabel}</SegmentButton>
         <SegmentButton segmentId={bitcoinSegmentId}
           >{$i18n.ckbtc.bitcoin}</SegmentButton
         >
-        <SegmentButton segmentId={ckBTCSegmentId}>{segmentLabel}</SegmentButton>
       </Segment>
     </div>
   {/if}

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -67,13 +67,7 @@ describe("BtcCkBTCReceiveModal", () => {
   });
 
   describe("with btc", () => {
-    it("should render BTC address", async () => {
-      const { getByText } = await renderReceiveModal({});
-
-      expect(getByText(mockBTCAddressTestnet)).toBeInTheDocument();
-    });
-
-    const selectCkBTC = async (container: HTMLElement) => {
+    const selectBTC = async (container: HTMLElement) => {
       const button = container.querySelector(
         "div.segment-button:nth-of-type(3) button"
       ) as HTMLButtonElement;
@@ -82,10 +76,16 @@ describe("BtcCkBTCReceiveModal", () => {
       await fireEvent.click(button);
     };
 
-    it("should render account identifier (without being shortened)", async () => {
+    it("should render BTC address", async () => {
       const { getByText, container } = await renderReceiveModal({});
 
-      await selectCkBTC(container);
+      await selectBTC(container);
+
+      expect(getByText(mockBTCAddressTestnet)).toBeInTheDocument();
+    });
+
+    it("should render account identifier (without being shortened)", async () => {
+      const { getByText, container } = await renderReceiveModal({});
 
       await waitFor(() =>
         expect(getByText(mockCkBTCMainAccount.identifier)).toBeInTheDocument()
@@ -93,7 +93,9 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should render a bitcoin description", async () => {
-      const { getByText } = await renderReceiveModal({});
+      const { getByText, container } = await renderReceiveModal({});
+
+      await selectBTC(container);
 
       const title = replacePlaceholders(en.wallet.token_address, {
         $tokenSymbol: en.ckbtc.bitcoin,
@@ -105,8 +107,6 @@ describe("BtcCkBTCReceiveModal", () => {
     it("should render a ckBTC description", async () => {
       const { getByText, container } = await renderReceiveModal({});
 
-      await selectCkBTC(container);
-
       const title = replacePlaceholders(en.wallet.token_address, {
         $tokenSymbol: en.ckbtc.test_title,
       });
@@ -115,7 +115,9 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should render a bitcoin logo", async () => {
-      const { getByTestId } = await renderReceiveModal({});
+      const { getByTestId, container } = await renderReceiveModal({});
+
+      await selectBTC(container);
 
       expect(getByTestId("logo")?.getAttribute("alt")).toEqual(
         en.ckbtc.bitcoin
@@ -124,8 +126,6 @@ describe("BtcCkBTCReceiveModal", () => {
 
     it("should render ckBTC logo", async () => {
       const { getByTestId, container } = await renderReceiveModal({});
-
-      await selectCkBTC(container);
 
       await waitFor(() =>
         expect(getByTestId("logo")?.getAttribute("alt")).toEqual(
@@ -139,7 +139,9 @@ describe("BtcCkBTCReceiveModal", () => {
     ) => {
       const spyUpdateBalance = jest.spyOn(services, "updateBalance");
 
-      const { getByTestId } = await renderReceiveModal({});
+      const { getByTestId, container } = await renderReceiveModal({});
+
+      await selectBTC(container);
 
       fireEvent.click(getByTestId(dataTid) as HTMLButtonElement);
 
@@ -155,7 +157,9 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should reload account after update balance", async () => {
-      const { getByTestId } = await renderReceiveModal({});
+      const { getByTestId, container } = await renderReceiveModal({});
+
+      await selectBTC(container);
 
       fireEvent.click(getByTestId("update-ckbtc-balance") as HTMLButtonElement);
 
@@ -167,9 +171,7 @@ describe("BtcCkBTCReceiveModal", () => {
     ) => {
       const spyUpdateBalance = jest.spyOn(services, "updateBalance");
 
-      const { getByTestId, container } = await renderReceiveModal({});
-
-      await selectCkBTC(container);
+      const { getByTestId } = await renderReceiveModal({});
 
       fireEvent.click(getByTestId(dataTid) as HTMLButtonElement);
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -85,7 +85,7 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should render account identifier (without being shortened)", async () => {
-      const { getByText, container } = await renderReceiveModal({});
+      const { getByText } = await renderReceiveModal({});
 
       await waitFor(() =>
         expect(getByText(mockCkBTCMainAccount.identifier)).toBeInTheDocument()
@@ -105,7 +105,7 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should render a ckBTC description", async () => {
-      const { getByText, container } = await renderReceiveModal({});
+      const { getByText } = await renderReceiveModal({});
 
       const title = replacePlaceholders(en.wallet.token_address, {
         $tokenSymbol: en.ckbtc.test_title,
@@ -125,7 +125,7 @@ describe("BtcCkBTCReceiveModal", () => {
     });
 
     it("should render ckBTC logo", async () => {
-      const { getByTestId, container } = await renderReceiveModal({});
+      const { getByTestId } = await renderReceiveModal({});
 
       await waitFor(() =>
         expect(getByTestId("logo")?.getAttribute("alt")).toEqual(


### PR DESCRIPTION
# Motivation

Instead of default "Bitcoin" segment, make "ckBTC" (or ckTESTBTC) the default

# Changes

- invert segment
- also same default ckBTC

# Screenshots

<img width="1536" alt="Capture d’écran 2023-03-21 à 16 06 54" src="https://user-images.githubusercontent.com/16886711/226649477-ca2eaa07-05d8-4c4a-ac42-e984e101646f.png">
<img width="1536" alt="Capture d’écran 2023-03-21 à 16 06 57" src="https://user-images.githubusercontent.com/16886711/226649491-3ffa3b76-204b-40a8-8b2d-5813de47440c.png">

<img width="1536" alt="Capture d’écran 2023-03-21 à 16 06 48" src="https://user-images.githubusercontent.com/16886711/226649462-8872e4d2-aad2-439b-b47e-acf64ba755ee.png">

