### PR TITLE
E2E: Disable Firefox until I can debug.

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,10 +48,11 @@ export default defineConfig({
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'], channel: "firefox" },
-    },
+    // TODO: Enable Firefox when flakiness is fixed.
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'], channel: "firefox" },
+    // },
     // {
     //   name: "chromium",
     //   use: { ...devices["Desktop Chrome"] },


### PR DESCRIPTION
# Motivation

E2E tests are currently quite flaky because of a combination of being slow and race conditions because of queryAndUpdate. The Firefox test seem to be especially affected by this.
Let's disable them until I have time to look into the race conditions and tweak the timeouts.

# Changes

Disable Firefox in Playwright config.

# Tests

None
