### PR TITLE
Disable ENABLE_CKBTC on local by default

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -353,7 +353,7 @@
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,
-          "ENABLE_CKBTC": true,
+          "ENABLE_CKBTC": false,
           "ENABLE_CKTESTBTC": false
         }
       },


### PR DESCRIPTION
# Motivation

It's not yet easy to run ckBTC canisters locally and without them there are lots of errors in the console when ENABLE_CKBTC is enabled.

# Changes

Change dfx.json to disable ENABLE_CKBTC on local network.

# Tests

`__featureFlags.list()` in the console to verify it's disabled by default.