### PR TITLE
Run e2e tests in parallel on CI.

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Let's not enable retries until we actually need them */
   retries: 0,
   /* Number of tests that can be run in parallel. */
-  workers: 6,
+  workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Let's not enable retries until we actually need them */
   retries: 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Number of tests that can be run in parallel. */
+  workers: 6,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ dotenv.config();
 export default defineConfig({
   testDir: "./src/tests/e2e",
   /* Maximum time one test can run for. */
-  timeout: 60 * 1000,
+  timeout: 120 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.


### PR DESCRIPTION
# Motivation

Reduce CI time.
Tests that run in parallel do run quite a bit slower per test, but overall they finish sooner because they don't have to wait for each other.
I tried 6 workers but it made the tests significantly slower.
We can try more once we have the more powerful runners.

# Changes

1. Set `workers: 3` in `frontend/playwright.config.ts` to allow Playwright e2e tests to run in parallel.
2. Increase timeout of individual tests.

# Tests

CI