### PR TITLE
Put the correct CI build link in proposals

### DIFF
--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Finds CI builds of the current commit.
+
+	Note: This searches through gihub logs.  Only fairly recent logs are readily accessible.
+	      Older runs may be found using high velues for the '--limit' flag but this is very slow.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
+clap.define short=c long=commit desc="The commit to find" variable=DFX_COMMIT default="$(git rev-parse HEAD)"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_COMMIT
+
+gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | "https://github.com/dfinity/nns-dapp/actions/runs/\(.databaseId)"'

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -18,10 +18,10 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
-clap.define short=c long=commit desc="The commit to find" variable=DFX_COMMIT default="$(git rev-parse HEAD)"
+clap.define short=c long=commit desc="The commit, tag or reference to find" variable=DFX_COMMIT default="HEAD"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-export DFX_COMMIT
+export DFX_COMMIT="$(git rev-parse "$DFX_COMMIT")"
 
 gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | "https://github.com/dfinity/nns-dapp/actions/runs/\(.databaseId)"'

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -22,6 +22,7 @@ clap.define short=c long=commit desc="The commit, tag or reference to find" vari
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-export DFX_COMMIT="$(git rev-parse "$DFX_COMMIT")"
+DFX_COMMIT="$(git rev-parse "$DFX_COMMIT")"
+export DFX_COMMIT
 
 gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | "https://github.com/dfinity/nns-dapp/actions/runs/\(.databaseId)"'

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -15,7 +15,7 @@ export DFX_NETWORK
 
 mkdir -p release/ci
 [[ "${CI:-}" != "" ]] || {
-  CI="$("$SOURCE_DIR/nns-dapp/ci-link" | tail -n1 | grep .)"
+  CI="$("$SOURCE_DIR/nns-dapp/ci-link" --commit tags/release-candidate | tail -n1 | grep .)"
 }
 WASM="release/ci/nns-dapp.wasm"
 if test -f "$WASM"; then

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -7,14 +7,16 @@ PATH="$SOURCE_DIR:$PATH"
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="mainnet"
+clap.define short=c long=ci desc="A link to the wasm build on CI" variable=CI default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 cd "$SOURCE_DIR/.."
 export DFX_NETWORK
 
 mkdir -p release/ci
-PR="$(git log -n1 tags/release-candidate --oneline | awk '{print $(NF)}' | tr -cd 0-9)"
-CI="https://github.com/dfinity/nns-dapp/pull/${PR}/checks"
+[[ "${CI:-}" != "" ]] || {
+  CI="$("$SOURCE_DIR/nns-dapp/ci-link" | tail -n1 | grep .)"
+}
 WASM="release/ci/nns-dapp.wasm"
 if test -f "$WASM"; then
   SHA="$(sha256sum "$WASM" | awk '{print $1}')"


### PR DESCRIPTION
# Motivation
We now merge PRs in github by means of a merge queue.  As a result, the link to a CI build in the proposal template is now wrong.

# Changes
* Add a script to search through CI builds for a build of the current commit.
* Use the script to populate the release template.

# Tests
### Finding builds of the main branch, at the time of testing:
```
max@sinkpad:~/dfn/nns-dapp/branches/ci-link (28:06)$ ./scripts/nns-dapp/ci-link --commit "$(git rev-parse main)"
https://github.com/dfinity/nns-dapp/actions/runs/4620117942
https://github.com/dfinity/nns-dapp/actions/runs/4619881512
max@sinkpad:~/dfn/nns-dapp/branches/ci-link (31:19)$ git rev-parse main
64f5dfa7d6637d7b5b4f3a4771924351497fa901
max@sinkpad:~/dfn/nns-dapp/branches/ci-link (32:01)$ 
```
Visiting these links should show the same commit.  And it does see the 64f5...

![Screenshot from 2023-04-05 17-53-49](https://user-images.githubusercontent.com/5982633/230136085-3ba9a3b3-2756-4391-b007-6097fa173fa0.png)

### Making a proposal template
The template uses `tags/release-candidate` and should find a build of that commit.

```
max@sinkpad:~/dfn/nns-dapp/branches/ci-link (44:19)$ scripts/nns-dapp/release-template
[SNIP]
max@sinkpad:~/dfn/nns-dapp/branches/ci-link (45:10)$ head release/PROPOSAL.md
# Upgrade frontend NNS Dapp canister to commit `f6e6d9446bd89b94de34e50e48979eca98bc3eb0`
Wasm sha256 hash: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (`https://github.com/dfinity/nns-dapp/actions/runs/4617012162`)

## Change Log:

* Write about...
* ... what has changed
* ... in simple bullet points
```
And indeed, again the link shows a build for the matching commit:
![Screenshot from 2023-04-05 18-09-01](https://user-images.githubusercontent.com/5982633/230140070-1d094824-3a9a-4a8e-80d1-a24c8164cb32.png)
