### PR TITLE
ckBTC transaction description sent to BTC Network

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -11,8 +11,14 @@
   import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CanisterId } from "$lib/types/canister";
+  import type { Transaction } from "$lib/types/transaction";
+  import { AccountTransactionType } from "$lib/types/transaction";
   import { i18n } from "$lib/stores/i18n";
+  import { decodeIcrcAccount } from "@dfinity/ledger";
+  import { nonNullish } from "@dfinity/utils";
+  import { transactionDescription } from "$lib/utils/ckbtc.utils";
 
+  export let minterCanisterId: CanisterId;
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
   export let account: Account;
@@ -45,11 +51,8 @@
     account,
   });
 
-  let descriptions: Record<string, string>;
-  $: descriptions = $i18n.ckbtc_transaction_names as unknown as Record<
-    string,
-    string
-  >;
+  const description = (transaction: Transaction): string | undefined =>
+    transactionDescription({ transaction, minterCanisterId });
 </script>
 
 <IcrcTransactionsList
@@ -58,5 +61,5 @@
   {transactions}
   {loading}
   {completed}
-  {descriptions}
+  {description}
 />

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -47,7 +47,7 @@
     account,
   });
 
-  const description = (transaction: Transaction): string | undefined =>
+  const mapDescription = (transaction: Transaction): string | undefined =>
     ckBTCTransactionDescription({ transaction, minterCanisterId });
 </script>
 
@@ -57,5 +57,5 @@
   {transactions}
   {loading}
   {completed}
-  {description}
+  {mapDescription}
 />

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -12,7 +12,7 @@
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CanisterId } from "$lib/types/canister";
   import type { Transaction } from "$lib/types/transaction";
-  import { transactionDescription } from "$lib/utils/ckbtc.utils";
+  import { ckBTCTransactionDescription } from "$lib/utils/ckbtc.utils";
 
   export let minterCanisterId: CanisterId;
   export let indexCanisterId: CanisterId;
@@ -48,7 +48,7 @@
   });
 
   const description = (transaction: Transaction): string | undefined =>
-    transactionDescription({ transaction, minterCanisterId });
+    ckBTCTransactionDescription({ transaction, minterCanisterId });
 </script>
 
 <IcrcTransactionsList

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -12,10 +12,6 @@
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CanisterId } from "$lib/types/canister";
   import type { Transaction } from "$lib/types/transaction";
-  import { AccountTransactionType } from "$lib/types/transaction";
-  import { i18n } from "$lib/stores/i18n";
-  import { decodeIcrcAccount } from "@dfinity/ledger";
-  import { nonNullish } from "@dfinity/utils";
   import { transactionDescription } from "$lib/utils/ckbtc.utils";
 
   export let minterCanisterId: CanisterId;

--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -12,7 +12,7 @@
   export let governanceCanisterId: Principal | undefined = undefined;
   export let description:
     | ((transaction: Transaction) => string | undefined)
-    | undefined;
+    | undefined = undefined;
 
   let transactionData: Transaction | undefined;
   $: transactionData = mapIcrcTransaction({

--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -10,7 +10,9 @@
   export let account: Account;
   export let toSelfTransaction: boolean;
   export let governanceCanisterId: Principal | undefined = undefined;
-  export let descriptions: Record<string, string> | undefined = undefined;
+  export let description:
+    | ((transaction: Transaction) => string | undefined)
+    | undefined;
 
   let transactionData: Transaction | undefined;
   $: transactionData = mapIcrcTransaction({
@@ -26,6 +28,6 @@
     {toSelfTransaction}
     transaction={transactionData}
     token={account.balance.token}
-    {descriptions}
+    {description}
   />
 {/if}

--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -10,7 +10,7 @@
   export let account: Account;
   export let toSelfTransaction: boolean;
   export let governanceCanisterId: Principal | undefined = undefined;
-  export let description:
+  export let mapDescription:
     | ((transaction: Transaction) => string | undefined)
     | undefined = undefined;
 
@@ -28,6 +28,6 @@
     {toSelfTransaction}
     transaction={transactionData}
     token={account.balance.token}
-    {description}
+    {mapDescription}
   />
 {/if}

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -6,13 +6,16 @@
   import IcrcTransactionCard from "./IcrcTransactionCard.svelte";
   import SkeletonCard from "../ui/SkeletonCard.svelte";
   import type { IcrcTransactionData } from "$lib/types/transaction";
+  import type { Transaction } from "$lib/types/transaction";
 
   export let account: Account;
   export let transactions: IcrcTransactionData[];
   export let loading: boolean;
   export let governanceCanisterId: Principal | undefined = undefined;
   export let completed = false;
-  export let descriptions: Record<string, string> | undefined = undefined;
+  export let description:
+    | ((transaction: Transaction) => string | undefined)
+    | undefined;
 </script>
 
 <div data-tid="transactions-list">
@@ -29,7 +32,7 @@
           {toSelfTransaction}
           {account}
           {governanceCanisterId}
-          {descriptions}
+          {description}
         />
       {/each}
     </InfiniteScroll>

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -13,7 +13,7 @@
   export let loading: boolean;
   export let governanceCanisterId: Principal | undefined = undefined;
   export let completed = false;
-  export let description:
+  export let mapDescription:
     | ((transaction: Transaction) => string | undefined)
     | undefined = undefined;
 </script>
@@ -32,7 +32,7 @@
           {toSelfTransaction}
           {account}
           {governanceCanisterId}
-          {description}
+          {mapDescription}
         />
       {/each}
     </InfiniteScroll>

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -15,7 +15,7 @@
   export let completed = false;
   export let description:
     | ((transaction: Transaction) => string | undefined)
-    | undefined;
+    | undefined = undefined;
 </script>
 
 <div data-tid="transactions-list">

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -16,7 +16,7 @@
   export let transaction: Transaction;
   export let toSelfTransaction = false;
   export let token: Token;
-  export let description:
+  export let mapDescription:
     | ((transaction: Transaction) => string | undefined)
     | undefined = undefined;
 
@@ -46,7 +46,7 @@
       : undefined;
 
   let customDescription: string | undefined;
-  $: customDescription = description?.(transaction);
+  $: customDescription = mapDescription?.(transaction);
 
   let identifier: string | undefined;
   $: identifier = isReceive ? from : to;

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -18,7 +18,7 @@
   export let token: Token;
   export let description:
     | ((transaction: Transaction) => string | undefined)
-    | undefined;
+    | undefined = undefined;
 
   let type: AccountTransactionType;
   let isReceive: boolean;

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -16,7 +16,9 @@
   export let transaction: Transaction;
   export let toSelfTransaction = false;
   export let token: Token;
-  export let descriptions: Record<string, string> | undefined = undefined;
+  export let description:
+    | ((transaction: Transaction) => string | undefined)
+    | undefined;
 
   let type: AccountTransactionType;
   let isReceive: boolean;
@@ -43,8 +45,8 @@
       ? $i18n.wallet.direction_to
       : undefined;
 
-  let description: string | undefined;
-  $: description = descriptions?.[type];
+  let customDescription: string | undefined;
+  $: customDescription = description?.(transaction);
 
   let identifier: string | undefined;
   $: identifier = isReceive ? from : to;
@@ -73,11 +75,11 @@
 
     <ColumnRow>
       <div slot="start" class="identifier">
-        {#if nonNullish(description)}
-          <p data-tid="transaction-description"><Html text={description} /></p>
-        {/if}
-
-        {#if nonNullish(identifier)}
+        {#if nonNullish(customDescription)}
+          <p data-tid="transaction-description">
+            <Html text={customDescription} />
+          </p>
+        {:else if nonNullish(identifier)}
           <Identifier size="medium" {label} {identifier} />
         {/if}
       </div>

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -181,6 +181,7 @@
             account={$selectedAccountStore.account}
             universeId={$selectedCkBTCUniverseIdStore}
             indexCanisterId={canisters.indexCanisterId}
+            minterCanisterId={canisters.minterCanisterId}
           />
         {/if}
       {:else}

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -74,7 +74,7 @@ export const assertCkBTCUserInputAmount = ({
   });
 };
 
-export const transactionDescription = ({
+export const ckBTCTransactionDescription = ({
   transaction: { type, to },
   minterCanisterId,
 }: {

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -9,9 +9,9 @@ import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import {
-  mockIcrcTransactionBurn,
   mockIcrcTransactionMint,
   mockIcrcTransactionsStoreSubscribe,
+  mockIcrcTransactionTransferToMinter,
   mockIcrcTransactionWithId,
 } from "$tests/mocks/icrc-transactions.mock";
 import { render } from "@testing-library/svelte";
@@ -29,6 +29,7 @@ describe("CkBTCTransactionList", () => {
         account: mockCkBTCMainAccount,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
         indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
+        minterCanisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
       },
     });
 
@@ -62,14 +63,14 @@ describe("CkBTCTransactionList", () => {
     expect(queryAllByTestId("transaction-card").length).toBe(1);
   });
 
-  it("should render description burn to btc network", () => {
+  it("should render description to btc network", () => {
     const store = {
       [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [
             {
               id: BigInt(123),
-              transaction: mockIcrcTransactionBurn,
+              transaction: mockIcrcTransactionTransferToMinter,
             },
           ],
           completed: false,

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -54,7 +54,7 @@ describe("TransactionCard", () => {
       type: AccountTransactionType.Burn,
     };
 
-    const { getByText, getByTestId } = renderTransactionCard({
+    const { getByText } = renderTransactionCard({
       transaction,
       description: spy,
     });

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -54,7 +54,7 @@ describe("TransactionCard", () => {
       type: AccountTransactionType.Burn,
     };
 
-    const { getByText } = renderTransactionCard({
+    const { getByText, getByTestId } = renderTransactionCard({
       transaction,
       description: spy,
     });
@@ -66,6 +66,20 @@ describe("TransactionCard", () => {
 
     expect(spy).toBeCalledTimes(1);
     expect(spy).toBeCalledWith(transaction);
+  });
+
+  it("should not render identifier if a description is provided", () => {
+    const transaction = {
+      ...mockTransactionReceiveDataFromMain,
+      type: AccountTransactionType.Burn,
+    };
+
+    const { getByTestId } = renderTransactionCard({
+      transaction,
+      description: () => "test",
+    });
+
+    expect(() => getByTestId("identifier")).toThrow();
   });
 
   it("renders sent headline", () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -21,16 +21,18 @@ import { render } from "@testing-library/svelte";
 describe("TransactionCard", () => {
   const renderTransactionCard = ({
     transaction = mockTransactionSendDataFromMain,
-    descriptions,
+    description,
   }: {
     transaction?: Transaction;
-    descriptions?: Record<string, string>;
+    description?:
+      | ((transaction: Transaction) => string | undefined)
+      | undefined;
   }) =>
     render(TransactionCard, {
       props: {
         transaction,
         token: ICPToken,
-        descriptions,
+        description,
       },
     });
 
@@ -46,12 +48,15 @@ describe("TransactionCard", () => {
   });
 
   it("renders received description", () => {
-    const { getByText, getByTestId } = renderTransactionCard({
-      transaction: {
-        ...mockTransactionReceiveDataFromMain,
-        type: AccountTransactionType.Burn,
-      },
-      descriptions: en.ckbtc_transaction_names,
+    const spy = jest.fn();
+    const transaction = {
+      ...mockTransactionReceiveDataFromMain,
+      type: AccountTransactionType.Burn,
+    };
+
+    const { getByText } = renderTransactionCard({
+      transaction,
+      description: spy,
     });
 
     const expectedText = replacePlaceholders(en.transaction_names.burn, {
@@ -59,9 +64,8 @@ describe("TransactionCard", () => {
     });
     expect(getByText(expectedText)).toBeInTheDocument();
 
-    expect(getByTestId("transaction-description")?.textContent).toEqual(
-      "To: BTC Network"
-    );
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith(transaction);
   });
 
   it("renders sent headline", () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -21,10 +21,10 @@ import { render } from "@testing-library/svelte";
 describe("TransactionCard", () => {
   const renderTransactionCard = ({
     transaction = mockTransactionSendDataFromMain,
-    description,
+    mapDescription,
   }: {
     transaction?: Transaction;
-    description?:
+    mapDescription?:
       | ((transaction: Transaction) => string | undefined)
       | undefined;
   }) =>
@@ -32,7 +32,7 @@ describe("TransactionCard", () => {
       props: {
         transaction,
         token: ICPToken,
-        description,
+        mapDescription: mapDescription,
       },
     });
 
@@ -56,7 +56,7 @@ describe("TransactionCard", () => {
 
     const { getByText } = renderTransactionCard({
       transaction,
-      description: spy,
+      mapDescription: spy,
     });
 
     const expectedText = replacePlaceholders(en.transaction_names.burn, {
@@ -76,7 +76,7 @@ describe("TransactionCard", () => {
 
     const { getByTestId } = renderTransactionCard({
       transaction,
-      description: () => "test",
+      mapDescription: () => "test",
     });
 
     expect(() => getByTestId("identifier")).toThrow();

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -2,115 +2,174 @@ import { RETRIEVE_BTC_MIN_AMOUNT } from "$lib/constants/bitcoin.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
-import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
+import { AccountTransactionType } from "$lib/types/transaction";
+import {
+  assertCkBTCUserInputAmount,
+  ckBTCTransactionDescription,
+} from "$lib/utils/ckbtc.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockTransactionSendDataFromMain } from "$tests/mocks/transaction.mock";
+import { encodeIcrcAccount } from "@dfinity/ledger";
 
 describe("ckbtc.utils", () => {
-  const params = {
-    networkBtc: true,
-    sourceAccount: mockMainAccount,
-    amount: 0.002,
-    bitcoinEstimatedFee: 1n,
-    transactionFee: 2n,
-    kytEstimatedFee: 3n,
-  };
+  describe("assertCkBTCUserInputAmount", () => {
+    const params = {
+      networkBtc: true,
+      sourceAccount: mockMainAccount,
+      amount: 0.002,
+      bitcoinEstimatedFee: 1n,
+      transactionFee: 2n,
+      kytEstimatedFee: 3n,
+    };
 
-  it("should not throw error", () => {
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        networkBtc: false,
-      })
-    ).not.toThrow();
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        sourceAccount: undefined,
-      })
-    ).not.toThrow();
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: undefined,
-      })
-    ).not.toThrow();
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: 0,
-      })
-    ).not.toThrow();
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: Number(RETRIEVE_BTC_MIN_AMOUNT),
-      })
-    ).not.toThrow();
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: Number(RETRIEVE_BTC_MIN_AMOUNT) + 0.1,
-      })
-    ).not.toThrow();
-
-    expect(() => assertCkBTCUserInputAmount(params)).not.toThrow();
-  });
-
-  it("should throw error if amount is lower than min retrieve btc amount", () => {
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP - 0.00001,
-      })
-    ).toThrow(
-      new CkBTCErrorRetrieveBtcMinAmount(
-        replacePlaceholders(en.error__ckbtc.retrieve_btc_min_amount, {
-          $amount: formatToken({
-            value: RETRIEVE_BTC_MIN_AMOUNT,
-            detailed: true,
-          }),
+    it("should not throw error", () => {
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          networkBtc: false,
         })
-      )
-    );
+      ).not.toThrow();
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          sourceAccount: undefined,
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: undefined,
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: 0,
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: Number(RETRIEVE_BTC_MIN_AMOUNT),
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: Number(RETRIEVE_BTC_MIN_AMOUNT) + 0.1,
+        })
+      ).not.toThrow();
+
+      expect(() => assertCkBTCUserInputAmount(params)).not.toThrow();
+    });
+
+    it("should throw error if amount is lower than min retrieve btc amount", () => {
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP - 0.00001,
+        })
+      ).toThrow(
+        new CkBTCErrorRetrieveBtcMinAmount(
+          replacePlaceholders(en.error__ckbtc.retrieve_btc_min_amount, {
+            $amount: formatToken({
+              value: RETRIEVE_BTC_MIN_AMOUNT,
+              detailed: true,
+            }),
+          })
+        )
+      );
+    });
+
+    it("should throw error if not enough funds available", () => {
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount:
+            Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP +
+            Number(params.transactionFee) / E8S_PER_ICP +
+            Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP,
+        })
+      ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+
+      const closestAmount =
+        Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP -
+        Number(params.bitcoinEstimatedFee) / E8S_PER_ICP -
+        Number(params.kytEstimatedFee) / E8S_PER_ICP -
+        Number(params.transactionFee) / E8S_PER_ICP;
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: closestAmount,
+        })
+      ).not.toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+
+      expect(() =>
+        assertCkBTCUserInputAmount({
+          ...params,
+          amount: closestAmount + 0.01,
+        })
+      ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+    });
   });
 
-  it("should throw error if not enough funds available", () => {
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount:
-          Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP +
-          Number(params.transactionFee) / E8S_PER_ICP +
-          Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP,
-      })
-    ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+  describe("ckBTCTransactionDescription", () => {
+    it("should return undefined", () => {
+      expect(
+        ckBTCTransactionDescription({
+          transaction: {
+            ...mockTransactionSendDataFromMain,
+            to: "aaaaa-aa",
+          },
+          minterCanisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
+        })
+      ).toBeUndefined();
 
-    const closestAmount =
-      Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP -
-      Number(params.bitcoinEstimatedFee) / E8S_PER_ICP -
-      Number(params.kytEstimatedFee) / E8S_PER_ICP -
-      Number(params.transactionFee) / E8S_PER_ICP;
+      expect(
+        ckBTCTransactionDescription({
+          transaction: {
+            ...mockTransactionSendDataFromMain,
+            to: undefined,
+          },
+          minterCanisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
+        })
+      ).toBeUndefined();
+    });
 
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: closestAmount,
-      })
-    ).not.toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+    it("should map to btc network", () => {
+      expect(
+        ckBTCTransactionDescription({
+          transaction: {
+            ...mockTransactionSendDataFromMain,
+            to: encodeIcrcAccount({
+              owner: mockCkBTCAdditionalCanisters.minterCanisterId,
+            }),
+          },
+          minterCanisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
+        })
+      ).toEqual(en.ckbtc_transaction_names.burn);
+    });
 
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: closestAmount + 0.01,
-      })
-    ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
+    it("should map from btc network", () => {
+      expect(
+        ckBTCTransactionDescription({
+          transaction: {
+            ...mockTransactionSendDataFromMain,
+            type: AccountTransactionType.Mint,
+          },
+          minterCanisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
+        })
+      ).toEqual(en.ckbtc_transaction_names.mint);
+    });
   });
 });

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -1,4 +1,5 @@
 import type { IcrcTransactionsStoreData } from "$lib/stores/icrc-transactions.store";
+import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import type { IcrcTransaction, IcrcTransactionWithId } from "@dfinity/ledger";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
@@ -56,19 +57,24 @@ const mockIcrcTransactionTransfer: IcrcTransaction = {
   ],
 };
 
-export const mockIcrcTransactionBurn: IcrcTransaction = {
-  kind: "burn",
+export const mockIcrcTransactionTransferToMinter: IcrcTransaction = {
+  kind: "transfer",
   timestamp: BigInt(12354),
-  burn: [
+  burn: [],
+  mint: [],
+  transfer: [
     {
-      amount: BigInt(33),
+      to: {
+        owner: mockCkBTCAdditionalCanisters.minterCanisterId,
+        subaccount: [],
+      },
       from: fakeAccount,
       memo: [],
       created_at_time: [BigInt(123)],
+      amount: BigInt(33),
+      fee: [BigInt(1)],
     },
   ],
-  mint: [],
-  transfer: [],
 };
 
 export const mockIcrcTransactionMint: IcrcTransaction = {


### PR DESCRIPTION
# Motivation

If `transaction.to.owner` is equals to minter, then display onl y `To: BTC Network`.
Per extenstion, when we display `From: BTC Network`, display only label too.

# Changes

- `descriptions` property becomes a function instead of a record
- create and use `ckBTCTransactionDescription` function to map ckBTC description 
- do not display identifier if a description is matching

# Tests

<img width="1536" alt="Capture d’écran 2023-05-01 à 08 32 50" src="https://user-images.githubusercontent.com/16886711/235417755-5496de93-5b50-4a81-abc2-7e93866e6181.png">

