### PR TITLE
Display transaction seconds information

### DIFF
--- a/frontend/src/lib/components/accounts/BitcoinTransactionInfo.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinTransactionInfo.svelte
@@ -5,11 +5,6 @@
 </script>
 
 {#if networkBtc}
-  <p class="label info">{$i18n.accounts.transaction_time}</p>
-  <p class="value no-margin">
-    {$i18n.ckbtc.about_thirty_minutes}
-  </p>
-
   <p class="label info">{$i18n.ckbtc.confirmations}</p>
   <p class="value no-margin">
     {$i18n.ckbtc.typically_twelve}

--- a/frontend/src/lib/components/transaction/TransactionDescription.svelte
+++ b/frontend/src/lib/components/transaction/TransactionDescription.svelte
@@ -2,6 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { nonNullish } from "@dfinity/utils";
   import type { TransactionNetwork } from "$lib/types/transaction";
+  import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
 
   export let destinationAddress: string;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
@@ -23,12 +24,22 @@
   </p>
 {/if}
 
+<p class="label time">{$i18n.accounts.transaction_time}</p>
+<p class="value no-margin">
+  {#if isTransactionNetworkBtc(selectedNetwork)}
+    {$i18n.ckbtc.about_thirty_minutes}
+  {:else}
+    {$i18n.accounts.transaction_time_seconds}
+  {/if}
+</p>
+
 <style lang="scss">
   .account-identifier {
     word-break: break-all;
     margin: 0 0 var(--padding);
   }
 
+  .time,
   .network,
   .desc {
     margin: var(--padding) 0 0;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -236,7 +236,8 @@
     "sending_amount": "Sending Amount",
     "total_deducted": "Total Deducted",
     "received_amount": "Received Amount",
-    "transaction_time": "Transaction Time"
+    "transaction_time": "Transaction Time",
+    "transaction_time_seconds": "Seconds"
   },
   "neurons": {
     "title": "Neurons",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -246,6 +246,7 @@ interface I18nAccounts {
   total_deducted: string;
   received_amount: string;
   transaction_time: string;
+  transaction_time_seconds: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/tests/lib/components/accounts/BitcoinTransactionInfo.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinTransactionInfo.spec.ts
@@ -7,15 +7,6 @@ import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
 
 describe("BitcoinTransactionInfo", () => {
-  it("should display estimated static transaction time", () => {
-    const { getByText } = render(BitcoinEstimatedTransactionTime, {
-      props: { networkBtc: true },
-    });
-
-    expect(getByText(en.accounts.transaction_time)).toBeInTheDocument();
-    expect(getByText(en.ckbtc.about_thirty_minutes)).toBeInTheDocument();
-  });
-
   it("should display confirmations", () => {
     const { getByText } = render(BitcoinEstimatedTransactionTime, {
       props: { networkBtc: true },

--- a/frontend/src/tests/lib/components/transaction/TransactionDescription.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionDescription.spec.ts
@@ -26,6 +26,27 @@ describe("TransactionDescription", () => {
     expect(getByText(en.accounts.description)).toBeInTheDocument();
   });
 
+  it("should render transaction time seconds", () => {
+    const { getByText } = render(TransactionDescription, {
+      props: { destinationAddress: mockMainAccount.identifier },
+    });
+
+    expect(getByText(en.accounts.transaction_time)).toBeInTheDocument();
+    expect(getByText(en.accounts.transaction_time_seconds)).toBeInTheDocument();
+  });
+
+  it("should render transaction time bitcoin", () => {
+    const { getByText } = render(TransactionDescription, {
+      props: {
+        destinationAddress: mockMainAccount.identifier,
+        selectedNetwork: TransactionNetwork.BTC_TESTNET,
+      },
+    });
+
+    expect(getByText(en.accounts.transaction_time)).toBeInTheDocument();
+    expect(getByText(en.ckbtc.about_thirty_minutes)).toBeInTheDocument();
+  });
+
   it("should not render network", () => {
     const { getByTestId } = render(TransactionDescription, {
       props: { destinationAddress: mockMainAccount.identifier },


### PR DESCRIPTION
# Motivation

On ICP network, display transaction information "Seconds" in review step.

# Changes

- display transaction time info for all transaction and seconds if icp

# Screenshot

<img width="1536" alt="Capture d’écran 2023-04-15 à 09 03 13" src="https://user-images.githubusercontent.com/16886711/232194474-d2b9f673-a869-472e-a79c-3cf84e63db00.png">

