### PR TITLE
Fix build flakiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY Cargo.lock .
 COPY Cargo.toml .
 COPY rs/backend/Cargo.toml rs/backend/Cargo.toml
 COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
-RUN mkdir -p rs/backend/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs && touch rs/sns_aggregator/src/lib.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp
+RUN mkdir -p rs/backend/src/bin rs/sns_aggregator/src && touch rs/backend/src/lib.rs rs/sns_aggregator/src/lib.rs && echo 'fn main(){}' | tee rs/backend/src/main.rs > rs/backend/src/bin/nns-dapp-check-args.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp
 # Install dfx
 WORKDIR /
 RUN DFX_VERSION="$(cat config/dfx_version)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"


### PR DESCRIPTION
# Motivation
Sometimes docker builds fail with:
```
#52 0.714    Compiling nns-dapp v2.0.26 (/build/rs/backend)
#52 0.790 error[E0432]: unresolved import `nns_dapp::arguments`
#52 0.790  --> rs/backend/src/bin/nns-dapp-check-args.rs:3:15
#52 0.790   |
#52 0.790 3 | use nns_dapp::arguments::CanisterArguments;
#52 0.790   |               ^^^^^^^^^ could not find `arguments` in `nns_dapp`
#52 0.790 
#52 0.802 For more information about this error, try `rustc --explain E0432`.
```

The code is correct and builds succeed outside docker.

Docker differs from local builds in that it pre-compiles libraries to cache them.  If we do not pre-compile, builds work again but are slow.

The code that pre-compiles the libraries replaces the actual code with aplaceholder, but the placeholder does not include files for all the libraries and main files in the actual code.  If we put in placeholders for all lib and main files, the code works.

# Changes
* Fix the pre-warming placeholder code.

# TODO
I believe that the pre-warming code is a bit hacky and would be best spun out into a dedicated file with tests.

# Tests
Local docker builds seem to work reliably now.