### PR TITLE
Add aggregator to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The [NNS front-end Dapp](https://nns.internetcomputer.org/) is a dapp that provi
 - Participate in the governance of the IC
 - Create and top up canisters
 
+The [SNS aggregator](https://3r4gx-wqaaa-aaaaq-aaaia-cai.ic0.app/) is a back-end canister that provides fast, certified data about SNS canisters.  It supports the NNS front-end dapp
+under situations of high load.
+
 ## Official build
 
 The official build should ideally be reproducible, so that independent parties


### PR DESCRIPTION
# Motivation
The aggregator is not mentioned in the README.  In particular, I became aware while writing an sns deploy script that the flavours of the aggregator build are not documented anywhere.

# Changes
* Add the sns aggregator to the README.
I actually expect that we would prefer to have the aggregator documentation in a  separate README but let's discuss first.

# Tests
- [x] Readability check: Do the humans reading this PR like it?