### PR TITLE
Fix: Deploy script also creates args for network

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -103,6 +103,7 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
   # Note:  NNS dapp is the only canister provided by this repo, however dfx.json
   #        includes other canisters for testing purposes.  If testing you MAY wish
   #        to deploy these other canisters as well, but you probably don't.
+  DFX_NETWORK="$DFX_NETWORK" ./config.sh
   dfx canister --network "$DFX_NETWORK" create nns-dapp --no-wallet || echo "canister for NNS Dapp may have been created already"
   dfx deploy nns-dapp --argument "$(cat nns-dapp-arg.did)" --upgrade-unchanged --network "$DFX_NETWORK" --no-wallet
   OWN_CANISTER_URL="$(grep OWN_CANISTER_URL <"$CONFIG_FILE" | sed "s|VITE_OWN_CANISTER_URL=||g")"


### PR DESCRIPTION
# Motivation

Current deploy.sh is confusing because you might set network to staging, but use arguments for medium09.

# Changes

* Add command to create config for the selected network within `./deploy.sh` script.

# Tests

I created the arguments for medium09, then deployed with `./deploy.sh --nns-dapp staging`. All good.
