### PR TITLE
Chore: Persist Sns Proposal Filters

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -3,4 +3,5 @@ export enum StoreLocalStorageKey {
   Theme = "nnsTheme",
   FeatureFlags = "nnsOverrideFeatureFlags",
   BitcoinConvertBlockIndexes = "nnsBitcoinConvertBlockIndexes",
+  SnsProposalFilters = "nnsSnsProposalFilters",
 }

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -1,3 +1,4 @@
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import type { Filter } from "$lib/types/filters";
 import type { Principal } from "@dfinity/principal";
 import type {
@@ -5,7 +6,8 @@ import type {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
 } from "@dfinity/sns";
-import { derived, writable, type Readable } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
+import { writableStored } from "./writable-stored";
 
 export interface ProjectFiltersStoreData {
   topics: Filter<SnsNervousSystemFunction>[];
@@ -49,7 +51,10 @@ const defaultProjectData: ProjectFiltersStoreData = {
  * TODO: persist to localstorage
  */
 export const initSnsFiltersStore = (): SnsFiltersStore => {
-  const { subscribe, set, update } = writable<SnsFiltersStoreData>({});
+  const { subscribe, set, update } = writableStored<SnsFiltersStoreData>({
+    key: StoreLocalStorageKey.SnsProposalFilters,
+    defaultValue: {},
+  });
 
   return {
     subscribe,


### PR DESCRIPTION
# Motivation

Users commonly use the same filters for proposals.

Persist the selection of the filters in local storage.

# Changes

* Create the sns filters store with our `writableStored` instead of `writable` from Svelte.

# Tests

Same functionality. Maybe there could be an end-to-end test for this in the future?
