### PR TITLE
GIX-1541: Get user location if needed

### DIFF
--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,0 +1,4 @@
+import type { SnsSummary } from "$lib/types/sns";
+
+// TODO: GIX-1545 Implement this function
+export const getDenyList = (_summary: SnsSummary) => [];

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,4 +1,4 @@
 import type { SnsSummary } from "$lib/types/sns";
 
 // TODO: GIX-1545 Implement this function
-export const getDenyList = (_summary: SnsSummary) => [];
+export const getDeniedCountries = (_summary: SnsSummary) => [];

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -43,6 +43,8 @@
   import { browser } from "$app/environment";
   import { IS_TEST_ENV } from "$lib/constants/mockable.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { userCountryIsNeeded } from "$lib/utils/projects.utils";
+  import { loadUserCountry } from "$lib/services/user-country.services";
 
   export let rootCanisterId: string | undefined | null;
 
@@ -159,6 +161,16 @@
         $projectDetailStore.swapCommitment = undefined;
       },
     });
+  }
+
+  let shouldLoadUserCountry = false;
+  $: shouldLoadUserCountry = userCountryIsNeeded({
+    summary: $projectDetailStore?.summary,
+    swapCommitment: $projectDetailStore?.swapCommitment,
+    loggedIn: $authSignedInStore,
+  });
+  $: if (shouldLoadUserCountry) {
+    loadUserCountry();
   }
 
   let unsubscribeWatchCommitment: () => void | undefined;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,4 +1,5 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import { getDenyList } from "$lib/getters/sns-summary";
 import type {
   SnsSummary,
   SnsSummarySwap,
@@ -182,10 +183,7 @@ export const userCountryIsNeeded = ({
   canUserParticipateToSwap({ summary, swapCommitment }) &&
   loggedIn &&
   nonNullish(summary) &&
-  // TODO: GIX-1541 Remove unncessary checking and casting of deny_list
-  "deny_list" in summary.swap &&
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  (summary.swap.deny_list as any).length > 0;
+  getDenyList(summary).length > 0;
 
 export const hasUserParticipatedToSwap = ({
   swapCommitment,

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,5 +1,5 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import { getDenyList } from "$lib/getters/sns-summary";
+import { getDeniedCountries } from "$lib/getters/sns-summary";
 import type {
   SnsSummary,
   SnsSummarySwap,
@@ -183,7 +183,7 @@ export const userCountryIsNeeded = ({
   canUserParticipateToSwap({ summary, swapCommitment }) &&
   loggedIn &&
   nonNullish(summary) &&
-  getDenyList(summary).length > 0;
+  getDeniedCountries(summary).length > 0;
 
 export const hasUserParticipatedToSwap = ({
   swapCommitment,

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -295,8 +295,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         ).toMatch(formatToken({ value: userCommitment }));
       });
 
-      // TODO: GIX-1541 use this test to show that button is disabled if user is in a country that is not allowed to participate
-      it("should NOT load user's country", async () => {
+      it("should not load user's country if no deny list", async () => {
         jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
         jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
           rootCanisterId: Principal.fromText(rootCanisterId),

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -10,6 +10,7 @@ import * as snsApi from "$lib/api/sns.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { pageStore } from "$lib/derived/page.derived";
+import * as summaryGetters from "$lib/getters/sns-summary";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
 import { authStore } from "$lib/stores/auth.store";
@@ -305,6 +306,20 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         render(ProjectDetail, props);
 
         expect(locationApi.queryUserCountryLocation).not.toBeCalled();
+      });
+
+      it("should load user's country if no deny list", async () => {
+        // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
+        jest.spyOn(summaryGetters, "getDenyList").mockReturnValue(["US"]);
+        jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
+        jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
+          rootCanisterId: Principal.fromText(rootCanisterId),
+          myCommitment: undefined,
+        } as SnsSwapCommitment);
+
+        render(ProjectDetail, props);
+
+        expect(locationApi.queryUserCountryLocation).toBeCalled();
       });
 
       it("should participate without user interaction if there is an open ticket.", async () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -308,9 +308,11 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         expect(locationApi.queryUserCountryLocation).not.toBeCalled();
       });
 
-      it("should load user's country if no deny list", async () => {
+      it("should load user's country if non-empty deny list", async () => {
         // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
-        jest.spyOn(summaryGetters, "getDenyList").mockReturnValue(["US"]);
+        jest
+          .spyOn(summaryGetters, "getDeniedCountries")
+          .mockReturnValue(["US"]);
         jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
         jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
           rootCanisterId: Principal.fromText(rootCanisterId),

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -296,32 +296,32 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         ).toMatch(formatToken({ value: userCommitment }));
       });
 
-      it("should not load user's country if no deny list", async () => {
-        jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
-        jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
-          rootCanisterId: Principal.fromText(rootCanisterId),
-          myCommitment: undefined,
-        } as SnsSwapCommitment);
+      describe("no open ticket and no commitment", () => {
+        beforeEach(() => {
+          jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
+          jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
+            rootCanisterId: Principal.fromText(rootCanisterId),
+            myCommitment: undefined,
+          } as SnsSwapCommitment);
+        });
 
-        render(ProjectDetail, props);
+        it("should not load user's country if no deny list", async () => {
+          // TODO: GIX-1545 Create a summary without deny list
+          render(ProjectDetail, props);
 
-        expect(locationApi.queryUserCountryLocation).not.toBeCalled();
-      });
+          expect(locationApi.queryUserCountryLocation).not.toBeCalled();
+        });
 
-      it("should load user's country if non-empty deny list", async () => {
-        // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
-        jest
-          .spyOn(summaryGetters, "getDeniedCountries")
-          .mockReturnValue(["US"]);
-        jest.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
-        jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
-          rootCanisterId: Principal.fromText(rootCanisterId),
-          myCommitment: undefined,
-        } as SnsSwapCommitment);
+        it("should load user's country if non-empty deny list", async () => {
+          // TODO: GIX-1545 Remove mock and create a summary with deny list
+          jest
+            .spyOn(summaryGetters, "getDeniedCountries")
+            .mockReturnValue(["US"]);
 
-        render(ProjectDetail, props);
+          render(ProjectDetail, props);
 
-        expect(locationApi.queryUserCountryLocation).toBeCalled();
+          expect(locationApi.queryUserCountryLocation).toBeCalled();
+        });
       });
 
       it("should participate without user interaction if there is an open ticket.", async () => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -345,7 +345,7 @@ describe("project-utils", () => {
 
     it("country is needed", () => {
       // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDenyList").mockReturnValue(["US"]);
+      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
       expect(
         userCountryIsNeeded({
           summary: summaryForLifecycle(SnsSwapLifecycle.Open),

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,4 +1,5 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import * as summaryGetters from "$lib/getters/sns-summary";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
@@ -274,6 +275,9 @@ describe("project-utils", () => {
   });
 
   describe("userCountryIsNeeded", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
     it("country not needed if no summary or swap information", () => {
       expect(
         userCountryIsNeeded({
@@ -281,28 +285,28 @@ describe("project-utils", () => {
           swapCommitment: undefined,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         userCountryIsNeeded({
           summary: null,
           swapCommitment: undefined,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         userCountryIsNeeded({
           summary: undefined,
           swapCommitment: null,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         userCountryIsNeeded({
           summary: null,
           swapCommitment: null,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("country not needed if sale is not open", () => {
@@ -312,7 +316,7 @@ describe("project-utils", () => {
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         userCountryIsNeeded({
@@ -320,7 +324,7 @@ describe("project-utils", () => {
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         userCountryIsNeeded({
@@ -328,7 +332,7 @@ describe("project-utils", () => {
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         userCountryIsNeeded({
@@ -336,18 +340,19 @@ describe("project-utils", () => {
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
-    // TODO: GIX-1541 Add a project with deny_list and test that returns true
-    it("country is NOT YET needed if sale is open and logged in", () => {
+    it("country is needed", () => {
+      // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
+      jest.spyOn(summaryGetters, "getDenyList").mockReturnValue(["US"]);
       expect(
         userCountryIsNeeded({
           summary: summaryForLifecycle(SnsSwapLifecycle.Open),
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(true);
     });
 
     it("country not needed if not logged in", () => {
@@ -357,7 +362,7 @@ describe("project-utils", () => {
           swapCommitment: mockSwapCommitment,
           loggedIn: false,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("country is not needed if max user commitment is reached", () => {
@@ -374,7 +379,7 @@ describe("project-utils", () => {
           },
           loggedIn: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -12,6 +12,7 @@ import {
   filterProjectsStatus,
   hasUserParticipatedToSwap,
   projectRemainingAmount,
+  userCountryIsNeeded,
   validParticipation,
 } from "$lib/utils/projects.utils";
 import {
@@ -258,6 +259,120 @@ describe("project-utils", () => {
               ],
             },
           },
+        })
+      ).toBeFalsy();
+    });
+
+    it("can participate to swap if max user commitment is not reached", () => {
+      expect(
+        canUserParticipateToSwap({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          swapCommitment: mockSwapCommitment,
+        })
+      ).toBeTruthy();
+    });
+  });
+
+  describe("userCountryIsNeeded", () => {
+    it("country not needed if no summary or swap information", () => {
+      expect(
+        userCountryIsNeeded({
+          summary: undefined,
+          swapCommitment: undefined,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+      expect(
+        userCountryIsNeeded({
+          summary: null,
+          swapCommitment: undefined,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+      expect(
+        userCountryIsNeeded({
+          summary: undefined,
+          swapCommitment: null,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+      expect(
+        userCountryIsNeeded({
+          summary: null,
+          swapCommitment: null,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+    });
+
+    it("country not needed if sale is not open", () => {
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Unspecified),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Pending),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Aborted),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+    });
+
+    // TODO: GIX-1541 Add a project with deny_list and test that returns true
+    it("country is NOT YET needed if sale is open and logged in", () => {
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBeFalsy();
+    });
+
+    it("country not needed if not logged in", () => {
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: false,
+        })
+      ).toBeFalsy();
+    });
+
+    it("country is not needed if max user commitment is reached", () => {
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          swapCommitment: {
+            rootCanisterId: mockSwapCommitment.rootCanisterId,
+            myCommitment: {
+              icp: [
+                createTransferableAmount(mockSnsParams.max_participant_icp_e8s),
+              ],
+            },
+          },
+          loggedIn: true,
         })
       ).toBeFalsy();
     });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -376,15 +376,6 @@ describe("project-utils", () => {
         })
       ).toBeFalsy();
     });
-
-    it("can participate to swap if max user commitment is not reached", () => {
-      expect(
-        canUserParticipateToSwap({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
-          swapCommitment: mockSwapCommitment,
-        })
-      ).toBeTruthy();
-    });
   });
 
   describe("has user participated to swap", () => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -277,8 +277,11 @@ describe("project-utils", () => {
   describe("userCountryIsNeeded", () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      // TODO: GIX-1545 Remove mock and create a summary with deny list
+      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
     });
-    it("country not needed if no summary or swap information", () => {
+
+    it("country not needed", () => {
       expect(
         userCountryIsNeeded({
           summary: undefined,
@@ -344,8 +347,6 @@ describe("project-utils", () => {
     });
 
     it("country is needed", () => {
-      // TODO: TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
       expect(
         userCountryIsNeeded({
           summary: summaryForLifecycle(SnsSwapLifecycle.Open),
@@ -353,6 +354,18 @@ describe("project-utils", () => {
           loggedIn: true,
         })
       ).toBe(true);
+    });
+
+    it("country not needed if empty list of denied countries", () => {
+      // TODO: GIX-1545 Remove mock and create a summary with deny list
+      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue([]);
+      expect(
+        userCountryIsNeeded({
+          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          swapCommitment: mockSwapCommitment,
+          loggedIn: true,
+        })
+      ).toBe(false);
     });
 
     it("country not needed if not logged in", () => {


### PR DESCRIPTION
# Motivation

We want to restrict participation of users from certain countries to participate in SNS swap.

In this PR: Load the location of the user when needed.

Note: Not fully functional yet because the backend is missing the necessary field.

# Changes

* New project util `userCountryIsNeeded`.
* Use new project util in ProjectDetail to call the service `loadUserCountry`.

# Tests

* Add tests for new project util
* Add test in ProjectDetail for new functionality.
