### PR TITLE
GIX-1518 Render BitcoinSetConfig proposal payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,16 @@ dependencies = [
 [[package]]
 name = "ic-btc-interface"
 version = "0.1.0"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=2c91aaae834dace5f1826ef41a910500d133d35e#2c91aaae834dace5f1826ef41a910500d133d35e"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-btc-interface"
+version = "0.1.0"
 source = "git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e#e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e"
 dependencies = [
  "candid",
@@ -1570,7 +1580,7 @@ version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0#89129b8212791d7e05cab62ff08eece2888a86e0"
 dependencies = [
  "candid",
- "ic-btc-interface",
+ "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "serde",
  "serde_bytes",
@@ -2087,7 +2097,7 @@ dependencies = [
  "candid",
  "float-cmp",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-btc-interface",
+ "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e)",
  "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
@@ -3314,6 +3324,7 @@ dependencies = [
  "futures",
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=2c91aaae834dace5f1826ef41a910500d133d35e)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-certified-map 0.3.4",

--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -135,7 +135,8 @@
     "UpdateAllowedPrincipals": "Update Allowed Principals",
     "RetireReplicaVersion": "Retire Replica Version",
     "InsertSnsWasmUpgradePathEntries": "Insert SNS-WASM Upgrade Path Entries",
-    "UpdateElectedReplicaVersions": "Update Elected Replica Versions"
+    "UpdateElectedReplicaVersions": "Update Elected Replica Versions",
+    "BitcoinSetConfig": "Set Bitcoin Config"
   },
   "nns_functions_description": {
     "Unspecified": "",
@@ -176,6 +177,7 @@
     "UpdateAllowedPrincipals": "Update the SNS-WASM canister's list of allowed principals. This list guards which principals can deploy an SNS.",
     "RetireReplicaVersion": "A proposal to retire previously elected and unused replica versions. The specified versions are removed from the list of blessed replica versions in the registry. This ensures that a replica can no longer be upgraded to these versions. The proposal will fail to remove replica version if that version is currently used by a subnet or unassigned node.",
     "InsertSnsWasmUpgradePathEntries": "Insert custom upgrade path entries into SNS-WASM for all SNSs, or for an SNS specified by its governance canister ID.",
-    "UpdateElectedReplicaVersions": "A proposal to update currently elected replica versions, by electing a new version, and/or unelecting multiple unused versions.<br/><br/>The version to elect (identified by the hash of the installation image) is added to the registry. Besides creating a record for that version, the proposal also appends that version to the list of elected versions that can be installed on a subnet. By itself, this proposal does not affect any upgrade.<br/><br/>The specified versions to unelect are removed from the registry and the elected versions record. This ensures that the replica cannot upgrade to these versions anymore."
+    "UpdateElectedReplicaVersions": "A proposal to update currently elected replica versions, by electing a new version, and/or unelecting multiple unused versions.<br/><br/>The version to elect (identified by the hash of the installation image) is added to the registry. Besides creating a record for that version, the proposal also appends that version to the list of elected versions that can be installed on a subnet. By itself, this proposal does not affect any upgrade.<br/><br/>The specified versions to unelect are removed from the registry and the elected versions record. This ensures that the replica cannot upgrade to these versions anymore.",
+    "BitcoinSetConfig": "A proposal to set the configuration of the underlying Bitcoin Canister that powers the Bitcoin API. The configuration includes whether or not the Bitcoin Canister should sync new blocks from the network, whether the API is enabled, the fees to charge, etc."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1106,6 +1106,7 @@ interface I18nNns_functions {
   RetireReplicaVersion: string;
   InsertSnsWasmUpgradePathEntries: string;
   UpdateElectedReplicaVersions: string;
+  BitcoinSetConfig: string;
 }
 
 interface I18nNns_functions_description {
@@ -1148,6 +1149,7 @@ interface I18nNns_functions_description {
   RetireReplicaVersion: string;
   InsertSnsWasmUpgradePathEntries: string;
   UpdateElectedReplicaVersions: string;
+  BitcoinSetConfig: string;
 }
 
 interface I18n {

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -33,6 +33,7 @@ dfn_candid = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05c
 dfn_core = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
+ic-btc-interface = { git = "https://github.com/dfinity/bitcoin-canister", rev="2c91aaae834dace5f1826ef41a910500d133d35e" }
 ic-certified-map = "0.3.4" # == https://github.com/dfinity/cdk-rs 6a15aa1616bcfdfdc4c120d17d37a089f5700c36
 ic-crypto-sha = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -193,6 +193,7 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
         36 => identity::<RetireReplicaVersionPayload>(payload_bytes),
         37 => transform::<InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesRequestHumanReadable>(payload_bytes),
         38 => identity::<UpdateElectedReplicaVersionsPayload>(payload_bytes),
+        39 => transform::<BitcoinSetConfigProposal, BitcoinSetConfigProposalHumanReadable>(payload_bytes),
         _ => Err("Unrecognised NNS function".to_string()),
     }
 }
@@ -606,6 +607,28 @@ mod def {
     // https://gitlab.com/dfinity-lab/public/ic/-/blob/90d82ff6e51a66306f9ddba820fcad984f4d85a5/rs/registry/canister/src/mutations/do_update_elected_replica_versions.rs#L193
     pub type UpdateElectedReplicaVersionsPayload =
         registry_canister::mutations::do_update_elected_replica_versions::UpdateElectedReplicaVersionsPayload;
+
+    // NNS function 39 - BitcoinSetConfig
+    // https://github.com/dfinity/ic/blob/ae00aff1373e9f6db375ff7076250a20bbf3eea0/rs/nns/governance/src/governance.rs#L8930
+    pub type BitcoinSetConfigProposal =
+        ic_nns_governance::governance::BitcoinSetConfigProposal;
+
+    #[derive(CandidType, Serialize, Deserialize)]
+    pub struct BitcoinSetConfigProposalHumanReadable {
+        pub network: ic_nns_governance::governance::BitcoinNetwork,
+        pub set_config_request: ic_btc_interface::SetConfigRequest,
+    }
+
+    impl From<BitcoinSetConfigProposal> for BitcoinSetConfigProposalHumanReadable {
+        fn from(proposal: BitcoinSetConfigProposal) -> Self {
+            let set_config_request: ic_btc_interface::SetConfigRequest =
+              candid::decode_one(&proposal.payload).unwrap();
+            BitcoinSetConfigProposalHumanReadable {
+                network: proposal.network,
+                set_config_request,
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -610,8 +610,7 @@ mod def {
 
     // NNS function 39 - BitcoinSetConfig
     // https://github.com/dfinity/ic/blob/ae00aff1373e9f6db375ff7076250a20bbf3eea0/rs/nns/governance/src/governance.rs#L8930
-    pub type BitcoinSetConfigProposal =
-        ic_nns_governance::governance::BitcoinSetConfigProposal;
+    pub type BitcoinSetConfigProposal = ic_nns_governance::governance::BitcoinSetConfigProposal;
 
     #[derive(CandidType, Serialize, Deserialize)]
     pub struct BitcoinSetConfigProposalHumanReadable {
@@ -621,8 +620,7 @@ mod def {
 
     impl From<BitcoinSetConfigProposal> for BitcoinSetConfigProposalHumanReadable {
         fn from(proposal: BitcoinSetConfigProposal) -> Self {
-            let set_config_request: ic_btc_interface::SetConfigRequest =
-              candid::decode_one(&proposal.payload).unwrap();
+            let set_config_request: ic_btc_interface::SetConfigRequest = candid::decode_one(&proposal.payload).unwrap();
             BitcoinSetConfigProposalHumanReadable {
                 network: proposal.network,
                 set_config_request,


### PR DESCRIPTION
# Motivation

A new nns function proposal type `BitcoinSetConfigProposal` was added in https://github.com/dfinity/ic/commit/a8e08f558c4db1dd009556d60af64fdb3e8e9c19#diff-98b58f03b1cbc116d2def85c2e6a81c4be8cda5e6f3cc994f0177db15d62c85e
We should be able to render the payload properly.


# Changes

1. Added dependency `ic-btc-interface` in `rs/backend/Cargo.toml`
2. (I would have had to update the ic revision in the Cargo.toml as well, to pull in the new proposal type, but it was already done in https://github.com/dfinity/nns-dapp/pull/2401)
3. Ran `cargo update` to update `Cargo.lock`
4. Changes in `proposals.rs` to parse the payload of `BitcoinSetConfigProposal` as `SetConfigRequest`.
5. Added i18n labels.

# Tests

## Installed the new governance canister locally
1. `dfx start --clean`
2. `rm $(dfx cache show)/wasms/*`
3. `DFX_IC_COMMIT=89129b8212791d7e05cab62ff08eece2888a86e0 dfx nns install`

## Downloaded new ic-admin and created a Bitcoin Config proposal

1. `IC_COMMIT=5d9d0297c523381a02fe40d926b0a36b05041dd6 bash -c 'curl "https://download.dfinity.systems/ic/$IC_COMMIT/openssl-static-binaries/x86_64-darwin/ic-admin.gz" | gunzip > ic-admin'`
2. `chmod +x ./ic-admin`
3. `./ic-admin --nns-url "http://localhost:$(dfx info replica-port)" propose-to-set-bitcoin-config mainnet --api-access false --stability-threshold 123 --test-neuron-proposer --summary "Bitcoin set config test"`

## Installed nns-dapp

1. Fix `local canister_ids.json`:
```
local_ids=".dfx/local/canister_ids.json"
nns_dapp_canister_id=qsgjb-riaaa-aaaaa-aaaga-cai
mkdir -p "$(dirname "$local_ids")"
echo "{
  \"nns-dapp\": {
    \"local\": \"$nns_dapp_canister_id\"
  }
}" >$local_ids
```
2. `./build.sh`
3. `dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall -v --argument "$(cat nns-dapp-arg-local.did)"`
## Checked that the proposal renders properly

<img width="786" alt="image" src="https://user-images.githubusercontent.com/122978264/235120399-3af9898a-a847-4837-b70c-71356ab11eda.png">

