### PR TITLE
fix: apply proposals visibility after neuron loading

### DIFF
--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -127,7 +127,7 @@
     debounceFindProposals?.();
   };
 
-  $: applyFilter($proposalsFiltersStore);
+  $: $definedNeuronsStore, applyFilter($proposalsFiltersStore);
 
   $: $authStore.identity, (() => proposalsFiltersStore.reload())();
 


### PR DESCRIPTION
# Motivation

Fix empty proposal list after load when `only-open` filter selected.
The visibility logic is also based on the user neurons presence in the proposal ballots (see `containsUnspecifiedBallot`)

# Changes

- reapply filter after neuron store changes

