### PR TITLE
Option to hide ledger fee in transaction

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -40,6 +40,7 @@
   export let showManualAddress = true;
   export let selectDestinationMethods: TransactionSelectDestinationMethods =
     "all";
+  export let showLedgerFee = true;
 
   export let mustSelectNetwork = false;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
@@ -146,7 +147,9 @@
   <div class="amount">
     <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
 
-    <TransactionFormFee {transactionFee} />
+    {#if showLedgerFee}
+      <TransactionFormFee {transactionFee} />
+    {/if}
 
     <slot name="additional-info" />
   </div>

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -6,7 +6,7 @@
   export let transactionFee: TokenAmount;
 </script>
 
-<div>
+<div data-tid="transaction-form-fee">
   <p class="fee label no-margin">
     <slot name="label">{$i18n.accounts.transaction_fee}</slot>
   </p>

--- a/frontend/src/lib/components/transaction/TransactionReview.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReview.svelte
@@ -16,6 +16,7 @@
   export let transactionFee: TokenAmount;
   export let token: Token;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
+  export let showLedgerFee = true;
 
   let sourceAccount: Account;
   let amount: number;
@@ -36,7 +37,7 @@
   <div class="info">
     <TransactionSource account={sourceAccount} />
 
-    <TransactionSummary {amount} {token} {transactionFee}>
+    <TransactionSummary {amount} {token} {transactionFee} {showLedgerFee}>
       <slot name="received-amount" slot="received-amount" />
     </TransactionSummary>
 

--- a/frontend/src/lib/components/transaction/TransactionSummary.svelte
+++ b/frontend/src/lib/components/transaction/TransactionSummary.svelte
@@ -9,6 +9,7 @@
   export let amount: number;
   export let token: Token;
   export let transactionFee: TokenAmount;
+  export let showLedgerFee = true;
 
   // If we made it this far, the number is valid.
   let tokenAmount: TokenAmount;
@@ -39,24 +40,31 @@
   <div data-tid="transaction-summary-sending-amount">
     <p class="label subtitle">{$i18n.accounts.sending_amount}</p>
     <p>
-      <AmountDisplay singleLine detailed amount={tokenAmount} />
+      <AmountDisplay
+        singleLine={showLedgerFee}
+        inline={!showLedgerFee}
+        detailed
+        amount={tokenAmount}
+      />
     </p>
   </div>
 
-  <div data-tid="transaction-summary-fee">
-    <p class="label subtitle">{ledgerFeeLabel}</p>
-    <p>
-      <AmountDisplay singleLine detailed amount={transactionFee} />
-    </p>
-  </div>
+  {#if showLedgerFee}
+    <div data-tid="transaction-summary-fee">
+      <p class="label subtitle">{ledgerFeeLabel}</p>
+      <p>
+        <AmountDisplay singleLine detailed amount={transactionFee} />
+      </p>
+    </div>
 
-  <div class="deducted" data-tid="transaction-summary-total-deducted">
-    <p class="label subtitle">{$i18n.accounts.total_deducted}</p>
+    <div class="deducted" data-tid="transaction-summary-total-deducted">
+      <p class="label subtitle">{$i18n.accounts.total_deducted}</p>
 
-    <p>
-      <AmountDisplay inline detailed amount={tokenTotalDeducted} />
-    </p>
-  </div>
+      <p>
+        <AmountDisplay inline detailed amount={tokenTotalDeducted} />
+      </p>
+    </div>
+  {/if}
 
   <div class="icon">
     <IconSouth />

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -25,6 +25,7 @@
     transactionInit.destinationAddress;
   let selectDestinationMethods: TransactionSelectDestinationMethods =
     transactionInit.selectDestinationMethods ?? "all";
+  let showLedgerFee = transactionInit.showLedgerFee ?? true;
 
   // User inputs exposed for bind in consumers and initialized with initial parameters when component is mounted.
   export let amount: number | undefined = transactionInit.amount;
@@ -126,6 +127,7 @@
       on:nnsClose
       {mustSelectNetwork}
       bind:selectedNetwork
+      {showLedgerFee}
       on:nnsOpenQRCodeReader={goQRCode}
     >
       <slot name="additional-info-form" slot="additional-info" />
@@ -142,6 +144,7 @@
       {disableSubmit}
       {token}
       {selectedNetwork}
+      {showLedgerFee}
       on:nnsBack={goBack}
       on:nnsSubmit
       on:nnsClose

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -17,7 +17,7 @@ export interface TransactionInit {
   /**
    * Fees are applied for transactions on the IC.
    * Yet, when user restart the conversion of ckBTC -> BTC from the withdrawal account, there is no transfer to the ledger.
-   * That si why with the help of this flag, the ledger fee can be skipped on the UI side.
+   * That is why with the help of this flag, the ledger fee can be skipped on the UI side.
    */
   showLedgerFee?: boolean;
 }

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -14,6 +14,12 @@ export interface TransactionInit {
   mustSelectNetwork?: boolean;
   amount?: number;
   selectDestinationMethods?: TransactionSelectDestinationMethods;
+  /**
+   * Fees are applied for transactions on the IC.
+   * Yet, when user restart the conversion of ckBTC -> BTC from the withdrawal account, there is no transfer to the ledger.
+   * That si why with the help of this flag, the ledger fee can be skipped on the UI side.
+   */
+  showLedgerFee?: boolean;
 }
 
 export type ValidateAmountFn = (params: {

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -45,6 +45,7 @@ describe("TransactionModal", () => {
     rootCanisterId,
     validateAmount,
     mustSelectNetwork = false,
+    showLedgerFee,
   }: {
     destinationAddress?: string;
     sourceAccount?: Account;
@@ -52,6 +53,7 @@ describe("TransactionModal", () => {
     rootCanisterId?: Principal;
     validateAmount?: ValidateAmountFn;
     mustSelectNetwork?: boolean;
+    showLedgerFee?: boolean;
   }) =>
     renderModal({
       component: TransactionModal,
@@ -63,6 +65,7 @@ describe("TransactionModal", () => {
           sourceAccount,
           destinationAddress,
           mustSelectNetwork,
+          showLedgerFee,
         },
       },
     });
@@ -354,6 +357,25 @@ describe("TransactionModal", () => {
         });
 
       expect(call).rejects.toThrowError();
+    });
+
+    it("should show the ledger fee", async () => {
+      const { queryByTestId } = await renderTransactionModal({
+        destinationAddress: mockMainAccount.identifier,
+        rootCanisterId: OWN_CANISTER_ID,
+      });
+
+      expect(queryByTestId("transaction-form-fee")).toBeInTheDocument();
+    });
+
+    it("should hide the ledger fee", async () => {
+      const { queryByTestId } = await renderTransactionModal({
+        destinationAddress: mockMainAccount.identifier,
+        rootCanisterId: OWN_CANISTER_ID,
+        showLedgerFee: false,
+      });
+
+      expect(queryByTestId("transaction-form-fee")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -94,12 +94,14 @@ describe("TransactionModal", () => {
     rootCanisterId,
     sourceAccount,
     mustSelectNetwork = false,
+    showLedgerFee,
   }: {
     destinationAddress?: string;
     sourceAccount?: Account;
     transactionFee?: TokenAmount;
     rootCanisterId?: Principal;
     mustSelectNetwork?: boolean;
+    showLedgerFee?: boolean;
   }): Promise<RenderResult<SvelteComponent>> => {
     const result = await renderTransactionModal({
       destinationAddress,
@@ -107,6 +109,7 @@ describe("TransactionModal", () => {
       transactionFee,
       rootCanisterId,
       mustSelectNetwork,
+      showLedgerFee,
     });
 
     const { getByTestId, container } = result;
@@ -262,6 +265,43 @@ describe("TransactionModal", () => {
       expect(
         getByText(formattedTransactionFeeICP(Number(fee.toE8s())))
       ).toBeInTheDocument();
+    });
+
+    it("should move to the last step and show ledger fees", async () => {
+      const fee = TokenAmount.fromE8s({
+        amount: BigInt(20_000),
+        token: {
+          symbol: "TST",
+          name: "Test token",
+        },
+      });
+      const { getByTestId } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+        transactionFee: fee,
+      });
+
+      expect(getByTestId("transaction-summary-fee")).toBeInTheDocument();
+      expect(
+        getByTestId("transaction-summary-total-deducted")
+      ).toBeInTheDocument();
+    });
+
+    it("should move to the last step and hide ledger fees", async () => {
+      const fee = TokenAmount.fromE8s({
+        amount: BigInt(20_000),
+        token: {
+          symbol: "TST",
+          name: "Test token",
+        },
+      });
+      const { getByTestId } = await renderEnter10ICPAndNext({
+        rootCanisterId: OWN_CANISTER_ID,
+        transactionFee: fee,
+        showLedgerFee: false,
+      });
+
+      expect(() => getByTestId("transaction-summary-fee")).toThrow();
+      expect(() => getByTestId("transaction-summary-total-deducted")).toThrow();
     });
 
     it("should move to the last step and trigger nnsSubmit event", async () => {


### PR DESCRIPTION
# Motivation

In case of retry of the conversion of ckBTC to BTC stuck in the withdrawal account, there is no transfer to the ledger and therefore no ledger fee to display in the transaction modal

# Changes

- add `showLedgerFee` option in transaction modal
- hide ledger fees if set to `false`
