### PR TITLE
Fix: Commitment project detail

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -12,7 +12,7 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import { isNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import ParticipateButton from "./ParticipateButton.svelte";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
@@ -68,7 +68,7 @@
     </div>
 
     <div class="actions content-cell-details">
-      {#if myCommitmentIcp !== undefined}
+      {#if nonNullish(myCommitmentIcp) && myCommitmentIcp.toE8s() > BigInt(0)}
         <div>
           <KeyValuePair testId="sns-user-commitment">
             <ProjectUserCommitmentLabel

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -5,13 +5,16 @@
 import ProjectStatusSection from "$lib/components/project-detail/ProjectStatusSection.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-import type { SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
+  createBuyersState,
   mockSnsFullProject,
   summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
+import { ProjectStatusSectionPo } from "$tests/page-objects/ProjectStatusSection.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 
@@ -23,6 +26,21 @@ describe("ProjectStatusSection", () => {
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
   });
+
+  const render = ({
+    summary,
+    swapCommitment,
+  }: {
+    summary?: SnsSummary;
+    swapCommitment?: SnsSwapCommitment;
+  }): ProjectStatusSectionPo => {
+    const { container } = renderContextCmp({
+      summary,
+      swapCommitment,
+      Component: ProjectStatusSection,
+    });
+    return new ProjectStatusSectionPo(new JestPageObjectElement(container));
+  };
 
   it("should render subtitle", () => {
     const { container } = renderContextCmp({
@@ -42,29 +60,26 @@ describe("ProjectStatusSection", () => {
     expect(queryByTestId("sns-project-current-commitment")).toBeInTheDocument();
   });
 
-  it("should render user commitment", () => {
-    const { queryByTestId } = renderContextCmp({
+  it("should render user commitment", async () => {
+    const po = render({
       summary: mockSnsFullProject.summary,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectStatusSection,
+      swapCommitment: {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        myCommitment: createBuyersState(BigInt(2_500_000_000)),
+      },
     });
-    expect(
-      queryByTestId("sns-user-commitment")
-        .querySelector('[data-tid="token-value-label"]')
-        .textContent.trim()
-    ).toBe("25.00 ICP");
+    expect(await po.getCommitmentAmount()).toBe("25.00");
   });
 
-  it("should not render user commitment if no commitment", () => {
-    const { queryByTestId } = renderContextCmp({
+  it("should not render user commitment if no commitment", async () => {
+    const po = render({
       summary: mockSnsFullProject.summary,
       swapCommitment: {
         rootCanisterId: mockSnsFullProject.rootCanisterId,
         myCommitment: undefined,
       },
-      Component: ProjectStatusSection,
     });
-    expect(queryByTestId("sns-user-commitment")).not.toBeInTheDocument();
+    expect(await po.getCommitmentAmountDisplayPo().isPresent()).toBe(false);
   });
 
   it("should render project participate button", async () => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -42,6 +42,31 @@ describe("ProjectStatusSection", () => {
     expect(queryByTestId("sns-project-current-commitment")).toBeInTheDocument();
   });
 
+  it("should render user commitment", () => {
+    const { queryByTestId } = renderContextCmp({
+      summary: mockSnsFullProject.summary,
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectStatusSection,
+    });
+    expect(
+      queryByTestId("sns-user-commitment")
+        .querySelector('[data-tid="token-value-label"]')
+        .textContent.trim()
+    ).toBe("25.00 ICP");
+  });
+
+  it("should not render user commitment if no commitment", () => {
+    const { queryByTestId } = renderContextCmp({
+      summary: mockSnsFullProject.summary,
+      swapCommitment: {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        myCommitment: undefined,
+      },
+      Component: ProjectStatusSection,
+    });
+    expect(queryByTestId("sns-user-commitment")).not.toBeInTheDocument();
+  });
+
   it("should render project participate button", async () => {
     const summary = summaryForLifecycle(SnsSwapLifecycle.Open);
     const { rootCanisterId } = summary;

--- a/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { ProjectStatusPo } from "$tests/page-objects/ProjectStatus.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ProjectStatusSectionPo extends BasePageObject {
@@ -15,7 +16,19 @@ export class ProjectStatusSectionPo extends BasePageObject {
     return ProjectStatusPo.under(this.root);
   }
 
+  getCommitmentAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root.byTestId("sns-user-commitment"));
+  }
+
   getStatus(): Promise<string> {
     return this.getProjectStatusPo().getStatus();
+  }
+
+  getCommitmentAmount(): Promise<string> {
+    return this.getCommitmentAmountDisplayPo().getAmount();
+  }
+
+  hasCommitmentAmount(): Promise<boolean> {
+    return this.getCommitmentAmountDisplayPo().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

Don't show commitment info if the user has no commitment.

# Changes

* Do not render the commitment line in ProjectStatusSection if the commitment is 0 or not present.

# Tests

* Add tests for commitment rendering in ProjectStatusSection.
