### PR TITLE
Inline calls to reloadSnsMetrics and remove it

### DIFF
--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -59,24 +59,11 @@
     unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
   }
 
-  const reloadSnsMetrics = async ({ forceFetch }: { forceFetch: boolean }) => {
-    const swapCanisterId = $projectDetailStore?.summary
-      ?.swapCanisterId as Principal;
-
-    if (isNullish(rootCanisterId) || isNullish(swapCanisterId)) {
-      return;
-    }
-
-    await loadSnsSwapMetrics({
-      rootCanisterId: Principal.fromText(rootCanisterId),
-      swapCanisterId,
-      forceFetch,
-    });
-  };
-
   const reload = async () => {
-    if (rootCanisterId === undefined || rootCanisterId === null) {
-      // We cannot reload data for an undefined rootCanisterd but we silent the error here because it most probably means that the user has already navigated away of the detail route
+    if (isNullish(rootCanisterId) || isNullish(swapCanisterId)) {
+      // We cannot reload data for an undefined rootCanisterd or swapCanisterId
+      // but we silence the error here because it most probably means that the
+      // user has already navigated away of the detail route
       return;
     }
 
@@ -84,7 +71,11 @@
       loadSnsTotalCommitment({ rootCanisterId, strategy: "update" }),
       loadSnsLifecycle({ rootCanisterId }),
       loadCommitment({ rootCanisterId, forceFetch: true }),
-      reloadSnsMetrics({ forceFetch: true }),
+      loadSnsSwapMetrics({
+        rootCanisterId: Principal.fromText(rootCanisterId),
+        swapCanisterId,
+        forceFetch: true,
+      }),
     ]);
   };
 
@@ -107,7 +98,11 @@
     nonNullish(rootCanisterId) &&
     enableWatchers
   ) {
-    reloadSnsMetrics({ forceFetch: false });
+    loadSnsSwapMetrics({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+      swapCanisterId,
+      forceFetch: false,
+    });
     unsubscribeWatchMetrics?.();
 
     unsubscribeWatchMetrics = watchSnsMetrics({


### PR DESCRIPTION
# Motivation

Simplify frontend/src/lib/pages/ProjectDetail.svelte to make https://github.com/dfinity/nns-dapp/pull/2112 easier to review.

The only thing reloadSnsMetrics does is check that rootCanisterId and swapCanisterId are non-nullish and then call loadSnsSwapMetrics. But if we make sure those are both non-nullish where we call reloadSnsMetrics, we can just call loadSnsSwapMetrics directly.

# Changes

1. Make sure rootCanisterId and swapCanisterId are non-nullish before calling reloadSnsMetrics.
2. Inline the calls to reloadSnsMetrics.
3. Remove reloadSnsMetrics.


# Tests

npm run test
npm run check
