### PR TITLE
feat: Add ic-wasm to the toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_VERSION' dfx.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' dfx.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.WASM_NM_VERSION' dfx.json > config/wasm_nm_version
+RUN jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json > config/ic_wasm_version
 
 # This is the "builder", i.e. the base image used later to build the final code.
 FROM base as builder
@@ -71,6 +72,7 @@ RUN dfx --version
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc"
 RUN didc --version
 RUN cargo install "wasm-nm@$(cat config/wasm_nm_version)" && command -v wasm-nm
+RUN cargo install "ic-wasm@$(cat config/ic_wasm_version)"
 
 # Title: Gets the deployment configuration
 # Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.

--- a/dfx.json
+++ b/dfx.json
@@ -690,6 +690,7 @@
       "config": {
         "NODE_VERSION": "18.14.2",
         "WASM_NM_VERSION": "0.2.0",
+	"IC_WASM_VERSION": "0.3.6",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",

--- a/dfx.json
+++ b/dfx.json
@@ -690,7 +690,7 @@
       "config": {
         "NODE_VERSION": "18.14.2",
         "WASM_NM_VERSION": "0.2.0",
-	"IC_WASM_VERSION": "0.3.6",
+        "IC_WASM_VERSION": "0.3.6",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",


### PR DESCRIPTION
# Motivation
We would like to include the git commit and API did in the nns-dapp and sns_aggregator wasm metadata sections.  The ic-wasm tool is currently the preferred method for adding custom sections.

Unfortunately its pre-built binaries do not work on the standard production linux (Ubuntu 20.04), due to the same issue that plagued a number of other ic projects in recent months.  So we have to fall back to cargo install, which works reliably but is slow.  CI will similarly be slow until ic-wasm is in the main branch docker cache.  So let's get it there soon.

# Changes
- Add ic-wasm to the toolchain

# TODO
- Use ic-wasm to add the desired custom sections.

# Tests
I have used ic-wasm locally to add custom sections