### PR TITLE
E2E: The user MUST be able to see a list of all their accounts

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -23,9 +23,11 @@ test("Test accounts requirements", async ({ page, context }) => {
   const subAccountName = "My second account";
   await nnsAccountsPo.addAccount(subAccountName);
 
-  // TODO:
+  // AU001: The user MUST be able to see a list of all their accounts
+  const accountNames = await nnsAccountsPo.getAccountNames();
+  expect(accountNames).toEqual([mainAccountName, subAccountName]);
 
-  // AU001:  The user MUST be able to see a list of all their accounts
+  // TODO:
 
   // AU004: The user MUST be able to transfer funds
 

--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -13,9 +13,9 @@ export class AccountCardPo extends BasePageObject {
   }
 
   static async allUnder(element: PageObjectElement): Promise<AccountCardPo[]> {
-    return Array.from(
-      await element.allByTestId(AccountCardPo.TID)
-    ).map((el) => new AccountCardPo(el));
+    return Array.from(await element.allByTestId(AccountCardPo.TID)).map(
+      (el) => new AccountCardPo(el)
+    );
   }
 
   getAccountName(): Promise<string> {

--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -2,14 +2,20 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountCardPo extends BasePageObject {
-  static readonly tid = "account-card";
+  private static readonly TID = "account-card";
 
   private constructor(root: PageObjectElement) {
     super(root);
   }
 
   static under(element: PageObjectElement): AccountCardPo {
-    return new AccountCardPo(element.byTestId(AccountCardPo.tid));
+    return new AccountCardPo(element.byTestId(AccountCardPo.TID));
+  }
+
+  static async allUnder(element: PageObjectElement): Promise<AccountCardPo[]> {
+    return Array.from(
+      await element.allByTestId(AccountCardPo.TID)
+    ).map((el) => new AccountCardPo(el));
   }
 
   getAccountName(): Promise<string> {

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -19,6 +19,15 @@ export class NnsAccountsPo extends BasePageObject {
     return AccountCardPo.under(this.root);
   }
 
+  getAccountCardPos(): Promise<AccountCardPo[]> {
+    return AccountCardPo.allUnder(this.root);
+  }
+
+  async getAccountNames(): Promise<string[]> {
+    const cards = await this.getAccountCardPos();
+    return Promise.all(cards.map((card) => card.getAccountName()));
+  }
+
   getNnsAddAccountPo(): NnsAddAccountPo {
     return NnsAddAccountPo.under(this.root);
   }

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -19,7 +19,9 @@ export const signInWithNewUser = async ({
   await iiPage.locator("input#captchaInput").fill("a");
   await iiPage.getByRole("button", { name: "Next" }).click();
   await iiPage.getByRole("button", { name: "Continue" }).click();
+  await iiPage.getByText("Choose a Recovery Method").waitFor();
   await iiPage.getByRole("button", { name: /Skip/ }).click();
+  await iiPage.getByRole("button", { name: "Add another device" }).waitFor();
   await iiPage.getByRole("button", { name: /Skip/ }).click();
   await iiPage.waitForEvent("close");
   await expect(iiPage.isClosed()).toBe(true);


### PR DESCRIPTION
# Motivation

Continuing with the accounts end-to-end test, we check the next requirement.

# Changes

1. Check the list of account names in the e2e test.
2. Required page object changes.
3. (not really related but somehow started causing trouble now) While signing in, make sure that we click the correct "Next" button otherwise we might click the same one a second time and get stuck on the next one.

# Tests

`npm run test-e2e`