### PR TITLE
GIX-1519: Stop using deprecated endpoint in SNS Aggregator. Part 4

### DIFF
--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -2,8 +2,8 @@
 use crate::types::ic_sns_governance::{GetMetadataResponse, ListNervousSystemFunctionsResponse};
 use crate::types::ic_sns_root::ListSnsCanistersResponse;
 use crate::types::ic_sns_swap::{
-    DerivedState, GetDerivedStateResponse, GetInitResponse, GetSaleParametersResponse, GetStateResponse, Init, Params,
-    Swap,
+    DerivedState, GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse, GetSaleParametersResponse,
+    GetStateResponse, Init, Params, Swap,
 };
 use crate::types::ic_sns_wasm::DeployedSns;
 use crate::types::upstream::UpstreamData;
@@ -40,6 +40,8 @@ pub struct SlowSnsData {
     pub init: Option<GetInitResponse>,
     /// The derived state of the swap
     pub derived_state: Option<GetDerivedStateResponse>,
+    /// The lifecycle of the swap
+    pub lifecycle: Option<GetLifecycleResponse>,
 }
 
 impl From<&UpstreamData> for SlowSnsData {
@@ -58,6 +60,7 @@ impl From<&UpstreamData> for SlowSnsData {
             swap_params: upstream.swap_params.clone(),
             init: upstream.init.clone(),
             derived_state: upstream.derived_state.clone(),
+            lifecycle: upstream.lifecycle.clone(),
         }
     }
 }

--- a/rs/sns_aggregator/src/types/upstream.rs
+++ b/rs/sns_aggregator/src/types/upstream.rs
@@ -5,7 +5,7 @@ use super::ic_sns_root::ListSnsCanistersResponse;
 use super::ic_sns_swap::{GetSaleParametersResponse, GetStateResponse};
 use super::ic_sns_wasm::DeployedSns;
 use super::{CandidType, Deserialize};
-use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse};
+use crate::types::ic_sns_swap::{GetDerivedStateResponse, GetInitResponse, GetLifecycleResponse};
 use candid::Nat;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use serde::Serialize;
@@ -58,4 +58,6 @@ pub struct UpstreamData {
     pub init: Option<GetInitResponse>,
     /// The derived state of the swap
     pub derived_state: Option<GetDerivedStateResponse>,
+    /// The lifecycle of the swap
+    pub lifecycle: Option<GetLifecycleResponse>,
 }


### PR DESCRIPTION
# Motivation

The SNS aggregator uses the deprecated endpoint `get_state`.

We want to move away from this endpoint.

This PR: Fetch swap parameters from new endpoint `get_lifecycle`.

# Changes

* Add new property `lifecycle` to `UpstreamData`.
* Fetch the data from `get_lifecycle` when we fetch the other data.
* Add new property `lifecycle` to `SlowSnsData` which is used to render the JSON.

# Tests

* There is no data transformation. And we still don't have integration tests to check calls to the backend.
