### PR TITLE
Implement waitForAbsent on JestPageObjectElement

### DIFF
--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -63,7 +63,10 @@ export class JestPageObjectElement implements PageObjectElement {
     // return this.querySelectorCount({ selector: `[data-tid=${tid}]`, count });
   }
 
-  private getRootAndFullSelector(): { rootElement: Element; fullSelector: string } {
+  private getRootAndFullSelector(): {
+    rootElement: Element;
+    fullSelector: string;
+  } {
     if (isNullish(this.parent)) {
       return { rootElement: this.element, fullSelector: ":scope" };
     }
@@ -75,7 +78,7 @@ export class JestPageObjectElement implements PageObjectElement {
   }
 
   async isPresent(): Promise<boolean> {
-    const {rootElement, fullSelector} = this.getRootAndFullSelector();
+    const { rootElement, fullSelector } = this.getRootAndFullSelector();
     this.element = rootElement.querySelector(fullSelector);
     return nonNullish(this.element);
   }


### PR DESCRIPTION
# Motivation

We use page objects for both e2e tests and jest unit tests.
The e2e tests and unit tests that use page objects will overlap more and more and it is good to use the same patterns in both of them.

Also, JestPageObjectElement.isPresent wasn't using the most recent state of the DOM to determine if an element is present.

# Changes

1. Add a private method `getRootAndFullSelector` to `JestPageObjectElement` to get the furthest available ancestor of the current element and the full selector to point from it to the current element.
2. Use `getRootAndFullSelector` to implement `isPresent` and update this.element.
3. Use `isPresent` to implement both `waitFor` and `waitForAbsent`.

`waitForAbsent` currently isn't used by any unit tests, but the new implementation is so straightforward that it will likely work and some testing from another branch suggests that it does.

# Tests

`npm run test`
