### PR TITLE
Fix branch restriction

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -1,7 +1,7 @@
 name: Populate docker cache
 on:
   push:
-    branch:
+    branches:
       - main
       # Use this branch for tests:
       - docker-main-test


### PR DESCRIPTION
# Motivation
The workflow to update the docker cache is supposed to run only on main and one development branch.  But it is running on all pushes.  Because the correct name for the filter is `branches` not `branch`.

# Changes
* Change `branch` to `branches`

# Tests
See CI - the "Populate docker cache" workflow should not run.