### PR TITLE
Add tsc types check

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build:post-process": "npm run build:csp",
     "i18n": "node --experimental-json-modules scripts/i18n.types.js",
     "dev": "npm run i18n && vite dev",
-    "build": "npm run i18n && vite build && npm run build:post-process",
+    "build": "npm run i18n && tsc --noEmit && vite build && npm run build:post-process",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --fail-on-warnings --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
# Motivation

Vite transpile only. We are fine because we have checks and are using editors as recommended by vite.
For even more safety, this PR adds `tsc` to the build as we did yesterday in II ([#1467](https://github.com/dfinity/internet-identity/pull/1467)).

Documentation: https://vitejs.dev/guide/features.html#transpile-only

