### PR TITLE
Uppercase enum storeLocalStorageKey

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -1,4 +1,4 @@
-export enum storeLocalStorageKey {
+export enum StoreLocalStorageKey {
   ProposalFilters = "nnsProposalFilters",
   Theme = "nnsTheme",
   FeatureFlags = "nnsOverrideFeatureFlags",

--- a/frontend/src/lib/stores/feature-flags.store.ts
+++ b/frontend/src/lib/stores/feature-flags.store.ts
@@ -4,7 +4,7 @@ import {
   type FeatureFlags,
   type FeatureKey,
 } from "$lib/constants/environment.constants";
-import { storeLocalStorageKey } from "$lib/constants/stores.constants";
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { derived, get, type Readable } from "svelte/store";
 import { writableStored } from "./writable-stored";
 
@@ -40,7 +40,7 @@ export const EDITABLE_FEATURE_FLAGS: Array<FeatureKey> = [
  */
 const initOverrideFeatureFlagsStore = (): OverrideFeatureFlagsStore => {
   const { subscribe, set, update } = writableStored<OverrideFeatureFlagsData>({
-    key: storeLocalStorageKey.FeatureFlags,
+    key: StoreLocalStorageKey.FeatureFlags,
     defaultValue: {},
   });
 

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
-import { storeLocalStorageKey } from "$lib/constants/stores.constants";
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import {
   concatenateUniqueProposals,
   excludeProposals,
@@ -127,7 +127,7 @@ const initProposalsStore = () => {
  */
 const initProposalsFiltersStore = () => {
   const { subscribe, update, set } = writableStored<ProposalsFiltersStore>({
-    key: storeLocalStorageKey.ProposalFilters,
+    key: StoreLocalStorageKey.ProposalFilters,
     defaultValue: DEFAULT_PROPOSALS_FILTERS,
   });
 

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -1,5 +1,5 @@
 import { browser } from "$app/environment";
-import type { storeLocalStorageKey } from "$lib/constants/stores.constants";
+import type { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { writable, type Unsubscriber, type Writable } from "svelte/store";
 
 type WritableStored<T> = Writable<T> & {
@@ -10,7 +10,7 @@ export const writableStored = <T>({
   key,
   defaultValue,
 }: {
-  key: storeLocalStorageKey;
+  key: StoreLocalStorageKey;
   defaultValue: T;
 }): WritableStored<T> => {
   const getInitialValue = (): T => {

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { storeLocalStorageKey } from "$lib/constants/stores.constants";
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { writableStored } from "$lib/stores/writable-stored";
 import { get } from "svelte/store";
 
@@ -20,7 +20,7 @@ describe("writableStored", () => {
 
   it("writes to local storage when state changes", () => {
     const store = writableStored({
-      key: storeLocalStorageKey.ProposalFilters,
+      key: StoreLocalStorageKey.ProposalFilters,
       defaultValue: { filter: "all" },
     });
 
@@ -28,18 +28,18 @@ describe("writableStored", () => {
     store.set(newState);
 
     expect(
-      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+      window.localStorage.getItem(StoreLocalStorageKey.ProposalFilters)
     ).toEqual(JSON.stringify(newState));
   });
 
   it("loads initial value from local storage if present", () => {
     const storedState = { filter: "active" };
     window.localStorage.setItem(
-      storeLocalStorageKey.ProposalFilters,
+      StoreLocalStorageKey.ProposalFilters,
       JSON.stringify(storedState)
     );
     const store = writableStored({
-      key: storeLocalStorageKey.ProposalFilters,
+      key: StoreLocalStorageKey.ProposalFilters,
       defaultValue: { filter: "all" },
     });
 
@@ -49,7 +49,7 @@ describe("writableStored", () => {
   it("loads default value if no value in local storage", () => {
     const defaultValue = { filter: "all" };
     const store = writableStored({
-      key: storeLocalStorageKey.ProposalFilters,
+      key: StoreLocalStorageKey.ProposalFilters,
       defaultValue,
     });
 
@@ -59,19 +59,19 @@ describe("writableStored", () => {
   it("unsubscribes storing in local storage", async () => {
     const defaultValue = { filter: "all" };
     const store = writableStored({
-      key: storeLocalStorageKey.ProposalFilters,
+      key: StoreLocalStorageKey.ProposalFilters,
       defaultValue,
     });
     const newState = { filter: "active" };
     store.set(newState);
     expect(
-      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+      window.localStorage.getItem(StoreLocalStorageKey.ProposalFilters)
     ).toEqual(JSON.stringify(newState));
 
     store.unsubscribeStorage();
     store.set(defaultValue);
     expect(
-      window.localStorage.getItem(storeLocalStorageKey.ProposalFilters)
+      window.localStorage.getItem(StoreLocalStorageKey.ProposalFilters)
     ).toEqual(JSON.stringify(newState));
   });
 });


### PR DESCRIPTION
# Motivation

Enums commonly and in our code base starts with an uppercase.

# Changes

- `storeLocalStorageKey` -> `StoreLocalStorageKey`