### PR TITLE
Add Jest specific implementation of PageObjectElement

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -13,6 +13,7 @@ import {
   mockSummary,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ProjectSwapDetailsPo } from "$tests/page-objects/ProjectSwapDetails.page-object";
 import { TokenAmount } from "@dfinity/nns";
 
@@ -103,7 +104,7 @@ describe("ProjectSwapDetails", () => {
       Component: ProjectSwapDetails,
     });
 
-    const po = ProjectSwapDetailsPo.under(container);
+    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
     expect(po.getTotalSupply()).toMatch(formatToken({ value: totalSupply }));
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -13,6 +13,7 @@ import {
   mockSnsNeuronWithPermissions,
 } from "$tests/mocks/sns-neurons.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
 import {
   SnsNeuronPermissionType,
@@ -46,7 +47,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.hasDisburseButton()).toBe(true);
   });
@@ -58,7 +59,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.isContentLoaded()).toBe(true);
     expect(po.hasDisburseButton()).toBe(false);
@@ -80,7 +81,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.hasDissolveButton()).toBe(true);
   });
@@ -92,7 +93,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.isContentLoaded()).toBe(true);
     expect(po.hasDissolveButton()).toBe(false);
@@ -107,7 +108,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
@@ -119,7 +120,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.isContentLoaded()).toBe(true);
     expect(po.hasIncreaseDissolveDelayButton()).toBe(false);
@@ -132,7 +133,7 @@ describe("SnsNeuronInfoStake", () => {
       reload: jest.fn(),
     });
 
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.hasIncreaseStakeButton()).toBe(true);
   });
@@ -147,7 +148,7 @@ describe("SnsNeuronInfoStake", () => {
       neuron,
       reload: jest.fn(),
     });
-    const po = SnsNeuronInfoStakePo.under(container);
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(po.isContentLoaded()).toBe(true);
     expect(po.hasIncreaseStakeButton()).toBe(false);

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -20,6 +20,7 @@ import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
+import { render } from "@testing-library/svelte";
 
 jest.mock("$lib/api/sns-aggregator.api");
 jest.mock("$lib/api/governance.api");

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -15,11 +15,11 @@ import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
-import { render } from "@testing-library/svelte";
 
 jest.mock("$lib/api/sns-aggregator.api");
 jest.mock("$lib/api/governance.api");
@@ -56,7 +56,7 @@ describe("NeuronDetail", () => {
 
     it("should load", async () => {
       const { container } = render(NeuronDetail, nnsProps);
-      const po = NeuronDetailPo.under(container);
+      const po = NeuronDetailPo.under(new JestPageObjectElement(container));
 
       expect(po.hasSnsNeuronDetailPo()).toBe(false);
       expect(po.hasNnsNeuronDetailPo()).toBe(true);
@@ -95,7 +95,7 @@ describe("NeuronDetail", () => {
       await loadSnsProjects();
       const { container } = render(NeuronDetail, { neuronId: testSnsNeuronId });
 
-      const po = NeuronDetailPo.under(container);
+      const po = NeuronDetailPo.under(new JestPageObjectElement(container));
       expect(po.isContentLoaded()).toBe(false);
       await waitFor(() => {
         expect(po.isContentLoaded()).toBe(true);
@@ -107,7 +107,7 @@ describe("NeuronDetail", () => {
 
     it("should load if sns projects are loaded after initial rendering", async () => {
       const { container } = render(NeuronDetail, { neuronId: testSnsNeuronId });
-      const po = NeuronDetailPo.under(container);
+      const po = NeuronDetailPo.under(new JestPageObjectElement(container));
       expect(po.isContentLoaded()).toBe(false);
 
       // Load SNS projects after rendering to make sure we don't load

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -13,6 +13,7 @@ import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -70,7 +71,7 @@ describe("Neurons", () => {
     });
 
     const { container } = render(Neurons);
-    const po = NeuronsPo.under(container);
+    const po = NeuronsPo.under(new JestPageObjectElement(container));
 
     expect(po.hasSnsNeuronsPo()).toBe(false);
     expect(po.hasNnsNeuronsPo()).toBe(true);
@@ -89,7 +90,7 @@ describe("Neurons", () => {
     });
 
     const { container } = render(Neurons);
-    const po = NeuronsPo.under(container);
+    const po = NeuronsPo.under(new JestPageObjectElement(container));
 
     expect(po.hasNnsNeuronsPo()).toBe(false);
     expect(po.hasSnsNeuronsPo()).toBe(true);
@@ -108,7 +109,7 @@ describe("Neurons", () => {
     });
 
     const { container } = render(Neurons);
-    const po = NeuronsPo.under(container);
+    const po = NeuronsPo.under(new JestPageObjectElement(container));
 
     expect(po.hasNnsNeuronsPo()).toBe(false);
     expect(po.hasSnsNeuronsPo()).toBe(false);

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -1,0 +1,27 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+/**
+ * An implementation of the PageObjectElement interface for Jest unit tests.
+ */
+export class JestPageObjectElement implements PageObjectElement {
+  private readonly element: Element;
+
+  constructor(element: Element) {
+    this.element = element;
+  }
+
+  querySelector(selector: string): JestPageObjectElement | null {
+    const el = this.element.querySelector(selector);
+    return el && new JestPageObjectElement(el);
+  }
+
+  querySelectorAll(selector: string): JestPageObjectElement[] {
+    return Array.from(this.element.querySelectorAll(selector)).map(
+      (el) => new JestPageObjectElement(el)
+    );
+  }
+
+  get textContent(): string {
+    return this.element.textContent;
+  }
+}

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -1,1 +1,9 @@
-export type PageObjectElement = Element;
+/**
+ * A platform agnostic interface for page objects to interact with elements.
+ * Platforms might include Jest and Playwright.
+ */
+export interface PageObjectElement {
+  querySelector(selector: string): PageObjectElement | null;
+  querySelectorAll(selector: string): PageObjectElement[];
+  get textContent(): string;
+}


### PR DESCRIPTION
# Motivation

We want to share page objects between Jest unit tests and Playwright e2e tests.
So we provide an interface abstracting the element to use by page objects.
This interface will have different implementations per platform.
This PR adds a first version of the Jest implementation.

# Changes


1. Add JestPageObjectElement and use it in all the tests to create page objects.
2. Change PageObjectElement to an interface implemented by JestPageObjectElement.
3. Add just a few methods on PageObjectElement to make current tests pass.

In the future we will change the interface to be more async so that it can be compatible with e2e but this will require more changes to the tests and page objects to accommodate so it will be different PRs.

# Tests

npm run test
npm run check
