### PR TITLE
Add .gz to internet-identity wasm URL

### DIFF
--- a/scripts/update-ii
+++ b/scripts/update-ii
@@ -4,7 +4,7 @@ set -euo pipefail
 : "Getting URL from latest redirect..."
 II_URL="$(
   set +o pipefail # We truncate the curl output, this is fine.
-  curl -v https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm 2>&1 |
+  curl -v https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz 2>&1 |
     awk '(($1 == "<") && ($2 == "location:")){print $3; exit 0}' |
     tr -d '[:space:]'
 )"


### PR DESCRIPTION
# Motivation

internet_identity stopped offering non-gzipped artifacts.
I'm not sure what this is used for but it seems to be (one of many reasons?) why the Nightly Publication workflow is failing.

# Changes

Add `.gz` to the internet_identity wasm URL in scripts/update-ii

# Tests

Ran the script and instead of causing an error, it updated `dfx.json`.