### PR TITLE
Make tid constants in page objects private and ALL CAPS.

### DIFF
--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -2,14 +2,14 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountCardPo extends BasePageObject {
-  static readonly tid = "account-card";
+  private static readonly TID = "account-card";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): AccountCardPo {
-    return new AccountCardPo(element.byTestId(AccountCardPo.tid));
+    return new AccountCardPo(element.byTestId(AccountCardPo.TID));
   }
 
   getAccountName(): Promise<string> {

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -4,14 +4,14 @@ import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountsPo extends BasePageObject {
-  static readonly tid = "accounts-component";
+  private static readonly TID = "accounts-component";
 
   constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): AccountsPo | null {
-    return new AccountsPo(element.byTestId(AccountsPo.tid));
+    return new AccountsPo(element.byTestId(AccountsPo.TID));
   }
 
   getNnsAccountsPo(): NnsAccountsPo {

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -3,14 +3,14 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class AmountDisplayPo extends BasePageObject {
-  static readonly tid = "token-value-label";
+  private static readonly TID = "token-value-label";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): AmountDisplayPo {
-    return new AmountDisplayPo(element.byTestId(AmountDisplayPo.tid));
+    return new AmountDisplayPo(element.byTestId(AmountDisplayPo.TID));
   }
 
   async getAmount(): Promise<string> {

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -3,14 +3,14 @@ import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class HashPo extends BasePageObject {
-  static readonly tid = "hash-component";
+  private static readonly TID = "hash-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): HashPo {
-    return new HashPo(element.byTestId(HashPo.tid));
+    return new HashPo(element.byTestId(HashPo.TID));
   }
 
   getTooltipPo(): TooltipPo {

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -4,14 +4,14 @@ import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-obje
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronDetailPo extends BasePageObject {
-  static readonly tid = "neuron-detail-component";
+  private static readonly TID = "neuron-detail-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NeuronDetailPo {
-    return new NeuronDetailPo(element.byTestId(NeuronDetailPo.tid));
+    return new NeuronDetailPo(element.byTestId(NeuronDetailPo.TID));
   }
 
   getNnsNeuronDetailPo(): NnsNeuronDetailPo {

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -4,14 +4,14 @@ import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronsPo extends BasePageObject {
-  static readonly tid = "neurons-component";
+  private static readonly TID = "neurons-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NeuronsPo {
-    return new NeuronsPo(element.byTestId(NeuronsPo.tid));
+    return new NeuronsPo(element.byTestId(NeuronsPo.TID));
   }
 
   getNnsNeuronsPo(): NnsNeuronsPo {

--- a/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
@@ -3,14 +3,14 @@ import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsAccountsFooterPo extends BasePageObject {
-  static readonly tid = "nns-accounts-footer-component";
+  private static readonly TID = "nns-accounts-footer-component";
 
   constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NnsAccountsFooterPo {
-    return new NnsAccountsFooterPo(element.byTestId(NnsAccountsFooterPo.tid));
+    return new NnsAccountsFooterPo(element.byTestId(NnsAccountsFooterPo.TID));
   }
 
   getSendButtonPo(): ButtonPo {

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -3,7 +3,7 @@ import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.pag
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronCardPo extends BasePageObject {
-  static readonly tid = "nns-neuron-card-component";
+  private static readonly TID = "nns-neuron-card-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
@@ -12,7 +12,7 @@ export class NnsNeuronCardPo extends BasePageObject {
   static async allUnder(
     element: PageObjectElement
   ): Promise<NnsNeuronCardPo[]> {
-    return Array.from(await element.allByTestId(NnsNeuronCardPo.tid)).map(
+    return Array.from(await element.allByTestId(NnsNeuronCardPo.TID)).map(
       (el) => new NnsNeuronCardPo(el)
     );
   }

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,14 +1,15 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+
 export class NnsNeuronCardTitlePo extends BasePageObject {
-  static readonly tid = "neuron-card-title";
+  private static readonly TID = "neuron-card-title";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronCardTitlePo {
-    return new NnsNeuronCardTitlePo(element.byTestId(NnsNeuronCardTitlePo.tid));
+    return new NnsNeuronCardTitlePo(element.byTestId(NnsNeuronCardTitlePo.TID));
   }
 
   getNeuronId(): Promise<string> {

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -3,14 +3,14 @@ import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronDetailPo extends BasePageObject {
-  static readonly tid = "nns-neuron-detail-component";
+  private static readonly TID = "nns-neuron-detail-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronDetailPo {
-    return new NnsNeuronDetailPo(element.byTestId(NnsNeuronDetailPo.tid));
+    return new NnsNeuronDetailPo(element.byTestId(NnsNeuronDetailPo.TID));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -4,14 +4,14 @@ import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronsPo extends BasePageObject {
-  static readonly tid = "nns-neurons-component";
+  private static readonly TID = "nns-neurons-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): NnsNeuronsPo {
-    return new NnsNeuronsPo(element.byTestId(NnsNeuronsPo.tid));
+    return new NnsNeuronsPo(element.byTestId(NnsNeuronsPo.TID));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -3,14 +3,14 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProjectSwapDetailsPo extends BasePageObject {
-  static readonly tid = "project-swap-details-component";
+  private static readonly TID = "project-swap-details-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): ProjectSwapDetailsPo {
-    return new ProjectSwapDetailsPo(element.byTestId(ProjectSwapDetailsPo.tid));
+    return new ProjectSwapDetailsPo(element.byTestId(ProjectSwapDetailsPo.TID));
   }
 
   getTotalSupply(): Promise<string> {

--- a/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
@@ -2,7 +2,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProposalSummarySectionPo extends BasePageObject {
-  static readonly tid = "proposal-summary-section-component";
+  private static readonly TID = "proposal-summary-section-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
@@ -10,7 +10,7 @@ export class ProposalSummarySectionPo extends BasePageObject {
 
   static under(element: PageObjectElement): ProposalSummarySectionPo {
     return new ProposalSummarySectionPo(
-      element.byTestId(ProposalSummarySectionPo.tid)
+      element.byTestId(ProposalSummarySectionPo.TID)
     );
   }
 

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -1,14 +1,15 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+
 export class SkeletonCardPo extends BasePageObject {
-  static readonly tid = "skeleton-card";
+  private static readonly TID = "skeleton-card";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static async allUnder(element: PageObjectElement): Promise<SkeletonCardPo[]> {
-    return Array.from(await element.allByTestId(SkeletonCardPo.tid)).map(
+    return Array.from(await element.allByTestId(SkeletonCardPo.TID)).map(
       (el) => new SkeletonCardPo(el)
     );
   }

--- a/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
@@ -2,13 +2,13 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SkeletonDetailsPo extends BasePageObject {
-  static readonly tid = "skeleton-details-component";
+  private static readonly TID = "skeleton-details-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): SkeletonDetailsPo | null {
-    return new SkeletonDetailsPo(element.byTestId(SkeletonDetailsPo.tid));
+    return new SkeletonDetailsPo(element.byTestId(SkeletonDetailsPo.TID));
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -3,7 +3,7 @@ import { SnsNeuronCardTitlePo } from "$tests/page-objects/SnsNeuronCardTitle.pag
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronCardPo extends BasePageObject {
-  static readonly tid = "sns-neuron-card-component";
+  private static readonly TID = "sns-neuron-card-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
@@ -12,7 +12,7 @@ export class SnsNeuronCardPo extends BasePageObject {
   static async allUnder(
     element: PageObjectElement
   ): Promise<SnsNeuronCardPo[]> {
-    return Array.from(await element.allByTestId(SnsNeuronCardPo.tid)).map(
+    return Array.from(await element.allByTestId(SnsNeuronCardPo.TID)).map(
       (el) => new SnsNeuronCardPo(el)
     );
   }

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -3,14 +3,14 @@ import { HashPo } from "$tests/page-objects/Hash.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronCardTitlePo extends BasePageObject {
-  static readonly tid = "sns-neuron-card-title";
+  private static readonly TID = "sns-neuron-card-title";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronCardTitlePo {
-    return new SnsNeuronCardTitlePo(element.byTestId(SnsNeuronCardTitlePo.tid));
+    return new SnsNeuronCardTitlePo(element.byTestId(SnsNeuronCardTitlePo.TID));
   }
 
   getNeuronId(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -3,14 +3,14 @@ import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronDetailPo extends BasePageObject {
-  static readonly tid = "sns-neuron-detail-component";
+  private static readonly TID = "sns-neuron-detail-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronDetailPo {
-    return new SnsNeuronDetailPo(element.byTestId(SnsNeuronDetailPo.tid));
+    return new SnsNeuronDetailPo(element.byTestId(SnsNeuronDetailPo.TID));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -4,14 +4,14 @@ import { SnsNeuronCardPo } from "$tests/page-objects/SnsNeuronCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronsPo extends BasePageObject {
-  static readonly tid = "sns-neurons-component";
+  private static readonly TID = "sns-neurons-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): SnsNeuronsPo {
-    return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.tid));
+    return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.TID));
   }
 
   getSkeletonCardPos(): Promise<SkeletonCardPo[]> {

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -4,14 +4,14 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SnsProposalSystemInfoSectionPo } from "./SnsProposalSystemInfoSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
-  static readonly tid = "sns-proposal-details-grid";
+  private static readonly TID = "sns-proposal-details-grid";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): SnsProposalDetailPo | null {
-    return new SnsProposalDetailPo(element.byTestId(SnsProposalDetailPo.tid));
+    return new SnsProposalDetailPo(element.byTestId(SnsProposalDetailPo.TID));
   }
 
   getSkeletonDetails(): SkeletonDetailsPo {

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -3,13 +3,13 @@ import { BasePageObject } from "./base.page-object";
 import { KeyValuePairPo } from "./KeyValuePair.page-object";
 
 export class SnsProposalSystemInfoSectionPo extends BasePageObject {
-  static readonly tid = "proposal-system-info-details-component";
+  private static readonly TID = "proposal-system-info-details-component";
 
   static under(
     element: PageObjectElement
   ): SnsProposalSystemInfoSectionPo | null {
     const el = element.querySelector(
-      `[data-tid=${SnsProposalSystemInfoSectionPo.tid}]`
+      `[data-tid=${SnsProposalSystemInfoSectionPo.TID}]`
     );
     return el && new SnsProposalSystemInfoSectionPo(el);
   }

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -3,14 +3,14 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class TooltipPo extends BasePageObject {
-  static readonly tid = "tooltip-component";
+  private static readonly TID = "tooltip-component";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): TooltipPo {
-    return new TooltipPo(element.byTestId(TooltipPo.tid));
+    return new TooltipPo(element.byTestId(TooltipPo.TID));
   }
 
   getText(): Promise<string> {


### PR DESCRIPTION
# Motivation

Minor style cleanup which was requested in https://github.com/dfinity/nns-dapp/pull/2188 and applied only to the page objects in that PR.
Most page object classes have
```
  static readonly tid = "foo";
```

# Changes

Change
```
  static readonly tid = "foo";
```
to
```
  private static readonly TID = "foo";
```

# Tests

npm run test