### PR TITLE
Chore: Use parent data-tid in KeyValuePairInfo

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.5.0-next-2023-04-17.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-04-17.2.tgz",
-      "integrity": "sha512-RSGXb4rnRmZ471uRC5joNMx2h9i/YGDJVuczg/SlbHboAAeLEcWX0h2hGM4pxFaJhGxuEz0WtsgvWd+6YEk4qg==",
+      "version": "2.6.0-next-2023-04-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-04-21.tgz",
+      "integrity": "sha512-F2XbROcV6V7Ez0dSlO7OY1jWnHLETiuh8adLRBAxweUySj5YiE+qZt9YmEYlHIcsDd0wjo2qBLDJWASWMNagvw==",
       "dependencies": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",
@@ -9939,9 +9939,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.5.0-next-2023-04-17.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.5.0-next-2023-04-17.2.tgz",
-      "integrity": "sha512-RSGXb4rnRmZ471uRC5joNMx2h9i/YGDJVuczg/SlbHboAAeLEcWX0h2hGM4pxFaJhGxuEz0WtsgvWd+6YEk4qg==",
+      "version": "2.6.0-next-2023-04-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-04-21.tgz",
+      "integrity": "sha512-F2XbROcV6V7Ez0dSlO7OY1jWnHLETiuh8adLRBAxweUySj5YiE+qZt9YmEYlHIcsDd0wjo2qBLDJWASWMNagvw==",
       "requires": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",

--- a/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
@@ -2,28 +2,16 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class KeyValuePairInfoPo extends BasePageObject {
-  private parent: PageObjectElement;
   private testId: string;
 
-  /**
-   * KeyValuePairInfo renders two components:
-   * - a div with the key value pair and a button
-   * - a div with the description information
-   *
-   * That's why we need to keep a reference to the parent element
-   * to be able to get the description information
-   */
   constructor({
-    parent,
     element,
     testId,
   }: {
     element: PageObjectElement;
-    parent: PageObjectElement;
     testId: string;
   }) {
     super(element);
-    this.parent = parent;
     this.testId = testId;
   }
 
@@ -36,7 +24,6 @@ export class KeyValuePairInfoPo extends BasePageObject {
   }): KeyValuePairInfoPo {
     return new KeyValuePairInfoPo({
       element: element.byTestId(testId),
-      parent: element,
       testId,
     });
   }
@@ -50,6 +37,6 @@ export class KeyValuePairInfoPo extends BasePageObject {
   }
 
   getDescriptionText(): Promise<string> {
-    return this.parent.byTestId(`${this.testId}-description`).getText();
+    return this.root.byTestId(`${this.testId}-description`).getText();
   }
 }

--- a/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
@@ -37,6 +37,6 @@ export class KeyValuePairInfoPo extends BasePageObject {
   }
 
   getDescriptionText(): Promise<string> {
-    return this.root.byTestId(`${this.testId}-description`).getText();
+    return this.getText(`${this.testId}-description`);
   }
 }


### PR DESCRIPTION
# Motivation

The page object of the KeyValuePairInfo was relying in the parent to get the description because the data-tid was not added at the root.

The PR in GIX Components: https://github.com/dfinity/gix-components/pull/199 sets the test id of KeyValuePairInfo in the root component.

# Changes

* Upgrade gix-components library.
* Change the way KeyValuePairInfoPo accesses the description text. There is no need to keep a reference to the parent.

# Tests

Changes only in test implementations, not no test changes.
