### PR TITLE
Lint: Forbid unreachable code

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -17,7 +17,8 @@ module.exports = {
     ecmaVersion: 2020,
   },
   rules: {
-    eqeqeq: ["error"],
+    "eqeqeq": ["error"],
+    "no-unreachable": ["error"],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -33,7 +33,7 @@ export class NnsWalletPo extends BasePageObject {
   }): Promise<void> {
     await this.clickSend();
     const modal = this.getIcpTransactionModalPo();
-    return modal.transferToAccount({
+    await modal.transferToAccount({
       accountName,
       expectedAccountAddress,
       amount,


### PR DESCRIPTION
# Motivation

Unreachable code is usually not intended.
Not allowing it helps to avoid mistakes.

# Changes

1. Configure eslint to forbid unreachable code.
2. Fix the place where we had unreachable code.

# Tests

CI
