### PR TITLE
Reinstate the checkout

### DIFF
--- a/scripts/nns-dapp/ci-consistency
+++ b/scripts/nns-dapp/ci-consistency
@@ -78,7 +78,7 @@ get_data() {
     done
 
     : Local docker build
-    docker_hash="$(./scripts/docker-build |& build_hash_from_logs)"
+    docker_hash="$(git checkout "$COMMIT" && ./scripts/docker-build |& build_hash_from_logs)"
     printf "% 64s Local docker build\n" "${docker_hash:-}"
 
     : Native build


### PR DESCRIPTION
# Motivation
When cleaning up the commit comparison tool I managed to delete the line where the local code is checked out.

# Changes
- Check out the commit being tested before running the local docker build.

# Tests