### PR TITLE
No reload of the transactions for withdrawal account

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -18,6 +18,7 @@
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
   import {
     convertCkBTCToBtc,
+    type ConvertCkBTCToBtcParams,
     retrieveBtc,
   } from "$lib/services/ckbtc-convert.services";
   import BitcoinEstimatedFee from "$lib/components/accounts/BitcoinEstimatedFee.svelte";
@@ -106,16 +107,20 @@
 
     const updateProgress = (step: ConvertBtcStep) => (progressStep = step);
 
-    const convert = withdrawalAccount ? retrieveBtc : convertCkBTCToBtc;
-
-    const { success } = await convert({
-      ...(!withdrawalAccount && { source: sourceAccount }),
+    const params: ConvertCkBTCToBtcParams = {
       destinationAddress,
       amount,
       universeId,
       canisters,
       updateProgress,
-    });
+    };
+
+    const { success } = withdrawalAccount
+      ? await retrieveBtc(params)
+      : await convertCkBTCToBtc({
+          source: sourceAccount,
+          ...params,
+        });
 
     if (success) {
       toastsSuccess({

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -109,7 +109,7 @@
     const convert = withdrawalAccount ? retrieveBtc : convertCkBTCToBtc;
 
     const { success } = await convert({
-      source: sourceAccount,
+      ...(!withdrawalAccount && { source: sourceAccount }),
       destinationAddress,
       amount,
       universeId,

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -22,7 +22,10 @@ import { ckBTCTransferTokens } from "./ckbtc-accounts.services";
 import { loadCkBTCAccountTransactions } from "./ckbtc-transactions.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
 
-export type ConvertCkBTCToBtcParams = IcrcTransferTokensUserParams & {
+export type ConvertCkBTCToBtcParams = Omit<
+  IcrcTransferTokensUserParams,
+  "source"
+> & {
   universeId: UniverseCanisterId;
   canisters: CkBTCAdditionalCanisters;
   updateProgress: (step: ConvertBtcStep) => void;
@@ -43,7 +46,8 @@ export const convertCkBTCToBtc = async ({
   universeId,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
-}: ConvertCkBTCToBtcParams): Promise<{
+}: ConvertCkBTCToBtcParams &
+  Pick<IcrcTransferTokensUserParams, "source">): Promise<{
   success: boolean;
 }> => {
   updateProgress(ConvertBtcStep.INITIALIZATION);
@@ -104,7 +108,7 @@ export const retrieveBtc = async ({
   universeId,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
-}: Omit<ConvertCkBTCToBtcParams, "source">): Promise<{
+}: ConvertCkBTCToBtcParams): Promise<{
   success: boolean;
 }> => {
   updateProgress(ConvertBtcStep.INITIALIZATION);

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -101,11 +101,10 @@ export const convertCkBTCToBtc = async ({
 export const retrieveBtc = async ({
   destinationAddress,
   amount,
-  source,
   universeId,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
-}: ConvertCkBTCToBtcParams): Promise<{
+}: Omit<ConvertCkBTCToBtcParams, "source">): Promise<{
   success: boolean;
 }> => {
   updateProgress(ConvertBtcStep.INITIALIZATION);
@@ -113,7 +112,6 @@ export const retrieveBtc = async ({
   return await retrieveBtcAndReload({
     destinationAddress,
     amount,
-    source,
     universeId,
     canisters: { minterCanisterId, indexCanisterId },
     updateProgress,
@@ -128,12 +126,13 @@ const retrieveBtcAndReload = async ({
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
   blockIndex,
-}: IcrcTransferTokensUserParams & {
-  universeId: UniverseCanisterId;
-  canisters: CkBTCAdditionalCanisters;
-  updateProgress: (step: ConvertBtcStep) => void;
-  blockIndex?: bigint;
-}): Promise<{
+}: Omit<IcrcTransferTokensUserParams, "source"> &
+  Partial<Pick<IcrcTransferTokensUserParams, "source">> & {
+    universeId: UniverseCanisterId;
+    canisters: CkBTCAdditionalCanisters;
+    updateProgress: (step: ConvertBtcStep) => void;
+    blockIndex?: bigint;
+  }): Promise<{
   success: boolean;
 }> => {
   updateProgress(ConvertBtcStep.SEND_BTC);
@@ -160,14 +159,18 @@ const retrieveBtcAndReload = async ({
     updateProgress(ConvertBtcStep.RELOAD);
 
     // Reload:
-    // - the transactions of the account for which the transfer was executed
+    // - if provided, the transactions of the account for which the transfer was executed
     // - the balance of the withdrawal account to display an information if some funds - from this transaction or another - are stuck and not been converted yet
     await Promise.all([
-      loadCkBTCAccountTransactions({
-        account: source,
-        canisterId: universeId,
-        indexCanisterId,
-      }),
+      ...(nonNullish(source)
+        ? [
+            loadCkBTCAccountTransactions({
+              account: source,
+              canisterId: universeId,
+              indexCanisterId,
+            }),
+          ]
+        : []),
       loadCkBTCWithdrawalAccount({
         universeId,
       }),

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -309,7 +309,7 @@ describe("ckbtc-convert-services", () => {
       });
 
       // We only test that the call is made here. Test should be covered by its respective service.
-      expect(loadCkBTCAccountTransactions).toBeCalled();
+      expect(loadCkBTCAccountTransactions).not.toBeCalled();
       expect(loadCkBTCWithdrawalAccount).toBeCalled();
 
       // SEND_BTC + RELOAD + DONE
@@ -336,17 +336,25 @@ describe("ckbtc-convert-services", () => {
       expect(updateProgressSpy).toBeCalledTimes(3);
     });
 
-    it("should reload transaction and withdrawal account on retrieve btc success", async () => {
+    it("should reload withdrawal account on retrieve btc success", async () => {
       await retrieveBtc({
         ...params,
         updateProgress: jest.fn(),
       });
 
-      expect(loadCkBTCAccountTransactions).toBeCalled();
       expect(loadCkBTCWithdrawalAccount).toBeCalled();
     });
 
-    it("should reload transaction and withdrawal account on retrieve btc error too", async () => {
+    it("should not reload transaction on retrieve btc success", async () => {
+      await retrieveBtc({
+        ...params,
+        updateProgress: jest.fn(),
+      });
+
+      expect(loadCkBTCAccountTransactions).not.toBeCalled();
+    });
+
+    it("should reload withdrawal account on retrieve btc error too", async () => {
       minterCanisterMock.retrieveBtc.mockImplementation(async () => {
         throw new Error();
       });
@@ -356,8 +364,20 @@ describe("ckbtc-convert-services", () => {
         updateProgress: jest.fn(),
       });
 
-      expect(loadCkBTCAccountTransactions).toBeCalled();
       expect(loadCkBTCWithdrawalAccount).toBeCalled();
+    });
+
+    it("should not reload transaction on retrieve btc error too", async () => {
+      minterCanisterMock.retrieveBtc.mockImplementation(async () => {
+        throw new Error();
+      });
+
+      await retrieveBtc({
+        ...params,
+        updateProgress: jest.fn(),
+      });
+
+      expect(loadCkBTCAccountTransactions).not.toBeCalled();
     });
   });
 });


### PR DESCRIPTION
# Motivation

When ckBTC are converted to BTC from the withdrawal account, it does not make much sense to reload the related transactions as these are nowhere used in NNS-dapp.

# Changes

- on `retrieveBTC` from withdrawal account, skip reload of the transactions.
