### PR TITLE
style: improve proposal summary and payload contrast

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -776,9 +776,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.5.0-next-2023-03-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-03-29.1.tgz",
-      "integrity": "sha512-gtz7czi2mFlRw3rZ5extSN0mMheK1iUObqFI2VeN+GOQd93unPx95x2nWkg6Jr5gjXwcZqGPc29RrXFMbvwm2A==",
+      "version": "2.5.0-next-2023-04-04.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-04-04.1.tgz",
+      "integrity": "sha512-iWl6ue1JZxzdOfy+uywHIjHeX/HLYNT24h8gKVr4t4iL/lJajXqSp4RZOfOOkRnBYJa6PvTqhp3CYcB9UNUxNA==",
       "dependencies": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",
@@ -9957,9 +9957,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.5.0-next-2023-03-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-03-29.1.tgz",
-      "integrity": "sha512-gtz7czi2mFlRw3rZ5extSN0mMheK1iUObqFI2VeN+GOQd93unPx95x2nWkg6Jr5gjXwcZqGPc29RrXFMbvwm2A==",
+      "version": "2.5.0-next-2023-04-04.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-04-04.1.tgz",
+      "integrity": "sha512-iWl6ue1JZxzdOfy+uywHIjHeX/HLYNT24h8gKVr4t4iL/lJajXqSp4RZOfOOkRnBYJa6PvTqhp3CYcB9UNUxNA==",
       "requires": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -37,7 +37,7 @@
 
     :global(a) {
       @include fonts.standard;
-      color: var(--tertiary);
+      color: var(--value-color);
 
       &:hover,
       &:active {


### PR DESCRIPTION
# Motivation

Reported by @nathanosdev, the colors of the payload and summary in proposals is not contrasting enough.

# PRs

- [ ] https://github.com/dfinity/gix-components/pull/184

# Screenshots

(After PR)

<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 30" src="https://user-images.githubusercontent.com/16886711/229842000-447fd013-095b-4db2-9004-0f819990dfac.png">
<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 34" src="https://user-images.githubusercontent.com/16886711/229842020-fbab671a-c241-40b3-9f37-a99ea6a1e82c.png">
<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 41" src="https://user-images.githubusercontent.com/16886711/229842045-ff5d584c-dd70-48f1-8026-b02113a053ff.png">
<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 44" src="https://user-images.githubusercontent.com/16886711/229842050-b0856bd2-7eb6-4301-ba4d-ac757e115607.png">
<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 50" src="https://user-images.githubusercontent.com/16886711/229842057-7169402d-3d79-4c56-9df6-9f1a4b235a1b.png">
<img width="1536" alt="Capture d’écran 2023-04-04 à 17 26 52" src="https://user-images.githubusercontent.com/16886711/229842060-835507e0-6f74-450d-b27d-ec402d5f47ae.png">

