### PR TITLE
refactor: extract getWithdrawalAccount to minter service

### DIFF
--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -1,7 +1,7 @@
+import { getWithdrawalAccount } from "$lib/services/ckbtc-minter.services";
 import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
 import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
 import type { UniverseCanisterId } from "$lib/types/universe";
-import type { WithdrawalAccount } from "@dfinity/ckbtc";
 import {
   MinterAlreadyProcessingError,
   MinterAmountTooLowError,
@@ -11,10 +11,9 @@ import {
   MinterTemporaryUnavailableError,
 } from "@dfinity/ckbtc";
 import { encodeIcrcAccount } from "@dfinity/ledger";
-import { assertNonNullish, fromNullable, isNullish } from "@dfinity/utils";
-import { getWithdrawalAccount, retrieveBtc } from "../api/ckbtc-minter.api";
+import { fromNullable, isNullish } from "@dfinity/utils";
+import { retrieveBtc } from "../api/ckbtc-minter.api";
 import { toastsError } from "../stores/toasts.store";
-import { toToastError } from "../utils/error.utils";
 import { numberToE8s } from "../utils/token.utils";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { ckBTCTransferTokens } from "./ckbtc-accounts.services";
@@ -48,26 +47,11 @@ export const convertCkBTCToBtc = async ({
 
   const identity = await getAuthenticatedIdentity();
 
-  let account: WithdrawalAccount | undefined;
+  const account = await getWithdrawalAccount({ minterCanisterId });
 
-  try {
-    account = await getWithdrawalAccount({
-      identity,
-      canisterId: minterCanisterId,
-    });
-  } catch (err: unknown) {
-    toastsError(
-      toToastError({
-        err,
-        fallbackErrorLabelKey: "error__ckbtc.withdrawal_account",
-      })
-    );
-
+  if (isNullish(account)) {
     return { success: false };
   }
-
-  // Account cannot be null here. We add this guard to comply with type safety.
-  assertNonNullish(account);
 
   // For simplicity and compatibility reason with the transferTokens interface we just encode the account here instead of extending the interface to support either account identifier or {owner; subaccount;} object.
   const ledgerAddress = encodeIcrcAccount({

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -23,9 +23,11 @@ import {
   MinterTemporaryUnavailableError,
   type EstimateWithdrawalFee,
   type EstimateWithdrawalFeeParams,
+  type WithdrawalAccount,
 } from "@dfinity/ckbtc";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
+import { getWithdrawalAccount as getWithdrawalAccountAPI } from "../api/ckbtc-minter.api";
 
 const getBTCAddress = async (minterCanisterId: CanisterId): Promise<string> => {
   const identity = await getAuthenticatedIdentity();
@@ -211,4 +213,30 @@ const mapUpdateBalanceError = (
   }
 
   return err;
+};
+
+export const getWithdrawalAccount = async ({
+  minterCanisterId,
+}: {
+  minterCanisterId: CanisterId;
+}): Promise<WithdrawalAccount | undefined> => {
+  const identity = await getAuthenticatedIdentity();
+
+  try {
+    const account = await getWithdrawalAccountAPI({
+      identity,
+      canisterId: minterCanisterId,
+    });
+
+    return account;
+  } catch (err: unknown) {
+    toastsError(
+      toToastError({
+        err,
+        fallbackErrorLabelKey: "error__ckbtc.withdrawal_account",
+      })
+    );
+
+    return undefined;
+  }
 };

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -27,6 +27,7 @@ import {
   MinterGenericError,
   MinterNoNewUtxosError,
   MinterTemporaryUnavailableError,
+  type WithdrawalAccount,
 } from "@dfinity/ckbtc";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -247,6 +248,30 @@ describe("ckbtc-minter-services", () => {
       expect(callback).toHaveBeenCalledWith(result);
       // Query + Update
       expect(callback).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getWithdrawalAccount", () => {
+    it("should call get withdrawal account", async () => {
+      const result: WithdrawalAccount = {
+        owner: mockCkBTCMainAccount.principal,
+        subaccount: [],
+      };
+
+      const spyGetWithdrawal = jest
+        .spyOn(minterApi, "getWithdrawalAccount")
+        .mockResolvedValue(result);
+
+      await services.getWithdrawalAccount({
+        minterCanisterId: CKBTC_MINTER_CANISTER_ID,
+      });
+
+      await waitFor(() =>
+        expect(spyGetWithdrawal).toBeCalledWith({
+          identity: mockIdentity,
+          canisterId: CKBTC_MINTER_CANISTER_ID,
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

We will need `getWithdrawalAccount` in PR #2430 for a new feature. Therefore this PR extract the dedicated service function that handle errors in the `minter.service`. That way we can avoid the try/catch/toastError.

Refactor  only.
