### PR TITLE
Estimated BTC and inter-network fees height decimals

### DIFF
--- a/frontend/src/lib/constants/bitcoin.constants.ts
+++ b/frontend/src/lib/constants/bitcoin.constants.ts
@@ -1,5 +1,3 @@
-export const BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC = 100_000_000;
-
 // The minimal amount of ckBTC that can be converted to BTC.
 // Reflects ckBTC minter state variable `retrieve_btc_min_amount`.
 // Value proposed and set with proposal https://dashboard.internetcomputer.org/proposal/111901.

--- a/frontend/src/lib/utils/bitcoin.utils.ts
+++ b/frontend/src/lib/utils/bitcoin.utils.ts
@@ -1,7 +1,7 @@
-import { BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC } from "$lib/constants/bitcoin.constants";
-
-const estimatedFee = (bitcoinEstimatedFee: bigint): number =>
-  Number(bitcoinEstimatedFee) / BITCOIN_ESTIMATED_FEE_TO_FORMATTED_BTC;
+import { formatToken } from "$lib/utils/token.utils";
 
 export const formatEstimatedFee = (bitcoinEstimatedFee: bigint): string =>
-  `${estimatedFee(bitcoinEstimatedFee)}`;
+  formatToken({
+    value: bitcoinEstimatedFee,
+    detailed: "height_decimals",
+  });

--- a/frontend/src/tests/lib/utils/bitcoin.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/bitcoin.utils.spec.ts
@@ -2,7 +2,8 @@ import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 
 describe("bitcoin.utils", () => {
   it("should format bitcoin estimated fee", () => {
+    expect(formatEstimatedFee(10n)).toEqual("0.00000010");
     expect(formatEstimatedFee(1083n)).toEqual("0.00001083");
-    expect(formatEstimatedFee(108310831083n)).toEqual("1083.10831083");
+    expect(formatEstimatedFee(108310831083n)).toEqual("1'083.10831083");
   });
 });


### PR DESCRIPTION
# Motivation

Estimated BTC and inter-network fees should be displayed with height decimals.

# Note

No test environment no problem, could not have detected it locally because I work with a value that has 8 decimals...

# Screenshots

After PR with mocked value that is not my working value:

<img width="1536" alt="Capture d’écran 2023-05-10 à 15 13 16" src="https://github.com/dfinity/nns-dapp/assets/16886711/cd9209a5-a54a-4849-b723-636c9f4a4cf0">

<img width="1536" alt="Capture d’écran 2023-05-10 à 15 13 14" src="https://github.com/dfinity/nns-dapp/assets/16886711/5a0e4a2f-bc97-46dd-a8d9-d648e09ad6bf">

