### PR TITLE
Include network in arg file paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,10 @@ jobs:
       - name: Install nns-dapp and sns_aggregator
         run: |
           echo "Create the nns-dapp install argument:"
-          DFX_NETWORK=local ./config.sh
+          export DFX_NETWORK=local
+          ./config.sh
           echo "Install:"
-          dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg.did)"
+          dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
           dfx canister install sns_aggregator --wasm sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
           # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:
           dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
@@ -162,7 +163,7 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count
         run: |
-          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp.wasm --mode upgrade --argument "$(cat nns-dapp-arg.did)"
+          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp.wasm --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
           postinstall_instructions="$(scripts/backend/get_upgrade_instructions)"
           echo "Installation consumed ${postinstall_instructions} instructions."
           echo "Cycles consumed are instructions * some factor that depends on subnet.  There is no guarantee that that formula will not change."

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -45,8 +45,8 @@ jobs:
           path: |
             ${{ matrix.BUILD_NAME }}-out/commit.txt
             ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
-            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.did
-            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg.bin
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-$${{ matrix.DFX_NETWORK }}.did
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-$${{ matrix.DFX_NETWORK }}.bin
             ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ canister_ids.json
 canister_ids.json.*
 e2e-tests/node_modules
 /deployment-config.json
-nns-dapp-arg.did
+nns-dapp-arg*
 release/
 
 .dfx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /build
 ARG DFX_NETWORK=mainnet
 RUN mkdir -p frontend
 RUN ./config.sh
-RUN didc encode "$(cat nns-dapp-arg.did)" | xxd -r -p >nns-dapp-arg.bin
+RUN didc encode "$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p >nns-dapp-arg-${DFX_NETWORK}.bin
 
 # Title: Gets the mainnet config, used for builds
 # Args: None.  This is fixed and studiously avoids depending on variables such as DFX_NETWORK.
@@ -94,8 +94,9 @@ SHELL ["bash", "-c"]
 COPY dfx.json config.sh /build/
 WORKDIR /build
 RUN mkdir -p frontend
-RUN DFX_NETWORK=mainnet ./config.sh
-RUN didc encode "$(cat nns-dapp-arg.did)" | xxd -r -p >nns-dapp-arg.bin
+ENV DFX_NETWORK=mainnet
+RUN ./config.sh
+RUN didc encode "$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p >nns-dapp-arg-${DFX_NETWORK}.bin
 
 # Title: Image to build the nns-dapp frontend.
 FROM builder AS build_frontend
@@ -160,7 +161,7 @@ RUN ./build-sns-aggregator.sh
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch
 COPY --from=configurator /build/deployment-config.json /
-COPY --from=configurator /build/nns-dapp-arg.did /build/nns-dapp-arg.bin /
+COPY --from=configurator /build/nns-dapp-arg* /
 # Note: The frontend/.env is kept for use with test deployments only.
 COPY --from=configurator /build/frontend/.env /frontend-config.sh
 COPY --from=build_nnsdapp /build/nns-dapp.wasm /

--- a/config.sh
+++ b/config.sh
@@ -19,13 +19,14 @@ set -euo pipefail
 
 : "Move into the repository root directory"
 pushd "$(dirname "${BASH_SOURCE[0]}")"
-ENV_FILE=${ENV_OUTPUT_FILE:-$PWD/frontend/.env}
-JSON_OUT="deployment-config.json"
-CANDID_ARGS_FILE="nns-dapp-arg.did"
 
 : "Scan environment:"
 test -n "$DFX_NETWORK" # Will fail if not defined.
 export DFX_NETWORK
+
+ENV_FILE=${ENV_OUTPUT_FILE:-$PWD/frontend/.env}
+JSON_OUT="deployment-config.json"
+CANDID_ARGS_FILE="nns-dapp-arg-${DFX_NETWORK}.did"
 
 first_not_null() {
   for x in "$@"; do

--- a/config.test
+++ b/config.test
@@ -16,8 +16,8 @@ clean_config() {
   echo "Stability test: Verifies that mainnet parameters have not changed unintentionally."
   echo "(If the mainnet parameters have changed intentionally, please update the values in this test.)"
 
-  clean_config
   DFX_NETWORK=mainnet
+  clean_config
   export DFX_NETWORK
   chronic ./config.sh
   json_diff="$(

--- a/config.test
+++ b/config.test
@@ -3,10 +3,12 @@ set -euo pipefail
 
 JSON_CONFIG="deployment-config.json"
 ENV_CONFIG="frontend/.env"
-ARG_CONFIG="nns-dapp-arg.did"
+arg_config() {
+  echo "nns-dapp-arg-${DFX_NETWORK}.did"
+}
 
-ALL_CONFIG=("$JSON_CONFIG" "$ENV_CONFIG" "$ARG_CONFIG")
 clean_config() {
+  ALL_CONFIG=("$JSON_CONFIG" "$ENV_CONFIG" "$(arg_config)")
   rm -f "${ALL_CONFIG[@]}"
 }
 
@@ -86,7 +88,7 @@ clean_config() {
   } >&2
 
   arg_diff="$(
-    diff "$ARG_CONFIG" <(
+    diff "$(arg_config)" <(
       cat <<-EOF
 		(opt record{
 		  args = vec {
@@ -116,7 +118,7 @@ clean_config() {
     )
   )"
   [[ "${arg_diff:-}" == "" ]] || {
-    printf "ERROR: %s\n" "Unexpected difference in $ARG_CONFIG:"
+    printf "ERROR: %s\n" "Unexpected difference in $(arg_config):"
     printf "%s\n" "$arg_diff"
     exit 1
   } >&2
@@ -137,9 +139,9 @@ clean_config() {
       exit 1
     } >&2
     : "Check value in arg"
-    ARG_NETWORK="$(idl2json <nns-dapp-arg.did | jq -r '.[0].args[]|select(.["0"] == "DFX_NETWORK")|.["1"]')"
+    ARG_NETWORK="$(idl2json <"$(arg_config)" | jq -r '.[0].args[]|select(.["0"] == "DFX_NETWORK")|.["1"]')"
     [[ "$DFX_NETWORK" == "$ARG_NETWORK" ]] || {
-      printf "ERROR: %s\n" "Unexpected DFX_NETWORK value in $ARG_CONFIG:" \
+      printf "ERROR: %s\n" "Unexpected DFX_NETWORK value in $(arg_config):" \
         "Expected: $DFX_NETWORK" \
         "Actual:   $ARG_NETWORK"
       exit 1

--- a/config.test
+++ b/config.test
@@ -17,7 +17,9 @@ clean_config() {
   echo "(If the mainnet parameters have changed intentionally, please update the values in this test.)"
 
   clean_config
-  DFX_NETWORK=mainnet chronic ./config.sh
+  DFX_NETWORK=mainnet
+  export DFX_NETWORK
+  chronic ./config.sh
   json_diff="$(
     diff "$JSON_CONFIG" <(
       cat <<-EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,7 +105,7 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
   #        to deploy these other canisters as well, but you probably don't.
   DFX_NETWORK="$DFX_NETWORK" ./config.sh
   dfx canister --network "$DFX_NETWORK" create nns-dapp --no-wallet || echo "canister for NNS Dapp may have been created already"
-  dfx deploy nns-dapp --argument "$(cat nns-dapp-arg.did)" --upgrade-unchanged --network "$DFX_NETWORK" --no-wallet
+  dfx deploy nns-dapp --argument "$(cat "nns-dapp-arg-${DFX_NETWORK}.did")" --upgrade-unchanged --network "$DFX_NETWORK" --no-wallet
   OWN_CANISTER_URL="$(grep OWN_CANISTER_URL <"$CONFIG_FILE" | sed "s|VITE_OWN_CANISTER_URL=||g")"
   echo "NNS Dapp deployed to: $OWN_CANISTER_URL"
 fi

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -68,7 +68,7 @@ rm -rf "${OUTDIR:-not-the-file-you-were-looking-for}"
 # In normal production builds, only these files will be generated,
 # but a small code change can easily produce much more.  We ensure that
 # even in such circumstances only expected files end up in ./.
-assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm "nns-dapp-arg-${DFX_NETWORK}.did" nns-dapp-arg-${DFX_NETWORK}.bin)
+assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm "nns-dapp-arg-${DFX_NETWORK}.did" "nns-dapp-arg-${DFX_NETWORK}.bin")
 for file in "${assets[@]}"; do
   rm -f "$file"
 done

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -68,7 +68,7 @@ rm -rf "${OUTDIR:-not-the-file-you-were-looking-for}"
 # In normal production builds, only these files will be generated,
 # but a small code change can easily produce much more.  We ensure that
 # even in such circumstances only expected files end up in ./.
-assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm nns-dapp-arg.did nns-dapp-arg.bin)
+assets=(assets.tar.xz nns-dapp.wasm sns_aggregator.wasm "nns-dapp-arg-${DFX_NETWORK}.did" nns-dapp-arg-${DFX_NETWORK}.bin)
 for file in "${assets[@]}"; do
   rm -f "$file"
 done

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -37,7 +37,7 @@ get_prod_wasm() {
 
 # Installs the current build of nns-dapp
 upgrade_nnsdapp() {
-  dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade --argument "$(cat nns-dapp-arg.did)"
+  dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
   scripts/dfx-canister-check-wasm-hash --wasm "$1" --canister nns-dapp
 }
 
@@ -56,7 +56,7 @@ if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
   upgrade_nnsdapp "$CURRENT_WASM"
 else
   dfx canister create nns-dapp
-  dfx canister install nns-dapp --wasm "$CURRENT_WASM" --argument "$(cat nns-dapp-arg.did)"
+  dfx canister install nns-dapp --wasm "$CURRENT_WASM" --argument "$(cat nns-dapp-arg-local.did)"
 fi
 echo "Checking that the current wasm is healthy..."
 verify_healthy

--- a/scripts/nns-dapp/release
+++ b/scripts/nns-dapp/release
@@ -118,8 +118,8 @@ WASM="./release/ci/nns-dapp.wasm"
 SHA="$(sha256sum <"$WASM" | awk '{print $1}')"
 
 # Gets the canister arguments
-ARG_DID="./release/nns-dapp-arg.did"
-ARG_PATH="./release/nns-dapp-arg.bin"
+ARG_DID="./release/nns-dapp-arg-${DFX_NETWORK}.did"
+ARG_PATH="./release/nns-dapp-arg-${DFX_NETWORK}.bin"
 test -e "$ARG_DID" || {
   echo "ERROR: Arguments need to be provided in $ARG_DID"
   exit 1

--- a/scripts/nns-dapp/release-check
+++ b/scripts/nns-dapp/release-check
@@ -14,13 +14,14 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="mainnet"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 cd ""
 
 # The deployment converts the did file to bianry at the last moment, like this:
-ARG_DID="./release/nns-dapp-arg.did"
-ARG_PATH="./release/nns-dapp-arg.bin"
+ARG_DID="./release/nns-dapp-arg-${DFX_NETWORK}.did"
+ARG_PATH="./release/nns-dapp-arg-${DFX_NETWORK}.bin"
 test -e "$ARG_DID" || {
   echo "ERROR: Arguments need to be provided in $ARG_DID"
   exit 1
@@ -28,5 +29,5 @@ test -e "$ARG_DID" || {
 didc encode "$(cat "$ARG_DID")" | xxd -r -p >"$ARG_PATH"
 # ... Check whether that produces a valid argument
 echo "Checking binary argument:"
-cargo run --bin nns-dapp-check-args -- ./release/nns-dapp-arg.bin
+cargo run --bin nns-dapp-check-args -- "./release/nns-dapp-arg-${DFX_NETWORK}.bin"
 echo "Check passes"

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -72,10 +72,10 @@ You may also want to verify the canister arguments.  In the proposal they are bi
 provides both binary and text formats and you can verify that the text format corresponds to the binary in the proposal.
 
 \`\`\`
-sha256sum nns-dapp-arg.bin
-didc encode "$(cat nns-dapp-arg.did)" | xxd -r -p | sha256sum
+sha256sum nns-dapp-arg-${DFX_NETWORK}.bin
+didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p | sha256sum
 \`\`\`
 EOF
 
 ./config.sh
-cp nns-dapp-arg.did ./release/nns-dapp-arg.did
+cp "nns-dapp-arg-${DFX_NETWORK}.did" "./release/nns-dapp-arg-${DFX_NETWORK}.did"


### PR DESCRIPTION
# Motivation
How is it possible to mess up when deploying to production?  One answer: It is possible to deploy testnet artefacts to mainnet.  Testnet and mainnet now use the same wasm, however it is possible to accidentally use testnet args on mainnet, especially when we test deployments beforehand on local and static testnets.

# Changes
- Rename nns-dapp-args.did and nns-dapp-args.bin to `nns-dapp-args-${$DFX_NETWORK}.did` and `...bin`

# Tests
- [x]  CI
- [x] Manually check that mainnet releases contain the right network and use the right arg files - see log in comment below.
- [x] Similarly check releases by proposal to a testnet - see log in comment below.