### PR TITLE
Escape the quotes

### DIFF
--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -45,9 +45,9 @@ pub fn configname2attributename(name: &str) -> String {
 /// Escapes a configuration value per the OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts
 pub fn configvalue2attributevalue(value: &str) -> String {
     value
-        .replace('&', "&amp")
+        .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
-        .replace('\'', "&#x27")
+        .replace('\'', "&#x27;")
 }

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -21,8 +21,9 @@ impl CanisterArguments {
         for (key, value) in &self.args {
             ans.push(' ');
             ans.push_str(&configname2attributename(key));
-            ans.push('=');
-            ans.push_str(&configvalue2attributevalue(value));
+            ans.push_str("=\"");
+            ans.push_str(&value.replace('"', "&quot;"));
+            ans.push('"');
         }
         ans.push('>');
         ans
@@ -39,9 +40,4 @@ impl CanisterArguments {
 /// This, in turn, will appear in JavaScript & family as camel case.
 pub fn configname2attributename(name: &str) -> String {
     "data-".to_owned() + &name.replace('_', "-").to_lowercase()
-}
-
-/// Escapes a configuration value
-pub fn configvalue2attributevalue(value: &str) -> String {
-    serde_json::Value::String(value.to_string()).to_string()
 }

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -22,7 +22,7 @@ impl CanisterArguments {
             ans.push(' ');
             ans.push_str(&configname2attributename(key));
             ans.push_str("=\"");
-            ans.push_str(&value.replace('"', "&quot;"));
+            ans.push_str(&configvalue2attributevalue(value));
             ans.push('"');
         }
         ans.push('>');
@@ -40,4 +40,14 @@ impl CanisterArguments {
 /// This, in turn, will appear in JavaScript & family as camel case.
 pub fn configname2attributename(name: &str) -> String {
     "data-".to_owned() + &name.replace('_', "-").to_lowercase()
+}
+
+/// Escapes a configuration value per the OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts
+pub fn configvalue2attributevalue(value: &str) -> String {
+    value
+        .replace('&', "&amp")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27")
 }


### PR DESCRIPTION
# Motivation
The nns-dapp arguments code encodes arguments as JSON.  Unfortunately JSON encoding doesn't work for HTML attributes.  For HTML attributes the only relevant character that we need to escape is `"` and that needs to be encoded as `&quot;` not `\"`.

# Changes
* Change the argument encoding to the attribute encoding recommended by OWASP.

# Tests