### PR TITLE
E2E: SNS swap participation

### DIFF
--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -1,0 +1,30 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+test("Test SNS governance", async ({ page, context }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("Network Nervous System frontend dapp");
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  await appPo.goToLaunchpad();
+
+  // D001: User can see the list of open sales
+  // TODO
+
+  // D002: User can see the list of successful sales
+  // TODO
+
+  // D003: User can see the details of one sale
+  // TODO
+
+  // D004: User can participate in a sale
+  // TODO
+
+  // D005: User can increase the participation in a sale
+  // TODO
+});

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -47,17 +47,18 @@ export class AppPo extends BasePageObject {
     return this.getMenuTogglePo().click();
   }
 
-  waitForContentLoaded(): Promise<void> {
-    // Wait for an arbitrary element that is present when the content is loaded.
-    return this.getButton("account-menu").waitFor();
+  waitForHeaderLoaded(): Promise<void> {
+    return this.root.byTestId("header-component").waitFor();
   }
 
   async openMenu(): Promise<void> {
-    // If the content isn't loaded yet, it looks like the menu toggle isn't
-    // there but it's just not there *yet*.
-    await this.waitForContentLoaded();
+    // On large viewports, the menu is always open, but on smaller windows, we
+    // need to click the menu toggle to open the menu. So we check if the menu toggle is
+    // there and wait for the menu to open if necessary.
 
-    // Whether the menu needs to be opened depends on the size of the viewport.
+    // If the header isn't loaded yet, it looks like the menu toggle isn't
+    // there but it's just not there *yet*.
+    await this.waitForHeaderLoaded();
     const isTogglePresent = await this.getMenuTogglePo().isPresent();
     if (isTogglePresent) {
       const backdrop = this.getBackdropPo();

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -47,7 +47,16 @@ export class AppPo extends BasePageObject {
     return this.getMenuTogglePo().click();
   }
 
+  waitForContentLoaded(): Promise<void> {
+    // Wait for an arbitrary element that is present when the content is loaded.
+    return this.getButton("account-menu").waitFor();
+  }
+
   async openMenu(): Promise<void> {
+    // If the content isn't loaded yet, it looks like the menu toggle isn't
+    // there but it's just not there *yet*.
+    await this.waitForContentLoaded();
+
     // Whether the menu needs to be opened depends on the size of the viewport.
     const isTogglePresent = await this.getMenuTogglePo().isPresent();
     if (isTogglePresent) {
@@ -76,6 +85,12 @@ export class AppPo extends BasePageObject {
   async goToNeurons(): Promise<void> {
     await this.openMenu();
     await this.getMenuItemsPo().clickNeuronStaking();
+    // Menu closes automatically.
+  }
+
+  async goToLaunchpad(): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().clickLaunchpad();
     // Menu closes automatically.
   }
 

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -9,8 +9,12 @@ export class MenuItemsPo extends BasePageObject {
     return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
   }
 
-  clickNeuronStaking(): void {
-    this.click("menuitem-neurons");
+  clickNeuronStaking(): Promise<void> {
+    return this.click("menuitem-neurons");
+  }
+
+  clickLaunchpad(): Promise<void> {
+    return this.click("menuitem-launchpad");
   }
 
   getGetTokensPo(): GetTokensPo {


### PR DESCRIPTION
# Motivation

We want to test SNS swap participation.
This just puts the test file in place to be extended in future PRs.

# Changes

1. Add frontend/src/tests/e2e/sns-participation.spec.ts which just signs in and navigates to the launchpad. It contains TODOs for what to test.
2. Add PO functionality for navigating to the launchpad.
3. Make sure the app is loaded before we check if we need to open the menu or not.
4. Make click methods in `MenuItems.page-object.ts` return a `Promise`. It was an oversight that they didn't.

# Tests

`npm run test-e2e`
