### PR TITLE
README.md in frontend/src/tests/e2e

### DIFF
--- a/frontend/src/tests/e2e/README.md
+++ b/frontend/src/tests/e2e/README.md
@@ -46,7 +46,7 @@ npx playwright show-report
 after it failed. It will show a screenshot of the moment it failed and a trace
 with a lot of screenshots and information about what happened during the test.
 
-If an end-to-end test failed on CI, you can download an extract
+If an end-to-end test failed on CI, you can download and extract
 `playwright-failure-results.zip` from GitHub and then use the report inside it
 with `playwright show-report`:
 ```

--- a/frontend/src/tests/e2e/README.md
+++ b/frontend/src/tests/e2e/README.md
@@ -1,0 +1,54 @@
+# Running end-to-end tests
+
+If you have a frontend running at `http://localhost:5173`, you can run
+end-to-end tests against it by running
+```
+npm run test-e2e
+```
+from the `frontend/` directory of this repo.
+
+To run an individual test, you can do something like
+```
+npm run test-e2e -- account
+```
+This will run on the e2e tests which have `account` in the filename.
+
+If the environment variable `CI` is set, then the tests will run against
+`VITE_OWN_CANISTER_URL` instead of `http://localhost:5173`. This is configured
+in `frontend/playwright.config.ts`.
+
+
+# Environment
+
+Some of the tests will require a specific environment, such as an existing SNS
+project. The enviroment that we run against on CI is created by
+[.github/workflows/run.yml](https://github.com/dfinity/snsdemo/blob/main/.github/workflows/run.yml)
+in ths snsdemo repository. After setting up the enviroment, it creates a
+snapshot of the replica state, which is then used for CI by the nns-dapp repo.
+
+You can run locally with such a snapshot by using `scripts/dev-local-state.sh`.
+However on Mac environments, this only seems to work if the snapshot was created
+on the same machine.
+
+
+# Debugging
+
+If you run an end-to-end test locally, you can see what it does by running
+headed:
+```
+npm run test-e2e -- --headed
+```
+
+You can also see what happened in a failed test by running
+```
+npx playwright show-report
+```
+after it failed. It will show a screenshot of the moment it failed and a trace
+with a lot of screenshots and information about what happened during the test.
+
+If an end-to-end test failed on CI, you can download an extract
+`playwright-failure-results.zip` from GitHub and then use the report inside it
+with `playwright show-report`:
+```
+npx playwright show-report ~/Downloads/playwright-failure-results/playwright-report/
+```

--- a/frontend/src/tests/e2e/README.md
+++ b/frontend/src/tests/e2e/README.md
@@ -11,7 +11,7 @@ To run an individual test, you can do something like
 ```
 npm run test-e2e -- account
 ```
-This will run on the e2e tests which have `account` in the filename.
+This will run only the e2e tests which have `account` in the filename.
 
 If the environment variable `CI` is set, then the tests will run against
 `VITE_OWN_CANISTER_URL` instead of `http://localhost:5173`. This is configured
@@ -27,7 +27,7 @@ in ths snsdemo repository. After setting up the enviroment, it creates a
 snapshot of the replica state, which is then used for CI by the nns-dapp repo.
 
 You can run locally with such a snapshot by using `scripts/dev-local-state.sh`.
-However on Mac environments, this only seems to work if the snapshot was created
+However, on Mac environments, this only seems to work if the snapshot was created
 on the same machine.
 
 


### PR DESCRIPTION
# Motivation

Document how Playwright end-to-end tests are used.

# Changes

Add a README.md file in frontend/src/tests/e2e

# Tests

None
