### PR TITLE
Fix: Participation flow

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -30,6 +30,10 @@
   let commitmentE8s: bigint | undefined;
   $: commitmentE8s = getCommitmentE8s(swapCommitment);
 
+  let userHasParticipated: boolean;
+  $: userHasParticipated =
+    commitmentE8s !== undefined && commitmentE8s > BigInt(0);
+
   const showProject = async () =>
     await goto(
       `${AppPath.Project}/?project=${project.rootCanisterId.toText()}`
@@ -40,7 +44,7 @@
   testId="project-card-component"
   role="link"
   on:click={showProject}
-  theme={commitmentE8s !== undefined ? "highlighted" : undefined}
+  theme={userHasParticipated ? "highlighted" : undefined}
 >
   <div class="title" slot="start">
     <Logo src={logo} alt={$i18n.sns_launchpad.project_logo} />

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -10,6 +10,7 @@
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import { goto } from "$app/navigation";
   import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let project: SnsFullProject;
 
@@ -32,7 +33,7 @@
 
   let userHasParticipated: boolean;
   $: userHasParticipated =
-    commitmentE8s !== undefined && commitmentE8s > BigInt(0);
+    nonNullish(commitmentE8s) && commitmentE8s > BigInt(0);
 
   const showProject = async () =>
     await goto(

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -40,7 +40,7 @@
   let myCommitment: TokenAmount | undefined = undefined;
   $: {
     const commitmentE8s = getCommitmentE8s(swapCommitment);
-    if (commitmentE8s !== undefined) {
+    if (commitmentE8s !== undefined && commitmentE8s > BigInt(0)) {
       myCommitment = TokenAmount.fromE8s({
         amount: commitmentE8s,
         token: ICPToken,
@@ -49,7 +49,7 @@
   }
 </script>
 
-<dl>
+<dl data-tid="project-card-swap-info-component">
   <!-- Sale is committed -->
   {#if lifecycle === SnsSwapLifecycle.Committed}
     <dt>{$i18n.sns_project_detail.status_completed}</dt>
@@ -70,7 +70,9 @@
 
   {#if myCommitment !== undefined}
     <dt><ProjectUserCommitmentLabel {summary} {swapCommitment} /></dt>
-    <dd><AmountDisplay amount={myCommitment} singleLine inheritSize /></dd>
+    <dd data-tid="commitment-token-value">
+      <AmountDisplay amount={myCommitment} singleLine inheritSize />
+    </dd>
   {/if}
 </dl>
 

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -16,6 +16,7 @@
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import ProjectUserCommitmentLabel from "$lib/components/project-detail/ProjectUserCommitmentLabel.svelte";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let project: SnsFullProject;
 
@@ -40,7 +41,7 @@
   let myCommitment: TokenAmount | undefined = undefined;
   $: {
     const commitmentE8s = getCommitmentE8s(swapCommitment);
-    if (commitmentE8s !== undefined && commitmentE8s > BigInt(0)) {
+    if (nonNullish(commitmentE8s) && commitmentE8s > BigInt(0)) {
       myCommitment = TokenAmount.fromE8s({
         amount: commitmentE8s,
         token: ICPToken,

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -71,6 +71,7 @@
     <div role="toolbar">
       <SignInGuard>
         {#if userCanParticipateToSwap}
+          <!-- TODO: Disable button until we have the commitment of the user -->
           {#if busy}
             <div class="loader" data-tid="connecting_sale_canister">
               <SpinnerText

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -68,6 +68,7 @@ export interface SnsSummary {
 
 export interface SnsSwapCommitment {
   rootCanisterId: RootCanisterId;
+  // sns swap canister doesn't return any `SnsSwapBuyerState` if user has no commitment
   myCommitment: SnsSwapBuyerState | undefined;
 }
 

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -197,7 +197,7 @@ export const getSwapCanisterAccount = ({
 
 /**
  * Returns `undefined` if swapCommitment is not present yet.
- * Returns `BigInt(0)` if myCommitment is present but user has no commitment or amount is not loaded
+ * Returns `BigInt(0)` if myCommitment is present but user has no commitment or amount is not present either.
  * Returns commitment e8s if commitment is defined.
  */
 export const getCommitmentE8s = (

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -206,11 +206,8 @@ export const getCommitmentE8s = (
   if (isNullish(swapCommitment)) {
     return undefined;
   }
-  if (isNullish(swapCommitment?.myCommitment)) {
-    return BigInt(0);
-  }
   return (
-    fromNullable(swapCommitment?.myCommitment.icp ?? [])?.amount_e8s ??
+    fromNullable(swapCommitment?.myCommitment?.icp ?? [])?.amount_e8s ??
     BigInt(0)
   );
 };

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -196,8 +196,8 @@ export const getSwapCanisterAccount = ({
 };
 
 /**
- * Returns `undefined` if commitment is not loaded yet.
- * Returns `BigInt(0)` if commitment is loaded but user has no commitment or amount is not loaded
+ * Returns `undefined` if swapCommitment is not present yet.
+ * Returns `BigInt(0)` if myCommitment is present but user has no commitment or amount is not loaded
  * Returns commitment e8s if commitment is defined.
  */
 export const getCommitmentE8s = (

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -197,17 +197,21 @@ export const getSwapCanisterAccount = ({
 
 /**
  * Returns `undefined` if commitment is not loaded yet.
- * Returns `BigInt(0)` if commitment is loaded but there is no ICP amount.
+ * Returns `BigInt(0)` if commitment is loaded but user has no commitment or amount is not loaded
  * Returns commitment e8s if commitment is defined.
  */
 export const getCommitmentE8s = (
-  swapCommitment?: SnsSwapCommitment | null
+  swapCommitment: SnsSwapCommitment | null | undefined
 ): bigint | undefined => {
-  if (isNullish(swapCommitment) || isNullish(swapCommitment.myCommitment)) {
+  if (isNullish(swapCommitment)) {
     return undefined;
   }
+  if (isNullish(swapCommitment?.myCommitment)) {
+    return BigInt(0);
+  }
   return (
-    fromNullable(swapCommitment.myCommitment.icp ?? [])?.amount_e8s ?? BigInt(0)
+    fromNullable(swapCommitment?.myCommitment.icp ?? [])?.amount_e8s ??
+    BigInt(0)
   );
 };
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -11,6 +11,8 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
+import { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
@@ -68,15 +70,48 @@ describe("ProjectCard", () => {
       ).toBeInTheDocument();
     });
 
-    it("should be highlighted", () => {
+    it("should be highlighted", async () => {
       const { container } = render(ProjectCard, {
         props: {
-          project: mockSnsFullProject,
+          project: {
+            ...mockSnsFullProject,
+            swapCommitment: {
+              rootCanisterId: mockSnsFullProject.rootCanisterId,
+              myCommitment: {
+                icp: [
+                  {
+                    transfer_start_timestamp_seconds: BigInt(123132),
+                    amount_e8s: BigInt(100_000_000),
+                    transfer_success_timestamp_seconds: BigInt(5443554),
+                  },
+                ],
+              },
+            },
+          },
         },
       });
 
-      const article = container.querySelector("article.highlighted");
-      expect(article).not.toBeNull();
+      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+
+      expect(await po.isHighlighted()).toBe(true);
+    });
+
+    it("should not be highlighted without commitment", async () => {
+      const { container } = render(ProjectCard, {
+        props: {
+          project: {
+            ...mockSnsFullProject,
+            swapCommitment: {
+              rootCanisterId: mockSnsFullProject.rootCanisterId,
+              myCommitment: undefined,
+            },
+          },
+        },
+      });
+
+      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+
+      expect(await po.isHighlighted()).toBe(false);
     });
 
     it("should display a spinner when the swapCommitment is not loaded", () => {

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -93,6 +93,25 @@ describe("ProjectCardSwapInfo", () => {
     expect(getByText(icpValue, { exact: false })).toBeInTheDocument();
   });
 
+  it("should not render my commitment if `undefined`", () => {
+    const { queryByTestId } = render(ProjectCardSwapInfo, {
+      props: {
+        project: {
+          ...mockSnsFullProject,
+          swapCommitment: {
+            rootCanisterId: mockSnsFullProject.rootCanisterId,
+            myCommitment: undefined,
+          },
+        },
+      },
+    });
+
+    expect(
+      queryByTestId("project-card-swap-info-component")
+    ).toBeInTheDocument();
+    expect(queryByTestId("commitment-token-value")).not.toBeInTheDocument();
+  });
+
   it("should render completed", () => {
     const { getByText } = render(ProjectCardSwapInfo, {
       props: {

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -81,6 +81,23 @@ describe("ParticipateButton", () => {
       );
     });
 
+    // TODO: Disable button until we have the commitment of the user
+    it("should show button when user has no commitment", () => {
+      snsTicketsStore.setNoTicket(rootCanisterIdMock);
+
+      const { queryByTestId } = renderContextCmp({
+        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        swapCommitment: {
+          rootCanisterId: mockSnsFullProject.rootCanisterId,
+          myCommitment: undefined,
+        },
+        Component: ParticipateButton,
+      });
+      expect(
+        queryByTestId("sns-project-participate-button")
+      ).toBeInTheDocument();
+    });
+
     it("should open swap participation modal on participate click", async () => {
       snsTicketsStore.setNoTicket(rootCanisterIdMock);
 

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -235,7 +235,7 @@ describe("sns-utils", () => {
       expect(getCommitmentE8s(commitment)).toEqual(commitmentE8s);
     });
 
-    it("returns 0 if no user commitment", () => {
+    it("returns 0 if no amount in commitment", () => {
       const commitment: SnsSwapCommitment = {
         rootCanisterId: mockPrincipal,
         myCommitment: {
@@ -245,12 +245,15 @@ describe("sns-utils", () => {
       expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
     });
 
-    it("returns undefined if commitment not loaded", () => {
-      const noCommitment: SnsSwapCommitment = {
+    it("returns 0 if no user commitment", () => {
+      const commitment: SnsSwapCommitment = {
         rootCanisterId: mockPrincipal,
         myCommitment: undefined,
       };
-      expect(getCommitmentE8s(noCommitment)).toBeUndefined();
+      expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
+    });
+
+    it("returns undefined if commitment not loaded", () => {
       expect(getCommitmentE8s(null)).toBeUndefined();
       expect(getCommitmentE8s(undefined)).toBeUndefined();
     });

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -10,7 +10,16 @@ export class ProjectCardPo extends BasePageObject {
     );
   }
 
+  static under(element: PageObjectElement): ProjectCardPo {
+    return new ProjectCardPo(element.byTestId(ProjectCardPo.TID));
+  }
+
   getProjectName(): Promise<string> {
     return this.getText("project-name");
+  }
+
+  async isHighlighted(): Promise<boolean> {
+    const classNames = await this.root.getAttribute("class");
+    return classNames.includes("highlighted");
   }
 }


### PR DESCRIPTION
# Motivation

Users could not participate in a swap because the button was not enabled.

# Changes

Main change:
* Fix logic in `getCommitmentE8s`. Differentiate better values of `0` (no commitment) and `undefined` (commitment not yet loaded).

Minor change:
* In ProjectCard, change the logic to find if the card needs to be highlighted or not.
* In ProjectCardSwapInfo, change the logic to know when to render user commitment.

# Tests

* Add a test in ParticipateButton component with no commitment.
* Add test case in ProjectCard for the highlighted logic.
* Add test case in ProjectCardSwapInfo for the commitment data rendering.
* Add test case in `getCommitmentE8s` to have a test for all cases.
* Add some functionality in ProjectCard page object to be used in the unit test.
