### PR TITLE
GIX-1220: SNS Proposal payload card

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalPayloadSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalPayloadSection.svelte
@@ -1,10 +1,25 @@
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
   import type { SnsProposalData } from "@dfinity/sns";
+  import { fromNullable, nonNullish } from "@dfinity/utils";
+  import ProposalSummary from "../proposal-detail/ProposalSummary.svelte";
 
   export let proposal: SnsProposalData;
+
+  let payload: string | undefined;
+  $: payload = fromNullable(proposal.payload_text_rendering);
 </script>
 
-<div class="content-cell-island">
-  TODO: Payload Section
-  {proposal.id[0]?.id}
-</div>
+{#if nonNullish(payload)}
+  <div
+    class="content-cell-island"
+    data-tid="sns-proposal-payload-section-component"
+  >
+    <h2 class="content-cell-title">
+      {$i18n.proposal_detail.payload}
+    </h2>
+    <div class="content-cell-details">
+      <ProposalSummary summary={payload} />
+    </div>
+  </div>
+{/if}

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
@@ -44,7 +44,7 @@ describe("SnsProposalPayloadSection", () => {
     it("should contain summary", async () => {
       const po = await renderComponent(props);
 
-      expect(await po.getPayloadText()).toContain(payload);
+      expect(await (await po.getPayloadText()).trim()).toBe(payload);
     });
   });
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
@@ -57,7 +57,7 @@ describe("SnsProposalPayloadSection", () => {
 
     it("should not render content", async () => {
       const po = await renderComponent(props);
-      expect(await po.hasContent()).toBe(false);
+      expect(await po.isPresent()).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalPayloadSection.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import SnsProposalPayloadSection from "$lib/components/sns-proposals/SnsProposalPayloadSection.svelte";
+import en from "$tests/mocks/i18n.mock";
+import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { SnsProposalPayloadSectionPo } from "$tests/page-objects/SnsProposalPayloadSection.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { SnsProposalData } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+jest.mock("$lib/utils/html.utils", () => ({
+  markdownToHTML: (value) => Promise.resolve(value),
+}));
+
+describe("SnsProposalPayloadSection", () => {
+  const renderComponent = async (props) => {
+    const { container } = render(SnsProposalPayloadSection, {
+      props,
+    });
+
+    await runResolvedPromises();
+
+    return SnsProposalPayloadSectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  describe("when payload is defined", () => {
+    const payload = "# Some Summary";
+    const proposal: SnsProposalData = {
+      ...mockSnsProposal,
+      payload_text_rendering: [payload],
+    };
+    const props = { proposal };
+
+    it("should render title", async () => {
+      const po = await renderComponent(props);
+
+      expect(await po.getCardTitle()).toBe(en.proposal_detail.payload);
+    });
+
+    it("should contain summary", async () => {
+      const po = await renderComponent(props);
+
+      expect(await po.getPayloadText()).toContain(payload);
+    });
+  });
+
+  describe("when payload is not defined", () => {
+    const proposal: SnsProposalData = {
+      ...mockSnsProposal,
+      payload_text_rendering: [],
+    };
+    const props = { proposal };
+
+    it("should not render content", async () => {
+      const po = await renderComponent(props);
+      expect(await po.hasContent()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
@@ -2,7 +2,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsProposalPayloadSectionPo extends BasePageObject {
-  static readonly tid = "sns-proposal-payload-section-component";
+  static readonly TID = "sns-proposal-payload-section-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
@@ -10,7 +10,7 @@ export class SnsProposalPayloadSectionPo extends BasePageObject {
 
   static under(element: PageObjectElement): SnsProposalPayloadSectionPo {
     return new SnsProposalPayloadSectionPo(
-      element.byTestId(SnsProposalPayloadSectionPo.tid)
+      element.byTestId(SnsProposalPayloadSectionPo.TID)
     );
   }
 
@@ -20,9 +20,5 @@ export class SnsProposalPayloadSectionPo extends BasePageObject {
 
   getPayloadText(): Promise<string> {
     return this.root.byTestId("proposal-summary-component").getText();
-  }
-
-  hasContent(): Promise<boolean> {
-    return this.root.isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
@@ -1,0 +1,28 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsProposalPayloadSectionPo extends BasePageObject {
+  static readonly tid = "sns-proposal-payload-section-component";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): SnsProposalPayloadSectionPo {
+    return new SnsProposalPayloadSectionPo(
+      element.byTestId(SnsProposalPayloadSectionPo.tid)
+    );
+  }
+
+  getCardTitle(): Promise<string> {
+    return this.root.querySelector("h2").getText();
+  }
+
+  getPayloadText(): Promise<string> {
+    return this.root.byTestId("proposal-summary-component").getText();
+  }
+
+  hasContent(): Promise<boolean> {
+    return this.root.isPresent();
+  }
+}


### PR DESCRIPTION
# Motivation

User can see the payload of an SNS Proposal.

# Changes

* Implement SnsProposalPayloadSection.svelte using ProposalSummary.svelte.

# Tests

* New page object SnsProposalPayloadSectionPo
* Test SnsProposalPayloadSection component with new PO.
