### PR TITLE
Reload all ckBTC transactions after update balance

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -40,7 +40,9 @@
 
     loading = true;
 
-    // We want to reload all transactions of the account
+    // We want to reload all transactions of the account from scratch.
+    // That way the skeletons will be displayed again which provides the user a visual feedback about the fact that all transactions are realoded.
+    // This is handy because the reload notably happens the "update balance" process - i.e. happens after the "busy spinner" has fade away.
     icrcTransactionsStore.resetAccount({
       universeId,
       accountIdentifier: account.identifier,

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -5,6 +5,7 @@ import type {
 import { removeKeys } from "$lib/utils/utils";
 import type { IcrcTransactionWithId } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import { writable, type Readable } from "svelte/store";
 
 export type IcrcAccountIdentifier = string;
@@ -38,6 +39,10 @@ export interface IcrcTransactionsStore
   }) => void;
   reset: () => void;
   resetUniverse: (canisterId: UniverseCanisterId) => void;
+  resetAccount: (params: {
+    universeId: UniverseCanisterId;
+    accountIdentifier: string;
+  }) => void;
 }
 
 /**
@@ -108,6 +113,30 @@ const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
           keysToRemove: [canisterId.toText()],
         })
       );
+    },
+
+    resetAccount({
+      universeId,
+      accountIdentifier,
+    }: {
+      universeId: UniverseCanisterId;
+      accountIdentifier: string;
+    }) {
+      update((currentState: IcrcTransactionsStoreData) => {
+        const projectState = currentState[universeId.toText()];
+        return {
+          ...removeKeys({
+            obj: currentState,
+            keysToRemove: [universeId.toText()],
+          }),
+          ...(nonNullish(projectState) && {
+            [universeId.toText()]: removeKeys({
+              obj: projectState,
+              keysToRemove: [accountIdentifier],
+            }),
+          }),
+        };
+      });
     },
   };
 };

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -38,7 +38,7 @@ export const getSortedTransactionsFromStore = ({
   account: Account;
 }): IcrcTransactionData[] =>
   mapToSelfTransaction(
-    store[canisterId.toText()]?.[account.identifier].transactions ?? []
+    store[canisterId.toText()]?.[account.identifier]?.transactions ?? []
   ).sort(({ transaction: txA }, { transaction: txB }) =>
     Number(txB.transaction.timestamp - txA.transaction.timestamp)
   );
@@ -209,4 +209,4 @@ export const isIcrcTransactionsCompleted = ({
   canisterId: UniverseCanisterId;
   account: Account;
 }): boolean =>
-  Boolean(store[canisterId.toText()]?.[account.identifier].completed);
+  Boolean(store[canisterId.toText()]?.[account.identifier]?.completed);

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -6,6 +6,7 @@ import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsLis
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/ckbtc-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import CkBTCTransactionsListTest from "$tests/lib/components/accounts/CkBTCTransactionsListTest.svelte";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import {
@@ -14,7 +15,7 @@ import {
   mockIcrcTransactionsStoreSubscribe,
   mockIcrcTransactionWithId,
 } from "$tests/mocks/icrc-transactions.mock";
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 
 jest.mock("$lib/services/ckbtc-transactions.services", () => {
   return {
@@ -43,10 +44,11 @@ describe("CkBTCTransactionList", () => {
     expect(spy).toBeCalled();
   });
 
-  it("should call service to load transactions when account changes", () => {
+  it("should call service to load transactions when account changes", async () => {
     const spy = jest.spyOn(services, "loadCkBTCAccountNextTransactions");
+    const spyReload = jest.spyOn(services, "loadCkBTCAccountTransactions");
 
-    const { rerender } = render(CkBTCTransactionsList, {
+    const { component } = render(CkBTCTransactionsListTest, {
       props: {
         account: mockCkBTCMainAccount,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
@@ -55,16 +57,12 @@ describe("CkBTCTransactionList", () => {
     });
 
     expect(spy).toBeCalledTimes(1);
+    expect(spyReload).toBeCalledTimes(0);
 
-    rerender({
-      props: {
-        account: mockCkBTCMainAccount,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-        indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
-      },
-    });
+    component.reloadAccount();
 
-    expect(spy).toBeCalledTimes(2);
+    expect(spy).toBeCalledTimes(1);
+    await waitFor(() => expect(spyReload).toBeCalledTimes(1));
   });
 
   it("should render transactions from store", () => {

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -19,6 +19,7 @@ import { render } from "@testing-library/svelte";
 jest.mock("$lib/services/ckbtc-transactions.services", () => {
   return {
     loadCkBTCAccountNextTransactions: jest.fn().mockResolvedValue(undefined),
+    loadCkBTCAccountTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsListTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsListTest.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { CanisterId } from "$lib/types/canister";
+  import type { UniverseCanisterId } from "$lib/types/universe";
+  import type { Account } from "$lib/types/account";
+  import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsList.svelte";
+
+  export let indexCanisterId: CanisterId;
+  export let universeId: UniverseCanisterId;
+  export let account: Account;
+
+  export const reloadAccount = () => (account = { ...account });
+</script>
+
+<CkBTCTransactionsList {indexCanisterId} {universeId} {account} />

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -61,6 +61,7 @@ jest.mock("$lib/services/ckbtc-accounts.services", () => {
 jest.mock("$lib/services/ckbtc-transactions.services", () => {
   return {
     loadCkBTCAccountNextTransactions: jest.fn().mockResolvedValue(undefined),
+    loadCkBTCAccountTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -31,6 +31,7 @@ jest.mock("$lib/services/ckbtc-accounts.services", () => {
 jest.mock("$lib/services/ckbtc-transactions.services", () => {
   return {
     loadCkBTCAccountNextTransactions: jest.fn().mockResolvedValue(undefined),
+    loadCkBTCAccountTransactions: jest.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
@@ -1,0 +1,60 @@
+import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCWithdrawalAccount,
+} from "$tests/mocks/ckbtc-accounts.mock";
+import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
+import { get } from "svelte/store";
+
+describe("icrc-transactions", () => {
+  it("should reset account", () => {
+    icrcTransactionsStore.addTransactions({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: mockCkBTCMainAccount.identifier,
+      oldestTxId: BigInt(10),
+      completed: false,
+    });
+
+    const accounts = get(icrcTransactionsStore);
+    expect(
+      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+    ).not.toBeUndefined();
+    expect(
+      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
+        mockCkBTCMainAccount.identifier
+      ]
+    ).not.toBeUndefined();
+
+    icrcTransactionsStore.addTransactions({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: mockCkBTCWithdrawalAccount.identifier,
+      oldestTxId: BigInt(10),
+      completed: false,
+    });
+
+    const accounts2 = get(icrcTransactionsStore);
+    expect(
+      accounts2[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
+        mockCkBTCWithdrawalAccount.identifier
+      ]
+    ).not.toBeUndefined();
+
+    icrcTransactionsStore.resetAccount({
+      universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      accountIdentifier: mockCkBTCMainAccount.identifier,
+    });
+
+    const accounts3 = get(icrcTransactionsStore);
+    expect(
+      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+    ).not.toBeUndefined();
+    expect(
+      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
+        mockCkBTCMainAccount.identifier
+      ]
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Motivation

I transferred new bitcoin on mainnet and despite the fact that load next transactions was effectivelly called after update balance, the new transactions were not displayed. I'm not sure if it's a timing issue or not that's why I though about reload all transactions after such process.

# Changes

- if account change, reload all transactions of the account

# Screenshots

Load next transactions happen but no new transaction displayed

![noreload](https://github.com/dfinity/nns-dapp/assets/16886711/ee6c8f39-29cb-4c52-9ff7-7d82b4e5607a)

Here locally update balance simulated to display the all reload

![reload](https://github.com/dfinity/nns-dapp/assets/16886711/764497c8-828b-4652-9144-0d8a9458c72d)


