### PR TITLE
E2E: Verify account transactions

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -2,6 +2,7 @@
   import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import type { Account } from "$lib/types/account";
   import { i18n } from "$lib/stores/i18n";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import NnsTransactionCard from "./NnsTransactionCard.svelte";
   import { getContext } from "svelte";
@@ -25,12 +26,14 @@
   $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
-{#if account === undefined || transactions === undefined}
-  <SkeletonCard cardType="info" />
-{:else if transactions.length === 0}
-  {$i18n.wallet.no_transactions}
-{:else}
-  {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}-${toSelfTransaction}`)}
-    <NnsTransactionCard {account} {transaction} {toSelfTransaction} />
-  {/each}
-{/if}
+<TestIdWrapper testId="transaction-list-component">
+  {#if account === undefined || transactions === undefined}
+    <SkeletonCard cardType="info" />
+  {:else if transactions.length === 0}
+    {$i18n.wallet.no_transactions}
+  {:else}
+    {#each extendedTransactions as { toSelfTransaction, transaction } (`${transaction.timestamp.timestamp_nanos}-${toSelfTransaction}`)}
+      <NnsTransactionCard {account} {transaction} {toSelfTransaction} />
+    {/each}
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -62,6 +62,22 @@ test("Test accounts requirements", async ({ page, context }) => {
   );
   expect(await nnsAccountsPo.getAccountBalance(subAccountName)).toEqual("5.00");
 
-  // TODO:
   // AU005: The user MUST be able to see the transactions of a specific account
+  const mainAccountAddress = await nnsAccountsPo.getAccountAddress(
+    mainAccountName
+  );
+  await nnsAccountsPo.openAccount(subAccountName);
+  const transactionList = appPo
+    .getWalletPo()
+    .getNnsWalletPo()
+    .getTransactionListPo();
+  await transactionList.waitForLoaded();
+  const transactions = await transactionList.getTransactionCardPos();
+  expect(transactions).toHaveLength(1);
+  const transaction = transactions[0];
+
+  expect(await transaction.getIdentifier()).toBe(
+    `Source: ${mainAccountAddress}`
+  );
+  expect(await transaction.getAmount()).toBe("+5.00");
 });

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -31,6 +31,10 @@ export class NnsAccountsPo extends BasePageObject {
     return cards[index];
   }
 
+  async openAccount(accountName: string): Promise<void> {
+    return (await this.getAccountCardPo(accountName)).click();
+  }
+
   async getAccountNames(): Promise<string[]> {
     const cards = await this.getAccountCardPos();
     return Promise.all(cards.map((card) => card.getAccountName()));

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { TransactionListPo } from "$tests/page-objects/TransactionList.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsWalletPo extends BasePageObject {
@@ -11,6 +12,10 @@ export class NnsWalletPo extends BasePageObject {
 
   getIcpTransactionModalPo(): IcpTransactionModalPo {
     return IcpTransactionModalPo.under(this.root);
+  }
+
+  getTransactionListPo(): TransactionListPo {
+    return TransactionListPo.under(this.root);
   }
 
   clickSend(): Promise<void> {

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -4,7 +4,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SkeletonCardPo extends BasePageObject {
   private static readonly TID = "skeleton-card";
 
-  static under(element: PageObjectElement): TransactionListPo {
+  static under(element: PageObjectElement): SkeletonCardPo {
     return new SkeletonCardPo(element.byTestId(SkeletonCardPo.TID));
   }
 

--- a/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SkeletonCard.page-object.ts
@@ -4,6 +4,10 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class SkeletonCardPo extends BasePageObject {
   private static readonly TID = "skeleton-card";
 
+  static under(element: PageObjectElement): TransactionListPo {
+    return new SkeletonCardPo(element.byTestId(SkeletonCardPo.TID));
+  }
+
   static async allUnder(element: PageObjectElement): Promise<SkeletonCardPo[]> {
     return Array.from(await element.allByTestId(SkeletonCardPo.TID)).map(
       (el) => new SkeletonCardPo(el)

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -1,0 +1,27 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TransactionCardPo extends BasePageObject {
+  private static readonly TID = "transaction-card";
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<TransactionCardPo[]> {
+    return Array.from(await element.allByTestId(TransactionCardPo.TID)).map(
+      (el) => new TransactionCardPo(el)
+    );
+  }
+
+  getIdentifier(): Promise<string> {
+    return this.getText("identifier");
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+
+  getAmount(): Promise<string> {
+    return this.getAmountDisplayPo().getAmount();
+  }
+}

--- a/frontend/src/tests/page-objects/TransactionList.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionList.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TransactionListPo extends BasePageObject {
+  private static readonly TID = "transaction-list-component";
+
+  static under(element: PageObjectElement): TransactionListPo {
+    return new TransactionListPo(element.byTestId(TransactionListPo.TID));
+  }
+
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
+  getTransactionCardPos(): Promise<TransactionCardPo[]> {
+    return TransactionCardPo.allUnder(this.root);
+  }
+
+  async waitForLoaded(): Promise<void> {
+    await this.waitFor();
+    await this.getSkeletonCardPo().waitForAbsent();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to have end-to-end test for product requirements.
In this PR we add:
AU005: The user MUST be able to see the transactions of a specific account.

# Changes

1. In the accounts e2e test, after making the transaction, check that the transaction can be seen in the subaccount.
2. Add a test ID to TransactionList.
3. Add page objects for TransactionList and TransactionCard
4. Add functionality in page objects for NnsAccounts, NnsWallet and SkeletonCard

# Tests

npm run test-e2e