### PR TITLE
SNS E2E: Navigate to the neurons tab

### DIFF
--- a/frontend/src/lib/components/ui/EmptyMessage.svelte
+++ b/frontend/src/lib/components/ui/EmptyMessage.svelte
@@ -1,4 +1,4 @@
-<p class="description empty"><slot /></p>
+<p class="description empty" data-tid="empty-message-component"><slot /></p>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -32,6 +32,14 @@ test("Test SNS governance", async ({ page, context }) => {
       .getBalance()
   ).toEqual("20.00");
 
+  await appPo.goToNeurons();
+  await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
+  expect(
+    await appPo.getNeuronsPo().getSnsNeuronsPo().getEmptyMessage()
+  ).toEqual(
+    `You have no ${snsProjectName} neurons. Stake a neuron to vote on proposals for ${snsProjectName}.`
+  );
+
   // TODO:
   // SN001: User can see the list of neurons
 

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,9 +1,10 @@
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
+import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 export class AppPo extends BasePageObject {
   getAccountsPo(): AccountsPo {
@@ -12,6 +13,10 @@ export class AppPo extends BasePageObject {
 
   getWalletPo(): WalletPo {
     return WalletPo.under(this.root);
+  }
+
+  getNeuronsPo(): NeuronsPo {
+    return NeuronsPo.under(this.root);
   }
 
   getMenuItemsPo(): MenuItemsPo {
@@ -61,6 +66,12 @@ export class AppPo extends BasePageObject {
       await this.toggleMenu();
       await backdrop.waitForAbsent();
     }
+  }
+
+  async goToNeurons(): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().clickNeuronStaking();
+    // Menu closes automatically.
   }
 
   async getTokens(amount: number): Promise<void> {

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -9,6 +9,10 @@ export class MenuItemsPo extends BasePageObject {
     return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
   }
 
+  clickNeuronStaking(): void {
+    this.click("menuitem-neurons");
+  }
+
   getGetTokensPo(): GetTokensPo {
     return GetTokensPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -10,8 +10,9 @@ export class SnsNeuronsPo extends BasePageObject {
     return new SnsNeuronsPo(element.byTestId(SnsNeuronsPo.TID));
   }
 
-  getSkeletonCardPos(): Promise<SkeletonCardPo[]> {
-    return SkeletonCardPo.allUnder(this.root);
+  getSkeletonCardPo(): SkeletonCardPo {
+    // There are multiple but we only need one.
+    return SkeletonCardPo.under(this.root);
   }
 
   getNeuronCardPos(): Promise<SnsNeuronCardPo[]> {
@@ -20,8 +21,17 @@ export class SnsNeuronsPo extends BasePageObject {
 
   async isContentLoaded(): Promise<boolean> {
     return (
-      (await this.isPresent()) && (await this.getSkeletonCardPos()).length === 0
+      (await this.isPresent()) && !(await this.getSkeletonCardPo().isPresent())
     );
+  }
+
+  async waitForContentLoaded(): Promise<void> {
+    await this.waitFor();
+    await this.getSkeletonCardPo().waitForAbsent();
+  }
+
+  getEmptyMessage(): Promise<string> {
+    return this.getText("empty-message-component");
   }
 
   async getNeuronIds(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -1,4 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { isNullish } from "@dfinity/utils";
 
 // Most page objects should extends BasePageObject instead.
 export class SimpleBasePageObject {
@@ -20,11 +21,17 @@ export class SimpleBasePageObject {
     return this.root.waitForAbsent();
   }
 
-  click(): Promise<void> {
-    return this.root.click();
+  click(tid: string | undefined): Promise<void> {
+    if (isNullish(tid)) {
+      return this.root.click();
+    }
+    return this.root.byTestId(tid).click();
   }
 
-  getText(tid: string): Promise<string> {
+  getText(tid: string | undefined): Promise<string> {
+    if (isNullish(tid)) {
+      return this.root.getText();
+    }
     return this.root.byTestId(tid).getText();
   }
 }


### PR DESCRIPTION
# Motivation

Continuing with SNS end-to-end test.

# Changes

1. In `frontend/src/tests/e2e/sns-governance.spec.ts` Navigate to the Neuron staking tab.
2. Add tid in `frontend/src/lib/components/ui/EmptyMessage.svelte`
3. Change `frontend/src/tests/page-objects/SnsNeurons.page-object.ts` to check whether the first skeleton card is present rather than whether the number of skeleton cards is 0. This is easier to use with waitFor.
4. For convenience, add optional `tid` arguments to `getText()` and `click` in SImpleBasePageObject to allow specifying specific child elements.

# Tests

`npm run test`
`npm run test-e2e`
