### PR TITLE
E2E: Check SNS balance after getTokens

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -24,6 +24,14 @@ test("Test SNS governance", async ({ page, context }) => {
   await snsUniverseCard.click();
   await appPo.getTokens(20);
 
+  expect(
+    await appPo
+      .getAccountsPo()
+      .getSnsAccountsPo()
+      .getMainAccountCardPo()
+      .getBalance()
+  ).toEqual("20.00");
+
   // TODO:
   // SN001: User can see the list of neurons
 

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -1,6 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-object";
+import { SnsAccountsPo } from "$tests/page-objects/SnsAccounts.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class AccountsPo extends BasePageObject {
@@ -12,6 +13,10 @@ export class AccountsPo extends BasePageObject {
 
   getNnsAccountsPo(): NnsAccountsPo {
     return NnsAccountsPo.under(this.root);
+  }
+
+  getSnsAccountsPo(): SnsAccountsPo {
+    return SnsAccountsPo.under(this.root);
   }
 
   getNnsAccountsFooterPo(): NnsAccountsFooterPo {

--- a/frontend/src/tests/page-objects/BaseAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/BaseAccounts.page-object.ts
@@ -1,0 +1,44 @@
+import { AccountCardPo } from "$tests/page-objects/AccountCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+
+export class BaseAccountsPo extends BasePageObject {
+  getMainAccountCardPo(): AccountCardPo {
+    // We assume the first card is the main card.
+    return AccountCardPo.under(this.root);
+  }
+
+  getAccountCardPos(): Promise<AccountCardPo[]> {
+    return AccountCardPo.allUnder(this.root);
+  }
+
+  async getAccountCardPo(accountName: string): Promise<AccountCardPo> {
+    const cards = await this.getAccountCardPos();
+    const names = await Promise.all(cards.map((card) => card.getAccountName()));
+    const index = names.indexOf(accountName);
+    if (index === -1) {
+      throw new Error(
+        `Account ${accountName} not found. Available accounts are ${names}`
+      );
+    }
+    return cards[index];
+  }
+
+  async openAccount(accountName: string): Promise<void> {
+    return (await this.getAccountCardPo(accountName)).click();
+  }
+
+  async getAccountNames(): Promise<string[]> {
+    const cards = await this.getAccountCardPos();
+    return Promise.all(cards.map((card) => card.getAccountName()));
+  }
+
+  async getAccountAddress(accountName: string): Promise<string> {
+    const card = await this.getAccountCardPo(accountName);
+    return card.getAccountAddress();
+  }
+
+  async getAccountBalance(accountName: string): Promise<string> {
+    const card = await this.getAccountCardPo(accountName);
+    return card.getBalance();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,53 +1,12 @@
-import { AccountCardPo } from "$tests/page-objects/AccountCard.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
 import { NnsAddAccountPo } from "$tests/page-objects/NnsAddAccount.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsAccountsPo extends BasePageObject {
+export class NnsAccountsPo extends BaseAccountsPo {
   private static readonly TID = "accounts-body";
 
   static under(element: PageObjectElement): NnsAccountsPo {
     return new NnsAccountsPo(element.byTestId(NnsAccountsPo.TID));
-  }
-
-  getMainAccountCardPo(): AccountCardPo {
-    // We assume the first card is the main card.
-    return AccountCardPo.under(this.root);
-  }
-
-  getAccountCardPos(): Promise<AccountCardPo[]> {
-    return AccountCardPo.allUnder(this.root);
-  }
-
-  async getAccountCardPo(accountName: string): Promise<AccountCardPo> {
-    const cards = await this.getAccountCardPos();
-    const names = await Promise.all(cards.map((card) => card.getAccountName()));
-    const index = names.indexOf(accountName);
-    if (index === -1) {
-      throw new Error(
-        `Account ${accountName} not found. Available accounts are ${names}`
-      );
-    }
-    return cards[index];
-  }
-
-  async openAccount(accountName: string): Promise<void> {
-    return (await this.getAccountCardPo(accountName)).click();
-  }
-
-  async getAccountNames(): Promise<string[]> {
-    const cards = await this.getAccountCardPos();
-    return Promise.all(cards.map((card) => card.getAccountName()));
-  }
-
-  async getAccountAddress(accountName: string): Promise<string> {
-    const card = await this.getAccountCardPo(accountName);
-    return card.getAccountAddress();
-  }
-
-  async getAccountBalance(accountName: string): Promise<string> {
-    const card = await this.getAccountCardPo(accountName);
-    return card.getBalance();
   }
 
   getNnsAddAccountPo(): NnsAddAccountPo {

--- a/frontend/src/tests/page-objects/SnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsAccounts.page-object.ts
@@ -1,0 +1,10 @@
+import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsAccountsPo extends BaseAccountsPo {
+  private static readonly TID = "sns-accounts-body";
+
+  static under(element: PageObjectElement): SnsAccountsPo {
+    return new SnsAccountsPo(element.byTestId(SnsAccountsPo.TID));
+  }
+}


### PR DESCRIPTION
# Motivation

Continue with end-to-end tests for SNS.

# Changes

1. In `frontend/src/tests/e2e/sns-governance.spec.ts`, check the Main account balance after getting tokens.
2. Factor out `BaseAccountsPo` from `NnsAccountsPo` and make `NnsAccountsPo` extend `BaseAccountsPo`.
3. Add `SnsAccountsPo` also extending `BaseAccountsPo`.

# Tests

`npm run test-e2e`
`npm run check`
`npm run test`
