### PR TITLE
GIX-1220: Display general SNS proposal info setup

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalDataSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalDataSection.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { SnsProposalData } from "@dfinity/sns";
+
+  export let proposal: SnsProposalData;
+</script>
+
+<div class="content-cell-island">
+  TODO: Proposal Data section
+  {proposal.id[0]?.id}
+</div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalPayloadSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalPayloadSection.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { SnsProposalData } from "@dfinity/sns";
+
+  export let proposal: SnsProposalData;
+</script>
+
+<div class="content-cell-island">
+  TODO: Payload Section
+  {proposal.id[0]?.id}
+</div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSummarySection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSummarySection.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { SnsProposalData } from "@dfinity/sns";
+
+  export let proposal: SnsProposalData;
+</script>
+
+<div class="content-cell-island">
+  TODO: Summary Section
+  {proposal.id[0]?.id}
+</div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { SnsProposalData } from "@dfinity/sns";
+
+  export let proposal: SnsProposalData;
+</script>
+
+<div class="content-cell-island">
+  TODO: System Info Section
+  {proposal.id[0]?.id}
+</div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalVotingSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalVotingSection.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { SnsProposalData } from "@dfinity/sns";
+
+  export let proposal: SnsProposalData;
+</script>
+
+<div class="content-cell-island">
+  TODO: Voting Section
+  {proposal.id[0]?.id}
+</div>

--- a/frontend/src/lib/components/ui/SkeletonDetails.svelte
+++ b/frontend/src/lib/components/ui/SkeletonDetails.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { SkeletonText } from "@dfinity/gix-components";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 </script>
 
-<div class="content-cell-title" data-tid="skeleton-details">
-  <SkeletonText tagName="h1" />
-</div>
-<div class="content-cell-details">
-  <SkeletonText />
-  <SkeletonText />
-  <SkeletonText />
-  <SkeletonText />
-  <SkeletonText />
-</div>
+<TestIdWrapper testId="skeleton-details">
+  <div class="content-cell-title">
+    <SkeletonText tagName="h1" />
+  </div>
+  <div class="content-cell-details">
+    <SkeletonText />
+    <SkeletonText />
+    <SkeletonText />
+    <SkeletonText />
+    <SkeletonText />
+  </div>
+</TestIdWrapper>

--- a/frontend/src/lib/components/ui/SkeletonDetails.svelte
+++ b/frontend/src/lib/components/ui/SkeletonDetails.svelte
@@ -2,7 +2,7 @@
   import { SkeletonText } from "@dfinity/gix-components";
 </script>
 
-<div class="content-cell-title">
+<div class="content-cell-title" data-tid="skeleton-details">
   <SkeletonText tagName="h1" />
 </div>
 <div class="content-cell-details">

--- a/frontend/src/lib/components/ui/SkeletonDetails.svelte
+++ b/frontend/src/lib/components/ui/SkeletonDetails.svelte
@@ -3,7 +3,7 @@
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
 </script>
 
-<TestIdWrapper testId="skeleton-details">
+<TestIdWrapper testId="skeleton-details-component">
   <div class="content-cell-title">
     <SkeletonText tagName="h1" />
   </div>

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -22,7 +22,7 @@
   // TODO: Use proposal to render the component.
   let proposal: SnsProposalData | "loading" | "error" = "loading";
 
-  const isProposal = (
+  const isLoadedProposal = (
     proposal: SnsProposalData | "loading" | "error"
   ): proposal is SnsProposalData =>
     proposal !== "loading" && proposal !== "error";
@@ -81,7 +81,7 @@
 </script>
 
 <div class="content-grid" data-tid="sns-proposal-details-grid">
-  {#if isProposal(proposal)}
+  {#if isLoadedProposal(proposal)}
     <div class="content-a">
       <SnsProposalSystemInfoSection {proposal} />
     </div>

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -10,11 +10,22 @@
   import type { SnsProposalData, SnsProposalId } from "@dfinity/sns";
   import { toastsError } from "$lib/stores/toasts.store";
   import { Principal } from "@dfinity/principal";
+  import SnsProposalSystemInfoSection from "$lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte";
+  import SnsProposalVotingSection from "$lib/components/sns-proposals/SnsProposalVotingSection.svelte";
+  import SnsProposalSummarySection from "$lib/components/sns-proposals/SnsProposalSummarySection.svelte";
+  import SnsProposalDataSection from "$lib/components/sns-proposals/SnsProposalDataSection.svelte";
+  import SkeletonDetails from "$lib/components/ui/SkeletonDetails.svelte";
+  import SnsProposalPayloadSection from "$lib/components/sns-proposals/SnsProposalPayloadSection.svelte";
 
   export let proposalIdText: string | undefined | null = undefined;
 
   // TODO: Use proposal to render the component.
   let proposal: SnsProposalData | "loading" | "error" = "loading";
+
+  const isProposal = (
+    proposal: SnsProposalData | "loading" | "error"
+  ): proposal is SnsProposalData =>
+    proposal !== "loading" && proposal !== "error";
 
   onMount(() => {
     // We don't render this page if not enabled, but to be safe we redirect to the NNS proposals page as well.
@@ -70,5 +81,31 @@
 </script>
 
 <div class="content-grid" data-tid="sns-proposal-details-grid">
-  <h1>SnsProposalDetail: {proposalIdText}</h1>
+  {#if isProposal(proposal)}
+    <div class="content-a">
+      <SnsProposalSystemInfoSection {proposal} />
+    </div>
+    <div class="content-b expand-content-b">
+      <SnsProposalVotingSection {proposal} />
+    </div>
+    <div class="content-c proposal-data-section">
+      <SnsProposalSummarySection {proposal} />
+      <SnsProposalDataSection {proposal} />
+      <SnsProposalPayloadSection {proposal} />
+    </div>
+  {:else}
+    <div class="content-a">
+      <div class="skeleton">
+        <SkeletonDetails />
+      </div>
+    </div>
+  {/if}
 </div>
+
+<style lang="scss">
+  .proposal-data-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--row-gap);
+  }
+</style>

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -103,9 +103,18 @@
 </div>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
   .proposal-data-section {
     display: flex;
     flex-direction: column;
     gap: var(--row-gap);
+  }
+
+  @include media.min-width(medium) {
+    // If this would be use elsewhere, we can extract some utility to gix-components
+    .content-b.expand-content-b {
+      grid-row-end: content-c;
+    }
   }
 </style>

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -7,7 +7,7 @@ import { pageStore } from "$lib/derived/page.derived";
 import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
-import * as snsGovernanceFake from "$tests/fakes/sns-governance-api.fake";
+import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -19,7 +19,7 @@ import { get } from "svelte/store";
 jest.mock("$lib/api/sns-governance.api");
 
 describe("SnsProposalDetail", () => {
-  snsGovernanceFake.install();
+  fakeSnsGovernanceApi.install();
 
   describe("not logged in", () => {
     const rootCanisterId = mockCanisterId;
@@ -34,7 +34,7 @@ describe("SnsProposalDetail", () => {
 
     it("should show skeleton while loading proposal", async () => {
       const proposalId = { id: BigInt(3) };
-      snsGovernanceFake.addProposalWith({
+      fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
         id: [proposalId],
@@ -54,7 +54,7 @@ describe("SnsProposalDetail", () => {
 
     it("should render content once proposal is loaded", async () => {
       const proposalId = { id: BigInt(3) };
-      snsGovernanceFake.addProposalWith({
+      fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
         id: [proposalId],
@@ -70,8 +70,10 @@ describe("SnsProposalDetail", () => {
         new JestPageObjectElement(container)
       );
       expect(po.getSkeletonDetails()).not.toBeNull();
+      expect(po.isContentLoaded()).toBe(false);
 
       await waitFor(() => expect(po.isContentLoaded()).toBe(true));
+      expect(po.getSkeletonDetails()).toBeNull();
     });
 
     it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {

--- a/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
@@ -1,0 +1,16 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SkeletonDetailsPo {
+  static readonly tid = "skeleton-details";
+
+  root: PageObjectElement;
+
+  private constructor(root: PageObjectElement) {
+    this.root = root;
+  }
+
+  static under(element: PageObjectElement): SkeletonDetailsPo | null {
+    const el = element.querySelector(`[data-tid=${SkeletonDetailsPo.tid}]`);
+    return el && new SkeletonDetailsPo(el);
+  }
+}

--- a/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
@@ -1,7 +1,7 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SkeletonDetailsPo {
-  static readonly tid = "skeleton-details";
+  static readonly tid = "skeleton-details-component";
 
   root: PageObjectElement;
 

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -1,24 +1,26 @@
-import { SkeletonCardPo } from "./SkeletonCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { isNullish } from "@dfinity/utils";
+import { SkeletonDetailsPo } from "./SkeletonDetails.page-object";
 
 export class SnsProposalDetailPo {
   static readonly tid = "sns-proposal-details-grid";
 
-  root: Element;
+  root: PageObjectElement;
 
-  private constructor(root: Element) {
+  private constructor(root: PageObjectElement) {
     this.root = root;
   }
 
-  static under(element: Element): SnsProposalDetailPo | null {
+  static under(element: PageObjectElement): SnsProposalDetailPo | null {
     const el = element.querySelector(`[data-tid=${SnsProposalDetailPo.tid}]`);
     return el && new SnsProposalDetailPo(el);
   }
 
-  getSkeletonCardPos(): SkeletonCardPo[] {
-    return SkeletonCardPo.allUnder(this.root);
+  getSkeletonDetails(): SkeletonDetailsPo | null {
+    return SkeletonDetailsPo.under(this.root);
   }
 
   isContentLoaded(): boolean {
-    return this.getSkeletonCardPos().length === 0;
+    return isNullish(this.getSkeletonDetails());
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -1,0 +1,24 @@
+import { SkeletonCardPo } from "./SkeletonCard.page-object";
+
+export class SnsProposalDetailPo {
+  static readonly tid = "sns-proposal-details-grid";
+
+  root: Element;
+
+  private constructor(root: Element) {
+    this.root = root;
+  }
+
+  static under(element: Element): SnsProposalDetailPo | null {
+    const el = element.querySelector(`[data-tid=${SnsProposalDetailPo.tid}]`);
+    return el && new SnsProposalDetailPo(el);
+  }
+
+  getSkeletonCardPos(): SkeletonCardPo[] {
+    return SkeletonCardPo.allUnder(this.root);
+  }
+
+  isContentLoaded(): boolean {
+    return this.getSkeletonCardPos().length === 0;
+  }
+}


### PR DESCRIPTION
# Motivation

User sees details of a specific SNS proposal.

In this PR: Setup the cards for the SnsProposalDetail page.

# Changes

* New components `SnsProposal<Xxx>Section.svelte` as placeholders. This will help develop the cards in parallel withour conflicts.
* SnsProposalDetail.svelte page renders SkeletonDetails or the placeholders when the proposal is loaded.

# Tests

* New test cases in SnsProposalDetail page spec. Skeleton is displayed initially and then content is loaded afterwards.
* New POs: SnsProposalDetailPo and SkeletonDetailsPo.
