### PR TITLE
GIX-1212: Add sns proposal filters reward status

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -9,6 +9,7 @@
   import type { Principal } from "@dfinity/principal";
   import FiltersWrapper from "../proposals/FiltersWrapper.svelte";
   import FiltersButton from "../ui/FiltersButton.svelte";
+  import SnsFilterRewardsModal from "$lib/modals/sns/proposals/SnsFilterRewardsModal.svelte";
 
   let modal: "topics" | "rewards" | "status" | undefined = undefined;
 
@@ -17,8 +18,8 @@
   let filtersStore: ProjectFiltersStoreData | undefined;
   $: filtersStore = $snsFiltersStore[rootCanisterId.toText()];
 
-  const openFilters = () => {
-    modal = "status";
+  const openFilters = (filtersModal: "topics" | "rewards" | "status") => {
+    modal = filtersModal;
   };
 
   const close = () => {
@@ -32,13 +33,30 @@
     totalFilters={filtersStore?.decisionStatus.length ?? 0}
     activeFilters={filtersStore?.decisionStatus.filter(({ checked }) => checked)
       .length ?? 0}
-    on:nnsFilter={openFilters}>{$i18n.voting.status}</FiltersButton
+    on:nnsFilter={() => openFilters("status")}
+    >{$i18n.voting.status}</FiltersButton
+  >
+  <FiltersButton
+    testId="filters-by-rewards"
+    totalFilters={filtersStore?.rewardStatus.length ?? 0}
+    activeFilters={filtersStore?.rewardStatus.filter(({ checked }) => checked)
+      .length ?? 0}
+    on:nnsFilter={() => openFilters("rewards")}
+    >{$i18n.voting.rewards}</FiltersButton
   >
 </FiltersWrapper>
 
 {#if modal === "status"}
   <SnsFilterStatusModal
     filters={filtersStore?.decisionStatus}
+    {rootCanisterId}
+    on:nnsClose={close}
+  />
+{/if}
+
+{#if modal === "rewards"}
+  <SnsFilterRewardsModal
+    filters={filtersStore?.rewardStatus}
     {rootCanisterId}
     on:nnsClose={close}
   />

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import FilterModal from "$lib/modals/common/FilterModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+  import type { Filter } from "$lib/types/filters";
+  import type { Principal } from "@dfinity/principal";
+  import type { SnsProposalRewardStatus } from "@dfinity/sns";
+  import { createEventDispatcher } from "svelte";
+
+  export let rootCanisterId: Principal;
+  export let filters: Filter<SnsProposalRewardStatus>[] = [];
+
+  // This is a temporary value to be used inside the modal. It's initialized based on the prop filters;
+  let selectedFilters: SnsProposalRewardStatus[] =
+    filters.filter(({ checked }) => checked).map(({ value }) => value) ?? [];
+  // This is a temporary value to be used inside the modal
+  let filtersValues: Filter<SnsProposalRewardStatus>[];
+  $: filtersValues = filters.map((filter) => ({
+    ...filter,
+    checked: selectedFilters.includes(filter.value),
+  }));
+
+  const dispatch = createEventDispatcher();
+  let filter: () => void;
+  $: filter = () => {
+    snsFiltersStore.setCheckRewardStatus({
+      checkedRewardStatus: selectedFilters,
+      rootCanisterId,
+    });
+    dispatch("nnsClose");
+  };
+
+  const onChange = ({
+    detail: { filter },
+  }: CustomEvent<{
+    filter: Filter<SnsProposalRewardStatus> | undefined;
+  }>) => {
+    if (filter === undefined) {
+      return;
+    }
+    selectedFilters = [
+      ...selectedFilters.filter((status) => status !== filter?.value),
+      // Toggle the checked value
+      ...(filter.checked ? [] : [filter.value]),
+    ];
+  };
+</script>
+
+<FilterModal
+  on:nnsClose
+  on:nnsConfirm={filter}
+  on:nnsChange={onChange}
+  filters={filtersValues}
+>
+  <span slot="title">{$i18n.voting.rewards}</span>
+</FilterModal>

--- a/frontend/src/lib/services/sns-filters.services.ts
+++ b/frontend/src/lib/services/sns-filters.services.ts
@@ -1,8 +1,12 @@
 import { i18n } from "$lib/stores/i18n";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+import type { Filter } from "$lib/types/filters";
 import { enumValues } from "$lib/utils/enum.utils";
 import type { Principal } from "@dfinity/principal";
-import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -13,17 +17,20 @@ export const loadSnsFilters = async (rootCanisterId: Principal) => {
     return;
   }
   const i18nKeys = get(i18n);
-  const filtersProjectData = {
+  const defaultFiltersProjectData = {
     topics: [],
     rewardStatus: [],
     decisionStatus: [],
   };
-  const mapDecisionStatus = (value: SnsProposalDecisionStatus) => {
+  // Load decision status, these are harcoded based on enum values
+  const mapDecisionStatus = (
+    value: SnsProposalDecisionStatus
+  ): Filter<SnsProposalDecisionStatus> => {
     return {
       id: String(value),
       value,
       name: i18nKeys.sns_status[value] ?? i18nKeys.core.unspecified,
-      checked: filtersProjectData.decisionStatus.some(
+      checked: defaultFiltersProjectData.decisionStatus.some(
         ({ checked, id }) => checked && id === String(value)
       ),
     };
@@ -38,5 +45,29 @@ export const loadSnsFilters = async (rootCanisterId: Principal) => {
   snsFiltersStore.setDecisionStatus({
     rootCanisterId,
     decisionStatus,
+  });
+
+  // Load reward status, these are harcoded based on enum values
+  const mapRewardStatus = (
+    value: SnsProposalRewardStatus
+  ): Filter<SnsProposalRewardStatus> => {
+    return {
+      id: String(value),
+      value,
+      name: i18nKeys.sns_rewards_status[value] ?? i18nKeys.core.unspecified,
+      checked: defaultFiltersProjectData.rewardStatus.some(
+        ({ checked, id }) => checked && id === String(value)
+      ),
+    };
+  };
+  const rewardStatus = enumValues(SnsProposalRewardStatus)
+    .filter(
+      (status) =>
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_UNSPECIFIED !== status
+    )
+    .map(mapRewardStatus);
+  snsFiltersStore.setRewardStatus({
+    rootCanisterId,
+    rewardStatus,
   });
 };

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -26,8 +26,22 @@ export interface SnsFiltersStore extends Readable<SnsFiltersStoreData> {
     rootCanisterId: Principal;
     checkedDecisionStatus: SnsProposalDecisionStatus[];
   }) => void;
+  setRewardStatus: (data: {
+    rootCanisterId: Principal;
+    rewardStatus: Filter<SnsProposalRewardStatus>[];
+  }) => void;
+  setCheckRewardStatus: (data: {
+    rootCanisterId: Principal;
+    checkedRewardStatus: SnsProposalRewardStatus[];
+  }) => void;
   reset: () => void;
 }
+
+const defaultProjectData: ProjectFiltersStoreData = {
+  topics: [],
+  rewardStatus: [],
+  decisionStatus: [],
+};
 
 /**
  * A store that contains the filters of the SNS proposals for each project.
@@ -48,11 +62,8 @@ export const initSnsFiltersStore = (): SnsFiltersStore => {
       decisionStatus: Filter<SnsProposalDecisionStatus>[];
     }) {
       update((currentState: SnsFiltersStoreData) => {
-        const projectFilters = currentState[rootCanisterId.toText()] || {
-          topics: [],
-          rewardStatus: [],
-          decisionStatus: [],
-        };
+        const projectFilters =
+          currentState[rootCanisterId.toText()] || defaultProjectData;
 
         return {
           ...currentState,
@@ -72,11 +83,8 @@ export const initSnsFiltersStore = (): SnsFiltersStore => {
       checkedDecisionStatus: SnsProposalDecisionStatus[];
     }) {
       update((currentState: SnsFiltersStoreData) => {
-        const projectFilters = currentState[rootCanisterId.toText()] || {
-          topics: [],
-          rewardStatus: [],
-          decisionStatus: [],
-        };
+        const projectFilters =
+          currentState[rootCanisterId.toText()] || defaultProjectData;
 
         return {
           ...currentState,
@@ -88,6 +96,51 @@ export const initSnsFiltersStore = (): SnsFiltersStore => {
                 checked: checkedDecisionStatus.includes(decisionStatus.value),
               })
             ),
+          },
+        };
+      });
+    },
+
+    setRewardStatus({
+      rootCanisterId,
+      rewardStatus,
+    }: {
+      rootCanisterId: Principal;
+      rewardStatus: Filter<SnsProposalRewardStatus>[];
+    }) {
+      update((currentState: SnsFiltersStoreData) => {
+        const projectFilters =
+          currentState[rootCanisterId.toText()] || defaultProjectData;
+
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            ...projectFilters,
+            rewardStatus,
+          },
+        };
+      });
+    },
+
+    setCheckRewardStatus({
+      rootCanisterId,
+      checkedRewardStatus,
+    }: {
+      rootCanisterId: Principal;
+      checkedRewardStatus: SnsProposalRewardStatus[];
+    }) {
+      update((currentState: SnsFiltersStoreData) => {
+        const projectFilters =
+          currentState[rootCanisterId.toText()] || defaultProjectData;
+
+        return {
+          ...currentState,
+          [rootCanisterId.toText()]: {
+            ...projectFilters,
+            rewardStatus: projectFilters.rewardStatus.map((status) => ({
+              ...status,
+              checked: checkedRewardStatus.includes(status.value),
+            })),
           },
         };
       });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -22,4 +22,15 @@ describe("SnsProposalsFilters", () => {
       expect(queryByTestId("filter-modal")).toBeInTheDocument()
     );
   });
+
+  it("should show filter modal when rewards filter is clicked", async () => {
+    const { queryByTestId } = render(SnsProposalsFilters);
+
+    const statusFilterButton = queryByTestId("filters-by-rewards");
+    statusFilterButton && fireEvent.click(statusFilterButton);
+
+    await waitFor(() =>
+      expect(queryByTestId("filter-modal")).toBeInTheDocument()
+    );
+  });
 });

--- a/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
@@ -77,7 +77,7 @@ describe("SnsFilterRewardsModal", () => {
     button && fireEvent.click(button);
   });
 
-  it("should filter filters", async () => {
+  it("should change reward status filters", async () => {
     const uncheckedFilters = filters.map((filter) => ({
       ...filter,
       checked: false,

--- a/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsFilterRewardsModal from "$lib/modals/sns/proposals/SnsFilterRewardsModal.svelte";
+import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+import type { Filter } from "$lib/types/filters";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
+import { clickByTestId } from "$tests/utils/utils.test-utils";
+import { SnsProposalRewardStatus } from "@dfinity/sns";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("SnsFilterRewardsModal", () => {
+  afterEach(() => {
+    snsFiltersStore.reset();
+  });
+  const filters: Filter<SnsProposalRewardStatus>[] = [
+    {
+      id: "1",
+      name: "status-1",
+      value: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+      checked: true,
+    },
+    {
+      id: "2",
+      name: "status-2",
+      value: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE,
+      checked: false,
+    },
+  ];
+  const props = {
+    rootCanisterId: mockPrincipal,
+    filters,
+  };
+
+  it("should display modal", () => {
+    const { container } = render(SnsFilterRewardsModal, {
+      props,
+    });
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should render title", () => {
+    const { getByText } = render(SnsFilterRewardsModal, {
+      props,
+    });
+
+    expect(getByText(en.voting.rewards)).toBeInTheDocument();
+  });
+
+  it("should render checkboxes", () => {
+    const { container } = render(SnsFilterRewardsModal, {
+      props,
+    });
+
+    expect(container.querySelectorAll("input[type=checkbox]")).toHaveLength(
+      filters.length
+    );
+  });
+
+  it("should forward close modal event", (done) => {
+    const { container, component } = render(SnsFilterRewardsModal, {
+      props,
+    });
+
+    component.$on("nnsClose", () => {
+      done();
+    });
+
+    const button: HTMLButtonElement | null = container.querySelector(
+      "button:first-of-type"
+    );
+
+    button && fireEvent.click(button);
+  });
+
+  it("should filter filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltersStore.setRewardStatus({
+      rootCanisterId: mockPrincipal,
+      rewardStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterRewardsModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    const firstInput = inputs[0];
+    fireEvent.click(firstInput);
+    await waitFor(() => expect(firstInput.checked).toBeTruthy());
+
+    const secondInput = inputs[1];
+    fireEvent.click(secondInput);
+    await waitFor(() => expect(secondInput.checked).toBeTruthy());
+
+    await clickByTestId(queryByTestId, "apply-filters");
+
+    const statuses = get(snsFiltersStore)[mockPrincipal.toText()]?.rewardStatus;
+
+    expect(statuses.filter(({ checked }) => checked).length).toEqual(2);
+  });
+});

--- a/frontend/src/tests/lib/services/sns-filters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-filters.services.spec.ts
@@ -2,15 +2,18 @@ import { loadSnsFilters } from "$lib/services/sns-filters.services";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { enumSize } from "$lib/utils/enum.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-filters services", () => {
   describe("loadSnsFilters", () => {
-    afterEach(() => {
+    beforeEach(() => {
       snsFiltersStore.reset();
     });
-    it("should load the sns filters store with status but not Unspecified", async () => {
+    it("should load the sns decision status filters store but not Unspecified", async () => {
       await loadSnsFilters(mockPrincipal);
 
       const projectStore = get(snsFiltersStore)[mockPrincipal.toText()];
@@ -22,6 +25,21 @@ describe("sns-filters services", () => {
         projectStore.decisionStatus.map(({ value }) => value)
       ).not.toContainEqual(
         SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED
+      );
+    });
+
+    it("should load the sns reward status filters store but not Unspecified", async () => {
+      await loadSnsFilters(mockPrincipal);
+
+      const projectStore = get(snsFiltersStore)[mockPrincipal.toText()];
+
+      expect(projectStore.rewardStatus).toHaveLength(
+        enumSize(SnsProposalRewardStatus) - 1
+      );
+      expect(
+        projectStore.rewardStatus.map(({ value }) => value)
+      ).not.toContainEqual(
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_UNSPECIFIED
       );
     });
 

--- a/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-filters.store.spec.ts
@@ -4,32 +4,58 @@ import {
 } from "$lib/stores/sns-filters.store";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { Principal } from "@dfinity/principal";
-import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+} from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-filters store", () => {
+  const rootCanisterId = mockPrincipal;
+  const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+  const decisionStatus = [
+    {
+      id: "1",
+      name: "status-1",
+      value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      checked: true,
+    },
+    {
+      id: "2",
+      name: "status-2",
+      value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
+      checked: true,
+    },
+  ];
+  const unCheckedDecisionStatus = decisionStatus.map((status) => ({
+    ...status,
+    checked: false,
+  }));
+  const rewardStatus = [
+    {
+      id: "1",
+      name: "status-1",
+      value: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+      checked: true,
+    },
+    {
+      id: "2",
+      name: "status-2",
+      value: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE,
+      checked: true,
+    },
+  ];
+  const unCheckedRewardStatus = rewardStatus.map((status) => ({
+    ...status,
+    checked: false,
+  }));
+
   describe("snsFiltersStore", () => {
     beforeEach(() => {
       snsFiltersStore.reset();
     });
 
     it("should setDecisionStatus in different projects", () => {
-      const rootCanisterId = mockPrincipal;
-      const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
-      const decisionStatus = [
-        {
-          id: "1",
-          name: "status-1",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-          checked: true,
-        },
-        {
-          id: "2",
-          name: "status-2",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-          checked: true,
-        },
-      ];
       snsFiltersStore.setDecisionStatus({ rootCanisterId, decisionStatus });
 
       const projectStore = get(snsFiltersStore)[rootCanisterId.toText()];
@@ -43,26 +69,26 @@ describe("sns-filters store", () => {
       expect(projectStore2.decisionStatus).toEqual(decisionStatus);
     });
 
-    it("setCheckDecisionStatus should check filters in different projects", () => {
-      const rootCanisterId = mockPrincipal;
-      const rootCanisterId2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
-      const decisionStatus = [
-        {
-          id: "1",
-          name: "status-1",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-          checked: false,
-        },
-        {
-          id: "2",
-          name: "status-2",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-          checked: false,
-        },
-      ];
+    it("should setRewardStatus in different projects", () => {
+      snsFiltersStore.setRewardStatus({ rootCanisterId, rewardStatus });
 
+      const projectStore = get(snsFiltersStore)[rootCanisterId.toText()];
+      expect(projectStore.rewardStatus).toEqual(rewardStatus);
+
+      snsFiltersStore.setRewardStatus({
+        rootCanisterId: rootCanisterId2,
+        rewardStatus,
+      });
+      const projectStore2 = get(snsFiltersStore)[rootCanisterId2.toText()];
+      expect(projectStore2.rewardStatus).toEqual(rewardStatus);
+    });
+
+    it("setCheckDecisionStatus should check filters in different projects", () => {
       // Project rootCanisterId
-      snsFiltersStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+      snsFiltersStore.setDecisionStatus({
+        rootCanisterId,
+        decisionStatus: unCheckedDecisionStatus,
+      });
       const projectStore = get(snsFiltersStore)[rootCanisterId.toText()];
       expect(
         projectStore.decisionStatus.filter(({ checked }) => checked).length
@@ -81,7 +107,7 @@ describe("sns-filters store", () => {
       // Project rootCanisterId2
       snsFiltersStore.setDecisionStatus({
         rootCanisterId: rootCanisterId2,
-        decisionStatus,
+        decisionStatus: unCheckedDecisionStatus,
       });
       const projectStore3 = get(snsFiltersStore)[rootCanisterId2.toText()];
       expect(
@@ -117,31 +143,80 @@ describe("sns-filters store", () => {
         projectStore6.decisionStatus.filter(({ checked }) => checked).length
       ).toEqual(1);
     });
+
+    it("setCheckRewardStatus should check filters in different projects", () => {
+      // Project rootCanisterId
+      snsFiltersStore.setRewardStatus({
+        rootCanisterId,
+        rewardStatus: unCheckedRewardStatus,
+      });
+      const projectStore = get(snsFiltersStore)[rootCanisterId.toText()];
+      expect(
+        projectStore.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(0);
+
+      const statuses = rewardStatus.map(({ value }) => value);
+      snsFiltersStore.setCheckRewardStatus({
+        rootCanisterId,
+        checkedRewardStatus: statuses,
+      });
+      const projectStore2 = get(snsFiltersStore)[rootCanisterId.toText()];
+      expect(
+        projectStore2.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(statuses.length);
+
+      // Project rootCanisterId2
+      snsFiltersStore.setRewardStatus({
+        rootCanisterId: rootCanisterId2,
+        rewardStatus: unCheckedRewardStatus,
+      });
+      const projectStore3 = get(snsFiltersStore)[rootCanisterId2.toText()];
+      expect(
+        projectStore3.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(0);
+
+      snsFiltersStore.setCheckRewardStatus({
+        rootCanisterId: rootCanisterId2,
+        checkedRewardStatus: [
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ],
+      });
+      const projectStore4 = get(snsFiltersStore)[rootCanisterId2.toText()];
+      expect(
+        projectStore4.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(1);
+
+      // Project 1 has not changed
+      const projectStore5 = get(snsFiltersStore)[rootCanisterId.toText()];
+      expect(
+        projectStore5.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(statuses.length);
+
+      // Uncheck from Project 2
+      snsFiltersStore.setCheckRewardStatus({
+        rootCanisterId,
+        checkedRewardStatus: [
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ],
+      });
+      const projectStore6 = get(snsFiltersStore)[rootCanisterId.toText()];
+      expect(
+        projectStore6.rewardStatus.filter(({ checked }) => checked).length
+      ).toEqual(1);
+    });
   });
 
   describe("snsSelectedFiltersStore", () => {
     beforeEach(() => {
       snsFiltersStore.reset();
     });
-    it("should return the selected decision status filters", () => {
-      const rootCanisterId = mockPrincipal;
-      const decisionStatus = [
-        {
-          id: "1",
-          name: "status-1",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-          checked: false,
-        },
-        {
-          id: "2",
-          name: "status-2",
-          value: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-          checked: false,
-        },
-      ];
 
+    it("should return the selected decision status filters", () => {
       // Project rootCanisterId
-      snsFiltersStore.setDecisionStatus({ rootCanisterId, decisionStatus });
+      snsFiltersStore.setDecisionStatus({
+        rootCanisterId,
+        decisionStatus: unCheckedDecisionStatus,
+      });
 
       expect(
         get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.decisionStatus
@@ -156,6 +231,29 @@ describe("sns-filters store", () => {
 
       expect(
         get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.decisionStatus
+      ).toHaveLength(1);
+    });
+
+    it("should return the selected reward status filters", () => {
+      // Project rootCanisterId
+      snsFiltersStore.setRewardStatus({
+        rootCanisterId,
+        rewardStatus: unCheckedRewardStatus,
+      });
+
+      expect(
+        get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.rewardStatus
+      ).toHaveLength(0);
+
+      snsFiltersStore.setCheckRewardStatus({
+        rootCanisterId,
+        checkedRewardStatus: [
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ],
+      });
+
+      expect(
+        get(snsSelectedFiltersStore)[rootCanisterId.toText()]?.rewardStatus
       ).toHaveLength(1);
     });
   });


### PR DESCRIPTION
# Motivation

Users want to filter SNS proposal by reward status.

# Changes

* New filters modal `SnsFilterRewardsModal`.
* Add rewards filters button in SnsProposalsFilters component.
* Open `SnsFilterRewardsModal` when rewards filter button is clicked.
* Load reward status filters in `loadSnsFilters` service.
* Add new methods to `snsFiltersStore` to manage reward status.

# Tests

* Test new modal `SnsFilterRewardsModal`.
* Add test case in `SnsProposalsFilters` for new button.
* Add test case in `loadSnsFilters` service.
* Add test case for new functionality in `snsFiltersStore`.
