### PR TITLE
ICRC account textual representation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-13.2.tgz",
-      "integrity": "sha512-ITkCAk9vi0qHj56TzShdLcg3MyoRiOdzHOUbt9n21XwrjCu2uCfAgM8ynSPPeSjtdIzG+NriuXKqoQl9KWfmyA==",
+      "version": "0.0.4-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.4-next-2023-04-18.tgz",
+      "integrity": "sha512-Ip2+bbHlPq/mOMafSqV1ICs2fGb0TnQ3B57ij/nW6JPCJmAEce2z6Wz1D6Iii7tgfRasryMsDljik41umi725A==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.9-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-13.2.tgz",
-      "integrity": "sha512-EzXlMfx9uHziSRm7qd+nzHEC9iBBJUgOAtqv9uvZXCrYDn++tbfHWAg2xblLNngo4XWqShSUIz8WbkGVIdlfXA==",
+      "version": "0.0.11-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.11-next-2023-04-18.tgz",
+      "integrity": "sha512-aOEVPvGnrrwcEa3Ate+u1GiuM4sRDTHn0NVlPjssvyRhAUstHNnYDK3mjf9ANihO/Cl1m+3yzfsaMKm3yS5xOQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.6-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-13.2.tgz",
-      "integrity": "sha512-8OlYXd/0cYN1sBciBOfQqyhz1ls0AK1cvhZbTQ3s/Si3vXUDf2+8uhjmSsNnMVg+IC4xesa6MCtIWHB74c8A/g==",
+      "version": "0.0.8-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.8-next-2023-04-18.tgz",
+      "integrity": "sha512-FWACXqSs7niGNHzQVSFqrBzOA82nuoAOvtf82wtO00dK/gvgQgLvdYE3Pjs+cdwP0CLI1eBOwzNDjrYJ9CvScg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.15.0-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-13.2.tgz",
-      "integrity": "sha512-rj0zcQqCGGqdfyHIxo32Y2QDMI+/O1/W6+1nnCszv3TpygN1sg2CXlHNyj5KdhwhARzIrp9YgDJ6PbhZ5rLY5g==",
+      "version": "0.16.0-next-2023-04-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.0-next-2023-04-18.1.tgz",
+      "integrity": "sha512-BdGgJdONsHRjNBYKVX0A8A/x9S65+1FDnv28xvJh6jsKBNY1dSVXAklltrzCu6S9dJ8cvkSgdR8fh1hWnlZ4Gg==",
       "dependencies": {
         "google-protobuf": "^3.21.2",
         "js-sha256": "^0.9.0",
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.13-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-13.2.tgz",
-      "integrity": "sha512-/bCLHlQ8KVPNmjNZPVL4hWm3KlpQ5MeW4TEKXiKETzg0kKWjSo8+srcBsjUKZa1nISDPYuExMdv/ABCR3WFyeg==",
+      "version": "0.0.15-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.15-next-2023-04-18.tgz",
+      "integrity": "sha512-ZlhgK18vOBwHSd8OBFEGP/B1RjG/t0E3jmwaH/L1X2n8nCdHLltpFfAx7F7iX14fRxnS+1XhF6bIhXzqjjCbSQ==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.13-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-13.2.tgz",
-      "integrity": "sha512-xWt2Tm+sr5GnVxE72ihEvJah2PJPojvVxaXYHZRaxAjLKuaOX0WS9eE07SUC7qONc0BUbZS7jnYcHRl3wugT7Q==",
+      "version": "0.0.15-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.15-next-2023-04-18.tgz",
+      "integrity": "sha512-IONvh57aRcjC+oF0ZcGSqGr/JV///R3CXpaezJEDzOwyO/Gcy5KhPXhn+Plkvc/8gDZIkA6aj3U4ktTgxct6eA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9923,9 +9923,9 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.2-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.2-next-2023-04-13.2.tgz",
-      "integrity": "sha512-ITkCAk9vi0qHj56TzShdLcg3MyoRiOdzHOUbt9n21XwrjCu2uCfAgM8ynSPPeSjtdIzG+NriuXKqoQl9KWfmyA==",
+      "version": "0.0.4-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.4-next-2023-04-18.tgz",
+      "integrity": "sha512-Ip2+bbHlPq/mOMafSqV1ICs2fGb0TnQ3B57ij/nW6JPCJmAEce2z6Wz1D6Iii7tgfRasryMsDljik41umi725A==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -9933,9 +9933,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.9-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.9-next-2023-04-13.2.tgz",
-      "integrity": "sha512-EzXlMfx9uHziSRm7qd+nzHEC9iBBJUgOAtqv9uvZXCrYDn++tbfHWAg2xblLNngo4XWqShSUIz8WbkGVIdlfXA==",
+      "version": "0.0.11-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.11-next-2023-04-18.tgz",
+      "integrity": "sha512-aOEVPvGnrrwcEa3Ate+u1GiuM4sRDTHn0NVlPjssvyRhAUstHNnYDK3mjf9ANihO/Cl1m+3yzfsaMKm3yS5xOQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -9959,15 +9959,15 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.6-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.6-next-2023-04-13.2.tgz",
-      "integrity": "sha512-8OlYXd/0cYN1sBciBOfQqyhz1ls0AK1cvhZbTQ3s/Si3vXUDf2+8uhjmSsNnMVg+IC4xesa6MCtIWHB74c8A/g==",
+      "version": "0.0.8-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.8-next-2023-04-18.tgz",
+      "integrity": "sha512-FWACXqSs7niGNHzQVSFqrBzOA82nuoAOvtf82wtO00dK/gvgQgLvdYE3Pjs+cdwP0CLI1eBOwzNDjrYJ9CvScg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.15.0-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.15.0-next-2023-04-13.2.tgz",
-      "integrity": "sha512-rj0zcQqCGGqdfyHIxo32Y2QDMI+/O1/W6+1nnCszv3TpygN1sg2CXlHNyj5KdhwhARzIrp9YgDJ6PbhZ5rLY5g==",
+      "version": "0.16.0-next-2023-04-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.0-next-2023-04-18.1.tgz",
+      "integrity": "sha512-BdGgJdONsHRjNBYKVX0A8A/x9S65+1FDnv28xvJh6jsKBNY1dSVXAklltrzCu6S9dJ8cvkSgdR8fh1hWnlZ4Gg==",
       "requires": {
         "google-protobuf": "^3.21.2",
         "js-sha256": "^0.9.0",
@@ -9984,17 +9984,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.13-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.13-next-2023-04-13.2.tgz",
-      "integrity": "sha512-/bCLHlQ8KVPNmjNZPVL4hWm3KlpQ5MeW4TEKXiKETzg0kKWjSo8+srcBsjUKZa1nISDPYuExMdv/ABCR3WFyeg==",
+      "version": "0.0.15-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.15-next-2023-04-18.tgz",
+      "integrity": "sha512-ZlhgK18vOBwHSd8OBFEGP/B1RjG/t0E3jmwaH/L1X2n8nCdHLltpFfAx7F7iX14fRxnS+1XhF6bIhXzqjjCbSQ==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.13-next-2023-04-13.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.13-next-2023-04-13.2.tgz",
-      "integrity": "sha512-xWt2Tm+sr5GnVxE72ihEvJah2PJPojvVxaXYHZRaxAjLKuaOX0WS9eE07SUC7qONc0BUbZS7jnYcHRl3wugT7Q==",
+      "version": "0.0.15-next-2023-04-18",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.15-next-2023-04-18.tgz",
+      "integrity": "sha512-IONvh57aRcjC+oF0ZcGSqGr/JV///R3CXpaezJEDzOwyO/Gcy5KhPXhn+Plkvc/8gDZIkA6aj3U4ktTgxct6eA==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -6,6 +6,7 @@ import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.sv
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
@@ -37,13 +38,14 @@ describe("IcrcTransactionCard", () => {
 
   const to = {
     owner: mockPrincipal,
-    subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+    subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
   };
   const from = {
     owner: mockPrincipal,
     subaccount: [] as [],
   };
   const transactionFromMainToSubaccount = createIcrcTransactionWithId(to, from);
+  const transactionToMainFromSubaccount = createIcrcTransactionWithId(from, to);
 
   beforeEach(() => {
     jest
@@ -143,14 +145,24 @@ describe("IcrcTransactionCard", () => {
     expect(identifier).toContain(en.wallet.direction_from);
   });
 
-  it("displays identifier for sent", () => {
+  it("displays identifier for sent for main sns account", () => {
     const { getByTestId } = renderTransactionCard(
       mockSnsMainAccount,
       transactionFromMainToSubaccount
     );
     const identifier = getByTestId("identifier")?.textContent;
 
-    expect(identifier).toContain(mockSnsSubAccount.identifier);
+    expect(identifier).toContain(mockSnsMainAccount.identifier);
     expect(identifier).toContain(en.wallet.direction_to);
+  });
+
+  it("displays identifier for sent for sub sns account", () => {
+    const { getByTestId } = renderTransactionCard(
+      mockSnsMainAccount,
+      transactionToMainFromSubaccount
+    );
+    const identifier = getByTestId("identifier")?.textContent;
+
+    expect(identifier).toContain(mockSnsSubAccount.identifier);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -44,8 +44,14 @@ describe("IcrcTransactionCard", () => {
     owner: mockPrincipal,
     subaccount: [] as [],
   };
-  const transactionFromMainToSubaccount = createIcrcTransactionWithId(to, from);
-  const transactionToMainFromSubaccount = createIcrcTransactionWithId(from, to);
+  const transactionFromMainToSubaccount = createIcrcTransactionWithId({
+    to,
+    from,
+  });
+  const transactionToMainFromSubaccount = createIcrcTransactionWithId({
+    to: from,
+    from: to,
+  });
 
   beforeEach(() => {
     jest
@@ -82,7 +88,10 @@ describe("IcrcTransactionCard", () => {
       owner: mockSnsFullProject.summary.governanceCanisterId,
       subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
     };
-    const stakeNeuronTransaction = createIcrcTransactionWithId(toGov, from);
+    const stakeNeuronTransaction = createIcrcTransactionWithId({
+      to: toGov,
+      from,
+    });
     stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
     const { getByText } = renderTransactionCard(
       mockSnsMainAccount,

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -10,6 +10,7 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
+import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
@@ -66,7 +67,7 @@ describe("ckbtc-convert-services", () => {
   describe("withdrawal account succeed", () => {
     const mockAccount = {
       owner: mockPrincipal,
-      subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+      subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
     };
 
     const getWithdrawalAccountSpy =

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -11,13 +11,14 @@ import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "$tests//mocks/sns-accounts.mock";
+import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 
 describe("icrc-transaction utils", () => {
   const to = {
     owner: mockPrincipal,
-    subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
+    subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
   };
   const from = {
     owner: mockPrincipal,

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -24,7 +24,10 @@ describe("icrc-transaction utils", () => {
     owner: mockPrincipal,
     subaccount: [] as [],
   };
-  const transactionFromMainToSubaccount = createIcrcTransactionWithId(to, from);
+  const transactionFromMainToSubaccount = createIcrcTransactionWithId({
+    to,
+    from,
+  });
   const recentTx = {
     id: BigInt(1234),
     transaction: {
@@ -46,7 +49,7 @@ describe("icrc-transaction utils", () => {
       timestamp: BigInt(1000),
     },
   };
-  const selfTransaction = createIcrcTransactionWithId(to, to);
+  const selfTransaction = createIcrcTransactionWithId({ to, from: to });
 
   describe("getSortedTransactionsFromStore", () => {
     it("should return transactions sorted by date", () => {
@@ -123,10 +126,10 @@ describe("icrc-transaction utils", () => {
         owner: governanceCanisterId,
         subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
       };
-      const stakeNeuronTransaction = createIcrcTransactionWithId(
-        toGovernance,
-        from
-      );
+      const stakeNeuronTransaction = createIcrcTransactionWithId({
+        to: toGovernance,
+        from,
+      });
       stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
       const data = mapIcrcTransaction({
         transaction: stakeNeuronTransaction,
@@ -145,10 +148,10 @@ describe("icrc-transaction utils", () => {
         owner: governanceCanisterId,
         subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
       };
-      const topUpNeuronTransaction = createIcrcTransactionWithId(
-        toGovernance,
-        from
-      );
+      const topUpNeuronTransaction = createIcrcTransactionWithId({
+        to: toGovernance,
+        from,
+      });
       topUpNeuronTransaction.transaction.transfer[0].memo = [];
       const data = mapIcrcTransaction({
         transaction: topUpNeuronTransaction,

--- a/frontend/src/tests/mocks/accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/accounts.store.mock.ts
@@ -20,6 +20,11 @@ export const mockMainAccount: Account = {
   type: "main",
 };
 
+export const mockSubAccountArray = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 1,
+];
+
 export const mockSubAccount: Account = {
   identifier:
     "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
@@ -27,10 +32,7 @@ export const mockSubAccount: Account = {
     amount: "1234567.8901",
     token: ICPToken,
   }) as TokenAmount,
-  subAccount: [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 1,
-  ],
+  subAccount: mockSubAccountArray,
   name: "test subaccount",
   type: "subAccount",
 };

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -8,10 +8,13 @@ export interface IcrcCandidAccount {
   subaccount: [] | [Uint8Array];
 }
 
-export const createIcrcTransactionWithId = (
-  to: IcrcCandidAccount,
-  from: IcrcCandidAccount
-): IcrcTransactionWithId => ({
+export const createIcrcTransactionWithId = ({
+  from,
+  to,
+}: {
+  to: IcrcCandidAccount;
+  from: IcrcCandidAccount;
+}): IcrcTransactionWithId => ({
   id: BigInt(123),
   transaction: {
     kind: "transfer",

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,5 +1,6 @@
 import type { SnsAccountsStoreData } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
+import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger";
 import { TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -21,14 +22,10 @@ export const mockSnsMainAccount: Account = {
   type: "main",
 };
 
-const subAccount = [
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 1,
-];
 export const mockSnsSubAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
-    subaccount: Uint8Array.from(subAccount),
+    subaccount: Uint8Array.from(mockSubAccountArray),
   }),
   balance: TokenAmount.fromString({
     amount: "5671234.0189",
@@ -37,7 +34,7 @@ export const mockSnsSubAccount: Account = {
       symbol: "TST",
     },
   }) as TokenAmount,
-  subAccount,
+  subAccount: mockSubAccountArray,
   name: "test subaccount",
   type: "subAccount",
 };


### PR DESCRIPTION
# Motivation

Bump ic-js to implement what might be the definitive textual encoding for ICRC-1 account.

Source of encoding 👉 https://github.com/dfinity/ICRC-1/pull/98

# PRs

- [x] https://github.com/dfinity/ic-js/pull/308

# Changes

- bump ic-js
- test: fix mock data from / to that were incorrectly set
- test: use object param to avoid from / to to be incorrectly set in the future
- test: partial mock subaccount array isn't supported anymore to encode/decode ICRC account as the decoded checks the validity of the checksum

