### PR TITLE
Remove hw chunk

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,16 +27,6 @@ const config: UserConfig = {
             return "qr";
           }
 
-          // Put ledger and anything commonjs polyfill in the same chunk
-          if (
-            ["@ledgerhq", "semver", "@zondax", "buffer"].find((lib) =>
-              folder.includes(lib)
-            ) !== undefined &&
-            folder.includes("node_modules")
-          ) {
-            return "hw";
-          }
-
           if (
             ["@sveltejs", "svelte", "@dfinity/gix-components"].find((lib) =>
               folder.includes(lib)


### PR DESCRIPTION
# Motivation

The purpose of the hw chunk was to load hardware wallet logic dynamically only when it's needed.
This does not appear to be working as the vendor chunk currently imports the hw chunk and the hw chunk can be seen to be loaded on initial load.

Additionally, the circular dependency between the chunks seems to occasionally trip up Rollup again to cause build reproducibility issues as well as E2e test flakiness.

# Changes

Remove the hw chunk from `frontend/vite.config.ts`.

# Tests

I did limited manual testing but I did not do any testing with hardware wallets.