### PR TITLE
Proposal title displayed as value

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -27,10 +27,6 @@
   .markdown {
     overflow-wrap: break-word;
 
-    :global(*) {
-      color: var(--label-color);
-    }
-
     :global(strong) {
       font-weight: var(--font-weight-bold);
     }

--- a/frontend/src/lib/components/proposal-detail/ProposalSummarySection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummarySection.svelte
@@ -15,7 +15,7 @@
   <div class="content-cell-details">
     <ProposalSummary {summary}>
       <svelte:fragment slot="title">
-        <h1>{title ?? ""}</h1>
+        <p class="value">{title ?? ""}</p>
 
         {#if url}
           <a


### PR DESCRIPTION
# Motivation

Displaying the proposal title as a `<p class="value"/>` instead of `h1` more the screen more consistent UI wise.

# Screenshots

Current

<img width="1536" alt="Capture d’écran 2023-04-24 à 07 01 02" src="https://user-images.githubusercontent.com/16886711/233904271-bc459729-798f-4123-a58f-17728d16f04b.png">
<img width="1536" alt="Capture d’écran 2023-04-24 à 07 01 27" src="https://user-images.githubusercontent.com/16886711/233904280-54ab58ff-cf71-4be5-ab21-623766b3a8d7.png">

After

<img width="1536" alt="Capture d’écran 2023-04-24 à 07 01 40" src="https://user-images.githubusercontent.com/16886711/233904309-a9a97f87-6af8-49dc-a24d-83e75f785310.png">
<img width="1536" alt="Capture d’écran 2023-04-24 à 07 01 44" src="https://user-images.githubusercontent.com/16886711/233904318-92fbee69-774f-4b80-ab7e-a096e151d245.png">
