### PR TITLE
Feat: Show info text for Last Distribution

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -58,7 +58,7 @@
       {/if}
 
       {#if nonNullish($nnsLatestRewardEventStore)}
-        <KeyValuePair testId="last-distribution-maturity">
+        <KeyValuePairInfo testId="last-distribution-maturity">
           <svelte:fragment slot="key"
             >{$i18n.neuron_detail.maturity_last_distribution}</svelte:fragment
           >
@@ -69,7 +69,12 @@
               )
             )}</span
           >
-        </KeyValuePair>
+          <svelte:fragment slot="info"
+            ><Html
+              text={$i18n.neuron_detail.maturity_last_distribution_info}
+            /></svelte:fragment
+          >
+        </KeyValuePairInfo>
       {/if}
     </div>
   {/if}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -546,7 +546,7 @@
     "community_fund_more_info": "Join the community fund to support growing projects on the IC. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/community-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about the community fund\" target=\"_blank\">Learn more</a> about how your neurons (un-staked) maturity is used.",
     "maturity_title": "Maturity",
     "maturity_last_distribution": "Last Maturity Distribution",
-    "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed.",
+    "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. <a href=\"https://wiki.internetcomputer.org/wiki/Roll-over_of_NNS_voting_rewards\" rel=\"noopener noreferrer\" aria-label=\"more info about the voting rewards\" target=\"_blank\">Learn more</a>",
     "stake_maturity": "Stake Maturity",
     "stake": "Stake",
     "spawn_neuron": "Spawn Neuron",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -546,6 +546,7 @@
     "community_fund_more_info": "Join the community fund to support growing projects on the IC. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/community-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about the community fund\" target=\"_blank\">Learn more</a> about how your neurons (un-staked) maturity is used.",
     "maturity_title": "Maturity",
     "maturity_last_distribution": "Last Maturity Distribution",
+    "maturity_last_distribution_info": "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed.",
     "stake_maturity": "Stake Maturity",
     "stake": "Stake",
     "spawn_neuron": "Spawn Neuron",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -569,6 +569,7 @@ interface I18nNeuron_detail {
   community_fund_more_info: string;
   maturity_title: string;
   maturity_last_distribution: string;
+  maturity_last_distribution_info: string;
   stake_maturity: string;
   stake: string;
   spawn_neuron: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -290,7 +290,7 @@ describe("NnsNeuronMaturityCard", () => {
 
       expect(await po.getLastDistributionMaturity()).toEqual("May 22, 1992");
       expect(await po.getLastDistributionMaturityDescription()).toEqual(
-        "Merge Maturity has been replaced by Stake Maturity. Learn more."
+        "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. Learn more"
       );
     });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -289,6 +289,9 @@ describe("NnsNeuronMaturityCard", () => {
       );
 
       expect(await po.getLastDistributionMaturity()).toEqual("May 22, 1992");
+      expect(await po.getLastDistributionMaturityDescription()).toEqual(
+        "Merge Maturity has been replaced by Stake Maturity. Learn more."
+      );
     });
 
     it("should not render last maturity distribution if not in store", async () => {

--- a/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
@@ -3,6 +3,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class KeyValuePairInfoPo extends BasePageObject {
   private parent: PageObjectElement;
+  private testId: string;
 
   /**
    * KeyValuePairInfo renders two components:
@@ -15,12 +16,15 @@ export class KeyValuePairInfoPo extends BasePageObject {
   constructor({
     parent,
     element,
+    testId,
   }: {
     element: PageObjectElement;
     parent: PageObjectElement;
+    testId: string;
   }) {
     super(element);
     this.parent = parent;
+    this.testId = testId;
   }
 
   static under({
@@ -31,8 +35,9 @@ export class KeyValuePairInfoPo extends BasePageObject {
     testId: string;
   }): KeyValuePairInfoPo {
     return new KeyValuePairInfoPo({
-      element: element.querySelector(`[data-tid=${testId}]`),
+      element: element.byTestId(testId),
       parent: element,
+      testId,
     });
   }
 
@@ -45,6 +50,6 @@ export class KeyValuePairInfoPo extends BasePageObject {
   }
 
   getDescriptionText(): Promise<string> {
-    return this.parent.byTestId("collapsible-content").getText();
+    return this.parent.byTestId(`${this.testId}-description`).getText();
   }
 }

--- a/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
@@ -1,0 +1,50 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class KeyValuePairInfoPo extends BasePageObject {
+  private parent: PageObjectElement;
+
+  /**
+   * KeyValuePairInfo renders two components:
+   * - a div with the key value pair and a button
+   * - a div with the description information
+   *
+   * That's why we need to keep a reference to the parent element
+   * to be able to get the description information
+   */
+  constructor({
+    parent,
+    element,
+  }: {
+    element: PageObjectElement;
+    parent: PageObjectElement;
+  }) {
+    super(element);
+    this.parent = parent;
+  }
+
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
+  }): KeyValuePairInfoPo {
+    return new KeyValuePairInfoPo({
+      element: element.querySelector(`[data-tid=${testId}]`),
+      parent: element,
+    });
+  }
+
+  async getValueText(): Promise<string> {
+    return this.root.querySelector("dd").getText();
+  }
+
+  clickInfoIcon(): Promise<void> {
+    return this.getButton().click();
+  }
+
+  getDescriptionText(): Promise<string> {
+    return this.parent.byTestId("collapsible-content").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { KeyValuePairPo } from "./KeyValuePair.page-object";
+import { KeyValuePairInfoPo } from "./KeyValuePairInfo.page-object";
 
 export class NnsNeuronMaturityCardPo extends BasePageObject {
   private static readonly TID = "nns-neuron-maturity-card-component";
@@ -11,8 +11,8 @@ export class NnsNeuronMaturityCardPo extends BasePageObject {
     );
   }
 
-  getLastDistributionPo(): KeyValuePairPo {
-    return KeyValuePairPo.under({
+  getLastDistributionPo(): KeyValuePairInfoPo {
+    return KeyValuePairInfoPo.under({
       element: this.root,
       testId: "last-distribution-maturity",
     });
@@ -20,5 +20,9 @@ export class NnsNeuronMaturityCardPo extends BasePageObject {
 
   getLastDistributionMaturity(): Promise<string> {
     return this.getLastDistributionPo().getValueText();
+  }
+
+  getLastDistributionMaturityDescription(): Promise<string> {
+    return this.getLastDistributionPo().getDescriptionText();
   }
 }


### PR DESCRIPTION
# Motivation

Show an explanation of the last distributed maturity in NNS.

# Changes

* Use a `KeyValuePairInfo` instead of just a `KeyValuePair` to render the last distributed maturity.

# Tests

* Test that description is also rendered.
