### PR TITLE
GIX-1519: Stop using deprecated endpoint in SNS Aggregator. Part 2

### DIFF
--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -1,7 +1,9 @@
 //! Slowly changing information about an SNS
 use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
-use crate::types::ic_sns_swap::{DerivedState, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params, Swap};
+use crate::types::ic_sns_swap::{
+    DerivedState, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params, Swap,
+};
 use crate::types::ic_sns_wasm::DeployedSns;
 use crate::types::upstream::UpstreamData;
 use crate::Icrc1Value;

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -1,7 +1,7 @@
 //! Slowly changing information about an SNS
 use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
-use crate::types::ic_sns_swap::{DerivedState, GetSaleParametersResponse, GetStateResponse, Init, Params, Swap};
+use crate::types::ic_sns_swap::{DerivedState, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params, Swap};
 use crate::types::ic_sns_wasm::DeployedSns;
 use crate::types::upstream::UpstreamData;
 use crate::Icrc1Value;
@@ -31,8 +31,10 @@ pub struct SlowSnsData {
     pub icrc1_fee: Nat,
     /// The ledger total tokens supply
     pub icrc1_total_supply: u64,
-    /// The initialization params of the swap
+    /// The swap params of the swap
     pub swap_params: Option<GetSaleParametersResponse>,
+    /// The initialization params of the swap
+    pub init: Option<GetInitResponse>,
 }
 
 impl From<&UpstreamData> for SlowSnsData {
@@ -49,6 +51,7 @@ impl From<&UpstreamData> for SlowSnsData {
             // Fallback to 0 if conversion to u64 fails.
             icrc1_total_supply: upstream.icrc1_total_supply.0.to_u64().unwrap_or(0),
             swap_params: upstream.swap_params.clone(),
+            init: upstream.init.clone(),
         }
     }
 }

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -9,6 +9,7 @@ use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use crate::types::ic_sns_swap::GetInitResponse;
 
 /// Data retrieved from upstream and stored as is, without aggregation or processing.
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
@@ -53,4 +54,6 @@ pub struct UpstreamData {
     pub icrc1_total_supply: Nat,
     /// The params of the swap
     pub swap_params: Option<GetSaleParametersResponse>,
+    // The initialization params of the swap
+    pub init: Option<GetInitResponse>,
 }

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -54,6 +54,6 @@ pub struct UpstreamData {
     pub icrc1_total_supply: Nat,
     /// The params of the swap
     pub swap_params: Option<GetSaleParametersResponse>,
-    // The initialization params of the swap
+    /// The initialization params of the swap
     pub init: Option<GetInitResponse>,
 }

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -5,11 +5,11 @@ use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::{GetSaleParametersResponse, GetStateResponse};
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
+use crate::types::ic_sns_swap::GetInitResponse;
 use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use serde::Serialize;
 use std::collections::BTreeMap;
-use crate::types::ic_sns_swap::GetInitResponse;
 
 /// Data retrieved from upstream and stored as is, without aggregation or processing.
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::convert_canister_id;
 use crate::fast_scheduler::FastScheduler;
 use crate::state::{State, STATE};
-use crate::types::ic_sns_swap::GetSaleParametersResponse;
+use crate::types::ic_sns_swap::{GetInitResponse, GetSaleParametersResponse};
 use crate::types::ic_sns_wasm::{DeployedSns, ListDeployedSnsesResponse};
 use crate::types::upstream::UpstreamData;
 use crate::types::{self, EmptyRecord, GetStateResponse, Icrc1Value, SnsTokens};
@@ -143,6 +143,18 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             Ok(response) => Some(response),
         };
 
+    let init_response: Option<GetInitResponse> =
+        match ic_cdk::api::call::call(swap_canister_id, "get_init", (EmptyRecord {},))
+            .await
+            .map(|response: (_,)| response.0)
+        {
+            Err(err) => {
+                crate::state::log(format!("Failed to get init: {err:?}"));
+                None
+            }
+            Ok(response) => Some(response),
+        };
+
     crate::state::log("Yay, got an SNS status".to_string());
     // If the SNS sale will open, collect data when it does.
     FastScheduler::global_schedule_sns(&swap_state);
@@ -158,6 +170,7 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         icrc1_fee,
         icrc1_total_supply,
         swap_params: swap_params_response,
+        init: init_response,
     };
     State::insert_sns(index, slow_data)
         .map_err(|err| crate::state::log(format!("Failed to create certified assets: {err:?}")))


### PR DESCRIPTION
# Motivation

The SNS aggregator uses the deprecated endpoint `get_state`.

We want to move away from this endpoint.

This PR: Fetch swap parameters from new endpoint `get_init`.

# Changes

* Add new property `init` to `UpstreamData`.
* Fetch the data from `get_init` when we fetch the other data.
* Add new property `init` to `SlowSnsData` which is used to render the JSON.

# Tests

* There is no data transformation. And we still don't have integration tests to check calls to the backend.
