### PR TITLE
Display ckBTC withdrawal account and animation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-05-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-02.1.tgz",
-      "integrity": "sha512-r595rPzm3aZodYsSrYjbqVZs4OcY9YMoc2WglANvrrpDeo1ghEIEazNY5UopfR0C7ESmX4FQxpMJjj1hc8o0ug==",
+      "version": "2.6.0-next-2023-05-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-03.1.tgz",
+      "integrity": "sha512-YdKmA5toGgJgyuk9Dq23v/fr/xOkP1wXqXgBfVuQxBDmrz5z7QZX7rbR2axhS1jhw2GgluVmEyHMeOeekjTnsg==",
       "dependencies": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",
@@ -9939,9 +9939,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-05-02.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-02.1.tgz",
-      "integrity": "sha512-r595rPzm3aZodYsSrYjbqVZs4OcY9YMoc2WglANvrrpDeo1ghEIEazNY5UopfR0C7ESmX4FQxpMJjj1hc8o0ug==",
+      "version": "2.6.0-next-2023-05-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-03.1.tgz",
+      "integrity": "sha512-YdKmA5toGgJgyuk9Dq23v/fr/xOkP1wXqXgBfVuQxBDmrz5z7QZX7rbR2axhS1jhw2GgluVmEyHMeOeekjTnsg==",
       "requires": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",

--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -69,9 +69,7 @@
     loading,
     (() => {
       transfersToBeCompleted =
-        loading || isNullish(account)
-          ? undefined
-          : accountBalance.toE8s() > 0n;
+        loading || isNullish(account) ? undefined : accountBalance.toE8s() > 0n;
     })();
 
   // Important: We do not explicitely use Svelte transition because according our test, use these here leads to breaking the routing.

--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -7,8 +7,11 @@
     type CkBTCBTCWithdrawalAccount,
     ckBTCWithdrawalAccountsStore,
   } from "$lib/stores/ckbtc-withdrawal-accounts.store";
-  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { i18n } from "$lib/stores/i18n";
+  import { Spinner, IconClock, IconCheck } from "@dfinity/gix-components";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { formatToken } from "$lib/utils/token.utils";
 
   const reloadAccount = async () => {
     if (isNullish($selectedCkBTCUniverseIdStore)) {
@@ -54,18 +57,116 @@
   $: accountBalance =
     account?.balance ??
     (TokenAmount.fromString({ amount: "0", token: ICPToken }) as TokenAmount);
+
+  let detailedAccountBalance: string;
+  $: detailedAccountBalance = formatToken({
+    value: accountBalance.toE8s(),
+    detailed: true,
+  });
+
+  let transfersToBeCompleted: boolean | undefined;
+  $: account,
+    loading,
+    (() => {
+      transfersToBeCompleted =
+        loading || isNullish(account)
+          ? undefined
+          : accountBalance.toE8s() > 0n;
+    })();
+
+  // Important: We do not explicitely use Svelte transition because according our test, use these here leads to breaking the routing.
+  // i.e. after navigating to details page getting two spit-pane div within the DOM.
+  let visibility: "visible" | "fade" | "hidden" = "hidden";
+  $: transfersToBeCompleted,
+    (() => {
+      if (isNullish(transfersToBeCompleted)) {
+        visibility = "visible";
+        return;
+      }
+
+      if (transfersToBeCompleted === true) {
+        visibility = "visible";
+        return;
+      }
+
+      // First set "fade" for animation purpose, then "hidden" to remove from the DOM
+      setTimeout(() => {
+        visibility = "fade";
+        setTimeout(() => (visibility = "hidden"), 200);
+      }, 1800);
+    })();
 </script>
 
-{#if nonNullish(account)}
+{#if visibility !== "hidden" && nonNullish(account)}
   <button
     class="card"
+    class:complete={transfersToBeCompleted}
+    class:ok={transfersToBeCompleted === false}
+    class:fade={visibility === "fade"}
     data-tid="open-restart-convert-ckbtc-to-btc"
-    disabled={isNullish(account.balance) || isNullish(account.identifier)}
+    disabled={transfersToBeCompleted !== true}
   >
     {#if loading}
-      Loading redeeming account...
+      <div>
+        <Spinner inline />
+      </div>
+      <span class="value">{$i18n.ckbtc.checking_incomplete_btc_transfers}</span>
+    {:else if transfersToBeCompleted === true}
+      <div><IconClock size="36px" /></div>
+      <span class="value"
+        >{replacePlaceholders($i18n.ckbtc.click_to_complete_btc_transfers, {
+          $amount: detailedAccountBalance,
+        })}</span
+      >
     {:else}
-      Redeeming account <AmountDisplay singleLine amount={accountBalance} />
+      <div><IconCheck size="36px" /></div>
+      <span class="value">{$i18n.ckbtc.all_btc_transfers_complete}</span>
     {/if}
   </button>
 {/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  button {
+    padding: var(--padding-2x) var(--padding-4x);
+    gap: var(--padding-2x);
+
+    @include media.min-width(medium) {
+      padding: var(--padding-2x);
+    }
+
+    opacity: 1;
+    transition: opacity ease-out var(--animation-time-normal);
+
+    &.fade {
+      opacity: 0;
+    }
+  }
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    position: relative;
+
+    min-width: var(--padding-4x);
+  }
+
+  span {
+    text-align: left;
+  }
+
+  .complete {
+    :global(svg) {
+      color: var(--negative-emphasis);
+    }
+  }
+
+  .ok {
+    :global(svg) {
+      color: var(--positive-emphasis);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/accounts/NnsAddAccount.svelte
+++ b/frontend/src/lib/components/accounts/NnsAddAccount.svelte
@@ -22,7 +22,7 @@
       on:click={openAddAccountModal}
       data-tid="open-add-account-modal"
     >
-      <IconAdd />
+      <div class="icon"><IconAdd /></div>
       {$i18n.accounts.add_account}
     </button>
   {/if}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -878,7 +878,10 @@
     "refresh_balance": "Refresh Balance",
     "confirmations": "Confirmations",
     "warning_transaction_failed": "Your ckBTC transaction failed",
-    "warning_transaction_description": "When sending your ckBTC to a BTC address, your transaction got stuck in the redeeming account. Visit the ckBTC accounts page to continue."
+    "warning_transaction_description": "When sending your ckBTC to a BTC address, your transaction got stuck in the redeeming account. Visit the ckBTC accounts page to continue.",
+    "checking_incomplete_btc_transfers": "Checking for incomplete BTC transfers",
+    "all_btc_transfers_complete": "All transfers are complete",
+    "click_to_complete_btc_transfers": "Click here to complete BTC transfer for $amount ckBTC"
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -927,6 +927,9 @@ interface I18nCkbtc {
   confirmations: string;
   warning_transaction_failed: string;
   warning_transaction_description: string;
+  checking_incomplete_btc_transfers: string;
+  all_btc_transfers_complete: string;
+  click_to_complete_btc_transfers: string;
 }
 
 interface I18nError__ckbtc {

--- a/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
@@ -9,12 +9,17 @@ import { AppPath } from "$lib/constants/routes.constants";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
 import { authStore } from "$lib/stores/auth.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
+  mockCkBTCToken,
   mockCkBTCWithdrawalAccount,
   mockCkBTCWithdrawalIcrcAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import en from "$tests/mocks/i18n.mock";
+import { TokenAmount } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("CkBTCWithdrawalAccount", () => {
@@ -110,10 +115,130 @@ describe("CkBTCWithdrawalAccount", () => {
         );
       });
 
+      it("should render the button disabled", async () => {
+        const { getByTestId } = render(CkBTCWithdrawalAccount);
+
+        await waitFor(() =>
+          expect(
+            getByTestId("open-restart-convert-ckbtc-to-btc")?.getAttribute(
+              "disabled"
+            )
+          ).not.toBeNull()
+        );
+      });
+
       it("should get account", async () => {
         render(CkBTCWithdrawalAccount);
 
         await waitFor(() => expect(spyGetCkBTCAccount).toHaveBeenCalled());
+      });
+    });
+  });
+
+  describe("messages", () => {
+    const balanceZero = TokenAmount.fromString({
+      amount: "0",
+      token: mockCkBTCToken,
+    }) as TokenAmount;
+
+    describe("with balance", () => {
+      beforeEach(() => {
+        ckBTCWithdrawalAccountsStore.set({
+          account: {
+            account: mockCkBTCWithdrawalAccount,
+            certified: true,
+          },
+          universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        });
+      });
+
+      it("should render a call to action if balance is bigger than zero", async () => {
+        const { getByText } = render(CkBTCWithdrawalAccount);
+
+        const balance = formatToken({
+          value: mockCkBTCWithdrawalAccount.balance.toE8s(),
+          detailed: true,
+        });
+
+        const label = replacePlaceholders(
+          en.ckbtc.click_to_complete_btc_transfers,
+          {
+            $amount: balance,
+          }
+        );
+
+        await waitFor(() => expect(getByText(label)).toBeInTheDocument());
+      });
+
+      it("should render the button disabled", async () => {
+        const { getByTestId } = render(CkBTCWithdrawalAccount);
+
+        await waitFor(() =>
+          expect(
+            getByTestId("open-restart-convert-ckbtc-to-btc")?.getAttribute(
+              "disabled"
+            )
+          ).toBeNull()
+        );
+      });
+    });
+
+    describe("with zero balance on load", () => {
+      beforeEach(() => {
+        ckBTCWithdrawalAccountsStore.set({
+          account: {
+            account: {
+              ...mockCkBTCWithdrawalAccount,
+              balance: balanceZero,
+            },
+            certified: true,
+          },
+          universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        });
+      });
+
+      it("should not render a call to action if balance is zero", async () => {
+        const { getByTestId } = render(CkBTCWithdrawalAccount);
+
+        expect(() =>
+          getByTestId("open-restart-convert-ckbtc-to-btc")
+        ).toThrow();
+      });
+    });
+
+    describe("with zero balance after load", () => {
+      beforeEach(() => {
+        jest.spyOn(minterServices, "getWithdrawalAccount").mockResolvedValue({
+          owner: mockCkBTCWithdrawalIcrcAccount.owner,
+          subaccount: [mockCkBTCWithdrawalIcrcAccount.subaccount],
+        });
+
+        jest.spyOn(ledgerApi, "getCkBTCAccount").mockResolvedValue({
+          ...mockCkBTCWithdrawalAccount,
+          balance: balanceZero,
+        });
+      });
+
+      it("should render a message that nothing should be completed", async () => {
+        const { getByText } = render(CkBTCWithdrawalAccount);
+
+        await waitFor(() =>
+          expect(
+            getByText(en.ckbtc.all_btc_transfers_complete)
+          ).toBeInTheDocument()
+        );
+      });
+
+      it("should keep the button disabled", async () => {
+        const { getByTestId } = render(CkBTCWithdrawalAccount);
+
+        await waitFor(() =>
+          expect(
+            getByTestId("open-restart-convert-ckbtc-to-btc")?.getAttribute(
+              "disabled"
+            )
+          ).not.toBeNull()
+        );
       });
     });
   });


### PR DESCRIPTION
# Motivation

On ckBTC accounts page, once per session, query and display the potential remaining balance of the withdrawal account (function introduced in PR #2430).

- If balance is bigger than zero, display a call to action that will ultimately open the transaction modal to unblock the funds (not part of this PR).
- If balance is zero, display a feedback to the user before hiding the information.

# PRs

- [x] https://github.com/dfinity/gix-components/pull/209

# Changes

- bump gix-cmp for styling and new icons
- implement UI logic

# Screenshots

![complete](https://user-images.githubusercontent.com/16886711/236137272-5e0e1a8c-6d33-40d3-a15b-5784ffe9f330.gif)
![nothingtodo](https://user-images.githubusercontent.com/16886711/236137302-f00d2120-6ddb-494f-9fec-0101c968b4de.gif)

