### PR TITLE
GIX-1481: Fetch the latest reward event

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-04.2.tgz",
-      "integrity": "sha512-tCGw4L5FZBjoizKevGtovGrVXfn9dDN+d0NNnxk7QtiaNNoN02VZKXzB55PYOyhBPsy4oxxubaR+21Zm3b4FKg==",
+      "version": "0.0.2-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-13.2.tgz",
+      "integrity": "sha512-ITkCAk9vi0qHj56TzShdLcg3MyoRiOdzHOUbt9n21XwrjCu2uCfAgM8ynSPPeSjtdIzG+NriuXKqoQl9KWfmyA==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.9-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-04.2.tgz",
-      "integrity": "sha512-rSUWQfLCv4xk/zu7Vljk2tRSsiZhMEAgeI1vas9CSiD45VpARCmzkwkqlDrzCCHRil+xCaE2wyLAoVpGqaBNbg==",
+      "version": "0.0.9-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-13.2.tgz",
+      "integrity": "sha512-EzXlMfx9uHziSRm7qd+nzHEC9iBBJUgOAtqv9uvZXCrYDn++tbfHWAg2xblLNngo4XWqShSUIz8WbkGVIdlfXA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.6-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-04.2.tgz",
-      "integrity": "sha512-GkwdxdIhKHUeU7m8TbMcvhz3KjvOptUhSiL8kVRYfbSPJYtrVxpBW7YEBrX1ZffUJgwMH2eZbUWUQss3YcR3SQ==",
+      "version": "0.0.6-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-13.2.tgz",
+      "integrity": "sha512-8OlYXd/0cYN1sBciBOfQqyhz1ls0AK1cvhZbTQ3s/Si3vXUDf2+8uhjmSsNnMVg+IC4xesa6MCtIWHB74c8A/g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.15.0-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-04.2.tgz",
-      "integrity": "sha512-3JUsUBrleKUaCG0r5Ocz8lwiH+hXv13O1iHKiRf3JXAopG/qp/kCGXpylBVaZ7q2gd259g1EP1083MCymtE0dA==",
+      "version": "0.15.0-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-13.2.tgz",
+      "integrity": "sha512-rj0zcQqCGGqdfyHIxo32Y2QDMI+/O1/W6+1nnCszv3TpygN1sg2CXlHNyj5KdhwhARzIrp9YgDJ6PbhZ5rLY5g==",
       "dependencies": {
         "google-protobuf": "^3.21.2",
         "js-sha256": "^0.9.0",
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.13-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-04.2.tgz",
-      "integrity": "sha512-Rk7n7V6EAAYO4amTvFVhAfSUkFB5Cu0zCqLsZIz1Y+U66FbQSwV4af+whLBbdFoeUyRO+vzSaiIZ6ctzNgfJRg==",
+      "version": "0.0.13-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-13.2.tgz",
+      "integrity": "sha512-/bCLHlQ8KVPNmjNZPVL4hWm3KlpQ5MeW4TEKXiKETzg0kKWjSo8+srcBsjUKZa1nISDPYuExMdv/ABCR3WFyeg==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.13-next-2023-04-04.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-04.4.tgz",
-      "integrity": "sha512-U1eWb+EYjhK7IVNAEc4j6UqbLdYAbEGLYbpfF4b7YXqXVvtoc1hoMSxlCFbJ4VI/25RLQDQkxPqLYyYlY6wxTA==",
+      "version": "0.0.13-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-13.2.tgz",
+      "integrity": "sha512-xWt2Tm+sr5GnVxE72ihEvJah2PJPojvVxaXYHZRaxAjLKuaOX0WS9eE07SUC7qONc0BUbZS7jnYcHRl3wugT7Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9923,9 +9923,9 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-04.2.tgz",
-      "integrity": "sha512-tCGw4L5FZBjoizKevGtovGrVXfn9dDN+d0NNnxk7QtiaNNoN02VZKXzB55PYOyhBPsy4oxxubaR+21Zm3b4FKg==",
+      "version": "0.0.2-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-13.2.tgz",
+      "integrity": "sha512-ITkCAk9vi0qHj56TzShdLcg3MyoRiOdzHOUbt9n21XwrjCu2uCfAgM8ynSPPeSjtdIzG+NriuXKqoQl9KWfmyA==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -9933,9 +9933,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.9-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-04.2.tgz",
-      "integrity": "sha512-rSUWQfLCv4xk/zu7Vljk2tRSsiZhMEAgeI1vas9CSiD45VpARCmzkwkqlDrzCCHRil+xCaE2wyLAoVpGqaBNbg==",
+      "version": "0.0.9-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-13.2.tgz",
+      "integrity": "sha512-EzXlMfx9uHziSRm7qd+nzHEC9iBBJUgOAtqv9uvZXCrYDn++tbfHWAg2xblLNngo4XWqShSUIz8WbkGVIdlfXA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -9959,15 +9959,15 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.6-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-04.2.tgz",
-      "integrity": "sha512-GkwdxdIhKHUeU7m8TbMcvhz3KjvOptUhSiL8kVRYfbSPJYtrVxpBW7YEBrX1ZffUJgwMH2eZbUWUQss3YcR3SQ==",
+      "version": "0.0.6-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-13.2.tgz",
+      "integrity": "sha512-8OlYXd/0cYN1sBciBOfQqyhz1ls0AK1cvhZbTQ3s/Si3vXUDf2+8uhjmSsNnMVg+IC4xesa6MCtIWHB74c8A/g==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.15.0-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-04.2.tgz",
-      "integrity": "sha512-3JUsUBrleKUaCG0r5Ocz8lwiH+hXv13O1iHKiRf3JXAopG/qp/kCGXpylBVaZ7q2gd259g1EP1083MCymtE0dA==",
+      "version": "0.15.0-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-13.2.tgz",
+      "integrity": "sha512-rj0zcQqCGGqdfyHIxo32Y2QDMI+/O1/W6+1nnCszv3TpygN1sg2CXlHNyj5KdhwhARzIrp9YgDJ6PbhZ5rLY5g==",
       "requires": {
         "google-protobuf": "^3.21.2",
         "js-sha256": "^0.9.0",
@@ -9984,17 +9984,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.13-next-2023-04-04.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-04.2.tgz",
-      "integrity": "sha512-Rk7n7V6EAAYO4amTvFVhAfSUkFB5Cu0zCqLsZIz1Y+U66FbQSwV4af+whLBbdFoeUyRO+vzSaiIZ6ctzNgfJRg==",
+      "version": "0.0.13-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-13.2.tgz",
+      "integrity": "sha512-/bCLHlQ8KVPNmjNZPVL4hWm3KlpQ5MeW4TEKXiKETzg0kKWjSo8+srcBsjUKZa1nISDPYuExMdv/ABCR3WFyeg==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.13-next-2023-04-04.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-04.4.tgz",
-      "integrity": "sha512-U1eWb+EYjhK7IVNAEc4j6UqbLdYAbEGLYbpfF4b7YXqXVvtoc1hoMSxlCFbJ4VI/25RLQDQkxPqLYyYlY6wxTA==",
+      "version": "0.0.13-next-2023-04-13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-13.2.tgz",
+      "integrity": "sha512-xWt2Tm+sr5GnVxE72ihEvJah2PJPojvVxaXYHZRaxAjLKuaOX0WS9eE07SUC7qONc0BUbZS7jnYcHRl3wugT7Q==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -5,6 +5,7 @@ import {
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
+  lastestRewardEvent,
   leaveCommunityFund,
   mergeMaturity,
   mergeNeurons,
@@ -128,6 +129,9 @@ export const governanceApiService = {
   },
   joinCommunityFund(params: ApiManageNeuronParams) {
     return clearCacheAfter(joinCommunityFund(params));
+  },
+  latestRewardEven(params: ApiQueryParams) {
+    return lastestRewardEvent(params);
   },
   leaveCommunityFund(params: ApiManageNeuronParams) {
     return clearCacheAfter(leaveCommunityFund(params));

--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -5,11 +5,11 @@ import {
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
-  lastestRewardEvent,
   leaveCommunityFund,
   mergeMaturity,
   mergeNeurons,
   queryKnownNeurons,
+  queryLastestRewardEvent,
   queryNeuron,
   queryNeurons,
   registerVote,
@@ -92,6 +92,9 @@ export const governanceApiService = {
   queryKnownNeurons(params: ApiQueryParams) {
     return queryKnownNeurons(params);
   },
+  queryLastestRewardEvent(params: ApiQueryParams) {
+    return queryLastestRewardEvent(params);
+  },
   queryNeuron(params: ApiQueryNeuronParams) {
     return queryNeuron(params);
   },
@@ -129,9 +132,6 @@ export const governanceApiService = {
   },
   joinCommunityFund(params: ApiManageNeuronParams) {
     return clearCacheAfter(joinCommunityFund(params));
-  },
-  latestRewardEven(params: ApiQueryParams) {
-    return lastestRewardEvent(params);
   },
   leaveCommunityFund(params: ApiManageNeuronParams) {
     return clearCacheAfter(leaveCommunityFund(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -17,6 +17,7 @@ import type {
   Vote,
 } from "@dfinity/nns";
 import { GovernanceCanister } from "@dfinity/nns";
+import type { RewardEvent } from "@dfinity/nns/dist/candid/governance";
 import type { Principal } from "@dfinity/principal";
 import { ledgerCanister as getLedgerCanister } from "./ledger.api";
 
@@ -467,6 +468,25 @@ export const registerVote = async ({
       neuronId
     )}) complete.`
   );
+};
+
+export const lastestRewardEvent = async ({
+  identity,
+  certified,
+}: ApiQueryParams): Promise<RewardEvent> => {
+  logWithTimestamp(
+    `Getting latest reward event call certified: ${certified}...`
+  );
+
+  const governance: GovernanceCanister = await governanceCanister({ identity });
+
+  try {
+    return governance.lastestRewardEvent(certified);
+  } finally {
+    logWithTimestamp(
+      `Getting latest reward event call certified: ${certified} complete.`
+    );
+  }
 };
 
 /**

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -16,8 +16,7 @@ import type {
   Topic,
   Vote,
 } from "@dfinity/nns";
-import { GovernanceCanister } from "@dfinity/nns";
-import type { RewardEvent } from "@dfinity/nns/dist/candid/governance";
+import { GovernanceCanister, type RewardEvent } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { ledgerCanister as getLedgerCanister } from "./ledger.api";
 
@@ -470,7 +469,7 @@ export const registerVote = async ({
   );
 };
 
-export const lastestRewardEvent = async ({
+export const queryLastestRewardEvent = async ({
   identity,
   certified,
 }: ApiQueryParams): Promise<RewardEvent> => {
@@ -478,10 +477,10 @@ export const lastestRewardEvent = async ({
     `Getting latest reward event call certified: ${certified}...`
   );
 
-  const governance: GovernanceCanister = await governanceCanister({ identity });
+  const { canister: governance } = await governanceCanister({ identity });
 
   try {
-    return governance.lastestRewardEvent(certified);
+    return governance.getLastestRewardEvent(certified);
   } finally {
     logWithTimestamp(
       `Getting latest reward event call certified: ${certified} complete.`

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -34,11 +34,13 @@
   import NnsNeuronProposalsCard from "$lib/components/neuron-detail/NnsNeuronProposalsCard.svelte";
   import Summary from "$lib/components/summary/Summary.svelte";
   import { listNeurons } from "$lib/services/neurons.services";
+  import { loadLatestRewardEvent } from "$lib/services/nns-reward-event.services";
 
   export let neuronIdText: string | undefined | null;
 
   onMount(() => {
     listNeurons();
+    loadLatestRewardEvent();
   });
 
   const mapNeuronId = (

--- a/frontend/src/lib/services/nns-reward-event.services.ts
+++ b/frontend/src/lib/services/nns-reward-event.services.ts
@@ -1,0 +1,18 @@
+import { governanceApiService } from "$lib/api-services/governance.api-service";
+import type { RewardEvent } from "@dfinity/nns";
+import { queryAndUpdate } from "./utils.services";
+
+// TODO: Implement
+export const loadLatestRewardEvent = (): Promise<void> => {
+  return queryAndUpdate<RewardEvent, unknown>({
+    request: (options) => governanceApiService.queryLastestRewardEvent(options),
+    onLoad: () => {
+      // TODO: Implement
+      // console.log(rewardEvent);
+    },
+    onError: ({ error: err }) => {
+      console.error(err);
+    },
+    logMessage: "Getting latest reward event for NNS",
+  });
+};

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -1,7 +1,7 @@
 import type { ApiQueryParams } from "$lib/api/governance.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { rewardEvent } from "$tests/mocks/nns-reward-event.mock";
+import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import {
   installImplAndBlockRest,
   makePausable,
@@ -58,7 +58,7 @@ async function queryLastestRewardEvent({
   identity: _,
   certified: __,
 }: ApiQueryParams): Promise<RewardEvent> {
-  return rewardEvent;
+  return mockRewardEvent;
 }
 
 /////////////////////////////////

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -1,18 +1,20 @@
 import type { ApiQueryParams } from "$lib/api/governance.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { rewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import {
   installImplAndBlockRest,
   makePausable,
 } from "$tests/utils/module.test-utils";
 import type { Identity } from "@dfinity/agent";
-import type { KnownNeuron, NeuronInfo } from "@dfinity/nns";
+import type { KnownNeuron, NeuronInfo, RewardEvent } from "@dfinity/nns";
 import { isNullish } from "@dfinity/utils";
 
 const modulePath = "$lib/api/governance.api";
 const fakeFunctions = {
   queryNeurons,
   queryKnownNeurons,
+  queryLastestRewardEvent,
 };
 
 //////////////////////////////////////////////
@@ -50,6 +52,13 @@ async function queryKnownNeurons({
   certified: __,
 }: ApiQueryParams): Promise<KnownNeuron[]> {
   return [];
+}
+
+async function queryLastestRewardEvent({
+  identity: _,
+  certified: __,
+}: ApiQueryParams): Promise<RewardEvent> {
+  return rewardEvent;
 }
 
 /////////////////////////////////

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -13,6 +13,7 @@ import {
   createMockKnownNeuron,
   createMockNeuron,
 } from "$tests/mocks/neurons.mock";
+import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { Topic, Vote } from "@dfinity/nns";
 import type { RewardEvent } from "@dfinity/nns/dist/candid/governance";
@@ -386,14 +387,7 @@ describe("neurons api-service", () => {
   });
 
   describe("queryLastestRewardEvent", () => {
-    const rewardEvent1: RewardEvent = {
-      rounds_since_last_distribution: [BigInt(1_000)],
-      day_after_genesis: BigInt(365),
-      actual_timestamp_seconds: BigInt(12234455555),
-      total_available_e8s_equivalent: BigInt(20_000_000_000),
-      distributed_e8s_equivalent: BigInt(2_000_000_000),
-      settled_proposals: [],
-    };
+    const rewardEvent1: RewardEvent = mockRewardEvent;
     const rewardEvent2: RewardEvent = {
       ...rewardEvent1,
       rounds_since_last_distribution: [BigInt(2_000)],

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -4,6 +4,7 @@ import {
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
+  lastestRewardEvent,
   leaveCommunityFund,
   mergeMaturity,
   mergeNeurons,
@@ -650,6 +651,24 @@ describe("neurons-api", () => {
         proposalId,
         vote: Vote.Yes,
       });
+    });
+  });
+
+  describe("lastestRewardEvent", () => {
+    const identity = mockIdentity;
+
+    it("should call the canister to get the latest reward", async () => {
+      const certified = true;
+      await lastestRewardEvent({
+        certified,
+        identity,
+      });
+      expect(mockGovernanceCanister.lastestRewardEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(mockGovernanceCanister.lastestRewardEvent).toHaveBeenCalledWith(
+        certified
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -4,11 +4,11 @@ import {
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
-  lastestRewardEvent,
   leaveCommunityFund,
   mergeMaturity,
   mergeNeurons,
   queryKnownNeurons,
+  queryLastestRewardEvent,
   queryNeuron,
   queryNeurons,
   registerVote,
@@ -654,19 +654,19 @@ describe("neurons-api", () => {
     });
   });
 
-  describe("lastestRewardEvent", () => {
+  describe("queryLastestRewardEvent", () => {
     const identity = mockIdentity;
 
     it("should call the canister to get the latest reward", async () => {
       const certified = true;
-      await lastestRewardEvent({
+      await queryLastestRewardEvent({
         certified,
         identity,
       });
-      expect(mockGovernanceCanister.lastestRewardEvent).toHaveBeenCalledTimes(
-        1
-      );
-      expect(mockGovernanceCanister.lastestRewardEvent).toHaveBeenCalledWith(
+      expect(
+        mockGovernanceCanister.getLastestRewardEvent
+      ).toHaveBeenCalledTimes(1);
+      expect(mockGovernanceCanister.getLastestRewardEvent).toHaveBeenCalledWith(
         certified
       );
     });

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -11,7 +11,7 @@ import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { rewardEvent } from "$tests/mocks/nns-reward-event.mock";
+import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -39,7 +39,9 @@ describe("NeuronDetail", () => {
     neuronsStore.reset();
     voteRegistrationStore.reset();
     jest.spyOn(api, "queryNeurons").mockResolvedValue([neuron, mockNeuron]);
-    jest.spyOn(api, "queryLastestRewardEvent").mockResolvedValue(rewardEvent);
+    jest
+      .spyOn(api, "queryLastestRewardEvent")
+      .mockResolvedValue(mockRewardEvent);
   });
 
   it("should query neurons", async () => {

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -11,6 +11,7 @@ import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { rewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -38,6 +39,7 @@ describe("NeuronDetail", () => {
     neuronsStore.reset();
     voteRegistrationStore.reset();
     jest.spyOn(api, "queryNeurons").mockResolvedValue([neuron, mockNeuron]);
+    jest.spyOn(api, "queryLastestRewardEvent").mockResolvedValue(rewardEvent);
   });
 
   it("should query neurons", async () => {

--- a/frontend/src/tests/mocks/nns-reward-event.mock.ts
+++ b/frontend/src/tests/mocks/nns-reward-event.mock.ts
@@ -1,0 +1,10 @@
+import type { RewardEvent } from "@dfinity/nns";
+
+export const rewardEvent: RewardEvent = {
+  rounds_since_last_distribution: [BigInt(1_000)],
+  day_after_genesis: BigInt(365),
+  actual_timestamp_seconds: BigInt(12234455555),
+  total_available_e8s_equivalent: BigInt(20_000_000_000),
+  distributed_e8s_equivalent: BigInt(2_000_000_000),
+  settled_proposals: [],
+};

--- a/frontend/src/tests/mocks/nns-reward-event.mock.ts
+++ b/frontend/src/tests/mocks/nns-reward-event.mock.ts
@@ -1,6 +1,6 @@
 import type { RewardEvent } from "@dfinity/nns";
 
-export const rewardEvent: RewardEvent = {
+export const mockRewardEvent: RewardEvent = {
   rounds_since_last_distribution: [BigInt(1_000)],
   day_after_genesis: BigInt(365),
   actual_timestamp_seconds: BigInt(12234455555),


### PR DESCRIPTION
# Motivation

We want to show the last time that maturity was distrubuted.

This PR: It implements the api functions to get latest reward events and sets up the service.

Upcoming PRs: Store the event in a store and use it in the component.

# Changes

* Upgrade next dependencies.
* New governance api function `queryLastestRewardEvent`.
* Add new method in Governance Api Service `queryLastestRewardEvent`. For now, no caching is done.
* Setup reward service `loadLatestRewardEvent` and use it in NnsNeuronDetail page mount.

# Tests

* Test new api function.
* Test new governance api service method.
* Mock api function where needed to pass current tests.
