### PR TITLE
Use new snsdemo snapshot CI E2E workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Get test environment
         run: |
-          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/testing/state.tar.xz > state.tar.xz
+          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/release-2023-04-21/snsdemo_snapshot_ubuntu-22.04.tar.xz > state.tar.xz
           dfx-snapshot-restore --snapshot state.tar.xz --verbose
           dfx identity use snsdemo8
           dfx-sns-demo-healthcheck


### PR DESCRIPTION
# Motivation

This snapshot has an open SNS swap, which we need to start end-to-end testing swap participation.

# Changes

Change the URL of the snsdemo snapshot we install in `.github/workflows/build.yml`.

# Tests

CI
