### PR TITLE
Include the commit in the wasm zip file

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -29,11 +29,14 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./${{ matrix.BUILD_NAME }}-out
+      - name: 'Record the git commit and any tags'
+        run: git log | head -n1 > ${{ matrix.BUILD_NAME }}-out/commit.txt
       - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
         uses: actions/upload-artifact@v3
         with:
           name: NNS ${{ matrix.BUILD_NAME }} wasm module and arguments
           path: |
+            ${{ matrix.BUILD_NAME }}-out/commit.txt
             ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
             ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.did
             ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.bin


### PR DESCRIPTION
# Motivation
When comparing wasm hashes, one possible reason for a mismatch is that different commits were compiled.  To make it easy to spot such an error, why not include the commit and any tags together with the assets from CI?

# Changes
- Add the first line of git log to the zip file created by CI containing the wasm.

# Tests
See CI assets