### PR TITLE
Add Base class for page objects.

### DIFF
--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
-export class AmountDisplayPo {
+export class AmountDisplayPo extends BasePageObject {
   static readonly tid = "token-value-label";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): AmountDisplayPo | null {

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -1,9 +1,9 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-export class ButtonPo {
-  root: PageObjectElement;
 
+export class ButtonPo extends BasePageObject {
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under({

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class HashPo {
+export class HashPo extends BasePageObject {
   static readonly tid = "hash-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): HashPo | null {

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -1,15 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NnsNeuronDetailPo } from "$tests/page-objects/NnsNeuronDetail.page-object";
 import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
-export class NeuronDetailPo {
+export class NeuronDetailPo extends BasePageObject {
   static readonly tid = "neuron-detail-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): NeuronDetailPo | null {

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -1,15 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
 import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
-export class NeuronsPo {
+export class NeuronsPo extends BasePageObject {
   static readonly tid = "neurons-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): NeuronsPo | null {

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsNeuronCardPo {
+export class NnsNeuronCardPo extends BasePageObject {
   static readonly tid = "nns-neuron-card-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static allUnder(element: PageObjectElement): NnsNeuronCardPo[] {

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,11 +1,10 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-export class NnsNeuronCardTitlePo {
+export class NnsNeuronCardTitlePo extends BasePageObject {
   static readonly tid = "neuron-card-title";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronCardTitlePo | null {

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsNeuronDetailPo {
+export class NnsNeuronDetailPo extends BasePageObject {
   static readonly tid = "nns-neuron-detail-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronDetailPo | null {

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,14 +1,13 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsNeuronsPo {
+export class NnsNeuronsPo extends BasePageObject {
   static readonly tid = "nns-neurons-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronsPo | null {

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -1,13 +1,12 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ProjectSwapDetailsPo {
+export class ProjectSwapDetailsPo extends BasePageObject {
   static readonly tid = "project-swap-details-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): ProjectSwapDetailsPo | null {

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -1,11 +1,10 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-export class SkeletonCardPo {
+export class SkeletonCardPo extends BasePageObject {
   static readonly tid = "skeleton-card";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static allUnder(element: PageObjectElement): SkeletonCardPo[] {

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SnsNeuronCardTitlePo } from "$tests/page-objects/SnsNeuronCardTitle.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsNeuronCardPo {
+export class SnsNeuronCardPo extends BasePageObject {
   static readonly tid = "sns-neuron-card-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static allUnder(element: PageObjectElement): SnsNeuronCardPo[] {

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { HashPo } from "$tests/page-objects/Hash.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsNeuronCardTitlePo {
+export class SnsNeuronCardTitlePo extends BasePageObject {
   static readonly tid = "sns-neuron-card-title";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronCardTitlePo | null {

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsNeuronDetailPo {
+export class SnsNeuronDetailPo extends BasePageObject {
   static readonly tid = "sns-neuron-detail-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronDetailPo | null {

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
@@ -1,15 +1,14 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { nonNullish } from "@dfinity/utils";
 
-export class SnsNeuronInfoStakePo {
+export class SnsNeuronInfoStakePo extends BasePageObject {
   static readonly tid = "sns-neuron-info-stake";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronInfoStakePo | null {

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,14 +1,13 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsNeuronCardPo } from "$tests/page-objects/SnsNeuronCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsNeuronsPo {
+export class SnsNeuronsPo extends BasePageObject {
   static readonly tid = "sns-neurons-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronsPo | null {

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -1,13 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
-export class TooltipPo {
+export class TooltipPo extends BasePageObject {
   static readonly tid = "tooltip-component";
 
-  root: PageObjectElement;
-
   private constructor(root: PageObjectElement) {
-    this.root = root;
+    super(root);
   }
 
   static under(element: PageObjectElement): TooltipPo | null {

--- a/frontend/src/tests/page-objects/base.page-object.ts
+++ b/frontend/src/tests/page-objects/base.page-object.ts
@@ -1,0 +1,9 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BasePageObject {
+  readonly root: PageObjectElement;
+
+  constructor(root: PageObjectElement) {
+    this.root = root;
+  }
+}


### PR DESCRIPTION
# Motivation

There will be some things convenient to share between all page objects like click() and isPresent().
Having a share base class makes these easy to add.

# Changes

1. Add BasePageObject class which holds the root element.
2. Make all page objects extend BasePageObject.
3. Pass the root element to the super constructor instead of holding on to it in each page object class.

# Tests

npm run test
npm run check
