### PR TITLE
Chore: Add more dummy SNS proposals

### DIFF
--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -148,16 +148,20 @@ export const makeSnsDummyProposals = async ({
     agent,
     canisterId: canisterIds.governanceCanisterId,
   });
-
   const { snsProposals } = await import("./sns-dummy.api");
 
   await Promise.all(
-    snsProposals.map((proposal) =>
-      canister.manageNeuron({
-        subaccount: neuronId.id,
-        command: [{ MakeProposal: proposal }],
-      })
-    )
+    snsProposals.map((proposal) => {
+      try {
+        return canister.manageNeuron({
+          subaccount: neuronId.id,
+          command: [{ MakeProposal: proposal }],
+        });
+      } catch (error) {
+        console.error("Error while making proposal: ", proposal.title);
+        console.error(error);
+      }
+    })
   );
 
   logWithTimestamp(`Making dummy proposals call complete.`);

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -150,18 +150,26 @@ export const makeSnsDummyProposals = async ({
   });
   const { snsProposals } = await import("./sns-dummy.api");
 
-  try {
-    await Promise.all(
-      snsProposals.map((proposal) =>
-        canister.manageNeuron({
+  const allCalls = await Promise.allSettled(
+    snsProposals.map((proposal) =>
+      canister
+        .manageNeuron({
           subaccount: neuronId.id,
           command: [{ MakeProposal: proposal }],
         })
-      )
-    );
-  } catch (error) {
-    console.error("Error while creating dummy proposals");
-    console.error(error);
+        .catch((error) => {
+          console.error(
+            "Error while creating dummy proposal: ",
+            proposal.title
+          );
+          console.error(error);
+          throw error;
+        })
+    )
+  );
+
+  if (allCalls.some((call) => call.status === "rejected")) {
+    throw new Error();
   }
 
   logWithTimestamp(`Making dummy proposals call complete.`);

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -150,19 +150,19 @@ export const makeSnsDummyProposals = async ({
   });
   const { snsProposals } = await import("./sns-dummy.api");
 
-  await Promise.all(
-    snsProposals.map((proposal) => {
-      try {
-        return canister.manageNeuron({
+  try {
+    await Promise.all(
+      snsProposals.map((proposal) =>
+        canister.manageNeuron({
           subaccount: neuronId.id,
           command: [{ MakeProposal: proposal }],
-        });
-      } catch (error) {
-        console.error("Error while making proposal: ", proposal.title);
-        console.error(error);
-      }
-    })
-  );
+        })
+      )
+    );
+  } catch (error) {
+    console.error("Error while creating dummy proposals");
+    console.error(error);
+  }
 
   logWithTimestamp(`Making dummy proposals call complete.`);
 };

--- a/frontend/src/lib/api/sns-dummy.api.ts
+++ b/frontend/src/lib/api/sns-dummy.api.ts
@@ -97,10 +97,133 @@ const nsFunctionProposal2 = {
   ] as [SnsAction],
 };
 
+const executeNSFunctionProposal = {
+  url: "internet-computer.org",
+  title: "Execute Generic Nervoys system Function",
+  summary:
+    "# Summary\nThis is a dummy proposal to execute a *nervous system function*.",
+  action: [
+    {
+      ExecuteGenericNervousSystemFunction: {
+        function_id: BigInt(5),
+        payload: new Uint8Array(),
+      },
+    },
+  ] as [SnsAction],
+};
+
+const removeNSFunctionProposal = {
+  url: "internet-computer.org",
+  title: "Remove Generic Nervoys system Function",
+  summary:
+    "# Summary\nThis is a dummy proposal to remove a *nervous system function*.",
+  action: [
+    {
+      RemoveGenericNervousSystemFunction: BigInt(1002),
+    },
+  ] as [SnsAction],
+};
+
+const upgradeProposal = {
+  url: "internet-computer.org",
+  title: "Upgrade to next version",
+  summary:
+    "# Summary\nThis is a dummy proposal to *upgrade* to the next version.",
+  action: [
+    {
+      UpgradeSnsToNextVersion: {},
+    },
+  ] as [SnsAction],
+};
+
+const registerDappCanisterProposal = {
+  url: "internet-computer.org",
+  title: "Register Dapp Canister",
+  summary:
+    "# Summary\nThis is a dummy proposal to register a new dapp canister.",
+  action: [
+    {
+      RegisterDappCanisters: {
+        canister_ids: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
+      },
+    },
+  ] as [SnsAction],
+};
+
+const transferFundsProposal = {
+  url: "internet-computer.org",
+  title: "Transfer tokens",
+  summary: "# Summary\nThis is a dummy proposal to *transfer* funds.",
+  action: [
+    {
+      TransferSnsTreasuryFunds: {
+        from_treasury: 1,
+        to_principal: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
+        to_subaccount: [],
+        memo: [BigInt(33333)],
+        amount_e8s: BigInt(100_000_000_000),
+      },
+    },
+  ] as [SnsAction],
+};
+
+const upgradeControlledCanisterProposal = {
+  url: "internet-computer.org",
+  title: "Upgrade canister",
+  summary: "# Summary\nThis is a dummy proposal to *upgrade* a canister.",
+  action: [
+    {
+      UpgradeSnsControlledCanister: {
+        new_canister_wasm: new Uint8Array(),
+        canister_id: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
+        canister_upgrade_arg: [],
+      },
+    },
+  ] as [SnsAction],
+};
+
+const deregisterCanisterProposal = {
+  url: "internet-computer.org",
+  title: "Deregister canister",
+  summary:
+    "# Summary\nThis is a dummy proposal to *deregister* a controlled canister.",
+  action: [
+    {
+      DeregisterDappCanisters: {
+        canister_ids: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
+        new_controllers: [
+          Principal.fromText(
+            "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+          ),
+        ],
+      },
+    },
+  ] as [SnsAction],
+};
+
+const unspecifiedProposal = {
+  url: "internet-computer.org",
+  title: "Unspecified",
+  summary: "# Summary\nThis is a dummy proposal to *upgrade* a canister.",
+  action: [
+    {
+      Unspecified: {},
+    },
+  ] as [SnsAction],
+};
+
 export const snsProposals = [
   motionProposal1,
   motionProposal2,
   manageSnsMetadataproposal,
   nsFunctionProposal1,
   nsFunctionProposal2,
+  executeNSFunctionProposal,
+  removeNSFunctionProposal,
+  upgradeProposal,
+  registerDappCanisterProposal,
+  transferFundsProposal,
+  upgradeControlledCanisterProposal,
+  deregisterCanisterProposal,
+  unspecifiedProposal,
 ];

--- a/frontend/src/lib/api/sns-dummy.api.ts
+++ b/frontend/src/lib/api/sns-dummy.api.ts
@@ -97,44 +97,47 @@ const nsFunctionProposal2 = {
   ] as [SnsAction],
 };
 
-const executeNSFunctionProposal = {
-  url: "internet-computer.org",
-  title: "Execute Generic Nervoys system Function",
-  summary:
-    "# Summary\nThis is a dummy proposal to execute a *nervous system function*.",
-  action: [
-    {
-      ExecuteGenericNervousSystemFunction: {
-        function_id: BigInt(5),
-        payload: new Uint8Array(),
-      },
-    },
-  ] as [SnsAction],
-};
+// We need to pass a proposal to add a function to the nervous system first
+// const executeNSFunctionProposal = {
+//   url: "internet-computer.org",
+//   title: "Execute Generic Nervoys system Function",
+//   summary:
+//     "# Summary\nThis is a dummy proposal to execute a *nervous system function*.",
+//   action: [
+//     {
+//       ExecuteGenericNervousSystemFunction: {
+//         function_id: BigInt(1002),
+//         payload: new Uint8Array(),
+//       },
+//     },
+//   ] as [SnsAction],
+// };
 
-const removeNSFunctionProposal = {
-  url: "internet-computer.org",
-  title: "Remove Generic Nervoys system Function",
-  summary:
-    "# Summary\nThis is a dummy proposal to remove a *nervous system function*.",
-  action: [
-    {
-      RemoveGenericNervousSystemFunction: BigInt(1002),
-    },
-  ] as [SnsAction],
-};
+// We need to pass a proposal to add a function to the nervous system first
+// const removeNSFunctionProposal = {
+//   url: "internet-computer.org",
+//   title: "Remove Generic Nervoys system Function",
+//   summary:
+//     "# Summary\nThis is a dummy proposal to remove a *nervous system function*.",
+//   action: [
+//     {
+//       RemoveGenericNervousSystemFunction: BigInt(1002),
+//     },
+//   ] as [SnsAction],
+// };
 
-const upgradeProposal = {
-  url: "internet-computer.org",
-  title: "Upgrade to next version",
-  summary:
-    "# Summary\nThis is a dummy proposal to *upgrade* to the next version.",
-  action: [
-    {
-      UpgradeSnsToNextVersion: {},
-    },
-  ] as [SnsAction],
-};
+// We need to deploy new version of the SNS canisters first.
+// const upgradeProposal = {
+//   url: "internet-computer.org",
+//   title: "Upgrade to next version",
+//   summary:
+//     "# Summary\nThis is a dummy proposal to *upgrade* to the next version.",
+//   action: [
+//     {
+//       UpgradeSnsToNextVersion: {},
+//     },
+//   ] as [SnsAction],
+// };
 
 const registerDappCanisterProposal = {
   url: "internet-computer.org",
@@ -167,20 +170,21 @@ const transferFundsProposal = {
   ] as [SnsAction],
 };
 
-const upgradeControlledCanisterProposal = {
-  url: "internet-computer.org",
-  title: "Upgrade canister",
-  summary: "# Summary\nThis is a dummy proposal to *upgrade* a canister.",
-  action: [
-    {
-      UpgradeSnsControlledCanister: {
-        new_canister_wasm: new Uint8Array(),
-        canister_id: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
-        canister_upgrade_arg: [],
-      },
-    },
-  ] as [SnsAction],
-};
+// TODO: Find a valid new_canister_wasm
+// const upgradeControlledCanisterProposal = {
+//   url: "internet-computer.org",
+//   title: "Upgrade canister",
+//   summary: "# Summary\nThis is a dummy proposal to *upgrade* a canister.",
+//   action: [
+//     {
+//       UpgradeSnsControlledCanister: {
+//         new_canister_wasm: new Uint8Array(),
+//         canister_id: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
+//         canister_upgrade_arg: [],
+//       },
+//     },
+//   ] as [SnsAction],
+// };
 
 const deregisterCanisterProposal = {
   url: "internet-computer.org",
@@ -201,29 +205,18 @@ const deregisterCanisterProposal = {
   ] as [SnsAction],
 };
 
-const unspecifiedProposal = {
-  url: "internet-computer.org",
-  title: "Unspecified",
-  summary: "# Summary\nThis is a dummy proposal to *upgrade* a canister.",
-  action: [
-    {
-      Unspecified: {},
-    },
-  ] as [SnsAction],
-};
-
 export const snsProposals = [
   motionProposal1,
   motionProposal2,
   manageSnsMetadataproposal,
   nsFunctionProposal1,
   nsFunctionProposal2,
-  executeNSFunctionProposal,
-  removeNSFunctionProposal,
-  upgradeProposal,
+  // The following proposals require specific state to be set up first.
+  // executeNSFunctionProposal,
+  // removeNSFunctionProposal,
+  // upgradeProposal,
+  // upgradeControlledCanisterProposal,
   registerDappCanisterProposal,
   transferFundsProposal,
-  upgradeControlledCanisterProposal,
   deregisterCanisterProposal,
-  unspecifiedProposal,
 ];

--- a/frontend/src/lib/api/sns-dummy.api.ts
+++ b/frontend/src/lib/api/sns-dummy.api.ts
@@ -98,20 +98,20 @@ const nsFunctionProposal2 = {
 };
 
 // We need to pass a proposal to add a function to the nervous system first
-// const executeNSFunctionProposal = {
-//   url: "internet-computer.org",
-//   title: "Execute Generic Nervoys system Function",
-//   summary:
-//     "# Summary\nThis is a dummy proposal to execute a *nervous system function*.",
-//   action: [
-//     {
-//       ExecuteGenericNervousSystemFunction: {
-//         function_id: BigInt(1002),
-//         payload: new Uint8Array(),
-//       },
-//     },
-//   ] as [SnsAction],
-// };
+const executeNSFunctionProposal = {
+  url: "internet-computer.org",
+  title: "Execute Generic Nervoys system Function",
+  summary:
+    "# Summary\nThis is a dummy proposal to execute a *nervous system function*.",
+  action: [
+    {
+      ExecuteGenericNervousSystemFunction: {
+        function_id: BigInt(1002),
+        payload: new Uint8Array(),
+      },
+    },
+  ] as [SnsAction],
+};
 
 // We need to pass a proposal to add a function to the nervous system first
 // const removeNSFunctionProposal = {
@@ -212,7 +212,7 @@ export const snsProposals = [
   nsFunctionProposal1,
   nsFunctionProposal2,
   // The following proposals require specific state to be set up first.
-  // executeNSFunctionProposal,
+  executeNSFunctionProposal,
   // removeNSFunctionProposal,
   // upgradeProposal,
   // upgradeControlledCanisterProposal,


### PR DESCRIPTION
# Motivation

Testnet users should create more types of dummy SNS proposals for better testing.

# Changes

* Add more dummy proposals in sns-dummy.api.
* Use allSettled and log individual fails for better debugging in testnet.

# Tests

* Not applicable. Functionality only for testnet.
