### PR TITLE
E2E: See committed swaps

### DIFF
--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -23,7 +23,12 @@ test("Test SNS participation", async ({ page, context }) => {
   expect(openProjects.length).toBe(1);
 
   // D002: User can see the list of successful sales
-  // TODO
+  await appPo.getLaunchpadPo().getCommittedProjectsPo().waitForContentLoaded();
+  const committedProjects: ProjectCardPo[] = await appPo
+    .getLaunchpadPo()
+    .getCommittedProjectsPo()
+    .getProjectCardPos();
+  expect(committedProjects.length).toBeGreaterThan(1);
 
   // D003: User can see the details of one sale
   // TODO

--- a/frontend/src/tests/page-objects/Launchpad.page-object.ts
+++ b/frontend/src/tests/page-objects/Launchpad.page-object.ts
@@ -12,4 +12,11 @@ export class LaunchpadPo extends BasePageObject {
   getOpenProjectsPo(): ProjectsPo {
     return ProjectsPo.under({ element: this.root, testId: "open-projects" });
   }
+
+  getCommittedProjectsPo(): ProjectsPo {
+    return ProjectsPo.under({
+      element: this.root,
+      testId: "committed-projects",
+    });
+  }
 }


### PR DESCRIPTION
# Motivation

Continuing with the SNS participation end-to-end test

# Changes

1. Test that the user can see a list of committed projects.
2. Add a getter for the list of the committed projects to the Launchpad page object.

# Tests

1. Created a dfx snapshot in the snsdemo repository at tag release-2023-04-27, which is what we run on CI.
2. Ran `npm run test-e2e` against that snapshot.
