### PR TITLE
fix: reload proposals on sns switch

### DIFF
--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -60,7 +60,11 @@
     }
   };
 
-  $: onSnsFiltersChanged($snsFiltersStore);
+  // Fetch the proposals only on filters or project change.
+  // TODO(e2e): cover this with e2e tests.
+  $: $snsOnlyProjectStore,
+    $snsFiltersStore,
+    (() => onSnsFiltersChanged($snsFiltersStore))();
 
   let loadingNextPage = false;
   let loadNextPage: () => void;

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -49,7 +49,7 @@
 
   $: onSnsProjectChanged($snsOnlyProjectStore);
 
-  const onSnsFiltersChanged = async (filters: SnsFiltersStoreData) => {
+  const fetchProposals = async (filters: SnsFiltersStoreData) => {
     // First call will have `filters` as `undefined`.
     // Once we have the initial filters, we load the proposals.
     if (
@@ -64,7 +64,7 @@
   // TODO(e2e): cover this with e2e tests.
   $: $snsOnlyProjectStore,
     $snsFiltersStore,
-    (() => onSnsFiltersChanged($snsFiltersStore))();
+    (() => fetchProposals($snsFiltersStore))();
 
   let loadingNextPage = false;
   let loadNextPage: () => void;


### PR DESCRIPTION
# Motivation

Fixes the bug when there is no sns proposals shown on the project switch.

# Changes

- add projectId listener for reload function

# Screenshot

![Screen Recording 2023-05-10 at 11 16 26](https://github.com/dfinity/nns-dapp/assets/98811342/fe2e32d2-69be-403d-9757-c3091647303e)


