### PR TITLE
Fix ubuntu version in workflow matrix

### DIFF
--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-20.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
         time: [now, future]
     steps:
       - name: Unbork mac

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-20.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
     steps:
       - name: Unbork mac
         run: |


### PR DESCRIPTION
# Motivation

The reproducibility tests run against different versions of MacOs and Ubuntu.
But https://github.com/dfinity/nns-dapp/pull/1825 and https://github.com/dfinity/nns-dapp/pull/1836 changed the version of Ubuntu we use everywhere, making the different versions in the matrix the same versions.

# Changes

Make the versions in the workflow matrix of .github/workflows/reproducible-assets.yaml and .github/workflows/reproducible.yaml different again, as before https://github.com/dfinity/nns-dapp/pull/1825.

# Tests

CI
