### PR TITLE
Script to start dfx with snapshot

### DIFF
--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -46,7 +46,7 @@ restore_backup() {
   sh "$RESTORE_BACKUP_SCRIPT_FILE"
 }
 
-# Restore the backup if the script fails or exists successfully.
+# Restore the backup if the script fails or exits successfully.
 trap restore_backup EXIT
 
 CLEAN_ARG=""

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -38,8 +38,6 @@ fi
 
 BACKUP_DIR="$HOME/dfx-state-backup-$(date +%s)"
 
-TOP_DIR=$(git rev-parse --show-toplevel)
-
 RESTORE_BACKUP_SCRIPT_FILE="$BACKUP_DIR/restore.sh"
 
 restore_backup() {

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Runs a local replica with state as saved by 
+  https://github.com/dfinity/snsdemo/blob/main/bin/dfx-state-save .
+  When the replica is stopped, the script restores original the state.
+
+  The script replaces existing dfx directories after moving them to a backup.
+  So if things go wrong this is potentially dangerous for your dfx state.
+  A restore scripts is placed in the backup directory, which might be helpful in
+  such cases.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=s long=snapshot desc="The snapshot .zip or .tar.xz file" variable=SNAPSHOT_ARCHIVE default="snapshot.tar.xz"
+clap.define short=c long=clean desc="Extract a clean state from the .zip file, even if a directory with extracted state exists" variable=CLEAN nargs=0 default="false"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# The $() causes an extra entry in the output of `ps` so without any other script
+# running, this will be 2.
+# We use `ps` because pgrep doesn't include shell scripts.
+# shellcheck disable=SC2009
+SCRIPT_COUNT="$(ps -A -o command | grep -c "^bash .*$(basename "$0")")"
+
+if pgrep replica || [ "$SCRIPT_COUNT" -gt 2 ]; then
+  echo "ERROR: There is already a replica running. Please stop it first."
+  exit 1
+fi
+
+BACKUP_DIR="$HOME/dfx-state-backup-$(date +%s)"
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+RESTORE_BACKUP_SCRIPT_FILE="$BACKUP_DIR/restore.sh"
+
+restore_backup() {
+  sh "$RESTORE_BACKUP_SCRIPT_FILE"
+}
+
+# Restore the backup if the script fails or exists successfully.
+trap restore_backup EXIT
+
+CLEAN_ARG=""
+if [ "$CLEAN" != "false" ]; then
+  CLEAN_ARG="--clean"
+fi
+
+"$SOURCE_DIR/dfx-snapshot-install" --backup-dir "$BACKUP_DIR" --snapshot "$SNAPSHOT_ARCHIVE" "$CLEAN_ARG"
+
+# Change to $HOME to avoid using nns-dapp dfx.json.
+cd "$HOME"
+echo "*********************************************************************"
+echo "*                                                                   *"
+echo "*  If the state was generated on a different type of machine, then  *"
+echo "*  starting the replica may just hang after a panic.                *"
+echo "*                                                                   *"
+echo "*********************************************************************"
+dfx start
+
+# The trap set above will restore the state before this script exits.


### PR DESCRIPTION
# Motivation

We have `scripts/dev-local-state.sh` which starts a replica (`dfx start`) *and* the frontend (`npm run dev`) with a given snapshot. I originally thought this would be convenient but it hasn't been for 2 reasons:
1. `npm ci` often causes the vite server to kill itself. This then makes the script also kill the replica, which is unnecessary.
2. Some scripts (e.g. in snsdemo) run a replica and start by killing any existing running replicas. Because `dev-local-state.sh` runs the replica in the background, it doesn't notice that it's killed and then it doesn't get an opportunity to restore the state.

# Changes

Add `scripts/dfx-snapshot-start` which is just like [dev-local-state.sh](https://github.com/dfinity/nns-dapp/blob/main/scripts/dev-local-state.sh) but it runs `dfx start` in the foreground instead of the background, and doesn't run `npm run dev`.



# Tests

Ran the script manually.