### PR TITLE
Transaction ckBTC simplify estimation label

### DIFF
--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -57,9 +57,17 @@
   fee={bitcoinEstimatedFee}
   testId="bitcoin-estimated-fee-display"
 >
-  {$i18n.accounts.estimated_bitcoin_transaction_fee}
+  {$i18n.accounts.bitcoin_transaction_fee_notice}
 </BitcoinFeeDisplay>
 
 <BitcoinFeeDisplay fee={kytEstimatedFee} testId="kyt-estimated-fee-display">
-  {$i18n.accounts.estimated_internetwork_fee}
+  {$i18n.accounts.internetwork_fee_notice}
 </BitcoinFeeDisplay>
+
+<p>{$i18n.accounts.estimation_notice}</p>
+
+<style lang="scss">
+  p {
+    margin: var(--padding) 0 0;
+  }
+</style>

--- a/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
@@ -11,13 +11,13 @@
 <div>
   <p class="label">
     {#if estimation}
-      {$i18n.accounts.estimated_amount_received}
+      {$i18n.accounts.received_amount_notice}
     {:else}
       {$i18n.accounts.received_amount}
     {/if}
   </p>
 
-  <p class="no-margin" data-tid={testId}>
+  <p class="no-margin" data-tid={testId} class:estimation>
     {#if estimation}<span class="value">≈</span>{/if}<AmountDisplay
       inline
       detailed
@@ -29,5 +29,9 @@
 <style lang="scss">
   p {
     margin: 0 0 var(--padding-0_5x);
+  }
+
+  .estimation {
+    padding: 0 0 var(--padding-0_5x);
   }
 </style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -229,13 +229,16 @@
     "network_btc_mainnet": "Bitcoin (BTC)",
     "network_btc_testnet": "Bitcoin (Testnet BTC)",
     "select_network": "Select network",
+    "bitcoin_transaction_fee_notice": "BTC Network Fee *",
     "estimated_bitcoin_transaction_fee": "Estimated BTC Network Fee",
+    "internetwork_fee_notice": "Internetwork Fee *",
     "estimated_internetwork_fee": "Estimated Internetwork Fee",
-    "estimated_amount_received": "Estimated Received Amount",
+    "estimation_notice": "* Estimation. Fees are applied when transfer is effective.",
     "receive_account": "Account",
     "sending_amount": "Sending Amount",
     "total_deducted": "Total Deducted",
     "received_amount": "Received Amount",
+    "received_amount_notice": "Received Amount *",
     "transaction_time": "Transaction Time"
   },
   "neurons": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -238,13 +238,16 @@ interface I18nAccounts {
   network_btc_mainnet: string;
   network_btc_testnet: string;
   select_network: string;
+  bitcoin_transaction_fee_notice: string;
   estimated_bitcoin_transaction_fee: string;
+  internetwork_fee_notice: string;
   estimated_internetwork_fee: string;
-  estimated_amount_received: string;
+  estimation_notice: string;
   receive_account: string;
   sending_amount: string;
   total_deducted: string;
   received_amount: string;
+  received_amount_notice: string;
   transaction_time: string;
 }
 

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -80,8 +80,21 @@ describe("BitcoinEstimatedAmountReceived", () => {
     });
 
     expect(
-      getByText(en.accounts.estimated_amount_received, { exact: false })
+      getByText(en.accounts.received_amount_notice, { exact: false })
     ).toBeInTheDocument();
+  });
+
+  it("should display label estimated notice", () => {
+    const { getByText } = render(BitcoinEstimatedAmountReceived, {
+      props: {
+        amount: undefined,
+        bitcoinEstimatedFee: undefined,
+        kytEstimatedFee: undefined,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      },
+    });
+
+    expect(getByText(en.accounts.estimation_notice)).toBeInTheDocument();
   });
 
   it("should display btc label", () => {

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
@@ -39,9 +39,7 @@ describe("TransactionReceivedTokenAmount", () => {
       props: { amount, estimation: true },
     });
 
-    expect(
-      getByText(en.accounts.estimated_amount_received)
-    ).toBeInTheDocument();
+    expect(getByText(en.accounts.received_amount_notice)).toBeInTheDocument();
   });
 
   it("should render estimation amount with equals sign", () => {


### PR DESCRIPTION
# Motivation

Instead of repeating "Estimated..." on review step, display a notice.

# Changes

- update label and display notice

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2023-04-15 à 08 30 23" src="https://user-images.githubusercontent.com/16886711/232193386-1e73c81b-4c71-4c63-8e07-c91bc58e04db.png">

After:

<img width="1536" alt="Capture d’écran 2023-04-15 à 08 42 13" src="https://user-images.githubusercontent.com/16886711/232193390-c6ad2339-3e67-4523-884d-13a3ed31931e.png">

