### PR TITLE
Summarize insertion

### DIFF
--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -364,7 +364,7 @@ pub fn insert_asset_into_state<S: Into<String> + Clone>(state: &State, path: S, 
 ///
 /// Note: Used both in init and post_upgrade
 pub fn init_assets() {
-    dfn_core::api::print("Inserting assets...".to_string());
+    dfn_core::api::print("Inserting assets...");
     let mut num_assets = 0;
     let compressed = include_bytes!("../../../assets.tar.xz").to_vec();
     let mut decompressed = Vec::new();

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -337,7 +337,6 @@ pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
 
 /// Insert an asset into the state and update the certificates.
 pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
-    dfn_core::api::print(format!("Inserting asset {}", &path.clone().into()));
     STATE.with(|state| {
         insert_asset_into_state(state, path, asset);
         update_root_hash(&state.asset_hashes.borrow_mut());
@@ -348,7 +347,6 @@ pub fn insert_asset<S: Into<String> + Clone>(path: S, asset: Asset) {
 /// Note:  This does NOT update the certificates.  To insert multiple assets, call
 ///        this repeatedly and then update the root hash.
 pub fn insert_asset_into_state<S: Into<String> + Clone>(state: &State, path: S, asset: Asset) {
-    dfn_core::api::print(format!("Inserting asset {}", &path.clone().into()));
     let mut asset_hashes = state.asset_hashes.borrow_mut();
     let mut assets = state.assets.borrow_mut();
     let path: String = path.into();
@@ -366,6 +364,8 @@ pub fn insert_asset_into_state<S: Into<String> + Clone>(state: &State, path: S, 
 ///
 /// Note: Used both in init and post_upgrade
 pub fn init_assets() {
+    dfn_core::api::print("Inserting assets...".to_string());
+    let mut num_assets = 0;
     let compressed = include_bytes!("../../../assets.tar.xz").to_vec();
     let mut decompressed = Vec::new();
     lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
@@ -395,21 +395,20 @@ pub fn init_assets() {
             entry.read_to_end(&mut bytes).unwrap();
 
             if name.ends_with("index.html.gz") {
-                dfn_core::api::print(format!("{}: {} + arguments", &name, bytes.len()));
                 let mut html = gunzip_string(&bytes);
                 if let Some(insertion_point) = html.find("</head>") {
                     html.insert_str(insertion_point, &arguments_html);
                 }
                 let html = template_engine.populate(&html);
                 bytes = gzip(html.as_bytes());
-            } else {
-                dfn_core::api::print(format!("{}: {}", &name, bytes.len()));
             }
 
             insert_asset_into_state(state, name, Asset::new(bytes));
+            num_assets += 1;
         }
         update_root_hash(&state.asset_hashes.borrow_mut());
-    })
+    });
+    dfn_core::api::print(format!("Inserted {num_assets} assets."));
 }
 
 impl StableState for Assets {


### PR DESCRIPTION
# Motivation
The Kibana logs are flooded with print statements about inserting assets.  We can probably survive with fewer and the mass of messages makes it harder to pick out other activity.

# Changes
- Print a count of asset insertions rather than a blow by blow narrative of every wonderful chunk that is now available.
- Print the canister install/upgrade arguments as a one-liner.  It's not as pretty when running locally but is much easier when getting the data in Kibana.  Not just easier, it turns out that a multi-line printout in Kibana logs the first line N times where N is the number of lines.  Spammy and information free.

# Tests
See a deployment log now:
```
[Canister st75y-vaaaa-aaaaa-aaalq-cai] post_upgrade with args: Some(CanisterArguments { args: [("CYCLES_MINTING_CANISTER_ID", "rkp4c-7iaaa-aaaaa-aaaca-cai"), ("DFX_NETWORK", "loc...[SNIP]
[Canister st75y-vaaaa-aaaaa-aaalq-cai] Inserting assets...
[Canister st75y-vaaaa-aaaaa-aaalq-cai] Inserted 263 assets.

```