### PR TITLE
Cleanup page objects

### DIFF
--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AccountCardPo extends BasePageObject {
   private static readonly TID = "account-card";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AccountCardPo {
     return new AccountCardPo(element.byTestId(AccountCardPo.TID));
   }

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AccountsPo {
     return new AccountsPo(element.byTestId(AccountsPo.TID));
   }

--- a/frontend/src/tests/page-objects/AddAccountModal.page-object.ts
+++ b/frontend/src/tests/page-objects/AddAccountModal.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AddAccountModalPo extends BasePageObject {
   private static readonly TID = "add-account-modal-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AddAccountModalPo {
     return new AddAccountModalPo(element.byTestId(AddAccountModalPo.TID));
   }

--- a/frontend/src/tests/page-objects/AddAccountType.page-object.ts
+++ b/frontend/src/tests/page-objects/AddAccountType.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AddAccountTypePo extends BasePageObject {
   private static readonly TID = "add-account-type-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AddAccountTypePo {
     return new AddAccountTypePo(element.byTestId(AddAccountTypePo.TID));
   }

--- a/frontend/src/tests/page-objects/AddSubAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/AddSubAccount.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AddSubAccountPo extends BasePageObject {
   private static readonly TID = "add-sub-account-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AddSubAccountPo {
     return new AddSubAccountPo(element.byTestId(AddSubAccountPo.TID));
   }

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -5,10 +5,6 @@ import { assertNonNullish } from "$tests/utils/utils.test-utils";
 export class AmountDisplayPo extends BasePageObject {
   private static readonly TID = "token-value-label";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AmountDisplayPo {
     return new AmountDisplayPo(element.byTestId(AmountDisplayPo.TID));
   }

--- a/frontend/src/tests/page-objects/AmountInput.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountInput.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class AmountInputPo extends BasePageObject {
   private static readonly TID = "amount-input-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): AmountInputPo {
     return new AmountInputPo(element.byTestId(AmountInputPo.TID));
   }

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -6,10 +6,6 @@ import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AppPo extends BasePageObject {
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   getAccountsPo(): AccountsPo {
     return AccountsPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -3,7 +3,6 @@ import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AppPo extends BasePageObject {
   getAccountsPo(): AccountsPo {

--- a/frontend/src/tests/page-objects/Backdrop.page-object.ts
+++ b/frontend/src/tests/page-objects/Backdrop.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class BackdropPo extends BasePageObject {
   private static readonly TID = "backdrop";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): BackdropPo {
     return new BackdropPo(element.byTestId(BackdropPo.TID));
   }

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -3,10 +3,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { isNullish } from "@dfinity/utils";
 
 export class ButtonPo extends SimpleBasePageObject {
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under({
     element,
     testId,

--- a/frontend/src/tests/page-objects/Dropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/Dropdown.page-object.ts
@@ -2,10 +2,6 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class DropdownPo extends BasePageObject {
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): DropdownPo {
     return new DropdownPo(element.querySelector("div.select"));
   }

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class GetTokensPo extends BasePageObject {
   static readonly TID = "get-tokens-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): GetTokensPo {
     return new GetTokensPo(element.byTestId(GetTokensPo.TID));
   }

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class HashPo extends BasePageObject {
   private static readonly TID = "hash-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): HashPo {
     return new HashPo(element.byTestId(HashPo.TID));
   }

--- a/frontend/src/tests/page-objects/IcpTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/IcpTransactionModal.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class IcpTransactionModalPo extends TransactionModalPo {
   private static readonly TID = "icp-transaction-modal-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): IcpTransactionModalPo {
     return new IcpTransactionModalPo(
       element.byTestId(IcpTransactionModalPo.TID)

--- a/frontend/src/tests/page-objects/Json.page-object.ts
+++ b/frontend/src/tests/page-objects/Json.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class JsonPo extends BasePageObject {
   static readonly tid = "json-root-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static async allUnder(element: PageObjectElement): Promise<JsonPo[]> {
     return Array.from(await element.allByTestId(JsonPo.tid)).map(
       (el) => new JsonPo(el)

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -2,10 +2,6 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class KeyValuePairPo extends BasePageObject {
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under({
     element,
     testId,

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class MenuItemsPo extends BasePageObject {
   private static readonly TID = "menu-items-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): MenuItemsPo {
     return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
   }

--- a/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronDetail.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NeuronDetailPo extends BasePageObject {
   private static readonly TID = "neuron-detail-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NeuronDetailPo {
     return new NeuronDetailPo(element.byTestId(NeuronDetailPo.TID));
   }

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NeuronsPo extends BasePageObject {
   private static readonly TID = "neurons-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NeuronsPo {
     return new NeuronsPo(element.byTestId(NeuronsPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsAccountsPo extends BasePageObject {
   private static readonly TID = "accounts-body";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsAccountsPo {
     return new NnsAccountsPo(element.byTestId(NnsAccountsPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsAccountsFooterPo extends BasePageObject {
   private static readonly TID = "nns-accounts-footer-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsAccountsFooterPo {
     return new NnsAccountsFooterPo(element.byTestId(NnsAccountsFooterPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsAddAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAddAccount.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsAddAccountPo extends BasePageObject {
   private static readonly TID = "nns-add-account-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsAddAccountPo {
     return new NnsAddAccountPo(element.byTestId(NnsAddAccountPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronCardPo extends BasePageObject {
   private static readonly TID = "nns-neuron-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static async allUnder(
     element: PageObjectElement
   ): Promise<NnsNeuronCardPo[]> {

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronCardTitlePo extends BasePageObject {
   private static readonly TID = "neuron-card-title";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsNeuronCardTitlePo {
     return new NnsNeuronCardTitlePo(element.byTestId(NnsNeuronCardTitlePo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsNeuronDetailPo {
     return new NnsNeuronDetailPo(element.byTestId(NnsNeuronDetailPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronsPo extends BasePageObject {
   private static readonly TID = "nns-neurons-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsNeuronsPo {
     return new NnsNeuronsPo(element.byTestId(NnsNeuronsPo.TID));
   }

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsWalletPo extends BasePageObject {
   private static readonly TID = "nns-wallet-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): NnsWalletPo {
     return new NnsWalletPo(element.byTestId(NnsWalletPo.TID));
   }

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class ProjectSwapDetailsPo extends BasePageObject {
   private static readonly TID = "project-swap-details-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): ProjectSwapDetailsPo {
     return new ProjectSwapDetailsPo(element.byTestId(ProjectSwapDetailsPo.TID));
   }

--- a/frontend/src/tests/page-objects/ProposalProposerActionsEntry.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalProposerActionsEntry.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { JsonPo } from "$tests/page-objects/Json.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { JsonPo } from "./Json.page-object";
 
 export class ProposalProposerActionsEntryPo extends BasePageObject {
   static readonly tid = "proposal-proposer-actions-entry-component";

--- a/frontend/src/tests/page-objects/ProposalProposerActionsEntry.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalProposerActionsEntry.page-object.ts
@@ -5,10 +5,6 @@ import { JsonPo } from "./Json.page-object";
 export class ProposalProposerActionsEntryPo extends BasePageObject {
   static readonly tid = "proposal-proposer-actions-entry-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): ProposalProposerActionsEntryPo {
     return new ProposalProposerActionsEntryPo(
       element.byTestId(ProposalProposerActionsEntryPo.tid)

--- a/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalSummarySection.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class ProposalSummarySectionPo extends BasePageObject {
   private static readonly TID = "proposal-summary-section-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): ProposalSummarySectionPo {
     return new ProposalSummarySectionPo(
       element.byTestId(ProposalSummarySectionPo.TID)

--- a/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SelectDestinationAddressPo extends BasePageObject {
   private static readonly TID = "select-destination";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SelectDestinationAddressPo {
     return new SelectDestinationAddressPo(
       element.byTestId(SelectDestinationAddressPo.TID)

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SkeletonCardPo extends BasePageObject {
   private static readonly TID = "skeleton-card";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static async allUnder(element: PageObjectElement): Promise<SkeletonCardPo[]> {
     return Array.from(await element.allByTestId(SkeletonCardPo.TID)).map(
       (el) => new SkeletonCardPo(el)

--- a/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonDetails.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SkeletonDetailsPo extends BasePageObject {
   private static readonly TID = "skeleton-details-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SkeletonDetailsPo | null {
     return new SkeletonDetailsPo(element.byTestId(SkeletonDetailsPo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
@@ -1,5 +1,5 @@
+import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TransactionModalPo } from "./TransactionModal.page-object";
 
 export class SnsIncreaseStakeNeuronModalPo extends TransactionModalPo {
   private static readonly TID = "sns-increase-stake-neuron-modal-component";

--- a/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
@@ -4,10 +4,6 @@ import { TransactionModalPo } from "./TransactionModal.page-object";
 export class SnsIncreaseStakeNeuronModalPo extends TransactionModalPo {
   private static readonly TID = "sns-increase-stake-neuron-modal-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(
     element: PageObjectElement
   ): SnsIncreaseStakeNeuronModalPo | null {

--- a/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCard.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronCardPo extends BasePageObject {
   private static readonly TID = "sns-neuron-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static async allUnder(
     element: PageObjectElement
   ): Promise<SnsNeuronCardPo[]> {

--- a/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronCardTitle.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronCardTitlePo extends BasePageObject {
   private static readonly TID = "sns-neuron-card-title";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronCardTitlePo {
     return new SnsNeuronCardTitlePo(element.byTestId(SnsNeuronCardTitlePo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -1,13 +1,13 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import { SnsIncreaseStakeNeuronModalPo } from "$tests/page-objects/SnsIncreaseStakeNeuronModal.page-object";
+import { SnsNeuronFollowingCardPo } from "$tests/page-objects/SnsNeuronFollowingCard.page-object";
+import { SnsNeuronHotkeysCardPo } from "$tests/page-objects/SnsNeuronHotkeysCard.page-object";
+import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
+import { SnsNeuronMaturityCardPo } from "$tests/page-objects/SnsNeuronMaturityCard.page-object";
+import { SnsNeuronMetaInfoCardPo } from "$tests/page-objects/SnsNeuronMetaInfoCard.page-object";
+import { SummaryPo } from "$tests/page-objects/Summary.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsIncreaseStakeNeuronModalPo } from "./SnsIncreaseStakeNeuronModal.page-object";
-import { SnsNeuronFollowingCardPo } from "./SnsNeuronFollowingCard.page-object";
-import { SnsNeuronHotkeysCardPo } from "./SnsNeuronHotkeysCard.page-object";
-import { SnsNeuronInfoStakePo } from "./SnsNeuronInfoStake.page-object";
-import { SnsNeuronMaturityCardPo } from "./SnsNeuronMaturityCard.page-object";
-import { SnsNeuronMetaInfoCardPo } from "./SnsNeuronMetaInfoCard.page-object";
-import { SummaryPo } from "./Summary.page-object";
 
 export class SnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "sns-neuron-detail-component";

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -12,10 +12,6 @@ import { SummaryPo } from "./Summary.page-object";
 export class SnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "sns-neuron-detail-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronDetailPo {
     return new SnsNeuronDetailPo(element.byTestId(SnsNeuronDetailPo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronFollowingCard.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronFollowingCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-following-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronFollowingCardPo {
     return new SnsNeuronFollowingCardPo(
       element.byTestId(SnsNeuronFollowingCardPo.TID)

--- a/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronHotkeysCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-hotkeys-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronHotkeysCardPo {
     return new SnsNeuronHotkeysCardPo(
       element.byTestId(SnsNeuronHotkeysCardPo.TID)

--- a/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronInfoStake.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronInfoStakePo extends BasePageObject {
   private static readonly TID = "sns-neuron-info-stake";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronInfoStakePo {
     return new SnsNeuronInfoStakePo(element.byTestId(SnsNeuronInfoStakePo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsNeuronMaturityCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMaturityCard.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronMaturityCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-maturity-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronMaturityCardPo {
     return new SnsNeuronMaturityCardPo(
       element.byTestId(SnsNeuronMaturityCardPo.TID)

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-meta-info-card-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronMetaInfoCardPo {
     return new SnsNeuronMetaInfoCardPo(
       element.byTestId(SnsNeuronMetaInfoCardPo.TID)

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsNeuronsPo extends BasePageObject {
   private static readonly TID = "sns-neurons-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsNeuronsPo {
     return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -6,10 +6,6 @@ import { SnsProposalSystemInfoSectionPo } from "./SnsProposalSystemInfoSection.p
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsProposalDetailPo | null {
     return new SnsProposalDetailPo(element.byTestId(SnsProposalDetailPo.TID));
   }

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -1,7 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonDetailsPo } from "$tests/page-objects/SkeletonDetails.page-object";
+import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsProposalSystemInfoSectionPo } from "./SnsProposalSystemInfoSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";

--- a/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalPayloadSection.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SnsProposalPayloadSectionPo extends BasePageObject {
   static readonly TID = "sns-proposal-payload-section-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SnsProposalPayloadSectionPo {
     return new SnsProposalPayloadSectionPo(
       element.byTestId(SnsProposalPayloadSectionPo.TID)

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -1,6 +1,6 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
-import { KeyValuePairPo } from "./KeyValuePair.page-object";
 
 export class SnsProposalSystemInfoSectionPo extends BasePageObject {
   private static readonly TID = "proposal-system-info-details-component";

--- a/frontend/src/tests/page-objects/Summary.page-object.ts
+++ b/frontend/src/tests/page-objects/Summary.page-object.ts
@@ -5,10 +5,6 @@ import { assertNonNullish } from "$tests/utils/utils.test-utils";
 export class SummaryPo extends BasePageObject {
   static readonly TID = "projects-summary";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): SummaryPo {
     return new SummaryPo(element.byTestId(SummaryPo.TID));
   }

--- a/frontend/src/tests/page-objects/TextInput.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInput.page-object.ts
@@ -1,6 +1,6 @@
+import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { isNullish } from "@dfinity/utils";
-import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
 
 export class TextInputPo extends SimpleBasePageObject {
   static under({

--- a/frontend/src/tests/page-objects/TextInput.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInput.page-object.ts
@@ -1,6 +1,6 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { isNullish } from "@dfinity/utils";
-import { SimpleBasePageObject } from "./simple-base.page-object";
+import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
 
 export class TextInputPo extends SimpleBasePageObject {
   static under({

--- a/frontend/src/tests/page-objects/Toggle.page-object.ts
+++ b/frontend/src/tests/page-objects/Toggle.page-object.ts
@@ -2,10 +2,6 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class TogglePo extends BasePageObject {
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): TogglePo {
     return new TogglePo(element.querySelector("div.toggle"));
   }

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -5,10 +5,6 @@ import { assertNonNullish } from "$tests/utils/utils.test-utils";
 export class TooltipPo extends BasePageObject {
   private static readonly TID = "tooltip-component";
 
-  private constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): TooltipPo {
     return new TooltipPo(element.byTestId(TooltipPo.TID));
   }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class TransactionFormPo extends BasePageObject {
   private static readonly TID = "transaction-step-1";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): TransactionFormPo {
     return new TransactionFormPo(element.byTestId(TransactionFormPo.TID));
   }

--- a/frontend/src/tests/page-objects/TransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionModal.page-object.ts
@@ -1,7 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { TransactionFormPo } from "$tests/page-objects/TransactionForm.page-object";
 import { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 
 // This should not be used directly but rather as a base class for specific
 // transaction modals.

--- a/frontend/src/tests/page-objects/TransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionModal.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 // This should not be used directly but rather as a base class for specific
 // transaction modals.
 export class TransactionModalPo extends BasePageObject {
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   getTransactionFormPo(): TransactionFormPo {
     return TransactionFormPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/TransactionReview.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionReview.page-object.ts
@@ -4,10 +4,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class TransactionReviewPo extends BasePageObject {
   private static readonly TID = "transaction-step-2";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): TransactionReviewPo {
     return new TransactionReviewPo(element.byTestId(TransactionReviewPo.TID));
   }

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -5,10 +5,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class WalletPo extends BasePageObject {
   private static readonly TID = "wallet-component";
 
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   static under(element: PageObjectElement): WalletPo {
     return new WalletPo(element.byTestId(WalletPo.TID));
   }

--- a/frontend/src/tests/page-objects/base.page-object.ts
+++ b/frontend/src/tests/page-objects/base.page-object.ts
@@ -1,7 +1,6 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { SimpleBasePageObject } from "$tests/page-objects/simple-base.page-object";
 import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
-import type { PageObjectElement } from "$tests/types/page-object.types";
 
 // We have 2 layers of base classes to avoid circular dependencies with classes
 // this class depends on.

--- a/frontend/src/tests/page-objects/base.page-object.ts
+++ b/frontend/src/tests/page-objects/base.page-object.ts
@@ -6,10 +6,6 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 // We have 2 layers of base classes to avoid circular dependencies with classes
 // this class depends on.
 export class BasePageObject extends SimpleBasePageObject {
-  constructor(root: PageObjectElement) {
-    super(root);
-  }
-
   getButton(testId?: string): ButtonPo {
     return ButtonPo.under({ element: this.root, testId });
   }


### PR DESCRIPTION
# Motivation

1. A constructor that only calls `super` with the same arguments is provided implicitly by default so no need to add one.
2. Relative imports don't work in Playwright tests. (I'm not sure why.)

# Changes

1. Remove unnecessary default constructors from page objects.
2. Replace relative imports with absolute imports in page objects.

# Tests

```
npm run test
npm run test-e2e
```