### PR TITLE
Chore: Back button from SNS Proposal Detail page keeps universe

### DIFF
--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -1,18 +1,10 @@
 <script lang="ts">
   import Layout from "$lib/components/layout/Layout.svelte";
   import Content from "$lib/components/layout/Content.svelte";
-  import { afterNavigate, goto } from "$app/navigation";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import type { Navigation } from "@sveltejs/kit";
-  import { referrerPathForNav } from "$lib/utils/page.utils";
+  import { goto } from "$app/navigation";
+  import { proposalsPathStore } from "$lib/derived/paths.derived";
 
-  let referrerPath: AppPath | undefined = undefined;
-  afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
-
-  const back = (): Promise<void> =>
-    goto(
-      referrerPath === AppPath.Launchpad ? AppPath.Launchpad : AppPath.Proposals
-    );
+  const back = (): Promise<void> => goto($proposalsPathStore);
 </script>
 
 <Layout>

--- a/frontend/src/tests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/tests/routes/app/proposals/layout.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { page } from "$mocks/$app/stores";
+import Layout from "$routes/(app)/(u)/(detail)/proposal/+layout.svelte";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Layout", () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should go back to the proposal page", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    const { queryByTestId } = render(Layout);
+
+    const { path } = get(pageStore);
+    expect(path).toEqual(AppPath.Proposal);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    await waitFor(() => {
+      const { path } = get(pageStore);
+      return expect(path).toEqual(AppPath.Proposals);
+    });
+  });
+
+  it("should keep the NNS universe when going back", async () => {
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+      },
+      routeId: AppPath.Proposal,
+    });
+    const { queryByTestId } = render(Layout);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    await waitFor(() => {
+      const { universe } = get(pageStore);
+      return expect(universe).toEqual(OWN_CANISTER_ID_TEXT);
+    });
+  });
+
+  it("should keep the SNS universe when going back", async () => {
+    page.mock({
+      data: {
+        universe: mockCanisterId.toText(),
+      },
+      routeId: AppPath.Proposal,
+    });
+    const { queryByTestId } = render(Layout);
+
+    const backButton = queryByTestId("back");
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+
+    await waitFor(() => {
+      const { universe } = get(pageStore);
+      return expect(universe).toEqual(mockCanisterId.toText());
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

User is in an SNS proposal detail page.
User clicks in the back icon.
User should see the list of proposals of the same SNS project.

Current: User sees the list of NNS proposals.

# Changes

* Use the `proposalsPathStore` in the back button of the layout used for the ProposalDetail page.

# Tests

* Add a test that renders the layouts and clicks in the back button. Add different scenarios testing the different functionality.
