### PR TITLE
Set -eu by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  NNS_CACHING_KEY: dv-0004
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -124,9 +125,9 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a chrome-wdio.log
       - name: Run firefox e2e tests
         working-directory: e2e-tests
+        # Allow Firefox to fail until the source of flakiness is found and fixed.
+        continue-on-error: true
         run: |
-          # Allow Firefox to fail until the source of flakiness is found and fixed.
-          # set -o pipefail
           export WDIO_BROWSER=firefox
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count


### PR DESCRIPTION
# Motivation
`run` commands don't give detailed output unless set -x is set at the beginning of every multiline run command. Invariably the log one needs is one where set -x has not yet been set, so one has to add set -x and rerun, which costs time. Better set it at the beginning of the build once for all.

Note: This does cause several lines of startup bash commands to be printed for every `run` command.  On balance, I think it is worth it.

# Changes
-  Set `-euxo pipefail` by default for every run command in `build.yaml`

# Tests
See CI