### PR TITLE
Add testId to ProjectCard

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -37,6 +37,7 @@
 </script>
 
 <Card
+  testId="project-card-component"
   role="link"
   on:click={showProject}
   theme={commitmentE8s !== undefined ? "highlighted" : undefined}

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -46,7 +46,7 @@ describe("Projects", () => {
       },
     });
 
-    expect(getAllByTestId("card").length).toBe(
+    expect(getAllByTestId("project-card-component").length).toBe(
       lifecycles.filter((lc) => lc === SnsSwapLifecycle.Open).length
     );
   });
@@ -77,7 +77,7 @@ describe("Projects", () => {
       },
     });
 
-    expect(getAllByTestId("card").length).toBe(
+    expect(getAllByTestId("project-card-component").length).toBe(
       lifecycles.filter((lc) => lc === SnsSwapLifecycle.Adopted).length
     );
   });
@@ -108,7 +108,7 @@ describe("Projects", () => {
       },
     });
 
-    expect(getAllByTestId("card").length).toBe(
+    expect(getAllByTestId("project-card-component").length).toBe(
       lifecycles.filter((lc) => lc === SnsSwapLifecycle.Committed).length
     );
   });


### PR DESCRIPTION
# Motivation

I'm adding a testId to `ProjectCard` in https://github.com/dfinity/nns-dapp/pull/2361 but it overrides the testId of the `Card` component, which causes an existing test to fail.
Because the test is unrelated to that PR, I'm updating it in this separate PR.

# Changes

1. Add testId on `Card` in `frontend/src/lib/components/launchpad/ProjectCard.svelte`.
2. Update `frontend/src/tests/lib/components/launchpad/Projects.spec.ts` to use that testId instead of the default `"card"` testId.

# Tests

`npm run test`
