### PR TITLE
Chore: Rename ProposalProposerInfoSection

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ProposalSystemInfoSection from "./ProposalSystemInfoSection.svelte";
-  import NnsProposalProposerInfoSection from "./NnsProposalProposerInfoSection.svelte";
+  import NnsProposalSummarySection from "./NnsProposalSummarySection.svelte";
   import ProposalVotingSection from "./ProposalVotingSection.svelte";
   import ProposalNavigation from "./ProposalNavigation.svelte";
   import { getContext } from "svelte";
@@ -28,7 +28,7 @@
       <ProposalVotingSection proposalInfo={$store.proposal} />
     </div>
     <div class="content-c proposal-data-section">
-      <NnsProposalProposerInfoSection proposalInfo={$store.proposal} />
+      <NnsProposalSummarySection proposalInfo={$store.proposal} />
 
       <NnsProposalProposerActionsEntry proposal={$store.proposal.proposal} />
 

--- a/frontend/src/lib/components/proposal-detail/NnsProposalSummarySection.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalSummarySection.svelte
@@ -2,7 +2,7 @@
   import type { ProposalInfo } from "@dfinity/nns";
   import { mapProposalInfo } from "$lib/utils/proposals.utils";
   import type { Proposal } from "@dfinity/nns";
-  import ProposalProposerInfoSection from "./ProposalProposerInfoSection.svelte";
+  import ProposalSummarySection from "./ProposalSummarySection.svelte";
 
   export let proposalInfo: ProposalInfo;
 
@@ -13,4 +13,4 @@
   $: ({ title, proposal, url } = mapProposalInfo(proposalInfo));
 </script>
 
-<ProposalProposerInfoSection {title} summary={proposal?.summary} {url} />
+<ProposalSummarySection {title} summary={proposal?.summary} {url} />

--- a/frontend/src/lib/components/proposal-detail/ProposalSummarySection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummarySection.svelte
@@ -7,8 +7,8 @@
   export let url: string | undefined;
 </script>
 
-<div class="content-cell-island" data-tid="proposal-proposer-info-component">
-  <h2 class="content-cell-title" data-tid="proposal-proposer-info-title">
+<div class="content-cell-island" data-tid="proposal-summary-section-component">
+  <h2 class="content-cell-title" data-tid="proposal-summary-title">
     {$i18n.proposal_detail.summary}
   </h2>
 
@@ -22,7 +22,7 @@
             target="_blank"
             href={url}
             rel="noopener noreferrer"
-            data-tid="proposal-proposer-info-url">{url}</a
+            data-tid="proposal-summary-url">{url}</a
           >
         {/if}
       </svelte:fragment>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSummarySection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSummarySection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { SnsProposalData } from "@dfinity/sns";
   import { fromNullable, nonNullish } from "@dfinity/utils";
-  import ProposalProposerInfoSection from "../proposal-detail/ProposalProposerInfoSection.svelte";
+  import ProposalSummarySection from "../proposal-detail/ProposalSummarySection.svelte";
 
   export let proposal: SnsProposalData;
 
@@ -11,7 +11,7 @@
 </script>
 
 {#if nonNullish(proposalData)}
-  <ProposalProposerInfoSection
+  <ProposalSummarySection
     title={proposalData.title}
     summary={proposalData.summary}
     url={proposalData.url}

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -54,7 +54,7 @@ describe("Proposal", () => {
   it("should render proposer proposal info", async () => {
     const { queryByTestId } = renderProposalModern();
     await waitFor(() =>
-      expect(queryByTestId("proposal-proposer-info-title")).toBeInTheDocument()
+      expect(queryByTestId("proposal-summary-title")).toBeInTheDocument()
     );
   });
 

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalSummarySection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalSummarySection.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import NnsProposalProposerInfoSection from "$lib/components/proposal-detail/NnsProposalProposerInfoSection.svelte";
+import NnsProposalSummarySection from "$lib/components/proposal-detail/NnsProposalSummarySection.svelte";
 import { mapProposalInfo } from "$lib/utils/proposals.utils";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { render, waitFor } from "@testing-library/svelte";
@@ -11,11 +11,11 @@ jest.mock("$lib/utils/html.utils", () => ({
   markdownToHTML: (value) => Promise.resolve(value),
 }));
 
-describe("NnsProposalProposerInfoSection", () => {
+describe("NnsProposalSummarySection", () => {
   const { title, proposal, url } = mapProposalInfo(mockProposalInfo);
 
   it("should render title", () => {
-    const renderResult = render(NnsProposalProposerInfoSection, {
+    const renderResult = render(NnsProposalSummarySection, {
       props: {
         proposalInfo: mockProposalInfo,
       },
@@ -26,7 +26,7 @@ describe("NnsProposalProposerInfoSection", () => {
   });
 
   it("should render summary", async () => {
-    const renderResult = render(NnsProposalProposerInfoSection, {
+    const renderResult = render(NnsProposalSummarySection, {
       props: {
         proposalInfo: mockProposalInfo,
       },
@@ -39,7 +39,7 @@ describe("NnsProposalProposerInfoSection", () => {
   });
 
   it("should render url", async () => {
-    const renderResult = render(NnsProposalProposerInfoSection, {
+    const renderResult = render(NnsProposalSummarySection, {
       props: {
         proposalInfo: mockProposalInfo,
       },

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalSummarySection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalSummarySection.spec.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import ProposalProposerInfoSection from "$lib/components/proposal-detail/ProposalProposerInfoSection.svelte";
+import ProposalSummarySection from "$lib/components/proposal-detail/ProposalSummarySection.svelte";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { ProposalProposerInfoSectionPo } from "$tests/page-objects/ProposalProposerInfoSection.page-object";
+import { ProposalSummarySectionPo } from "$tests/page-objects/ProposalSummarySection.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
@@ -11,22 +11,20 @@ jest.mock("$lib/utils/html.utils", () => ({
   markdownToHTML: (value) => Promise.resolve(value),
 }));
 
-describe("ProposalProposerInfoSection", () => {
+describe("ProposalSummarySection", () => {
   const title = "title";
   const summary = "# Some Summary";
   const url = "https://nns.internetcomputer.org/";
   const props = { title, summary, url };
 
   const renderComponent = async () => {
-    const { container } = render(ProposalProposerInfoSection, {
+    const { container } = render(ProposalSummarySection, {
       props,
     });
 
     await runResolvedPromises();
 
-    return ProposalProposerInfoSectionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return ProposalSummarySectionPo.under(new JestPageObjectElement(container));
   };
 
   it("should render title", async () => {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSummarySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSummarySection.spec.ts
@@ -4,7 +4,7 @@
 import SnsProposalSummarySection from "$lib/components/sns-proposals/SnsProposalSummarySection.svelte";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { ProposalProposerInfoSectionPo } from "$tests/page-objects/ProposalProposerInfoSection.page-object";
+import { ProposalSummarySectionPo } from "$tests/page-objects/ProposalSummarySection.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { SnsProposalData } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
@@ -21,9 +21,7 @@ describe("SnsProposalSummarySection", () => {
 
     await runResolvedPromises();
 
-    return ProposalProposerInfoSectionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return ProposalSummarySectionPo.under(new JestPageObjectElement(container));
   };
 
   describe("when proposal is defined", () => {

--- a/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
@@ -1,16 +1,16 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ProposalProposerInfoSectionPo extends BasePageObject {
-  static readonly tid = "proposal-proposer-info-component";
+export class ProposalSummarySectionPo extends BasePageObject {
+  static readonly tid = "proposal-summary-section-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
-  static under(element: PageObjectElement): ProposalProposerInfoSectionPo {
-    return new ProposalProposerInfoSectionPo(
-      element.byTestId(ProposalProposerInfoSectionPo.tid)
+  static under(element: PageObjectElement): ProposalSummarySectionPo {
+    return new ProposalSummarySectionPo(
+      element.byTestId(ProposalSummarySectionPo.tid)
     );
   }
 
@@ -19,7 +19,7 @@ export class ProposalProposerInfoSectionPo extends BasePageObject {
   }
 
   getProposalUrlText(): Promise<string> {
-    return this.root.byTestId("proposal-proposer-info-url").getText();
+    return this.root.byTestId("proposal-summary-url").getText();
   }
 
   getProposalSummary(): Promise<string> {

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -118,9 +118,7 @@ describe("Proposal detail page when not logged in user", () => {
       await waitFor(() => expect(queryProposal).toHaveBeenCalledTimes(2));
 
       await waitFor(() =>
-        expect(
-          queryByTestId("proposal-proposer-info-title")
-        ).toBeInTheDocument()
+        expect(queryByTestId("proposal-summary-title")).toBeInTheDocument()
       );
       expect(queryByTestId("proposal-system-info-details")).toBeInTheDocument();
       await waitFor(() =>
@@ -191,7 +189,7 @@ describe("Proposal detail page when not logged in user", () => {
           queryByTestId("proposal-system-info-details")
         ).toBeInTheDocument()
       );
-      expect(queryByTestId("proposal-proposer-info-title")).toBeInTheDocument();
+      expect(queryByTestId("proposal-summary-title")).toBeInTheDocument();
       expect(queryByTestId("login-button")).toBeInTheDocument();
       expect(
         queryByTestId("voting-confirmation-toolbar")


### PR DESCRIPTION
# Motivation

Rename components to make clearer what they render.

# Changes

* Rename file NnsProposalProposerInfoSection.svelte to NnsProposalSummarySection.svelte
* Rename file ProposalProposerInfoSection.svelte to ProposalSummarySection.svelte
* Rename data tid to be consistent with file rename.

# Tests

* Rename testing file for each of the renamed files.
* Change data tids after change.
