### PR TITLE
Fix: Copy contents of .dfx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .*
 !.rustfmt.toml
 !.gitignore
+!.dfx/**/*
 
 build-inputs.txt
 assets.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ RUN dfx --version
 # Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.
 FROM builder AS configurator
 SHELL ["bash", "-c"]
-COPY dfx.json config.sh .df[x] canister_ids.jso[n] /build/
+COPY dfx.json config.sh canister_ids.jso[n] /build/
+COPY .df[x]/ /build/.dfx
 WORKDIR /build
 ARG DFX_NETWORK=mainnet
 RUN mkdir -p frontend


### PR DESCRIPTION
# Motivation
Strange bug, whereby locally `./scripts/docker-build --network XXX` was not picking up the aggregator canister ID.

The dockerfile pulls in .dfx, precisely to support locally deployed, non-standard canister IDs.

On closer inspection, .dfx was being pulled in but as an empty directory.

`.*` is listed in .dockerignore.  But exempting `.dfx` in `.dockerignore` alone does not help.

In the COPY documentation, it states that if `src` is a directory, it must end in a `/`.  That did not help.

But having a separate copy command for `.dfx` does work.

# Changes
* Exempt `.dfx` from `.dockerignore`.
* Move the `.dfx` copy command to a separate step.

# Tests
* Manually tested that a local aggregator canister ID is now picked up.
* Manually tested that if I then remove `.dfx`, the locally deployed aggregator canister ID is no longer found.
How to test this in CI in a reasonable time?  It would be necessary to find  away of sharing the docker cache with the buildx action.