### PR TITLE
Chore: Fix flaky test

### DIFF
--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -13,6 +13,7 @@ import {
   importSnsWasmCanister,
 } from "$lib/proxy/api.import.proxy";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   deployedSnsMock,
   governanceCanisterIdMock,
@@ -23,7 +24,7 @@ import {
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
 import { SnsSwapCanister } from "@dfinity/sns";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/proxy/api.import.proxy");
 
@@ -70,8 +71,8 @@ describe("sns-sale.api", () => {
 
   it("should query open ticket", async () => {
     const apiTicket = snsTicketMock({
-      rootCanisterId: rootCanisterIdMock,
-      owner: mockIdentity.getPrincipal(),
+      rootCanisterId: principal(1),
+      owner: principal(2),
     }).ticket;
     const snsSwapCanister = mock<SnsSwapCanister>();
     snsSwapCanister.getOpenTicket.mockResolvedValue(apiTicket);

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -23,7 +23,7 @@ import {
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
 import { SnsSwapCanister } from "@dfinity/sns";
-import { mock } from "jest-mock-extended";
+import mock from "jest-mock-extended/lib/Mock";
 
 jest.mock("$lib/proxy/api.import.proxy");
 
@@ -69,13 +69,12 @@ describe("sns-sale.api", () => {
   });
 
   it("should query open ticket", async () => {
+    const apiTicket = snsTicketMock({
+      rootCanisterId: rootCanisterIdMock,
+      owner: mockIdentity.getPrincipal(),
+    }).ticket;
     const snsSwapCanister = mock<SnsSwapCanister>();
-    snsSwapCanister.getOpenTicket.mockResolvedValue(
-      snsTicketMock({
-        rootCanisterId: rootCanisterIdMock,
-        owner: mockIdentity.getPrincipal(),
-      }).ticket
-    );
+    snsSwapCanister.getOpenTicket.mockResolvedValue(apiTicket);
     jest
       .spyOn(SnsSwapCanister, "create")
       .mockImplementation((): SnsSwapCanister => snsSwapCanister);
@@ -86,7 +85,7 @@ describe("sns-sale.api", () => {
     });
 
     expect(result).not.toBeNull();
-    expect(result).toEqual(ticket.ticket);
+    expect(result).toEqual(apiTicket);
   });
 
   it("should create new sale ticket", async () => {


### PR DESCRIPTION
# Motivation

There was a flaky test that would fail unexpectedly.

# Changes

* Fix the test in sns sale api spec. The expectation compares to what the mocked method returns.

The reason it was flaky was because it was comparing to another ticket created at the beginning of the test. Creating this test tickets uses Date.now(), which meant that it was comparing two different tickets created with the same parameters, but because of Date.now, they could be different tickets.

# Tests

Only test changes.
