### PR TITLE
Feat: Add caching for known neurons calls

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -39,10 +39,28 @@ import {
 import { SECONDS_IN_MINUTE } from "$lib/constants/constants";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import type { Identity } from "@dfinity/agent";
-import type { NeuronInfo } from "@dfinity/nns";
+import type { KnownNeuron, NeuronInfo } from "@dfinity/nns";
 import { isNullish, nonNullish } from "@dfinity/utils";
 
 const cacheExpirationDurationSeconds = 5 * SECONDS_IN_MINUTE;
+
+interface KnownNeuronsCache {
+  knownNeurons: KnownNeuron[];
+  // When the neurons were cached.
+  timestampSeconds: number;
+}
+
+let knownNeuronsCache: KnownNeuronsCache | null = null;
+
+const hasValidKnownNeuronsCache = (): boolean => {
+  if (isNullish(knownNeuronsCache)) {
+    return false;
+  }
+  return (
+    nowInSeconds() - knownNeuronsCache.timestampSeconds <
+    cacheExpirationDurationSeconds
+  );
+};
 
 interface NeuronsCache {
   neurons: NeuronInfo[];
@@ -56,6 +74,7 @@ let neuronsCache: NeuronsCache | null = null;
 
 export const clearCache = () => {
   neuronsCache = null;
+  knownNeuronsCache = null;
 };
 
 const hasValidCachedNeurons = (identity: Identity): boolean => {
@@ -88,8 +107,19 @@ export const resetNeuronsApiService = () => {
 
 export const governanceApiService = {
   // Read calls
-  queryKnownNeurons(params: ApiQueryParams) {
-    return queryKnownNeurons(params);
+  async queryKnownNeurons(params: ApiQueryParams) {
+    if (nonNullish(knownNeuronsCache) && hasValidKnownNeuronsCache()) {
+      return knownNeuronsCache.knownNeurons;
+    }
+    const promise = queryKnownNeurons(params);
+    if (!params.certified) {
+      return promise;
+    }
+    knownNeuronsCache = {
+      knownNeurons: await promise,
+      timestampSeconds: nowInSeconds(),
+    };
+    return knownNeuronsCache.knownNeurons;
   },
   queryNeuron(params: ApiQueryNeuronParams) {
     return queryNeuron(params);

--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -57,7 +57,7 @@ const hasValidKnownNeuronsCache = (): boolean => {
     return false;
   }
   return (
-    nowInSeconds() - knownNeuronsCache.timestampSeconds <
+    nowInSeconds() - knownNeuronsCache.timestampSeconds <=
     cacheExpirationDurationSeconds
   );
 };

--- a/frontend/src/lib/services/known-neurons.services.ts
+++ b/frontend/src/lib/services/known-neurons.services.ts
@@ -1,4 +1,4 @@
-import * as api from "$lib/api/governance.api";
+import { governanceApiService } from "$lib/api-services/governance.api-service";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { KnownNeuron } from "@dfinity/nns";
@@ -6,7 +6,7 @@ import { queryAndUpdate } from "./utils.services";
 
 export const listKnownNeurons = (): Promise<void> => {
   return queryAndUpdate<KnownNeuron[], unknown>({
-    request: (options) => api.queryKnownNeurons(options),
+    request: (options) => governanceApiService.queryKnownNeurons(options),
     onLoad: ({ response: neurons }) => knownNeuronsStore.setNeurons(neurons),
     onError: ({ error: err, certified, identity }) => {
       console.error(err);


### PR DESCRIPTION
# Motivation

Reduce the number of calls by caching the known neurons.

# Changes

* Service to load known neuron  `listKnownNeurons` uses api service layer.
* Implemet caching for `queryKnownNeurons` in the Governance Api Sevice. Caching doesn't depend on identity because it's the same for all users.

# Tests

* Test that caching works as expected.
