### PR TITLE
GIX-1519: Stop using deprecated endpoint in SNS Aggregator. Part 3

### DIFF
--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -2,7 +2,8 @@
 use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
 use crate::types::ic_sns_swap::{
-    DerivedState, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params, Swap,
+    DerivedState, GetDerivedStateResponse, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params,
+    Swap,
 };
 use crate::types::ic_sns_wasm::DeployedSns;
 use crate::types::upstream::UpstreamData;
@@ -37,6 +38,8 @@ pub struct SlowSnsData {
     pub swap_params: Option<GetSaleParametersResponse>,
     /// The initialization params of the swap
     pub init: Option<GetInitResponse>,
+    /// The derived state of the swap
+    pub derived_state: Option<GetDerivedStateResponse>,
 }
 
 impl From<&UpstreamData> for SlowSnsData {
@@ -54,6 +57,7 @@ impl From<&UpstreamData> for SlowSnsData {
             icrc1_total_supply: upstream.icrc1_total_supply.0.to_u64().unwrap_or(0),
             swap_params: upstream.swap_params.clone(),
             init: upstream.init.clone(),
+            derived_state: upstream.derived_state.clone(),
         }
     }
 }

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -5,7 +5,7 @@ use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::{GetSaleParametersResponse, GetStateResponse};
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
-use crate::types::ic_sns_swap::GetInitResponse;
+use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse};
 use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use serde::Serialize;
@@ -56,4 +56,6 @@ pub struct UpstreamData {
     pub swap_params: Option<GetSaleParametersResponse>,
     /// The initialization params of the swap
     pub init: Option<GetInitResponse>,
+    /// The derived state of the swap
+    pub derived_state: Option<GetDerivedStateResponse>,
 }

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::convert_canister_id;
 use crate::fast_scheduler::FastScheduler;
 use crate::state::{State, STATE};
-use crate::types::ic_sns_swap::{GetInitResponse, GetSaleParametersResponse};
+use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse, GetSaleParametersResponse};
 use crate::types::ic_sns_wasm::{DeployedSns, ListDeployedSnsesResponse};
 use crate::types::upstream::UpstreamData;
 use crate::types::{self, EmptyRecord, GetStateResponse, Icrc1Value, SnsTokens};
@@ -155,6 +155,18 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
             Ok(response) => Some(response),
         };
 
+    let derived_state_response: Option<GetDerivedStateResponse> =
+        match ic_cdk::api::call::call(swap_canister_id, "get_derived_state", (EmptyRecord {},))
+            .await
+            .map(|response: (_,)| response.0)
+        {
+            Err(err) => {
+                crate::state::log(format!("Failed to get derived state: {err:?}"));
+                None
+            }
+            Ok(response) => Some(response),
+        };
+
     crate::state::log("Yay, got an SNS status".to_string());
     // If the SNS sale will open, collect data when it does.
     FastScheduler::global_schedule_sns(&swap_state);
@@ -171,6 +183,7 @@ async fn get_sns_data(index: u64, sns_canister_ids: DeployedSns) -> anyhow::Resu
         icrc1_total_supply,
         swap_params: swap_params_response,
         init: init_response,
+        derived_state: derived_state_response,
     };
     State::insert_sns(index, slow_data)
         .map_err(|err| crate::state::log(format!("Failed to create certified assets: {err:?}")))


### PR DESCRIPTION
# Motivation

The SNS aggregator uses the deprecated endpoint `get_state`.

We want to move away from this endpoint.

This PR: Fetch swap parameters from new endpoint `get_derived_state`.

# Changes

* Add new property `derived_state` to `UpstreamData`.
* Fetch the data from `get_derived_state` when we fetch the other data.
* Add new property `derived_state` to `SlowSnsData` which is used to render the JSON.

# Tests

* There is no data transformation. And we still don't have integration tests to check calls to the backend.
