### PR TITLE
Fix argument autoconfig

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -183,9 +183,9 @@ echo "$json" >"$JSON_OUT"
 
 # Creates the candid arguments passed when the canister is installed.
 cat <<EOF >"$CANDID_ARGS_FILE"
-(record{
+(opt record{
   args = vec {
-$(jq -r 'to_entries | .[] | "    record{ 0=\(.key | tojson); 1=\(.value | tostring | gsub("\"";"&quot;") | tojson) };"' "$JSON_OUT")
+$(jq -r 'to_entries | .[] | "    record{ 0=\(.key | tojson); 1=\(.value | tostring | tojson) };"' "$JSON_OUT")
   };
 })
 EOF


### PR DESCRIPTION
# Motivation
The argument template has two errors, due to erroneous copying from the testing branch to the small slice merged into main:
* The argument is optional, but `opt` is missing from the code in main.
* Quotes are escaped in the rust code, so the escapes are no longer needed in the template.