### PR TITLE
Use auto subscription instead of onDestroy in Login.svelte

### DIFF
--- a/frontend/src/lib/pages/Login.svelte
+++ b/frontend/src/lib/pages/Login.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
-  import type { Unsubscriber } from "svelte/store";
   import { authStore } from "$lib/stores/auth.store";
   import type { AuthStoreData } from "$lib/stores/auth.store";
   import { isSignedIn } from "$lib/utils/auth.utils";

--- a/frontend/src/lib/pages/Login.svelte
+++ b/frontend/src/lib/pages/Login.svelte
@@ -28,7 +28,6 @@
   };
 
   $: redirectWhenSignedIn($authStore);
-
 </script>
 
 <LoginTitle />

--- a/frontend/src/lib/pages/Login.svelte
+++ b/frontend/src/lib/pages/Login.svelte
@@ -13,21 +13,22 @@
 
   let signedIn = false;
 
-  const unsubscribe: Unsubscriber = authStore.subscribe(
-    async ({ identity }: AuthStoreData) => {
-      signedIn = isSignedIn(identity);
+  const redirectWhenSignedIn = async ({
+    identity,
+  }: AuthStoreData): Promise<void> => {
+    signedIn = isSignedIn(identity);
 
-      if (!signedIn) {
-        return;
-      }
-
-      await goto(buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }), {
-        replaceState: true,
-      });
+    if (!signedIn) {
+      return;
     }
-  );
 
-  onDestroy(unsubscribe);
+    await goto(buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }), {
+      replaceState: true,
+    });
+  };
+
+  $: redirectWhenSignedIn($authStore);
+
 </script>
 
 <LoginTitle />


### PR DESCRIPTION
# Motivation

When subscribing to a Svelte store, you need to make sure to unsubscribe at the appropriate time to avoid a memory leak.
When access a store via `$store` in a Svelte component, the subscribe/unsubscribe is automatic and can't be forgotten.

# Changes

1. In Login.svelte, use `$authStore` instead of subscribing/unsubscribing explicitly.

# Tests

Added logging in Login.svelte and auth.store.ts to understand when and how often is subscribed and unsubscribed and manually tested that it's the same with and without this change.