### PR TITLE
Remove symbol estimation ≈ for ckBTC amounts

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
@@ -18,11 +18,7 @@
   </p>
 
   <p class="no-margin" data-tid={testId} class:estimation>
-    {#if estimation}<span class="value">≈</span>{/if}<AmountDisplay
-      inline
-      detailed
-      {amount}
-    />
+    <AmountDisplay inline detailed {amount} />
   </p>
 </div>
 

--- a/frontend/src/lib/utils/bitcoin.utils.ts
+++ b/frontend/src/lib/utils/bitcoin.utils.ts
@@ -4,4 +4,4 @@ const estimatedFee = (bitcoinEstimatedFee: bigint): number =>
   Number(bitcoinEstimatedFee) / BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC;
 
 export const formatEstimatedFee = (bitcoinEstimatedFee: bigint): string =>
-  `≈${estimatedFee(bitcoinEstimatedFee)}`;
+  `${estimatedFee(bitcoinEstimatedFee)}`;

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
@@ -50,7 +50,7 @@ describe("TransactionReceivedTokenAmount", () => {
     });
 
     expect(getByTestId(testId)?.textContent).toContain(
-      `≈${formatToken({ value: amount.toE8s(), detailed: true })}`
+      `${formatToken({ value: amount.toE8s(), detailed: true })}`
     );
   });
 });

--- a/frontend/src/tests/lib/utils/bitcoin.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/bitcoin.utils.spec.ts
@@ -2,7 +2,7 @@ import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 
 describe("bitcoin.utils", () => {
   it("should format bitcoin estimated fee", () => {
-    expect(formatEstimatedFee(1083n)).toEqual("≈0.00001083");
-    expect(formatEstimatedFee(108310831083n)).toEqual("≈1083.10831083");
+    expect(formatEstimatedFee(1083n)).toEqual("0.00001083");
+    expect(formatEstimatedFee(108310831083n)).toEqual("1083.10831083");
   });
 });


### PR DESCRIPTION
# Motivation

Remove symbol estimation `≈` for ckBTC amounts as requested.

