### PR TITLE
Ignore playwright dirs for prettier

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
+/playwright*
 .env
 .env.*
 !.env.example


### PR DESCRIPTION
# Motivation

`npm run check` complains about `playwright-report/index.html` not being formatted by prettier.

# Changes

Add `/playwright*` to `frontend/.prettierignore`

# Tests

After `npm run check` complained, added the line to `frontend/.prettierignore` and ran `npm run check` again.