### PR TITLE
Fix: Typo in file names in docker build uploads

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -58,8 +58,8 @@ jobs:
           path: |
             ${{ matrix.BUILD_NAME }}-out/commit.txt
             ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
-            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-$${{ matrix.DFX_NETWORK }}.did
-            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-$${{ matrix.DFX_NETWORK }}.bin
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-${{ matrix.DFX_NETWORK }}.did
+            ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-${{ matrix.DFX_NETWORK }}.bin
             ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release


### PR DESCRIPTION
# Motivation

Argument files were not in the zip file from docker-build job.

# Changes

* There is a typo in the name of the files.

# Tests

Wait for the CI to create and upload the files.
