### PR TITLE
feat: bind snsProposalStore

### DIFF
--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -25,6 +25,7 @@ import type { SelectedProposalStore } from "$lib/types/selected-proposal.context
 import type { SelectedSnsNeuronStore } from "$lib/types/sns-neuron-detail.context";
 import type { WalletStore } from "$lib/types/wallet.context";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
+import type { SnsProposalData } from "@dfinity/sns";
 import {
   derived,
   readable,
@@ -83,6 +84,12 @@ const transactionsStore = writable<Transaction[] | undefined>(undefined);
 export const debugTransactions = (transactions: Transaction[] | undefined) => {
   transactionsStore.set(transactions);
 };
+const snsProposalStore = writable<SnsProposalData | undefined>(undefined);
+export const debugSnsProposalStore = (
+  proposal: SnsProposalData | undefined
+) => {
+  snsProposalStore.set(proposal);
+};
 
 /**
  * Collects state of all available stores (also from context)
@@ -115,6 +122,7 @@ export const initDebugStore = () =>
       snsProjectsStore,
       snsFunctionsStore,
       transactionsFeesStore,
+      snsProposalStore,
     ],
     ([
       $busyStore,
@@ -141,6 +149,7 @@ export const initDebugStore = () =>
       $projectsStore,
       $snsFunctionsStore,
       $transactionsFeesStore,
+      $snsProposalStore,
     ]) => ({
       busy: $busyStore,
       accounts: $accountsStore,
@@ -163,6 +172,7 @@ export const initDebugStore = () =>
       snsTransactions: $snsTransactionsStore,
       selectedSnsNeuron: $selectedSnsNeuronStore,
       transactions: $transactionsStore,
+      snsProposal: $snsProposalStore,
       projects: $projectsStore,
       snsFunctions: $snsFunctionsStore,
       transactionsFees: $transactionsFeesStore,

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -20,7 +20,7 @@
   import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { snsProposalIdString } from "$lib/utils/sns-proposals.utils";
   import { authSignedInStore } from "$lib/derived/auth.derived";
-    import { debugSnsProposalStore } from "../derived/debug.derived";
+  import { debugSnsProposalStore } from "../derived/debug.derived";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -42,7 +42,7 @@
   const setProposal = (value: typeof proposal) => {
     proposal = value;
     debugSnsProposalStore(value);
-  }
+  };
 
   const goBack = async (
     universe: UniverseCanisterIdText | undefined

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -20,6 +20,7 @@
   import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { snsProposalIdString } from "$lib/utils/sns-proposals.utils";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+    import { debugSnsProposalStore } from "../derived/debug.derived";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -37,6 +38,11 @@
   // TODO: Use proposal to render the component.
   let proposal: SnsProposalData | undefined;
   let updating = false;
+
+  const setProposal = (value: typeof proposal) => {
+    proposal = value;
+    debugSnsProposalStore(value);
+  }
 
   const goBack = async (
     universe: UniverseCanisterIdText | undefined
@@ -90,7 +96,7 @@
         if (snsProposalIdString(proposalData) !== proposalIdText) {
           return;
         }
-        proposal = proposalData;
+        setProposal(proposalData);
       },
       handleError: () => goBack(universeCanisterIdAtTimeOfRequest),
       reloadForBallots,
@@ -134,7 +140,7 @@
       }
     } else {
       // Reset proposal to the initial state.
-      proposal = undefined;
+      setProposal(undefined);
     }
   };
 


### PR DESCRIPTION
# Motivation

Add selected sns proposal to the debug store. Otherwise there is currently no another way to see the sns proposal details.

# Changes

- new debug store `snsProposalStore`

# Screenshot

<img width="599" alt="image" src="https://user-images.githubusercontent.com/98811342/236848574-41f062c6-33ac-42e4-a36f-0d25902991e0.png">
