### PR TITLE
Fix nightly tagging

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -26,13 +26,13 @@ jobs:
           : Log commit and existing tags
           git rev-parse HEAD
           git tag --points-at HEAD
+          readarray -t TAGS < <(git tag --points-at HEAD)
           : Log tag that triggered this run, if any
           GH_REF="${{github.ref}}"
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || {
-                  GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-            echo "Tag: $GH_TAG"
-          }
+          GH_TAG="${GH_REF_WITHOUT_PREFIX}"
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          echo tags: "${TAGS[@]}"
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
       # Build and upload testnet assets

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -70,6 +70,7 @@ jobs:
           GH_REF="${{github.ref}}"
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
           GH_TAG="${GH_REF_WITHOUT_PREFIX}"
+          : ... This run was not triggered by a tag OR the tag is already included OR add the github event tag to the list of tags.
           [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for t in "${TAGS[@]}"; do [[ "$t" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
           echo Tags: "${TAGS[@]}"
           : Get a list of assets

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -31,7 +31,7 @@ jobs:
           GH_REF="${{github.ref}}"
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
           GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
           echo tags: "${TAGS[@]}"
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -69,11 +69,13 @@ jobs:
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
           GH_TAG="${GH_REF_WITHOUT_PREFIX}"
           [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          echo Tags: "${TAGS[@]}"
           : Get a list of assets
           cd "${{ matrix.BUILD_NAME }}-out"
           daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
           cp nns-dapp.wasm "$daily_build_name"
           artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
+          echo "Assets:"
           ls -l "${artefacts[@]}"
           : Make or update a release for every tag
           for tag in "${TAGS[@]}" ; do

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -62,12 +62,21 @@ jobs:
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release
         run: |
+          : Get a list of tags
+          readarray -t TAGS < <(git tag --points-at HEAD)
+          : Add tag that triggered this run, if any.  There is no guarantee that it has been included already.
+          GH_REF="${{github.ref}}"
+          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
+          GH_TAG="${GH_REF_WITHOUT_PREFIX}"
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          : Get a list of assets
           cd "${{ matrix.BUILD_NAME }}-out"
           daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
           cp nns-dapp.wasm "$daily_build_name"
           artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
           ls -l "${artefacts[@]}"
-          for tag in $(git tag --points-at HEAD) ; do
+          : Make or update a release for every tag
+          for tag in "${TAGS[@]}" ; do
             : Creates or updates a release for the tag
             if gh release view "$tag"
             then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,6 +20,19 @@ jobs:
             DFX_NETWORK: "mainnet"
     steps:
       - uses: actions/checkout@v3
+      - name: Print tags
+        run: |
+          set -x
+          : Log commit and existing tags
+          git rev-parse HEAD
+          git tag --points-at HEAD
+          : Log tag that triggered this run, if any
+          GH_REF="${{github.ref}}"
+          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || {
+                  GH_TAG="${GH_REF_WITHOUT_PREFIX}"
+            echo "Tag: $GH_TAG"
+          }
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
       # Build and upload testnet assets

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Print tags
         run: |
           set -x
+          : Note: This printout is for debugging.  Please keep it in main until tags are handled correctly.
           : Log commit and existing tags
           git rev-parse HEAD
           git tag --points-at HEAD
@@ -31,7 +32,8 @@ jobs:
           GH_REF="${{github.ref}}"
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
           GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          : ... This run was not triggered by a tag OR the tag is already included OR add the github event tag to the list of tags.
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for t in "${TAGS[@]}"; do [[ "$t" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
           echo tags: "${TAGS[@]}"
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
@@ -68,7 +70,7 @@ jobs:
           GH_REF="${{github.ref}}"
           GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
           GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for e in "${TAGS[@]}"; do [[ "$e" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for t in "${TAGS[@]}"; do [[ "$t" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
           echo Tags: "${TAGS[@]}"
           : Get a list of assets
           cd "${{ matrix.BUILD_NAME }}-out"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,6 +21,13 @@ jobs:
           : Log commit and existing tags
           git rev-parse HEAD
           git tag --points-at HEAD
+          : Log tag that triggered this run, if any
+          GH_REF="${{github.ref}}"
+          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
+          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || {
+                  GH_TAG="${GH_REF_WITHOUT_PREFIX}"
+            echo "Tag: $GH_TAG"
+          }
           : Add a tag if appropriate
           if git tag --points-at HEAD | grep -E '\<nightly-'
           then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,13 +21,6 @@ jobs:
           : Log commit and existing tags
           git rev-parse HEAD
           git tag --points-at HEAD
-          : Log tag that triggered this run, if any
-          GH_REF="${{github.ref}}"
-          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || {
-                  GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-            echo "Tag: $GH_TAG"
-          }
           : Add a tag if appropriate
           if git tag --points-at HEAD | grep -E '\<nightly-'
           then echo "Skipping as there is already a nightly tag on commit $(git rev-parse HEAD)"


### PR DESCRIPTION
# Motivation
Triggering builds with tags is unreliable.  Presumably there is a race condition between adding a tag to git and triggering the run, so the list of tags known to git may or may not include the tag that triggered an event.

# Changes
- Check whether a docker-build workflow was triggered by a tag.  If so, add the tag to the list of tags for this commit, if it is not already there.

# Tests
Only time will tell for sure.  But pushing a tag does show the tag being identified in the github workflow.