### PR TITLE
Fix: Set II release to be used

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -29,7 +29,7 @@
       "type": "custom",
       "wasm": "internet_identity_dev.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-01-31/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"
@@ -727,7 +727,7 @@
     "medium06": {
       "config": {
         "FETCH_ROOT_KEY": true,
-        "HOST": "https://medium06.testnet.dfinity.network",
+        "HOST": "https://medium06.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_2": true,
           "ENABLE_SNS_VOTING": true,


### PR DESCRIPTION
# Motivation

Deploying II from nns-dapp repo to a testnet deploys a broken II for testnets.

This PR sets the II version to be used, instead of relying in the latest version.

# Changes

* Change build step for internet_identity project in dfx.json

# Tests

Not applicable
