### PR TITLE
Hash comparison tool

### DIFF
--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -8,6 +8,10 @@ print_help() {
 
 	Finds CI builds of the current commit.
 
+	Example usage, scanning a range of commits:
+	$(basename "$0") -c fab6e718a13d58d23044b708c99910957a671a4d..main --limit 2000 --nth 10 |& tee ,max-search-3
+	Note: The |& ensures that stderr is also written to the file.  Soometimes fetching logs from github fails.
+
 	Note: This searches through gihub logs.  Only fairly recent logs are readily accessible.
 	      Older runs may be found using high velues for the '--limit' flag but this is very slow.
 

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -8,9 +8,13 @@ print_help() {
 
 	Finds CI builds of the current commit.
 
-	Example usage, scanning a range of commits:
+	Example: Checking consistent builds of the current commit
+	$(basename "$0")
+
+	Example: Scanning a range of commits:
 	$(basename "$0") -c fab6e718a13d58d23044b708c99910957a671a4d..main --limit 2000 --nth 10 |& tee ,max-search-3
-	Note: The |& ensures that stderr is also written to the file.  Soometimes fetching logs from github fails.
+	Note: The |& ensures that stderr is also written to the file.  Sometimes fetching logs from github fails.
+	Warning: The script will check out each commit in turn.
 
 	Note: This searches through gihub logs.  Only fairly recent logs are readily accessible.
 	      Older runs may be found using high velues for the '--limit' flag but this is very slow.
@@ -33,7 +37,7 @@ get_data() {
     COMMIT="$(git rev-parse "$1")"
     export COMMIT
 
-    printf "\n\n## Commit %s %s\n\`\`\`" "$COMMIT" "$(git show -s --format=%ci "$COMMIT")"
+    printf '\n\n## Commit %s %s\n```\n' "$COMMIT" "$(git show -s --format=%ci "$COMMIT")"
 
     build_hash_from_logs() {
       sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
@@ -75,7 +79,7 @@ get_data() {
     #esac
     #printf "% 64s Local native build\n" "${native_hash:-}"
 
-    printf "\`\`\`\n\n"
+    printf '```\n\n'
   ) || true
 }
 

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -18,6 +18,7 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
+clap.define short=f long=file desc="The file to compare" variable=DFX_ASSET default="nns-dapp.wasm"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -26,14 +27,32 @@ export DFX_COMMIT
 
 echo "Commit: $DFX_COMMIT"
 
-readarray runs <(gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId')
 
-echo Build hashes for assets.tar.xz:
+build_hash_from_logs() {
+	sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
+}
+
+echo "Build hashes for $DFX_ASSET:"
+: CI builds:
+logfile=",ci-builds-of-${DFX_COMMIT}.txt"
+test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' > "$logfile"
+readarray -t runs < "$logfile"
 for run in "${runs[@]}" ; do
-	hash="$(gh run view "$run" --log | grep 'Build mainnet nns-dapp Docker image' | sed -nr 's&.* ([a-z0-9]{64}) +\/build\/assets.tar.xz.*&\1&g;ta;b;:a;p')"
-	echo -- "$hash $run"
+	: Cache the logfile:
+	logfile=",ci-log-${DFX_LIMIT}-$run.log"
+	test -e "$logfile" || gh run view "$run" --log > "$logfile"
+	hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
+	echo "$hash $run"
 done
-docker_hash="$(./scripts/docker-build |& sed -nr 's&.* ([a-z0-9]{64}) +\/build\/assets.tar.xz.*&\1&g;ta;b;:a;p' || printf "% -64s" FAILED)"
-echo "$docker_hash Local docker build"
-native_hash="$({ rm -f assets.tar.xz && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum assets.tar.xz)"
-echo "$native_hash Local native build"
+
+: Local docker build
+docker_hash="$(./scripts/docker-build |& build_hash_from_logs)"
+printf "% 64s Local docker build\n" "${docker_hash:-}"
+
+: Native build
+case "$DFX_ASSET" in
+assets.tar.xz)
+native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum "$DFX_ASSET")"
+;;
+esac
+printf "% 64s Local native build\n" "${native_hash:-}"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -27,7 +27,7 @@ print_help() {
 	Warning: The script will check out each commit in turn.
 
 	Note: This searches through gihub logs.  Only fairly recent logs are readily accessible.
-	      Older runs may be found using high velues for the '--limit' flag but this is very slow.
+	      Older runs may be found using high values for the '--limit' flag but this is very slow.
 
 	EOF
 }
@@ -37,7 +37,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
 clap.define short=f long=file desc="The file to compare" variable=DFX_ASSET default="nns-dapp.wasm"
-clap.define short=c long=commit desc="The commit to check (will be checked out)" variable=DFX_COMMIT default="HEAD"
+clap.define short=c long=commit desc="The commit to check (will be checked out).  May be a range, as defined here: https://git-scm.com/docs/git-log" variable=DFX_COMMIT default="HEAD"
 clap.define short=n long=nth desc="Test every Nth commit" variable=DFX_NTH default="1"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -28,12 +28,13 @@ export DFX_COMMIT
 echo "Commit: $DFX_COMMIT"
 
 build_hash_from_logs() {
-  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
+  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
 }
 
 echo "Build hashes for $DFX_ASSET:"
 : CI builds:
-logfile=",ci-builds-of-${DFX_COMMIT}.txt"
+LOG_END="$(($(date +%s) / 3600))"
+logfile=",ci-builds-of-${DFX_LIMIT}-${LOG_END}.txt"
 test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' >"$logfile"
 readarray -t runs <"$logfile"
 for run in "${runs[@]}"; do

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -27,22 +27,21 @@ export DFX_COMMIT
 
 echo "Commit: $DFX_COMMIT"
 
-
 build_hash_from_logs() {
-	sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
+  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
 }
 
 echo "Build hashes for $DFX_ASSET:"
 : CI builds:
 logfile=",ci-builds-of-${DFX_COMMIT}.txt"
-test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' > "$logfile"
-readarray -t runs < "$logfile"
-for run in "${runs[@]}" ; do
-	: Cache the logfile:
-	logfile=",ci-log-${DFX_LIMIT}-$run.log"
-	test -e "$logfile" || gh run view "$run" --log > "$logfile"
-	hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
-	echo "$hash $run"
+test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' >"$logfile"
+readarray -t runs <"$logfile"
+for run in "${runs[@]}"; do
+  : Cache the logfile:
+  logfile=",ci-log-${DFX_LIMIT}-$run.log"
+  test -e "$logfile" || gh run view "$run" --log >"$logfile"
+  hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
+  echo "$hash $run"
 done
 
 : Local docker build
@@ -52,7 +51,7 @@ printf "% 64s Local docker build\n" "${docker_hash:-}"
 : Native build
 case "$DFX_ASSET" in
 assets.tar.xz)
-native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum "$DFX_ASSET")"
-;;
+  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
+  ;;
 esac
 printf "% 64s Local native build\n" "${native_hash:-}"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -6,7 +6,17 @@ PATH="$SOURCE_DIR:$PATH"
 print_help() {
   cat <<-EOF
 
-	Finds CI builds of the current commit.
+	Compares CI and local docker builds.
+
+	For a single commit, this:
+	* Searches for builds of the commit in CI and gets the build hashes.
+	* Checks out the commit, if it is not HEAD.
+	* Builds the commit locally in docker.
+	* Prints the results.
+
+	For a range of commits, this:
+	* Gets each commit in the range, optionally picking only every nth one.
+	* Checks out and compares builds of that commit.
 
 	Example: Checking consistent builds of the current commit
 	$(basename "$0")

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -27,28 +27,27 @@ export DFX_COMMIT
 
 echo "Commit: $DFX_COMMIT"
 
-
 build_hash_from_logs() {
-	sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
+  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
 }
 
 echo "Build hashes for $DFX_ASSET:"
 : CI builds:
 logfile=",ci-builds-of-${DFX_COMMIT}.txt"
-test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' > "$logfile"
-readarray -t runs < "$logfile"
-for run in "${runs[@]}" ; do
-	: Cache the logfile:
-	logfile=",ci-log-${DFX_LIMIT}-$run.log"
-	test -e "$logfile" || gh run view "$run" --log > "$logfile"
-	hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
-	echo "$hash $run"
-	: Get the assets
-	logfile=",ci-assets-$run"
-	test -d "$logfile" || (
-	  mkdir "$logfile"
-	  cd "$logfile"
-	  gh run download "$run"
+test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' >"$logfile"
+readarray -t runs <"$logfile"
+for run in "${runs[@]}"; do
+  : Cache the logfile:
+  logfile=",ci-log-${DFX_LIMIT}-$run.log"
+  test -e "$logfile" || gh run view "$run" --log >"$logfile"
+  hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
+  echo "$hash $run"
+  : Get the assets
+  logfile=",ci-assets-$run"
+  test -d "$logfile" || (
+    mkdir "$logfile"
+    cd "$logfile"
+    gh run download "$run"
   )
 done
 
@@ -59,7 +58,7 @@ printf "% 64s Local docker build\n" "${docker_hash:-}"
 : Native build
 case "$DFX_ASSET" in
 assets.tar.xz)
-native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum "$DFX_ASSET")"
-;;
+  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
+  ;;
 esac
 printf "% 64s Local native build\n" "${native_hash:-}"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -30,10 +30,10 @@ source "$(clap.build)"
 
 get_data() {
   (
-    DFX_COMMIT="$(git rev-parse "$1")"
-    export DFX_COMMIT
+    COMMIT="$(git rev-parse "$1")"
+    export COMMIT
 
-    printf "\n\n## Commit $DFX_COMMIT $(git show -s --format=%ci "$DFX_COMMIT")\n\`\`\`\n"
+    printf "\n\n## Commit %s %s\n\`\`\`" "$COMMIT" "$(git show -s --format=%ci "$COMMIT")"
 
     build_hash_from_logs() {
       sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
@@ -44,7 +44,7 @@ get_data() {
     LOG_END="$(($(date +%s) / 3600))"
     logfile=",ci-builds-of-${DFX_LIMIT}-${LOG_END}.txt"
     test -s "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha >"$logfile"
-    readarray -t runs < <(jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' "$logfile")
+    readarray -t runs < <(jq '.[] | select(.headSha==env.COMMIT) | select(.conclusion=="success") | .databaseId' "$logfile")
     for run in "${runs[@]}"; do
       : Cache the logfile:
       logfile=",ci-log-${DFX_LIMIT}-$run.log"
@@ -80,7 +80,7 @@ get_data() {
 }
 
 if [[ "$DFX_COMMIT" == *..* ]]; then
-  git log --pretty=%P "$DFX_COMMIT" | awk -v nth="$DFX_NTH" '(NR%nth == 0)' | while read line; do get_data "$line"; done
+  git log --pretty=%P "$DFX_COMMIT" | awk -v nth="$DFX_NTH" '(NR%nth == 0)' | while read -r line; do get_data "$line"; done
 else
   get_data "$DFX_COMMIT"
 fi

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -35,8 +35,8 @@ echo "Build hashes for $DFX_ASSET:"
 : CI builds:
 LOG_END="$(($(date +%s) / 3600))"
 logfile=",ci-builds-of-${DFX_LIMIT}-${LOG_END}.txt"
-test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' >"$logfile"
-readarray -t runs <"$logfile"
+test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha >"$logfile"
+readarray -t runs < <(jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' "$logfile")
 for run in "${runs[@]}"; do
   : Cache the logfile:
   logfile=",ci-log-${DFX_LIMIT}-$run.log"
@@ -57,9 +57,9 @@ docker_hash="$(./scripts/docker-build |& build_hash_from_logs)"
 printf "% 64s Local docker build\n" "${docker_hash:-}"
 
 : Native build
-case "$DFX_ASSET" in
-assets.tar.xz)
-  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
-  ;;
-esac
-printf "% 64s Local native build\n" "${native_hash:-}"
+#case "$DFX_ASSET" in
+#assets.tar.xz)
+#  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
+#  ;;
+#esac
+#printf "% 64s Local native build\n" "${native_hash:-}"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -19,47 +19,64 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
 clap.define short=f long=file desc="The file to compare" variable=DFX_ASSET default="nns-dapp.wasm"
+clap.define short=c long=commit desc="The commit to check (will be checked out)" variable=DFX_COMMIT default="HEAD"
+clap.define short=n long=nth desc="Test every Nth commit" variable=DFX_NTH default="1"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-DFX_COMMIT="$(git rev-parse "HEAD")"
-export DFX_COMMIT
+get_data() {
+  (
+    DFX_COMMIT="$(git rev-parse "$1")"
+    export DFX_COMMIT
 
-echo "Commit: $DFX_COMMIT"
+    printf "\n\n## Commit $DFX_COMMIT $(git show -s --format=%ci "$DFX_COMMIT")\n\`\`\`\n"
 
-build_hash_from_logs() {
-  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
+    build_hash_from_logs() {
+      sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
+    }
+
+    echo "Build hashes for $DFX_ASSET:"
+    : CI builds:
+    LOG_END="$(($(date +%s) / 3600))"
+    logfile=",ci-builds-of-${DFX_LIMIT}-${LOG_END}.txt"
+    test -s "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha >"$logfile"
+    readarray -t runs < <(jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' "$logfile")
+    for run in "${runs[@]}"; do
+      : Cache the logfile:
+      logfile=",ci-log-${DFX_LIMIT}-$run.log"
+      test -s "$logfile" || gh run view "$run" --log >"$logfile"
+      hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
+      echo "$hash $run"
+      : Get the assets
+      logfile=",ci-assets-$run"
+      test -d "$logfile" || (
+        rm -fr "$logfile.tmp"
+        mkdir "$logfile.tmp"
+        pushd "$logfile.tmp" >/dev/null
+        gh run download "$run" || true
+        popd >/dev/null
+        mv "$logfile.tmp" "$logfile"
+      )
+    done
+
+    : Local docker build
+    docker_hash="$(./scripts/docker-build |& build_hash_from_logs)"
+    printf "% 64s Local docker build\n" "${docker_hash:-}"
+
+    : Native build
+    #case "$DFX_ASSET" in
+    #assets.tar.xz)
+    #  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
+    #  ;;
+    #esac
+    #printf "% 64s Local native build\n" "${native_hash:-}"
+
+    printf "\`\`\`\n\n"
+  ) || true
 }
 
-echo "Build hashes for $DFX_ASSET:"
-: CI builds:
-LOG_END="$(($(date +%s) / 3600))"
-logfile=",ci-builds-of-${DFX_LIMIT}-${LOG_END}.txt"
-test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha >"$logfile"
-readarray -t runs < <(jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' "$logfile")
-for run in "${runs[@]}"; do
-  : Cache the logfile:
-  logfile=",ci-log-${DFX_LIMIT}-$run.log"
-  test -e "$logfile" || gh run view "$run" --log >"$logfile"
-  hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
-  echo "$hash $run"
-  : Get the assets
-  logfile=",ci-assets-$run"
-  test -d "$logfile" || (
-    mkdir "$logfile"
-    cd "$logfile"
-    gh run download "$run"
-  )
-done
-
-: Local docker build
-docker_hash="$(./scripts/docker-build |& build_hash_from_logs)"
-printf "% 64s Local docker build\n" "${docker_hash:-}"
-
-: Native build
-#case "$DFX_ASSET" in
-#assets.tar.xz)
-#  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
-#  ;;
-#esac
-#printf "% 64s Local native build\n" "${native_hash:-}"
+if [[ "$DFX_COMMIT" == *..* ]]; then
+  git log --pretty=%P "$DFX_COMMIT" | awk -v nth="$DFX_NTH" '(NR%nth == 0)' | while read line; do get_data "$line"; done
+else
+  get_data "$DFX_COMMIT"
+fi

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -27,21 +27,29 @@ export DFX_COMMIT
 
 echo "Commit: $DFX_COMMIT"
 
+
 build_hash_from_logs() {
-  sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
+	sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p'
 }
 
 echo "Build hashes for $DFX_ASSET:"
 : CI builds:
 logfile=",ci-builds-of-${DFX_COMMIT}.txt"
-test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' >"$logfile"
-readarray -t runs <"$logfile"
-for run in "${runs[@]}"; do
-  : Cache the logfile:
-  logfile=",ci-log-${DFX_LIMIT}-$run.log"
-  test -e "$logfile" || gh run view "$run" --log >"$logfile"
-  hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
-  echo "$hash $run"
+test -e "$logfile" || gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId' > "$logfile"
+readarray -t runs < "$logfile"
+for run in "${runs[@]}" ; do
+	: Cache the logfile:
+	logfile=",ci-log-${DFX_LIMIT}-$run.log"
+	test -e "$logfile" || gh run view "$run" --log > "$logfile"
+	hash="$(grep 'Build mainnet nns-dapp Docker image' "$logfile" | build_hash_from_logs)"
+	echo "$hash $run"
+	: Get the assets
+	logfile=",ci-assets-$run"
+	test -d "$logfile" || (
+	  mkdir "$logfile"
+	  cd "$logfile"
+	  gh run download "$run"
+  )
 done
 
 : Local docker build
@@ -51,7 +59,7 @@ printf "% 64s Local docker build\n" "${docker_hash:-}"
 : Native build
 case "$DFX_ASSET" in
 assets.tar.xz)
-  native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh; } &>/dev/null && sha256sum "$DFX_ASSET")"
-  ;;
+native_hash="$({ rm -f "$DFX_ASSET" && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum "$DFX_ASSET")"
+;;
 esac
 printf "% 64s Local native build\n" "${native_hash:-}"

--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Finds CI builds of the current commit.
+
+	Note: This searches through gihub logs.  Only fairly recent logs are readily accessible.
+	      Older runs may be found using high velues for the '--limit' flag but this is very slow.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=l long=limit desc="The number of runs to search though" variable=DFX_LIMIT default="200"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+DFX_COMMIT="$(git rev-parse "HEAD")"
+export DFX_COMMIT
+
+echo "Commit: $DFX_COMMIT"
+
+readarray runs <(gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | .databaseId')
+
+echo Build hashes for assets.tar.xz:
+for run in "${runs[@]}" ; do
+	hash="$(gh run view "$run" --log | grep 'Build mainnet nns-dapp Docker image' | sed -nr 's&.* ([a-z0-9]{64}) +\/build\/assets.tar.xz.*&\1&g;ta;b;:a;p')"
+	echo -- "$hash $run"
+done
+docker_hash="$(./scripts/docker-build |& sed -nr 's&.* ([a-z0-9]{64}) +\/build\/assets.tar.xz.*&\1&g;ta;b;:a;p' || printf "% -64s" FAILED)"
+echo "$docker_hash Local docker build"
+native_hash="$({ rm -f assets.tar.xz && DFX_NETWORK=mainnet ./config.sh && ./build-frontend.sh ; } &>/dev/null && sha256sum assets.tar.xz)"
+echo "$native_hash Local native build"


### PR DESCRIPTION
# Motivation
We need to be able to find inconsistent builds across CI and local docker builds, as used by verifiers.

# Changes
* Add a script that looks for CI builds of a commit and compares  those builds with the local docker build.
* Add the ability to scan a range of commits

# Tests

Sample output.  This shows that CI run 4701442653 produced a different hash from other CI runs and the local docker build.

You can see the run here: https://github.com/dfinity/nns-dapp/actions/runs/4701442653

## Commit b9fecaacd0f6c6a05a6eb56ef84af48dfcd4dba8 2023-04-13 14:13:55 +0000
```
Build hashes for nns-dapp.wasm:
dce3d050e0826e5586ac196ae620de3979d3b778d998e401dc9f25928772460a 4703965352
3350f1ec42a95d7d1196ca1ec62900e7bb82769e02ec3d0bf4ec8e0d182cc362 4701442653
dce3d050e0826e5586ac196ae620de3979d3b778d998e401dc9f25928772460a 4690422724
dce3d050e0826e5586ac196ae620de3979d3b778d998e401dc9f25928772460a 4690262262
dce3d050e0826e5586ac196ae620de3979d3b778d998e401dc9f25928772460a Local docker build
```