### PR TITLE
Enable Firefox in e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Prepare for Playwright end-to-end tests
         working-directory: frontend
         run: |
+          npx playwright install --with-deps firefox
           npm ci
       - name: Wait for aggregator to get all SNSs
         run: |

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,13 +48,13 @@ export default defineConfig({
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'], channel: "firefox" },
+    },
     // {
     //   name: "chromium",
     //   use: { ...devices["Desktop Chrome"] },
-    // },
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
     // },
     // {
     //   name: 'webkit',


### PR DESCRIPTION
# Motivation

I want to delete the old e2e tests.
Some of the old e2e tests run against Firefox so I want the new e2e tests to run against Firefox to make sure we don't lose any test coverage when we delete old e2e tests.

# Changes

1. Enable running playwright tests against Firefox.
2. Install Firefox for Playwright in CI workflow.

# Tests

CI.
