### PR TITLE
fix: transaction edit submit form with "Enter"

### DIFF
--- a/frontend/src/lib/components/accounts/AddressInput.svelte
+++ b/frontend/src/lib/components/accounts/AddressInput.svelte
@@ -45,6 +45,7 @@
   <svelte:fragment slot="inner-end">
     {#if qrCode}
       <button
+        type="button"
         data-tid="address-qr-code-scanner"
         class="icon-only"
         on:click|stopPropagation={onClickQRCode}

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -29,6 +29,13 @@ describe("AddressInput", () => {
       expect(getByTestId("address-qr-code-scanner")).not.toBeNull();
     });
 
+    it("should render a qr code scanner button with explicit type button", () => {
+      const { getByTestId } = render(AddressInput, { props });
+      expect(
+        getByTestId("address-qr-code-scanner")?.getAttribute("type")
+      ).toEqual("button");
+    });
+
     it("should not render a qr code scanner button", () => {
       const { getByTestId } = render(AddressInput, {
         props: {


### PR DESCRIPTION
# Motivation

Depending where the focus was set, the new QR code button hijacked submitting the form on transaction edit modal first step with "Enter" key.

# Changes

- explicitely set `type` to `button`
