### PR TITLE
Build only one wasm

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -18,8 +18,6 @@ jobs:
         include:
           - BUILD_NAME: "mainnet"
             DFX_NETWORK: "mainnet"
-          - BUILD_NAME: "local"
-            DFX_NETWORK: "local"
     steps:
       - uses: actions/checkout@v3
       - name: Set up docker buildx


### PR DESCRIPTION
# Motivation
The wasm build no longer depends on network, so there is no need to build it for two networks.

The only difference between the docker build outputs is whether the arguments are prepared for mainnet or localhost.  The mainnet arguments can be used for release verification.  If we really need the localhost arguments we can generate them by running ./config.sh.

# Changes
* run the docker build for mainnet only.

# Tests
See CI