### PR TITLE
Add PageObjectElement.byTestId

### DIFF
--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -11,9 +11,7 @@ export class AccountsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): AccountsPo | null {
-    return new AccountsPo(
-      element.querySelector(`[data-tid=${AccountsPo.tid}]`)
-    );
+    return new AccountsPo(element.byTestId(AccountsPo.tid));
   }
 
   getNnsAccountsFooterPo(): NnsAccountsFooterPo {

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -10,9 +10,7 @@ export class AmountDisplayPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): AmountDisplayPo {
-    return new AmountDisplayPo(
-      element.querySelector(`[data-tid=${AmountDisplayPo.tid}]`)
-    );
+    return new AmountDisplayPo(element.byTestId(AmountDisplayPo.tid));
   }
 
   async getAmount(): Promise<string> {

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -10,7 +10,7 @@ export class HashPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): HashPo {
-    return new HashPo(element.querySelector(`[data-tid=${HashPo.tid}]`));
+    return new HashPo(element.byTestId(HashPo.tid));
   }
 
   getTooltipPo(): TooltipPo {

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -11,9 +11,7 @@ export class NeuronDetailPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NeuronDetailPo {
-    return new NeuronDetailPo(
-      element.querySelector(`[data-tid=${NeuronDetailPo.tid}]`)
-    );
+    return new NeuronDetailPo(element.byTestId(NeuronDetailPo.tid));
   }
 
   getNnsNeuronDetailPo(): NnsNeuronDetailPo {

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -11,7 +11,7 @@ export class NeuronsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NeuronsPo {
-    return new NeuronsPo(element.querySelector(`[data-tid=${NeuronsPo.tid}]`));
+    return new NeuronsPo(element.byTestId(NeuronsPo.tid));
   }
 
   getNnsNeuronsPo(): NnsNeuronsPo {

--- a/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
@@ -10,9 +10,7 @@ export class NnsAccountsFooterPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NnsAccountsFooterPo {
-    return new NnsAccountsFooterPo(
-      element.querySelector(`[data-tid=${NnsAccountsFooterPo.tid}]`)
-    );
+    return new NnsAccountsFooterPo(element.byTestId(NnsAccountsFooterPo.tid));
   }
 
   getSendButtonPo(): ButtonPo {

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -8,9 +8,7 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NnsNeuronCardTitlePo {
-    return new NnsNeuronCardTitlePo(
-      element.querySelector(`[data-tid=${NnsNeuronCardTitlePo.tid}]`)
-    );
+    return new NnsNeuronCardTitlePo(element.byTestId(NnsNeuronCardTitlePo.tid));
   }
 
   getNeuronId(): Promise<string> {

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -10,9 +10,7 @@ export class NnsNeuronDetailPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NnsNeuronDetailPo {
-    return new NnsNeuronDetailPo(
-      element.querySelector(`[data-tid=${NnsNeuronDetailPo.tid}]`)
-    );
+    return new NnsNeuronDetailPo(element.byTestId(NnsNeuronDetailPo.tid));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -11,9 +11,7 @@ export class NnsNeuronsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): NnsNeuronsPo {
-    return new NnsNeuronsPo(
-      element.querySelector(`[data-tid=${NnsNeuronsPo.tid}]`)
-    );
+    return new NnsNeuronsPo(element.byTestId(NnsNeuronsPo.tid));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -10,9 +10,7 @@ export class ProjectSwapDetailsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): ProjectSwapDetailsPo {
-    return new ProjectSwapDetailsPo(
-      element.querySelector(`[data-tid=${ProjectSwapDetailsPo.tid}]`)
-    );
+    return new ProjectSwapDetailsPo(element.byTestId(ProjectSwapDetailsPo.tid));
   }
 
   getTotalSupply(): Promise<string> {

--- a/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
@@ -9,8 +9,6 @@ export class SkeletonDetailsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SkeletonDetailsPo | null {
-    return new SkeletonDetailsPo(
-      element.querySelector(`[data-tid=${SkeletonDetailsPo.tid}]`)
-    );
+    return new SkeletonDetailsPo(element.byTestId(SkeletonDetailsPo.tid));
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -10,9 +10,7 @@ export class SnsNeuronCardTitlePo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SnsNeuronCardTitlePo {
-    return new SnsNeuronCardTitlePo(
-      element.querySelector(`[data-tid=${SnsNeuronCardTitlePo.tid}]`)
-    );
+    return new SnsNeuronCardTitlePo(element.byTestId(SnsNeuronCardTitlePo.tid));
   }
 
   getNeuronId(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -10,9 +10,7 @@ export class SnsNeuronDetailPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SnsNeuronDetailPo {
-    return new SnsNeuronDetailPo(
-      element.querySelector(`[data-tid=${SnsNeuronDetailPo.tid}]`)
-    );
+    return new SnsNeuronDetailPo(element.byTestId(SnsNeuronDetailPo.tid));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
@@ -11,9 +11,7 @@ export class SnsNeuronInfoStakePo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SnsNeuronInfoStakePo {
-    return new SnsNeuronInfoStakePo(
-      element.querySelector(`[data-tid=${SnsNeuronInfoStakePo.tid}]`)
-    );
+    return new SnsNeuronInfoStakePo(element.byTestId(SnsNeuronInfoStakePo.tid));
   }
 
   private getButton(testId: string): ButtonPo {

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -11,9 +11,7 @@ export class SnsNeuronsPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SnsNeuronsPo {
-    return new SnsNeuronsPo(
-      element.querySelector(`[data-tid=${SnsNeuronsPo.tid}]`)
-    );
+    return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.tid));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -10,9 +10,7 @@ export class SnsProposalDetailPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): SnsProposalDetailPo | null {
-    return new SnsProposalDetailPo(
-      element.querySelector(`[data-tid=${SnsProposalDetailPo.tid}]`)
-    );
+    return new SnsProposalDetailPo(element.byTestId(SnsProposalDetailPo.tid));
   }
 
   getSkeletonDetails(): SkeletonDetailsPo {

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -10,7 +10,7 @@ export class TooltipPo extends BasePageObject {
   }
 
   static under(element: PageObjectElement): TooltipPo {
-    return new TooltipPo(element.querySelector(`[data-tid=${TooltipPo.tid}]`));
+    return new TooltipPo(element.byTestId(TooltipPo.tid));
   }
 
   getText(): Promise<string> {

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -26,6 +26,10 @@ export class JestPageObjectElement implements PageObjectElement {
     );
   }
 
+  byTestId(tid: string): JestPageObjectElement {
+    return this.querySelector(`[data-tid=${tid}]`);
+  }
+
   async isPresent(): Promise<boolean> {
     return nonNullish(this.element);
   }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -16,6 +16,10 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
     return new PlaywrightPageObjectElement(this.locator.locator(selector));
   }
 
+  byTestId(tid: string): PlaywrightPageObjectElement {
+    return this.querySelector(`[data-tid=${tid}]`);
+  }
+
   getText(): Promise<string> {
     return this.locator.textContent();
   }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -5,6 +5,7 @@
 export interface PageObjectElement {
   querySelector(selector: string): PageObjectElement;
   querySelectorAll(selector: string): Promise<PageObjectElement[]>;
+  byTestId(tid: string): PageObjectElement;
   isPresent(): Promise<boolean>;
   getText(): Promise<string | null>;
   click(): Promise<void>;


### PR DESCRIPTION
# Motivation

We get page object elements by test ID a lot. Add `byTestId` function for convenience and

# Changes

1. Add `byTestId` function to `PageObjectElement` for convenience and readability.
2. Use it instead of querySelectorAll in places where the selector only specifies a test ID.

# Tests

npm run test