### PR TITLE
Log pre-upgrade cycle count

### DIFF
--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -48,16 +48,16 @@ fn main() {}
 #[pre_upgrade]
 fn pre_upgrade() {
     dfn_core::api::print(format!(
-        "pre_upgrade instruction_counter before saving state: {:?}",
-        ic_cdk::api::instruction_counter
+        "pre_upgrade instruction_counter before saving state: {}",
+        ic_cdk::api::instruction_counter()
     ));
     STATE.with(|s| {
         let bytes = s.encode();
         stable::set(&bytes);
     });
     dfn_core::api::print(format!(
-        "pre_upgrade instruction_counter after saving state: {:?}",
-        ic_cdk::api::instruction_counter
+        "pre_upgrade instruction_counter after saving state: {}",
+        ic_cdk::api::instruction_counter()
     ));
 }
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -47,10 +47,18 @@ fn main() {}
 
 #[pre_upgrade]
 fn pre_upgrade() {
+    dfn_core::api::print(format!(
+        "pre_upgrade instruction_counter before saving state: {}",
+        ic_cdk::api::instruction_counter
+    ));
     STATE.with(|s| {
         let bytes = s.encode();
         stable::set(&bytes);
     });
+    dfn_core::api::print(format!(
+        "pre_upgrade instruction_counter after saving state: {}",
+        ic_cdk::api::instruction_counter
+    ));
 }
 
 #[post_upgrade]

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -48,7 +48,7 @@ fn main() {}
 #[pre_upgrade]
 fn pre_upgrade() {
     dfn_core::api::print(format!(
-        "pre_upgrade instruction_counter before saving state: {}",
+        "pre_upgrade instruction_counter before saving state: {:?}",
         ic_cdk::api::instruction_counter
     ));
     STATE.with(|s| {
@@ -56,7 +56,7 @@ fn pre_upgrade() {
         stable::set(&bytes);
     });
     dfn_core::api::print(format!(
-        "pre_upgrade instruction_counter after saving state: {}",
+        "pre_upgrade instruction_counter after saving state: {:?}",
         ic_cdk::api::instruction_counter
     ));
 }


### PR DESCRIPTION
# Motivation
We are concerned that the pre-upgrade cycle count may be too high and may cause the canister to fail to upgrade.

Storing pre-upgrade cycle counts in the stats structure is a bit tricky, as data would have to be stored in stable memory and the cycles are consumed by storing data in stable memory.  This can be solved if we upgrade the memory structure (extremely carefully!) to the new stable memory library.  That also supports stable structures, which makes this problem go away.

In the meantime, a simple solution is to print out the instruction counter counter and look at the replica logs; we run one of the servers on the nns subnet so have access to logs there.  Longer term, logs will be available to all canisters via a ring buffer but that is work in progress.

# Changes
- Print the instruction count at the beginning and end of the `pre_upgrade` hook.

# Tests