### PR TITLE
queuedStore to mitigate queryAndUpdate race condition

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -23,7 +23,10 @@ import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/ledger.services.proxy";
 import type { AccountsStoreData } from "$lib/stores/accounts.store";
-import { accountsStore } from "$lib/stores/accounts.store";
+import {
+  accountsStore,
+  type SingleMutationAccountsStore,
+} from "$lib/stores/accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account, AccountType } from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";
@@ -119,6 +122,7 @@ export const loadAccounts = async ({
 };
 
 type SyncAccontsErrorHandler = (params: {
+  mutableStore: SingleMutationAccountsStore;
   err: unknown;
   certified: boolean;
 }) => void;
@@ -130,9 +134,11 @@ type SyncAccontsErrorHandler = (params: {
  * Resets accountsStore and shows toast for certified errors.
  */
 const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
+  mutableStore,
   err,
   certified,
 }: {
+  mutableStore: SingleMutationAccountsStore;
   err: unknown;
   certified: boolean;
 }) => {
@@ -140,7 +146,7 @@ const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
     return;
   }
 
-  accountsStore.reset();
+  mutableStore.reset(certified);
 
   toastsError(
     toToastError({
@@ -156,13 +162,14 @@ const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
 const syncAccountsWithErrorHandler = (
   errorHandler: SyncAccontsErrorHandler
 ): Promise<void> => {
+  const mutableStore = accountsStore.getSingleMutationStore();
   return queryAndUpdate<AccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),
-    onLoad: ({ response: accounts }) => accountsStore.set(accounts),
+    onLoad: ({ response: accounts }) => mutableStore.set(accounts),
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      errorHandler({ err, certified });
+      errorHandler({ mutableStore, err, certified });
     },
     logMessage: "Syncing Accounts",
     strategy: FORCE_CALL_STRATEGY,
@@ -191,11 +198,16 @@ export const loadBalance = async ({
 }: {
   accountIdentifier: string;
 }): Promise<void> => {
+  const mutableStore = accountsStore.getSingleMutationStore();
   return queryAndUpdate<bigint, unknown>({
     request: ({ identity, certified }) =>
       queryAccountBalance({ identity, certified, accountIdentifier }),
-    onLoad: ({ response: balanceE8s }) => {
-      accountsStore.setBalance({ accountIdentifier, balanceE8s });
+    onLoad: ({ certified, response: balanceE8s }) => {
+      mutableStore.setBalance({
+        certified,
+        accountIdentifier,
+        balanceE8s,
+      });
     },
     onError: ({ error: err, certified }) => {
       console.error(err);
@@ -449,12 +461,13 @@ export const pollAccounts = async (certified = true) => {
   }
 
   try {
+    const mutableStore = accountsStore.getSingleMutationStore();
     const identity = await getAuthenticatedIdentity();
     const certifiedAccounts = await pollLoadAccounts({
       identity,
       certified: overrideCertified,
     });
-    accountsStore.set(certifiedAccounts);
+    mutableStore.set(certifiedAccounts);
   } catch (err) {
     // Don't show error if polling was cancelled
     if (pollingCancelled(err)) {

--- a/frontend/src/lib/stores/queued-store.ts
+++ b/frontend/src/lib/stores/queued-store.ts
@@ -1,0 +1,178 @@
+import { derived, writable, type Readable } from "svelte/store";
+
+// A "queued store" is Svelte store which is aware of the queryAndUpdate
+// mechanism. It keeps a queue of mutations which have been applied based on
+// query (as opposed to update) responses. This way, when a update response for
+// an older reqeust comes in, the store can re-apply the mutations from newer
+// query responses to make sure the old update response doesn't revert newer
+// data.
+//
+// Example usage:
+// const { subscribe, getSingleMutationStore } = queuedStore(initialData);
+// const loadData = async () => {
+//   const { set, update } = getSingleMutationStore();
+//   return queryAndUpdate({
+//     request: ...
+//     onLoad: ({ response: data, certified }) => set({ data, certified }),
+//     ...
+//   });
+// };
+
+type StoreMutation<StoreData> = (StoreData) => StoreData;
+
+type MutationKey = number;
+
+interface StoreMutationEntry<StoreData> {
+  mutationKey: MutationKey;
+  certifiedMutation: StoreMutation<StoreData> | undefined;
+  nonCertifiedMutation: StoreMutation<StoreData> | undefined;
+}
+
+interface QueuedStoreData<StoreData> {
+  // Initial data with only certified mutations applied.
+  certifiedData: StoreData;
+  // Mutations which have not yet been applied to certifiedData.
+  mutationQueue: StoreMutationEntry<StoreData>[];
+}
+
+// A store on which operations can be performed for a single mutation.
+// Note that the changes applied for both the query and update response count as
+// a single mutation and should be applied using the same store. The purpose of
+// this store is to be able to associate the query and update response of the
+// same mutation.
+export interface SingleMutationStore<StoreData> {
+  set: ({ data, certified }: { data: StoreData; certified: boolean }) => void;
+  update: ({
+    mutation,
+    certified,
+  }: {
+    mutation: StoreMutation<StoreData>;
+    certified: boolean;
+  }) => void;
+}
+
+interface QueuedStore<StoreData> extends Readable<StoreData> {
+  getSingleMutationStore: () => SingleMutationStore<StoreData>;
+}
+
+export const queuedStore = <StoreData>(
+  initialData: StoreData
+): QueuedStore<StoreData> => {
+  const initialQueuedStoreData: QueuedStoreData<StoreData> = {
+    certifiedData: initialData,
+    mutationQueue: [],
+  };
+  const underlyingStore = writable<QueuedStoreData<StoreData>>(
+    initialQueuedStoreData
+  );
+
+  const exposedStore = derived<Readable<QueuedStoreData<StoreData>>, StoreData>(
+    underlyingStore,
+    ({ certifiedData, mutationQueue }) => {
+      let data = certifiedData;
+      for (const entry of mutationQueue) {
+        const mutation = entry.certifiedMutation || entry.nonCertifiedMutation;
+        if (mutation) {
+          data = mutation(data);
+        }
+      }
+      return data;
+    }
+  );
+
+  const addMutation = ({
+    mutationKey,
+    certified,
+    mutation,
+    storeData,
+  }: {
+    mutationKey: MutationKey;
+    certified: boolean;
+    mutation: StoreMutation<StoreData>;
+    storeData: QueuedStoreData<StoreData>;
+  }): QueuedStoreData<StoreData> => {
+    let { certifiedData, mutationQueue } = storeData;
+
+    // Update the entry in the queue with the given mutation key.
+    mutationQueue = mutationQueue.map((entry) => {
+      if (entry.mutationKey === mutationKey) {
+        return certified
+          ? {
+              ...entry,
+              certifiedMutation: mutation,
+            }
+          : {
+              ...entry,
+              nonCertifiedMutation: mutation,
+            };
+      }
+      return entry;
+    });
+
+    // Apply finalized mutations from the front of the queue.
+    while (mutationQueue.length > 0 && mutationQueue[0].certifiedMutation) {
+      const mutation = mutationQueue.shift().certifiedMutation;
+      certifiedData = mutation(certifiedData);
+    }
+
+    return {
+      certifiedData,
+      mutationQueue,
+    };
+  };
+
+  let nextMutationKey = 1;
+
+  return {
+    subscribe: exposedStore.subscribe,
+
+    getSingleMutationStore: () => {
+      const mutationKey = nextMutationKey++;
+      underlyingStore.update((storeData) => {
+        const { mutationQueue } = storeData;
+        const newEntry = {
+          mutationKey,
+          certifiedMutation: undefined,
+          nonCertifiedMutation: undefined,
+        };
+        // We reserve a spot at the end of the queue, but we actually don't
+        // know if mutations should be applied in the order they were
+        // reserved. And we *can't know* unless we know the block height
+        // corresponding to each response.
+        return {
+          ...storeData,
+          mutationQueue: [...mutationQueue, newEntry],
+        };
+      });
+
+      return {
+        set({ data, certified }: { data: StoreData; certified: boolean }) {
+          underlyingStore.update((storeData) =>
+            addMutation({
+              mutationKey,
+              certified,
+              mutation: (_) => data,
+              storeData,
+            })
+          );
+        },
+        update({
+          mutation,
+          certified,
+        }: {
+          mutation: StoreMutation<StoreData>;
+          certified: boolean;
+        }) {
+          underlyingStore.update((storeData) =>
+            addMutation({
+              mutationKey,
+              certified,
+              mutation,
+              storeData,
+            })
+          );
+        },
+      };
+    },
+  };
+};

--- a/frontend/src/lib/stores/queued-store.ts
+++ b/frontend/src/lib/stores/queued-store.ts
@@ -112,9 +112,11 @@ export const queuedStore = <StoreData>(
 
     // Apply finalized mutations from the front of the queue.
     while (mutationQueue.length > 0 && isFinal(mutationQueue[0])) {
+      // Becuase of the condition above, entry and mutation are guaranteed to
+      // be defined.
       const entry = mutationQueue.shift();
-      const mutation = entry.certifiedMutation || entry.nonCertifiedMutation;
-      certifiedData = mutation(certifiedData);
+      const mutation = entry?.certifiedMutation || entry?.nonCertifiedMutation;
+      mutation && (certifiedData = mutation(certifiedData));
     }
     updateExposedData();
   };

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -471,7 +471,7 @@ describe("accounts-services", () => {
       });
     });
 
-    it.only("old update response does not replace newer response", async () => {
+    it("old update response does not replace newer response", async () => {
       const queryMainBalanceE8s = BigInt(10_000_000);
       const updateMainBalanceE8s = BigInt(20_000_000);
       const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -361,7 +361,7 @@ describe("accounts-services", () => {
         .mockImplementation(({ certified }) =>
           certified ? updateBalanceResponse : queryBalanceResponse
         );
-      const queryAccountSpy = jest
+      jest
         .spyOn(nnsdappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
       const accountsWith = ({

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -72,7 +72,7 @@ describe("accounts-services", () => {
     jest.spyOn(console, "error").mockImplementation(jest.fn);
     jest.clearAllMocks();
     toastsStore.reset();
-    accountsStore.reset();
+    accountsStore.resetForTesting();
   });
 
   describe("getOrCreateAccount", () => {
@@ -297,6 +297,115 @@ describe("accounts-services", () => {
         },
       ]);
     });
+
+    it("update response replaces query response", async () => {
+      const queryMainBalanceE8s = BigInt(10_000_000);
+      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
+      let resolveUpdateResponse;
+      const updateBalanceResponse = new Promise<bigint>((resolve) => {
+        resolveUpdateResponse = () => resolve(updateMainBalanceE8s);
+      });
+
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockImplementation(({ certified }) =>
+          certified ? updateBalanceResponse : queryBalanceResponse
+        );
+      jest
+        .spyOn(nnsdappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+      const accountsWith = ({
+        mainBalanceE8s,
+        certified,
+      }: {
+        mainBalanceE8s: bigint;
+        certified: boolean;
+      }) => ({
+        main: {
+          ...mockMainAccount,
+          balance: TokenAmount.fromE8s({
+            amount: mainBalanceE8s,
+            token: ICPToken,
+          }),
+        },
+        subAccounts: [],
+        hardwareWallets: [],
+        certified,
+      });
+      await syncAccounts();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
+      );
+
+      resolveUpdateResponse();
+      await runResolvedPromises();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: updateMainBalanceE8s, certified: true })
+      );
+    });
+
+    it("old update response does not replace newer response", async () => {
+      const queryMainBalanceE8s = BigInt(10_000_000);
+      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
+      let resolveUpdateResponse;
+      const updateBalanceResponse = new Promise<bigint>((resolve) => {
+        resolveUpdateResponse = () => resolve(updateMainBalanceE8s);
+      });
+
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockImplementation(({ certified }) =>
+          certified ? updateBalanceResponse : queryBalanceResponse
+        );
+      const queryAccountSpy = jest
+        .spyOn(nnsdappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+      const accountsWith = ({
+        mainBalanceE8s,
+        certified,
+      }: {
+        mainBalanceE8s: bigint;
+        certified: boolean;
+      }) => ({
+        main: {
+          ...mockMainAccount,
+          balance: TokenAmount.fromE8s({
+            amount: mainBalanceE8s,
+            token: ICPToken,
+          }),
+        },
+        subAccounts: [],
+        hardwareWallets: [],
+        certified,
+      });
+      await syncAccounts();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
+      );
+
+      const newerMainBalanceE8s = BigInt(30_000_000);
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(newerMainBalanceE8s);
+      await syncAccounts();
+      await runResolvedPromises();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: newerMainBalanceE8s, certified: true })
+      );
+
+      resolveUpdateResponse();
+      await runResolvedPromises();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: newerMainBalanceE8s, certified: true })
+      );
+    });
   });
 
   describe("loadBalance", () => {
@@ -360,6 +469,66 @@ describe("accounts-services", () => {
         level: "error",
         text: expect.stringContaining(error.message),
       });
+    });
+
+    it.only("old update response does not replace newer response", async () => {
+      const queryMainBalanceE8s = BigInt(10_000_000);
+      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
+      let resolveUpdateResponse;
+      const updateBalanceResponse = new Promise<bigint>((resolve) => {
+        resolveUpdateResponse = () => resolve(updateMainBalanceE8s);
+      });
+
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockImplementation(({ certified }) =>
+          certified ? updateBalanceResponse : queryBalanceResponse
+        );
+      jest
+        .spyOn(nnsdappApi, "queryAccount")
+        .mockResolvedValue(mockAccountDetails);
+      const accountsWith = ({
+        mainBalanceE8s,
+        certified,
+      }: {
+        mainBalanceE8s: bigint;
+        certified?: boolean;
+      }) => ({
+        main: {
+          ...mockMainAccount,
+          balance: TokenAmount.fromE8s({
+            amount: mainBalanceE8s,
+            token: ICPToken,
+          }),
+        },
+        subAccounts: [],
+        hardwareWallets: [],
+        certified,
+      });
+      await syncAccounts();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
+      );
+
+      const newerMainBalanceE8s = BigInt(30_000_000);
+      jest
+        .spyOn(ledgerApi, "queryAccountBalance")
+        .mockResolvedValue(newerMainBalanceE8s);
+      await loadBalance({ accountIdentifier: mockMainAccount.identifier });
+      await runResolvedPromises();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: newerMainBalanceE8s })
+      );
+
+      resolveUpdateResponse();
+      await runResolvedPromises();
+
+      expect(get(accountsStore)).toEqual(
+        accountsWith({ mainBalanceE8s: newerMainBalanceE8s })
+      );
     });
   });
 

--- a/frontend/src/tests/lib/stores/queued-store.spec.ts
+++ b/frontend/src/tests/lib/stores/queued-store.spec.ts
@@ -1,0 +1,121 @@
+import { queuedStore } from "$lib/stores/queued-store";
+import { get } from "svelte/store";
+
+describe("queuedStore", () => {
+  it("should expose initial data", () => {
+    const store = queuedStore("foo");
+    expect(get(store)).toEqual("foo");
+  });
+
+  it("should set data", () => {
+    const store = queuedStore("foo");
+    const { set } = store.getSingleMutationStore();
+    expect(get(store)).toEqual("foo");
+    set({ data: "bar", certified: true });
+    expect(get(store)).toEqual("bar");
+  });
+
+  it("should update data", () => {
+    const store = queuedStore("Hello, ");
+    const { update } = store.getSingleMutationStore();
+    expect(get(store)).toEqual("Hello, ");
+    update({ mutation: (s) => s + "world!", certified: true });
+    expect(get(store)).toEqual("Hello, world!");
+  });
+
+  it("should replace updates from the same single mutation store", () => {
+    const store = queuedStore("Hello, ");
+    const { update } = store.getSingleMutationStore();
+    expect(get(store)).toEqual("Hello, ");
+    update({ mutation: (s) => s + "world!", certified: false });
+    expect(get(store)).toEqual("Hello, world!");
+    update({ mutation: (s) => s + "everybody!", certified: true });
+    expect(get(store)).toEqual("Hello, everybody!");
+  });
+
+  it("set out of order should not set stale data", () => {
+    const oldData = "old data";
+    const newData = "new data";
+    const store = queuedStore("");
+
+    const { set: set1 } = store.getSingleMutationStore();
+    set1({ data: oldData, certified: false });
+    expect(get(store)).toEqual(oldData);
+
+    const { set: set2 } = store.getSingleMutationStore();
+    set2({ data: newData, certified: false });
+    expect(get(store)).toEqual(newData);
+
+    set2({ data: newData, certified: true });
+    expect(get(store)).toEqual(newData);
+
+    set1({ data: oldData, certified: true });
+    expect(get(store)).toEqual(newData);
+  });
+
+  it("should apply multiple mutations in the original order", () => {
+    const store = queuedStore("");
+    const { set } = store.getSingleMutationStore();
+    set({ data: "Hello, ", certified: false });
+    expect(get(store)).toEqual("Hello, ");
+
+    const { update } = store.getSingleMutationStore();
+    update({ mutation: (s) => s + "world!", certified: false });
+    expect(get(store)).toEqual("Hello, world!");
+
+    set({ data: "Goodbye, ", certified: true });
+    expect(get(store)).toEqual("Goodbye, world!");
+
+    update({ mutation: (s) => s + "everybody!", certified: true });
+    expect(get(store)).toEqual("Goodbye, everybody!");
+  });
+
+  it("can cancel a mutation", () => {
+    const store = queuedStore("");
+    const { set, cancel } = store.getSingleMutationStore();
+    cancel();
+    const setAfterCancel = () => set({ data: "foo", certified: false });
+    expect(setAfterCancel).toThrowError("No entry found for this mutation");
+  });
+
+  it("should fail to apply a mutation that's already finalized", () => {
+    const store = queuedStore("foo");
+    const { set } = store.getSingleMutationStore();
+    set({ data: "bar", certified: true });
+    const secondSet = () => set({ data: "beep", certified: true });
+    expect(secondSet).toThrowError("No entry found for this mutation");
+  });
+
+  it("should fail to apply the same non-certified mutation twice", () => {
+    const store = queuedStore("foo");
+    const { set } = store.getSingleMutationStore();
+    set({ data: "bar", certified: false });
+    const secondSet = () => set({ data: "beep", certified: false });
+    expect(secondSet).toThrowError(
+      "We already have a nonCertifiedMutation for this entry"
+    );
+  });
+
+  it("should fail to apply the same certified mutation twice", () => {
+    const store = queuedStore("foo");
+    // We need to put a non-certified mutation in front of the certified
+    // mutation or the certified mutation will immediately finalize.
+    const { set: set1 } = store.getSingleMutationStore();
+    set1({ data: "bar", certified: false });
+
+    const { set: set2 } = store.getSingleMutationStore();
+    set2({ data: "beep", certified: true });
+    const secondSet = () => set2({ data: "bloop", certified: true });
+    expect(secondSet).toThrowError(
+      "We already have a certifiedMutation for this entry"
+    );
+  });
+
+  it("should finalize a mutation on query response with 'query' strategy", () => {
+    const store = queuedStore("foo");
+    const { set } = store.getSingleMutationStore("query");
+    set({ data: "bar", certified: false });
+    const secondSet = () => set({ data: "beep", certified: true });
+    expect(secondSet).toThrowError("No entry found for this mutation");
+  });
+});


### PR DESCRIPTION
# Motivation

There is a race condition with queryAndUpdate. If you call queryAndUpdate again before the "update" from the first queryAndUpdate responds, then when the first update does respond, it can overwrite responses from the second queryAndUpdate with old data.
This is causing end-to-end tests to be flaky.

To mitigate this I implemented a "store wrapper" which keeps the pending mutations in a queue. Then if an older mutation responds later, it is placed in the correct place in the queue and all mutations are reapplied in the correct order.
By "correct" order, I mean the order in which the original queryAndUpdate calls happened.
Whether this is actually the correct order, we can't know unless we get the block height in the response, which we currently don't.

To match responses from the same queryAndUpdate call, the caller is required to request a one-time use store and apply to it just the mutations corresponding to that queryAndUpdate.

# Changes

1. Implemented `queuedStore` which wraps a writable store and applies the queue mechanism described above.
2. Changed accountsStore to use queuedStore.
3. Updated accounts service to use the new accountsStore API.
4. Temporarily added methods for the original API of accountsStore for backwards compatibility until all existing tests have been updated.

# Tests

Added tests for queuedStore, accountsStore and accounts service.