### PR TITLE
GIX-1481: Render last maturity distribution date

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -18,6 +18,9 @@
   } from "$lib/utils/neuron.utils";
   import { accountsStore } from "$lib/stores/accounts.store";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
+  import { nonNullish } from "@dfinity/utils";
+  import { secondsToDate } from "$lib/utils/date.utils";
 
   export let neuron: NeuronInfo;
 
@@ -27,6 +30,11 @@
     identity: $authStore.identity,
     accounts: $accountsStore,
   });
+
+  let showDetails: boolean;
+  $: showDetails =
+    nonNullish(neuron.fullNeuron?.stakedMaturityE8sEquivalent) ||
+    nonNullish($nnsLatestRewardEventStore);
 </script>
 
 <CardInfo>
@@ -40,13 +48,30 @@
     <h3 slot="value">{formattedTotalMaturity(neuron)}</h3>
   </KeyValuePairInfo>
 
-  {#if neuron.fullNeuron?.stakedMaturityE8sEquivalent !== undefined}
-    <KeyValuePair testId="staked-maturity">
-      <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
-      <span slot="value" class="staked-maturity"
-        >{formattedStakedMaturity(neuron)}</span
-      >
-    </KeyValuePair>
+  {#if showDetails}
+    <div class="details">
+      {#if nonNullish(neuron.fullNeuron?.stakedMaturityE8sEquivalent)}
+        <KeyValuePair testId="staked-maturity">
+          <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
+          <span slot="value">{formattedStakedMaturity(neuron)}</span>
+        </KeyValuePair>
+      {/if}
+
+      {#if nonNullish($nnsLatestRewardEventStore)}
+        <KeyValuePair testId="last-distribution-maturity">
+          <svelte:fragment slot="key"
+            >{$i18n.neuron_detail.maturity_last_distribution}</svelte:fragment
+          >
+          <span slot="value"
+            >{secondsToDate(
+              Number(
+                $nnsLatestRewardEventStore.rewardEvent.actual_timestamp_seconds
+              )
+            )}</span
+          >
+        </KeyValuePair>
+      {/if}
+    </div>
   {/if}
 
   {#if isControllable}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -37,7 +37,7 @@
     nonNullish($nnsLatestRewardEventStore);
 </script>
 
-<CardInfo>
+<CardInfo testId="nns-neuron-maturity-card-component">
   <KeyValuePairInfo testId="maturity">
     <h3 slot="key">{$i18n.neuron_detail.maturity_title}</h3>
     <svelte:fragment slot="info"

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturityCard.svelte
@@ -42,13 +42,15 @@
   </KeyValuePair>
 
   {#if hasStakedMaturity(neuron)}
-    <KeyValuePair testId="staked-maturity">
-      <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
+    <div class="details">
+      <KeyValuePair testId="staked-maturity">
+        <svelte:fragment slot="key">{$i18n.neurons.staked}</svelte:fragment>
 
-      <span slot="value" class="staked-maturity"
-        >{formattedStakedMaturity(neuron)}</span
-      >
-    </KeyValuePair>
+        <span slot="value">{formattedStakedMaturity(neuron)}</span>
+      </KeyValuePair>
+
+      <!-- TODO: Add Last maturity distribution date -->
+    </div>
   {/if}
 
   {#if allowedToStakeMaturity}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -542,6 +542,7 @@
     "auto_stake_maturity_off_success": "Stopped automatically staking new maturity.",
     "community_fund_more_info": "Join the community fund to support growing projects on the IC. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/community-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about the community fund\" target=\"_blank\">Learn more</a> about how your neurons (un-staked) maturity is used.",
     "maturity_title": "Maturity",
+    "maturity_last_distribution": "Last Maturity Distribution",
     "stake_maturity": "Stake Maturity",
     "stake": "Stake",
     "spawn_neuron": "Spawn Neuron",

--- a/frontend/src/lib/themes/mixins/_neuron.scss
+++ b/frontend/src/lib/themes/mixins/_neuron.scss
@@ -12,10 +12,6 @@
     padding-top: var(--padding-2x);
   }
 
-  .staked-maturity {
-    margin: var(--padding-0_5x) 0 0;
-  }
-
   .details {
     display: flex;
     flex-flow: column;

--- a/frontend/src/lib/themes/mixins/_neuron.scss
+++ b/frontend/src/lib/themes/mixins/_neuron.scss
@@ -15,6 +15,13 @@
   .staked-maturity {
     margin: var(--padding-0_5x) 0 0;
   }
+
+  .details {
+    display: flex;
+    flex-flow: column;
+    gap: var(--padding-1_5x);
+    margin: var(--padding-0_5x) 0 0;
+  }
 }
 
 @mixin neuron-card-content {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -565,6 +565,7 @@ interface I18nNeuron_detail {
   auto_stake_maturity_off_success: string;
   community_fund_more_info: string;
   maturity_title: string;
+  maturity_last_distribution: string;
   stake_maturity: string;
   stake: string;
   spawn_neuron: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -22,13 +22,8 @@ import {
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
-// TODO: Fix prettier command. For some reason it moves the JestPageObjectElement import after the KeyValuePairPo import.
-// Yet, it doesn't happen in other files like NnsNeuronDetails.spec.ts
-// VSCode prettier plugin works fine.
-// prettier-ignore
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-// prettier-ignore
-import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
+import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 
@@ -289,12 +284,11 @@ describe("NnsNeuronMaturityCard", () => {
         },
       });
 
-      const keyValuePairPo = KeyValuePairPo.under({
-        element: new JestPageObjectElement(container),
-        testId: "last-distribution-maturity",
-      });
+      const po = NnsNeuronMaturityCardPo.under(
+        new JestPageObjectElement(container)
+      );
 
-      expect(await keyValuePairPo.getValueText()).toEqual("May 22, 1992");
+      expect(await po.getLastDistributionMaturity()).toEqual("May 22, 1992");
     });
 
     it("should not render last maturity distribution if not in store", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -22,8 +22,8 @@ import {
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -268,8 +268,10 @@ describe("NnsNeuronMaturityCard", () => {
     it("should render last maturity distribution if present in store", async () => {
       const rewardEvent = {
         ...mockRewardEvent,
-        actual_timestamp_seconds: BigInt(new Date("1992-05-22T21:00:00").getTime() / 1000),
-      }
+        actual_timestamp_seconds: BigInt(
+          new Date("1992-05-22T21:00:00").getTime() / 1000
+        ),
+      };
       nnsLatestRewardEventStore.setLatestRewardEvent({
         rewardEvent,
         certified: true,
@@ -297,8 +299,10 @@ describe("NnsNeuronMaturityCard", () => {
           testComponent: NnsNeuronMaturityCard,
         },
       });
-      
-      expect(queryByTestId("last-distribution-maturity")).not.toBeInTheDocument();
+
+      expect(
+        queryByTestId("last-distribution-maturity")
+      ).not.toBeInTheDocument();
     });
-  })
+  });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -22,7 +22,12 @@ import {
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
+// TODO: Fix prettier command. For some reason it moves the JestPageObjectElement import after the KeyValuePairPo import.
+// Yet, it doesn't happen in other files like NnsNeuronDetails.spec.ts
+// VSCode prettier plugin works fine.
+// prettier-ignore
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+// prettier-ignore
 import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -6,6 +6,7 @@ import NnsNeuronMaturityCard from "$lib/components/neuron-detail/NnsNeuronMaturi
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import {
   formattedStakedMaturity,
   formattedTotalMaturity,
@@ -20,6 +21,9 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 
@@ -255,4 +259,46 @@ describe("NnsNeuronMaturityCard", () => {
       );
     });
   });
+
+  describe("last maturity distribution", () => {
+    beforeEach(() => {
+      nnsLatestRewardEventStore.reset();
+    });
+
+    it("should render last maturity distribution if present in store", async () => {
+      const rewardEvent = {
+        ...mockRewardEvent,
+        actual_timestamp_seconds: BigInt(new Date("1992-05-22T21:00:00").getTime() / 1000),
+      }
+      nnsLatestRewardEventStore.setLatestRewardEvent({
+        rewardEvent,
+        certified: true,
+      });
+
+      const { container } = render(NeuronContextActionsTest, {
+        props: {
+          neuron,
+          testComponent: NnsNeuronMaturityCard,
+        },
+      });
+
+      const keyValuePairPo = KeyValuePairPo.under({
+        element: new JestPageObjectElement(container),
+        testId: "last-distribution-maturity",
+      });
+
+      expect(await keyValuePairPo.getValueText()).toEqual("May 22, 1992");
+    });
+
+    it("should not render last maturity distribution if not in store", async () => {
+      const { queryByTestId } = render(NeuronContextActionsTest, {
+        props: {
+          neuron,
+          testComponent: NnsNeuronMaturityCard,
+        },
+      });
+      
+      expect(queryByTestId("last-distribution-maturity")).not.toBeInTheDocument();
+    });
+  })
 });

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -14,7 +14,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
+import { NnsNeuronDetailPo } from "$tests/page-objects/NnsNeuronDetail.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -132,11 +132,10 @@ describe("NeuronDetail", () => {
 
     await runResolvedPromises();
 
-    const keyValuePairPo = KeyValuePairPo.under({
-      element: new JestPageObjectElement(container),
-      testId: "last-distribution-maturity",
-    });
+    const po = NnsNeuronDetailPo.under(new JestPageObjectElement(container));
 
-    expect(await keyValuePairPo.getValueText()).toEqual("May 22, 1992");
+    expect(await po.getMaturityCardPo().getLastDistributionMaturity()).toEqual(
+      "May 22, 1992"
+    );
   });
 });

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsNeuronMaturityCardPo } from "./NnsNeuronMaturityCard.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";
@@ -17,5 +18,9 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return (
       (await this.isPresent()) && (await this.getSkeletonCardPos()).length === 0
     );
+  }
+
+  getMaturityCardPo(): NnsNeuronMaturityCardPo {
+    return NnsNeuronMaturityCardPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { KeyValuePairPo } from "./KeyValuePair.page-object";
+
+export class NnsNeuronMaturityCardPo extends BasePageObject {
+  private static readonly TID = "nns-neuron-maturity-card-component";
+
+  static under(element: PageObjectElement): NnsNeuronMaturityCardPo {
+    return new NnsNeuronMaturityCardPo(
+      element.byTestId(NnsNeuronMaturityCardPo.TID)
+    );
+  }
+
+  getLastDistributionPo(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "last-distribution-maturity",
+    });
+  }
+
+  getLastDistributionMaturity(): Promise<string> {
+    return this.getLastDistributionPo().getValueText();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to show the last time that maturity was distributed.

This PR implements rendering the date of the last reward in the maturity card.

# Changes

* Render another KeyValuePair in NnsNeuronMaturityCard with the latest maturity distribution date.
* Adapt styles to combine both staked maturity and latest distribution pairs.

# Tests

* Add test in NnsNeuronDetail page to check that last maturity distribution date is rendered.
* Add test in NnsNeuronMaturityCard to check that last maturity distribution date is rendered or not.
