### PR TITLE
Helper function to make a fake api pausable

### DIFF
--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -1,13 +1,16 @@
 import type { ApiQueryParams } from "$lib/api/governance.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
+import {
+  installImplAndBlockRest,
+  makePausable,
+} from "$tests/utils/module.test-utils";
 import type { Identity } from "@dfinity/agent";
 import type { KnownNeuron, NeuronInfo } from "@dfinity/nns";
 import { isNullish } from "@dfinity/utils";
 
 const modulePath = "$lib/api/governance.api";
-const implementedFunctions = {
+const fakeFunctions = {
   queryNeurons,
   queryKnownNeurons,
 };
@@ -21,11 +24,6 @@ const neurons: Map<string, NeuronInfo[]> = new Map();
 
 const mapKey = (identity: Identity) => identity.getPrincipal().toText();
 
-// When the fake is paused, all calls to the fake will be queued until the fake
-// is resumed.
-let isPaused = false;
-const pendingCalls: (() => void)[] = [];
-
 const getNeurons = (identity: Identity) => {
   const key = mapKey(identity);
   let neuronList = neurons.get(key);
@@ -36,75 +34,41 @@ const getNeurons = (identity: Identity) => {
   return neuronList;
 };
 
-/**
- * Calls the passed function and returns its result.
- * If the fake is paused, the function will be queued and an unresolved promise
- * is returned which will resolve when the fake is resumed and the function
- * called.
- */
-const wrapMaybePaused = async <T>(fn: () => Promise<T>): Promise<T> => {
-  if (!isPaused) {
-    return fn();
-  }
-  let resolve: (value: Promise<T>) => void;
-  const responsePromise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  pendingCalls.push(() => {
-    resolve(fn());
-  });
-  return responsePromise;
-};
-
 ////////////////////////
 // Fake implementations:
 ////////////////////////
 
-function queryNeurons({
+async function queryNeurons({
   identity,
   certified: _,
 }: ApiQueryParams): Promise<NeuronInfo[]> {
-  return wrapMaybePaused(async () => {
-    return getNeurons(identity);
-  });
+  return getNeurons(identity);
 }
 
-function queryKnownNeurons({
+async function queryKnownNeurons({
   identity: _,
   certified: __,
 }: ApiQueryParams): Promise<KnownNeuron[]> {
-  return wrapMaybePaused(async () => {
-    return [];
-  });
+  return [];
 }
 
 /////////////////////////////////
 // Functions to control the fake:
 /////////////////////////////////
 
+const {
+  pause,
+  resume,
+  reset: resetPaused,
+  pausableFunctions: implementedFunctions,
+} = makePausable(fakeFunctions);
+
 const reset = () => {
   neurons.clear();
-  pendingCalls.length = 0;
-  isPaused = false;
+  resetPaused();
 };
 
-export const pause = () => {
-  if (isPaused) {
-    throw new Error("The fake was already paused");
-  }
-  isPaused = true;
-};
-
-export const resume = () => {
-  if (!isPaused) {
-    throw new Error("The fake wasn't paused.");
-  }
-  for (const call of pendingCalls) {
-    call();
-  }
-  pendingCalls.length = 0;
-  isPaused = false;
-};
+export { pause, resume };
 
 export const addNeuronWith = ({
   identity = mockIdentity,


### PR DESCRIPTION
# Motivation

`governance-api` and `sns-governance-api` can both be paused and resumed.
The code to make that work is pretty much duplicate.
And making other fake apis pausable would mean more duplicate code.

# Changes

1. Add a helper function `makePausable` to make a fake API pausable.
2. Use the helper instead of the duplicated code in `governance-api` and `sns-governance-api`.

# Tests

Tests still pass.