### PR TITLE
Make test-exports failure less confusing

### DIFF
--- a/scripts/nns-dapp/test-exports
+++ b/scripts/nns-dapp/test-exports
@@ -14,7 +14,22 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=w long=wasm desc="The location of the nns-dapp wasm." variable=DFX_WASM_PATH default="nns-dapp.wasm"
+clap.define short=u long=update-golden desc="Update the exports golden file" variable=UPDATE_GOLDEN nargs=0 default="false"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-diff <(sort rs/backend/nns-dapp-exports.txt) <(wasm-nm -je <(gunzip <"$DFX_WASM_PATH") | sort)
+GOLDEN_FILE="rs/backend/nns-dapp-exports.txt"
+
+if [ "$UPDATE_GOLDEN" = "true" ]; then
+  echo "Updating golden file"
+  wasm-nm -je <(gunzip <"$DFX_WASM_PATH") | sort > "$GOLDEN_FILE"
+  exit 0
+fi
+
+if diff <(sort "$GOLDEN_FILE") <(wasm-nm -je <(gunzip <"$DFX_WASM_PATH") | sort); then
+  echo "Exports match"
+else
+  echo "Exports do not match"
+  echo "If this looks correct, run '$0 --wasm $DFX_WASM_PATH --update-golden' to update the golden file"
+  exit 1
+fi

--- a/scripts/nns-dapp/test-exports
+++ b/scripts/nns-dapp/test-exports
@@ -22,7 +22,7 @@ GOLDEN_FILE="rs/backend/nns-dapp-exports.txt"
 
 if [ "$UPDATE_GOLDEN" = "true" ]; then
   echo "Updating golden file"
-  wasm-nm -je <(gunzip <"$DFX_WASM_PATH") | sort > "$GOLDEN_FILE"
+  wasm-nm -je <(gunzip <"$DFX_WASM_PATH") | sort >"$GOLDEN_FILE"
   exit 0
 fi
 


### PR DESCRIPTION
# Motivation

When dependencies change, the build can fail with output like this:
```
Sanity check
0a1
> canister_global_timer
9a11
> canister_update <ic-cdk internal> timer_executor
```
This is quite confusing.

# Changes

1. Explain the failure
2. Give instructions for what to do
3. Add functionality to update the `nns-dapp-exports.txt` file.

Now it looks like this:
```
Sanity check
0a1
> canister_global_timer
9a11
> canister_update <ic-cdk internal> timer_executor
Exports do not match
If this looks correct, run 'scripts/nns-dapp/test-exports --wasm nns-dapp.wasm --update-golden' to update the golden file
```

# Tests

1. Manually changed `nns-dapp-exports.txt` and ran `DFX_NETWORK=local ./build.sh` to see it fail.
2. Followed the instructions and ran the build again to see it pass.