### PR TITLE
ckBTC max input should not reduce ledger fee

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -11,7 +11,7 @@
   import type { Account } from "$lib/types/account";
   import type { WizardStep } from "@dfinity/gix-components";
   import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
-  import type { TokenAmount } from "@dfinity/nns";
+  import { TokenAmount } from "@dfinity/nns";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
@@ -50,6 +50,15 @@
       showLedgerFee: false,
     }),
   };
+
+  // If ckBTC are converted to BTC from the withdrawal account there is no transfer to the ckBTC ledger, therefore no related fee will be applied
+  let fee: TokenAmount;
+  $: fee = withdrawalAccount
+    ? TokenAmount.fromE8s({
+        amount: 0n,
+        token: transactionFee.token,
+      })
+    : transactionFee;
 
   let selectedNetwork: TransactionNetwork | undefined = withdrawalAccount
     ? isUniverseCkTESTBTC(universeId)
@@ -154,7 +163,7 @@
       networkBtc,
       sourceAccount: selectedAccount,
       amount,
-      transactionFee: transactionFee.toE8s(),
+      transactionFee: fee.toE8s(),
       bitcoinEstimatedFee,
       kytEstimatedFee,
     });
@@ -170,7 +179,7 @@
   on:nnsClose
   bind:currentStep
   {token}
-  {transactionFee}
+  transactionFee={fee}
   {transactionInit}
   bind:selectedNetwork
   {validateAmount}

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -33,7 +33,7 @@ import {
 } from "$tests/utils/transaction-modal.test.utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { TokenAmount } from "@dfinity/nns";
-import { type RenderResult, fireEvent, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import * as minterApi from "$lib/api/ckbtc-minter.api";
+import { BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC } from "$lib/constants/bitcoin.constants";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
@@ -32,7 +33,8 @@ import {
 } from "$tests/utils/transaction-modal.test.utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { TokenAmount } from "@dfinity/nns";
-import { waitFor } from "@testing-library/svelte";
+import { type RenderResult, fireEvent, waitFor } from "@testing-library/svelte";
+import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 
 jest.mock("$lib/services/ckbtc-accounts.services", () => {
@@ -348,6 +350,49 @@ describe("CkBTCTransactionModal", () => {
     });
   });
 
+  const testMax = async (result: RenderResult<SvelteComponent>) => {
+    const max = result.getByTestId("max-button");
+    max && fireEvent.click(max);
+
+    await tick();
+
+    const input: HTMLInputElement = result.container.querySelector(
+      "input[name='amount']"
+    );
+    expect(input?.value).toEqual(
+      `${
+        Number(mockCkBTCMainAccount.balance.toE8s() - mockCkBTCToken.fee) /
+        BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC
+      }`
+    );
+  };
+
+  it("should apply max minus fee for ckBTC transfer", async () => {
+    const result = await renderTransactionModal();
+
+    await testTransferFormTokens({
+      result,
+      selectedNetwork: TransactionNetwork.ICP,
+      destinationAddress: mockCkBTCMainAccount.identifier,
+      amount: "0.002",
+    });
+
+    await testMax(result);
+  });
+
+  it("should apply max minus fee for ckBTC to BTC conversion", async () => {
+    const result = await renderTransactionModal();
+
+    await testTransferFormTokens({
+      result,
+      selectedNetwork: TransactionNetwork.BTC_TESTNET,
+      destinationAddress: mockBTCAddressTestnet,
+      amount: "0.002",
+    });
+
+    await testMax(result);
+  });
+
   describe("withdrawal account", () => {
     it("should not render ledger fee on first step", async () => {
       const result = await renderTransactionModal(mockCkBTCWithdrawalAccount);
@@ -451,6 +496,31 @@ describe("CkBTCTransactionModal", () => {
 
       // In progress + sending BTC + reload
       expect(result.container.querySelectorAll("div.step").length).toEqual(3);
+    });
+
+    it("should apply max without deducting fee", async () => {
+      const result = await renderTransactionModal(mockCkBTCWithdrawalAccount);
+
+      await testTransferFormTokens({
+        result,
+        destinationAddress: mockBTCAddressTestnet,
+        amount: "0.002",
+      });
+
+      const max = result.getByTestId("max-button");
+      max && fireEvent.click(max);
+
+      await tick();
+
+      const input: HTMLInputElement = result.container.querySelector(
+        "input[name='amount']"
+      );
+      expect(input?.value).toEqual(
+        `${
+          Number(mockCkBTCWithdrawalAccount.balance.toE8s()) /
+          BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC
+        }`
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -3,8 +3,8 @@
  */
 
 import * as minterApi from "$lib/api/ckbtc-minter.api";
-import { BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC } from "$lib/constants/bitcoin.constants";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
 import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
@@ -362,7 +362,7 @@ describe("CkBTCTransactionModal", () => {
     expect(input?.value).toEqual(
       `${
         Number(mockCkBTCMainAccount.balance.toE8s() - mockCkBTCToken.fee) /
-        BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC
+        E8S_PER_ICP
       }`
     );
   };
@@ -516,10 +516,7 @@ describe("CkBTCTransactionModal", () => {
         "input[name='amount']"
       );
       expect(input?.value).toEqual(
-        `${
-          Number(mockCkBTCWithdrawalAccount.balance.toE8s()) /
-          BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC
-        }`
+        `${Number(mockCkBTCWithdrawalAccount.balance.toE8s()) / E8S_PER_ICP}`
       );
     });
   });


### PR DESCRIPTION
# Motivation

When converting ckBTC to BTC from the withdrawal account there is no transfer to the ledger, therefore no related fee and therefore when user click "Max", such fee should not be deducted from the account balance.
