### PR TITLE
Install a pre-built optimizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV NODE_VERSION=16.17.1
 RUN jq -r .dfx dfx.json > config/dfx_version
 RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_VERSION' dfx.json > config/didc_version
-RUN printf "%s" "0.3.1" > config/optimizer_version
+RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' dfx.json > config/optimizer_version
 
 # This is the "builder", i.e. the base image used later to build the final code.
 FROM base as builder
@@ -50,7 +50,7 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 ENV PATH=/cargo/bin:$PATH
 RUN cargo --version
 # Install IC CDK optimizer
-RUN cargo install --version "$(cat config/optimizer_version)" ic-cdk-optimizer
+RUN curl -L --fail --retry 5 "https://github.com/dfinity/cdk-rs/releases/download/$(cat config/optimizer_version)/ic-cdk-optimizer-$(cat config/optimizer_version)-ubuntu-20.04.tar.gz" | gunzip | tar -x "ic-cdk-optimizer-$(cat config/optimizer_version)-ubuntu-20.04/ic-cdk-optimizer" --to-stdout | install -m755 /dev/stdin /usr/local/bin/ic-cdk-optimizer
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty
 # `lib.rs`. Then we remove the dummy source files to make sure cargo rebuild

--- a/dfx.json
+++ b/dfx.json
@@ -1028,6 +1028,7 @@
         "NODE_VERSION": "18.14.2",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
+	"OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2022-11-17",
         "IC_COMMIT": "aebee24076c67a57ff638d9eb9fe4a1d7561850d"
       },

--- a/dfx.json
+++ b/dfx.json
@@ -1028,7 +1028,7 @@
         "NODE_VERSION": "18.14.2",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
-	"OPTIMIZER_VERSION": "0.3.6",
+        "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2022-11-17",
         "IC_COMMIT": "aebee24076c67a57ff638d9eb9fe4a1d7561850d"
       },


### PR DESCRIPTION
# Motivation
Docker builds on M1 macs are hard.  One sticking point is building the optimizer, which seems to consume inordinate resources.  Given that the optimizer is now available as a pre-built download, let's use it.

# Changes
- In the dockerfile, download the optimizer instead of building it.
- Put the optimizer version in dfx, along with other versions.
- Bump the optimizer to the latest available version.

# Tests
* See CI
* And let's see whether this gets M1 mac builds further