### PR TITLE
fix: "estimated amount received BTC" should not be displayed for ckBTC network

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -165,7 +165,12 @@
       bind:bitcoinEstimatedFee
     />
 
-    <BitcoinEstimatedAmountReceived {bitcoinEstimatedFee} amount={userAmount} />
+    {#if networkBtc}
+      <BitcoinEstimatedAmountReceived
+        {bitcoinEstimatedFee}
+        amount={userAmount}
+      />
+    {/if}
   </svelte:fragment>
   <svelte:fragment slot="additional-info-review">
     <BitcoinEstimatedFeeDisplay {bitcoinEstimatedFee} />

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -256,4 +256,17 @@ describe("CkBTCTransactionModal", () => {
     );
     expect(result.getByTestId("bitcoin-estimated-amount")).not.toBeNull();
   });
+
+  it("should not render btc estimation info on first step", async () => {
+    const result = await renderTransactionModal();
+
+    await testTransferFormTokens({
+      result,
+      selectedNetwork: TransactionNetwork.ICP_CKTESTBTC,
+      destinationAddress: mockCkBTCMainAccount.identifier,
+      amount: "0.002",
+    });
+
+    expect(() => result.getByTestId("bitcoin-estimated-fee")).toThrow();
+  });
 });


### PR DESCRIPTION
# Motivation

"Estimated amount received: xxxxx BTC" should not be displayed for ckBTC.

# Changes

- use related component according network

# Screenshot

<img width="1536" alt="Capture d’écran 2023-03-22 à 17 37 41" src="https://user-images.githubusercontent.com/16886711/226976816-270f4d66-6d2e-46ae-8efb-24b2539bfab6.png">

