### PR TITLE
Rename sns aggregator arg

### DIFF
--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -21,8 +21,8 @@ AGGREGATOR_CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai"
 WASM="./release/docker/sns_aggregator.wasm"
 SHA="$(sha256sum <"$WASM" | awk '{print $1}')"
 
-ARG_DID="./release/arg.did"
-ARG_PATH="./release/arg.bin"
+ARG_DID="./release/sns_aggregator_arg.did"
+ARG_PATH="./release/sns_aggregator_arg.bin"
 didc encode "$(cat "$ARG_DID")" | xxd -r -p >"$ARG_PATH"
 
 set ic-admin --pin "$DFX_HSM_PIN" --nns-url https://ic0.app --use-hsm --key-id 01 --slot 0 propose-to-change-nns-canister --proposer "$NEURON" --canister-id "$AGGREGATOR_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file ./release/AGGREGATOR_PROPOSAL.md --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -60,5 +60,5 @@ sha256sum sns_aggregator.wasm
 \`\`\`
 EOF
 
-ARG_DID="./release/arg.did"
+ARG_DID="./release/sns_aggregator_arg.did"
 echo '(record{})' >"$ARG_DID"


### PR DESCRIPTION
# Motivation
The nns-dapp is about to get arguments as well, which makes "args.did" ambiguous.

# Changes
- Rename `arg` to `sns_aggregator_arg`.

# Tests
None