### PR TITLE
GIX-1220: SNS proposal - Render system info

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -9,7 +9,6 @@
     SnsNervousSystemFunction,
     SnsNeuronId,
     SnsProposalData,
-    SnsProposalId,
   } from "@dfinity/sns";
   import { nonNullish } from "@dfinity/utils";
   import ProposalSystemInfoEntry from "../proposal-detail/ProposalSystemInfoEntry.svelte";
@@ -20,19 +19,16 @@
 
   $: loadSnsNervousSystemFunctions(rootCanisterId);
 
-  let id: SnsProposalId | undefined;
   let topic: string | undefined;
   let topicDescription: string | undefined;
   let statusString: string;
   let statusDescription: string | undefined;
   let rewardStatusString: string;
   let rewardStatusDescription: string | undefined;
-
   let proposal_creation_timestamp_seconds: bigint;
   let decided_timestamp_seconds: bigint;
   let executed_timestamp_seconds: bigint;
   let failed_timestamp_seconds: bigint;
-
   let proposer: SnsNeuronId | undefined;
 
   let nsFunctions: SnsNervousSystemFunction[];
@@ -41,17 +37,16 @@
 
   $: ({
     topic,
-    statusString,
-    rewardStatusString,
     topicDescription,
+    statusString,
     statusDescription,
+    rewardStatusString,
     rewardStatusDescription,
     proposal_creation_timestamp_seconds,
     decided_timestamp_seconds,
     executed_timestamp_seconds,
     failed_timestamp_seconds,
     proposer,
-    id,
   } = mapProposalInfo({ proposalData: proposal, nsFunctions }));
 </script>
 
@@ -70,9 +65,7 @@
         value={topic}
         description={topicDescription}
       />
-    {/if}
 
-    {#if nonNullish(topic)}
       <ProposalSystemInfoEntry
         labelKey="topic_prefix"
         testId="proposal-system-info-topic"

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { i18n } from "$lib/stores/i18n";
   import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import { secondsToDateTime } from "$lib/utils/date.utils";
@@ -16,6 +17,8 @@
 
   export let proposal: SnsProposalData;
   export let rootCanisterId: Principal;
+
+  $: loadSnsNervousSystemFunctions(rootCanisterId);
 
   let id: SnsProposalId | undefined;
   let topic: string | undefined;

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -37,7 +37,7 @@
 
   let nsFunctions: SnsNervousSystemFunction[];
   $: nsFunctions =
-    $snsFunctionsStore[rootCanisterId.toText()].nsFunctions || [];
+    $snsFunctionsStore[rootCanisterId.toText()]?.nsFunctions || [];
 
   $: ({
     topic,
@@ -55,14 +55,13 @@
   } = mapProposalInfo({ proposalData: proposal, nsFunctions }));
 </script>
 
-<div class="content-cell-island">
+<div
+  class="content-cell-island"
+  data-tid="proposal-system-info-details-component"
+>
   <h1 class="content-cell-title">{topic ?? ""}</h1>
 
-  <div
-    class="content-cell-details"
-    data-tid="proposal-system-info-details"
-    data-proposal-id={id?.id}
-  >
+  <div class="content-cell-details">
     <!-- TODO: Confirm with product that we show both Type and Topic as the same for now -->
     {#if nonNullish(topic)}
       <ProposalSystemInfoEntry

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -1,10 +1,134 @@
 <script lang="ts">
-  import type { SnsProposalData } from "@dfinity/sns";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+  import { secondsToDateTime } from "$lib/utils/date.utils";
+  import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
+  import type { Principal } from "@dfinity/principal";
+  import type {
+    SnsNervousSystemFunction,
+    SnsNeuronId,
+    SnsProposalData,
+    SnsProposalId,
+  } from "@dfinity/sns";
+  import { nonNullish } from "@dfinity/utils";
+  import ProposalSystemInfoEntry from "../proposal-detail/ProposalSystemInfoEntry.svelte";
+  import SnsProposerEntry from "./SnsProposerEntry.svelte";
 
   export let proposal: SnsProposalData;
+  export let rootCanisterId: Principal;
+
+  let id: SnsProposalId | undefined;
+  let topic: string | undefined;
+  let topicDescription: string | undefined;
+  let statusString: string;
+  let statusDescription: string | undefined;
+  let rewardStatusString: string;
+  let rewardStatusDescription: string | undefined;
+
+  let proposal_creation_timestamp_seconds: bigint;
+  let decided_timestamp_seconds: bigint;
+  let executed_timestamp_seconds: bigint;
+  let failed_timestamp_seconds: bigint;
+
+  let proposer: SnsNeuronId | undefined;
+
+  let nsFunctions: SnsNervousSystemFunction[];
+  $: nsFunctions =
+    $snsFunctionsStore[rootCanisterId.toText()].nsFunctions || [];
+
+  $: ({
+    topic,
+    statusString,
+    rewardStatusString,
+    topicDescription,
+    statusDescription,
+    rewardStatusDescription,
+    proposal_creation_timestamp_seconds,
+    decided_timestamp_seconds,
+    executed_timestamp_seconds,
+    failed_timestamp_seconds,
+    proposer,
+    id,
+  } = mapProposalInfo({ proposalData: proposal, nsFunctions }));
 </script>
 
 <div class="content-cell-island">
-  TODO: System Info Section
-  {proposal.id[0]?.id}
+  <h1 class="content-cell-title">{topic ?? ""}</h1>
+
+  <div
+    class="content-cell-details"
+    data-tid="proposal-system-info-details"
+    data-proposal-id={id?.id}
+  >
+    <!-- TODO: Confirm with product that we show both Type and Topic as the same for now -->
+    {#if nonNullish(topic)}
+      <ProposalSystemInfoEntry
+        labelKey="type_prefix"
+        testId="proposal-system-info-type"
+        value={topic}
+        description={topicDescription}
+      />
+    {/if}
+
+    {#if nonNullish(topic)}
+      <ProposalSystemInfoEntry
+        labelKey="topic_prefix"
+        testId="proposal-system-info-topic"
+        value={topic}
+        description={topicDescription}
+      />
+    {/if}
+
+    <ProposalSystemInfoEntry
+      labelKey="status_prefix"
+      testId="proposal-system-info-status"
+      value={statusString}
+      description={statusDescription}
+    />
+
+    <ProposalSystemInfoEntry
+      labelKey="reward_prefix"
+      testId="proposal-system-info-reward"
+      value={rewardStatusString}
+      description={rewardStatusDescription}
+    />
+
+    <ProposalSystemInfoEntry
+      labelKey="created_prefix"
+      testId="proposal-system-info-created"
+      value={secondsToDateTime(proposal_creation_timestamp_seconds)}
+      description={$i18n.proposal_detail.created_description}
+    />
+
+    {#if decided_timestamp_seconds > BigInt(0)}
+      <ProposalSystemInfoEntry
+        labelKey="decided_prefix"
+        testId="proposal-system-info-decided"
+        value={secondsToDateTime(decided_timestamp_seconds)}
+        description={$i18n.proposal_detail.decided_description}
+      />
+    {/if}
+
+    {#if executed_timestamp_seconds > BigInt(0)}
+      <ProposalSystemInfoEntry
+        labelKey="executed_prefix"
+        testId="proposal-system-info-executed"
+        value={secondsToDateTime(executed_timestamp_seconds)}
+        description={$i18n.proposal_detail.executed_description}
+      />
+    {/if}
+
+    {#if failed_timestamp_seconds > BigInt(0)}
+      <ProposalSystemInfoEntry
+        labelKey="failed_prefix"
+        testId="proposal-system-info-failed"
+        value={secondsToDateTime(failed_timestamp_seconds)}
+        description={$i18n.proposal_detail.failed_description}
+      />
+    {/if}
+
+    {#if nonNullish(proposer)}
+      <SnsProposerEntry {proposer} />
+    {/if}
+  </div>
 </div>

--- a/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+  import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
+  import type { SnsNeuronId } from "@dfinity/sns";
+  import Hash from "../ui/Hash.svelte";
+
+  export let proposer: SnsNeuronId;
+
+  let proposerText: string;
+  $: proposerText = subaccountToHexString(proposer.id);
+</script>
+
+<KeyValuePairInfo testId="proposal-system-info-proposer">
+  <svelte:fragment slot="key"
+    >{$i18n.proposal_detail.proposer_prefix}</svelte:fragment
+  >
+
+  <svelte:fragment slot="value">
+    <Hash
+      className="value"
+      tagName="span"
+      text={proposerText}
+      id="proposer-id"
+      testId="proposal-system-info-proposer-value"
+    />
+  </svelte:fragment>
+
+  <svelte:fragment slot="info">
+    <Html text={$i18n.proposal_detail.proposer_description} />
+  </svelte:fragment>
+</KeyValuePairInfo>

--- a/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
@@ -22,7 +22,6 @@
       tagName="span"
       text={proposerText}
       id="proposer-id"
-      testId="proposal-system-info-proposer-value"
     />
   </svelte:fragment>
 

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -16,7 +16,7 @@
 
 <span data-tid="hash-component">
   <Tooltip {id} {text}>
-    <svelte:element this={tagName} data-tid={testId} class={className ?? ""}>
+    <svelte:element this={tagName} data-tid={testId} class={className}>
       {shortenText}</svelte:element
     >
   </Tooltip>

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -8,6 +8,7 @@
   export let id: string;
   export let text: string;
   export let showCopy = false;
+  export let className: string | undefined = undefined;
 
   let shortenText: string;
   $: shortenText = shortenWithMiddleEllipsis(text);
@@ -15,7 +16,7 @@
 
 <span data-tid="hash-component">
   <Tooltip {id} {text}>
-    <svelte:element this={tagName} data-tid={testId}>
+    <svelte:element this={tagName} data-tid={testId} class={className ?? ""}>
       {shortenText}</svelte:element
     >
   </Tooltip>

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -39,10 +39,17 @@
   // By storing the canister id as a text, we avoid calling the block below if the store is updated with the same value.
   let rootCanisterIdText: undefined | string;
   $: rootCanisterIdText = $snsOnlyProjectStore?.toText();
+  let rootCanisterId: Principal | undefined;
+  $: rootCanisterId = nonNullish(rootCanisterIdText)
+    ? Principal.fromText(rootCanisterIdText)
+    : undefined;
   $: {
     // TODO: Fix race condition in case the user changes the proposal before the first one hasn't loaded yet.
-    if (nonNullish(proposalIdText) && nonNullish(rootCanisterIdText)) {
-      const rootCanisterId = Principal.fromText(rootCanisterIdText);
+    if (
+      nonNullish(proposalIdText) &&
+      nonNullish(rootCanisterIdText) &&
+      nonNullish(rootCanisterId)
+    ) {
       // We need this to be used in the handleError callback.
       // Otherwise, TS doesn't believe that the value of `rootCanisterIdText` won't change.
       const rootCanisterIdAtTimeOfRequest = rootCanisterIdText;
@@ -81,9 +88,9 @@
 </script>
 
 <div class="content-grid" data-tid="sns-proposal-details-grid">
-  {#if isLoadedProposal(proposal)}
+  {#if isLoadedProposal(proposal) && nonNullish(rootCanisterId)}
     <div class="content-a">
-      <SnsProposalSystemInfoSection {proposal} />
+      <SnsProposalSystemInfoSection {proposal} {rootCanisterId} />
     </div>
     <div class="content-b expand-content-b">
       <SnsProposalVotingSection {proposal} />

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -83,6 +83,9 @@
           replaceState: true,
         });
       }
+    } else {
+      // Reset proposal to the initial state.
+      proposal = "loading";
     }
   }
 </script>

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -64,6 +64,7 @@ export type SnsProposalDataMap = {
   topicDescription?: string;
 };
 
+// TODO: Return also a type and the type description that for now maps to the topic
 export const mapProposalInfo = ({
   proposalData,
   nsFunctions,

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -8,7 +8,7 @@ import { secondsToDateTime } from "$lib/utils/date.utils";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
-import * as snsGovernanceApiFake from "$tests/fakes/sns-governance-api.fake";
+import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
@@ -22,7 +22,7 @@ import { get } from "svelte/store";
 jest.mock("$lib/api/sns-governance.api");
 
 describe("ProposalSystemInfoSection", () => {
-  snsGovernanceApiFake.install();
+  fakeSnsGovernanceApi.install();
 
   const rootCanisterId = mockCanisterId;
   const nervousFunction = nervousSystemFunctionMock;
@@ -30,7 +30,7 @@ describe("ProposalSystemInfoSection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     snsFunctionsStore.reset();
-    snsGovernanceApiFake.addNervousSystemFunctionWith({
+    fakeSnsGovernanceApi.addNervousSystemFunctionWith({
       rootCanisterId,
       ...nervousFunction,
     });
@@ -58,11 +58,11 @@ describe("ProposalSystemInfoSection", () => {
     };
 
     it("should load the nervous functions in the store", async () => {
-      snsGovernanceApiFake.pause();
+      fakeSnsGovernanceApi.pause();
       render(ProposalSystemInfoSection, { props });
 
       expect(get(snsFunctionsStore)[rootCanisterId.toText()]).toBeUndefined();
-      snsGovernanceApiFake.resume();
+      fakeSnsGovernanceApi.resume();
 
       await waitFor(() =>
         expect(

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -15,6 +15,7 @@ import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsProposalDecisionStatus } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -25,7 +26,13 @@ describe("ProposalSystemInfoSection", () => {
   fakeSnsGovernanceApi.install();
 
   const rootCanisterId = mockCanisterId;
-  const nervousFunction = nervousSystemFunctionMock;
+  const testNervousFunctionId = BigInt(1);
+  const testNervousFunctionName = "test function";
+  const nervousFunction = {
+    ...nervousSystemFunctionMock,
+    id: testNervousFunctionId,
+    name: testNervousFunctionName,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -42,7 +49,7 @@ describe("ProposalSystemInfoSection", () => {
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
         proposalId: BigInt(2),
       }),
-      action: nervousFunction.id,
+      action: testNervousFunctionId,
     };
     const {
       rewardStatusString,
@@ -77,13 +84,9 @@ describe("ProposalSystemInfoSection", () => {
         new JestPageObjectElement(container)
       );
 
-      await waitFor(() =>
-        expect(
-          get(snsFunctionsStore)[rootCanisterId.toText()].nsFunctions.length
-        ).toBeGreaterThan(0)
-      );
+      await runResolvedPromises();
 
-      expect(await po.getTitleText()).toEqual(nervousFunction.name);
+      expect(await po.getTitleText()).toEqual(testNervousFunctionName);
     });
 
     it("should render type info from the nervous function", async () => {
@@ -93,13 +96,9 @@ describe("ProposalSystemInfoSection", () => {
         new JestPageObjectElement(container)
       );
 
-      await waitFor(() =>
-        expect(
-          get(snsFunctionsStore)[rootCanisterId.toText()].nsFunctions
-        ).toEqual([nervousFunction])
-      );
+      await runResolvedPromises();
 
-      expect(await po.getTypeText()).toBe(nervousFunction.name);
+      expect(await po.getTypeText()).toBe(testNervousFunctionName);
     });
 
     it("should render topic info from the nervous function", async () => {
@@ -109,13 +108,9 @@ describe("ProposalSystemInfoSection", () => {
         new JestPageObjectElement(container)
       );
 
-      await waitFor(() =>
-        expect(
-          get(snsFunctionsStore)[rootCanisterId.toText()].nsFunctions
-        ).toEqual([nervousFunction])
-      );
+      await runResolvedPromises();
 
-      expect(await po.getTopicText()).toBe(nervousFunction.name);
+      expect(await po.getTopicText()).toBe(testNervousFunctionName);
     });
 
     it("should render open status", async () => {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import ProposalSystemInfoSection from "$lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+import { secondsToDateTime } from "$lib/utils/date.utils";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
+import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
+import * as snsGovernanceApiFake from "$tests/fakes/sns-governance-api.fake";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import en from "$tests/mocks/i18n.mock";
+import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
+import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("ProposalSystemInfoSection", () => {
+  snsGovernanceApiFake.install();
+
+  const rootCanisterId = mockCanisterId;
+  const nervousFunction = nervousSystemFunctionMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    snsFunctionsStore.reset();
+    snsGovernanceApiFake.addNervousSystemFunctionWith({
+      rootCanisterId,
+      ...nervousFunction,
+    });
+  });
+
+  describe("open proposal", () => {
+    const openProposal = {
+      ...createSnsProposal({
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        proposalId: BigInt(2),
+      }),
+      action: nervousFunction.id,
+    };
+    const { rewardStatusString, proposer, decided_timestamp_seconds } =
+      mapProposalInfo({
+        proposalData: openProposal,
+        nsFunctions: [nervousFunction],
+      });
+    const props = {
+      proposal: openProposal,
+      rootCanisterId,
+    };
+
+    it("should request nervous system functions if not present in store", async () => {
+      snsGovernanceApiFake.pause();
+      render(ProposalSystemInfoSection, { props });
+
+      expect(get(snsFunctionsStore)).toBeUndefined();
+      snsGovernanceApiFake.resume();
+
+      await waitFor(() =>
+        expect(
+          get(snsFunctionsStore)[rootCanisterId.toText()].nsFunctions
+        ).toEqual([nervousFunction])
+      );
+      expect;
+    });
+
+    it("should render topic as title", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getTitleText()).toEqual(nervousFunction.name);
+    });
+
+    it("should render type info from the nervous function", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getTypeText()).toBe(nervousFunction.name);
+    });
+
+    it("should render topic info from the nervous function", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getTopicText()).toBe(nervousFunction.name);
+    });
+
+    it("should render open status", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getDecisionStatusText()).toBe(
+        en.sns_status[SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN]
+      );
+    });
+
+    it("should render reward status info", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getRewardStatusText()).toBe(rewardStatusString);
+    });
+
+    it("should render created timestamp", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getCreatedText()).toBe(
+        secondsToDateTime(decided_timestamp_seconds)
+      );
+    });
+
+    it("should not render any timestamps", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getDecidedText()).toBe("");
+      expect(await po.getExecutedText()).toBe("");
+      expect(await po.getFailedText()).toBe("");
+    });
+
+    it("should render proposer info", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getProposerText()).toBe(
+        shortenWithMiddleEllipsis(subaccountToHexString(proposer.id))
+      );
+    });
+  });
+
+  describe("adopted proposal", () => {
+    it("should render adopted status", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getDecisionStatusText()).toBe(
+        en.sns_status[
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED
+        ]
+      );
+    });
+
+    it("should render decided timestamp", async () => {});
+  });
+
+  describe("executed proposal", () => {
+    it("should render executed status", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getDecisionStatusText()).toBe(
+        en.sns_status[
+          SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED
+        ]
+      );
+    });
+
+    it("should render executed timestamp", async () => {});
+  });
+
+  describe("failed proposal", () => {
+    it("should render failed status", async () => {
+      const { container } = render(ProposalSystemInfoSection, { props });
+
+      const po = SnsProposalSystemInfoSectionPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      expect(await po.getDecisionStatusText()).toBe(
+        en.sns_status[SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED]
+      );
+    });
+
+    it("should render fialed timestamp", async () => {});
+  });
+});

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -34,6 +34,16 @@ describe("ProposalSystemInfoSection", () => {
     name: testNervousFunctionName,
   };
 
+  const renderComponent = async (props) => {
+    const { container } = render(ProposalSystemInfoSection, { props });
+
+    await runResolvedPromises();
+
+    return SnsProposalSystemInfoSectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     snsFunctionsStore.reset();
@@ -79,46 +89,25 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render topic as title", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
-
-      await runResolvedPromises();
+      const po = await renderComponent(props);
 
       expect(await po.getTitleText()).toEqual(testNervousFunctionName);
     });
 
     it("should render type info from the nervous function", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
-
-      await runResolvedPromises();
+      const po = await renderComponent(props);
 
       expect(await po.getTypeText()).toBe(testNervousFunctionName);
     });
 
     it("should render topic info from the nervous function", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
-
-      await runResolvedPromises();
+      const po = await renderComponent(props);
 
       expect(await po.getTopicText()).toBe(testNervousFunctionName);
     });
 
     it("should render open status", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getDecisionStatusText()).toBe(
         en.sns_status[SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN]
@@ -126,21 +115,13 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render reward status info", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getRewardStatusText()).toBe(rewardStatusString);
     });
 
     it("should render created timestamp", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getCreatedText()).toBe(
         secondsToDateTime(proposal_creation_timestamp_seconds)
@@ -148,11 +129,7 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should not render any timestamps", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getDecidedText()).toBeNull();
       expect(await po.getExecutedText()).toBeNull();
@@ -160,11 +137,7 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render proposer info", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getProposerText()).toContain(
         shortenWithMiddleEllipsis(subaccountToHexString(proposer.id))
@@ -184,11 +157,7 @@ describe("ProposalSystemInfoSection", () => {
       rootCanisterId,
     };
     it("should render adopted status", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getDecisionStatusText()).toBe(
         en.sns_status[
@@ -198,11 +167,7 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render decided timestamp", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getDecidedText()).toBe(
         secondsToDateTime(adoptedProposal.decided_timestamp_seconds)
@@ -222,11 +187,7 @@ describe("ProposalSystemInfoSection", () => {
       rootCanisterId,
     };
     it("should render executed status", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getDecisionStatusText()).toBe(
         en.sns_status[
@@ -236,11 +197,7 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render executed timestamp", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getExecutedText()).toBe(
         secondsToDateTime(executedProposal.executed_timestamp_seconds)
@@ -259,12 +216,9 @@ describe("ProposalSystemInfoSection", () => {
       proposal: failedProposal,
       rootCanisterId,
     };
-    it("should render failed status", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
 
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+    it("should render failed status", async () => {
+      const po = await renderComponent(props);
 
       expect(await po.getDecisionStatusText()).toBe(
         en.sns_status[SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED]
@@ -272,11 +226,7 @@ describe("ProposalSystemInfoSection", () => {
     });
 
     it("should render fialed timestamp", async () => {
-      const { container } = render(ProposalSystemInfoSection, { props });
-
-      const po = SnsProposalSystemInfoSectionPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent(props);
 
       expect(await po.getFailedText()).toBe(
         secondsToDateTime(failedProposal.failed_timestamp_seconds)

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -99,7 +99,9 @@ describe("SnsProposalDetail", () => {
       expect(await po.hasSystemInfoSection()).toBe(false);
       fakeSnsGovernanceApi.resume();
 
-      expect(await po.hasSystemInfoSection()).toBe(true);
+      await waitFor(async () =>
+        expect(await po.hasSystemInfoSection()).toBe(true)
+      );
     });
 
     it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -104,6 +104,37 @@ describe("SnsProposalDetail", () => {
       );
     });
 
+    it("should render the name of the nervous function", async () => {
+      const proposalId = { id: BigInt(3) };
+      const functionId = BigInt(12);
+      const functionName = "test function";
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
+        rootCanisterId,
+        id: functionId,
+        name: functionName,
+      });
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [proposalId],
+        action: functionId,
+      });
+
+      const { container } = render(SnsProposalDetail, {
+        props: {
+          proposalIdText: proposalId.id.toString(),
+        },
+      });
+
+      const po = SnsProposalDetailPo.under(
+        new JestPageObjectElement(container)
+      );
+
+      await waitFor(async () =>
+        expect(await po.getSystemInfoSectionTitle()).toBe(functionName)
+      );
+    });
+
     it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {
       render(SnsProposalDetail, {
         props: {

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -78,6 +78,30 @@ describe("SnsProposalDetail", () => {
       expect(await po.getSkeletonDetails().isPresent()).toBe(false);
     });
 
+    it("should render system info content", async () => {
+      fakeSnsGovernanceApi.pause();
+      const proposalId = { id: BigInt(3) };
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [proposalId],
+      });
+
+      const { container } = render(SnsProposalDetail, {
+        props: {
+          proposalIdText: proposalId.id.toString(),
+        },
+      });
+
+      const po = SnsProposalDetailPo.under(
+        new JestPageObjectElement(container)
+      );
+      expect(await po.hasSystemInfoSection()).toBe(false);
+      fakeSnsGovernanceApi.resume();
+
+      expect(await po.hasSystemInfoSection()).toBe(true);
+    });
+
     it("should redirect to the list of sns proposals if proposal id is not a valid id", async () => {
       render(SnsProposalDetail, {
         props: {

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class KeyValuePairPo extends BasePageObject {
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
+  }): KeyValuePairPo | null {
+    const el = element.querySelector(`[data-tid=${testId}]`);
+    return el && new KeyValuePairPo(el);
+  }
+
+  async getValueText(): Promise<string> {
+    const valueElement = await this.root.querySelector("dd");
+    return valueElement.getText();
+  }
+}

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -12,13 +12,11 @@ export class KeyValuePairPo extends BasePageObject {
   }: {
     element: PageObjectElement;
     testId: string;
-  }): KeyValuePairPo | null {
-    const el = element.querySelector(`[data-tid=${testId}]`);
-    return el && new KeyValuePairPo(el);
+  }): KeyValuePairPo {
+    return new KeyValuePairPo(element.querySelector(`[data-tid=${testId}]`));
   }
 
   async getValueText(): Promise<string> {
-    const valueElement = await this.root.querySelector("dd");
-    return valueElement.getText();
+    return this.root.querySelector("dd").getText();
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonDetailsPo } from "$tests/page-objects/SkeletonDetails.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsProposalSystemInfoSectionPo } from "./SnsProposalSystemInfoSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   static readonly tid = "sns-proposal-details-grid";
@@ -21,5 +22,13 @@ export class SnsProposalDetailPo extends BasePageObject {
     return (
       (await this.isPresent()) && !(await this.getSkeletonDetails().isPresent())
     );
+  }
+
+  getSystemInfoSection(): SnsProposalSystemInfoSectionPo {
+    return SnsProposalSystemInfoSectionPo.under(this.root);
+  }
+
+  hasSystemInfoSection(): Promise<boolean> {
+    return this.getSystemInfoSection().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -24,11 +24,15 @@ export class SnsProposalDetailPo extends BasePageObject {
     );
   }
 
-  getSystemInfoSection(): SnsProposalSystemInfoSectionPo {
+  getSystemInfoSectionPo(): SnsProposalSystemInfoSectionPo {
     return SnsProposalSystemInfoSectionPo.under(this.root);
   }
 
   hasSystemInfoSection(): Promise<boolean> {
-    return this.getSystemInfoSection().isPresent();
+    return this.getSystemInfoSectionPo().isPresent();
+  }
+
+  getSystemInfoSectionTitle(): Promise<string> {
+    return this.getSystemInfoSectionPo().getTitleText();
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -1,0 +1,83 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+import { KeyValuePairPo } from "./KeyValuePair.page-object";
+
+export class SnsProposalSystemInfoSectionPo extends BasePageObject {
+  static readonly tid = "proposal-system-info-details-component";
+
+  static under(
+    element: PageObjectElement
+  ): SnsProposalSystemInfoSectionPo | null {
+    const el = element.querySelector(
+      `[data-tid=${SnsProposalSystemInfoSectionPo.tid}]`
+    );
+    return el && new SnsProposalSystemInfoSectionPo(el);
+  }
+
+  getTitleText(): Promise<string> {
+    return this.root.querySelector("h1")?.getText();
+  }
+
+  getTypeText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-type",
+    }).getValueText();
+  }
+
+  getTopicText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-topic",
+    }).getValueText();
+  }
+
+  getDecisionStatusText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-status",
+    }).getValueText();
+  }
+
+  getRewardStatusText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-reward",
+    }).getValueText();
+  }
+
+  getCreatedText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-created",
+    }).getValueText();
+  }
+
+  getDecidedText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-decided",
+    }).getValueText();
+  }
+
+  getExecutedText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-executed",
+    }).getValueText();
+  }
+
+  getFailedText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-failed",
+    }).getValueText();
+  }
+
+  getProposerText(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "proposal-system-info-proposer",
+    }).getValueText();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -15,7 +15,7 @@ export class SnsProposalSystemInfoSectionPo extends BasePageObject {
   }
 
   getTitleText(): Promise<string> {
-    return this.root.querySelector("h1")?.getText();
+    return this.root.querySelector("h1").getText();
   }
 
   getTypeText(): Promise<string> {


### PR DESCRIPTION
# Motivation

User should be able to see the metadata of an SNS proposal.

# Changes

Main change:
* Implement SnsProposalSystemInfoSection.svelte.

Minor changes:
* New component SnsProposerEntry.svelte to handle the logic of the proposal key value. Not now, it will be in another PR, but that will open the neuron modal if the user is logged in.
* Add new prop `className` to the Hash.svelte component.
* Minor changes in the SnsProposalDetail.svelte to add `rootCanisterId` in the scope so that it can be passed to SnsProposalSystemInfoSection. No change in functionality. The other component that will need it is the SnsProposalVotingSection.

# Tests

* New scenario in  SnsProposalDetail that tests presence of the metadata.
* Test all the functionality of SnsProposerEntry
* New POs: KeyValuePairPo and SnsProposalSystemInfoSectionPo
