### PR TITLE
Declare feature flag

### DIFF
--- a/rs/sns_aggregator/Cargo.toml
+++ b/rs/sns_aggregator/Cargo.toml
@@ -28,3 +28,6 @@ serde_json = "1.0.91"
 sha2 = "0.10.6"
 anyhow = "1.0.68"
 num-traits = "0.2.15"
+
+[features]
+reconfigurable = []


### PR DESCRIPTION
# Motivation
The `sns_aggregator` has a feature flag.  Rather surprisingly, it works even though it is not set in the Cargo.toml.  Still, it is better to declare it.

# Changes
- Declare the feature flag

# Tests
- Using the `--features` flag did not work but does now:
```
Main:
max@sinkpad:~/dfn/nns-dapp (4)$ cargo check -p sns_aggregator --features reconfigurable
error: none of the selected packages contains these features: reconfigurable
max@sinkpad:~/dfn/nns-dapp (11)$ 

This branch:
max@sinkpad:~/dfn/nns-dapp/branches/declare-feature (12:58)$ cargo check -p sns_aggregator --features reconfigurable
[successful output]
```

- [By default features are not enabled](https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature), so the feature flag should not be enabled for non-dev builds. Still, to double check:
```
On main only the dev build has the reconfigure function:

max@sinkpad:~/dfn/nns-dapp (9:32)$ wasm-nm <(gunzip < ./out/sns_aggregator_dev.wasm) | grep reconf
e canister_update reconfigure
max@sinkpad:~/dfn/nns-dapp (9:40)$ wasm-nm <(gunzip < ./out/sns_aggregator.wasm) | grep reconf
max@sinkpad:~/dfn/nns-dapp (9:44)$ 

On this branch it is the same:

max@sinkpad:~/dfn/nns-dapp/branches/declare-feature (58:51)$ wasm-nm <(gunzip < ./out/sns_aggregator_dev.wasm) | grep reconf
e canister_update reconfigure
max@sinkpad:~/dfn/nns-dapp/branches/declare-feature (59:02)$ wasm-nm <(gunzip < ./out/sns_aggregator.wasm) | grep reconf
max@sinkpad:~/dfn/nns-dapp/branches/declare-feature (59:09)$ 
```
Furthermore the docker build outputs are identical for main and this branch.  So this really does nothing other than the intended effect: Declare the feature in the standard way so that it can be used in the standard way.