### PR TITLE
Load next transactions after refresh balance

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { Account } from "$lib/types/account";
-  import { onMount } from "svelte";
   import { loadCkBTCAccountNextTransactions } from "$lib/services/ckbtc-transactions.services";
   import type { IcrcTransactionData } from "$lib/types/transaction";
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
@@ -29,7 +28,7 @@
     loading = false;
   };
 
-  onMount(async () => await loadTransactions());
+  $: account, (async () => loadTransactions())();
 
   let transactions: IcrcTransactionData[];
   $: transactions = getSortedTransactionsFromStore({

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -42,6 +42,30 @@ describe("CkBTCTransactionList", () => {
     expect(spy).toBeCalled();
   });
 
+  it("should call service to load transactions when account changes", () => {
+    const spy = jest.spyOn(services, "loadCkBTCAccountNextTransactions");
+
+    const { rerender } = render(CkBTCTransactionsList, {
+      props: {
+        account: mockCkBTCMainAccount,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
+      },
+    });
+
+    expect(spy).toBeCalledTimes(1);
+
+    rerender({
+      props: {
+        account: mockCkBTCMainAccount,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
+      },
+    });
+
+    expect(spy).toBeCalledTimes(2);
+  });
+
   it("should render transactions from store", () => {
     const store = {
       [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {


### PR DESCRIPTION
# Motivation

On ckBTC wallet page there is newly a "Refresh balance" button that used to be in the modal.

When executed it reloads the account but, did not reload anymore the transactions because well, it was moved without it.

This PR load the next transactions after such actions.

# Note

I just load the next transactions and do not reload everything because a successful "refresh balance" produces a new transaction.

# Changes

- instead of `onMount` call load on any account changes
