### PR TITLE
Wait for replica to stop before restoring state

### DIFF
--- a/scripts/dev-local-state.sh
+++ b/scripts/dev-local-state.sh
@@ -212,6 +212,10 @@ echo "*  Fortunately, it did not hang. This may actually work!  *"
 echo "*                                                         *"
 echo "***********************************************************"
 
+# If there are any errors below we still want to stop the replica before
+# restoring the state.
+set +e
+
 # Run frontend development server.
 cd "$TOP_DIR"
 DFX_NETWORK=local ./config.sh


### PR DESCRIPTION
# Motivation

`scripts/dev-local-state.sh` set `-e` which means that it kills itself on any error.
It also traps to restore the state before exiting.
But `dfx start` runs in the background and we want to stop it before restoring the state.
So we should disable `set -e` once the replica is running.

# Changes

`set +e` once the local replica is running.

# Tests

1. Ran `scripts/dev-local-state.sh`
2. Deleted `frontend/node_modules` while the script was running
3. Witnessed Vite server crashing
4. Checked that replica was stopped before state was restored.
