### PR TITLE
Manual triggers for docker builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,6 @@ on:
     inputs:
       no_cache:
         description: 'no-cache'
-        required: true
         default: false
         type: boolean
 concurrency:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,13 @@
 name: Docker build
 on:
   push:
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: 'no-cache'
+        required: true
+        default: false
+        type: boolean
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,6 +33,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=${{ matrix.DFX_NETWORK }}
+          no-cache: ${{ inputs.no_cache || false }}
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./${{ matrix.BUILD_NAME }}-out

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -10,7 +10,7 @@ on:
       network:
         description: 'Network'
         required: true
-        default: 'mainnet'
+        default: 'local'
         type: string
       no_cache:
         description: 'no-cache'

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -37,7 +37,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=${{ matrix.DFX_NETWORK }}
-          cache-from: type=gha,scope=cached-stage
+          #cache-from: type=gha,scope=cached-stage
           cache-to: type=gha,scope=cached-stage,mode=max
           outputs: type=cacheonly
           target: scratch

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -9,7 +9,6 @@ on:
     inputs:
       network:
         description: 'Network'
-        required: true
         default: 'local'
         type: string
       no_cache:

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -5,24 +5,24 @@ on:
       - main
       # Use this branch for tests:
       - docker-main-test
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network'
+        required: true
+        default: 'mainnet'
+        type: string
+      no_cache:
+        description: 'no-cache'
+        required: true
+        default: false
+        type: boolean
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   builder:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          # Note: It seems that having several entries here upsets the cache.
-          # Having just one entry makes others faster, but we use local builds more
-          # than mainnet, so let's prioritize that.  Soon this will be a non-issue
-          # anyway as we will pass the network as an argument.
-          # It would still be nice to figure out why; presumably there is a single
-          # cache that gets wiped out and replaced, not added to.  And there is probably
-          # a namespace one can provide to prevent differing builds from clobbering each other.
-          - BUILD_NAME: "local"
-            DFX_NETWORK: "local"
     steps:
       - uses: actions/checkout@v3
       # We use buildx and its GitHub Actions caching support `type=gha`. For
@@ -36,8 +36,9 @@ jobs:
           context: .
           file: Dockerfile
           build-args: |
-            DFX_NETWORK=${{ matrix.DFX_NETWORK }}
-          #cache-from: type=gha,scope=cached-stage
+            DFX_NETWORK=${{ inputs.network || 'local' }}
+          no-cache: ${{ inputs.no_cache || false }}
+          cache-from: type=gha,scope=cached-stage
           cache-to: type=gha,scope=cached-stage,mode=max
           outputs: type=cacheonly
           target: scratch


### PR DESCRIPTION
# Motivation
Releases are blocked by non-reproducible builds.  Builds are reproducible when run without a cache.

# Changes
- Allow docker builds to be triggered manually, with or without cache.

# Tests
Docker builds on CI match local builds when the cache is disabled.  Example:

## Commit 2e010aee0597aeeba4987beed471945d8068e453 2023-03-27 14:58:00 +0000
```
Previous HEAD position was 29ebcc863 GIX-1220: SNS proposal - Render system info (#2171)
HEAD is now at 2e010aee0 Improve aggregator test logs (#2177)
Commit: 2e010aee0597aeeba4987beed471945d8068e453
Build hashes for nns-dapp.wasm:
b8945925745ac559fe412e3bd6b72e33d7123c63154068039a4cbf575f404842 4545507226
b8945925745ac559fe412e3bd6b72e33d7123c63154068039a4cbf575f404842 4545354957
0cf7bce91ca1d36cc7a036b78ff8e9c6b1f767c4713d29429c3baf3e52f612bd Local docker build
                                                                 Local native build
Commit: 2e010aee0597aeeba4987beed471945d8068e453
Build hashes for assets.tar.xz:
2697a9276c1a6d2e16739f02cbedc3965381c7905d0562d9e6210eb2875c0817 4545507226
2697a9276c1a6d2e16739f02cbedc3965381c7905d0562d9e6210eb2875c0817 4545354957
48b6ad01c88a7954dfa85410ddf5ac76bf53550de08e0a38b9df75a8ccd8ed18 Local docker build <-------------------
604fa16850ae9859312e80dd4327b86c05f2bcb5599b959539bdcb4ccba94c5e  assets.tar.xz Local native build
```

^^^
- [x] Rerun local build with no cache:
  - Result:
```
48b6ad01c88a7954dfa85410ddf5ac76bf53550de08e0a38b9df75a8ccd8ed18  assets.tar.xz
0cf7bce91ca1d36cc7a036b78ff8e9c6b1f767c4713d29429c3baf3e52f612bd  nns-dapp.wasm
1259ea905071fe1d506963d3e70dcced405616a9ccf5b685c616a20b814de622  sns_aggregator.wasm
```
- [x] Rerun CI with no cache
  - Made a branch (upstream-cache-check), added nocache, and pushed.  Result from CI:
```
0cf7bce91ca1d36cc7a036b78ff8e9c6b1f767c4713d29429c3baf3e52f612bd 4675771642 <-- Matches local build
```
