### PR TITLE
Don't expose syncAccounts error handler

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -153,8 +153,8 @@ const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
 /**
  * Loads the account data using the ledger and the nns dapp canister.
  */
-export const syncAccounts = (
-  errorHandler: SyncAccontsErrorHandler = defaultErrorHandlerAccounts
+const syncAccountsWithErrorHandler = (
+  errorHandler: SyncAccontsErrorHandler
 ): Promise<void> => {
   return queryAndUpdate<AccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),
@@ -169,6 +169,9 @@ export const syncAccounts = (
   });
 };
 
+export const syncAccounts = () =>
+  syncAccountsWithErrorHandler(defaultErrorHandlerAccounts);
+
 const ignoreErrors: SyncAccontsErrorHandler = () => undefined;
 
 /**
@@ -176,7 +179,7 @@ const ignoreErrors: SyncAccontsErrorHandler = () => undefined;
  *
  * It ignores errors and does not show any toasts. Accounts will be synced again.
  */
-export const initAccounts = () => syncAccounts(ignoreErrors);
+export const initAccounts = () => syncAccountsWithErrorHandler(ignoreErrors);
 
 /**
  * Queries the balance of an account and loads it in the store.

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -281,7 +281,7 @@ describe("accounts-services", () => {
       expect(accounts).toEqual(mockAccounts);
     });
 
-    it("should show toast on error if no handler is passed", async () => {
+    it("should show toast on error", async () => {
       const errorTest = "test";
       jest.spyOn(ledgerApi, "queryAccountBalance");
       jest
@@ -296,25 +296,6 @@ describe("accounts-services", () => {
           text: `${en.error.accounts_not_found} ${errorTest}`,
         },
       ]);
-    });
-
-    it("should use handler passed", async () => {
-      const errorTest = new Error("test");
-      jest.spyOn(ledgerApi, "queryAccountBalance");
-      jest.spyOn(nnsdappApi, "queryAccount").mockRejectedValue(errorTest);
-
-      const handler = jest.fn();
-      await syncAccounts(handler);
-
-      expect(handler).toBeCalledTimes(2);
-      expect(handler).toBeCalledWith({
-        err: errorTest,
-        certified: false,
-      });
-      expect(handler).toBeCalledWith({
-        err: errorTest,
-        certified: true,
-      });
     });
   });
 


### PR DESCRIPTION
# Motivation

`syncAccounts` has an errorHandler parameter but this is only used by `initAccounts` in the same file.
By limiting the functionality we export out of the file it becomes easier to refactor without breaking anything.

# Changes

1. Add `syncAccountsWithErrorHandler` (which is not exported) and called by both `initAccounts` and `syncAccounts`.
2. Remove the optional errorHandler parameter from `syncAccounts`.
3. Remove the tests that test this parameter.

# Tests

Unused functionality is removed so the corresponding tests are removed.
`initAccounts` is still tested separately as it was before.
