### PR TITLE
Cleanup: Remove old methods from accountsStore

### DIFF
--- a/frontend/src/lib/stores/accounts.store.ts
+++ b/frontend/src/lib/stores/accounts.store.ts
@@ -37,21 +37,9 @@ export interface AccountsStore extends Readable<AccountsStoreData> {
     strategy?: QueryAndUpdateStrategy | undefined
   ) => SingleMutationAccountsStore;
   resetForTesting: () => void;
-  // Temporary for backwards compatibility
-  // TODO: Remove.
-  set: (data: AccountsStoreData) => void;
-  // Temporary for backwards compatibility
-  // TODO: Remove.
-  setBalance: ({
-    accountIdentifier,
-    balanceE8s,
-  }: {
-    accountIdentifier: string;
-    balanceE8s: bigint;
-  }) => void;
-  // Temporary for backwards compatibility
-  // TODO: Remove.
-  reset: () => void;
+  // Set the store contents if you don't care about the queryAndUpdate race
+  // condition.
+  setForTesting: (data: AccountsStoreData) => void;
 }
 
 /**
@@ -124,35 +112,9 @@ const initAccountsStore = (): AccountsStore => {
     getSingleMutationAccountsStore,
     resetForTesting,
 
-    // Temporary for backwards compatibility
-    // TODO: Remove.
-    set(accounts: AccountsStoreData) {
+    setForTesting(accounts: AccountsStoreData) {
       const mutableStore = getSingleMutationAccountsStore();
       mutableStore.set(accounts);
-    },
-
-    // Temporary for backwards compatibility
-    // TODO: Remove.
-    setBalance({
-      accountIdentifier,
-      balanceE8s,
-    }: {
-      accountIdentifier: string;
-      balanceE8s: bigint;
-    }) {
-      const mutableStore = getSingleMutationAccountsStore();
-      mutableStore.setBalance({
-        accountIdentifier,
-        balanceE8s,
-        certified: true,
-      });
-    },
-
-    // Temporary for backwards compatibility
-    // TODO: Remove.
-    reset() {
-      const mutableStore = getSingleMutationAccountsStore();
-      mutableStore.set(initialAccounts);
     },
   };
 };

--- a/frontend/src/tests/lib/components/accounts/SelectAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccount.spec.ts
@@ -14,6 +14,10 @@ import en from "$tests/mocks/i18n.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("SelectAccount", () => {
+  beforeEach(() => {
+    accountsStore.resetForTesting();
+  });
+
   it("should render a skeleton-card until accounts loaded", () => {
     const { container } = render(SelectAccount);
 
@@ -63,7 +67,7 @@ describe("SelectAccount", () => {
   });
 
   it("should render a title with subaccount", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,
@@ -78,12 +82,10 @@ describe("SelectAccount", () => {
     await waitFor(() =>
       expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
     );
-
-    accountsStore.reset();
   });
 
   it("should render a title with hardware wallet", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: [mockSubAccount],
@@ -98,12 +100,10 @@ describe("SelectAccount", () => {
     await waitFor(() =>
       expect(queryByText(en.accounts.my_accounts)).toBeInTheDocument()
     );
-
-    accountsStore.reset();
   });
 
   it("should not render a title with hardware wallet if these kind of accounts should be hidden", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: [mockSubAccount],
@@ -117,12 +117,10 @@ describe("SelectAccount", () => {
     });
 
     expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
-
-    accountsStore.reset();
   });
 
   it("should render no title if no accounts listed", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: undefined,
@@ -135,8 +133,6 @@ describe("SelectAccount", () => {
     });
 
     expect(queryByText(en.accounts.my_accounts)).not.toBeInTheDocument();
-
-    accountsStore.reset();
   });
 
   it("should filter an account for a given identifier", () => {

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -20,14 +20,11 @@ describe("SelectAccountDropdown", () => {
   describe("no accounts", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-    afterEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
     });
 
     const props = { rootCanisterId: OWN_CANISTER_ID };
     it("should render spinner", () => {
-      accountsStore.reset();
       const { getByTestId } = render(SelectAccountDropdown, { props });
 
       expect(getByTestId("spinner")).toBeInTheDocument();
@@ -43,7 +40,7 @@ describe("SelectAccountDropdown", () => {
     const hardwareWallets = [mockHardwareWalletAccount];
 
     beforeEach(() => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts,
         hardwareWallets,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -28,7 +28,7 @@ describe("DisburseButton", () => {
 
   it("opens disburse nns neuron modal", async () => {
     // To avoid that the modal requests the accounts
-    accountsStore.set(mockAccountsStoreData);
+    accountsStore.setForTesting(mockAccountsStoreData);
     const { container, queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -29,7 +29,7 @@ describe("NnsIncreaseStakeButton", () => {
 
   it("opens Increase Neuron Stake Modal", async () => {
     // To avoid that the modal requests the accounts
-    accountsStore.set(mockAccountsStoreData);
+    accountsStore.setForTesting(mockAccountsStoreData);
     const { container } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
@@ -53,7 +53,7 @@ describe("NnsNeurons", () => {
 
     it("should open stake neuron modal", async () => {
       // To avoid that the modal requests the accounts
-      accountsStore.set(mockAccountsStoreData);
+      accountsStore.setForTesting(mockAccountsStoreData);
       const { queryByTestId, queryByText, getByTestId } =
         render(NnsNeuronsFooter);
 

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -103,7 +103,7 @@ describe("ParticipateButton", () => {
 
       // When the modal appears, it will trigger `pollAccounts`
       // which trigger api calls if accounts are not loaded.
-      accountsStore.set(mockAccountsStoreData);
+      accountsStore.setForTesting(mockAccountsStoreData);
 
       const { getByTestId } = renderContextCmp({
         summary: mockSnsFullProject.summary,

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -10,7 +10,7 @@ import { get } from "svelte/store";
 describe("accounts", () => {
   describe("nnsAccountsListStore", () => {
     it("returns nns accounts in an array", () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSnsMainAccount],
         hardwareWallets: [],

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -18,7 +18,7 @@ import { get } from "svelte/store";
 
 describe("universes-accounts", () => {
   it("should derive Nns accounts", () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],
@@ -61,7 +61,7 @@ describe("universes-accounts", () => {
   });
 
   it("should derive all accounts", () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -73,7 +73,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should render a dropdown to select account", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: undefined,
@@ -89,7 +89,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should select account", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -53,7 +53,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -143,7 +143,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts store is empty", () => {
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
     });
     it("should fetch accounts and render account selector", async () => {
       const mainBalanceE8s = BigInt(10_000_000);
@@ -167,7 +167,7 @@ describe("DisburseNnsNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -63,7 +63,7 @@ describe("IncreaseNeuronStakeModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      accountsStore.set(mockAccountsStoreData);
+      accountsStore.setForTesting(mockAccountsStoreData);
     });
 
     it("should call top up neuron", async () => {

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -56,7 +56,7 @@ describe("MergeNeuronsModal", () => {
     neurons: NeuronInfo[],
     hardwareWalletAccounts: Account[] = []
   ): Promise<RenderResult<SvelteComponent>> => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       hardwareWallets: hardwareWalletAccounts,
     });
@@ -83,7 +83,7 @@ describe("MergeNeuronsModal", () => {
 
     afterEach(() => {
       jest.clearAllMocks();
-      accountsStore.reset();
+      accountsStore.resetForTesting();
     });
 
     it("renders title", async () => {

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -31,7 +31,7 @@ describe("SpawnNeuronModal", () => {
   };
 
   beforeAll(() =>
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     })

--- a/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
@@ -96,7 +96,7 @@ describe("StakeNeuronModal", () => {
     const newBalanceE8s = BigInt(10_000_000);
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      accountsStore.set({
+      accountsStore.setForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -403,7 +403,7 @@ describe("StakeNeuronModal", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       neuronsStore.setNeurons({ neurons: [], certified: true });
-      accountsStore.set({
+      accountsStore.setForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -521,7 +521,7 @@ describe("StakeNeuronModal", () => {
   describe("when accounts are not loaded", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       const mainBalanceE8s = BigInt(10_000_000);
       jest
         .spyOn(ledgerApi, "queryAccountBalance")
@@ -546,7 +546,7 @@ describe("StakeNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -117,8 +117,8 @@ describe("ParticipateSwapModal", () => {
 
   describe("when accounts are available", () => {
     beforeEach(() => {
-      accountsStore.reset();
-      accountsStore.set(mockAccountsStoreData);
+      accountsStore.resetForTesting();
+      accountsStore.setForTesting(mockAccountsStoreData);
     });
 
     const participate = async ({
@@ -253,7 +253,7 @@ describe("ParticipateSwapModal", () => {
     let queryAccountSpy: jest.SpyInstance;
     let queryAccountBalanceSpy: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -290,7 +290,7 @@ describe("ParticipateSwapModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -33,7 +33,7 @@ describe("NnsAccounts", () => {
 
   describe("when there are accounts", () => {
     beforeEach(() => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [],
         hardwareWallets: [],
@@ -66,7 +66,7 @@ describe("NnsAccounts", () => {
     });
 
     it("should render subaccount cards", () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [],
@@ -83,7 +83,7 @@ describe("NnsAccounts", () => {
     });
 
     it("should render hardware wallet account cards", () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -103,7 +103,7 @@ describe("NnsAccounts", () => {
   describe("summary", () => {
     beforeAll(() => {
       jest.clearAllMocks();
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -120,7 +120,7 @@ describe("NnsAccounts", () => {
 
   describe("when no accounts", () => {
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       const mainBalanceE8s = BigInt(10_000_000);
       jest
         .spyOn(ledgerApi, "queryAccountBalance")
@@ -150,7 +150,7 @@ describe("NnsAccounts", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -80,7 +80,7 @@ describe("NnsWallet", () => {
   describe("no accounts", () => {
     beforeEach(() => {
       cancelPollAccounts();
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest
         .spyOn(nnsDappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
@@ -124,7 +124,7 @@ describe("NnsWallet", () => {
   describe("accounts loaded", () => {
     beforeAll(() => {
       jest.clearAllMocks();
-      accountsStore.set(mockAccountsStoreData);
+      accountsStore.setForTesting(mockAccountsStoreData);
     });
 
     it("should render nns project name", async () => {
@@ -225,7 +225,7 @@ describe("NnsWallet", () => {
 
   describe("accounts loaded (Hardware Wallet)", () => {
     beforeEach(() => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -253,7 +253,7 @@ describe("NnsWallet", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -88,7 +88,7 @@ describe("Accounts", () => {
       accounts: [mockSnsMainAccount],
     });
 
-    accountsStore.set(mockAccountsStoreData);
+    accountsStore.setForTesting(mockAccountsStoreData);
   });
 
   it("should render NnsAccounts by default", () => {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -43,7 +43,7 @@ describe("Wallet", () => {
         lifecycle: SnsSwapLifecycle.Committed,
       })
     );
-    accountsStore.set(mockAccountsStoreData);
+    accountsStore.setForTesting(mockAccountsStoreData);
   });
 
   beforeAll(() =>

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -414,7 +414,7 @@ describe("accounts-services", () => {
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       expect(get(accountsStore).main.balance).toEqual(mockMainAccount.balance);
@@ -445,7 +445,7 @@ describe("accounts-services", () => {
           }
           throw new Error("test");
         });
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -459,7 +459,7 @@ describe("accounts-services", () => {
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockRejectedValue(error);
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -657,7 +657,7 @@ describe("accounts-services", () => {
     });
 
     it("should sync destination balances after transfer ICP to own account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -851,18 +851,17 @@ describe("accounts-services", () => {
 
   describe("getAccountIdentity", () => {
     it("returns user identity if main account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentity(
         mockMainAccount.identifier
       );
       expect(expectedIdentity).toBe(mockIdentity);
-      accountsStore.reset();
     });
 
     it("returns user identity if main account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -870,11 +869,10 @@ describe("accounts-services", () => {
         mockMainAccount.identifier
       );
       expect(expectedIdentity).toBe(mockIdentity);
-      accountsStore.reset();
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -884,24 +882,22 @@ describe("accounts-services", () => {
       );
       expect(expectedIdentity).toBe(mockIdentity);
       expect(getLedgerIdentityProxy).toBeCalled();
-      accountsStore.reset();
     });
   });
 
   describe("getAccountIdentityByPrincipal", () => {
     it("returns user identity if main account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentityByPrincipal(
         mockMainAccount.principal?.toText() as string
       );
       expect(expectedIdentity).toBe(mockIdentity);
-      accountsStore.reset();
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -911,11 +907,10 @@ describe("accounts-services", () => {
       );
       expect(expectedIdentity).toBe(mockIdentity);
       expect(getLedgerIdentityProxy).toBeCalled();
-      accountsStore.reset();
     });
 
     it("returns null if no main account nor hardware wallet account", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -923,7 +918,6 @@ describe("accounts-services", () => {
         "gje2w-p7x7x-yuy72-bllam-x2itq-znokr-jnvf6-5dzn4-45jiy-5wvbo-uqe"
       );
       expect(expectedIdentity).toBeUndefined();
-      accountsStore.reset();
     });
   });
 
@@ -943,7 +937,7 @@ describe("accounts-services", () => {
     };
 
     beforeEach(() => {
-      accountsStore.reset();
+      accountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -21,7 +21,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
     });
     const neuron = {
@@ -41,7 +41,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy with message if neuron controlled by hardware wallet", async () => {
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -209,7 +209,7 @@ describe("neurons-services", () => {
     spyGetNeuron.mockClear();
     jest.clearAllMocks();
     neuronsStore.reset();
-    accountsStore.reset();
+    accountsStore.resetForTesting();
     resetIdentity();
     resetAccountIdentity();
     toastsStore.reset();
@@ -826,7 +826,7 @@ describe("neurons-services", () => {
         ...mockHardwareWalletAccount,
         principal: smallerVersionIdentity.getPrincipal(),
       };
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [hwAccount],
       });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -144,7 +144,7 @@ describe("sns-api", () => {
     jest.clearAllMocks();
 
     snsTicketsStore.reset();
-    accountsStore.reset();
+    accountsStore.resetForTesting();
 
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNotifyPaymentFailureApi.mockResolvedValue(undefined);
@@ -935,7 +935,7 @@ describe("sns-api", () => {
       jest.useFakeTimers().setSystemTime(now);
     });
     it("should call postprocess and APIs", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
@@ -962,7 +962,7 @@ describe("sns-api", () => {
     });
 
     it("should update account's balance in the store", async () => {
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
@@ -990,7 +990,7 @@ describe("sns-api", () => {
         owner: mockIdentity.getPrincipal(),
         subaccount: arrayOfNumberToUint8Array(mockSubAccount.subAccount),
       });
-      accountsStore.set({
+      accountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -47,7 +47,7 @@ describe("Accounts", () => {
 
   it("should create a subaccount in NNS", async () => {
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-    accountsStore.set({
+    accountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/2445 introduced a new interface for the `accountsStore`.
It kept the old interface temporarily for backwards compatibility so we didn't have to update all the existing tests in the same PR.
This PR removes the old interface.

# Changes

1. Remove `set`, `setBalance` and `reset` from `accountsStre`.
2. Add `setForTesting` to be used by tests only.
3. Update tests to use `setForTesting` and `resetForTesting`.
4. (Re)move a few occasional cleanups from tests/afterEach to beforeEach.

# Tests

`npm run test`
