### PR TITLE
refactor: transaction modal init param

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -35,7 +35,7 @@
 
   let transactionInit: TransactionInit = {
     sourceAccount: selectedAccount,
-    mustSelectNetwork: isUniverseCkTESTBTC(universeId)
+    mustSelectNetwork: isUniverseCkTESTBTC(universeId),
   };
 
   let selectedNetwork: TransactionNetwork | undefined = undefined;

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -3,7 +3,7 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import type { NewTransaction } from "$lib/types/transaction";
+  import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
   import type { TransactionNetwork } from "$lib/types/transaction";
   import type { ValidateAmountFn } from "$lib/types/transaction";
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
@@ -32,6 +32,11 @@
   export let universeId: UniverseCanisterId;
   export let token: IcrcTokenMetadata;
   export let transactionFee: TokenAmount;
+
+  let transactionInit: TransactionInit = {
+    sourceAccount: selectedAccount,
+    mustSelectNetwork: isUniverseCkTESTBTC(universeId)
+  };
 
   let selectedNetwork: TransactionNetwork | undefined = undefined;
   let bitcoinEstimatedFee: bigint | undefined | null = undefined;
@@ -141,8 +146,7 @@
   bind:currentStep
   {token}
   {transactionFee}
-  sourceAccount={selectedAccount}
-  mustSelectNetwork={isUniverseCkTESTBTC(universeId)}
+  {transactionInit}
   bind:selectedNetwork
   {validateAmount}
   bind:amount={userAmount}

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -11,8 +11,13 @@
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { WizardStep } from "@dfinity/gix-components";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
+  import type { TransactionInit } from "$lib/types/transaction";
 
   export let selectedAccount: Account | undefined = undefined;
+
+  let transactionInit: TransactionInit = {
+    sourceAccount: selectedAccount,
+  };
 
   let currentStep: WizardStep;
 
@@ -59,7 +64,7 @@
   on:nnsSubmit={transfer}
   on:nnsClose
   bind:currentStep
-  sourceAccount={selectedAccount}
+  {transactionInit}
   transactionFee={$mainTransactionFeeStoreAsToken}
 >
   <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -12,11 +12,16 @@
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import type { Account } from "$lib/types/account";
   import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
+  import type { TransactionInit } from "$lib/types/transaction";
 
   // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
   // This way we can reuse this component in a dashboard page.
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
+
+  let transactionInit: TransactionInit = {
+    sourceAccount: selectedAccount,
+  };
 
   let currentStep: WizardStep;
 
@@ -60,7 +65,7 @@
     bind:currentStep
     token={$snsTokenSymbolSelectedStore}
     transactionFee={$snsSelectedTransactionFeeStore}
-    sourceAccount={selectedAccount}
+    {transactionInit}
   >
     <svelte:fragment slot="title"
       >{title ?? $i18n.accounts.send}</svelte:fragment

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -13,8 +13,13 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { pollAccounts } from "$lib/services/accounts.services";
+  import type {TransactionInit} from "$lib/types/transaction";
 
   export let neuron: NeuronInfo;
+
+  let transactionInit: TransactionInit = {
+    destinationAddress: neuron.fullNeuron?.accountIdentifier,
+  };
 
   onMount(() => {
     pollAccounts();
@@ -67,7 +72,7 @@
     on:nnsSubmit={topUp}
     on:nnsClose
     bind:currentStep
-    destinationAddress={neuron.fullNeuron?.accountIdentifier}
+    {transactionInit}
     transactionFee={$mainTransactionFeeStoreAsToken}
   >
     <svelte:fragment slot="title"

--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -13,7 +13,7 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import { pollAccounts } from "$lib/services/accounts.services";
-  import type {TransactionInit} from "$lib/types/transaction";
+  import type { TransactionInit } from "$lib/types/transaction";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
@@ -5,6 +5,7 @@
   import type { Token, TokenAmount } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import type { ValidateAmountFn } from "$lib/types/transaction";
+  import type {TransactionInit} from "$lib/types/transaction";
 
   export let token: Token;
   export let rootCanisterId: Principal;
@@ -12,6 +13,10 @@
   export let transactionFee: TokenAmount;
   export let currentStep: WizardStep;
   export let validateAmount: ValidateAmountFn = () => undefined;
+
+  let transactionInit: TransactionInit = {
+    destinationAddress: governanceCanisterId.toText(),
+  };
 </script>
 
 <TransactionModal
@@ -22,7 +27,7 @@
   {token}
   {transactionFee}
   {validateAmount}
-  destinationAddress={governanceCanisterId.toText()}
+  {transactionInit}
 >
   <slot name="title" slot="title" />
   <svelte:fragment slot="destination-info">

--- a/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsTransactionModal.svelte
@@ -5,7 +5,7 @@
   import type { Token, TokenAmount } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import type { ValidateAmountFn } from "$lib/types/transaction";
-  import type {TransactionInit} from "$lib/types/transaction";
+  import type { TransactionInit } from "$lib/types/transaction";
 
   export let token: Token;
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -43,6 +43,7 @@
     cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
+  import {TransactionInit} from "$lib/types/transaction";
 
   onMount(() => {
     pollAccounts(false);
@@ -68,12 +69,17 @@
   let destinationAddress: string | undefined;
   $: (async () => {
     destinationAddress =
-      $projectDetailStore.summary?.swapCanisterId !== undefined
+      nonNullish($projectDetailStore.summary?.swapCanisterId)
         ? (
             await getSwapAccount($projectDetailStore.summary?.swapCanisterId)
           ).toHex()
         : undefined;
   })();
+
+  let transactionInit: TransactionInit | undefined;
+  $: transactionInit = nonNullish(destinationAddress) ? {
+    destinationAddress
+          } : undefined
 
   let params: SnsParams;
   $: ({
@@ -188,7 +194,7 @@
 </script>
 
 <!-- Edge case. If it's not defined, button to open this modal is not shown -->
-{#if destinationAddress !== undefined}
+{#if nonNullish(transactionInit)}
   <TransactionModal
     rootCanisterId={OWN_CANISTER_ID}
     bind:currentStep
@@ -196,7 +202,7 @@
     on:nnsClose
     on:nnsSubmit={participate}
     {validateAmount}
-    {destinationAddress}
+    {transactionInit}
     disableSubmit={!accepted || busy}
     skipHardwareWallets
     transactionFee={$mainTransactionFeeStoreAsToken}

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -43,7 +43,7 @@
     cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
-  import { TransactionInit } from "$lib/types/transaction";
+  import type { TransactionInit } from "$lib/types/transaction";
 
   onMount(() => {
     pollAccounts(false);

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -68,11 +68,12 @@
 
   let destinationAddress: string | undefined;
   $: (async () => {
-    destinationAddress = nonNullish($projectDetailStore.summary?.swapCanisterId)
-      ? (
-          await getSwapAccount($projectDetailStore.summary?.swapCanisterId)
-        ).toHex()
-      : undefined;
+    destinationAddress =
+      $projectDetailStore.summary?.swapCanisterId !== undefined
+        ? (
+            await getSwapAccount($projectDetailStore.summary?.swapCanisterId)
+          ).toHex()
+        : undefined;
   })();
 
   let transactionInit: TransactionInit | undefined;

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -43,7 +43,7 @@
     cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/accounts.services";
-  import {TransactionInit} from "$lib/types/transaction";
+  import { TransactionInit } from "$lib/types/transaction";
 
   onMount(() => {
     pollAccounts(false);
@@ -68,18 +68,19 @@
 
   let destinationAddress: string | undefined;
   $: (async () => {
-    destinationAddress =
-      nonNullish($projectDetailStore.summary?.swapCanisterId)
-        ? (
-            await getSwapAccount($projectDetailStore.summary?.swapCanisterId)
-          ).toHex()
-        : undefined;
+    destinationAddress = nonNullish($projectDetailStore.summary?.swapCanisterId)
+      ? (
+          await getSwapAccount($projectDetailStore.summary?.swapCanisterId)
+        ).toHex()
+      : undefined;
   })();
 
   let transactionInit: TransactionInit | undefined;
-  $: transactionInit = nonNullish(destinationAddress) ? {
-    destinationAddress
-          } : undefined
+  $: transactionInit = nonNullish(destinationAddress)
+    ? {
+        destinationAddress,
+      }
+    : undefined;
 
   let params: SnsParams;
   $: ({

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -21,7 +21,7 @@
   let destinationAddress: string | undefined =
     transactionInit.destinationAddress;
 
-  // User inputs exposed for bind in consumers and initialized with initial parameters
+  // User inputs exposed for bind in consumers and initialized with initial parameters when component is mounted.
   export let amount: number | undefined = transactionInit.amount;
 
   // User inputs exposed for bind in consumers
@@ -38,6 +38,15 @@
   export let validateAmount: ValidateAmountFn = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
+  // Init configuration only once when component is mounting. The configuration should not vary when user interact with the form.
+  let canSelectDestination = isNullish(transactionInit.destinationAddress);
+  let canSelectSource = isNullish(transactionInit.sourceAccount);
+  let mustSelectNetwork = transactionInit.mustSelectNetwork ?? false;
+
+  let selectedDestinationAddress: string | undefined = destinationAddress;
+  let showManualAddress = true;
+
+  // Wizard modal steps and navigation
   const STEP_FORM = "Form";
   const STEP_PROGRESS = "Progress";
   const STEP_QRCODE = "QRCode";
@@ -60,14 +69,6 @@
       title: "",
     },
   ];
-
-  // Init configuration only once when component is mounting. The configuration should not vary when user interact with the form.
-  let canSelectDestination = isNullish(transactionInit.destinationAddress);
-  let canSelectSource = isNullish(transactionInit.sourceAccount);
-  let mustSelectNetwork = transactionInit.mustSelectNetwork ?? false;
-
-  let selectedDestinationAddress: string | undefined = destinationAddress;
-  let showManualAddress = true;
 
   let modal: WizardModal;
 

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -7,27 +7,31 @@
   import { ICPToken, TokenAmount, type Token } from "@dfinity/nns";
   import type { Principal } from "@dfinity/principal";
   import type {
+    TransactionInit,
     TransactionNetwork,
     ValidateAmountFn,
   } from "$lib/types/transaction";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
+  import {isNullish, nonNullish} from "@dfinity/utils";
+
+  export let transactionInit: TransactionInit = {};
+
+  // User inputs initialized with given initial parameters when component is mounted. If initial parameters vary, we do not want to overwrite what the user would have already entered.
+  let sourceAccount: Account | undefined = transactionInit.sourceAccount;
+  let destinationAddress: string | undefined = transactionInit.destinationAddress;
 
   export let rootCanisterId: Principal;
   export let currentStep: WizardStep | undefined = undefined;
-  export let sourceAccount: Account | undefined = undefined;
   export let token: Token = ICPToken;
   export let transactionFee: TokenAmount;
   export let disableSubmit = false;
   // Max amount accepted by the transaction wihout fees
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
-  export let mustSelectNetwork = false;
   export let validateAmount: ValidateAmountFn = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
 
-  // User inputs
-  let selectedAccount: Account | undefined = sourceAccount;
-  export let destinationAddress: string | undefined = undefined;
+  // User inputs exposed because bind in consumers
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
   export let amount: number | undefined = undefined;
 
@@ -54,15 +58,15 @@
     },
   ];
 
-  let modal: WizardModal;
+  // Init configuration only once when component is mounting. The configuration should not vary when user interact with the form.
+  let canSelectDestination = isNullish(transactionInit.destinationAddress);
+  let canSelectSource = isNullish(transactionInit.sourceAccount);
+  let mustSelectNetwork = transactionInit.mustSelectNetwork ?? false;
 
-  // If destination or source are passed as prop, they are used.
-  // But the component doesn't bind them to the props.
-  // This way we can identify whether to show a dropdown to select destination or source.
   let selectedDestinationAddress: string | undefined = destinationAddress;
-  let canSelectDestination = destinationAddress === undefined;
-  let canSelectSource = sourceAccount === undefined;
   let showManualAddress = true;
+
+  let modal: WizardModal;
 
   const goNext = () => {
     modal.next();
@@ -100,7 +104,7 @@
       {transactionFee}
       {validateAmount}
       bind:selectedDestinationAddress
-      bind:selectedAccount
+      bind:selectedAccount={sourceAccount}
       bind:amount
       bind:showManualAddress
       {skipHardwareWallets}
@@ -115,11 +119,11 @@
       <slot name="additional-info-form" slot="additional-info" />
     </TransactionForm>
   {/if}
-  {#if currentStep?.name === "Review" && selectedAccount !== undefined && amount !== undefined && selectedDestinationAddress !== undefined}
+  {#if currentStep?.name === "Review" && nonNullish(sourceAccount) && amount !== undefined && selectedDestinationAddress !== undefined}
     <TransactionReview
       transaction={{
         destinationAddress: selectedDestinationAddress,
-        sourceAccount: selectedAccount,
+        sourceAccount,
         amount,
       }}
       {transactionFee}

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -12,28 +12,31 @@
     ValidateAmountFn,
   } from "$lib/types/transaction";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
-  import {isNullish, nonNullish} from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
 
   export let transactionInit: TransactionInit = {};
 
   // User inputs initialized with given initial parameters when component is mounted. If initial parameters vary, we do not want to overwrite what the user would have already entered.
   let sourceAccount: Account | undefined = transactionInit.sourceAccount;
-  let destinationAddress: string | undefined = transactionInit.destinationAddress;
+  let destinationAddress: string | undefined =
+    transactionInit.destinationAddress;
+
+  // User inputs exposed for bind in consumers and initialized with initial parameters
+  export let amount: number | undefined = transactionInit.amount;
+
+  // User inputs exposed for bind in consumers
+  export let selectedNetwork: TransactionNetwork | undefined = undefined;
 
   export let rootCanisterId: Principal;
   export let currentStep: WizardStep | undefined = undefined;
   export let token: Token = ICPToken;
   export let transactionFee: TokenAmount;
   export let disableSubmit = false;
-  // Max amount accepted by the transaction wihout fees
+  // Max amount accepted by the transaction without fees
   export let maxAmount: bigint | undefined = undefined;
   export let skipHardwareWallets = false;
   export let validateAmount: ValidateAmountFn = () => undefined;
   // TODO: Add transaction fee as a Token parameter https://dfinity.atlassian.net/browse/L2-990
-
-  // User inputs exposed because bind in consumers
-  export let selectedNetwork: TransactionNetwork | undefined = undefined;
-  export let amount: number | undefined = undefined;
 
   const STEP_FORM = "Form";
   const STEP_PROGRESS = "Progress";

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -8,6 +8,13 @@ export type NewTransaction = {
   amount: number;
 };
 
+export interface TransactionInit {
+  sourceAccount?: Account;
+  destinationAddress?: string;
+  mustSelectNetwork?: boolean;
+  amount?: number;
+}
+
 export type ValidateAmountFn = (params: {
   amount: number | undefined;
   selectedAccount: Account | undefined;

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -59,12 +59,14 @@ describe("TransactionModal", () => {
     renderModal({
       component: TransactionModal,
       props: {
-        destinationAddress,
-        sourceAccount,
         transactionFee,
         rootCanisterId,
         validateAmount,
-        mustSelectNetwork,
+        transactionInit: {
+          sourceAccount,
+          destinationAddress,
+          mustSelectNetwork,
+        },
       },
     });
 


### PR DESCRIPTION
# Motivation

Transaction modal has various properties. Some are values, some are initial parameters, such as providing the default source account.

When we will implement payment deep linking, there will be also muliple parameters (destination, token, amount). 

That's why this PR introduce an object for the initial parameters of the transaction modal. That way we can distinguish better what a parameters and also prepare the deep linking (as we will be able to pass down a single objects).

# Changes

No features change, refactoring of properties only.
