### PR TITLE
npm ci before playwright install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
       - name: Prepare for Playwright end-to-end tests
         working-directory: frontend
         run: |
-          npx playwright install --with-deps firefox
           npm ci
+          npx playwright install --with-deps firefox
       - name: Wait for aggregator to get all SNSs
         run: |
           set +x


### PR DESCRIPTION
# Motivation

[In CI](https://github.com/dfinity/nns-dapp/actions/runs/4794994667/jobs/8529002330) I'm seeing this message:
```
╔═══════════════════════════════════════════════════════════════════════════════╗
║ WARNING: It looks like you are running 'npx playwright install' without first ║
║ installing your project's dependencies.                                       ║
║                                                                               ║
║ To avoid unexpected behavior, please install your dependencies first, and     ║
║ then run Playwright's install command:                                        ║
║                                                                               ║
║     npm install                                                               ║
║     npx playwright install                                                    ║
║                                                                               ║
║ If your project does not yet depend on Playwright, first install the          ║
║ applicable npm package (most commonly @playwright/test), and                  ║
║ then run Playwright's install command to download the browsers:               ║
║                                                                               ║
║     npm install @playwright/test                                              ║
║     npx playwright install                                                    ║
║                                                                               ║
╚═══════════════════════════════════════════════════════════════════════════════╝
```

This goes away if I put `npm ci` before `npx playwright install --with-deps firefox` instead of after it.
I thought that's what I had done anyway but apparently not.

# Changes

1. Put `npm ci` before `npx playwright install --with-deps firefox` instead of after it, in `.github/workflows/build.yml`.

# Tests

[Checked CI](https://github.com/dfinity/nns-dapp/actions/runs/4788444233/jobs/8515058149?pr=2373) and the message is gone.