### PR TITLE
Chore: No TVL call if no TVL canister id

### DIFF
--- a/frontend/src/lib/api/tvl.api.cjs.ts
+++ b/frontend/src/lib/api/tvl.api.cjs.ts
@@ -1,13 +1,14 @@
 import { TVLCanister } from "$lib/canisters/tvl/tvl.canister";
 import type { TvlResult } from "$lib/canisters/tvl/tvl.types";
+import { TVL_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
 /**
  * HTTP-Agent explicit CJS import for compatibility with web worker - avoid Error [RollupError]: Unexpected token (Note that you need plugins to import files that are not JavaScript)
  */
-import { TVL_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HttpAgent } from "@dfinity/agent/lib/cjs/index";
 
 export const queryTVL = async ({
@@ -17,6 +18,10 @@ export const queryTVL = async ({
   identity: Identity;
   certified: boolean;
 }): Promise<TvlResult | undefined> => {
+  if (isNullish(TVL_CANISTER_ID)) {
+    return undefined;
+  }
+
   logWithTimestamp(`Getting canister ${TVL_CANISTER_ID.toText()} TVL call...`);
 
   const { getTVL } = await canister({ identity, canisterId: TVL_CANISTER_ID });

--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -15,7 +15,8 @@ export const CYCLES_MINTING_CANISTER_ID = Principal.fromText(
 );
 export const WASM_CANISTER_ID = envVars.wasmCanisterId;
 
-export const TVL_CANISTER_ID: Principal = nonNullish(envVars?.tvlCanisterId)
+export const TVL_CANISTER_ID: Principal | undefined = nonNullish(
+  envVars?.tvlCanisterId
+)
   ? Principal.fromText(envVars?.tvlCanisterId)
-  : // TODO: Return undefined and manage `undefined` in tvl api function
-    Principal.fromText("ewh3f-3qaaa-aaaap-aazjq-cai");
+  : undefined;

--- a/frontend/src/tests/lib/api/tvl.api.spec.ts
+++ b/frontend/src/tests/lib/api/tvl.api.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { queryTVL } from "$lib/api/tvl.api.cjs";
 import { TVLCanister } from "$lib/canisters/tvl/tvl.canister";
 import { AnonymousIdentity } from "@dfinity/agent";
@@ -37,11 +36,11 @@ describe("tvl api", () => {
 
   describe("with tvl canister id set", () => {
     beforeEach(async () => {
-      // `import` returns "readonly" propertlies.
-      // casting to `any` is needed to change the value
+      // `import` returns "readonly" properties.
+      // casting is needed to change the value
       const canisterIds = (await import(
         "$lib/constants/canister-ids.constants"
-      )) as any;
+      )) as { TVL_CANISTER_ID: Principal };
       canisterIds.TVL_CANISTER_ID = defaultTVLCanisterId;
     });
 
@@ -68,11 +67,11 @@ describe("tvl api", () => {
 
   describe("with tvl canister id not set", () => {
     beforeEach(async () => {
-      // `import` returns "readonly" propertlies.
-      // casting to `any` is needed to change the value
+      // `import` returns "readonly" properties.
+      // casting is needed to change the value
       const canisterIds = (await import(
         "$lib/constants/canister-ids.constants"
-      )) as any;
+      )) as { TVL_CANISTER_ID: Principal };
       canisterIds.TVL_CANISTER_ID = undefined;
     });
 

--- a/frontend/src/tests/lib/api/tvl.api.spec.ts
+++ b/frontend/src/tests/lib/api/tvl.api.spec.ts
@@ -37,7 +37,8 @@ describe("tvl api", () => {
 
   describe("with tvl canister id set", () => {
     beforeEach(async () => {
-      // Casting to `any` is needed to change the value at runtime
+      // `import` returns "readonly" propertlies.
+      // casting to `any` is needed to change the value
       const canisterIds = (await import(
         "$lib/constants/canister-ids.constants"
       )) as any;
@@ -67,7 +68,8 @@ describe("tvl api", () => {
 
   describe("with tvl canister id not set", () => {
     beforeEach(async () => {
-      // Casting to `any` is needed to change the value at runtime
+      // `import` returns "readonly" propertlies.
+      // casting to `any` is needed to change the value
       const canisterIds = (await import(
         "$lib/constants/canister-ids.constants"
       )) as any;


### PR DESCRIPTION
# Motivation

TVl calls create an error on testnet where there is no TVL canister.

# Changes

* Return `undefined` and skip call If TVL_CANISTER_ID is not present in tvl api.

# Tests

* Add a test in tvl api to check new use case.