### PR TITLE
Add testId to Projects component

### DIFF
--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import ProjectCard from "./ProjectCard.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonProjectCard from "$lib/components/ui/SkeletonProjectCard.svelte";
   import { keyOf } from "$lib/utils/utils";
   import { snsQueryStoreIsLoading } from "$lib/stores/sns.store";
@@ -12,6 +13,7 @@
   import { filterProjectsStatus } from "$lib/utils/projects.utils";
   import { Html } from "@dfinity/gix-components";
 
+  export let testId: string | undefined = undefined;
   export let status: SnsSwapLifecycle;
 
   let projects: SnsFullProject[];
@@ -38,24 +40,26 @@
   });
 </script>
 
-{#if loading}
-  <div class="card-grid">
-    <SkeletonProjectCard />
-    <SkeletonProjectCard />
-    <SkeletonProjectCard />
-  </div>
-{:else}
-  <div class="card-grid">
-    {#each projects as project (project.rootCanisterId.toText())}
-      <ProjectCard {project} />
-    {/each}
-  </div>
-  {#if projects.length === 0}
-    <p data-tid="no-projects-message" class="no-projects description">
-      <Html text={noProjectsMessageLabel} />
-    </p>
+<TestIdWrapper {testId}>
+  {#if loading}
+    <div class="card-grid">
+      <SkeletonProjectCard />
+      <SkeletonProjectCard />
+      <SkeletonProjectCard />
+    </div>
+  {:else}
+    <div class="card-grid">
+      {#each projects as project (project.rootCanisterId.toText())}
+        <ProjectCard {project} />
+      {/each}
+    </div>
+    {#if projects.length === 0}
+      <p data-tid="no-projects-message" class="no-projects description">
+        <Html text={noProjectsMessageLabel} />
+      </p>
+    {/if}
   {/if}
-{/if}
+</TestIdWrapper>
 
 <style lang="scss">
   // match page spinner

--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -13,7 +13,7 @@
   import { filterProjectsStatus } from "$lib/utils/projects.utils";
   import { Html } from "@dfinity/gix-components";
 
-  export let testId: string | undefined = undefined;
+  export let testId: string;
   export let status: SnsSwapLifecycle;
 
   let projects: SnsFullProject[];

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -28,16 +28,16 @@
 
 <main>
   <h2>{$i18n.sns_launchpad.open_projects}</h2>
-  <Projects status={SnsSwapLifecycle.Open} />
+  <Projects testId="open-projects" status={SnsSwapLifecycle.Open} />
 
   {#if showAdopted}
     <h2>{$i18n.sns_launchpad.upcoming_projects}</h2>
-    <Projects status={SnsSwapLifecycle.Adopted} />
+    <Projects testId="upcoming-projects" status={SnsSwapLifecycle.Adopted} />
   {/if}
 
   {#if showCommitted}
     <h2>{$i18n.sns_launchpad.committed_projects}</h2>
-    <Projects status={SnsSwapLifecycle.Committed} />
+    <Projects testId="committed-projects" status={SnsSwapLifecycle.Committed} />
   {/if}
 
   <h2>{$i18n.sns_launchpad.proposals}</h2>

--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -42,6 +42,7 @@ describe("Projects", () => {
 
     const { getAllByTestId } = render(Projects, {
       props: {
+        testId: "open-projects",
         status: SnsSwapLifecycle.Open,
       },
     });
@@ -73,6 +74,7 @@ describe("Projects", () => {
 
     const { getAllByTestId } = render(Projects, {
       props: {
+        testId: "upcoming-projects",
         status: SnsSwapLifecycle.Adopted,
       },
     });
@@ -104,6 +106,7 @@ describe("Projects", () => {
 
     const { getAllByTestId } = render(Projects, {
       props: {
+        testId: "committed-projects",
         status: SnsSwapLifecycle.Committed,
       },
     });
@@ -124,6 +127,7 @@ describe("Projects", () => {
 
     const { queryByTestId } = render(Projects, {
       props: {
+        testId: "open-projects",
         status: SnsSwapLifecycle.Open,
       },
     });
@@ -142,6 +146,7 @@ describe("Projects", () => {
 
     const { queryByTestId } = render(Projects, {
       props: {
+        testId: "upcoming-projects",
         status: SnsSwapLifecycle.Adopted,
       },
     });
@@ -160,6 +165,7 @@ describe("Projects", () => {
 
     const { queryByTestId } = render(Projects, {
       props: {
+        testId: "committed-projects",
         status: SnsSwapLifecycle.Committed,
       },
     });
@@ -170,6 +176,7 @@ describe("Projects", () => {
   it("should render skeletons", async () => {
     const { getAllByTestId } = render(Projects, {
       props: {
+        testId: "open-projects",
         status: SnsSwapLifecycle.Open,
       },
     });


### PR DESCRIPTION
# Motivation

I'm adding a required testId to the `Projects` component in #2361 which causes warnings in an existing test.
Because the test is unrelated to that PR, I'm updating it in this separate PR.

# Changes

1. Add testId wrapper to frontend/src/lib/components/launchpad/Projects.svelte
2. Add testIds in frontend/src/tests/lib/components/launchpad/Projects.spec.ts

# Tests

`npm run test`
