### PR TITLE
Remove unnecessary steps from checks.yml workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,19 +67,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install dfx
-        run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-      - name: Provide a config
-        run: ./config.sh
       - name: Install dependencies
         run: npm ci
         working-directory: ./frontend
-      - name: Compile typescript
-        run: npm run build
-        working-directory: ./frontend
-      # Temporarily disabled:
-      #- name: Run linter
-      #  run: npm run check
       - name: Test
         run: npm run test
         working-directory: ./frontend
@@ -98,15 +88,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install dfx
-        run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-      - name: Provide a config
-        run: ./config.sh
       - name: Install dependencies
         run: npm ci
-        working-directory: ./frontend
-      - name: Compile typescript
-        run: npm run build
         working-directory: ./frontend
       - name: Run linter
         run: npm run check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
 jobs:
   formatting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Motivation

Cleaning up.

# Changes

1. `npm run test` and `npm run test` don't need `dfx` or `.env` so remove those steps from the `svelte-tests` and `svelte-lint` jobs.
2. Remove comment about temporarily disabling lint. It's already no longer disabled.
3. Add default `bash -euxlo pipefail {0}` to fail in a more predictable way and log what happens.

# Tests

CI
