### PR TITLE
Fix confirm cycles overflow style

### DIFF
--- a/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/ConfirmCyclesCanister.svelte
@@ -26,17 +26,19 @@
 </script>
 
 <div class="wrapper" data-tid="confirm-cycles-canister-screen">
-  <div class="conversion">
-    <h3>{formatNumber(amount, { minFraction: 2, maxFraction: 2 })}</h3>
-    <p>{$i18n.core.icp}</p>
+  <p class="conversion">
+    <span class="value"
+      >{formatNumber(amount, { minFraction: 2, maxFraction: 2 })}</span
+    >
+    <span>{$i18n.core.icp}</span>
     {#if tCyclesFormatted !== undefined}
-      <p>{$i18n.canisters.converted_to}</p>
-      <h3>
+      <span class="description">{$i18n.canisters.converted_to}</span>
+      <span class="value">
         {formatNumber(tCyclesFormatted, { minFraction: 2, maxFraction: 2 })}
-      </h3>
-      <p>{$i18n.canisters.t_cycles}</p>
+      </span>
+      <span>{$i18n.canisters.t_cycles}</span>
     {/if}
-  </div>
+  </p>
   <div>
     <TransactionSource {account} />
   </div>
@@ -58,7 +60,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   .wrapper {
     display: flex;
@@ -66,20 +68,7 @@
     gap: var(--padding);
   }
 
-  .conversion {
-    padding: 0 0 var(--padding-4x);
-
-    p,
-    h3 {
-      margin: 0;
-      display: inline-block;
-    }
-
-    @include media.min-width(small) {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: var(--padding);
-    }
+  .value {
+    @include fonts.h3;
   }
 </style>


### PR DESCRIPTION
# Notes

Just a patch. Someday we should take the time to review the all canister creation flow and integrate the `Transaction` components.

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2023-04-18 à 07 11 50" src="https://user-images.githubusercontent.com/16886711/232678518-f44fda37-0906-42da-8502-99cffafe9bad.png">

After:

<img width="1536" alt="Capture d’écran 2023-04-18 à 07 19 06" src="https://user-images.githubusercontent.com/16886711/232678538-7aa9ab18-4050-4c00-ae65-e233057c7131.png">
<img width="1536" alt="Capture d’écran 2023-04-18 à 07 18 54" src="https://user-images.githubusercontent.com/16886711/232678551-89fbccfc-9f4c-4177-896c-0fd21ee46635.png">
