### PR TITLE
Do not delete malformed yaml files

### DIFF
--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -10,6 +10,6 @@ case "${1:-}" in
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
   # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
-  list_files | while read -r line; do yq --inplace . "$line" ; done
+  list_files | while read -r line; do yq --inplace . "$line"; done
   ;;
 esac

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -9,7 +9,6 @@ case "${1:-}" in
 --list) list_files ;;
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
-  # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
   list_files | while read -r line; do yq --inplace . "$line"; done
   ;;
 esac

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
 list_files() {

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
 list_files() {
@@ -10,6 +11,6 @@ case "${1:-}" in
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
   # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
-  list_files | while read -r line; do cat <<<"$(yq . "$line")" >"$line"; done
+  list_files | while read -r line; do yq --inplace . "$line" ; done
   ;;
 esac


### PR DESCRIPTION
# Motivation
If a yaml file is malformed, the existing yaml formatter will delete it.

# Changes
- Use `yq --inplace`
  - I have verified that it does not change the original file if it fails.
  - `--inplace` [writes to a temp file and replaces the original only if there is no error.](https://github.com/mikefarah/yq/blob/5fd2890d1b7faa2cda61c016e81bce0c841b10cb/cmd/evalute_sequence_command.go#L70)

# Tests
## Main deletes malformed
Here we corrupt a yaml file and demonstrate that "formatting" it erases the file.
```
max@sinkpad:~/dfn/nns-dapp (1day,09:42:23)$ git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.

# Corrupt a YAML file:
max@sinkpad:~/dfn/nns-dapp (1day,09:42:28)$ printf "%s\n" foo bar >> .github/workflows/build.yml 
max@sinkpad:~/dfn/nns-dapp (1day,09:42:33)$ tail .github/workflows/build.yml
    needs: ["build"]
    if: ${{ always() }}
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3
      - uses: ./.github/actions/needs_success
        with:
          needs: '${{ toJson(needs) }}'
foo
bar <-- not valid yaml

# Formatting erases the file:
max@sinkpad:~/dfn/nns-dapp (1day,09:42:37)$ ./scripts/fmt-yaml 
Error: bad file '.github/workflows/build.yml': yaml: line 174: could not find expected ':'
max@sinkpad:~/dfn/nns-dapp (1day,09:42:46)$ tail .github/workflows/build.yml

max@sinkpad:~/dfn/nns-dapp (1day,09:42:53)$ git checkout .github/workflows/build.yml
Updated 1 path from the index
max@sinkpad:~/dfn/nns-dapp (1day,09:43:10)$ 
```
### PR leaves malformed intact
Here we demonstrate that formatting with the same corruption leaves the corrupted file intact.
```
max@sinkpad:~/dfn/nns-dapp (1day,09:44:02)$ git checkout no-delete-yaml
Switched to branch 'no-delete-yaml'
Your branch is up to date with 'origin/no-delete-yaml'.
max@sinkpad:~/dfn/nns-dapp (1day,09:44:22)$ tail .github/workflows/build.yml
          rm -rf screenshots
  build-pass:
    needs: ["build"]
    if: ${{ always() }}
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3
      - uses: ./.github/actions/needs_success
        with:
          needs: '${{ toJson(needs) }}'
max@sinkpad:~/dfn/nns-dapp (1day,09:44:31)$ printf "%s\n" foo bar >> .github/workflows/build.yml 
max@sinkpad:~/dfn/nns-dapp (1day,09:42:33)$ tail .github/workflows/build.yml
    needs: ["build"]
    if: ${{ always() }}
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3
      - uses: ./.github/actions/needs_success
        with:
          needs: '${{ toJson(needs) }}'
foo
bar
max@sinkpad:~/dfn/nns-dapp (1day,09:44:36)$ ./scripts/fmt-yaml 
Error: bad file '.github/workflows/build.yml': yaml: line 174: could not find expected ':'
max@sinkpad:~/dfn/nns-dapp (1day,09:44:41)$ tail .github/workflows/build.yml
    needs: ["build"]
    if: ${{ always() }}
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3
      - uses: ./.github/actions/needs_success
        with:
          needs: '${{ toJson(needs) }}'
foo
bar
max@sinkpad:~/dfn/nns-dapp (1day,09:44:44)$ git checkout .github/workflows/build.yml
Updated 1 path from the index
```
### PR still formats
Here we demonstrate that the formatter still works.  We add some whitespace and the formatter removes it again.
```
max@sinkpad:~/dfn/nns-dapp (1day,09:46:08)$ printf "%s\n" "" "" >> .github/workflows/build.yml 
max@sinkpad:~/dfn/nns-dapp (1day,09:46:24)$ git diff
diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
index 723ca2493..eb0506582 100644
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,3 +171,5 @@ jobs:
       - uses: ./.github/actions/needs_success
         with:
           needs: '${{ toJson(needs) }}'
+
+
max@sinkpad:~/dfn/nns-dapp (1day,09:46:31)$ ./scripts/fmt-yaml 
max@sinkpad:~/dfn/nns-dapp (1day,09:46:36)$ git diff
max@sinkpad:~/dfn/nns-dapp (1day,09:46:43)$ 
```