### PR TITLE
GIX-1416: Set icrc1_total_supply as required

### DIFF
--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -58,7 +58,7 @@ export type CachedSns = {
    * @deprecated we will use the icrc1_metadata.fee as source information for the fee
    */
   icrc1_fee?: bigint;
-  icrc1_total_supply?: bigint;
+  icrc1_total_supply: bigint;
 };
 
 type CachedSnsMetadataDto = {
@@ -135,7 +135,7 @@ type CachedSnsDto = {
   };
   icrc1_metadata: CachedSnsTokenMetadataDto;
   icrc1_fee: [] | [number];
-  icrc1_total_supply?: number;
+  icrc1_total_supply: number;
 };
 
 const convertOptionalNumToBigInt = (
@@ -275,9 +275,7 @@ const convertSnsData = ({
   },
   icrc1_metadata: convertIcrc1Metadata(icrc1_metadata),
   icrc1_fee: convertOptionalNumToBigInt(icrc1_fee[0]),
-  icrc1_total_supply: nonNullish(icrc1_total_supply)
-    ? BigInt(icrc1_total_supply)
-    : undefined,
+  icrc1_total_supply: BigInt(icrc1_total_supply),
 });
 
 const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -73,14 +73,11 @@ export const loadSnsProjects = async (): Promise<void> => {
     ];
     snsQueryStore.setData(snsQueryStoreData);
     snsTotalTokenSupplyStore.setTotalTokenSupplies(
-      cachedSnses
-        .filter(({ icrc1_total_supply }) => nonNullish(icrc1_total_supply))
-        .map(({ icrc1_total_supply, canister_ids }) => ({
-          rootCanisterId: Principal.fromText(canister_ids.root_canister_id),
-          // TS is not smart enought to know that we filtered out the undefined icrc1_fee above.
-          totalSupply: icrc1_total_supply as bigint,
-          certified: true,
-        }))
+      cachedSnses.map(({ icrc1_total_supply, canister_ids }) => ({
+        rootCanisterId: Principal.fromText(canister_ids.root_canister_id),
+        totalSupply: icrc1_total_supply,
+        certified: true,
+      }))
     );
     snsFunctionsStore.setProjectsFunctions(
       cachedSnses.map((sns) => ({

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -36,21 +36,4 @@ describe("sns-aggregator api", () => {
       expect(sns).toEqual(aggregatorSnsMock);
     });
   });
-
-  it("should include icrc1_total_supply property", async () => {
-    const mockFetch = jest.fn();
-    const totalSupply = BigInt(2000_000_000);
-    const aggregatedSnsesResponse = [
-      { ...aggregatedSnses[0], icrc1_total_supply: totalSupply },
-    ];
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(aggregatedSnsesResponse),
-      })
-    );
-    global.fetch = mockFetch;
-    const snses = await querySnsProjects();
-    expect(snses[0].icrc1_total_supply).toEqual(totalSupply);
-  });
 });

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -175,20 +175,5 @@ describe("SNS public services", () => {
       expect(data?.certified).toBeTruthy();
       expect(data?.totalSupply).toEqual(totalSupply);
     });
-
-    it("should not load the store if total token supply not present", async () => {
-      jest
-        .spyOn(aggregatorApi, "querySnsProjects")
-        .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
-        );
-
-      await loadSnsProjects();
-
-      const rootCanisterId = aggregatorSnsMock.canister_ids.root_canister_id;
-      const supplies = get(snsTotalTokenSupplyStore);
-      const data = supplies[rootCanisterId];
-      expect(data).toBeUndefined();
-    });
   });
 });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.json
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.json
@@ -107,7 +107,8 @@
       ["icrc1:symbol", { "Text": "CFD" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 1100000000000
   },
   {
     "index": 10,
@@ -214,7 +215,8 @@
       ["icrc1:symbol", { "Text": "PETE" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 1000000000000
   },
   {
     "index": 9,
@@ -321,7 +323,8 @@
       ["icrc1:symbol", { "Text": "NOT_CFD_I" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 900000000000
   },
   {
     "index": 8,
@@ -413,7 +416,8 @@
       ["icrc1:symbol", { "Text": "NOT_CFD" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 800000000000
   },
   {
     "index": 7,
@@ -520,7 +524,8 @@
       ["icrc1:symbol", { "Text": "NOT_CFD" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 700000000000
   },
   {
     "index": 6,
@@ -627,7 +632,8 @@
       ["icrc1:symbol", { "Text": "HAXOH" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 600000000000
   },
   {
     "index": 5,
@@ -719,7 +725,8 @@
       ["icrc1:symbol", { "Text": "RUSOW" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 500000000000
   },
   {
     "index": 4,
@@ -826,7 +833,8 @@
       ["icrc1:symbol", { "Text": "TALOD" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 400000000000
   },
   {
     "index": 3,
@@ -933,7 +941,8 @@
       ["icrc1:symbol", { "Text": "PEKAP" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 300000000000
   },
   {
     "index": 2,
@@ -1040,6 +1049,7 @@
       ["icrc1:symbol", { "Text": "FEGEN" }],
       ["icrc1:fee", { "Nat": [1000] }]
     ],
-    "icrc1_fee": [1000]
+    "icrc1_fee": [1000],
+    "icrc1_total_supply": 200000000000
   }
 ]

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -144,6 +144,7 @@ export const aggregatorSnsMock: CachedSns = {
     ["icrc1:fee", { Nat: aggregatorTokenMock.fee }],
   ],
   icrc1_fee: aggregatorTokenMock.fee,
+  icrc1_total_supply: BigInt(1100_000_000_000),
 };
 
 export const aggregatorSnsMockWith = ({


### PR DESCRIPTION
# Motivation

A few weeks ago we added a new field in the SNS aggregator. The NNS Dapp upgraded first and to handle backwards compatibility we set the field as optional.

Now that SNS aggregator was upgraded we can set the field `icrc1_total_supply` as required.

# Changes

Main change:
* Set field icrc1_total_supply required in the data from aggregator `CachedSnsMetadataDto`.

Minor change:
* No need to filter out by icrc1_total_supply not defined when setting the `snsTotalTokenSupplyStore` from SNS aggregator.

# Tests

* Add the new field in the SNS Aggregator mocks.
* Remove icrc1_total_supply specific test cases. The field is now required and expected with the mock.
