### PR TITLE
Extend getIcrcAccount with owner and subaccount

### DIFF
--- a/frontend/src/lib/api/ckbtc-ledger.api.ts
+++ b/frontend/src/lib/api/ckbtc-ledger.api.ts
@@ -1,6 +1,6 @@
 import { createAgent } from "$lib/api/agent.api";
 import {
-  getIcrcMainAccount,
+  getIcrcAccount,
   getIcrcToken,
   icrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
@@ -29,8 +29,9 @@ export const getCkBTCAccounts = async ({
     canister: { metadata, balance },
   } = await ckBTCLedgerCanister({ identity, canisterId });
 
-  const mainAccount = await getIcrcMainAccount({
-    identity,
+  const mainAccount = await getIcrcAccount({
+    owner: identity.getPrincipal(),
+    type: "main",
     certified,
     getBalance: balance,
     getMetadata: metadata,

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -1,10 +1,9 @@
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import type { Account } from "$lib/types/account";
+import type { Account, AccountType } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
-import type { Identity } from "@dfinity/agent";
 import type {
   BalanceParams,
   IcrcTokenMetadataResponse,
@@ -23,27 +22,29 @@ import {
   isNullish,
   nonNullish,
   toNullable,
+  uint8ArrayToArrayOfNumber,
 } from "@dfinity/utils";
 
-export const getIcrcMainAccount = async ({
-  identity,
+export const getIcrcAccount = async ({
+  owner,
+  subaccount,
   certified,
+  type,
   getBalance,
   getMetadata: ledgerMetadata,
 }: {
-  identity: Identity;
-  certified: boolean;
+  type: AccountType;
   getBalance: (params: BalanceParams) => Promise<IcrcTokens>;
   /**
    * TODO: integrate ckBTC fee
    * @deprecated metadata should not be called here and token should not be interpreted per account because it is the same token for all accounts
    */
   getMetadata: (params: QueryParams) => Promise<IcrcTokenMetadataResponse>;
-}): Promise<Account> => {
-  const mainAccountIdentifier = { owner: identity.getPrincipal() };
+} & BalanceParams): Promise<Account> => {
+  const account = { owner, subaccount };
 
-  const [mainBalanceE8s, metadata] = await Promise.all([
-    getBalance({ ...mainAccountIdentifier, certified }),
+  const [balanceE8s, metadata] = await Promise.all([
+    getBalance({ ...account, certified }),
     ledgerMetadata({ certified }),
   ]);
 
@@ -54,13 +55,16 @@ export const getIcrcMainAccount = async ({
   }
 
   return {
-    identifier: encodeIcrcAccount(mainAccountIdentifier),
-    principal: identity.getPrincipal(),
+    identifier: encodeIcrcAccount(account),
+    principal: owner,
+    ...(nonNullish(subaccount) && {
+      subAccount: uint8ArrayToArrayOfNumber(subaccount),
+    }),
     balance: TokenAmount.fromE8s({
-      amount: mainBalanceE8s,
+      amount: balanceE8s,
       token: projectToken,
     }),
-    type: "main",
+    type,
   };
 };
 

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,5 +1,5 @@
 import {
-  getIcrcMainAccount,
+  getIcrcAccount,
   getIcrcToken,
   icrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
@@ -29,8 +29,9 @@ export const getSnsAccounts = async ({
     certified,
   });
 
-  const mainAccount = await getIcrcMainAccount({
-    identity,
+  const mainAccount = await getIcrcAccount({
+    owner: identity.getPrincipal(),
+    type: "main",
     certified,
     getBalance,
     getMetadata,

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -1,5 +1,5 @@
 import {
-  getIcrcMainAccount,
+  getIcrcAccount,
   getIcrcToken,
   icrcTransfer,
 } from "$lib/api/icrc-ledger.api";
@@ -16,9 +16,10 @@ describe("icrc-ledger api", () => {
     it("returns main account with balance and project token metadata", async () => {
       const metadataSpy = jest.fn().mockResolvedValue(mockQueryTokenResponse);
 
-      const account = await getIcrcMainAccount({
+      const account = await getIcrcAccount({
         certified: true,
-        identity: mockIdentity,
+        owner: mockIdentity.getPrincipal(),
+        type: "main",
         getBalance: balanceSpy,
         getMetadata: metadataSpy,
       });
@@ -26,6 +27,11 @@ describe("icrc-ledger api", () => {
       expect(account).not.toBeUndefined();
 
       expect(account.balance.toE8s()).toEqual(BigInt(10_000_000));
+
+      expect(account.principal.toText()).toEqual(
+        mockIdentity.getPrincipal().toText()
+      );
+      expect(account.type).toEqual("main");
 
       expect(balanceSpy).toBeCalled();
       expect(metadataSpy).toBeCalled();
@@ -37,9 +43,10 @@ describe("icrc-ledger api", () => {
       };
 
       const call = () =>
-        getIcrcMainAccount({
+        getIcrcAccount({
           certified: true,
-          identity: mockIdentity,
+          owner: mockIdentity.getPrincipal(),
+          type: "main",
           getBalance: balanceSpy,
           getMetadata: metadataSpy,
         });


### PR DESCRIPTION
# Motivation

We need to query the balance of Icrc ledger for other accounts than `main`. This PR extends the API to supports the `owner` as an argument.