### PR TITLE
E2E: Remove expect timeout

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -13,8 +13,9 @@ export default defineConfig({
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
+     * 0 for no limit.
      */
-    timeout: 10000,
+    timeout: 0,
   },
   /* Run tests in files in parallel */
   fullyParallel: false,


### PR DESCRIPTION
# Motivation

Creating a neuron can take longer than 10 seconds.
The test expects the modal to be closed within 10 seconds and sometimes [times out](https://github.com/dfinity/nns-dapp/actions/runs/4744468055).

# Changes

Remove the 10 second timeout for expect calls.
Rely on the 60 second timeout for the entire test.

# Tests

`npm run test-e2e`
