### PR TITLE
Include arguments with the artifacts

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -32,8 +32,13 @@ jobs:
       - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
         uses: actions/upload-artifact@v3
         with:
-          name: NNS ${{ matrix.BUILD_NAME }} backend wasm module
-          path: ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
+          name: NNS ${{ matrix.BUILD_NAME }} wasm module and arguments
+          path: |
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.did
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.bin
+            ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
+            ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release
         run: |
           cd "${{ matrix.BUILD_NAME }}-out"


### PR DESCRIPTION
# Motivation
Deployments of the nns-dapp now need arguments.  It is good if a reference set of arguments is created in CI to check against, in the same way that local builds of the wasm are checked against CI builds.

# Changes
* Include the build configuration in the CI artifacts.  In particular:
  * `deployment-config.json` - the config from which all other config is derived.
  * `nns-dapp-arg.did` - the text format of the argument, used when deploying directly
  * `nns-dapp-arg.bin` - the binary form of the argument, used when deploying by proposal
  * `frontend-config.sh` - the contents of the .env file, used when doing front end develpment.

# Tests
* See the artifacts when CI runs.  As an added bonus, the wasm may no longer be double-unzipped by mac.  Let's see.