### PR TITLE
GIX-1505: Fix prod preview

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -41,10 +41,12 @@ The [canister_ids.json] data provides the list of canister IDs available for var
 
 ## Preview
 
-To run a production like environment locally agains a replica run:
+To run a production like environment locally against a replica run:
 
 ```bash
-DFX_NETWORK=<replica-network> npm run preview
+DFX_NETWORK=<replica-network> ../config.sh
+npm run build
+npm run preview
 ```
 
 ### Configure

--- a/HACKING.md
+++ b/HACKING.md
@@ -39,6 +39,14 @@ Once you have a running replica with nns installed and a fixed
 
 The [canister_ids.json] data provides the list of canister IDs available for various test environments.
 
+## Preview
+
+To run a production like environment locally agains a replica run:
+
+```bash
+DFX_NETWORK=<replica-network> npm run preview
+```
+
 ### Configure
 
 To develop and run locally the dapp against a testnet, proceed as following:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "i18n": "node --experimental-json-modules scripts/i18n.types.js",
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && tsc --noEmit && vite build && npm run build:post-process",
-    "preview": "../config.sh && npm run build && vite preview",
+    "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --fail-on-warnings --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "pprettier --check './**/*.{ts,js,mjs,json,scss,svelte,html}' && eslint --max-warnings 0 .",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "i18n": "node --experimental-json-modules scripts/i18n.types.js",
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && tsc --noEmit && vite build && npm run build:post-process",
-    "preview": "vite preview",
+    "preview": "../config.sh && npm run build && vite preview",
     "check": "svelte-kit sync && svelte-check --fail-on-warnings --tsconfig ./tsconfig.json && npm run lint",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "pprettier --check './**/*.{ts,js,mjs,json,scss,svelte,html}' && eslint --max-warnings 0 .",

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -1,22 +1,25 @@
 import { getEnvVars } from "$lib/utils/env-vars.utils";
-import { addRawToUrl } from "$lib/utils/env.utils";
+import { addRawToUrl, isLocalhost } from "$lib/utils/env.utils";
+import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
 
 const envVars = getEnvVars();
 
 export const DFX_NETWORK = envVars.dfxNetwork;
 export const HOST = envVars.host;
 export const DEV = import.meta.env.DEV;
+
 export const FETCH_ROOT_KEY: boolean = envVars.fetchRootKey === "true";
 
 const snsAggregatorUrlEnv = envVars.snsAggregatorUrl ?? "";
 const snsAggregatorUrl = (url: string) => {
   try {
     const { hostname } = new URL(url);
-    if (hostname.includes("localhost") || hostname.includes("127.0.0.1")) {
+    if (isLocalhost(hostname)) {
       return url;
     }
 
-    if (DEV) {
+    // If the nns-dapp is running in loalhost, we need to add `raw` to the URL to avoid CORS issues.
+    if (DEV || (isBrowser && isLocalhost(window.location.hostname))) {
       return addRawToUrl(url);
     }
 

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -18,8 +18,8 @@ const snsAggregatorUrl = (url: string) => {
       return url;
     }
 
-    // If the nns-dapp is running in loalhost, we need to add `raw` to the URL to avoid CORS issues.
-    if (DEV || (isBrowser && isLocalhost(window.location.hostname))) {
+    // If the nns-dapp is running in localhost, we need to add `raw` to the URL to avoid CORS issues.
+    if (isBrowser && isLocalhost(window.location.hostname)) {
       return addRawToUrl(url);
     }
 

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -147,8 +147,7 @@ export const getEnvVars = (): EnvironmentVars => {
   // We need to check `isBrowser` to skip the check when running the build.
   const isDevServer =
     localDevelopment ||
-    (isBrowser &&
-      (window.location.port === "5173" || window.location.port === "4173"));
+    (isBrowser && ["5173", "4173"].includes(window.location.port));
   if (!isBrowser || isDevServer) {
     return getBuildEnvVars();
   }

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -127,9 +127,28 @@ const getBuildEnvVars = (): EnvironmentVars => {
   return envVars;
 };
 
+/**
+ * Returns the environment variables depending on the environment.
+ *
+ * The environment variables might be set in the HTML or from the build environment variables.
+ *
+ * We use the build environment variables when one of the following conditions is true:
+ * - Not in the browser
+ * - Local development server
+ *
+ * All the other scenarios use the HTML environment variables.
+ *
+ * @returns {EnvironmentVars}
+ */
 export const getEnvVars = (): EnvironmentVars => {
-  if (isBrowser && !localDev) {
-    return getHtmlEnvVars();
+  // There are two instances of local dev server:
+  // - The local dev server started by `npm run dev`
+  // - The local dev server started by `npm run preview`. The only way to distinguis this one is by the port.
+  // We need to check `isBrowser` to skip the check when running the build.
+  const isLocalDevServer =
+    localDev || (isBrowser && window.location.port !== "");
+  if (!isBrowser || isLocalDevServer) {
+    return getBuildEnvVars();
   }
-  return getBuildEnvVars();
+  return getHtmlEnvVars();
 };

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -1,7 +1,7 @@
 import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
 import { isNullish } from "@dfinity/utils";
 
-const localDev = import.meta.env.DEV;
+const localDevelopment = import.meta.env.DEV;
 
 type EnvironmentVars = {
   // Environments without ckBTC canisters are valid
@@ -145,9 +145,11 @@ export const getEnvVars = (): EnvironmentVars => {
   // - The local dev server started by `npm run dev`
   // - The local dev server started by `npm run preview`. The only way to distinguis this one is by the port.
   // We need to check `isBrowser` to skip the check when running the build.
-  const isLocalDevServer =
-    localDev || (isBrowser && window.location.port !== "");
-  if (!isBrowser || isLocalDevServer) {
+  const isDevServer =
+    localDevelopment ||
+    (isBrowser &&
+      (window.location.port === "5173" || window.location.port === "4173"));
+  if (!isBrowser || isDevServer) {
     return getBuildEnvVars();
   }
   return getHtmlEnvVars();

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -28,3 +28,6 @@ export const addRawToUrl = (urlString: string): string => {
 
   return hasTrailingSlash ? url.toString() : url.toString().slice(0, -1);
 };
+
+export const isLocalhost = (hostname: string) =>
+  hostname.includes("localhost") || hostname.includes("127.0.0.1");

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { addRawToUrl, isNnsAlternativeOrigin } from "$lib/utils/env.utils";
+import {
+  addRawToUrl,
+  isLocalhost,
+  isNnsAlternativeOrigin,
+} from "$lib/utils/env.utils";
 
 describe("env-utils", () => {
   describe("isNnsAlternativeOrigin", () => {
@@ -121,6 +125,24 @@ describe("env-utils", () => {
       expect(() => addRawToUrl(invalid2)).toThrow(
         new TypeError(`Invalid URL: ${invalid2}`)
       );
+    });
+  });
+
+  describe("isLocalhost", () => {
+    it("return false when hostname is not localhost", () => {
+      expect(
+        isLocalhost(
+          "53zcu-tiaaa-aaaaa-qaaba-cai.medium09.testnet.dfinity.network"
+        )
+      ).toBe(false);
+      expect(isLocalhost("internetcomputer.org")).toBe(false);
+      expect(isLocalhost("nns.ic0.app")).toBe(false);
+    });
+
+    it("return true when hostname is localhost", () => {
+      expect(isLocalhost("localhost:3000")).toBe(true);
+      expect(isLocalhost("127.0.0.1:3000")).toBe(true);
+      expect(isLocalhost("xxxx.localhost")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Fix `npm run preview` which runs a production-like environment.

# Changes

Main change:
* Logic inside `getEnvVars`. Force to use the build env vars if the port is set. This is the case for local dev server and preview.

Minor changes:
* Add `raw` to the SNS aggregator url when running from localhost as well. This is skipped if the `url` of the aggregator already includes `localhost`.
* New env util `isLocalhost`.

# Tests

* Test new env util.

I tested the three ways:
* Deploy to testnet
* Local dev server
* Preview

# Docs

Add a comment on how to run `npm run preview`.
