### PR TITLE
No test in ckbtc canister names

### DIFF
--- a/scripts/ckbtc/deploy-ckbtc
+++ b/scripts/ckbtc/deploy-ckbtc
@@ -3,16 +3,16 @@
 # Original source
 # https://github.com/dfinity/ckBTC-Minter-Frontend/blob/master/local_deploy.sh
 
-dfx canister create ckbtc_test_ledger --network "$DFX_NETWORK"
-dfx canister create ckbtc_test_minter --network "$DFX_NETWORK"
+dfx canister create ckbtc_ledger --network "$DFX_NETWORK"
+dfx canister create ckbtc_minter --network "$DFX_NETWORK"
 
-MINTERID="$(dfx canister id ckbtc_test_minter --network "$DFX_NETWORK")"
+MINTERID="$(dfx canister id ckbtc_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
-LEDGERID="$(dfx canister id ckbtc_test_ledger --network "$DFX_NETWORK")"
+LEDGERID="$(dfx canister id ckbtc_ledger --network "$DFX_NETWORK")"
 echo "$LEDGERID"
 
 # echo "Step 2: deploying minter canister..."
-dfx deploy ckbtc_test_minter --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_minter --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
        btc_network = variant { Regtest };
        ledger_id = principal \"$LEDGERID\";
@@ -28,7 +28,7 @@ dfx deploy ckbtc_test_minter --network "$DFX_NETWORK" --argument "(variant {
 
 echo "Step 3: deploying ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy ckbtc_test_ledger --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_ledger --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckBTC\";
      token_name = \"Token ckBTC\";
@@ -46,23 +46,23 @@ dfx deploy ckbtc_test_ledger --network "$DFX_NETWORK" --argument "(variant {
 })" --mode=reinstall
 
 echo "Step 4: deploying index canister..."
-dfx deploy ckbtc_test_index --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode=reinstall
+dfx deploy ckbtc_index --network "$DFX_NETWORK" --argument "(record { ledger_id = principal \"$LEDGERID\" })" --mode=reinstall
 
 # Example to mint ckBTC
 
-# BTCADDRESS="$(dfx canister call ckbtc_test_minter get_btc_address '(record {subaccount=null;})')"
-# dfx canister call ckbtc_test_minter update_balance '(record {subaccount=null;})'
-# WITHDRAWALADDRESS="$(dfx canister call ckbtc_test_minter get_withdrawal_account)"
+# BTCADDRESS="$(dfx canister call ckbtc_minter get_btc_address '(record {subaccount=null;})')"
+# dfx canister call ckbtc_minter update_balance '(record {subaccount=null;})'
+# WITHDRAWALADDRESS="$(dfx canister call ckbtc_minter get_withdrawal_account)"
 # echo $BTCADDRESS
 # echo $WITHDRAWALADDRESS
 #
 # cleaned_output=$(echo $WITHDRAWALADDRESS | sed -re 's/^\(|, \)$//g')
 #
-# dfx canister call ckbtc_test_ledger icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+# dfx canister call ckbtc_ledger icrc1_transfer "(record {from=null; to=$cleaned_output; amount=1000000; fee=null; memo=null; created_at_time=null;})"
 #
 # Execute the command to get the input string and save the result
-# dfx canister call ckbtc_test_minter retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
+# dfx canister call ckbtc_minter retrieve_btc '(record {fee = null; address="bcrt1qu9za0uzzd3kjjecgv7waqq0ynn8dl8l538q0xl"; amount=10000})'
 
 echo "Step 5: transfer ckBTC to principal..."
 # record { owner= principal “”;}
-dfx canister call ckbtc_test_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"73avq-yvrvj-kuzxq-kttlj-nkaz4-tecy6-biuud-3ymeg-guvci-naire-uqe\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"
+dfx canister call ckbtc_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"73avq-yvrvj-kuzxq-kttlj-nkaz4-tecy6-biuud-3ymeg-guvci-naire-uqe\";}; amount=1000000; fee=null; memo=null; created_at_time=null;})"


### PR DESCRIPTION
# Motivation
I understand that the test environment ckbtc canister names should have the prefix ckbtc_ with no test.

# Changes
* `s/ckbtc_test_/ckbtc_/g`

# Tests
None.