### PR TITLE
Run formatting in parallel to other CI checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,6 @@ jobs:
                   exit 1
           }
   cargo-tests:
-    needs: formatting
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -54,7 +53,6 @@ jobs:
         env:
           RUST_BACKTRACE: 1
   svelte-tests:
-    needs: formatting
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -86,7 +84,6 @@ jobs:
         run: npm run test
         working-directory: ./frontend
   svelte-lint:
-    needs: formatting
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -115,7 +112,6 @@ jobs:
         run: npm run check
         working-directory: ./frontend
   e2e-lint:
-    needs: formatting
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -141,7 +137,6 @@ jobs:
         run: npm run lint
         working-directory: ./e2e-tests
   shell-checks:
-    needs: formatting
     name: ShellCheck
     runs-on: ubuntu-20.04
     steps:
@@ -151,7 +146,6 @@ jobs:
         env:
           SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
   ic-commit-consistency:
-    needs: formatting
     name: IC Commit
     runs-on: ubuntu-20.04
     steps:
@@ -173,7 +167,6 @@ jobs:
                   exit 1
           fi
   release-templating-works:
-    needs: formatting
     name: Release template
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
# Motivation
Faster CI.  At present, unit tests and linters wait for the formatting check before proceeding.  This saves CPU cycles but extends the runtime of our slowest workflow by a couple of minutes.

# Changes
* Remove formatting as a dependency of other checks.  It is still required for the workflow to succeed.
### Before
![Screenshot from 2023-04-05 18-34-34](https://user-images.githubusercontent.com/5982633/230146803-cb0471f8-8d12-4c66-af67-80b125269f9b.png)

### After
![Screenshot from 2023-04-05 18-35-05](https://user-images.githubusercontent.com/5982633/230146733-bf33e255-e11f-4baf-b016-46753f41c415.png)


# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
