### PR TITLE
Add PageObjectElement type

### DIFF
--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -1,15 +1,16 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class AmountDisplayPo {
   static readonly tid = "token-value-label";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): AmountDisplayPo | null {
+  static under(element: PageObjectElement): AmountDisplayPo | null {
     const el = element.querySelector(`[data-tid=${AmountDisplayPo.tid}]`);
     return el && new AmountDisplayPo(el);
   }

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -1,7 +1,8 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
 export class ButtonPo {
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
@@ -9,7 +10,7 @@ export class ButtonPo {
     element,
     testId,
   }: {
-    element: Element;
+    element: PageObjectElement;
     testId: string;
   }): ButtonPo | null {
     const el = element.querySelector(`button[data-tid=${testId}]`);

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -1,15 +1,16 @@
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class HashPo {
   static readonly tid = "hash-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): HashPo | null {
+  static under(element: PageObjectElement): HashPo | null {
     const el = element.querySelector(`[data-tid=${HashPo.tid}]`);
     return el && new HashPo(el);
   }

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -1,17 +1,18 @@
 import { NnsNeuronDetailPo } from "$tests/page-objects/NnsNeuronDetail.page-object";
 import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
 export class NeuronDetailPo {
   static readonly tid = "neuron-detail-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: HTMLElement): NeuronDetailPo | null {
+  static under(element: PageObjectElement): NeuronDetailPo | null {
     const el = element.querySelector(`[data-tid=${NeuronDetailPo.tid}]`);
     return el && new NeuronDetailPo(el);
   }

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -1,17 +1,18 @@
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
 import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
 export class NeuronsPo {
   static readonly tid = "neurons-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: HTMLElement): NeuronsPo | null {
+  static under(element: PageObjectElement): NeuronsPo | null {
     const el = element.querySelector(`[data-tid=${NeuronsPo.tid}]`);
     return el && new NeuronsPo(el);
   }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -1,15 +1,16 @@
 import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronCardPo {
   static readonly tid = "nns-neuron-card-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static allUnder(element: Element): NnsNeuronCardPo[] {
+  static allUnder(element: PageObjectElement): NnsNeuronCardPo[] {
     return Array.from(
       element.querySelectorAll(`[data-tid=${NnsNeuronCardPo.tid}]`)
     ).map((el) => new NnsNeuronCardPo(el));

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,13 +1,14 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronCardTitlePo {
   static readonly tid = "neuron-card-title";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): NnsNeuronCardTitlePo | null {
+  static under(element: PageObjectElement): NnsNeuronCardTitlePo | null {
     const el = element.querySelector(`[data-tid=${NnsNeuronCardTitlePo.tid}]`);
     return el && new NnsNeuronCardTitlePo(el);
   }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,15 +1,16 @@
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronDetailPo {
   static readonly tid = "nns-neuron-detail-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): NnsNeuronDetailPo | null {
+  static under(element: PageObjectElement): NnsNeuronDetailPo | null {
     const el = element.querySelector(`[data-tid=${NnsNeuronDetailPo.tid}]`);
     return el && new NnsNeuronDetailPo(el);
   }

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,16 +1,17 @@
 import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronsPo {
   static readonly tid = "nns-neurons-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): NnsNeuronsPo | null {
+  static under(element: PageObjectElement): NnsNeuronsPo | null {
     const el = element.querySelector(`[data-tid=${NnsNeuronsPo.tid}]`);
     return el && new NnsNeuronsPo(el);
   }

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -1,15 +1,16 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProjectSwapDetailsPo {
   static readonly tid = "project-swap-details-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): ProjectSwapDetailsPo | null {
+  static under(element: PageObjectElement): ProjectSwapDetailsPo | null {
     const el = element.querySelector(`[data-tid=${ProjectSwapDetailsPo.tid}]`);
     return el && new ProjectSwapDetailsPo(el);
   }

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -1,13 +1,14 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SkeletonCardPo {
   static readonly tid = "skeleton-card";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static allUnder(element: Element): SkeletonCardPo[] {
+  static allUnder(element: PageObjectElement): SkeletonCardPo[] {
     return Array.from(
       element.querySelectorAll(`[data-tid=${SkeletonCardPo.tid}]`)
     ).map((el) => new SkeletonCardPo(el));

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -1,15 +1,16 @@
 import { SnsNeuronCardTitlePo } from "$tests/page-objects/SnsNeuronCardTitle.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronCardPo {
   static readonly tid = "sns-neuron-card-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static allUnder(element: Element): SnsNeuronCardPo[] {
+  static allUnder(element: PageObjectElement): SnsNeuronCardPo[] {
     return Array.from(
       element.querySelectorAll(`[data-tid=${SnsNeuronCardPo.tid}]`)
     ).map((el) => new SnsNeuronCardPo(el));

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -1,15 +1,16 @@
 import { HashPo } from "$tests/page-objects/Hash.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronCardTitlePo {
   static readonly tid = "sns-neuron-card-title";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): SnsNeuronCardTitlePo | null {
+  static under(element: PageObjectElement): SnsNeuronCardTitlePo | null {
     const el = element.querySelector(`[data-tid=${SnsNeuronCardTitlePo.tid}]`);
     return el && new SnsNeuronCardTitlePo(el);
   }

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -1,15 +1,16 @@
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronDetailPo {
   static readonly tid = "sns-neuron-detail-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): SnsNeuronDetailPo | null {
+  static under(element: PageObjectElement): SnsNeuronDetailPo | null {
     const el = element.querySelector(`[data-tid=${SnsNeuronDetailPo.tid}]`);
     return el && new SnsNeuronDetailPo(el);
   }

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
@@ -1,17 +1,18 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
 export class SnsNeuronInfoStakePo {
   static readonly tid = "sns-neuron-info-stake";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): SnsNeuronInfoStakePo | null {
+  static under(element: PageObjectElement): SnsNeuronInfoStakePo | null {
     const el = element.querySelector(`[data-tid=${SnsNeuronInfoStakePo.tid}]`);
     return el && new SnsNeuronInfoStakePo(el);
   }

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,16 +1,17 @@
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsNeuronCardPo } from "$tests/page-objects/SnsNeuronCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronsPo {
   static readonly tid = "sns-neurons-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): SnsNeuronsPo | null {
+  static under(element: PageObjectElement): SnsNeuronsPo | null {
     const el = element.querySelector(`[data-tid=${SnsNeuronsPo.tid}]`);
     return el && new SnsNeuronsPo(el);
   }

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -1,15 +1,16 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class TooltipPo {
   static readonly tid = "tooltip-component";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): TooltipPo | null {
+  static under(element: PageObjectElement): TooltipPo | null {
     const el = element.querySelector(`[data-tid=${TooltipPo.tid}]`);
     return el && new TooltipPo(el);
   }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -1,0 +1,1 @@
+export type PageObjectElement = Element;


### PR DESCRIPTION
# Motivation

We want to reuse page objects between unit tests and e2e tests.
Currently page objects each have a root element of type `Element`, which can not be used for e2e tests.
I want to introduce an interface `PageObjectElement` which abstracts the functionality of Element and will have separate implementations for unit tests and e2e tests.
In this PR, I introduce the `PageObjectElement` but it's still equal to `Element`. This allows me to let page objects work with `PageObjectElement` while not changing anything else yet.

# Changes

1. Add `type PageObjectElement = Element`
2. Declare the root elements of page objects of type PageObjectElement instead of Element (or instead of HTMLElement in some accidental cases).

# Tests

`npm run test`
`npm run check`