### PR TITLE
Use page objects in example e2e test

### DIFF
--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { accountsStore } from "$lib/stores/accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
@@ -15,18 +16,20 @@
   const reload = async () => await syncAccounts();
 </script>
 
-{#if modal === "NewTransaction"}
-  <IcpTransactionModal on:nnsClose={closeModal} />
-{/if}
+<TestIdWrapper testId="nns-accounts-footer-component">
+  {#if modal === "NewTransaction"}
+    <IcpTransactionModal on:nnsClose={closeModal} />
+  {/if}
 
-{#if nonNullish($accountsStore)}
-  <Footer>
-    <button
-      class="primary full-width"
-      on:click={openNewTransaction}
-      data-tid="open-new-transaction">{$i18n.accounts.send}</button
-    >
+  {#if nonNullish($accountsStore)}
+    <Footer>
+      <button
+        class="primary full-width"
+        on:click={openNewTransaction}
+        data-tid="open-new-transaction">{$i18n.accounts.send}</button
+      >
 
-    <ReceiveButton type="nns-receive" canSelectAccount {reload} />
-  </Footer>
-{/if}
+      <ReceiveButton type="nns-receive" canSelectAccount {reload} />
+    </Footer>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
   import NnsAccountsFooter from "$lib/components/accounts/NnsAccountsFooter.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import {
     isCkBTCUniverseStore,
     isNnsUniverseStore,
@@ -90,25 +91,27 @@
     );
 </script>
 
-<main>
-  <SummaryUniverse />
+<TestIdWrapper testId="accounts-component">
+  <main>
+    <SummaryUniverse />
+
+    {#if $isNnsUniverseStore}
+      <NnsAccounts {goToWallet} />
+    {:else if $isCkBTCUniverseStore}
+      <CkBTCAccounts {goToWallet} />
+    {:else if nonNullish($snsProjectSelectedStore)}
+      <SnsAccounts {goToWallet} />
+    {/if}
+  </main>
 
   {#if $isNnsUniverseStore}
-    <NnsAccounts {goToWallet} />
+    <NnsAccountsFooter />
   {:else if $isCkBTCUniverseStore}
-    <CkBTCAccounts {goToWallet} />
+    <CkBTCAccountsFooter />
   {:else if nonNullish($snsProjectSelectedStore)}
-    <SnsAccounts {goToWallet} />
+    <SnsAccountsFooter />
   {/if}
-</main>
-
-{#if $isNnsUniverseStore}
-  <NnsAccountsFooter />
-{:else if $isCkBTCUniverseStore}
-  <CkBTCAccountsFooter />
-{:else if nonNullish($snsProjectSelectedStore)}
-  <SnsAccountsFooter />
-{/if}
+</TestIdWrapper>
 
 {#if $isCkBTCUniverseStore}
   <CkBTCAccountsModals />

--- a/frontend/src/tests/e2e/example.spec.ts
+++ b/frontend/src/tests/e2e/example.spec.ts
@@ -1,3 +1,5 @@
+import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
@@ -5,5 +7,8 @@ test("Log in and click Send button", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Network Nervous System frontend dapp");
   await signInWithNewUser({ page, context });
-  await page.getByRole("button", { name: "Send" }).click();
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const accountsPo = AccountsPo.under(pageElement);
+  await accountsPo.clickSend();
 });

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -1,0 +1,26 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
+
+export class AccountsPo extends BasePageObject {
+  static readonly tid = "accounts-component";
+
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): AccountsPo | null {
+    return new AccountsPo(
+      element.querySelector(`[data-tid=${AccountsPo.tid}]`)
+    );
+  }
+
+  getNnsAccountsFooterPo(): NnsAccountsFooterPo {
+    return NnsAccountsFooterPo.under(this.root);
+  }
+
+  clickSend(): Promise<void> {
+    return this.getNnsAccountsFooterPo().clickSend();
+  }
+}

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -15,4 +15,8 @@ export class ButtonPo extends BasePageObject {
   }): ButtonPo {
     return new ButtonPo(element.querySelector(`button[data-tid=${testId}]`));
   }
+
+  click(): Promise<void> {
+    return this.root.click();
+  }
 }

--- a/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
@@ -1,0 +1,28 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsAccountsFooterPo extends BasePageObject {
+  static readonly tid = "nns-accounts-footer-component";
+
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): NnsAccountsFooterPo {
+    return new NnsAccountsFooterPo(
+      element.querySelector(`[data-tid=${NnsAccountsFooterPo.tid}]`)
+    );
+  }
+
+  getSendButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "open-new-transaction",
+    });
+  }
+
+  async clickSend() {
+    return this.getSendButtonPo().click();
+  }
+}

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -1,5 +1,6 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { isNullish, nonNullish } from "@dfinity/utils";
+import { fireEvent } from "@testing-library/svelte";
 
 /**
  * An implementation of the PageObjectElement interface for Jest unit tests.
@@ -32,5 +33,9 @@ export class JestPageObjectElement implements PageObjectElement {
   // Resolves to null if the element is not present.
   async getText(): Promise<string | null> {
     return this.element && this.element.textContent;
+  }
+
+  async click(): Promise<void> {
+    await fireEvent.click(this.element);
   }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -1,0 +1,30 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { type Locator, type Page } from "@playwright/test";
+
+export class PlaywrightPageObjectElement implements PageObjectElement {
+  readonly locator: Locator;
+
+  constructor(locator: Locator | Page) {
+    this.locator = locator;
+  }
+
+  static fromPage(page: Page): PlaywrightPageObjectElement {
+    return new PlaywrightPageObjectElement(page.locator("body"));
+  }
+
+  querySelector(selector: string): PlaywrightPageObjectElement {
+    return new PlaywrightPageObjectElement(this.locator.locator(selector));
+  }
+
+  getText(): Promise<string> {
+    return this.locator.textContent();
+  }
+
+  async isPresent(): Promise<boolean> {
+    return (await this.locator.count()) > 0;
+  }
+
+  click(): Promise<void> {
+    return this.locator.click();
+  }
+}

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -7,4 +7,5 @@ export interface PageObjectElement {
   querySelectorAll(selector: string): Promise<PageObjectElement[]>;
   isPresent(): Promise<boolean>;
   getText(): Promise<string | null>;
+  click(): Promise<void>;
 }


### PR DESCRIPTION
# Motivation

Page objects now work with both Jest unit tests and Playwright e2e tests.
The example test now demonstrates this.
In the next PR I want to write a proper e2e for the accounts tab.

# Changes

1. Add a Playwright specific implementation of `PageObjectElement`.
2. Add a click function to PageObjectElement and ButtonPo.
3. Add minimal page objects for `Accounts` and `NnsAccountsFooter`.
4. Add TestIdWrappers to the components for their page objects.

# Tests

npm run test-e2e
npm run test