### PR TITLE
Nightly tag

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -62,8 +62,8 @@ jobs:
             then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true
             else gh release create --title "Release for tags/$tag" --draft --notes "Build artefacts from tag: $tag" "$tag" "${artefacts[@]}"
             fi
-            : If the tag is for a proposal, make it public
-            [[ "$tag" != proposal-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
+            : If the tag is for a proposal or nightly, make it public
+            [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,7 +52,9 @@ jobs:
       - name: Release
         run: |
           cd "${{ matrix.BUILD_NAME }}-out"
-          artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz)
+          daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
+          cp nns-dapp.wasm "$daily_build_name"
+          artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
           ls -l "${artefacts[@]}"
           for tag in $(git tag --points-at HEAD) ; do
             : Creates or updates a release for the tag

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,7 +66,7 @@ jobs:
           # the pushing fail
           pull_strategy: "NO-PULL"
   nightly-passes:
-    needs: ["update-ii", "update-chromedriver"]
+    needs: ["tag-main", "update-ii", "update-chromedriver"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,7 +1,7 @@
 name: Nightly Publication
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "10 0 * * *"
   push:
     branches:
       # Commit to the nightly branch and push to test.
@@ -10,6 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  tag-main:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Tag main
+        run: |
+                tag_name="$(date +nightly-%Y-%m-%d)"
+                git tag "${tag_name}"
+                git push origin "refs/tags/${tag_name}"
   update-ii:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,10 @@ jobs:
       - name: Tag main
         run: |
           set -x
+          : Log commit and existing tags
+          git rev-parse HEAD
           git tag --points-at HEAD
+          : Add a tag if appropriate
           if git tag --points-at HEAD | grep -E '\<nightly-'
           then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"
           else

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Tag main
         run: |
-                if git tag --points-at HEAD | grep -E '\<nightly-'
-                then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"
-                else
-                  tag_name="$(date +nightly-%Y-%m-%d)"
-                  git tag "${tag_name}"
-                  git push origin "refs/tags/${tag_name}"
-                fi
+          if git tag --points-at HEAD | grep -E '\<nightly-'
+          then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"
+          else
+            tag_name="$(date +nightly-%Y-%m-%d)"
+            git tag "${tag_name}"
+            git push origin "refs/tags/${tag_name}"
+          fi
   update-ii:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Tag main
         run: |
+          set -x
+          git tag --points-at HEAD
           if git tag --points-at HEAD | grep -E '\<nightly-'
           then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"
           else

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,9 +17,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Tag main
         run: |
-                tag_name="$(date +nightly-%Y-%m-%d)"
-                git tag "${tag_name}"
-                git push origin "refs/tags/${tag_name}"
+                if git tag --points-at HEAD | grep -E '\<nightly-'
+                then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"
+                else
+                  tag_name="$(date +nightly-%Y-%m-%d)"
+                  git tag "${tag_name}"
+                  git push origin "refs/tags/${tag_name}"
+                fi
   update-ii:
     runs-on: ubuntu-20.04
     steps:

--- a/dfx.json
+++ b/dfx.json
@@ -29,7 +29,7 @@
       "type": "custom",
       "wasm": "internet_identity_dev.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-04-12/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-01-31/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"

--- a/dfx.json
+++ b/dfx.json
@@ -29,7 +29,7 @@
       "type": "custom",
       "wasm": "internet_identity_dev.wasm",
       "candid": "internet_identity.did",
-      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-01-31/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
+      "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-04-12/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"


### PR DESCRIPTION
# Motivation
We wish to test a recent build (not prod) against the rest of the IC test environment.

## Requirements
* Nightly release
* No need to make a new release if there is an existing release
* The nns-dapp wasm should be available with the commit in the filename.

# Changes
* To the nightly workflow, add a job that tags the head of main with `nightly-YYY-mm-dd`
* In the docker-build job that creates releases:
  * Make a copy of the wasm that includes the commit in the name and include it in the release artefacts.
  * Make nightly releases public, so that the wasms are accessible

# Tests
* I have triggered the workflow manually by pushing to the develop branch.  It is hard to get workflows to get tags, so I have not been able to confirm that no new releases are created if there are no changes.  I have been able to confirm that the nightly job creates tags and that the tags trigger workflows.