### PR TITLE
Typecheck page objects

### DIFF
--- a/frontend/src/tests/page-objects/AddSubAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/AddSubAccount.page-object.ts
@@ -13,6 +13,6 @@ export class AddSubAccountPo extends BasePageObject {
   }
 
   clickCreate(): Promise<void> {
-    this.getButton("create-account-button").click();
+    return this.getButton("create-account-button").click();
   }
 }

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,5 +1,6 @@
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";

--- a/frontend/src/tests/page-objects/AppPo.spec.ts
+++ b/frontend/src/tests/page-objects/AppPo.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+
+// Playwright doesn't typecheck the test code or its dependencies.
+// So we often have type errors in page objects that are only used in Playwright
+// tests. Those page objects are typically accessed through AppPo, so by having
+// a Jest test depend on AppPo, we can typecheck those page objects.
+describe("AppPo", () => {
+  it("Type check all page objects under AppPo", () => {
+    new AppPo(new JestPageObjectElement(document.body));
+  });
+});

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -21,14 +21,14 @@ export class SimpleBasePageObject {
     return this.root.waitForAbsent();
   }
 
-  click(tid: string | undefined): Promise<void> {
+  click(tid: string | undefined = undefined): Promise<void> {
     if (isNullish(tid)) {
       return this.root.click();
     }
     return this.root.byTestId(tid).click();
   }
 
-  getText(tid: string | undefined): Promise<string> {
+  getText(tid: string | undefined = undefined): Promise<string> {
     if (isNullish(tid)) {
       return this.root.getText();
     }


### PR DESCRIPTION
# Motivation

Somehow, Playwright doesn't do typechecking.
So page objects which are only used in Playwright tests, often have type errors which are only caught when those page objects are first used in a Jest test.
Most/all page objects used by Playwright tests are (indirectly) depended on by `AppPo`.

# Changes

1. Add a dummy Jest test which depends on AppPo.
2. Fix discovered issues.

# Tests

`npm run test`
