### PR TITLE
Fix: Spacing in last maturity distribution

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -58,23 +58,27 @@
       {/if}
 
       {#if nonNullish($nnsLatestRewardEventStore)}
-        <KeyValuePairInfo testId="last-distribution-maturity">
-          <svelte:fragment slot="key"
-            >{$i18n.neuron_detail.maturity_last_distribution}</svelte:fragment
-          >
-          <span slot="value"
-            >{secondsToDate(
-              Number(
-                $nnsLatestRewardEventStore.rewardEvent.actual_timestamp_seconds
-              )
-            )}</span
-          >
-          <svelte:fragment slot="info"
-            ><Html
-              text={$i18n.neuron_detail.maturity_last_distribution_info}
-            /></svelte:fragment
-          >
-        </KeyValuePairInfo>
+        <!-- Extra div to avoid the gap of the flex container to be applied between the collapsible header and its content -->
+        <div>
+          <KeyValuePairInfo testId="last-distribution-maturity">
+            <svelte:fragment slot="key"
+              >{$i18n.neuron_detail.maturity_last_distribution}</svelte:fragment
+            >
+            <span slot="value"
+              >{secondsToDate(
+                Number(
+                  $nnsLatestRewardEventStore.rewardEvent
+                    .actual_timestamp_seconds
+                )
+              )}</span
+            >
+            <svelte:fragment slot="info"
+              ><Html
+                text={$i18n.neuron_detail.maturity_last_distribution_info}
+              /></svelte:fragment
+            >
+          </KeyValuePairInfo>
+        </div>
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
# Motivation

There is too much space when the information about the last maturity distribution is rendered.

# Changes

* Add a wrapper around the KeyValuePairInfo that renders the description so that the container style do not apply to the header and description.

# Tests

Not applicable. Only style has changed.
