### PR TITLE
feat (aggregator): Include timestamps in logs

### DIFF
--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use ic_cdk::api::management_canister::provisional::CanisterId;
+use ic_cdk::api::time;
 use ic_cdk::timer::TimerId;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -120,6 +121,8 @@ thread_local! {
 /// Log to console and store for retrieval by query calls.
 pub fn log(message: String) {
     ic_cdk::api::print(&message);
+    let now = time();
+    let message = format!("{now}: {message}");
     STATE.with(|state| {
         state.log.borrow_mut().push_back(message);
         if state.log.borrow().len() > 200 {


### PR DESCRIPTION
# Motivation
It would be really convenient to have timestamps in logs, surprise surprise.

We have very basic logs in the sns_aggregator, basically because a nice clean solution should be coming for all canisters with https://dfinity.atlassian.net/browse/IC-272 so it is not worth putting a huge amount of effort into a custom solution.  However work on the "nice" implementation has not started on that yet.  So we need a minimally better stop-gap solution.

# Changes
* Add timestamps to logs.
  * Note: The timestamps use the IC's native time, which provides nanoseconds.  No attempt is made to spend cycles to format the timestamps or do anything fancy whatsoever.

# Tests
```
max@sinkpad:~/dfn/nns-dapp/branches/log-timestamps (6:25)$ dfx-snapshot-restore --snapshot ~/.cache/dfinity/versions/0.13.1/snapshots/state.tar.xz
max@sinkpad:~/dfn/nns-dapp/branches/log-timestamps (6:25)$ ./scripts/docker-build
[SNIP]
fb266c953a2b9e43d80635ec70caae6d1998ddf9380418022cf6d2267e0b23aa  assets.tar.xz
dce3d050e0826e5586ac196ae620de3979d3b778d998e401dc9f25928772460a  nns-dapp.wasm
712402e0181b9ceb2e6d2eaca5efeb15f9dada8b212e1898255930f8e48e8fdf  sns_aggregator.wasm
79cda0d2b763e4e0652d63da9a947c6574e998ea02c94c4e68a69cde8be403db  nns-dapp-arg.did
3098bf74c0dcdafcc7bdd5ef1a3f1b75c15ce55b0a6f8f7290a1d1bf9fe7a39e  nns-dapp-arg.bin
FIN
max@sinkpad:~/dfn/nns-dapp/branches/log-timestamps (1:59)$ dfx canister install sns_aggregator --wasm sns_aggregator.wasm 
Installing code for canister sns_aggregator, with canister ID qvhpv-4qaaa-aaaaa-aaagq-cai
max@sinkpad:~/dfn/nns-dapp/branches/log-timestamps (6:25)$ ./scripts/sns/aggregator/get_log 
1681508570166810973: Calling init...
1681508570166810973: 
///////////////////////////
// R E C O N F I G U R E //
///////////////////////////
// New configuration:
        None
///////////////////////////

1681508570166810973: Using existing config.
1681508570166810973: Inserting asset /favicon.ico
1681508570166810973: Inserting asset /index.html
1681508570166810973: Set interval to 120000
1681508570166810973: Set interval to 10000
1681508570166810973: Getting upstream data...
1681508570166810973: Maybe have SNSs
```