### PR TITLE
Use grep instead of sed in ci-consistency

### DIFF
--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -50,7 +50,7 @@ get_data() {
     printf '\n\n## Commit %s %s\n```\n' "$COMMIT" "$(git show -s --format=%ci "$COMMIT")"
 
     build_hash_from_logs() {
-      sed -nr 's&.*\<([a-z0-9]{64}) +(\/build\/)?'"$DFX_ASSET"'.*&\1&g;ta;b;:a;p' | tail -n1 | grep .
+      grep -o -E '[a-z0-9]{64} +(\/build\/)?'"$DFX_ASSET" | tail -n1 | cut -d' ' -f1
     }
 
     echo "Build hashes for $DFX_ASSET:"


### PR DESCRIPTION
# Motivation

Default `sed` on Mac is different from `sed` on Linux and does not support all the same features.

# Changes

Use a simpler grep command to get the hash from the log.

# Tests

`scripts/nns-dapp/ci-consistency -c  9820416751a40d477ae33d15dcd6e5736ca46fd6..0a78d9c380901d26e5841b58bc2467209544e1cb`