### PR TITLE
Fix: Add SNS Aggregator URL placeholder in CSP

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -8,6 +8,9 @@ import { findHtmlFiles } from "./build.utils.mjs";
 
 dotenv.config();
 
+const aggregatorCanisterUrl = process.env.VITE_AGGREGATOR_CANISTER_URL;
+const isAggregatorCanisterUrlDefined = aggregatorCanisterUrl.length > 0;
+
 const buildCsp = (htmlFile) => {
   // 1. We extract the start script parsed by SvelteKit into the html file
   const indexHTMLWithoutStartScript = extractStartScript(htmlFile);
@@ -212,6 +215,10 @@ const cspConnectSrc = () => {
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
   ];
+
+  if (isAggregatorCanisterUrlDefined) {
+    src.push(aggregatorCanisterUrl);
+  }
 
   return src
     .filter((url) => url !== undefined)

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -210,6 +210,7 @@ const cspConnectSrc = () => {
     "${{HOST}}",
     "${{GOVERNANCE_CANISTER_URL}}",
     "${{LEDGER_CANISTER_URL}}",
+    "${{SNS_AGGREGATOR_URL}}",
     // TODO: solve with a worker
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -8,9 +8,6 @@ import { findHtmlFiles } from "./build.utils.mjs";
 
 dotenv.config();
 
-const aggregatorCanisterUrl = process.env.VITE_AGGREGATOR_CANISTER_URL;
-const isAggregatorCanisterUrlDefined = aggregatorCanisterUrl.length > 0;
-
 const buildCsp = (htmlFile) => {
   // 1. We extract the start script parsed by SvelteKit into the html file
   const indexHTMLWithoutStartScript = extractStartScript(htmlFile);
@@ -215,10 +212,6 @@ const cspConnectSrc = () => {
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
   ];
-
-  if (isAggregatorCanisterUrlDefined) {
-    src.push(aggregatorCanisterUrl);
-  }
 
   return src
     .filter((url) => url !== undefined)

--- a/frontend/src/lib/constants/sns.constants.ts
+++ b/frontend/src/lib/constants/sns.constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_SNS_LOGO = "/assets/sns-logo-default.svg";
 export const AGGREGATOR_CANISTER_VERSION = "v1";
-export const AGGREGATOR_CANISTER_PATH = "/sns/list/latest/slow.json";
+export const AGGREGATOR_CANISTER_PATH = "/sns/list/page/0/slow.json";
 export const SALE_PARTICIPATION_RETRY_SECONDS = 2;
 export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 10_000;

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -18,7 +18,7 @@ describe("sns-aggregator api", () => {
       global.fetch = mockFetch;
       await querySnsProjects();
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/latest/slow.json`
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
       );
     });
 


### PR DESCRIPTION
# Motivation

We want wasms that are agnostic to the testnet they will be installed in.

In this PR: I added a missing env var (SNS_AGGREGATOR_URL) used for the CSP rule.

# Changes

* Add placeholder `SNS_AGGREGATOR_URL` in CSP content-src rule.

# Tests

Not applicable
