### PR TITLE
Make it possible to pause fake governance API

### DIFF
--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -334,6 +334,7 @@ export const resume = () => {
     call();
   }
   pendingCalls.length = 0;
+  isPaused = false;
 };
 
 const createNeuronId = ({

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -56,12 +56,14 @@ describe("NeuronDetail", () => {
     });
 
     it("should load", async () => {
+      fakeGovernanceApi.pause();
       const { container } = render(NeuronDetail, nnsProps);
       const po = NeuronDetailPo.under(new JestPageObjectElement(container));
 
       expect(await po.hasSnsNeuronDetailPo()).toBe(false);
       expect(await po.hasNnsNeuronDetailPo()).toBe(true);
       expect(await po.getNnsNeuronDetailPo().isContentLoaded()).toBe(false);
+      fakeGovernanceApi.resume();
       await waitFor(async () => {
         expect(await po.getNnsNeuronDetailPo().isContentLoaded()).toBe(true);
       });
@@ -94,10 +96,12 @@ describe("NeuronDetail", () => {
 
     it("should load", async () => {
       await loadSnsProjects();
+      fakeSnsGovernanceApi.pause();
       const { container } = render(NeuronDetail, { neuronId: testSnsNeuronId });
 
       const po = NeuronDetailPo.under(new JestPageObjectElement(container));
       expect(await po.isContentLoaded()).toBe(false);
+      fakeSnsGovernanceApi.resume();
       await waitFor(async () => {
         expect(await po.isContentLoaded()).toBe(true);
       });

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -77,6 +77,7 @@ describe("Neurons", () => {
     expect(await po.hasSnsNeuronsPo()).toBe(false);
     expect(await po.hasNnsNeuronsPo()).toBe(true);
     expect(await po.getNnsNeuronsPo().isContentLoaded()).toBe(false);
+    fakeGovernanceApi.resume();
     await waitFor(async () => {
       expect(await po.getNnsNeuronsPo().isContentLoaded()).toBe(true);
     });
@@ -97,6 +98,7 @@ describe("Neurons", () => {
     expect(await po.hasNnsNeuronsPo()).toBe(false);
     expect(await po.hasSnsNeuronsPo()).toBe(true);
     expect(await po.getSnsNeuronsPo().isContentLoaded()).toBe(false);
+    fakeSnsGovernanceApi.resume();
     await waitFor(async () => {
       expect(await po.getSnsNeuronsPo().isContentLoaded()).toBe(true);
     });

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -65,6 +65,7 @@ describe("Neurons", () => {
   });
 
   it("should render NnsNeurons by default", async () => {
+    fakeGovernanceApi.pause();
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Neurons,
@@ -85,6 +86,7 @@ describe("Neurons", () => {
   });
 
   it("should render project page when a committed project is selected", async () => {
+    fakeSnsGovernanceApi.pause();
     page.mock({
       data: { universe: testCommittedSnsCanisterId.toText() },
     });


### PR DESCRIPTION
# Motivation

When expecting a component to be in loading state we shouldn't rely on arbitrary promises not to be resolved yet.

# Changes

1. Make it possible to pause fake governance API same as fake SNS governance API.
2. Pause the API in tests that explicitly expect a component to be in loading state.
3. Add missing `isPaused = false` in resume of fake SNS governance API.

# Tests

`npm run test`
