### PR TITLE
Fix aggregator URL on local

### DIFF
--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -14,7 +14,7 @@ const snsAggregatorUrlEnv = envVars.snsAggregatorUrl ?? "";
 const snsAggregatorUrl = (url: string) => {
   try {
     const { hostname } = new URL(url);
-    if (["localhost", "127.0.0.1"].includes(hostname)) {
+    if (hostname.includes("localhost") || hostname.includes("127.0.0.1")) {
       return url;
     }
 


### PR DESCRIPTION
# Motivation

When the frontend runs on localhost but the aggregator on testnet, we have to add `.raw` to the URL to avoid CORS issues.
But when the aggregator also runs on localhost, this is not necessary and doesn't work.
We had logic for this but it was broken.

# Changes

Check if the hostname contains `localhost` or `127.0.0.1` instead of checking if it's equal.

# Tests

Manually tested against local and against testnet.