### PR TITLE
GIX-1555 Support conditions in AdditionalInfoForm

### DIFF
--- a/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
+++ b/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
@@ -8,7 +8,7 @@
   import { i18n } from "$lib/stores/i18n";
 
   export let conditionsToAccept: string | undefined = undefined;
-  export let areConditionsAccepted: boolean = false;
+  export let areConditionsAccepted = false;
 
   export let userHasParticipated: boolean;
   export let minCommitment: TokenAmount;

--- a/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
+++ b/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
@@ -2,32 +2,55 @@
   import type { TokenAmount } from "@dfinity/nns";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import IcpText from "$lib/components/ic/ICPText.svelte";
+  import { nonNullish } from "@dfinity/utils";
+  import { Checkbox } from "@dfinity/gix-components";
   import { KeyValuePair } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
+
+  export let conditionsToAccept: string | undefined = undefined;
+  export let areConditionsAccepted: boolean = false;
 
   export let userHasParticipated: boolean;
   export let minCommitment: TokenAmount;
   export let maxCommitment: TokenAmount;
 </script>
 
-{#if userHasParticipated}
-  <p class="right">
-    {$i18n.sns_project_detail.max_left}
-    <AmountDisplay singleLine amount={maxCommitment} />
-  </p>
-{:else}
-  <KeyValuePair>
-    <IcpText slot="key" amount={minCommitment}>
-      <span class="description">{$i18n.core.min}</span>
-    </IcpText>
-    <IcpText slot="value" amount={maxCommitment}>
-      <span class="description">{$i18n.core.max}</span>
-    </IcpText>
-  </KeyValuePair>
-{/if}
+<div data-tid="additional-info-form-component" class="additional-info">
+  {#if nonNullish(conditionsToAccept)}
+    <Checkbox
+      text="block"
+      inputId="agree"
+      checked={areConditionsAccepted}
+      on:nnsChange={() => (areConditionsAccepted = !areConditionsAccepted)}
+    >
+      <span data-tid="conditions">{conditionsToAccept}</span>
+    </Checkbox>
+  {/if}
+
+  {#if userHasParticipated}
+    <p class="right">
+      {$i18n.sns_project_detail.max_left}
+      <AmountDisplay singleLine amount={maxCommitment} />
+    </p>
+  {:else}
+    <KeyValuePair>
+      <IcpText slot="key" amount={minCommitment}>
+        <span class="description">{$i18n.core.min}</span>
+      </IcpText>
+      <IcpText slot="value" amount={maxCommitment}>
+        <span class="description">{$i18n.core.max}</span>
+      </IcpText>
+    </KeyValuePair>
+  {/if}
+</div>
 
 <style lang="scss">
   p {
     margin: 0;
+  }
+  .additional-info {
+    --checkbox-label-order: 1;
+    --padding: var(--padding-2x);
+    --checkbox-padding: var(--padding) 0;
   }
 </style>

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoForm.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+import { get, writable, type Writable } from "svelte/store";
+import AdditionalInfoFormTest from "./AdditionalInfoFormTest.svelte";
+
+const renderComponent = ({
+  conditionsToAccept,
+  areConditionsAcceptedStore,
+}: {
+  conditionsToAccept: string | undefined;
+  areConditionsAcceptedStore?: Writable<boolean> | undefined;
+}): AdditionalInfoFormPo => {
+  const { container } = render(AdditionalInfoFormTest, {
+    conditionsToAccept,
+    areConditionsAcceptedStore,
+  });
+  return AdditionalInfoFormPo.under(new JestPageObjectElement(container));
+};
+
+describe("AdditionalInfoForm", () => {
+  it("should render conditions if present", async () => {
+    const conditionsToAccept = "I agree to sell my soul";
+    const po = renderComponent({ conditionsToAccept });
+    expect(await po.hasConditions()).toBe(true);
+    expect(await po.getConditions()).toBe(conditionsToAccept);
+  });
+
+  it("should not render conditions if not present", async () => {
+    const conditionsToAccept = undefined;
+    const po = renderComponent({ conditionsToAccept });
+    expect(await po.hasConditions()).toBe(false);
+  });
+
+  it("should export the checkbox state", async () => {
+    const conditionsToAccept = "I agree to sell my soul";
+    const areConditionsAcceptedStore = writable<boolean>(false);
+    const po = renderComponent({
+      conditionsToAccept,
+      areConditionsAcceptedStore,
+    });
+    expect(get(areConditionsAcceptedStore)).toBe(false);
+    await po.toggleConditionsAccepted();
+    expect(get(areConditionsAcceptedStore)).toBe(true);
+    await po.toggleConditionsAccepted();
+    expect(get(areConditionsAcceptedStore)).toBe(false);
+  });
+});

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import AdditionalInfoForm from "$lib/components/sale/AdditionalInfoForm.svelte";
+  import { ICPToken, TokenAmount } from "@dfinity/nns";
+
+  export let conditionsToAccept: string | undefined;
+  export let areConditionsAcceptedStore: Writable<boolean>;
+  let areConditionsAccepted: boolean = false;
+
+  $: areConditionsAcceptedStore &&
+    areConditionsAcceptedStore.set(areConditionsAccepted);
+
+  const minCommitment = TokenAmount.fromString({
+    amount: "1.00",
+    token: ICPToken,
+  });
+  const maxCommitment = TokenAmount.fromString({
+    amount: "1000.00",
+    token: ICPToken,
+  });
+  const userHasParticipated = false;
+</script>
+
+<AdditionalInfoForm
+  {minCommitment}
+  {maxCommitment}
+  {userHasParticipated}
+  bind:areConditionsAccepted
+  {conditionsToAccept}
+/>

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import AdditionalInfoForm from "$lib/components/sale/AdditionalInfoForm.svelte";
   import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import type { Writable } from "svelte/store";
 
   export let conditionsToAccept: string | undefined;
   export let areConditionsAcceptedStore: Writable<boolean>;
-  let areConditionsAccepted: boolean = false;
+  let areConditionsAccepted = false;
 
   $: areConditionsAcceptedStore &&
     areConditionsAcceptedStore.set(areConditionsAccepted);

--- a/frontend/src/tests/page-objects/AdditionalInfoForm.page-object.ts
+++ b/frontend/src/tests/page-objects/AdditionalInfoForm.page-object.ts
@@ -1,0 +1,22 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class AdditionalInfoFormPo extends BasePageObject {
+  private static readonly TID = "additional-info-form-component";
+
+  static under(element: PageObjectElement): AdditionalInfoFormPo {
+    return new AdditionalInfoFormPo(element.byTestId(AdditionalInfoFormPo.TID));
+  }
+
+  hasConditions(): Promise<boolean> {
+    return this.root.byTestId("conditions").isPresent();
+  }
+
+  getConditions(): Promise<string> {
+    return this.getText("conditions");
+  }
+
+  toggleConditionsAccepted(): Promise<void> {
+    return this.click("checkbox");
+  }
+}


### PR DESCRIPTION
# Motivation

We want to allow SNS params to include conditions that have to be agreed to by swap participants.
This PR only updates the component that will display the conditions and the checkbox.
It is not hooked up to anything yet.

# Changes

1. In `frontend/src/lib/components/sale/AdditionalInfoForm.svelte` render conditions and a checkbox if conditions are passed as optional props.
2. Add a page object for `AdditionalInfoForm`.
3. Add a `AdditionalInfoFormTest` component to assist in testing by passing a svelte store to read out the value of the checkbox.
4. Add tests.

# Tests

1. Added a unit test.
2. Confirmed manually that nothing is displayed yet because the props aren't passed to the component.
