### PR TITLE
Chore: Prepare for force query calls

### DIFF
--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -76,6 +76,7 @@ export const syncSnsNeurons = async (
   rootCanisterId: Principal
 ): Promise<void> => {
   return queryAndUpdate<SnsNeuron[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsNeurons({
         rootCanisterId,


### PR DESCRIPTION
# Motivation

To make sure we have a good UX when there are a lot of visitors we want to avoid update calls. There is a flag (`FORCE_CALL_STRATEGY`) that changes all query calls to "query".

In this PR: Use the flag also in SNS neurons.

# Changes

* Use `FORCE_CALL_STRATEGY` flag in sns neurons services.

# Tests

We don't have specific tests for this flag.
