### PR TITLE
Feat/no permission ineligible reason

### DIFF
--- a/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
@@ -17,8 +17,11 @@
 
   let neuron: SnsNeuron | undefined | null = $store.neuron;
 
-  const openModal = async () => {
+  const openAddPermissionsModal = async () => {
     openSnsNeuronModal({ type: "dev-add-permissions" });
+  };
+  const openRemovePermissionsModal = async () => {
+    openSnsNeuronModal({ type: "dev-remove-permissions" });
   };
 </script>
 
@@ -41,7 +44,13 @@
   {/each}
 
   <div>
-    <button on:click={openModal} class="primary">Add Permissions</button>
+    <button on:click={openAddPermissionsModal} class="primary"
+      >Add Permissions</button
+    >
+    &nbsp;
+    <button on:click={openRemovePermissionsModal} class="primary"
+      >Remove Permissions</button
+    >
   </div>
 </CardInfo>
 

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -7,6 +7,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
   import type { NeuronIneligibilityReason } from "$lib/utils/neuron.utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let ineligibleNeurons: IneligibleNeuronData[] = [];
   export let minSnsDissolveDelaySeconds: bigint;
@@ -24,13 +25,16 @@
     }
   );
   const reasonText = ({ reason }: IneligibleNeuronData) =>
-    ((
-      {
-        since: $i18n.proposal_detail__ineligible.reason_since,
-        "no-permission": $i18n.proposal_detail__ineligible.reason_no_permission,
-        short: reasonShort,
-      } as Record<NeuronIneligibilityReason, string>
-    )[reason]);
+    nonNullish(reason)
+      ? (
+          {
+            since: $i18n.proposal_detail__ineligible.reason_since,
+            "no-permission":
+              $i18n.proposal_detail__ineligible.reason_no_permission,
+            short: reasonShort,
+          } as Record<NeuronIneligibilityReason, string>
+        )[reason]
+      : "unknown";
 </script>
 
 {#if visible}

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -6,7 +6,7 @@
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
-  import { NeuronIneligibilityReason } from "$lib/utils/neuron.utils";
+  import type { NeuronIneligibilityReason } from "$lib/utils/neuron.utils";
 
   export let ineligibleNeurons: IneligibleNeuronData[] = [];
   export let minSnsDissolveDelaySeconds: bigint;

--- a/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/IneligibleNeuronsCard.svelte
@@ -6,6 +6,7 @@
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
+  import { NeuronIneligibilityReason } from "$lib/utils/neuron.utils";
 
   export let ineligibleNeurons: IneligibleNeuronData[] = [];
   export let minSnsDissolveDelaySeconds: bigint;
@@ -13,7 +14,6 @@
   let visible = false;
   $: visible = ineligibleNeurons.length > 0;
 
-  const reasonSince = $i18n.proposal_detail__ineligible.reason_since;
   let reasonShort: string;
   $: reasonShort = replacePlaceholders(
     $i18n.proposal_detail__ineligible.reason_short,
@@ -23,6 +23,14 @@
       ),
     }
   );
+  const reasonText = ({ reason }: IneligibleNeuronData) =>
+    ((
+      {
+        since: $i18n.proposal_detail__ineligible.reason_since,
+        "no-permission": $i18n.proposal_detail__ineligible.reason_no_permission,
+        short: reasonShort,
+      } as Record<NeuronIneligibilityReason, string>
+    )[reason]);
 </script>
 
 {#if visible}
@@ -41,9 +49,7 @@
           {shortenWithMiddleEllipsis(
             neuron.neuronIdString,
             SNS_NEURON_ID_DISPLAY_LENGTH
-          )}<small
-            >{neuron.reason === "since" ? reasonSince : reasonShort}</small
-          >
+          )}<small>{reasonText(neuron)}</small>
         </li>
       {/each}
     </ul>

--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -160,6 +160,7 @@
           identity: $authStore.identity,
         }),
         proposal,
+        identity: $authStore.identity,
       })
     : [];
   let minSnsDissolveDelaySeconds: bigint;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -522,6 +522,7 @@
     "headline": "Ineligible Neurons",
     "text": "The following neurons had a dissolve delay of less than $minDissolveDelay at the time the proposal was submitted, or were created after the proposal was submitted, and therefore are not eligible to vote on it:",
     "reason_since": "created after the proposal",
+    "reason_no_permission": "no voting permission",
     "reason_short": "dissolve delay < $minDissolveDelay"
   },
   "neuron_detail": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -873,7 +873,7 @@
     "about_thirty_minutes": "Typically 30-60min",
     "transaction_success_about_thirty_minutes": "Transaction completed. Estimated time ≈30 minutes.",
     "loading_address": "Loading the address",
-    "incoming_bitcoin_network": "Incoming Bitcoin network transactions require 12 confirmations. Check status on the",
+    "incoming_bitcoin_network": "Incoming Bitcoin network transactions require 12 confirmations. Check status on a",
     "block_explorer": "block explorer",
     "refresh_balance": "Refresh Balance",
     "confirmations": "Confirmations",

--- a/frontend/src/lib/modals/sns/neurons/AddPermissionsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/AddPermissionsModal.svelte
@@ -27,11 +27,11 @@
   let modeLabel = mode === "add" ? "Add" : "Remove";
   const steps: WizardSteps = [
     {
-      name: `Principal`,
+      name: "Principal",
       title: `${modeLabel} Principal`,
     },
     {
-      name: `Permissions`,
+      name: "Permissions",
       title: "Select Permissions",
     },
   ];

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -161,6 +161,17 @@
           {neuronId}
           {reloadNeuron}
           on:nnsClose={close}
+          mode="add"
+        />
+      {/if}
+
+      {#if type === "dev-remove-permissions" && IS_TESTNET}
+        <AddPermissionsModal
+          {rootCanisterId}
+          {neuronId}
+          {reloadNeuron}
+          on:nnsClose={close}
+          mode="remove"
         />
       {/if}
     {/if}

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -124,19 +124,6 @@ export const registerVoteDemo = async ({
       rootCanisterId,
     });
 
-    const $snsProposalsStore = get(snsProposalsStore);
-
-    console.log(
-      "Proposal after voting:",
-      (
-        $snsProposalsStore[rootCanisterId.toText()]
-          ?.proposals as SnsProposalData[]
-      )?.find(
-        ({ id }) =>
-          fromDefinedNullable(id).id === fromDefinedNullable(proposal.id).id
-      )
-    );
-
     toastsSuccess({
       labelKey: `${registrations} votes were successfully registered`,
     });

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -544,6 +544,7 @@ interface I18nProposal_detail__ineligible {
   headline: string;
   text: string;
   reason_since: string;
+  reason_no_permission: string;
   reason_short: string;
 }
 

--- a/frontend/src/lib/types/sns-neuron-detail.modal.ts
+++ b/frontend/src/lib/types/sns-neuron-detail.modal.ts
@@ -8,6 +8,7 @@ export type SnsNeuronModalType =
   | "stake-maturity"
   | "split-neuron"
   | "dev-add-permissions"
+  | "dev-remove-permissions"
   | "auto-stake-maturity";
 
 export interface SnsNeuronModal {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -840,7 +840,7 @@ export type NeuronIneligibilityReason = "since" | "short" | "no-permission";
  */
 export interface IneligibleNeuronData {
   neuronIdString: string;
-  reason: NeuronIneligibilityReason | "unknown";
+  reason: NeuronIneligibilityReason | undefined;
 }
 export const filterIneligibleNnsNeurons = ({
   neurons,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -830,6 +830,9 @@ export const validTopUpAmount = ({
 export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
   BigInt(Math.min(Number(ageSeconds), SECONDS_IN_FOUR_YEARS));
 
+/** NNS neuron can be ineligible only for two reasons: "since" and "short" */
+export type NeuronIneligibilityReason = "since" | "short" | "no-permission";
+
 /**
  * Represents an entry in the list of ineligible neurons.
  * - 'short': the neuron is too young to vote
@@ -837,7 +840,7 @@ export const neuronAge = ({ ageSeconds }: NeuronInfo): bigint =>
  */
 export interface IneligibleNeuronData {
   neuronIdString: string;
-  reason: "since" | "short";
+  reason: NeuronIneligibilityReason;
 }
 export const filterIneligibleNnsNeurons = ({
   neurons,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -840,7 +840,7 @@ export type NeuronIneligibilityReason = "since" | "short" | "no-permission";
  */
 export interface IneligibleNeuronData {
   neuronIdString: string;
-  reason: NeuronIneligibilityReason;
+  reason: NeuronIneligibilityReason | "unknown";
 }
 export const filterIneligibleNnsNeurons = ({
   neurons,

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -708,15 +708,15 @@ export const snsNeuronsIneligibilityReasons = ({
     return "since";
   }
 
+  if (!hasPermissionToVote({ neuron, identity })) {
+    return "no-permission";
+  }
+
   const dissolveTooShort: boolean =
     ballots.find(([ballotNeuronId]) => ballotNeuronId === neuronId) ===
     undefined;
   if (dissolveTooShort) {
     return "short";
-  }
-
-  if (!hasPermissionToVote({ neuron, identity })) {
-    return "no-permission";
   }
 
   return undefined;

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -825,15 +825,19 @@ export const getSnsNeuronVote = ({
 
 export const snsNeuronsToIneligibleNeuronData = ({
   neurons,
-  proposal: { proposal_creation_timestamp_seconds },
+  proposal,
+  identity,
 }: {
   neurons: SnsNeuron[];
   proposal: SnsProposalData;
+  identity: Identity;
 }): IneligibleNeuronData[] =>
   neurons.map((neuron) => ({
     neuronIdString: getSnsNeuronIdAsHexString(neuron),
     reason:
-      neuron.created_timestamp_seconds > proposal_creation_timestamp_seconds
-        ? "since"
-        : "short",
+      snsNeuronsIneligibilityReasons({
+        neuron,
+        proposal,
+        identity,
+      }) ?? "unknown",
   }));

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -712,10 +712,10 @@ export const snsNeuronsIneligibilityReasons = ({
     return "no-permission";
   }
 
-  const dissolveTooShort: boolean =
+  const noBallot: boolean =
     ballots.find(([ballotNeuronId]) => ballotNeuronId === neuronId) ===
     undefined;
-  if (dissolveTooShort) {
+  if (noBallot) {
     return "short";
   }
 

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -834,10 +834,9 @@ export const snsNeuronsToIneligibleNeuronData = ({
 }): IneligibleNeuronData[] =>
   neurons.map((neuron) => ({
     neuronIdString: getSnsNeuronIdAsHexString(neuron),
-    reason:
-      snsNeuronsIneligibilityReasons({
-        neuron,
-        proposal,
-        identity,
-      }) ?? "unknown",
+    reason: snsNeuronsIneligibilityReasons({
+      neuron,
+      proposal,
+      identity,
+    }),
   }));

--- a/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/IneligibleNeuronsCard.spec.ts
@@ -46,7 +46,7 @@ describe("IneligibleNeuronsCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("should display ineligible neurons (< 6 months) ", () => {
+  it("should display ineligible neurons with reason 'short'", () => {
     const { getByText } = render(IneligibleNeuronsCard, {
       props: {
         ineligibleNeurons: [
@@ -85,6 +85,22 @@ describe("IneligibleNeuronsCard", () => {
     expect(
       (container.querySelector("small") as HTMLElement).textContent
     ).toEqual(en.proposal_detail__ineligible.reason_since);
+  });
+
+  it("should display ineligible neurons due to reason 'no-permission'", () => {
+    const { getByText, container } = render(IneligibleNeuronsCard, {
+      ineligibleNeurons: [
+        {
+          neuronIdString: "111",
+          reason: "no-permission",
+        },
+      ] as IneligibleNeuronData[],
+      minSnsDissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE),
+    });
+    expect(getByText("111", { exact: false })).toBeInTheDocument();
+    expect(
+      (container.querySelector("small") as HTMLElement).textContent
+    ).toEqual(en.proposal_detail__ineligible.reason_no_permission);
   });
 
   it("should display multiple ineligible neurons", () => {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -18,6 +18,7 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import type { Ballot, NeuronInfo, ProposalInfo } from "@dfinity/nns";
 import { GovernanceCanister, ProposalStatus, Vote } from "@dfinity/nns";
+import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { fireEvent, screen } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -37,6 +38,9 @@ describe("VotingCard", () => {
     createdTimestampSeconds: BigInt(BigInt(1000)),
     dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
     neuronId,
+    permission_type: Int32Array.from([
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+    ]),
   }));
 
   const renderVotingCard = () =>

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -9,7 +9,10 @@ import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import { page } from "$mocks/$app/stores";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
   createMockSnsNeuron,
@@ -19,7 +22,8 @@ import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { mockSnsCanisterId } from "$tests/mocks/sns.api.mock";
 import { NeuronState, Vote } from "@dfinity/nns";
 import type { SnsNeuron, SnsProposalData } from "@dfinity/sns";
-import { SnsVote, type SnsBallot } from "@dfinity/sns";
+import { SnsNeuronPermissionType, SnsVote, type SnsBallot } from "@dfinity/sns";
+import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { fromDefinedNullable } from "@dfinity/utils";
 import { fireEvent, screen } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
@@ -57,18 +61,29 @@ describe("SnsVotingCard", () => {
     ballots: testBallots,
     proposal_creation_timestamp_seconds: BigInt(Date.now()),
   };
+  const permissionsWithTypeVote = [
+    {
+      principal: [mockIdentity.getPrincipal()],
+      permission_type: Int32Array.from([
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+      ]),
+    } as NeuronPermission,
+  ];
+
   const testNeurons: SnsNeuron[] = [
     {
       ...createMockSnsNeuron({
         id: [1],
         state: NeuronState.Locked,
       }),
+      permissions: permissionsWithTypeVote,
     },
     {
       ...createMockSnsNeuron({
         id: [2],
         state: NeuronState.Locked,
       }),
+      permissions: permissionsWithTypeVote,
     },
   ];
   const spyRegisterVote = jest

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -19,10 +19,23 @@ import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
+import {
+  SnsNeuronPermissionType,
+  SnsSwapLifecycle,
+  type SnsNeuron,
+} from "@dfinity/sns";
+import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+const permissionsWithTypeVote = [
+  {
+    principal: [mockIdentity.getPrincipal()],
+    permission_type: Int32Array.from([
+      SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+    ]),
+  } as NeuronPermission,
+];
 describe("SnsNeuronCard", () => {
   beforeAll(() => {
     jest
@@ -161,6 +174,7 @@ describe("SnsNeuronCard", () => {
               WhenDissolvedTimestampSeconds: BigInt(ONE_YEAR_FROM_NOW),
             },
           ],
+          permissions: permissionsWithTypeVote,
         },
         ...defaultProps,
       },

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -10,7 +10,10 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
-import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import {
+  createMockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { NeuronState } from "@dfinity/nns";
 import type { SnsProposalData } from "@dfinity/sns";
@@ -68,6 +71,7 @@ describe("sns-vote-registration-services", () => {
       proposal,
       vote,
       updateProposalCallback: reloadProposalCallback,
+      snsParameters: snsNervousSystemParametersMock,
     });
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -129,6 +129,7 @@ const testVotedNeuronA: SnsNeuron = {
       id: arrayOfNumberToUint8Array([1, 2, 3]),
     },
   ],
+  permissions: permissionsWithTypeVote,
 };
 const testVotedNeuronB: SnsNeuron = {
   ...mockSnsNeuron,
@@ -137,6 +138,7 @@ const testVotedNeuronB: SnsNeuron = {
       id: arrayOfNumberToUint8Array([1, 1, 1]),
     },
   ],
+  permissions: permissionsWithTypeVote,
 };
 const testNotVotedNeuron: SnsNeuron = {
   ...mockSnsNeuron,
@@ -145,6 +147,7 @@ const testNotVotedNeuron: SnsNeuron = {
       id: arrayOfNumberToUint8Array([3, 2, 1]),
     },
   ],
+  permissions: permissionsWithTypeVote,
 };
 
 describe("sns-neuron utils", () => {
@@ -2081,6 +2084,7 @@ describe("sns-neuron utils", () => {
         snsNeuronsToIneligibleNeuronData({
           neurons: [testVotedNeuronA],
           proposal: testProposal,
+          identity: mockIdentity,
         })
       ).toEqual([
         expect.objectContaining({
@@ -2107,6 +2111,7 @@ describe("sns-neuron utils", () => {
             },
           ],
           proposal: testProposal,
+          identity: mockIdentity,
         })
       ).toEqual([
         {


### PR DESCRIPTION
# Motivation

The new ineligibility reason "no-permission" was introduced. Because of the sns neuron can be ineligible because of permission absence.

# Changes

- new type `NeuronIneligibilityReason`
- util function `snsNeuronsIneligibilityReasons`
- add new reason support to the `<IneligibleCard>`
- "dev-remove-permissions" dev feature (needs for testing)

# Tests

- update ineligibility related tests
- snsNeuronsIneligibilityReasons
- IneligibleCard supports new reason

# Screenshots

<img width="367" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/091bfd9e-91f1-45c2-b129-595e9273fada">

## Remove Permissions modal

<img width="548" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/fea40509-7c0a-47c4-97b0-ab8282652233">

<img width="431" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3d27f9be-09ec-4ac6-b5aa-4b2620355aa9">


