### PR TITLE
Transaction network readonly

### DIFF
--- a/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
@@ -58,40 +58,30 @@
   $: selectedDestinationAddress, onDestinationAddressInput();
 </script>
 
-<div class:placeholder={!notEmptyString(selectedNetwork)}>
-  <p class="label">{$i18n.accounts.network}</p>
-
-  <Dropdown
-    name="network"
-    bind:selectedValue={selectedNetwork}
-    testId="select-network-dropdown"
+<Dropdown
+  name="network"
+  bind:selectedValue={selectedNetwork}
+  testId="select-network-dropdown"
+>
+  <option disabled selected value={undefined} class="hidden"
+    ><span class="description">{$i18n.accounts.select_network}</span></option
   >
-    <option disabled selected value={undefined} class="hidden"
-      ><span class="description">{$i18n.accounts.select_network}</span></option
+  <DropdownItem value={TransactionNetwork.ICP}
+    >{$i18n.accounts.network_icp}</DropdownItem
+  >
+  {#if ckTESTBTC}
+    <DropdownItem value={TransactionNetwork.BTC_TESTNET}
+      >{$i18n.accounts.network_btc_testnet}</DropdownItem
     >
-    <DropdownItem value={TransactionNetwork.ICP}
-      >{$i18n.accounts.network_icp}</DropdownItem
+  {:else}
+    <DropdownItem value={TransactionNetwork.BTC_MAINNET}
+      >{$i18n.accounts.network_btc_mainnet}</DropdownItem
     >
-    {#if ckTESTBTC}
-      <DropdownItem value={TransactionNetwork.BTC_TESTNET}
-        >{$i18n.accounts.network_btc_testnet}</DropdownItem
-      >
-    {:else}
-      <DropdownItem value={TransactionNetwork.BTC_MAINNET}
-        >{$i18n.accounts.network_btc_mainnet}</DropdownItem
-      >
-    {/if}
-  </Dropdown>
-</div>
+  {/if}
+</Dropdown>
 
 <style lang="scss">
   .hidden {
     display: none;
-  }
-
-  .placeholder {
-    :global(select) {
-      color: var(--disable-contrast);
-    }
   }
 </style>

--- a/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
@@ -2,12 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { Dropdown, DropdownItem } from "@dfinity/gix-components";
   import { TransactionNetwork } from "$lib/types/transaction";
-  import {
-    debounce,
-    isNullish,
-    nonNullish,
-    notEmptyString,
-  } from "@dfinity/utils";
+  import { debounce, isNullish, nonNullish } from "@dfinity/utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import {

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -15,14 +15,14 @@
   import { NotEnoughAmountError } from "$lib/types/common.errors";
   import type { Principal } from "@dfinity/principal";
   import { translate } from "$lib/utils/i18n.utils";
-  import SelectNetworkDropdown from "$lib/components/accounts/SelectNetworkDropdown.svelte";
   import type {
-    TransactionNetwork,
+    TransactionNetwork as TransactionNetworkType,
     ValidateAmountFn,
   } from "$lib/types/transaction";
   import { isNullish } from "@dfinity/utils";
   import TransactionFromAccount from "$lib/components/transaction/TransactionFromAccount.svelte";
   import TransactionFormFee from "$lib/components/transaction/TransactionFormFee.svelte";
+  import TransactionNetwork from "$lib/components/transaction/TransactionNetwork.svelte";
 
   // Tested in the TransactionModal
   export let rootCanisterId: Principal;
@@ -39,7 +39,8 @@
   export let showManualAddress = true;
 
   export let mustSelectNetwork = false;
-  export let selectedNetwork: TransactionNetwork | undefined = undefined;
+  export let selectedNetwork: TransactionNetworkType | undefined = undefined;
+  export let networkReadonly: boolean | undefined = undefined;
 
   export let validateAmount: ValidateAmountFn = () => undefined;
 
@@ -132,10 +133,11 @@
   {/if}
 
   {#if mustSelectNetwork}
-    <SelectNetworkDropdown
+    <TransactionNetwork
       bind:selectedNetwork
       universeId={rootCanisterId}
       {selectedDestinationAddress}
+      {networkReadonly}
     />
   {/if}
 

--- a/frontend/src/lib/components/transaction/TransactionNetwork.svelte
+++ b/frontend/src/lib/components/transaction/TransactionNetwork.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { UniverseCanisterId } from "$lib/types/universe";
+  import { TransactionNetwork } from "$lib/types/transaction";
+  import SelectNetworkDropdown from "$lib/components/accounts/SelectNetworkDropdown.svelte";
+  import { notEmptyString } from "@dfinity/utils";
+  import { i18n } from "$lib/stores/i18n";
+
+  export let universeId: UniverseCanisterId;
+  export let selectedNetwork: TransactionNetwork | undefined = undefined;
+  export let selectedDestinationAddress: string | undefined = undefined;
+  export let networkReadonly: boolean | undefined = undefined;
+</script>
+
+<div class:placeholder={!notEmptyString(selectedNetwork)}>
+  <p class="label">{$i18n.accounts.network}</p>
+
+  {#if networkReadonly}
+    <p class="network">
+      {$i18n.accounts[selectedNetwork ?? TransactionNetwork.ICP]}
+    </p>
+  {:else}
+    <SelectNetworkDropdown
+      bind:selectedNetwork
+      {universeId}
+      {selectedDestinationAddress}
+    />
+  {/if}
+</div>
+
+<style lang="scss">
+  .placeholder {
+    :global(select) {
+      color: var(--disable-contrast);
+    }
+  }
+
+  .label {
+    padding: var(--padding-0_5x) 0;
+  }
+
+  p {
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -22,6 +22,7 @@
   let sourceAccount: Account | undefined = transactionInit.sourceAccount;
   let destinationAddress: string | undefined =
     transactionInit.destinationAddress;
+  let networkReadonly = transactionInit.networkReadonly;
 
   // User inputs exposed for bind in consumers and initialized with initial parameters when component is mounted.
   export let amount: number | undefined = transactionInit.amount;
@@ -121,6 +122,7 @@
       on:nnsClose
       {mustSelectNetwork}
       bind:selectedNetwork
+      {networkReadonly}
       on:nnsOpenQRCodeReader={goQRCode}
     >
       <slot name="additional-info-form" slot="additional-info" />

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -12,6 +12,7 @@ export interface TransactionInit {
   sourceAccount?: Account;
   destinationAddress?: string;
   mustSelectNetwork?: boolean;
+  networkReadonly?: boolean;
   amount?: number;
 }
 


### PR DESCRIPTION
# Motivation

We need an option to display the selected network in the transaction form as readonly because converting ckBTC from the remaining balance of the withdrawal account should happens on the BTC network only.

# Changes

- add option `networkReadonly` to transaction init parameters
- new component that display either the network as readonly or the existing dropdown
