### PR TITLE
Feat: Change user country store type

### DIFF
--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -76,7 +76,6 @@ export const syncSnsNeurons = async (
   rootCanisterId: Principal
 ): Promise<void> => {
   return queryAndUpdate<SnsNeuron[], unknown>({
-    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsNeurons({
         rootCanisterId,

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -76,6 +76,7 @@ export const syncSnsNeurons = async (
   rootCanisterId: Principal
 ): Promise<void> => {
   return queryAndUpdate<SnsNeuron[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       querySnsNeurons({
         rootCanisterId,

--- a/frontend/src/lib/services/user-country.services.ts
+++ b/frontend/src/lib/services/user-country.services.ts
@@ -1,10 +1,13 @@
 import { queryUserCountryLocation } from "$lib/api/location.api";
-import { userCountryStore } from "$lib/stores/user-country.store";
+import {
+  isUserCountryLoadedStore,
+  userCountryStore,
+} from "$lib/stores/user-country.store";
 import { get } from "svelte/store";
 
 export const loadUserCountry = async () => {
   try {
-    if (get(userCountryStore) !== undefined) {
+    if (get(isUserCountryLoadedStore)) {
       return;
     }
     const countryCode = await queryUserCountryLocation();

--- a/frontend/src/lib/services/user-country.services.ts
+++ b/frontend/src/lib/services/user-country.services.ts
@@ -8,9 +8,10 @@ export const loadUserCountry = async () => {
       return;
     }
     const countryCode = await queryUserCountryLocation();
-    userCountryStore.set(countryCode);
+    userCountryStore.set({ isoCode: countryCode });
   } catch (e: unknown) {
-    // TODO: Implement error handling
+    // Print the error to the console for debugging purposes
     console.error(e);
+    userCountryStore.set(new Error("Error loading user country"));
   }
 };

--- a/frontend/src/lib/stores/user-country.store.ts
+++ b/frontend/src/lib/stores/user-country.store.ts
@@ -2,18 +2,18 @@ import type { Country } from "$lib/types/location";
 import { derived, writable } from "svelte/store";
 
 /**
- * - Loading: undefined
+ * - Not Loaded: "not loaded"
  * - Error: Error
  * - Success: Country
  */
-type UserCountryStore = Country | Error | undefined;
+type UserCountryStore = Country | Error | "not loaded";
 
 // Stores the user's country code
-export const userCountryStore = writable<UserCountryStore>(undefined);
+export const userCountryStore = writable<UserCountryStore>("not loaded");
 
-export const isUserCountryLoadingStore = derived(
+export const isUserCountryLoadedStore = derived(
   userCountryStore,
-  ($userCountry) => $userCountry === undefined
+  ($userCountry) => $userCountry !== "not loaded"
 );
 export const isUserCountryErrorStore = derived(
   userCountryStore,

--- a/frontend/src/lib/stores/user-country.store.ts
+++ b/frontend/src/lib/stores/user-country.store.ts
@@ -1,5 +1,21 @@
-import type { CountryCode } from "$lib/types/location";
-import { writable } from "svelte/store";
+import type { Country } from "$lib/types/location";
+import { derived, writable } from "svelte/store";
+
+/**
+ * - Loading: undefined
+ * - Error: Error
+ * - Success: Country
+ */
+type UserCountryStore = Country | Error | undefined;
 
 // Stores the user's country code
-export const userCountryStore = writable<CountryCode | undefined>(undefined);
+export const userCountryStore = writable<UserCountryStore>(undefined);
+
+export const isUserCountryLoadingStore = derived(
+  userCountryStore,
+  ($userCountry) => $userCountry === undefined
+);
+export const isUserCountryErrorStore = derived(
+  userCountryStore,
+  ($userCountry) => $userCountry instanceof Error
+);

--- a/frontend/src/lib/types/location.ts
+++ b/frontend/src/lib/types/location.ts
@@ -1,2 +1,6 @@
 // TODO: Union of all country codes?
 export type CountryCode = string;
+
+export type Country = {
+  isoCode: CountryCode;
+};

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -15,7 +15,7 @@ describe("location services", () => {
 
   describe("loadUserLocation", () => {
     it("should set the location store to api response", async () => {
-      expect(get(userCountryStore)).toBeUndefined();
+      expect(get(userCountryStore)).toBe("not loaded");
 
       const countryCode = "CH";
       jest

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -11,9 +11,13 @@ describe("location services", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
   describe("loadUserLocation", () => {
+    beforeEach(() => {
+      userCountryStore.set("not loaded");
+    });
     it("should set the location store to api response", async () => {
       expect(get(userCountryStore)).toBe("not loaded");
 

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -27,6 +27,20 @@ describe("location services", () => {
       expect(get(userCountryStore)).toEqual({ isoCode: countryCode });
     });
 
+    it("should set the location store to error if api fails", async () => {
+      expect(get(userCountryStore)).toBe("not loaded");
+
+      jest
+        .spyOn(locationApi, "queryUserCountryLocation")
+        .mockRejectedValue(new Error("test"));
+
+      await loadUserCountry();
+
+      expect(get(userCountryStore)).toEqual(
+        new Error("Error loading user country")
+      );
+    });
+
     it("should not call api if location store is already set", async () => {
       const countryCode = "CH";
       const apiFn = jest

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -24,7 +24,7 @@ describe("location services", () => {
 
       await loadUserCountry();
 
-      expect(get(userCountryStore)).toBe(countryCode);
+      expect(get(userCountryStore)).toEqual({ isoCode: countryCode });
     });
 
     it("should not call api if location store is already set", async () => {
@@ -32,7 +32,7 @@ describe("location services", () => {
       const apiFn = jest
         .spyOn(locationApi, "queryUserCountryLocation")
         .mockResolvedValue(countryCode);
-      userCountryStore.set("CH");
+      userCountryStore.set({ isoCode: countryCode });
 
       await loadUserCountry();
 

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -38,5 +38,17 @@ describe("location services", () => {
 
       expect(apiFn).not.toHaveBeenCalled();
     });
+
+    it("should not call api if location store has an error", async () => {
+      const countryCode = "CH";
+      const apiFn = jest
+        .spyOn(locationApi, "queryUserCountryLocation")
+        .mockResolvedValue(countryCode);
+      userCountryStore.set(new Error("test"));
+
+      await loadUserCountry();
+
+      expect(apiFn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/tests/lib/stores/user-country.store.spec.ts
+++ b/frontend/src/tests/lib/stores/user-country.store.spec.ts
@@ -1,13 +1,13 @@
 import {
   isUserCountryErrorStore,
-  isUserCountryLoadingStore,
+  isUserCountryLoadedStore,
   userCountryStore,
 } from "$lib/stores/user-country.store";
 import { get } from "svelte/store";
 
 describe("userCountryStore", () => {
   beforeEach(() => {
-    userCountryStore.set(undefined);
+    userCountryStore.set("not loaded");
   });
 
   describe("userCountryStore", () => {
@@ -22,28 +22,28 @@ describe("userCountryStore", () => {
     });
   });
 
-  describe("isUserCountryLoadingStore", () => {
+  describe("isUserCountryLoadedStore", () => {
     beforeEach(() => {
-      userCountryStore.set(undefined);
+      userCountryStore.set("not loaded");
     });
 
-    it("should return true when the location is undefined", () => {
-      userCountryStore.set(undefined);
-      expect(get(isUserCountryLoadingStore)).toBe(true);
+    it("should return false when the location is 'not loaded'", () => {
+      userCountryStore.set("not loaded");
+      expect(get(isUserCountryLoadedStore)).toBe(false);
     });
 
-    it("should return false when the location is not undefined", () => {
+    it("should return true when the location is loaded", () => {
       userCountryStore.set({ isoCode: "CH" });
-      expect(get(isUserCountryLoadingStore)).toEqual(false);
+      expect(get(isUserCountryLoadedStore)).toEqual(true);
 
       userCountryStore.set(new Error("Error"));
-      expect(get(isUserCountryLoadingStore)).toEqual(false);
+      expect(get(isUserCountryLoadedStore)).toEqual(true);
     });
   });
 
   describe("isUserCountryErrorStore", () => {
     beforeEach(() => {
-      userCountryStore.set(undefined);
+      userCountryStore.set("not loaded");
     });
 
     it("should return true when the location is an error", () => {
@@ -55,7 +55,7 @@ describe("userCountryStore", () => {
       userCountryStore.set({ isoCode: "CH" });
       expect(get(isUserCountryErrorStore)).toEqual(false);
 
-      userCountryStore.set(undefined);
+      userCountryStore.set("not loaded");
       expect(get(isUserCountryErrorStore)).toEqual(false);
     });
   });

--- a/frontend/src/tests/lib/stores/user-country.store.spec.ts
+++ b/frontend/src/tests/lib/stores/user-country.store.spec.ts
@@ -1,15 +1,62 @@
-import { userCountryStore } from "$lib/stores/user-country.store";
+import {
+  isUserCountryErrorStore,
+  isUserCountryLoadingStore,
+  userCountryStore,
+} from "$lib/stores/user-country.store";
 import { get } from "svelte/store";
 
 describe("userCountryStore", () => {
   beforeEach(() => {
     userCountryStore.set(undefined);
   });
-  it("should set the location store", () => {
-    userCountryStore.set("CH");
-    expect(get(userCountryStore)).toEqual("CH");
 
-    userCountryStore.set("US");
-    expect(get(userCountryStore)).toEqual("US");
+  describe("userCountryStore", () => {
+    it("should set the location store", () => {
+      const ch = { isoCode: "CH" };
+      userCountryStore.set(ch);
+      expect(get(userCountryStore)).toEqual(ch);
+
+      const us = { isoCode: "US" };
+      userCountryStore.set(us);
+      expect(get(userCountryStore)).toEqual(us);
+    });
+  });
+
+  describe("isUserCountryLoadingStore", () => {
+    beforeEach(() => {
+      userCountryStore.set(undefined);
+    });
+
+    it("should return true when the location is undefined", () => {
+      userCountryStore.set(undefined);
+      expect(get(isUserCountryLoadingStore)).toBe(true);
+    });
+
+    it("should return false when the location is not undefined", () => {
+      userCountryStore.set({ isoCode: "CH" });
+      expect(get(isUserCountryLoadingStore)).toEqual(false);
+
+      userCountryStore.set(new Error("Error"));
+      expect(get(isUserCountryLoadingStore)).toEqual(false);
+    });
+  });
+
+  describe("isUserCountryErrorStore", () => {
+    beforeEach(() => {
+      userCountryStore.set(undefined);
+    });
+
+    it("should return true when the location is an error", () => {
+      userCountryStore.set(new Error("Error"));
+      expect(get(isUserCountryErrorStore)).toBe(true);
+    });
+
+    it("should return false when the location is not an error", () => {
+      userCountryStore.set({ isoCode: "CH" });
+      expect(get(isUserCountryErrorStore)).toEqual(false);
+
+      userCountryStore.set(undefined);
+      expect(get(isUserCountryErrorStore)).toEqual(false);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

We need to handle three states in the country store: loading, error and success.

In this PR: We change the type of the data in the store to better manage the different states.

# Changes

* Change the type inside `userCountryStore`.
* Add two derived stores with the logic for the error and the loading state.
* New type `Country`.

# Tests

* Fix tests accordingly.
* Add tests for two new derived stores.
