### PR TITLE
E2E: Check SNS neuron detail

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -40,7 +40,9 @@ test("Test SNS governance", async ({ page, context }) => {
     `You have no ${snsProjectName} neurons. Stake a neuron to vote on proposals for ${snsProjectName}.`
   );
 
-  await appPo.getNeuronsPo().getSnsNeuronsFooterPo().stakeNeuron(5);
+  const stake = 5;
+  const formattedStake = "5.00";
+  await appPo.getNeuronsPo().getSnsNeuronsFooterPo().stakeNeuron(stake);
 
   // SN001: User can see the list of neurons
   const neuronCards = await appPo
@@ -48,9 +50,14 @@ test("Test SNS governance", async ({ page, context }) => {
     .getSnsNeuronsPo()
     .getNeuronCardPos();
   expect(neuronCards.length).toBe(1);
-  expect(await neuronCards[0].getStake()).toEqual("5.00");
+  const neuronCard = neuronCards[0];
+  expect(await neuronCard.getStake()).toEqual(formattedStake);
 
   // SN002: User can see the details of a neuron
+  await neuronCard.click();
+  const neuronDetail = appPo.getNeuronDetailPo().getSnsNeuronDetailPo();
+  expect(await neuronDetail.getTitle()).toBe(snsProjectName);
+  expect(await neuronDetail.getStake()).toBe(formattedStake);
 
   // SN003: User can add a hotkey
 

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -127,7 +127,7 @@ describe("SnsNeuronDetail", () => {
     it("should render sns project name", async () => {
       const po = await renderComponent(props);
 
-      expect(await (await po.getTitle()).trim()).toBe(projectName);
+      expect(await po.getTitle()).toBe(projectName);
     });
 
     it("should render cards", async () => {
@@ -155,7 +155,7 @@ describe("SnsNeuronDetail", () => {
       const po = await renderComponent(props);
 
       // `neuronStake` to string formatted as expected
-      expect(await po.getStakeCardPo().getStakeAmount()).toBe("1.00");
+      expect(await po.getStake()).toBe("1.00");
       const amountToStake = 20;
       fakeSnsGovernanceApi.setNeuronWith({
         rootCanisterId,
@@ -167,7 +167,7 @@ describe("SnsNeuronDetail", () => {
       await runResolvedPromises();
 
       // `neuronStake` + 10 to string and formatted as expected
-      expect(await po.getStakeCardPo().getStakeAmount()).toBe("21.00");
+      expect(await po.getStake()).toBe("21.00");
       expect(increaseStakeNeuron).toHaveBeenCalledTimes(1);
       expect(increaseStakeNeuron).toHaveBeenCalledWith({
         neuronId: validNeuronId,

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,6 +1,7 @@
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
+import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
@@ -17,6 +18,10 @@ export class AppPo extends BasePageObject {
 
   getNeuronsPo(): NeuronsPo {
     return NeuronsPo.under(this.root);
+  }
+
+  getNeuronDetailPo(): NeuronDetailPo {
+    return NeuronDetailPo.under(this.root);
   }
 
   getMenuItemsPo(): MenuItemsPo {

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { NnsNeuronMaturityCardPo } from "./NnsNeuronMaturityCard.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";

--- a/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturityCard.page-object.ts
@@ -1,6 +1,6 @@
+import { KeyValuePairInfoPo } from "$tests/page-objects/KeyValuePairInfo.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { KeyValuePairInfoPo } from "./KeyValuePairInfo.page-object";
 
 export class NnsNeuronMaturityCardPo extends BasePageObject {
   private static readonly TID = "nns-neuron-maturity-card-component";

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -42,6 +42,10 @@ export class SnsNeuronDetailPo extends BasePageObject {
     return SnsNeuronInfoStakePo.under(this.root);
   }
 
+  getStake(): Promise<string> {
+    return this.getStakeCardPo().getStakeAmount();
+  }
+
   getFollowingCardPo(): SnsNeuronFollowingCardPo {
     return SnsNeuronFollowingCardPo.under(this.root);
   }
@@ -50,8 +54,8 @@ export class SnsNeuronDetailPo extends BasePageObject {
     return SummaryPo.under(this.root);
   }
 
-  getTitle(): Promise<string> {
-    return this.getSummaryPo().getTitle();
+  async getTitle(): Promise<string> {
+    return (await this.getSummaryPo().getTitle()).trim();
   }
 
   getIncreaseStakeModalPo(): SnsIncreaseStakeNeuronModalPo {


### PR DESCRIPTION
# Motivation

Continue with SNS end-to-end test.

# Changes

1. Check the neuron detail in the e2e test.
2. Make the SnsNeuronDetailsPo accessible via AppPo.
3. Add convenience getStake method to SnsNeuronDetailsPo.
4. Conveniently trim the result of getTitle() in SnsNeuronDetailsPo.
5. Update existing `frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts` to use the new convenience methods as well.
6. Change relative imports that break Playwright to absolute imports.

# Tests

`npm run test e2e -- sns`
`npm run test`
`npm run check`