### PR TITLE
Make ckBTC ledger API return a single account

### DIFF
--- a/frontend/src/lib/api/ckbtc-ledger.api.ts
+++ b/frontend/src/lib/api/ckbtc-ledger.api.ts
@@ -6,40 +6,48 @@ import {
   type IcrcTransferParams,
 } from "$lib/api/icrc-ledger.api";
 import { HOST } from "$lib/constants/environment.constants";
-import type { Account } from "$lib/types/account";
+import type { Account, AccountType } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { HttpAgent, Identity } from "@dfinity/agent";
-import { IcrcLedgerCanister, type IcrcBlockIndex } from "@dfinity/ledger";
+import {
+  IcrcLedgerCanister,
+  type BalanceParams,
+  type IcrcBlockIndex,
+} from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 
-export const getCkBTCAccounts = async ({
+export const getCkBTCAccount = async ({
   identity,
   certified,
   canisterId,
+  ...rest
 }: {
   identity: Identity;
   certified: boolean;
   canisterId: Principal;
-}): Promise<Account[]> => {
-  // TODO: Support subaccounts
-  logWithTimestamp("Getting ckBTC accounts: call...");
+  type: AccountType;
+} & BalanceParams): Promise<Account> => {
+  logWithTimestamp("Getting ckBTC account: call...");
 
   const {
     canister: { metadata, balance },
   } = await ckBTCLedgerCanister({ identity, canisterId });
 
-  const mainAccount = await getIcrcAccount({
-    owner: identity.getPrincipal(),
-    type: "main",
+  const callParams = {
     certified,
     getBalance: balance,
     getMetadata: metadata,
+  };
+
+  const account = await getIcrcAccount({
+    ...rest,
+    ...callParams,
   });
 
-  logWithTimestamp("Getting ckBTC accounts: done");
+  logWithTimestamp("Getting ckBTC account: done");
 
-  return [mainAccount];
+  return account;
 };
 
 export const getCkBTCToken = async ({

--- a/frontend/src/lib/services/ckbtc-accounts-balance.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-balance.services.ts
@@ -1,5 +1,5 @@
 import { getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
-import { loadCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
+import { getCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -20,7 +20,7 @@ const loadCkBTCAccountsBalance = (
 ): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     request: ({ certified, identity }) =>
-      loadCkBTCAccounts({ identity, certified, universeId }),
+      getCkBTCAccounts({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/services/ckbtc-accounts-balance.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-balance.services.ts
@@ -1,4 +1,5 @@
-import { getCkBTCAccounts, getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
+import { getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
+import { loadCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -19,7 +20,7 @@ const loadCkBTCAccountsBalance = (
 ): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     request: ({ certified, identity }) =>
-      getCkBTCAccounts({ identity, certified, canisterId: universeId }),
+      loadCkBTCAccounts({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -1,0 +1,29 @@
+import { getCkBTCAccount } from "$lib/api/ckbtc-ledger.api";
+import type { Account, AccountType } from "$lib/types/account";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+
+export const loadCkBTCAccounts = async ({
+  identity,
+  certified,
+  universeId,
+}: {
+  identity: Identity;
+  certified: boolean;
+  universeId: Principal;
+}): Promise<Account[]> => {
+  // TODO: Support subaccounts
+  const mainAccount: { owner: Principal; type: AccountType } = {
+    owner: identity.getPrincipal(),
+    type: "main",
+  };
+
+  const account = await getCkBTCAccount({
+    identity,
+    certified,
+    canisterId: universeId,
+    ...mainAccount,
+  });
+
+  return [account];
+};

--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -3,7 +3,7 @@ import type { Account, AccountType } from "$lib/types/account";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
-export const loadCkBTCAccounts = async ({
+export const getCkBTCAccounts = async ({
   identity,
   certified,
   universeId,

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -3,7 +3,7 @@ import type { IcrcTransferParams } from "$lib/api/icrc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
-import { loadCkBTCAccounts as loadCkBTCAccountsServices } from "$lib/services/ckbtc-accounts-loader.services";
+import { getCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
 import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
 import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
@@ -30,7 +30,7 @@ export const loadCkBTCAccounts = async ({
   return queryAndUpdate<Account[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      loadCkBTCAccountsServices({ identity, certified, universeId }),
+      getCkBTCAccounts({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -1,8 +1,9 @@
-import { ckBTCTransfer, getCkBTCAccounts } from "$lib/api/ckbtc-ledger.api";
+import { ckBTCTransfer } from "$lib/api/ckbtc-ledger.api";
 import type { IcrcTransferParams } from "$lib/api/icrc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
+import { loadCkBTCAccounts as loadCkBTCAccountsServices } from "$lib/services/ckbtc-accounts-loader.services";
 import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
 import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
@@ -29,7 +30,7 @@ export const loadCkBTCAccounts = async ({
   return queryAndUpdate<Account[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      getCkBTCAccounts({ identity, certified, canisterId: universeId }),
+      loadCkBTCAccountsServices({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
@@ -1,6 +1,6 @@
 import {
   ckBTCTransfer,
-  getCkBTCAccounts,
+  getCkBTCAccount,
   getCkBTCToken,
 } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -23,7 +23,7 @@ describe("ckbtc-ledger api", () => {
 
   afterAll(() => jest.clearAllMocks());
 
-  describe("getCkBTCAccounts", () => {
+  describe("getCkBTCAccount", () => {
     it("returns main account with balance and token metadata", async () => {
       const metadataSpy = ledgerCanisterMock.metadata.mockResolvedValue(
         mockQueryTokenResponse
@@ -32,18 +32,17 @@ describe("ckbtc-ledger api", () => {
         BigInt(10_000_000)
       );
 
-      const accounts = await getCkBTCAccounts({
+      const account = await getCkBTCAccount({
         certified: true,
         identity: mockIdentity,
         canisterId: CKBTC_LEDGER_CANISTER_ID,
+        type: "main",
+        owner: mockIdentity.getPrincipal(),
       });
 
-      expect(accounts.length).toBeGreaterThan(0);
+      expect(account).not.toBeUndefined();
 
-      const main = accounts.find(({ type }) => type === "main");
-      expect(main).not.toBeUndefined();
-
-      expect(main?.balance.toE8s()).toEqual(BigInt(10_000_000));
+      expect(account?.balance.toE8s()).toEqual(BigInt(10_000_000));
 
       expect(balanceSpy).toBeCalled();
       expect(metadataSpy).toBeCalled();
@@ -53,10 +52,12 @@ describe("ckbtc-ledger api", () => {
       ledgerCanisterMock.metadata.mockResolvedValue([]);
 
       const call = () =>
-        getCkBTCAccounts({
+        getCkBTCAccount({
           certified: true,
           identity: mockIdentity,
           canisterId: CKBTC_LEDGER_CANISTER_ID,
+          type: "main",
+          owner: mockIdentity.getPrincipal(),
         });
 
       expect(call).rejects.toThrowError();

--- a/frontend/src/tests/lib/services/ckbtc-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-balance.services.spec.ts
@@ -43,8 +43,8 @@ describe("ckbtc-accounts-balance.services", () => {
       .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
     const spyQuery = jest
-      .spyOn(ledgerApi, "getCkBTCAccounts")
-      .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+      .spyOn(ledgerApi, "getCkBTCAccount")
+      .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
     await services.uncertifiedLoadCkBTCAccountsBalance(params);
 
@@ -65,8 +65,8 @@ describe("ckbtc-accounts-balance.services", () => {
       .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
     jest
-      .spyOn(ledgerApi, "getCkBTCAccounts")
-      .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+      .spyOn(ledgerApi, "getCkBTCAccount")
+      .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
     await services.uncertifiedLoadCkBTCAccountsBalance(params);
 
@@ -87,7 +87,7 @@ describe("ckbtc-accounts-balance.services", () => {
 
   it("should toast error", async () => {
     jest.spyOn(console, "error").mockImplementation(() => undefined);
-    jest.spyOn(ledgerApi, "getCkBTCAccounts").mockRejectedValue(new Error());
+    jest.spyOn(ledgerApi, "getCkBTCAccount").mockRejectedValue(new Error());
 
     await services.uncertifiedLoadCkBTCAccountsBalance(params);
 

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -3,10 +3,7 @@
  */
 
 import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
-import {
-  CKBTC_MINTER_CANISTER_ID,
-  CKBTC_UNIVERSE_CANISTER_ID,
-} from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/ckbtc-accounts-loader.services";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import {
+  CKBTC_MINTER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import * as services from "$lib/services/ckbtc-accounts-loader.services";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import { waitFor } from "@testing-library/svelte";
+
+describe("ckbtc-accounts-loader-services", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("loadCkBTCAccounts", () => {
+    it("should call get CkBTC account", async () => {
+      const spyEstimateFee = jest
+        .spyOn(ledgerApi, "getCkBTCAccount")
+        .mockResolvedValue(mockCkBTCMainAccount);
+
+      await services.loadCkBTCAccounts({
+        identity: mockIdentity,
+        certified: true,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      await waitFor(() =>
+        expect(spyEstimateFee).toBeCalledWith({
+          identity: mockIdentity,
+          certified: true,
+          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+          owner: mockIdentity.getPrincipal(),
+          type: "main",
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -12,13 +12,13 @@ import { waitFor } from "@testing-library/svelte";
 describe("ckbtc-accounts-loader-services", () => {
   afterEach(() => jest.clearAllMocks());
 
-  describe("loadCkBTCAccounts", () => {
+  describe("getCkBTCAccounts", () => {
     it("should call get CkBTC account", async () => {
       const spyEstimateFee = jest
         .spyOn(ledgerApi, "getCkBTCAccount")
         .mockResolvedValue(mockCkBTCMainAccount);
 
-      await services.loadCkBTCAccounts({
+      await services.getCkBTCAccounts({
         identity: mockIdentity,
         certified: true,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -38,8 +38,8 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call api.getSnsAccounts and load neurons in store", async () => {
       const spyQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccounts")
-        .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+        .spyOn(ledgerApi, "getCkBTCAccount")
+        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
 
@@ -57,7 +57,7 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call error callback", async () => {
       const spyQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccounts")
+        .spyOn(ledgerApi, "getCkBTCAccount")
         .mockRejectedValue(new Error());
 
       const spy = jest.fn();
@@ -90,7 +90,7 @@ describe("ckbtc-accounts-services", () => {
       });
 
       jest
-        .spyOn(ledgerApi, "getCkBTCAccounts")
+        .spyOn(ledgerApi, "getCkBTCAccount")
         .mockImplementation(() => Promise.reject(undefined));
 
       await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -113,8 +113,8 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call ckBTC accounts and token and load them in store", async () => {
       const spyAccountsQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccounts")
-        .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+        .spyOn(ledgerApi, "getCkBTCAccount")
+        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       const spyTokenQuery = jest
         .spyOn(ledgerApi, "getCkBTCToken")
@@ -147,8 +147,8 @@ describe("ckbtc-accounts-services", () => {
 
   describe("ckBTCTransferTokens", () => {
     const spyAccounts = jest
-      .spyOn(ledgerApi, "getCkBTCAccounts")
-      .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+      .spyOn(ledgerApi, "getCkBTCAccount")
+      .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -93,8 +93,8 @@ describe("ckbtc-convert-services", () => {
 
     describe("transfer tokens succeed", () => {
       jest
-        .spyOn(ledgerApi, "getCkBTCAccounts")
-        .mockImplementation(() => Promise.resolve([mockCkBTCMainAccount]));
+        .spyOn(ledgerApi, "getCkBTCAccount")
+        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       const transferSpy = ledgerCanisterMock.transfer.mockResolvedValue(123n);
 


### PR DESCRIPTION
# Motivation

We will need to fetch the balance of another pseudo ckBTC account - the withdrawal account - in PR #2430.
That's why this PR makes the ckBTC ledger API returns a single account and extract the logic of fetching the main account into a new service. That way we can in the other PR add a new function that will fetch the account using the same API..

Refactor  only.