### PR TITLE
Wait for aggregator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,10 +111,10 @@ jobs:
           npm ci
       - name: Wait for aggregator to get all SNSs
         run: |
-          for (( i=300; i>0; i-- )); do
-             num_sns="$(for ((i=0; i<3; i++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$i/slow.json" | jq length ; } 2>/dev/null ; done | awk '{i+=$1}END{print i}')"
+          for (( try=300; try>0; try-- )); do
+             num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
-             printf "\r #SNS: % 4d   Tries remaining: 4d" "$num_sns" "$i"
+             printf "\r #SNS: % 4d   Tries remaining: 4d" "$num_sns" "$try"
              sleep 1
           done
       - name: Run Playwright end-to-end tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
           npm ci
       - name: Wait for aggregator to get all SNSs
         run: |
+          set +x
           for (( try=300; try>0; try-- )); do
              num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
              num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
              printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
-             sleep 2
+             sleep 10
           done
       - name: Run Playwright end-to-end tests
         working-directory: frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           DFX_NETWORK=local ./config.sh
           echo "Install:"
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
-          dfx canister install sns_aggregator --wasm out/sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+          dfx canister install sns_aggregator --wasm sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # Is the argument not passed through, or why is this so slow?
           dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           DFX_NETWORK=local ./config.sh
           echo "Install:"
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
-          dfx canister install sns_aggregator --wasm sns_aggregator.wasm --upgrade-unchanged --mode reinstall --yes
+          dfx canister install sns_aggregator --wasm sns_aggregator.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.
           jq '.canisters.internet_identity.remote.id={}' dfx.json > dfx.json.v2 && mv dfx.json.v2 dfx.json
           curl --retry 5 --fail -sSL "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm" -o internet_identity_dev.wasm
@@ -109,6 +109,13 @@ jobs:
         working-directory: frontend
         run: |
           npm ci
+      - name: Wait for aggregator to get all SNSs
+        run: |
+          for (( i=300; i>0; i-- )); do
+             (( $(seq 0 1 | xargs -I{} curl -sS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/{}/slow.json" | jq '.[]|.index' | wc -l) < 12)) || break
+             printf "\r % 4d" "$i"
+             sleep 1
+          done
       - name: Run Playwright end-to-end tests
         working-directory: frontend
         run: npm run test-e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
              num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
              printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
-             sleep 1
+             sleep 2
           done
       - name: Run Playwright end-to-end tests
         working-directory: frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
           echo "Install:"
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
           dfx canister install sns_aggregator --wasm sns_aggregator.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+          # Is the argument not passed through, or why is this so slow?
+          dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.
           jq '.canisters.internet_identity.remote.id={}' dfx.json > dfx.json.v2 && mv dfx.json.v2 dfx.json
           curl --retry 5 --fail -sSL "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm" -o internet_identity_dev.wasm
@@ -116,7 +118,7 @@ jobs:
              num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
              printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
-             sleep 10
+             sleep 2
           done
       - name: Run Playwright end-to-end tests
         working-directory: frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,9 @@ jobs:
       - name: Wait for aggregator to get all SNSs
         run: |
           for (( i=300; i>0; i-- )); do
-             (( $(seq 0 1 | xargs -I{} curl -sS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/{}/slow.json" | jq '.[]|.index' | wc -l) < 12)) || break
-             printf "\r % 4d" "$i"
+             num_sns="$(for ((i=0; i<3; i++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$i/slow.json" | jq length ; } 2>/dev/null ; done | awk '{i+=$1}END{print i}')"
+             (( num_sns < 12)) || break
+             printf "\r #SNS: % 4d   Tries remaining: 4d" "$num_sns" "$i"
              sleep 1
           done
       - name: Run Playwright end-to-end tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Wait for aggregator to get all SNSs
         run: |
           for (( try=300; try>0; try-- )); do
-             num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null ; done | awk '{i+=$1}END{print i}')"
+             num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
              printf "\r #SNS: % 4d   Tries remaining: 4d" "$num_sns" "$try"
              sleep 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
           dfx canister install sns_aggregator --wasm sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # Is the argument not passed through, or why is this so slow?
-          dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+          #dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.
           jq '.canisters.internet_identity.remote.id={}' dfx.json > dfx.json.v2 && mv dfx.json.v2 dfx.json
           curl --retry 5 --fail -sSL "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm" -o internet_identity_dev.wasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
           echo "Install:"
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
           dfx canister install sns_aggregator --wasm sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
-          # Is the argument not passed through, or why is this so slow?
-          #dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+          # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:
+          dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.
           jq '.canisters.internet_identity.remote.id={}' dfx.json > dfx.json.v2 && mv dfx.json.v2 dfx.json
           curl --retry 5 --fail -sSL "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm" -o internet_identity_dev.wasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           for (( try=300; try>0; try-- )); do
              num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
              (( num_sns < 12)) || break
-             printf "\r #SNS: % 4d   Tries remaining: 4d" "$num_sns" "$try"
+             printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
              sleep 1
           done
       - name: Run Playwright end-to-end tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           DFX_NETWORK=local ./config.sh
           echo "Install:"
           dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
-          dfx canister install sns_aggregator --wasm sns_aggregator.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+          dfx canister install sns_aggregator --wasm out/sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # Is the argument not passed through, or why is this so slow?
           dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # We wish to upgrade the II canister, so the II canister is no longer remote per the dfx remote canister concept.


### PR DESCRIPTION
# Motivation
Apparently e2e tests are flaking out because the aggregator doesn't have enough data when the e2e tests run.

# Changes
* Configure the aggregator collect data quickly.
  * Note: The local replica has an artificial delay to make timing realistic.  In the next dfx that delay is configurable, so it can be made short for fast CI tests or it can be made long to simulate usage in a stressed environment.  This would help here as well, once we upgrade.
*  Wait for the aggregator to have 12 SNS before running e2e tests

# Tests
See CI