### PR TITLE
Bump snsdemo to xz

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -33,7 +33,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Apr 4 2023 with xz compressed state
-          ref: 'c3f569b8c04ee4435b3984a3b1184daad77bb0fc'
+          ref: '8160f742e10fbd1ac89549a5880ae047ff8f290d'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -32,8 +32,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Mar 27 2023 with saved state tools
-          ref: '480a86f555cc9fbee246ba0ecf8a20a4ff705dbc'
+          # Version from Apr 4 2023 with xz compressed state
+          ref: '276253f7124960da7dd81b4b62f78e7a8f0ccdea'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
@@ -43,8 +43,8 @@ jobs:
           dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Get test environment
         run: |
-          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/tip/state.zip > state.zip
-          dfx-state-install -f state.zip --verbose
+          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/tip/state.tar.xz > state.tar.xz
+          dfx-snapshot-restore --snapshot state.tar.xz --verbose
           dfx identity use snsdemo8
           dfx-sns-demo-healthcheck
       - name: Upgrade to the current aggregator

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -33,7 +33,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Apr 4 2023 with xz compressed state
-          ref: '276253f7124960da7dd81b4b62f78e7a8f0ccdea'
+          ref: 'c3f569b8c04ee4435b3984a3b1184daad77bb0fc'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Apr 4 2023 with xz compressed state
-          ref: 'c3f569b8c04ee4435b3984a3b1184daad77bb0fc'
+          ref: '8160f742e10fbd1ac89549a5880ae047ff8f290d'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Mar 27 2023 with saved state tools
-          ref: '480a86f555cc9fbee246ba0ecf8a20a4ff705dbc'
+          # Version from Apr 4 2023 with xz compressed state
+          ref: '276253f7124960da7dd81b4b62f78e7a8f0ccdea'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
@@ -48,8 +48,8 @@ jobs:
           dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Get test environment
         run: |
-          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/tip/state.zip > state.zip
-          dfx-state-install -f state.zip
+          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/tip/state.tar.xz > state.tar.xz
+          dfx-snapshot-restore --snapshot state.tar.xz --verbose
           dfx identity use snsdemo8
           dfx-sns-demo-healthcheck
       - name: Install nns-dapp and sns_aggregator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
           # Version from Apr 4 2023 with xz compressed state
-          ref: '276253f7124960da7dd81b4b62f78e7a8f0ccdea'
+          ref: 'c3f569b8c04ee4435b3984a3b1184daad77bb0fc'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Motivation
`xz` does an amazing job of compressing replica state files, reducing our 333Mb snapshots to around 66Mb.

# Changes
* Bump snsdemo to a version using xz compressed state snapshots

# Tests
* See CI