### PR TITLE
fix: change the message after successful increase sns neuron stake

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -66,7 +66,7 @@
 
     if (success) {
       toastsSuccess({
-        labelKey: "sns_neurons.stake_sns_neuron_success",
+        labelKey: "accounts.transaction_success",
         substitutions: {
           $tokenSymbol: token.symbol,
         },


### PR DESCRIPTION
# Motivation

Update toast message after successful increase sns neuron stake.

# Changes

- update i18n path to be the same as nns version.

# Screenshot
<img width="1492" alt="Screenshot 2023-04-04 at 09 44 40" src="https://user-images.githubusercontent.com/98811342/229724022-809046cb-2d95-4e38-b614-c115034735f4.png">

