### PR TITLE
GIX-1546: Integrate Geo Location Services

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -206,6 +206,9 @@ const cspConnectSrc = () => {
     "https://identity.ic0.app",
     // We still allow users to access the app with the old URL
     "https://nns.ic0.app",
+    // Location services
+    "https://api.geoiplookup.net",
+    "https://api.iplocation.net",
     "${{OWN_CANISTER_URL}}",
     "${{HOST}}",
     "${{GOVERNANCE_CANISTER_URL}}",

--- a/frontend/src/lib/api/location.api.ts
+++ b/frontend/src/lib/api/location.api.ts
@@ -1,25 +1,46 @@
 import type { CountryCode } from "$lib/types/location";
 
-// TODO: Add to env vars?
-// const TOKEN = "XXXXXX";
+// https://geoiplookup.net/
+const getLocationFromGeoIP = async (): Promise<CountryCode> => {
+  const URL = "https://api.geoiplookup.net/?json=true";
+  const response = await fetch(URL);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch user location from GeoIP");
+  }
+
+  const data = await response.json();
+  return data.countrycode;
+};
+
+// https://api.iplocation.net/
+const getLocationFromIpLocation = async (): Promise<CountryCode> => {
+  const BASE_URL = "https://api.iplocation.net";
+  const ipResponse = await fetch(`${BASE_URL}/?cmd=get-ip`);
+  if (!ipResponse.ok) {
+    throw new Error("Failed to fetch ip from IP Location");
+  }
+  const { ip } = await ipResponse.json();
+
+  const response = await fetch(`${BASE_URL}/?ip=${ip}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch user location from IP Location");
+  }
+
+  const data = await response.json();
+  return data.country_code2;
+};
 
 /**
- * Fetches the user's country location using IPInfo API
+ * Fetches the user's country location two different services.
  *
  * @returns {CountryCode}
  */
 export const queryUserCountryLocation = async (): Promise<CountryCode> => {
-  return "CH";
-  // TODO: We have two options:
-  // 1. Use the IPInfo API to get the user's country location
-  // 2. Use a service provided by the Boundary Nodes
-  // const response = await fetch(`https://ipinfo.io/json?token=${TOKEN}`);
-
-  // if (!response.ok) {
-  //   throw new Error("Failed to fetch user location");
-  // }
-
-  // const data = await response.json();
-
-  // return data.country;
+  try {
+    return await getLocationFromGeoIP();
+  } catch (_) {
+    return await getLocationFromIpLocation();
+  }
 };

--- a/frontend/src/tests/lib/api/location.api.spec.ts
+++ b/frontend/src/tests/lib/api/location.api.spec.ts
@@ -1,0 +1,85 @@
+import { queryUserCountryLocation } from "$lib/api/location.api";
+
+describe("location api", () => {
+  describe("queryUserCountryLocation", () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    describe("if GeoIP service works", () => {
+      it("should return country code", async () => {
+        const countryCode = "CH";
+        const mockFetch = jest.fn();
+        mockFetch.mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ countrycode: countryCode }),
+          })
+        );
+        global.fetch = mockFetch;
+
+        const result = await queryUserCountryLocation();
+        expect(result).toEqual(countryCode);
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://api.geoiplookup.net/?json=true"
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("if GeoIP service fails", () => {
+      it("should call IPLocation service and return country code", async () => {
+        const countryCode = "CH";
+        const ip = "1.1.1.1";
+        const mockFetch = jest.fn();
+        mockFetch
+          .mockReturnValueOnce(
+            Promise.resolve({
+              ok: false,
+            })
+          )
+          .mockReturnValueOnce(
+            Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ ip }),
+            })
+          )
+          .mockReturnValueOnce(
+            Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ country_code2: countryCode }),
+            })
+          );
+        global.fetch = mockFetch;
+
+        const BASE_URL = "https://api.iplocation.net";
+        const result = await queryUserCountryLocation();
+        expect(result).toEqual(countryCode);
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://api.geoiplookup.net/?json=true"
+        );
+        expect(mockFetch).toHaveBeenCalledWith(`${BASE_URL}/?cmd=get-ip`);
+        expect(mockFetch).toHaveBeenCalledWith(`${BASE_URL}/?ip=${ip}`);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    describe("if GeoIP and IPLocation services fail", () => {
+      it("should raise error", async () => {
+        const mockFetch = jest.fn();
+        mockFetch.mockReturnValue(
+          Promise.resolve({
+            ok: false,
+          })
+        );
+        global.fetch = mockFetch;
+
+        const call = async () => queryUserCountryLocation();
+        await expect(call).rejects.toThrow(
+          "Failed to fetch ip from IP Location"
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to restrict participation of users from certain countries to participate in SNS swap.

This PR: Integrate with two location services that return the user location.

# Changes

* Implement two services in location api function.
* Add CSP rules for both new services.

# Tests

* Add test for location api function.