### PR TITLE
Docker build e2e

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,11 @@ jobs:
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
+      - name: Get node version
+        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Deploy NNS and SNS canisters
         run: |
           # Note: This deploys standard NNS canisters but with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,9 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a chrome-wdio.log
       - name: Run firefox e2e tests
         working-directory: e2e-tests
+        # Allow Firefox to fail until the source of flakiness is found and fixed.
+        continue-on-error: true
         run: |
-          # Allow Firefox to fail until the source of flakiness is found and fixed.
-          # set -o pipefail
           export WDIO_BROWSER=firefox
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,26 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
+      - name: set-env
+        run: ./build-config.sh >> $GITHUB_ENV
+      # Cache based on the Cargo.lock
+      # The cache key is always an exact match or no match (i.e. no
+      # "restore-keys"-style matching). Because (in case of an exact match)
+      # GitHub actions won't (re-)upload the cache after the build, it means that
+      # our cache won't just grow forever.
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+      # Cache the ic-cdk-optimizer
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/ic-cdk-optimizer
+          key: ${{ runner.os }}-ic-cdk-optimizer-${{ env.IC_CDK_OPTIMIZER_VERSION }}-v2
       - name: Build wasms
         uses: docker/build-push-action@v3
         with:
@@ -38,7 +58,13 @@ jobs:
       # Helps with debugging
       - name: Versions
         run: |
+          set -x
           dfx --version
+          node --version
+          npm --version
+          rustc --version
+          cargo --version
+          ic-cdk-optimizer --version
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           # - The current code for the nns-dapp
           # - The II version specified in dfx.json
           # - Functional SNS canisters
+          ls -l
           ./scripts/dfx-nns-deploy-custom --features sns
       - name: Basic downgrade-upgrade test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
           # - The current code for the nns-dapp
           # - The II version specified in dfx.json
           # - Functional SNS canisters
-          ls -l
           ./scripts/dfx-nns-deploy-custom --features sns
       - name: Basic downgrade-upgrade test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,13 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .
-      - name: Install Software
+      - name: Install tools
         run: |
-          ./scripts/setup --profile ~/.bashrc
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+          dfx-software-idl2json-install
+          dfx cache install
+        env:
+          GH_TOKEN: ${{ github.token }}
       # Helps with debugging
       - name: Versions
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,4 @@
-# A Native build
-# XXX: This makes some of 'checks.yml' redundant. This will be fixed as soon as
-# we have end-to-end tests working.
-# https://dfinity.atlassian.net/browse/L2-191
-name: Native build
+name: E2e test
 # We use "push" events so that we have the actual commit. In "pull_request"
 # events we get a merge commit with main instead. The merge commit can be
 # useful to check that the code would pass tests once merged, but here it just
@@ -13,8 +9,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  NNS_CACHING_KEY: dv-0004
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -22,40 +16,18 @@ jobs:
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
-      - name: set-env
-        run: ./build-config.sh >> $GITHUB_ENV
-      # Cache based on the Cargo.lock
-      # The cache key is always an exact match or no match (i.e. no
-      # "restore-keys"-style matching). Because (in case of an exact match)
-      # GitHub actions won't (re-)upload the cache after the build, it means that
-      # our cache won't just grow forever.
-      - uses: actions/cache@v3
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build wasms
+        uses: docker/build-push-action@v3
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-      # Cache the ic-cdk-optimizer
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/ic-cdk-optimizer
-          key: ${{ runner.os }}-ic-cdk-optimizer-${{ env.IC_CDK_OPTIMIZER_VERSION }}-v2
-      - name: Install Software
-        run: |
-          ./scripts/setup --profile ~/.bashrc
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # Helps with debugging
-      - name: Versions
-        run: |
-          set -x
-          dfx --version
-          node --version
-          npm --version
-          rustc --version
-          cargo --version
-          ic-cdk-optimizer --version
+          context: .
+          file: Dockerfile
+          build-args: |
+            DFX_NETWORK=local
+          cache-from: type=gha,scope=cached-stage
+          # Exports the artefacts from the final stage
+          outputs: .
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:
@@ -69,11 +41,6 @@ jobs:
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
-      - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
       - name: Deploy NNS and SNS canisters
         run: |
           # Note: This deploys standard NNS canisters but with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,26 +21,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
-      - name: set-env
-        run: ./build-config.sh >> $GITHUB_ENV
-      # Cache based on the Cargo.lock
-      # The cache key is always an exact match or no match (i.e. no
-      # "restore-keys"-style matching). Because (in case of an exact match)
-      # GitHub actions won't (re-)upload the cache after the build, it means that
-      # our cache won't just grow forever.
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-      # Cache the ic-cdk-optimizer
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/ic-cdk-optimizer
-          key: ${{ runner.os }}-ic-cdk-optimizer-${{ env.IC_CDK_OPTIMIZER_VERSION }}-v2
       - name: Build wasms
         uses: docker/build-push-action@v3
         with:
@@ -51,16 +31,6 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .
-      # Helps with debugging
-      - name: Versions
-        run: |
-          set -x
-          dfx --version
-          node --version
-          npm --version
-          rustc --version
-          cargo --version
-          ic-cdk-optimizer --version
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,13 +51,6 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .
-      - name: Install tools
-        run: |
-          dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
-          dfx-software-idl2json-install
-          dfx cache install
-        env:
-          GH_TOKEN: ${{ github.token }}
       # Helps with debugging
       - name: Versions
         run: |
@@ -81,6 +74,7 @@ jobs:
       - name: Install SNS script dependencies
         run: |
           dfx-sns-demo-install
+          dfx cache install
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
       - uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .
+      - name: Install Software
+        run: |
+          ./scripts/setup --profile ~/.bashrc
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # Helps with debugging
+      - name: Versions
+        run: |
+          dfx --version
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-defaults:
-  run:
-    shell: bash -euxlo pipefail {0}
+env:
+  NNS_CACHING_KEY: dv-0004
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -100,9 +99,9 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a chrome-wdio.log
       - name: Run firefox e2e tests
         working-directory: e2e-tests
-        # Allow Firefox to fail until the source of flakiness is found and fixed.
-        continue-on-error: true
         run: |
+          # Allow Firefox to fail until the source of flakiness is found and fixed.
+          # set -o pipefail
           export WDIO_BROWSER=firefox
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count

--- a/scripts/dfx-nns-deploy-custom
+++ b/scripts/dfx-nns-deploy-custom
@@ -19,7 +19,7 @@ source "$(clap.build)"
 : "Make sure that old wasms are purged"
 rm -f nns-dapp.wasm nns-dapp_local.wasm
 
-: "Build nns-dapp for local use, with standard canister IDs, and inject into the wasm cache."
+: "Inject the nns-dapp into the wasm cache."
 "$SOURCE_DIR"/dfx-software-nd-cache
 
 : "Get our chosen version of II and inject it into the wasm cache."

--- a/scripts/dfx-nns-deploy-custom
+++ b/scripts/dfx-nns-deploy-custom
@@ -16,9 +16,6 @@ clap.define short=f long=features desc="The feature set you would like in the te
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-: "Make sure that old wasms are purged"
-rm -f nns-dapp.wasm nns-dapp_local.wasm
-
 : "Inject the nns-dapp into the wasm cache."
 "$SOURCE_DIR"/dfx-software-nd-cache
 

--- a/scripts/dfx-software-nd-cache
+++ b/scripts/dfx-software-nd-cache
@@ -3,7 +3,7 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
   cat <<-EOF
-	Builds the nns-dapp wasm and installs it in the dfx cache.
+	Installs the nns-dapp wasm in the dfx cache.
 
 	Note: Doing this will set the nns-dapp version deployed by 'dfx nns install'
 	      to the version in the current codebase.  Our version is usually
@@ -23,9 +23,6 @@ LOCAL_ND_WASM="$(jq -r '.canisters["nns-dapp"].wasm' dfx.json)"
 : "Set the canister ID"
 : "Note: This should be the canister ID used by dfx nns install.  That, in turn, should soon match production.  But not yet."
 "$SOURCE_DIR/dfx-canister-set-id" --network local --canister_name nns-dapp --canister_id "qsgjb-riaaa-aaaaa-aaaga-cai"
-
-: "Build the wasm"
-dfx build nns-dapp
 
 : "Put the wasm into the cache, for use by 'dfx nns install'"
 mkdir -p "$DFX_WASMS_DIR"


### PR DESCRIPTION
# Motivation
Faster CI.  We already have builds cached in docker.  Reusing the cache means that we don't need to rebuild unless we need to.  Furthermore, even on cache miss, a docker build takes about 4 minutes which is about as long as it takes just to install the native build tools without even starting to build.

# Changes
- docker-build the nns-dapp
- Don't build locally
- Remove unneeded tool installation and an unused env var.

# Tests
See CI