### PR TITLE
chore: Update bash argument parser

### DIFF
--- a/scripts/clap.bash
+++ b/scripts/clap.bash
@@ -95,7 +95,7 @@ cat << XXX
 usage: \$(basename "\$0") [OPTIONS]
 
 OPTIONS:
-        $clap_usage
+        ${clap_usage:-}
 
         -? --help  :  usage
 
@@ -109,8 +109,8 @@ XXX
 [[ "\${COMP_LINE:-}" == "" ]] || [[ "\${COMP_POINT:-}" == "" ]] || {
 	COMP_CURRENT="${1:-}"
 	case "\$COMP_CURRENT" in
-	"")	compgen -W "$clap_flags" -- "\$COMP_CURRENT" ;;
-	-*)	compgen -W "$clap_flags" -- "\$COMP_CURRENT" ;;
+	"")	compgen -W "${clap_flags:-}" -- "\$COMP_CURRENT" ;;
+	-*)	compgen -W "${clap_flags:-}" -- "\$COMP_CURRENT" ;;
 	*)	compgen -f -- "\$COMP_CURRENT" ;;
 	esac
 	exit 0
@@ -127,7 +127,7 @@ while [ \$# -ne 0 ]; do
         case "\$param" in
                 $clap_flag_match
                 "-?"|--help)
-			print_help
+			[[ "$(type -t print_help)" != function ]] || print_help
 			echo
                         usage
                         exit 0;;


### PR DESCRIPTION
# Motivation
The upstream bash argument parser fixed an issue whereby a missing `print_help()` could cause an error.  The fix was implemented in https://github.com/dfinity/snsdemo/pull/99 and tested in https://github.com/dfinity/snsdemo/pull/102  Pulling in the latest code will fix that issue in our copy of the argument parser.

# Changes
* Bump the bash argument parser to the latest version in snsdemo.

# Tests
* The parser is tested upstream
* There are no breaking changes in the API
* CI should verify that there are no unintended breaking changes.