### PR TITLE
E2E: Wait for SNS neurons to be loaded.

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -45,6 +45,7 @@ test("Test SNS governance", async ({ page, context }) => {
   await appPo.getNeuronsPo().getSnsNeuronsFooterPo().stakeNeuron(stake);
 
   // SN001: User can see the list of neurons
+  await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
   const neuronCards = await appPo
     .getNeuronsPo()
     .getSnsNeuronsPo()


### PR DESCRIPTION
# Motivation

Avoid flakiness in the end-to-end test.
Previously I assumed that when the stake neuron modal is closed, the neurons are already loaded.
But I noticed at least once that the test failed because the neurons weren't loaded.

# Changes

Wait for sns neurons to be loaded before checking that the neuron cards are there.

# Tests

`npm run test-e2e`
