### PR TITLE
Bump yq version

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -129,13 +129,18 @@ install_jq_linux() {
   sudo apt-get install jq
 }
 
+ARCH="$(uname -p | sed 's/x86_64/amd64/g')"
+YQ_VERSION="4.33.1"
 install_yq_darwin() {
   echo "Installing yq..."
-  brew install yq
+  tempfile="$(mktemp ,yq-XXXXXXXX)"
+  curl -Lf "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_${ARCH}" >"$tempfile"
+  install -m 755 "$tempfile" "$USER_BIN/yq"
+  rm "$tempfile"
 }
 install_yq_linux() {
   echo "Installing yq..."
-  sudo snap install yq
+  curl -Lf "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH}" | install -m 755 /dev/stdin "$USER_BIN/yq"
 }
 
 install_npm_darwin() {


### PR DESCRIPTION
# Motivation
`yq` now has readonly support for toml.  This allows us to read values from Cargo.toml.  E.g. when mocking out crates to warm the cargo cache, we could now potentially use:
```
yq -r .workspace.members[] Cargo.toml -o json | xargs -I{} cargo new "{}"
```
Similarly the newer `yq` can be used to probe the cargo lockfiles.

# Changes
- Install `yq` from source, to be sure to get the version released a few hours ago.

# Tests
See CI.

For toml, I have used `yq` on the toml feature branch and verified that the code still works in the release.