### PR TITLE
Remove paths and baseUrl from frontend/src/tests/tsconfig.json and ad…

### DIFF
--- a/frontend/src/tests/tsconfig.json
+++ b/frontend/src/tests/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "../../tsconfig.spec.json",
-  "compilerOptions": {
-    "baseUrl": "..",
-    "paths": {
-      "$tests/*": ["tests/*"]
-    }
-  }
+  "extends": "../../tsconfig.spec.json"
 }

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": false,
+    "baseUrl": ".",
     "paths": {
       "$lib": ["src/lib"],
       "$lib/*": ["src/lib/*"],


### PR DESCRIPTION
# Motivation

Overriding paths in `frontend/src/tests/tsconfig.json` for Playwright, caused IDEs to show errors on imports using paths defined in `frontend/tsconfig.spec.json`. Playwright didn't pick up those paths before because it requires baseUrl to be set in tsconfig.json.

# Changes

Remove the paths override in `frontend/src/tests/tsconfig.json` and set `baseUrl` in `frontend/tsconfig.spec.json` so that Playwright picks up the paths definition from there.

# Tests

`npm run test`
`npm run test-e2e`
Looked in VSCode and verified with @peterpeterparker for Webstorm
