### PR TITLE
Ignore playwright dirs for lint

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
+/playwright*
 .env
 .env.*
 !.env.example


### PR DESCRIPTION
# Motivation

`eslint` complains about JS files in `frontend/playwright-report/trace/`.

# Changes

Add `/playwright*` to `frontend/.eslintignore`

# Tests

After `npm run check` complained, added the line to `frontend/.eslintignore` and ran `npm run check` again.