### PR TITLE
Height decimals on transaction review

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-05-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-05.1.tgz",
-      "integrity": "sha512-cmgmqaQ11pCZ6OfM9/VyQxqr0SsIC+wr9pnB6dJB9l2F7OBWCGMc8V8o11WKQTNIn6GvtEIx60OUPAfZNAoVhw==",
+      "version": "2.6.0-next-2023-05-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-09.1.tgz",
+      "integrity": "sha512-y+suvtmhgxuerbkwbESw9w9mkHS7t4rq78ZTu36cwc3CoByFSiGhBaHqE4E/Y4hRbQr3PWtWHOayLXCz2F5LBQ==",
       "dependencies": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",
@@ -9940,9 +9940,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-05-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-05.1.tgz",
-      "integrity": "sha512-cmgmqaQ11pCZ6OfM9/VyQxqr0SsIC+wr9pnB6dJB9l2F7OBWCGMc8V8o11WKQTNIn6GvtEIx60OUPAfZNAoVhw==",
+      "version": "2.6.0-next-2023-05-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-05-09.1.tgz",
+      "integrity": "sha512-y+suvtmhgxuerbkwbESw9w9mkHS7t4rq78ZTu36cwc3CoByFSiGhBaHqE4E/Y4hRbQr3PWtWHOayLXCz2F5LBQ==",
       "requires": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
@@ -48,7 +48,9 @@
   </p>
 
   <p class="no-margin" data-tid="bitcoin-estimated-fee">
-    <span class="value">{formatEstimatedFee(bitcoinEstimatedFee)}</span>
+    <span class="value tabular-num"
+      >{formatEstimatedFee(bitcoinEstimatedFee)}</span
+    >
     <span class="label">{$i18n.ckbtc.btc}</span>
   </p>
 {/if}

--- a/frontend/src/lib/components/accounts/BitcoinFeeDisplay.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinFeeDisplay.svelte
@@ -11,7 +11,7 @@
 {#if nonNullish(fee)}
   <KeyValuePair {testId}>
     <span class="label" slot="key"><slot /></span>
-    <span class="value num" slot="value">
+    <span class="value tabular-num" slot="value">
       {formatEstimatedFee(fee)}
       <span class="label">{$i18n.ckbtc.btc}</span>
     </span>

--- a/frontend/src/lib/components/accounts/BitcoinFeeDisplay.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinFeeDisplay.svelte
@@ -11,7 +11,7 @@
 {#if nonNullish(fee)}
   <KeyValuePair {testId}>
     <span class="label" slot="key"><slot /></span>
-    <span class="value" slot="value">
+    <span class="value num" slot="value">
       {formatEstimatedFee(fee)}
       <span class="label">{$i18n.ckbtc.btc}</span>
     </span>

--- a/frontend/src/lib/components/accounts/BitcoinKYTFee.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinKYTFee.svelte
@@ -37,7 +37,7 @@
   </p>
 
   <p class="no-margin" data-tid="kyt-estimated-fee">
-    <span class="value">{formatEstimatedFee(kytFee)}</span>
+    <span class="value tabular-num">{formatEstimatedFee(kytFee)}</span>
     <span class="label">{$i18n.ckbtc.btc}</span>
   </p>
 {/if}

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -12,7 +12,7 @@
   export let text = false;
   export let inheritSize = false;
   export let sign: "+" | "-" | "" = "";
-  export let detailed = false;
+  export let detailed: boolean | "height_decimals" = false;
 </script>
 
 <div
@@ -25,7 +25,10 @@
   class:plus-sign={sign === "+"}
   data-tid="token-value-label"
 >
-  <span data-tid="token-value" class="value"
+  <span
+    data-tid="token-value"
+    class="value"
+    class:num={detailed === "height_decimals"}
     >{`${sign}${formatToken({ value: amount.toE8s(), detailed })}`}</span
   >
   <span class="label">{label !== undefined ? label : amount.token.symbol}</span>

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -28,7 +28,7 @@
   <span
     data-tid="token-value"
     class="value"
-    class:num={detailed === "height_decimals"}
+    class:tabular-num={detailed === "height_decimals"}
     >{`${sign}${formatToken({ value: amount.toE8s(), detailed })}`}</span
   >
   <span class="label">{label !== undefined ? label : amount.token.symbol}</span>

--- a/frontend/src/lib/components/transaction/TransactionFormFee.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormFee.svelte
@@ -11,7 +11,13 @@
     <slot name="label">{$i18n.accounts.transaction_fee}</slot>
   </p>
 
-  <p class="no-margin"><AmountDisplay amount={transactionFee} singleLine /></p>
+  <p class="no-margin">
+    <AmountDisplay
+      amount={transactionFee}
+      singleLine
+      detailed="height_decimals"
+    />
+  </p>
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionReceivedTokenAmount.svelte
@@ -18,7 +18,7 @@
   </p>
 
   <p class="no-margin" data-tid={testId} class:estimation>
-    <AmountDisplay inline detailed {amount} />
+    <AmountDisplay inline detailed="height_decimals" {amount} />
   </p>
 </div>
 

--- a/frontend/src/lib/components/transaction/TransactionSource.svelte
+++ b/frontend/src/lib/components/transaction/TransactionSource.svelte
@@ -20,7 +20,12 @@
 
 <KeyValuePair>
   <span class="label" slot="key">{$i18n.accounts.balance}</span>
-  <AmountDisplay slot="value" singleLine detailed amount={account.balance} />
+  <AmountDisplay
+    slot="value"
+    singleLine
+    detailed="height_decimals"
+    amount={account.balance}
+  />
 </KeyValuePair>
 
 <style lang="scss">

--- a/frontend/src/lib/components/transaction/TransactionSummary.svelte
+++ b/frontend/src/lib/components/transaction/TransactionSummary.svelte
@@ -39,20 +39,34 @@
 <article class="container">
   <KeyValuePair testId="transaction-summary-sending-amount">
     <span class="label" slot="key">{$i18n.accounts.sending_amount}</span>
-    <AmountDisplay slot="value" singleLine detailed amount={tokenAmount} />
+    <AmountDisplay
+      slot="value"
+      singleLine
+      detailed="height_decimals"
+      amount={tokenAmount}
+    />
   </KeyValuePair>
 
   {#if showLedgerFee}
     <KeyValuePair testId="transaction-summary-fee">
       <span class="label" slot="key">{ledgerFeeLabel}</span>
-      <AmountDisplay slot="value" singleLine detailed amount={transactionFee} />
+      <AmountDisplay
+        slot="value"
+        singleLine
+        detailed="height_decimals"
+        amount={transactionFee}
+      />
     </KeyValuePair>
 
     <div class="deducted" data-tid="transaction-summary-total-deducted">
       <p class="label subtitle">{$i18n.accounts.total_deducted}</p>
 
       <p>
-        <AmountDisplay inline detailed amount={tokenTotalDeducted} />
+        <AmountDisplay
+          inline
+          detailed="height_decimals"
+          amount={tokenTotalDeducted}
+        />
       </p>
     </div>
   {/if}

--- a/frontend/src/lib/constants/icp.constants.ts
+++ b/frontend/src/lib/constants/icp.constants.ts
@@ -4,6 +4,8 @@ export const ONE_TRILLION = 1_000_000_000_000;
 
 export const ICP_DISPLAYED_DECIMALS = 2;
 
+export const ICP_DISPLAYED_HEIGHT_DECIMALS = 8;
+
 /**
  * TODO: remove and replace with Icrc "decimals"
  * @deprecated use decimals in IcrcTokenMetadata

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -2,6 +2,7 @@ import {
   E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
   ICP_DISPLAYED_DECIMALS_DETAILED,
+  ICP_DISPLAYED_HEIGHT_DECIMALS,
 } from "$lib/constants/icp.constants";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 
@@ -19,25 +20,34 @@ const countDecimals = (value: number): number => {
  * - ICP with round number (12.0) should be displayed 12.00
  * - ICP should be displayed with max. 2 decimals (12.1 → 12.10, 12.12353 → 12.12, 12.00003 → 12.00) in Accounts, but with up to 8 decimals without tailing 0s in transaction details.
  * - However, if ICP value is lower than 0.01 then it should be as it is without tailing 0s up to 8 decimals (e.g., 0.000003 is displayed as 0.000003)
+ *
+ * Jira GIX-1563:
+ * - However, if requested, some amount might be displayed with a fix length of 8 decimals, regardless if leading zero or no leading zero
  */
 export const formatToken = ({
   value,
   detailed = false,
 }: {
   value: bigint;
-  detailed?: boolean;
+  detailed?: boolean | "height_decimals";
 }): string => {
   if (value === BigInt(0)) {
     return "0";
   }
 
   const converted = Number(value) / E8S_PER_ICP;
-  const decimals: number =
+
+  const decimalsICP = (): number =>
     converted < 0.01
       ? Math.max(countDecimals(converted), ICP_DISPLAYED_DECIMALS)
       : detailed
       ? Math.min(countDecimals(converted), ICP_DISPLAYED_DECIMALS_DETAILED)
       : ICP_DISPLAYED_DECIMALS;
+
+  const decimals =
+    detailed === "height_decimals"
+      ? ICP_DISPLAYED_HEIGHT_DECIMALS
+      : decimalsICP();
 
   return new Intl.NumberFormat("en-US", {
     minimumFractionDigits: decimals,

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -5,6 +5,7 @@
 import BitcoinEstimatedAmountReceived from "$lib/components/accounts/BitcoinEstimatedAmountReceived.svelte";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
+import { formatToken } from "$lib/utils/token.utils";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 
@@ -122,7 +123,10 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
     expect((element?.textContent ?? "").trim()).toEqual(
-      `${formatEstimatedFee(0n)} ${en.ckbtc.btc}`
+      `${formatToken({
+        value: 0n,
+        detailed: "height_decimals",
+      })} ${en.ckbtc.btc}`
     );
   });
 
@@ -138,7 +142,10 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
     expect((element?.textContent ?? "").trim()).toEqual(
-      `${formatEstimatedFee(0n)} ${en.ckbtc.btc}`
+      `${formatToken({
+        value: 0n,
+        detailed: "height_decimals",
+      })} ${en.ckbtc.btc}`
     );
   });
 
@@ -154,7 +161,10 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
 
-    const resultBtc = `${formatEstimatedFee(987_000n)} ${en.ckbtc.btc}`;
+    const resultBtc = `${formatToken({
+      value: 987_000n,
+      detailed: "height_decimals",
+    })} ${en.ckbtc.btc}`;
     expect(element?.textContent ?? "").toContain(resultBtc);
   });
 });

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedAmount.spec.ts
@@ -15,7 +15,7 @@ describe("TransactionReceivedAmount", () => {
 
     expect(
       getByTestId("transaction-summary-total-received")?.textContent.trim()
-    ).toEqual("123.567 ICP");
+    ).toEqual("123.56700000 ICP");
   });
 
   it("should render ckBTC amount", () => {
@@ -25,6 +25,6 @@ describe("TransactionReceivedAmount", () => {
 
     expect(
       getByTestId("transaction-summary-total-received")?.textContent.trim()
-    ).toEqual(`123.567 ${mockCkBTCToken.symbol}`);
+    ).toEqual(`123.56700000 ${mockCkBTCToken.symbol}`);
   });
 });

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
@@ -20,7 +20,9 @@ describe("TransactionReceivedTokenAmount", () => {
     });
 
     expect(
-      getByText(formatToken({ value: amount.toE8s(), detailed: true }))
+      getByText(
+        formatToken({ value: amount.toE8s(), detailed: "height_decimals" })
+      )
     ).toBeInTheDocument();
 
     expect(getByText(amount.token.symbol)).toBeInTheDocument();

--- a/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
@@ -26,7 +26,7 @@ describe("TransactionSource", () => {
     expect(getByTestId("token-value")?.textContent ?? "").toEqual(
       `${formatToken({
         value: mockMainAccount.balance.toE8s(),
-        detailed: true,
+        detailed: "height_decimals",
       })}`
     );
   });

--- a/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
@@ -34,7 +34,9 @@ describe("TransactionSummary", () => {
 
     expect(block.textContent).toContain(en.accounts.sending_amount);
     expect(block.textContent).toContain(
-      `${formatToken({ value: e8s, detailed: true })} ${token.symbol}`
+      `${formatToken({ value: e8s, detailed: "height_decimals" })} ${
+        token.symbol
+      }`
     );
   });
 
@@ -51,9 +53,10 @@ describe("TransactionSummary", () => {
 
     expect(block.textContent).toContain(label);
     expect(block.textContent).toContain(
-      `${formatToken({ value: transactionFee.toE8s(), detailed: true })} ${
-        token.symbol
-      }`
+      `${formatToken({
+        value: transactionFee.toE8s(),
+        detailed: "height_decimals",
+      })} ${token.symbol}`
     );
   });
 
@@ -68,7 +71,7 @@ describe("TransactionSummary", () => {
     expect(block.textContent).toContain(
       `${formatToken({
         value: e8s + transactionFee.toE8s(),
-        detailed: true,
+        detailed: "height_decimals",
       })} ${token.symbol}`
     );
   });

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -10,7 +10,7 @@ import { authStore } from "$lib/stores/auth.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
-import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
+import { formatToken } from "$lib/utils/token.utils";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
@@ -240,7 +240,15 @@ describe("TransactionModal", () => {
         ).includes(mockMainAccount.identifier)
       ).toBeTruthy();
       expect(
-        getByText(formattedTransactionFeeICP(DEFAULT_TRANSACTION_FEE_E8S))
+        getByText(
+          formatToken({
+            value: TokenAmount.fromE8s({
+              amount: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+              token: ICPToken,
+            }).toE8s(),
+            detailed: "height_decimals",
+          })
+        )
       ).toBeInTheDocument();
     });
 
@@ -263,7 +271,15 @@ describe("TransactionModal", () => {
         ).includes(mockMainAccount.identifier)
       ).toBeTruthy();
       expect(
-        getByText(formattedTransactionFeeICP(Number(fee.toE8s())))
+        getByText(
+          formatToken({
+            value: TokenAmount.fromE8s({
+              amount: fee.toE8s(),
+              token: ICPToken,
+            }).toE8s(),
+            detailed: "height_decimals",
+          })
+        )
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -60,6 +60,48 @@ describe("token-utils", () => {
     ).toEqual(`2'000'000.00`);
   });
 
+  it("should format token detailed with height decimals", () => {
+    expect(
+      formatToken({ value: BigInt(0), detailed: "height_decimals" })
+    ).toEqual("0");
+    expect(
+      formatToken({ value: BigInt(1), detailed: "height_decimals" })
+    ).toEqual("0.00000001");
+    expect(
+      formatToken({ value: BigInt(10), detailed: "height_decimals" })
+    ).toEqual("0.00000010");
+    expect(
+      formatToken({ value: BigInt(100), detailed: "height_decimals" })
+    ).toEqual("0.00000100");
+    expect(
+      formatToken({ value: BigInt(100000000), detailed: "height_decimals" })
+    ).toEqual("1.00000000");
+    expect(
+      formatToken({ value: BigInt(1000000000), detailed: "height_decimals" })
+    ).toEqual("10.00000000");
+    expect(
+      formatToken({ value: BigInt(1010000000), detailed: "height_decimals" })
+    ).toEqual("10.10000000");
+    expect(
+      formatToken({ value: BigInt(1012300000), detailed: "height_decimals" })
+    ).toEqual("10.12300000");
+    expect(
+      formatToken({ value: BigInt(20000000000), detailed: "height_decimals" })
+    ).toEqual("200.00000000");
+    expect(
+      formatToken({ value: BigInt(20000000001), detailed: "height_decimals" })
+    ).toEqual("200.00000001");
+    expect(
+      formatToken({ value: BigInt(200000000000), detailed: "height_decimals" })
+    ).toEqual(`2'000.00000000`);
+    expect(
+      formatToken({
+        value: BigInt(200000000000000),
+        detailed: "height_decimals",
+      })
+    ).toEqual(`2'000'000.00000000`);
+  });
+
   describe("sumTokenAmounts", () => {
     it("should add amounts of token", () => {
       const icp0 = TokenAmount.fromString({


### PR DESCRIPTION
# Motivation

We must display height decimals on transaction review.

# PRs

- [x] https://github.com/dfinity/gix-components/pull/210

# Changes

- add `height_decimals` display
