### PR TITLE
Chore: Remove SNS Aggregator fallback if less than 2

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -27,10 +27,6 @@ export const loadSnsProjects = async (): Promise<void> => {
   try {
     const cachedSnses = await querySnsProjects();
     const identity = getCurrentIdentity();
-    // TODO: Remove after SNS aggregator is upgraded and persists data after upgrades.
-    if (cachedSnses.length < 2) {
-      throw new Error("SNS aggregator did not return enough projects.");
-    }
     // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
     // The SNS Aggregator gives us the canister ids of the SNS projects.
     await Promise.all(

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -190,16 +190,5 @@ describe("SNS public services", () => {
       const data = supplies[rootCanisterId];
       expect(data).toBeUndefined();
     });
-
-    it("should use fallback if the sns aggregator returns less than 2 projects", async () => {
-      jest
-        .spyOn(aggregatorApi, "querySnsProjects")
-        .mockImplementation(() => Promise.resolve([aggregatorSnsMock]));
-
-      await loadSnsProjects();
-
-      expect(snsApi.queryAllSnsMetadata).toBeCalled();
-      expect(snsApi.querySnsSwapStates).toBeCalled();
-    });
   });
 });


### PR DESCRIPTION
# Motivation

Remove the check on the SNS aggregator for the number of SNSs to force a fallback.

This is not necessary anymore because the SNS aggregator persists the data between upgrades.

# Changes

* Remove check on ths SNS aggregator response to trigger the fallback.

# Tests

* Remove test of the fallback
