### PR TITLE
feat: btc and kyt fees should not be considered for minimal input amount

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -155,8 +155,6 @@
       sourceAccount: selectedAccount,
       amount,
       transactionFee: transactionFee.toE8s(),
-      bitcoinEstimatedFee,
-      kytEstimatedFee,
     });
 
     return undefined;

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -12,15 +12,11 @@ export const assertCkBTCUserInputAmount = ({
   networkBtc,
   sourceAccount,
   amount,
-  bitcoinEstimatedFee,
-  kytEstimatedFee,
   transactionFee,
 }: {
   networkBtc: boolean;
   sourceAccount: Account | undefined;
   amount: number | undefined;
-  bitcoinEstimatedFee: bigint | undefined | null;
-  kytEstimatedFee: bigint | undefined | null;
   transactionFee: bigint;
 }) => {
   if (!networkBtc) {
@@ -60,10 +56,6 @@ export const assertCkBTCUserInputAmount = ({
 
   assertEnoughAccountFunds({
     account: sourceAccount,
-    amountE8s:
-      amountE8s +
-      transactionFee +
-      (bitcoinEstimatedFee ?? BigInt(0)) +
-      (kytEstimatedFee ?? BigInt(0)),
+    amountE8s: amountE8s + transactionFee,
   });
 };

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -13,9 +13,7 @@ describe("ckbtc.utils", () => {
     networkBtc: true,
     sourceAccount: mockMainAccount,
     amount: 0.002,
-    bitcoinEstimatedFee: 1n,
-    transactionFee: 2n,
-    kytEstimatedFee: 3n,
+    transactionFee: 1n,
   };
 
   it("should not throw error", () => {
@@ -64,7 +62,7 @@ describe("ckbtc.utils", () => {
     expect(() => assertCkBTCUserInputAmount(params)).not.toThrow();
   });
 
-  it("should throw error if amount is lower than min retrieve btc amount", () => {
+  it.only("should throw error if amount is lower than min retrieve btc amount", () => {
     expect(() =>
       assertCkBTCUserInputAmount({
         ...params,
@@ -90,26 +88,6 @@ describe("ckbtc.utils", () => {
           Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP +
           Number(params.transactionFee) / E8S_PER_ICP +
           Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP,
-      })
-    ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
-
-    const closestAmount =
-      Number(params.sourceAccount.balance.toE8s()) / E8S_PER_ICP -
-      Number(params.bitcoinEstimatedFee) / E8S_PER_ICP -
-      Number(params.kytEstimatedFee) / E8S_PER_ICP -
-      Number(params.transactionFee) / E8S_PER_ICP;
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: closestAmount,
-      })
-    ).not.toThrow(new NotEnoughAmountError("error.insufficient_funds"));
-
-    expect(() =>
-      assertCkBTCUserInputAmount({
-        ...params,
-        amount: closestAmount + 0.01,
       })
     ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
   });


### PR DESCRIPTION
# Motivation

It is now requested to not consider the btc and kyt fees for the comparison of the minimal amount to convert ckBTC to BTC.
