### PR TITLE
Fail fast for e2e errors

### DIFF
--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -141,6 +141,7 @@ export const config: WebdriverIO.Config = {
   reporters: ["spec"],
 
   mochaOpts: {
+    bail: true,
     ui: "bdd",
     timeout: 60000,
     retries: 1,


### PR DESCRIPTION
# Motivation
E2e tests broke earlier this morning; every test timed out.  But it took 15-18 minutes to see the screenshots of each test.  This test run time is significantly higher than usual, but this error state occurred and the slow response time slowed attempts to diagnose the cause.

The screenshots are available only after the test has complete in its entirety.

# Changes
* Set the mocha flag to bail out on error.
  Note: If some tests in a spec file fail, the test does not exit immediately.  The spec completes and then the e2e tests are killed.

# Tests
See CI