### PR TITLE
ckBTC display error as info

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -886,6 +886,7 @@
     "get_btc_no_account": "An account should be provided to execute this feature",
     "get_btc_no_universe": "A ckBTC environment should be provided to execute this feature",
     "update_balance": "Sorry, the balance cannot be updated.",
+    "no_new_confirmed_btc": "Updated available ckBTC : No new confirmed BTC.",
     "withdrawal_account": "Sorry, no withdrawal account can be found.",
     "retrieve_btc": "Sorry, retrieving BTC failed.",
     "malformed_address": "Address malformed.",

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -137,7 +137,7 @@ export const updateBalance = async ({
     // Few errors returned by the minter are considered to be displayed as information for the user
     if (err instanceof CkBTCInfoKey) {
       toastsShow({
-        labelKey: err.key,
+        labelKey: err.message,
         level: "info",
       });
 
@@ -171,7 +171,7 @@ const mapUpdateBalanceError = (
   }
 
   if (err instanceof MinterNoNewUtxosError) {
-    return new CkBTCInfoKey(labels.error__ckbtc.no_new_utxo);
+    return new CkBTCInfoKey(labels.error__ckbtc.no_new_confirmed_btc);
   }
 
   if (err instanceof MinterGenericError) {

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -8,9 +8,13 @@ import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
 import { i18n } from "$lib/stores/i18n";
-import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
+import {
+  toastsError,
+  toastsShow,
+  toastsSuccess,
+} from "$lib/stores/toasts.store";
 import type { CanisterId } from "$lib/types/canister";
-import { CkBTCErrorKey } from "$lib/types/ckbtc.errors";
+import { CkBTCErrorKey, CkBTCInfoKey } from "$lib/types/ckbtc.errors";
 import { toToastError } from "$lib/utils/error.utils";
 import {
   MinterAlreadyProcessingError,
@@ -110,7 +114,7 @@ export const updateBalance = async ({
 }: {
   minterCanisterId: CanisterId;
   reload: (() => Promise<void>) | undefined;
-}): Promise<{ success: boolean; err?: unknown }> => {
+}): Promise<{ success: boolean; err?: CkBTCErrorKey | unknown }> => {
   startBusy({
     initiator: "update-ckbtc-balance",
   });
@@ -130,6 +134,16 @@ export const updateBalance = async ({
   } catch (error: unknown) {
     const err = mapUpdateBalanceError(error);
 
+    // Few errors returned by the minter are considered to be displayed as information for the user
+    if (err instanceof CkBTCInfoKey) {
+      toastsShow({
+        labelKey: err.key,
+        level: "info",
+      });
+
+      return { success: true };
+    }
+
     toastsError({
       labelKey: "error__ckbtc.update_balance",
       err,
@@ -141,7 +155,9 @@ export const updateBalance = async ({
   }
 };
 
-const mapUpdateBalanceError = (err: unknown): unknown => {
+const mapUpdateBalanceError = (
+  err: unknown
+): CkBTCErrorKey | CkBTCInfoKey | unknown => {
   const labels = get(i18n);
 
   if (err instanceof MinterTemporaryUnavailableError) {
@@ -155,7 +171,7 @@ const mapUpdateBalanceError = (err: unknown): unknown => {
   }
 
   if (err instanceof MinterNoNewUtxosError) {
-    return new CkBTCErrorKey(labels.error__ckbtc.no_new_utxo);
+    return new CkBTCInfoKey(labels.error__ckbtc.no_new_utxo);
   }
 
   if (err instanceof MinterGenericError) {

--- a/frontend/src/lib/types/ckbtc.errors.ts
+++ b/frontend/src/lib/types/ckbtc.errors.ts
@@ -1,3 +1,15 @@
 export class CkBTCErrorKey extends Error {}
 
+export class CkBTCInfoKey {
+  private readonly labelKey: string;
+
+  constructor(labelKey: string) {
+    this.labelKey = labelKey;
+  }
+
+  get key() {
+    return this.labelKey;
+  }
+}
+
 export class CkBTCErrorRetrieveBtcMinAmount extends Error {}

--- a/frontend/src/lib/types/ckbtc.errors.ts
+++ b/frontend/src/lib/types/ckbtc.errors.ts
@@ -1,14 +1,10 @@
 export class CkBTCErrorKey extends Error {}
 
 export class CkBTCInfoKey {
-  private readonly labelKey: string;
+  public readonly message: string;
 
-  constructor(labelKey: string) {
-    this.labelKey = labelKey;
-  }
-
-  get key() {
-    return this.labelKey;
+  constructor(message: string) {
+    this.message = message;
   }
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -935,6 +935,7 @@ interface I18nError__ckbtc {
   get_btc_no_account: string;
   get_btc_no_universe: string;
   update_balance: string;
+  no_new_confirmed_btc: string;
   withdrawal_account: string;
   retrieve_btc: string;
   malformed_address: string;

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -6,6 +6,7 @@ import * as minterApi from "$lib/api/ckbtc-minter.api";
 import { CKBTC_MINTER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/ckbtc-minter.services";
 import * as busyStore from "$lib/stores/busy.store";
+import * as toastsStore from "$lib/stores/toasts.store";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockBTCAddressTestnet } from "$tests/mocks/ckbtc-accounts.mock";
@@ -139,16 +140,20 @@ describe("ckbtc-minter-services", () => {
       expect(result).toEqual({ success: false, err });
     });
 
-    it("should return no new UTXOs error", async () => {
+    it("should handle no new UTXOs info", async () => {
       jest.spyOn(minterApi, "updateBalance").mockImplementation(async () => {
         throw new MinterNoNewUtxosError();
       });
 
-      const err = new ApiErrorKey(en.error__ckbtc.no_new_utxo);
+      const spyOnToastsShow = jest.spyOn(toastsStore, "toastsShow");
 
       const result = await services.updateBalance(params);
 
-      expect(result).toEqual({ success: false, err });
+      expect(result).toEqual({ success: true });
+      expect(spyOnToastsShow).toHaveBeenCalledWith({
+        level: "info",
+        labelKey: en.error__ckbtc.no_new_confirmed_btc,
+      });
     });
   });
 


### PR DESCRIPTION
# Motivation

> The "error" message when there are no new UXTOs looks to "error" like to me ("Sorry, the balance cannot be updated. There are no new UTXOs to process."). This is expected behaviour, not an error. I'm not sure users know what UXTOs are. Can we remove the (!) symbol and simply say "Updated available ckBTC : No new confirmed BTC "

# Changes

- display UTXO error as info
