### PR TITLE
Feat: Use only type for SNS proposals, no topic

### DIFF
--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -10,9 +10,9 @@
   export let id: bigint | undefined;
   export let title: string | undefined;
   export let color: ProposalStatusColor | undefined;
-  export let topic: string | undefined;
+  export let topic: string | undefined = undefined;
   export let proposer: string | undefined;
-  export let type: string | undefined = undefined;
+  export let type: string | undefined;
   export let deadlineTimestampSeconds: bigint | undefined;
 </script>
 
@@ -24,7 +24,7 @@
 
     <div class="meta-data">
       {#if type !== undefined}
-        <KeyValuePair>
+        <KeyValuePair testId="proposal-type">
           <span slot="key">{$i18n.proposal_detail.type_prefix}</span>
           <span
             slot="value"
@@ -35,7 +35,7 @@
       {/if}
 
       {#if topic !== undefined}
-        <KeyValuePair testId="proposal-topic">
+        <KeyValuePair>
           <span slot="key">{$i18n.proposal_detail.topic_prefix}</span>
           <span slot="value" class="meta-data-value">{topic ?? ""}</span>
         </KeyValuePair>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -30,7 +30,7 @@
   let title: string | undefined;
   let color: ProposalStatusColor | undefined;
 
-  let topic: string | undefined;
+  let type: string | undefined;
   let proposer: SnsNeuronId | undefined;
   let proposerString: string | undefined;
   $: proposerString =
@@ -44,7 +44,7 @@
     id,
     title,
     color,
-    topic,
+    type,
     proposer,
     current_deadline_timestamp_seconds: deadlineTimestampSeconds,
     status,
@@ -83,7 +83,7 @@
   id={id?.id}
   {title}
   {color}
-  {topic}
+  {type}
   proposer={proposerString}
   {deadlineTimestampSeconds}
   >{#if demoVoteEnable}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -19,8 +19,8 @@
 
   $: loadSnsNervousSystemFunctions(rootCanisterId);
 
-  let topic: string | undefined;
-  let topicDescription: string | undefined;
+  let type: string | undefined;
+  let typeDescription: string | undefined;
   let statusString: string;
   let statusDescription: string | undefined;
   let rewardStatusString: string;
@@ -36,8 +36,8 @@
     $snsFunctionsStore[rootCanisterId.toText()]?.nsFunctions || [];
 
   $: ({
-    topic,
-    topicDescription,
+    type,
+    typeDescription,
     statusString,
     statusDescription,
     rewardStatusString,
@@ -54,23 +54,15 @@
   class="content-cell-island"
   data-tid="proposal-system-info-details-component"
 >
-  <h1 class="content-cell-title">{topic ?? ""}</h1>
+  <h1 class="content-cell-title">{type ?? ""}</h1>
 
   <div class="content-cell-details">
-    <!-- TODO: Confirm with product that we show both Type and Topic as the same for now -->
-    {#if nonNullish(topic)}
+    {#if nonNullish(type)}
       <ProposalSystemInfoEntry
         labelKey="type_prefix"
         testId="proposal-system-info-type"
-        value={topic}
-        description={topicDescription}
-      />
-
-      <ProposalSystemInfoEntry
-        labelKey="topic_prefix"
-        testId="proposal-system-info-topic"
-        value={topic}
-        description={topicDescription}
+        value={type}
+        description={typeDescription}
       />
     {/if}
 

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -61,8 +61,8 @@ export type SnsProposalDataMap = {
   color: ProposalStatusColor | undefined;
 
   // Mapped from Nervous Functions
-  topic?: string;
-  topicDescription?: string;
+  type?: string;
+  typeDescription?: string;
 };
 
 // TODO: Return also a type and the type description that for now maps to the topic
@@ -148,8 +148,8 @@ export const mapProposalInfo = ({
     color: SNS_PROPOSAL_COLOR[decisionStatus],
 
     // Mapped from Nervous Functions
-    topic: nsFunction?.name,
-    topicDescription: nsFunction?.description[0],
+    type: nsFunction?.name,
+    typeDescription: nsFunction?.description[0],
   };
 };
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -88,7 +88,7 @@ describe("ProposalSystemInfoSection", () => {
       );
     });
 
-    it("should render topic as title", async () => {
+    it("should render type as title", async () => {
       const po = await renderComponent(props);
 
       expect(await po.getTitleText()).toEqual(testNervousFunctionName);
@@ -98,12 +98,6 @@ describe("ProposalSystemInfoSection", () => {
       const po = await renderComponent(props);
 
       expect(await po.getTypeText()).toBe(testNervousFunctionName);
-    });
-
-    it("should render topic info from the nervous function", async () => {
-      const po = await renderComponent(props);
-
-      expect(await po.getTopicText()).toBe(testNervousFunctionName);
     });
 
     it("should render open status", async () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -79,7 +79,7 @@ describe("SnsProposals", () => {
           expect(queryByTestId("proposal-card")).toBeInTheDocument()
         );
 
-        expect(queryByTestId("proposal-topic").innerHTML).toMatch(functionName);
+        expect(queryByTestId("proposal-type").innerHTML).toMatch(functionName);
       });
 
       it("should load decision status filters", async () => {

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -250,7 +250,7 @@ describe("sns-proposals utils", () => {
       );
     });
 
-    it("should use the functions passed to set topic and topic description", () => {
+    it("should use the functions passed to set type and type description", () => {
       const proposalData = {
         ...mockSnsProposal,
         action: nervousSystemFunctionMock.id,
@@ -260,8 +260,8 @@ describe("sns-proposals utils", () => {
         proposalData,
         nsFunctions: [nervousSystemFunctionMock],
       });
-      expect(mappedProposal.topic).toBe(nervousSystemFunctionMock.name);
-      expect(mappedProposal.topicDescription).toBe(
+      expect(mappedProposal.type).toBe(nervousSystemFunctionMock.name);
+      expect(mappedProposal.typeDescription).toBe(
         nervousSystemFunctionMock.description[0]
       );
     });

--- a/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalSystemInfoSection.page-object.ts
@@ -25,13 +25,6 @@ export class SnsProposalSystemInfoSectionPo extends BasePageObject {
     }).getValueText();
   }
 
-  getTopicText(): Promise<string> {
-    return KeyValuePairPo.under({
-      element: this.root,
-      testId: "proposal-system-info-topic",
-    }).getValueText();
-  }
-
   getDecisionStatusText(): Promise<string> {
     return KeyValuePairPo.under({
       element: this.root,


### PR DESCRIPTION
# Motivation

Align NNS Dapp with the agreements reached within the team on how to deal with Type and Topic for SNS proposals.

Result:
* Topic does not exist yet for SNS proposals.
* The type is the name of the nervous function.

# Changes

* Change mapProposalInfo in sns proposal utils to return the type and typeDescription instead of topic and topicDescription.
* Do not render topic and type items in the SnsProposalSystemInfoSection. Render only the type item.
* Render the type as title in the SnsProposalSystemInfoSection component.

# Tests

* Adapt tests to new functionality and also change the test descriptions to match the changes.
* Remove getTopicText from SnsProposalSystemInfoSection page object.
* Change testId in SnsProposalCard and add it to the type. This is used to test that the nervous functions are properly loaded in the SnsProposals component test.
