### PR TITLE
Add more test specific files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@ frontend/node_modules/
 frontend/public/build/
 frontend/public/assets/
 frontend/src/tests/
+frontend/playwright*
+frontend/jest*
+frontend/tsconfig.spec.json
 e2e-tests
 **/*.wasm
 /deployment-config.json


### PR DESCRIPTION
# Motivation

We don't run tests in Docker and we don't need test specific files to run the Docker build.

# Changes

Add test specific frontend files to `.dockerignore`.

# Tests

CI