### PR TITLE
GIX-1219: Manage errors when fetching SNS proposal data

### DIFF
--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -8,6 +8,7 @@
   import { getSnsProposalById } from "$lib/services/$public/sns-proposals.services";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import type { SnsProposalData, SnsProposalId } from "@dfinity/sns";
+  import { toastsError } from "$lib/stores/toasts.store";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -32,16 +33,42 @@
         getSnsProposalById({
           rootCanisterId: $snsOnlyProjectStore,
           proposalId,
+  // By setting a local variable, we avoid calling the below text when the whole store is changes.
+  let rootCanisterId = $snsOnlyProjectStore;
+
+  // TODO: Fix race condition in case the user changes the proposal before the first one hasn't loaded yet.
+  $: {
+    if (nonNullish(proposalIdText) && nonNullish(rootCanisterId)) {
+      // We can't be sure that `snsOnlyProjectStore` is the same when `handleError` is called.
+      const rootCanisterIdText = rootCanisterId.toText();
+      try {
+        const proposalId = BigInt(proposalIdText);
+        proposal = "loading";
+        getSnsProposalById({
+          rootCanisterId,
+          proposalId: { id: proposalId },
           setProposal: ({ proposal: proposalData }) => {
             proposal = proposalData;
           },
           handleError: () => {
             // TODO: redirect
+            goto(buildProposalsUrl({ universe: rootCanisterIdText }), {
+              replaceState: true,
+            });
           },
         });
       } catch (error) {
         proposal = "error";
         // TODO: Add a toast for this error and redirect
+        toastsError({
+          labelKey: "error.wrong_proposal_id",
+          substitutions: {
+            $proposalId: proposalIdText,
+          },
+        });
+        goto(buildProposalsUrl({ universe: rootCanisterIdText }), {
+          replaceState: true,
+        });
       }
     }
   }

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -102,11 +102,6 @@ const getNervousFunctions = (rootCanisterId: Principal) => {
   return nervousFunctionsList;
 };
 
-enum ImplementationsKeys {
-  queryProposal = "queryProposal",
-}
-const errorsMap: Map<ImplementationsKeys, Error> = new Map();
-
 ////////////////////////
 // Fake implementations:
 ////////////////////////
@@ -242,6 +237,9 @@ async function queryProposals({
   return proposals.get(mapKey({ identity, rootCanisterId })) || [];
 }
 
+/**
+ * Throws if no proposal is found for the given proposalId.
+ */
 async function queryProposal({
   identity,
   rootCanisterId,
@@ -252,10 +250,7 @@ async function queryProposal({
   identity: Identity;
   certified: boolean;
   proposalId: SnsProposalId;
-}): Promise<SnsProposalData | undefined> {
-  if (errorsMap.has(ImplementationsKeys.queryProposal)) {
-    throw errorsMap.get(ImplementationsKeys.queryProposal);
-  }
+}): Promise<SnsProposalData> {
   const proposal = proposals
     .get(mapKey({ identity, rootCanisterId }))
     .find(({ id }) => fromNullable(id).id === proposalId.id);
@@ -275,7 +270,6 @@ const reset = () => {
   neurons.clear();
   proposals.clear();
   nervousFunctions.clear();
-  errorsMap.clear();
 };
 
 const createNeuronId = ({
@@ -334,10 +328,6 @@ export const addProposalWith = ({
   };
   proposalsList.push(proposal);
   return proposal;
-};
-
-export const setQueryProposalError = (error: Error) => {
-  errorsMap.set(ImplementationsKeys.queryProposal, error);
 };
 
 export const addNervousSystemFunctionWith = ({

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
+import { authStore } from "$lib/stores/auth.store";
+import { page } from "$mocks/$app/stores";
+import * as snsGovernanceFake from "$tests/fakes/sns-governance-api.fake";
+import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+jest.mock("$lib/api/sns-governance.api");
+
+const blockedApiPaths = ["$lib/api/sns-governance.api"];
+
+describe("SnsProposalDetail", () => {
+  blockAllCallsTo(blockedApiPaths);
+  snsGovernanceFake.install();
+
+  describe("not logged in", () => {
+    const rootCanisterId = mockCanisterId;
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreNoIdentitySubscribe);
+      page.mock({ data: { universe: rootCanisterId.toText() } });
+    });
+
+    it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {
+      render(SnsProposalDetail, {
+        props: {
+          proposalIdText: "invalid",
+        },
+      });
+      await waitFor(() => {
+        const { path } = get(pageStore);
+        return expect(path).toEqual(AppPath.Proposals);
+      });
+    });
+
+    it("should redirect to the list of sns proposals if proposal is not found", async () => {
+      snsGovernanceFake.setQueryProposalError(new Error("Some error"));
+      render(SnsProposalDetail, {
+        props: {
+          proposalIdText: "2",
+        },
+      });
+      await waitFor(() => {
+        const { path } = get(pageStore);
+        return expect(path).toEqual(AppPath.Proposals);
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -10,16 +10,12 @@ import { page } from "$mocks/$app/stores";
 import * as snsGovernanceFake from "$tests/fakes/sns-governance-api.fake";
 import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
-import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 jest.mock("$lib/api/sns-governance.api");
 
-const blockedApiPaths = ["$lib/api/sns-governance.api"];
-
 describe("SnsProposalDetail", () => {
-  blockAllCallsTo(blockedApiPaths);
   snsGovernanceFake.install();
 
   describe("not logged in", () => {
@@ -46,7 +42,8 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should redirect to the list of sns proposals if proposal is not found", async () => {
-      snsGovernanceFake.setQueryProposalError(new Error("Some error"));
+      // There is no proposal with id 2 in the fake implementation.
+      // Therefore, the page should redirect to the list of proposals.
       render(SnsProposalDetail, {
         props: {
           proposalIdText: "2",


### PR DESCRIPTION
# Motivation

User should be redirected to the SNS proposals list if there is some problem loading the specific proposal.

# Changes

Changes in SnsProposalDetail.svelte page:
* Redirect if the parameter can't be parsed to a bigint.
* Redirect if there is an error when loading the proposal

# Tests

* Add test for SnsProposalDetail.svelte page. Add test case for each of the above scenarios.
* Add error capabilities to the sns governance api fake.
