### PR TITLE
Add frontend/src/tests to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@ web-assets
 frontend/node_modules/
 frontend/public/build/
 frontend/public/assets/
+frontend/src/tests/
 e2e-tests
 **/*.wasm
 /deployment-config.json


### PR DESCRIPTION
# Motivation

Building the wasm doesn't depend on the frontend tests.
So if we only make changes to frontend tests, we don't need to rebuild the wasm.
If we make Docker ignore the frontend tests, it will take the wasm from the cache instead of rebuilding it, if all the changes are only in the frontend tests.

# Changes

Add `frontend/src/tests/` to `.dockerignore`.

# Tests

CI
