### PR TITLE
Feat/sns ineligible neurons

### DIFF
--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -1,23 +1,17 @@
 <script lang="ts">
-  import { ineligibleNeurons as filterIneligibleNeurons } from "@dfinity/nns";
-  import type { ProposalInfo, NeuronInfo } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import ProposalContentCell from "./ProposalContentCell.svelte";
+  import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
+  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+  import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
 
-  export let proposalInfo: ProposalInfo;
-  export let neurons: NeuronInfo[];
+  export let ineligibleNeurons: IneligibleNeuronData[] = [];
 
-  let ineligibleNeurons: NeuronInfo[];
   let visible = false;
-
-  $: ineligibleNeurons = filterIneligibleNeurons({
-    neurons,
-    proposal: proposalInfo,
-  });
   $: visible = ineligibleNeurons.length > 0;
 
-  const reason = ({ createdTimestampSeconds }: NeuronInfo): string =>
-    createdTimestampSeconds > proposalInfo.proposalTimestampSeconds
+  const reasonText = (reason: "since" | "short"): string =>
+    reason === "since"
       ? $i18n.proposal_detail__ineligible.reason_since
       : $i18n.proposal_detail__ineligible.reason_short;
 </script>
@@ -28,8 +22,11 @@
     <p class="description">{$i18n.proposal_detail__ineligible.text}</p>
     <ul>
       {#each ineligibleNeurons as neuron}
-        <li class="value">
-          {neuron.neuronId}<small>{reason(neuron)}</small>
+        <li class="value" title={neuron.neuronIdString}>
+          {shortenWithMiddleEllipsis(
+            neuron.neuronIdString,
+            SNS_NEURON_ID_DISPLAY_LENGTH
+          )}<small>{reasonText(neuron.reason)}</small>
         </li>
       {/each}
     </ul>

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -4,29 +4,46 @@
   import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
 
   export let ineligibleNeurons: IneligibleNeuronData[] = [];
+  export let minSnsDissolveDelaySeconds: bigint;
 
   let visible = false;
   $: visible = ineligibleNeurons.length > 0;
 
-  const reasonText = (reason: "since" | "short"): string =>
-    reason === "since"
-      ? $i18n.proposal_detail__ineligible.reason_since
-      : $i18n.proposal_detail__ineligible.reason_short;
+  const reasonSince = $i18n.proposal_detail__ineligible.reason_since;
+  let reasonShort: string;
+  $: reasonShort = replacePlaceholders(
+    $i18n.proposal_detail__ineligible.reason_short,
+    {
+      $minDissolveDelay: secondsToDissolveDelayDuration(
+        minSnsDissolveDelaySeconds
+      ),
+    }
+  );
 </script>
 
 {#if visible}
   <ProposalContentCell>
     <h4 slot="start">{$i18n.proposal_detail__ineligible.headline}</h4>
-    <p class="description">{$i18n.proposal_detail__ineligible.text}</p>
+    <p class="description">
+      {replacePlaceholders($i18n.proposal_detail__ineligible.text, {
+        $minDissolveDelay: secondsToDissolveDelayDuration(
+          minSnsDissolveDelaySeconds
+        ),
+      })}
+    </p>
     <ul>
       {#each ineligibleNeurons as neuron}
         <li class="value" title={neuron.neuronIdString}>
           {shortenWithMiddleEllipsis(
             neuron.neuronIdString,
             SNS_NEURON_ID_DISPLAY_LENGTH
-          )}<small>{reasonText(neuron.reason)}</small>
+          )}<small
+            >{neuron.reason === "since" ? reasonSince : reasonShort}</small
+          >
         </li>
       {/each}
     </ul>

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -46,7 +46,7 @@
           })}
           title={voteMapper({ neuron: neuron.idString, vote: neuron.vote })}
         >
-          <p class="value">
+          <p class="value" title={neuron.idString}>
             {shortenWithMiddleEllipsis(
               neuron.idString,
               SNS_NEURON_ID_DISPLAY_LENGTH

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -35,6 +35,8 @@
   import VotingNeuronSelectList from "$lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte";
   import {
     type CompactNeuronInfo,
+    filterIneligibleNnsNeurons,
+    type IneligibleNeuronData,
     votedNeuronDetails,
   } from "$lib/utils/neuron.utils";
 
@@ -118,6 +120,12 @@
       proposal: proposalInfo,
     });
   }
+
+  let ineligibleNeurons: IneligibleNeuronData[];
+  $: ineligibleNeurons = filterIneligibleNnsNeurons({
+    neurons: $definedNeuronsStore,
+    proposal: proposalInfo,
+  });
 </script>
 
 <BottomSheet>
@@ -135,10 +143,7 @@
           <VotingNeuronSelect>
             <VotingNeuronSelectList disabled={voteRegistration !== undefined} />
             <MyVotes {neuronsVotedForProposal} />
-            <IneligibleNeuronsCard
-              {proposalInfo}
-              neurons={$definedNeuronsStore}
-            />
+            <IneligibleNeuronsCard {ineligibleNeurons} />
           </VotingNeuronSelect>
         {:else}
           <div class="loader">

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -39,6 +39,9 @@
     type IneligibleNeuronData,
     votedNeuronDetails,
   } from "$lib/utils/neuron.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 
   export let proposalInfo: ProposalInfo;
 
@@ -143,7 +146,12 @@
           <VotingNeuronSelect>
             <VotingNeuronSelectList disabled={voteRegistration !== undefined} />
             <MyVotes {neuronsVotedForProposal} />
-            <IneligibleNeuronsCard {ineligibleNeurons} />
+            <IneligibleNeuronsCard
+              {ineligibleNeurons}
+              minSnsDissolveDelaySeconds={BigInt(
+                NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE
+              )}
+            />
           </VotingNeuronSelect>
         {:else}
           <div class="loader">

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -39,8 +39,6 @@
     type IneligibleNeuronData,
     votedNeuronDetails,
   } from "$lib/utils/neuron.utils";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 
   export let proposalInfo: ProposalInfo;

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -61,8 +61,6 @@
       </p>
       <Countdown slot="value" {deadlineTimestampSeconds} />
     </KeyValuePair>
-
-    <slot />
   </Card>
 </li>
 

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -13,12 +13,7 @@
   } from "@dfinity/sns";
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
-  import { registerVoteDemo } from "$lib/services/$public/sns-proposals.services";
-  import { isSignedIn } from "$lib/utils/auth.utils";
-  import { authStore } from "$lib/stores/auth.store";
-  import { SnsProposalDecisionStatus, SnsVote } from "@dfinity/sns";
-  import { busy, startBusy } from "@dfinity/gix-components";
-  import { stopBusy } from "$lib/stores/busy.store";
+  import { SnsProposalDecisionStatus } from "@dfinity/sns";
 
   export let proposalData: SnsProposalData;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
@@ -58,22 +53,6 @@
       })
     );
 
-  // DEMO VOTING
-  let signedIn = false;
-  $: signedIn = isSignedIn($authStore.identity);
-
-  // TODO(demo): remove after voting implementation
-  let demoVoteEnable = false;
-  $: demoVoteEnable =
-    signedIn &&
-    status === SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN;
-
-  // TODO(demo): remove after voting implementation
-  const vote = async (vote: SnsVote) => {
-    startBusy({ initiator: "load-sns-accounts" });
-    await registerVoteDemo({ proposal: proposalData, vote });
-    stopBusy("load-sns-accounts");
-  };
 </script>
 
 <ProposalCard
@@ -86,29 +65,5 @@
   {type}
   proposer={proposerString}
   {deadlineTimestampSeconds}
-  >{#if demoVoteEnable}
-    <div class="demo-vote">
-      <button
-        class="secondary"
-        disabled={$busy}
-        on:click|preventDefault|stopPropagation={() => vote(SnsVote.Yes)}
-        >Vote Yes</button
-      >
-      <button
-        class="secondary"
-        disabled={$busy}
-        on:click|preventDefault|stopPropagation={() => vote(SnsVote.No)}
-        >Vote No</button
-      >
-    </div>
-  {/if}</ProposalCard
+  ></ProposalCard
 >
-
-<style lang="scss">
-  .demo-vote {
-    margin-top: var(--padding-2x);
-    display: flex;
-    justify-content: start;
-    gap: var(--padding);
-  }
-</style>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -13,7 +13,7 @@
   } from "@dfinity/sns";
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
-  import { SnsProposalDecisionStatus } from "@dfinity/sns";
+  import type { SnsProposalDecisionStatus } from "@dfinity/sns";
 
   export let proposalData: SnsProposalData;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
@@ -52,7 +52,6 @@
         proposalId: `${id?.id}`,
       })
     );
-
 </script>
 
 <ProposalCard
@@ -65,5 +64,4 @@
   {type}
   proposer={proposerString}
   {deadlineTimestampSeconds}
-  ></ProposalCard
->
+/>

--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -11,7 +11,7 @@
     SnsProposalData,
     SnsVote,
   } from "@dfinity/sns";
-  import { fromDefinedNullable, isNullish, nonNullish } from "@dfinity/utils";
+  import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
   import { sortedSnsUserNeuronsStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { UniverseCanisterIdText } from "$lib/types/universe";
@@ -43,11 +43,8 @@
     IneligibleNeuronData,
   } from "$lib/utils/neuron.utils";
   import MyVotes from "$lib/components/proposal-detail/MyVotes.svelte";
-  import { ineligibleSnsNeurons } from "$lib/utils/sns-neuron.utils.js";
+  import { ineligibleSnsNeurons } from "$lib/utils/sns-neuron.utils";
   import IneligibleNeuronsCard from "$lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
-  import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 
   export let proposal: SnsProposalData;
   export let reloadProposal: () => Promise<void>;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,3 +1,4 @@
+import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
 import { E8S_PER_ICP } from "./icp.constants";
@@ -15,6 +16,7 @@ export const CANDID_PARSER_VERSION = "2.2.1";
 
 export const DISSOLVE_DELAY_MULTIPLIER = 1;
 export const AGE_MULTIPLIER = 0.25;
+export const NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE = SECONDS_IN_HALF_YEAR;
 
 const FIRST_TOPICS = [
   Topic.Unspecified,

--- a/frontend/src/lib/constants/sns-neurons.constants.ts
+++ b/frontend/src/lib/constants/sns-neurons.constants.ts
@@ -15,4 +15,4 @@ export const MANAGE_HOTKEY_PERMISSIONS = [
 
 export const UNSPECIFIED_FUNCTION_ID = BigInt(0);
 
-export const SNS_NEURON_ID_DISPLAY_LENGTH = 12;
+export const SNS_NEURON_ID_DISPLAY_LENGTH = 14;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -519,9 +519,9 @@
   },
   "proposal_detail__ineligible": {
     "headline": "Ineligible Neurons",
-    "text": "The following neurons had a dissolve delay of less than 6 months at the time the proposal was submitted, or were created after the proposal was submitted, and therefore are not eligible to vote on it:",
+    "text": "The following neurons had a dissolve delay of less than $minDissolveDelay at the time the proposal was submitted, or were created after the proposal was submitted, and therefore are not eligible to vote on it:",
     "reason_since": "created after the proposal",
-    "reason_short": "dissolve delay < 6 months"
+    "reason_short": "dissolve delay < $minDissolveDelay"
   },
   "neuron_detail": {
     "title": "Neuron",

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -32,6 +32,7 @@ import {
   NeuronState,
   Topic,
   Vote,
+  ineligibleNeurons,
   votedNeurons,
   type BallotInfo,
   type Followees,
@@ -828,3 +829,25 @@ export const validTopUpAmount = ({
 
 export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
   BigInt(Math.min(Number(ageSeconds), SECONDS_IN_FOUR_YEARS));
+
+export interface IneligibleNeuronData {
+  neuronIdString: string;
+  reason: "since" | "short";
+}
+export const filterIneligibleNnsNeurons = ({
+  neurons,
+  proposal,
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): IneligibleNeuronData[] =>
+  ineligibleNeurons({
+    neurons,
+    proposal,
+  }).map(({ createdTimestampSeconds, neuronId }) => ({
+    neuronIdString: neuronId.toString(),
+    reason:
+      createdTimestampSeconds > proposal.proposalTimestampSeconds
+        ? "since"
+        : "short",
+  }));

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -830,6 +830,11 @@ export const validTopUpAmount = ({
 export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
   BigInt(Math.min(Number(ageSeconds), SECONDS_IN_FOUR_YEARS));
 
+/**
+ * Represents an entry in the list of ineligible neurons.
+ * - 'short': the neuron is too young to vote
+ * - 'since': the neuron was created after the proposal was submitted
+ */
 export interface IneligibleNeuronData {
   neuronIdString: string;
   reason: "since" | "short";

--- a/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
@@ -2,28 +2,15 @@
  * @jest-environment jsdom
  */
 import IneligibleNeuronsCard from "$lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
+import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
 import en from "$tests/mocks/i18n.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { mockProposalInfo } from "$tests/mocks/proposal.mock";
-import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-
-const proposalTimestampSeconds = BigInt(100);
-const proposalInfo = {
-  ...mockProposalInfo,
-  proposalTimestampSeconds,
-} as ProposalInfo;
-const neuron = {
-  ...mockNeuron,
-  createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
-} as NeuronInfo;
 
 describe("IneligibleNeuronsCard", () => {
   it("should be hidden if no neurons", () => {
     const { queryByTestId } = render(IneligibleNeuronsCard, {
       props: {
-        proposalInfo,
-        neurons: [],
+        ineligibleNeurons: [],
       },
     });
     expect(queryByTestId("neuron-card")).not.toBeInTheDocument();
@@ -32,13 +19,12 @@ describe("IneligibleNeuronsCard", () => {
   it("should display texts", () => {
     const { getByText } = render(IneligibleNeuronsCard, {
       props: {
-        proposalInfo,
-        neurons: [
+        ineligibleNeurons: [
           {
-            neuron,
-            createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
+            neuronIdString: "123",
+            reason: "short",
           },
-        ],
+        ] as IneligibleNeuronData[],
       },
     });
     expect(
@@ -50,14 +36,12 @@ describe("IneligibleNeuronsCard", () => {
   it("should display ineligible neurons (< 6 months) ", () => {
     const { getByText } = render(IneligibleNeuronsCard, {
       props: {
-        proposalInfo: { ...proposalInfo, ballots: [] },
-        neurons: [
+        ineligibleNeurons: [
           {
-            ...neuron,
-            createdTimestampSeconds: proposalTimestampSeconds - BigInt(1),
-            neuronId: BigInt(123),
+            neuronIdString: "123",
+            reason: "short",
           },
-        ] as NeuronInfo[],
+        ] as IneligibleNeuronData[],
       },
     });
     expect(getByText("123", { exact: false })).toBeInTheDocument();
@@ -68,19 +52,12 @@ describe("IneligibleNeuronsCard", () => {
 
   it("should display ineligible neurons (created after proposal) ", () => {
     const { getByText, container } = render(IneligibleNeuronsCard, {
-      props: {
-        proposalInfo: {
-          ...proposalInfo,
-          ballots: [],
+      ineligibleNeurons: [
+        {
+          neuronIdString: "111",
+          reason: "since",
         },
-        neurons: [
-          {
-            ...neuron,
-            neuronId: BigInt(111),
-            createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
-          },
-        ] as NeuronInfo[],
-      },
+      ] as IneligibleNeuronData[],
     });
     expect(getByText("111", { exact: false })).toBeInTheDocument();
     expect(
@@ -91,23 +68,16 @@ describe("IneligibleNeuronsCard", () => {
   it("should display multiple ineligible neurons", () => {
     const { container, getByText } = render(IneligibleNeuronsCard, {
       props: {
-        proposalInfo: {
-          ...proposalInfo,
-          proposalTimestampSeconds,
-          ballots: [],
-        },
-        neurons: [
+        ineligibleNeurons: [
           {
-            ...neuron,
-            neuronId: BigInt(111),
-            createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
+            neuronIdString: "111",
+            reason: "since",
           },
           {
-            ...neuron,
-            neuronId: BigInt(222),
-            createdTimestampSeconds: proposalTimestampSeconds,
+            neuronIdString: "222",
+            reason: "short",
           },
-        ] as NeuronInfo[],
+        ] as IneligibleNeuronData[],
       },
     });
     expect(container.querySelectorAll("li").length).toBe(2);

--- a/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
@@ -2,6 +2,9 @@
  * @jest-environment jsdom
  */
 import IneligibleNeuronsCard from "$lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
+import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
+import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import type { IneligibleNeuronData } from "$lib/utils/neuron.utils";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
@@ -11,6 +14,7 @@ describe("IneligibleNeuronsCard", () => {
     const { queryByTestId } = render(IneligibleNeuronsCard, {
       props: {
         ineligibleNeurons: [],
+        minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
       },
     });
     expect(queryByTestId("neuron-card")).not.toBeInTheDocument();
@@ -25,12 +29,21 @@ describe("IneligibleNeuronsCard", () => {
             reason: "short",
           },
         ] as IneligibleNeuronData[],
+        minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
       },
     });
     expect(
       getByText(en.proposal_detail__ineligible.headline)
     ).toBeInTheDocument();
-    expect(getByText(en.proposal_detail__ineligible.text)).toBeInTheDocument();
+    expect(
+      getByText(
+        replacePlaceholders(en.proposal_detail__ineligible.text, {
+          $minDissolveDelay: secondsToDissolveDelayDuration(
+            BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
+          ),
+        })
+      )
+    ).toBeInTheDocument();
   });
 
   it("should display ineligible neurons (< 6 months) ", () => {
@@ -42,11 +55,19 @@ describe("IneligibleNeuronsCard", () => {
             reason: "short",
           },
         ] as IneligibleNeuronData[],
+        minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
       },
     });
     expect(getByText("123", { exact: false })).toBeInTheDocument();
     expect(
-      getByText(en.proposal_detail__ineligible.reason_short, { exact: false })
+      getByText(
+        replacePlaceholders(en.proposal_detail__ineligible.reason_short, {
+          $minDissolveDelay: secondsToDissolveDelayDuration(
+            BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
+          ),
+        }),
+        { exact: false }
+      )
     ).toBeInTheDocument();
   });
 
@@ -58,6 +79,7 @@ describe("IneligibleNeuronsCard", () => {
           reason: "since",
         },
       ] as IneligibleNeuronData[],
+      minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
     });
     expect(getByText("111", { exact: false })).toBeInTheDocument();
     expect(
@@ -78,6 +100,7 @@ describe("IneligibleNeuronsCard", () => {
             reason: "short",
           },
         ] as IneligibleNeuronData[],
+        minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
       },
     });
     expect(container.querySelectorAll("li").length).toBe(2);
@@ -85,7 +108,14 @@ describe("IneligibleNeuronsCard", () => {
       (container.querySelector("small") as HTMLElement).textContent
     ).toEqual(en.proposal_detail__ineligible.reason_since);
     expect(
-      getByText(en.proposal_detail__ineligible.reason_short, { exact: false })
+      getByText(
+        replacePlaceholders(en.proposal_detail__ineligible.reason_short, {
+          $minDissolveDelay: secondsToDissolveDelayDuration(
+            BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE)
+          ),
+        }),
+        { exact: false }
+      )
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

Display ineligible sns neurons.

# Changes

- refactor `<IneligibleNeuronsCard>` to work with `IneligibleNeuronData` structure
- dynamic descriptions because of different minimal DissolveDelay
- add `IneligibleNeuronsCard` to `SnsVotingCard`
- remove ~~DEMO VOTING BUTTONS~~

# Tests

- adjust tests after refactoring
- util `filterIneligibleNnsNeurons`

# Screenshots

<img width="543" alt="image" src="https://user-images.githubusercontent.com/98811342/235959752-8605aa59-0ae0-4342-b786-d88c0cb837ec.png">

<img width="548" alt="image" src="https://user-images.githubusercontent.com/98811342/235959878-d7506bf6-7f01-4861-b187-11ea8bc0e632.png">


