### PR TITLE
Release directly from the nightly job

### DIFF
--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -12,6 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Release
+      shell: bash
       run: |
         set -euxo pipefail
         cd "${{ inputs.assets_dir }}"

--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -8,7 +8,6 @@ inputs:
   token:
     desctiption: "Github access token used to make the release"
     required: true
-  token:
 runs:
   using: "composite"
   steps:

--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: "The directory containing the assets.  Usually, the docker out directory."
     required: true
   token:
-    desctiption: "Github access token used to make the release"
+    description: "Github access token used to make the release"
     required: true
 runs:
   using: "composite"

--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -1,0 +1,33 @@
+name: 'Release the nns-dapp'
+description: |
+  Creates or updates a release for every tag pointing at HEAD.
+inputs:
+  assets_dir:
+    description: "The directory containing the assets.  Usually, the docker out directory."
+    required: true
+  token:
+    desctiption: "Github access token used to make the release"
+    required: true
+  token:
+runs:
+  using: "composite"
+  steps:
+    - name: Release
+      run: |
+        set -euxo pipefail
+        cd "${{ inputs.assets_dir }}"
+        daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
+        cp nns-dapp.wasm "$daily_build_name"
+        artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
+        ls -l "${artefacts[@]}"
+        for tag in $(git tag --points-at HEAD) ; do
+          : Creates or updates a release for the tag
+          if gh release view "$tag"
+          then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true
+          else gh release create --title "Release for tags/$tag" --draft --notes "Build artefacts from tag: $tag" "$tag" "${artefacts[@]}"
+          fi
+          : If the tag is for a proposal or nightly, make it public
+          [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
+        done
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,21 +20,6 @@ jobs:
             DFX_NETWORK: "mainnet"
     steps:
       - uses: actions/checkout@v3
-      - name: Print tags
-        run: |
-          set -x
-          : Note: This printout is for debugging.  Please keep it in main until tags are handled correctly.
-          : Log commit and existing tags
-          git rev-parse HEAD
-          git tag --points-at HEAD
-          readarray -t TAGS < <(git tag --points-at HEAD)
-          : Log tag that triggered this run, if any
-          GH_REF="${{github.ref}}"
-          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
-          GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-          : ... This run was not triggered by a tag OR the tag is already included OR add the github event tag to the list of tags.
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for t in "${TAGS[@]}"; do [[ "$t" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
-          echo tags: "${TAGS[@]}"
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
       # Build and upload testnet assets
@@ -64,24 +49,12 @@ jobs:
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release
         run: |
-          : Get a list of tags
-          readarray -t TAGS < <(git tag --points-at HEAD)
-          : Add tag that triggered this run, if any.  There is no guarantee that it has been included already.
-          GH_REF="${{github.ref}}"
-          GH_REF_WITHOUT_PREFIX="${GH_REF#refs/tags/}"
-          GH_TAG="${GH_REF_WITHOUT_PREFIX}"
-          : ... This run was not triggered by a tag OR the tag is already included OR add the github event tag to the list of tags.
-          [[ "$GH_REF" == "$GH_REF_WITHOUT_PREFIX" ]] || (for t in "${TAGS[@]}"; do [[ "$t" == "$GH_TAG" ]] && exit 0; done; exit 1) || TAGS+=( "${GH_TAG}" )
-          echo Tags: "${TAGS[@]}"
-          : Get a list of assets
           cd "${{ matrix.BUILD_NAME }}-out"
           daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
           cp nns-dapp.wasm "$daily_build_name"
           artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
-          echo "Assets:"
           ls -l "${artefacts[@]}"
-          : Make or update a release for every tag
-          for tag in "${TAGS[@]}" ; do
+          for tag in $(git tag --points-at HEAD) ; do
             : Creates or updates a release for the tag
             if gh release view "$tag"
             then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -48,23 +48,10 @@ jobs:
             ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
       - name: Release
-        run: |
-          cd "${{ matrix.BUILD_NAME }}-out"
-          daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
-          cp nns-dapp.wasm "$daily_build_name"
-          artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
-          ls -l "${artefacts[@]}"
-          for tag in $(git tag --points-at HEAD) ; do
-            : Creates or updates a release for the tag
-            if gh release view "$tag"
-            then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true
-            else gh release create --title "Release for tags/$tag" --draft --notes "Build artefacts from tag: $tag" "$tag" "${artefacts[@]}"
-            fi
-            : If the tag is for a proposal or nightly, make it public
-            [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/release_nns_dapp
+        with:
+          assets_dir: '${{ matrix.BUILD_NAME }}-out'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Upload ${{ matrix.BUILD_NAME }} frontend assets'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,7 +1,7 @@
 name: Nightly Publication
 on:
   schedule:
-    - cron: "10 0 * * *"
+    - cron: "10 * * * *"
   push:
     branches:
       # Commit to the nightly branch and push to test.
@@ -29,6 +29,23 @@ jobs:
             git tag "${tag_name}"
             git push origin "refs/tags/${tag_name}"
           fi
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+      # Build and upload testnet assets
+      - name: Build nns-dapp Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha,scope=cached-stage
+          outputs: out
+      - name: 'Record the git commit and any tags'
+        run: git log | head -n1 > out/commit.txt
+      - name: Release
+        uses: ./.github/actions/release_nns_dapp
+        with:
+          assets_dir: 'out'
+          token: ${{ secrets.GITHUB_TOKEN }}
   update-ii:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
# Motivation
Nightly releases are not working reliably.

# Changes
- Factor out the release code into an action
- Call the action from nightly
- Increase the frequency of the nightly job to hourly

# Tests
Ultimately:  Delete the release for today, wait an hour, check.

I have triggered the build manually but there is no guarantee that manual triggers behave in the same way.