### PR TITLE
First bit of accounts e2e test.

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -1,0 +1,31 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+test("Test accounts requirements", async ({ page, context }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("Network Nervous System frontend dapp");
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  // The user has a main account
+  const mainAccountName = "Main";
+  const nnsAccountsPo = appPo.getAccountsPo().getNnsAccountsPo();
+  expect(
+    await nnsAccountsPo.getMainAccountCardPo().getAccountName(),
+    mainAccountName
+  );
+
+  // TODO:
+
+  // AU002: The user MUST be able to create an additional account
+
+  // AU001:  The user MUST be able to see a list of all their accounts
+
+  // AU004: The user MUST be able to transfer funds
+
+  // AU005: The user MUST be able to see the transactions of a specific account
+});

--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class AccountCardPo extends BasePageObject {
+  static readonly tid = "account-card";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): AccountCardPo {
+    return new AccountCardPo(element.byTestId(AccountCardPo.tid));
+  }
+
+  getAccountName(): Promise<string> {
+    return this.root.byTestId("account-name").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
-
+import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountsPo extends BasePageObject {
   static readonly tid = "accounts-component";
@@ -12,6 +12,10 @@ export class AccountsPo extends BasePageObject {
 
   static under(element: PageObjectElement): AccountsPo | null {
     return new AccountsPo(element.byTestId(AccountsPo.tid));
+  }
+
+  getNnsAccountsPo(): NnsAccountsPo {
+    return NnsAccountsPo.under(this.root);
   }
 
   getNnsAccountsFooterPo(): NnsAccountsFooterPo {

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,0 +1,13 @@
+import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class AppPo extends BasePageObject {
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  getAccountsPo(): AccountsPo {
+    return AccountsPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,0 +1,20 @@
+import { AccountCardPo } from "$tests/page-objects/AccountCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsAccountsPo extends BasePageObject {
+  static readonly tid = "accounts-body";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): NnsAccountsPo {
+    return new NnsAccountsPo(element.byTestId(NnsAccountsPo.tid));
+  }
+
+  getMainAccountCardPo(): AccountCardPo {
+    // We assume the first card is the main card.
+    return AccountCardPo.under(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

Moving to Playwright tests which reuse page objects from unit tests.
Starting with accounts tests for the 4 accounts related requirements.

# Changes

1. Add frontend/src/tests/e2e/accounts.spec.ts with just the beginnings of the e2e test, testing that there is a Main account by default.
2. Add page objects for NnsAccounts and AccountCard.
3. Add AppPo to refer to top-level page objects.

I'm not sure about AppPo but it's easy to change later so I think it makes sense to go with it for now and have another look when there is some more stuff there.
But happy to do something different if you have a suggestion.

# Tests

In 3 different terminals:
```
dfx start --clean
scripts/dev-local.sh
npm run test-e2e
```