### PR TITLE
Move the nns-dapp release template

### DIFF
--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/../.."
 mkdir -p release/ci
 PR="$(git log -n1 tags/release-candidate --oneline | awk '{print $(NF)}' | tr -cd 0-9)"
 CI="https://github.com/dfinity/nns-dapp/pull/${PR}/checks"


### PR DESCRIPTION
# Motivation
We now have two projects that both need releases, so "PROPOSAL_TEMPLATE" is ambiguous.

# Changes
* Move the propsal template and update the relative paths to match.

TODO: Update [the release SOP](https://www.notion.so/SOP-Deploy-NNS-dapp-to-mainnet-5347d7438dc04b088c61abd0edb3abd4).

# Tests
I have run the release template script from the new location and verified that the template was populated.