### PR TITLE
fix: exponent format on max click

### DIFF
--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -20,6 +20,22 @@
   export let placeholderLabelKey: string;
   export let showInfo = true;
   export let testId: string | undefined = undefined;
+
+  // replace exponent format (1e-4) w/ plain (0.0001)
+  const fixExponentFormat = (): void => {
+    // number to toLocaleString doesn't support decimals for values >= ~1e16
+    const asString = Number(value).toLocaleString("en", {
+      useGrouping: false,
+      maximumFractionDigits: 8,
+    });
+
+    if (!isNaN(Number(asString))) {
+      value = asString;
+    }
+  };
+  $: if (`${value}`.includes("e")) {
+    fixExponentFormat();
+  }
 </script>
 
 <div class="wrapper" data-tid={testId} class:error>


### PR DESCRIPTION
# Motivation

When a user clicks on the 'Max' button and has a very small amount of tokens left, the value appears in exponential format, which is incorrect. The fix checks and replaces any Xe-Y formatted value on change.

# Changes

TBD

# Screenshot

## Before
<img width="521" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/87f5833b-883a-41c6-8df7-5a267219fc9f">

## After
![Screen Recording 2023-05-11 at 10 27 07](https://github.com/dfinity/nns-dapp/assets/98811342/53188468-02c4-45b3-a141-c302b150c6d6)
