### PR TITLE
Delete assets before build

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -61,6 +61,9 @@ rm -rf "${OUTDIR:-not-the-file-you-were-looking-for}"
 # but a small code change can easily produce much more.  We ensure that
 # even in such circumstances only expected files end up in ./.
 assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm)
+for file in "${assets[@]}"; do
+  rm -f "$file"
+done
 
 set -x
 DOCKER_BUILDKIT=1 docker build \

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -10,6 +10,6 @@ case "${1:-}" in
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
   # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
-  list_files | while read -r line; do yq --inplace . "$line" ; done
+  list_files | while read -r line; do yq --inplace . "$line"; done
   ;;
 esac

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -9,7 +9,6 @@ case "${1:-}" in
 --list) list_files ;;
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
-  # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
   list_files | while read -r line; do yq --inplace . "$line"; done
   ;;
 esac

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
 list_files() {

--- a/scripts/fmt-yaml
+++ b/scripts/fmt-yaml
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 cd "$(dirname "$(realpath "$0")")/.." || exit
 
 list_files() {
@@ -10,6 +11,6 @@ case "${1:-}" in
 --check) list_files | while read -r line; do diff <(yq . "$line") "$line"; done | if grep .; then exit 1; fi ;;
 *)
   # shellcheck disable=SC2094 # Reading and writing in the same pipeline is fine if done, as here, reading completely before writing.
-  list_files | while read -r line; do cat <<<"$(yq . "$line")" >"$line"; done
+  list_files | while read -r line; do yq --inplace . "$line" ; done
   ;;
 esac


### PR DESCRIPTION
# Motivation
If docker-build fails and the user fails to notice, the user may believe that some old artifacts are the output and deploy or validate the wrong files.  Let's remove that risk.

# Changes
* Delete artifacts before building

# Tests
See CI