### PR TITLE
Chore: Expand SnsProposalDetail test cases

### DIFF
--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -93,7 +93,7 @@ describe("SnsProposalDetail", () => {
       expect(await po.getSkeletonDetails().isPresent()).toBe(false);
     });
 
-    it("should render the name of the nervous function", async () => {
+    it("should render the name of the nervous function as title", async () => {
       const functionId = BigInt(12);
       const functionName = "test function";
       fakeSnsGovernanceApi.addNervousSystemFunctionWith({

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -12,6 +12,7 @@ import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsProposalDetailPo } from "$tests/page-objects/SnsProposalDetail.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -20,9 +21,22 @@ jest.mock("$lib/api/sns-governance.api");
 
 describe("SnsProposalDetail", () => {
   fakeSnsGovernanceApi.install();
+  const proposalId = { id: BigInt(3) };
+  const rootCanisterId = mockCanisterId;
+
+  const renderComponent = async () => {
+    const { container } = render(SnsProposalDetail, {
+      props: {
+        proposalIdText: proposalId.id.toString(),
+      },
+    });
+
+    await runResolvedPromises();
+
+    return SnsProposalDetailPo.under(new JestPageObjectElement(container));
+  };
 
   describe("not logged in", () => {
-    const rootCanisterId = mockCanisterId;
     beforeEach(() => {
       jest.clearAllMocks();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
@@ -40,20 +54,20 @@ describe("SnsProposalDetail", () => {
         id: [proposalId],
       });
 
+      fakeSnsGovernanceApi.pause();
       const { container } = render(SnsProposalDetail, {
         props: {
           proposalIdText: proposalId.id.toString(),
         },
       });
-
       const po = SnsProposalDetailPo.under(
         new JestPageObjectElement(container)
       );
       expect(await po.getSkeletonDetails().isPresent()).toBe(true);
+      fakeSnsGovernanceApi.resume();
     });
 
     it("should render content once proposal is loaded", async () => {
-      const proposalId = { id: BigInt(3) };
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
@@ -66,7 +80,6 @@ describe("SnsProposalDetail", () => {
           proposalIdText: proposalId.id.toString(),
         },
       });
-
       const po = SnsProposalDetailPo.under(
         new JestPageObjectElement(container)
       );
@@ -75,37 +88,12 @@ describe("SnsProposalDetail", () => {
 
       fakeSnsGovernanceApi.resume();
       await waitFor(async () => expect(await po.isContentLoaded()).toBe(true));
+      expect(await po.hasSummarySection()).toBe(true);
+      expect(await po.hasSystemInfoSection()).toBe(true);
       expect(await po.getSkeletonDetails().isPresent()).toBe(false);
     });
 
-    it("should render system info content", async () => {
-      fakeSnsGovernanceApi.pause();
-      const proposalId = { id: BigInt(3) };
-      fakeSnsGovernanceApi.addProposalWith({
-        identity: new AnonymousIdentity(),
-        rootCanisterId,
-        id: [proposalId],
-      });
-
-      const { container } = render(SnsProposalDetail, {
-        props: {
-          proposalIdText: proposalId.id.toString(),
-        },
-      });
-
-      const po = SnsProposalDetailPo.under(
-        new JestPageObjectElement(container)
-      );
-      expect(await po.hasSystemInfoSection()).toBe(false);
-      fakeSnsGovernanceApi.resume();
-
-      await waitFor(async () =>
-        expect(await po.hasSystemInfoSection()).toBe(true)
-      );
-    });
-
     it("should render the name of the nervous function", async () => {
-      const proposalId = { id: BigInt(3) };
       const functionId = BigInt(12);
       const functionName = "test function";
       fakeSnsGovernanceApi.addNervousSystemFunctionWith({
@@ -120,18 +108,26 @@ describe("SnsProposalDetail", () => {
         action: functionId,
       });
 
-      const { container } = render(SnsProposalDetail, {
-        props: {
-          proposalIdText: proposalId.id.toString(),
-        },
-      });
-
-      const po = SnsProposalDetailPo.under(
-        new JestPageObjectElement(container)
-      );
+      const po = await renderComponent();
 
       await waitFor(async () =>
         expect(await po.getSystemInfoSectionTitle()).toBe(functionName)
+      );
+    });
+
+    it("should render the payload", async () => {
+      const payload = "# Test payload";
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [proposalId],
+        payload_text_rendering: [payload],
+      });
+
+      const po = await renderComponent();
+
+      await waitFor(async () =>
+        expect(await (await po.getPayloadText()).trim()).toBe(payload)
       );
     });
 

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -64,7 +64,6 @@ describe("SnsProposalDetail", () => {
         new JestPageObjectElement(container)
       );
       expect(await po.getSkeletonDetails().isPresent()).toBe(true);
-      fakeSnsGovernanceApi.resume();
     });
 
     it("should render content once proposal is loaded", async () => {

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -2,6 +2,8 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonDetailsPo } from "$tests/page-objects/SkeletonDetails.page-object";
 import { SnsProposalSystemInfoSectionPo } from "$tests/page-objects/SnsProposalSystemInfoSection.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ProposalSummarySectionPo } from "./ProposalSummarySection.page-object";
+import { SnsProposalPayloadSectionPo } from "./SnsProposalPayloadSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";
@@ -30,5 +32,21 @@ export class SnsProposalDetailPo extends BasePageObject {
 
   getSystemInfoSectionTitle(): Promise<string> {
     return this.getSystemInfoSectionPo().getTitleText();
+  }
+
+  getPayloadSectionPo(): SnsProposalPayloadSectionPo {
+    return SnsProposalPayloadSectionPo.under(this.root);
+  }
+
+  getPayloadText(): Promise<string> {
+    return this.getPayloadSectionPo().getPayloadText();
+  }
+
+  getSummarySectionPo(): ProposalSummarySectionPo {
+    return ProposalSummarySectionPo.under(this.root);
+  }
+
+  hasSummarySection(): Promise<boolean> {
+    return this.getSummarySectionPo().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

Add missing test cases in SnsProposalDetail spec.

# Changes

* Expose Payload and Summary Section in SnsProposalDetail page object.
* Add test case for payload section specifically that renders the actual payload. It's important that we test that the payload field is rendered, not just the card.
* Add expect for SystemInfoSection and SymmarySection presence in test case for content loaded. Test on contents are done in each component test.
* Pause and resume the fake in the test for the skeleton. This way the test case is controlled.

# Tests

List of changes above.
