### PR TITLE
E2E: Get ICP

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -11,6 +11,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { AppPath } from "$lib/constants/routes.constants";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import GetTokens from "$lib/components/ic/GetTokens.svelte";
   import {
     accountsPathStore,
@@ -85,18 +86,20 @@
   ];
 </script>
 
-{#each routes as { context, label, href, icon, statusIcon, selected } (context)}
-  <MenuItem {href} testId={`menuitem-${context}`} {selected}>
-    <svelte:component this={icon} slot="icon" />
-    <svelte:fragment
-      >{keyOf({ obj: $i18n.navigation, key: label })}</svelte:fragment
-    >
-    <svelte:component this={statusIcon} slot="statusIcon" />
-  </MenuItem>
-{/each}
+<TestIdWrapper testId="menu-items-component">
+  {#each routes as { context, label, href, icon, statusIcon, selected } (context)}
+    <MenuItem {href} testId={`menuitem-${context}`} {selected}>
+      <svelte:component this={icon} slot="icon" />
+      <svelte:fragment
+        >{keyOf({ obj: $i18n.navigation, key: label })}</svelte:fragment
+      >
+      <svelte:component this={statusIcon} slot="statusIcon" />
+    </MenuItem>
+  {/each}
 
-{#if IS_TESTNET}
-  <GetTokens />
-{/if}
+  {#if IS_TESTNET}
+    <GetTokens />
+  {/if}
 
-<MenuMetrics />
+  <MenuMetrics />
+</TestIdWrapper>

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -3,6 +3,7 @@
    * Transfer ICP to current principal. For test purpose only and only available on "testnet" too.
    */
   import { Modal } from "@dfinity/gix-components";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Input from "$lib/components/ui/Input.svelte";
   import { getICPs, getTokens } from "$lib/services/dev.services";
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
@@ -71,52 +72,54 @@
   $: signedIn = isSignedIn($authStore.identity);
 </script>
 
-{#if signedIn}
-  <button
-    role="menuitem"
-    data-tid="get-icp-button"
-    on:click|preventDefault|stopPropagation={() => (visible = true)}
-    class="open"
-  >
-    <IconAccountBalance />
-    <span>{`Get ${token.symbol}`}</span>
-  </button>
-{/if}
+<TestIdWrapper testId="get-tokens-component">
+  {#if signedIn}
+    <button
+      role="menuitem"
+      data-tid="get-icp-button"
+      on:click|preventDefault|stopPropagation={() => (visible = true)}
+      class="open"
+    >
+      <IconAccountBalance />
+      <span>{`Get ${token.symbol}`}</span>
+    </button>
+  {/if}
 
-<Modal {visible} role="alert" on:nnsClose={onClose}>
-  <span slot="title">{`Get ${token.symbol}`}</span>
+  <Modal {visible} role="alert" on:nnsClose={onClose}>
+    <span slot="title">{`Get ${token.symbol}`}</span>
 
-  <form
-    id="get-icp-form"
-    data-tid="get-icp-form"
-    on:submit|preventDefault={onSubmit}
-  >
-    <span class="label">How much?</span>
+    <form
+      id="get-icp-form"
+      data-tid="get-icp-form"
+      on:submit|preventDefault={onSubmit}
+    >
+      <span class="label">How much?</span>
 
-    <Input
-      placeholderLabelKey="core.amount"
-      name="tokens"
-      inputType="icp"
-      bind:value={inputValue}
-      disabled={transferring}
-    />
-  </form>
+      <Input
+        placeholderLabelKey="core.amount"
+        name="tokens"
+        inputType="icp"
+        bind:value={inputValue}
+        disabled={transferring}
+      />
+    </form>
 
-  <button
-    form="get-icp-form"
-    data-tid="get-icp-submit"
-    type="submit"
-    class="primary"
-    slot="footer"
-    disabled={invalidForm || transferring}
-  >
-    {#if transferring}
-      <Spinner />
-    {:else}
-      Get tokens
-    {/if}
-  </button>
-</Modal>
+    <button
+      form="get-icp-form"
+      data-tid="get-icp-submit"
+      type="submit"
+      class="primary"
+      slot="footer"
+      disabled={invalidForm || transferring}
+    >
+      {#if transferring}
+        <Spinner />
+      {:else}
+        Get tokens
+      {/if}
+    </button>
+  </Modal>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";

--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -27,6 +27,9 @@ test("Test accounts requirements", async ({ page, context }) => {
   const accountNames = await nnsAccountsPo.getAccountNames();
   expect(accountNames).toEqual([mainAccountName, subAccountName]);
 
+  // Get some ICP to be able to transfer
+  await appPo.getIcp(20);
+
   // TODO:
 
   // AU004: The user MUST be able to transfer funds

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,5 +1,7 @@
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AppPo extends BasePageObject {
@@ -9,5 +11,56 @@ export class AppPo extends BasePageObject {
 
   getAccountsPo(): AccountsPo {
     return AccountsPo.under(this.root);
+  }
+
+  getMenuItemsPo(): MenuItemsPo {
+    return MenuItemsPo.under(this.root);
+  }
+
+  // Note that the universe selector and the main content have separate
+  // backdrops. We just get the first one because we only use it to know if the
+  // menu is open.
+  getBackdropPo(): BackdropPo {
+    return BackdropPo.under(this.root);
+  }
+
+  getMenuTogglePo(): ButtonPo {
+    return this.getButton("menu-toggle");
+  }
+
+  toggleMenu(): Promise<void> {
+    return this.getMenuTogglePo().click();
+  }
+
+  async openMenu(): Promise<void> {
+    // Whether the menu needs to be opened depends on the size of the viewport.
+    const isTogglePresent = await this.getMenuTogglePo().isPresent();
+    if (isTogglePresent) {
+      const backdrop = this.getBackdropPo();
+      if (await backdrop.isPresent()) {
+        throw Error("Menu is already open");
+      }
+      await this.toggleMenu();
+      await backdrop.waitFor();
+    }
+  }
+
+  async closeMenu(): Promise<void> {
+    // Whether the menu needs to be closed depends on the size of the viewport.
+    const isTogglePresent = await this.getMenuTogglePo().isPresent();
+    if (isTogglePresent) {
+      const backdrop = this.getBackdropPo();
+      if (!(await backdrop.isPresent())) {
+        throw Error("Menu is already closed");
+      }
+      await this.toggleMenu();
+      await backdrop.waitForAbsent();
+    }
+  }
+
+  async getIcp(amount: number): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().getGetTokensPo().getIcp(amount);
+    await this.closeMenu();
   }
 }

--- a/frontend/src/tests/page-objects/Backdrop.page-object.ts
+++ b/frontend/src/tests/page-objects/Backdrop.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BackdropPo extends BasePageObject {
+  private static readonly TID = "backdrop";
+
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): BackdropPo {
+    return new BackdropPo(element.byTestId(BackdropPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -1,0 +1,37 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class GetTokensPo extends BasePageObject {
+  static readonly TID = "get-tokens-component";
+
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): GetTokensPo {
+    return new GetTokensPo(element.byTestId(GetTokensPo.TID));
+  }
+
+  clickGetTokens(): Promise<void> {
+    return this.getButton("get-icp-button").click();
+  }
+
+  clickSubmit(): Promise<void> {
+    return this.getButton("get-icp-submit").click();
+  }
+
+  enterAmount(amount: number): Promise<void> {
+    return this.getTextInput().typeText(amount.toString());
+  }
+
+  waitForModalClosed(): Promise<void> {
+    return this.root.byTestId("get-icp-form").waitForAbsent();
+  }
+
+  async getIcp(amount: number): Promise<void> {
+    await this.clickGetTokens();
+    await this.enterAmount(amount);
+    await this.clickSubmit();
+    await this.waitForModalClosed();
+  }
+}

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -16,12 +16,12 @@ export class GetTokensPo extends BasePageObject {
     return this.getButton("get-icp-button").click();
   }
 
-  clickSubmit(): Promise<void> {
-    return this.getButton("get-icp-submit").click();
-  }
-
   enterAmount(amount: number): Promise<void> {
     return this.getTextInput().typeText(amount.toString());
+  }
+
+  clickSubmit(): Promise<void> {
+    return this.getButton("get-icp-submit").click();
   }
 
   waitForModalClosed(): Promise<void> {

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -1,0 +1,19 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { GetTokensPo } from "$tests/page-objects/GetTokens.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class MenuItemsPo extends BasePageObject {
+  private static readonly TID = "menu-items-component";
+
+  constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): MenuItemsPo {
+    return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
+  }
+
+  getGetTokensPo(): GetTokensPo {
+    return GetTokensPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -13,7 +13,9 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   }
 
   querySelector(selector: string): PlaywrightPageObjectElement {
-    return new PlaywrightPageObjectElement(this.locator.locator(selector));
+    return new PlaywrightPageObjectElement(
+      this.locator.locator(selector).first()
+    );
   }
 
   async querySelectorAll(

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -11,4 +11,12 @@ export class SimpleBasePageObject {
   isPresent(): Promise<boolean> {
     return this.root.isPresent();
   }
+
+  waitFor(): Promise<boolean> {
+    return this.root.waitFor();
+  }
+
+  waitForAbsent(): Promise<boolean> {
+    return this.root.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -12,11 +12,11 @@ export class SimpleBasePageObject {
     return this.root.isPresent();
   }
 
-  waitFor(): Promise<boolean> {
+  waitFor(): Promise<void> {
     return this.root.waitFor();
   }
 
-  waitForAbsent(): Promise<boolean> {
+  waitForAbsent(): Promise<void> {
     return this.root.waitForAbsent();
   }
 }


### PR DESCRIPTION
# Motivation

We want to test that it's possible to make transactions. For that we need some tokens.
So the "Get ICP" button should be usable from the end-to-end test.

# Changes

1. Add getting 20 ICP to the accounts e2e test.
2. Add required page objects.
3. Add test IDs to components.
4. Add `.first()` to the locator in in `querySelector()` in PlaywrightPageObjectElement to make the behavior similar to actual querySelector and to get the first backdrop without error.

# Tests

`npm run test-e2e -- --headed`
