### PR TITLE
Replace toBeFalsy() with more specific expectations

### DIFF
--- a/frontend/src/tests/lib/components/common/AddPrincipal.spec.ts
+++ b/frontend/src/tests/lib/components/common/AddPrincipal.spec.ts
@@ -51,7 +51,7 @@ describe("PrincipalInput", () => {
     const buttonElement = getByTestId("add-principal-button");
 
     await waitFor(() =>
-      expect(buttonElement.hasAttribute("disabled")).toBeFalsy()
+      expect(buttonElement.hasAttribute("disabled")).toBe(false)
     );
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/actions/AutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/AutoStakeMaturity.spec.ts
@@ -30,7 +30,7 @@ describe("AutoStakeMaturity", () => {
       return;
     }
 
-    expect(inputElement.checked).toBeFalsy();
+    expect(inputElement.checked).toBe(false);
   };
 
   it("renders checked if auto stake already on", () => testCheckBox(true));

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -66,7 +66,7 @@ describe("JoinCommunityFundCheckbox", () => {
     });
 
     const inputElement = queryByTestId("checkbox") as HTMLInputElement;
-    expect(inputElement.checked).toBeFalsy();
+    expect(inputElement.checked).toBe(false);
   });
 
   it("allows neuron to join community fund", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -60,7 +60,7 @@ describe("NnsAutoStakeMaturity", () => {
       return;
     }
 
-    expect(inputElement.checked).toBeFalsy();
+    expect(inputElement.checked).toBe(false);
   };
 
   it("renders checked if auto stake already on", () => testCheckBox(true));

--- a/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
@@ -29,7 +29,7 @@ describe("StakeMaturityButton", () => {
     });
 
     const button = getByTestId("stake-maturity-button");
-    await waitFor(() => expect(button.hasAttribute("disabled")).toBeFalsy());
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBe(false));
   });
 
   it("should be disabled", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -62,7 +62,7 @@ describe("SnsAutoStakeMaturity", () => {
       return;
     }
 
-    expect(inputElement.checked).toBeFalsy();
+    expect(inputElement.checked).toBe(false);
   };
 
   it("renders checked if auto stake already on", () => testCheckBox(true));

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -52,7 +52,7 @@ describe("SplitSnsNeuronButton", () => {
 
     const button = getByTestId("split-neuron-button");
     expect(button).toBeInTheDocument();
-    expect(button.hasAttribute("disabled")).toBeFalsy();
+    expect(button.hasAttribute("disabled")).toBe(false);
   });
 
   it("should open split neuron modal", async () => {

--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -46,6 +46,6 @@ describe("IntersectionDirectives", () => {
     render(IntersectionTest);
 
     expect(spy).toHaveBeenCalled();
-    expect(testIntersecting).toBeFalsy();
+    expect(testIntersecting).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -59,7 +59,7 @@ describe("IcpTransactionModal", () => {
     const toggle = container.querySelector("input[id='toggle']");
     toggle && fireEvent.click(toggle);
     await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      expect(participateButton?.hasAttribute("disabled")).toBe(false)
     );
 
     fireEvent.click(participateButton);

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -81,7 +81,7 @@ describe("IncreaseNeuronStakeModal", () => {
       const input = container.querySelector("input[name='amount']");
       input && fireEvent.input(input, { target: { value: icpAmount } });
       await waitFor(() =>
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(participateButton?.hasAttribute("disabled")).toBe(false)
       );
 
       fireEvent.click(participateButton);

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -98,7 +98,7 @@ describe("ParticipateSwapModal", () => {
     const input = container.querySelector("input[name='amount']");
     input && fireEvent.input(input, { target: { value: icpAmount } });
     await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      expect(participateButton?.hasAttribute("disabled")).toBe(false)
     );
 
     fireEvent.click(participateButton);
@@ -131,7 +131,7 @@ describe("ParticipateSwapModal", () => {
       const acceptInput = container.querySelector("[type='checkbox']");
       acceptInput && (await fireEvent.click(acceptInput));
       await waitFor(() =>
-        expect(confirmButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(confirmButton?.hasAttribute("disabled")).toBe(false)
       );
 
       fireEvent.click(confirmButton);
@@ -172,7 +172,7 @@ describe("ParticipateSwapModal", () => {
       const acceptInput = container.querySelector("[type='checkbox']");
       acceptInput && (await fireEvent.click(acceptInput));
       await waitFor(() =>
-        expect(confirmButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(confirmButton?.hasAttribute("disabled")).toBe(false)
       );
 
       fireEvent.click(confirmButton);
@@ -200,7 +200,7 @@ describe("ParticipateSwapModal", () => {
         const acceptInput = container.querySelector("[type='checkbox']");
         acceptInput && (await fireEvent.click(acceptInput));
         await waitFor(() =>
-          expect(confirmButton?.hasAttribute("disabled")).toBeFalsy()
+          expect(confirmButton?.hasAttribute("disabled")).toBe(false)
         );
 
         fireEvent.click(confirmButton);
@@ -223,7 +223,7 @@ describe("ParticipateSwapModal", () => {
         const acceptInput = container.querySelector("[type='checkbox']");
         acceptInput && (await fireEvent.click(acceptInput));
         await waitFor(() =>
-          expect(confirmButton?.hasAttribute("disabled")).toBeFalsy()
+          expect(confirmButton?.hasAttribute("disabled")).toBe(false)
         );
 
         fireEvent.click(confirmButton);
@@ -243,7 +243,7 @@ describe("ParticipateSwapModal", () => {
         const input = container.querySelector("input[name='amount']");
         input && (await fireEvent.input(input, { target: { value: "10" } }));
 
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy();
+        expect(participateButton?.hasAttribute("disabled")).toBe(false);
       });
     });
   });

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -127,7 +127,7 @@ describe("TransactionModal", () => {
     toggle && fireEvent.click(toggle);
 
     await waitFor(() =>
-      expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+      expect(participateButton?.hasAttribute("disabled")).toBe(false)
     );
 
     fireEvent.click(participateButton);
@@ -203,7 +203,7 @@ describe("TransactionModal", () => {
       toggle && fireEvent.click(toggle);
 
       await waitFor(() =>
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(participateButton?.hasAttribute("disabled")).toBe(false)
       );
     });
 
@@ -355,7 +355,7 @@ describe("TransactionModal", () => {
       toggle && fireEvent.click(toggle);
 
       await waitFor(() =>
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(participateButton?.hasAttribute("disabled")).toBe(false)
       );
 
       fireEvent.click(participateButton);
@@ -471,7 +471,7 @@ describe("TransactionModal", () => {
         fireEvent.input(addressInput, { target: { value: "aaaaa-aa" } });
 
       await waitFor(() =>
-        expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+        expect(participateButton?.hasAttribute("disabled")).toBe(false)
       );
 
       fireEvent.click(participateButton);

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -642,7 +642,7 @@ describe("sns-neurons-services", () => {
         account: mockSnsMainAccount,
       });
 
-      expect(success).toBeFalsy();
+      expect(success).toBe(false);
       expect(spyStake).not.toBeCalled();
     });
   });
@@ -1087,7 +1087,7 @@ describe("sns-neurons-services", () => {
       });
 
       expect(toastsError).toBeCalled();
-      expect(success).toBeFalsy();
+      expect(success).toBe(false);
       expect(spySplitNeuron).not.toBeCalled();
     });
   });

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -214,14 +214,14 @@ describe("api-utils", () => {
           );
         const onLoad = jest.fn();
 
-        expect(updateDone).toBeFalsy();
-        expect(queryDone).toBeFalsy();
+        expect(updateDone).toBe(false);
+        expect(queryDone).toBe(false);
         await queryAndUpdate<number, unknown>({
           request,
           onLoad,
         });
         expect(updateDone).toBeTruthy();
-        expect(queryDone).toBeFalsy();
+        expect(queryDone).toBe(false);
       });
 
       it("should log", async () => {

--- a/frontend/src/tests/lib/stores/accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/accounts.store.spec.ts
@@ -57,7 +57,7 @@ describe("accountsStore", () => {
 
   it("should set certified data", () => {
     const { certified: initialCertified } = get(accountsStore);
-    expect(initialCertified).toBeFalsy();
+    expect(initialCertified).toBe(undefined);
 
     accountsStoreSet({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -53,7 +53,7 @@ describe("sns.store", () => {
       const $snsProposalsStore = get(snsProposalsStore);
 
       expect($snsProposalsStore?.proposals).toEqual(proposals);
-      expect($snsProposalsStore?.certified).toBeFalsy();
+      expect($snsProposalsStore?.certified).toBe(false);
     });
 
     it("should filter open proposals", () => {

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -162,14 +162,14 @@ describe("accounts-utils", () => {
             network: undefined,
             rootCanisterId: OWN_CANISTER_ID,
           })
-        ).toBeFalsy();
+        ).toBe(false);
         expect(
           invalidAddress({
             address: mockAddressInputValid,
             network: TransactionNetwork.ICP,
             rootCanisterId: OWN_CANISTER_ID,
           })
-        ).toBeFalsy();
+        ).toBe(false);
       });
 
       it("should return false for Icrc accounts", () => {
@@ -179,14 +179,14 @@ describe("accounts-utils", () => {
             network: undefined,
             rootCanisterId: mockCanisterId,
           })
-        ).toBeFalsy();
+        ).toBe(false);
         expect(
           invalidAddress({
             address: subaccountString,
             network: TransactionNetwork.ICP,
             rootCanisterId: mockCanisterId,
           })
-        ).toBeFalsy();
+        ).toBe(false);
       });
 
       it("should return false for BTC", () => {
@@ -196,7 +196,7 @@ describe("accounts-utils", () => {
             network: TransactionNetwork.BTC_TESTNET,
             rootCanisterId: mockCanisterId,
           })
-        ).toBeFalsy();
+        ).toBe(false);
       });
 
       it("should not be a valid ICP address", () => {
@@ -254,7 +254,7 @@ describe("accounts-utils", () => {
       });
 
       it("should be a valid ICP address", () => {
-        expect(invalidIcpAddress(mockAddressInputValid)).toBeFalsy();
+        expect(invalidIcpAddress(mockAddressInputValid)).toBe(false);
       });
 
       it("should return false for sns accounts", () => {
@@ -274,7 +274,7 @@ describe("accounts-utils", () => {
       });
 
       it("should return false for sns accounts", () => {
-        expect(invalidIcrcAddress(subaccountString)).toBeFalsy();
+        expect(invalidIcrcAddress(subaccountString)).toBe(false);
       });
     });
 
@@ -286,7 +286,7 @@ describe("accounts-utils", () => {
             network: TransactionNetwork.BTC_TESTNET,
             rootCanisterId: mockCanisterId,
           })
-        ).toBeFalsy();
+        ).toBe(false);
 
         expect(
           invalidAddress({
@@ -294,7 +294,7 @@ describe("accounts-utils", () => {
             network: TransactionNetwork.BTC_MAINNET,
             rootCanisterId: mockCanisterId,
           })
-        ).toBeFalsy();
+        ).toBe(false);
       });
 
       it("should return invalid for BTC", () => {
@@ -356,7 +356,7 @@ describe("accounts-utils", () => {
     });
 
     it("should not be an empty address", () => {
-      expect(emptyAddress("test")).toBeFalsy();
+      expect(emptyAddress("test")).toBe(false);
     });
   });
 
@@ -382,12 +382,12 @@ describe("accounts-utils", () => {
     });
 
     it("returns false if type no hardware wallet", () => {
-      expect(isAccountHardwareWallet(mockMainAccount)).toBeFalsy();
-      expect(isAccountHardwareWallet(mockSubAccount)).toBeFalsy();
+      expect(isAccountHardwareWallet(mockMainAccount)).toBe(false);
+      expect(isAccountHardwareWallet(mockSubAccount)).toBe(false);
     });
 
     it("returns false if no account", () => {
-      expect(isAccountHardwareWallet(undefined)).toBeFalsy();
+      expect(isAccountHardwareWallet(undefined)).toBe(false);
     });
   });
 
@@ -649,6 +649,6 @@ describe("accounts-utils", () => {
     it("should have accounts", () =>
       expect(hasAccounts([mockMainAccount])).toBeTruthy());
 
-    it("should not have accounts", () => expect(hasAccounts([])).toBeFalsy());
+    it("should not have accounts", () => expect(hasAccounts([])).toBe(false));
   });
 });

--- a/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -3,8 +3,8 @@ import { mockIdentity } from "$tests/mocks/auth.store.mock";
 
 describe("auth-utils", () => {
   it("should not be signed in", () => {
-    expect(isSignedIn(undefined)).toBeFalsy();
-    expect(isSignedIn(null)).toBeFalsy();
+    expect(isSignedIn(undefined)).toBe(false);
+    expect(isSignedIn(null)).toBe(false);
   });
 
   it("should be signed in", () => {

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -44,7 +44,7 @@ describe("env-utils", () => {
         },
       });
 
-      expect(isNnsAlternativeOrigin()).toBeFalsy();
+      expect(isNnsAlternativeOrigin()).toBe(false);
 
       Object.defineProperty(window, "location", {
         writable: true,
@@ -54,7 +54,7 @@ describe("env-utils", () => {
         },
       });
 
-      expect(isNnsAlternativeOrigin()).toBeFalsy();
+      expect(isNnsAlternativeOrigin()).toBe(false);
 
       Object.defineProperty(window, "location", {
         writable: true,
@@ -64,7 +64,7 @@ describe("env-utils", () => {
         },
       });
 
-      expect(isNnsAlternativeOrigin()).toBeFalsy();
+      expect(isNnsAlternativeOrigin()).toBe(false);
 
       Object.defineProperty(window, "location", {
         writable: true,
@@ -74,7 +74,7 @@ describe("env-utils", () => {
         },
       });
 
-      expect(isNnsAlternativeOrigin()).toBeFalsy();
+      expect(isNnsAlternativeOrigin()).toBe(false);
 
       Object.defineProperty(window, "location", {
         writable: true,
@@ -84,7 +84,7 @@ describe("env-utils", () => {
         },
       });
 
-      expect(isNnsAlternativeOrigin()).toBeFalsy();
+      expect(isNnsAlternativeOrigin()).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -35,7 +35,7 @@ describe("navigation-utils", () => {
           effectivePreviousPath: AppPath.Canister,
           currentData: ["test"],
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should reload if not expected route referrer", () => {
@@ -217,14 +217,14 @@ describe("navigation-utils", () => {
           currentPath: AppPath.Authentication,
           paths: [AppPath.Accounts, AppPath.Wallet],
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         isSelectedPath({
           currentPath: null,
           paths: [AppPath.Accounts, AppPath.Wallet],
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -285,13 +285,13 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: fullNeuronWithoutEnoughStake,
       };
-      expect(hasValidStake(neuronWithoutEnoughStake)).toBeFalsy();
+      expect(hasValidStake(neuronWithoutEnoughStake)).toBe(false);
 
       const neuronWithoutFullNeuron = {
         ...mockNeuron,
       };
       neuronWithoutFullNeuron.fullNeuron = undefined;
-      expect(hasValidStake(neuronWithoutFullNeuron)).toBeFalsy();
+      expect(hasValidStake(neuronWithoutFullNeuron)).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -197,16 +197,16 @@ describe("project-utils", () => {
           summary: undefined,
           swapCommitment: undefined,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         canUserParticipateToSwap({ summary: null, swapCommitment: undefined })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         canUserParticipateToSwap({ summary: undefined, swapCommitment: null })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         canUserParticipateToSwap({ summary: null, swapCommitment: null })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("cannot participate to swap if sale is not open", () => {
@@ -215,28 +215,28 @@ describe("project-utils", () => {
           summary: summaryForLifecycle(SnsSwapLifecycle.Unspecified),
           swapCommitment: mockSwapCommitment,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         canUserParticipateToSwap({
           summary: summaryForLifecycle(SnsSwapLifecycle.Pending),
           swapCommitment: mockSwapCommitment,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         canUserParticipateToSwap({
           summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
           swapCommitment: mockSwapCommitment,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         canUserParticipateToSwap({
           summary: summaryForLifecycle(SnsSwapLifecycle.Aborted),
           swapCommitment: mockSwapCommitment,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("can participate to swap if sale is open", () => {
@@ -261,7 +261,7 @@ describe("project-utils", () => {
             },
           },
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("can participate to swap if max user commitment is not reached", () => {
@@ -409,19 +409,19 @@ describe("project-utils", () => {
         hasUserParticipatedToSwap({
           swapCommitment: undefined,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hasUserParticipatedToSwap({
           swapCommitment: null,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hasUserParticipatedToSwap({
           swapCommitment: mockSnsSwapCommitment(principal(3)),
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hasUserParticipatedToSwap({
@@ -432,7 +432,7 @@ describe("project-utils", () => {
             },
           },
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -127,7 +127,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -139,7 +139,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -151,7 +151,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -163,7 +163,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -183,7 +183,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -203,7 +203,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -215,7 +215,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -227,7 +227,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -242,7 +242,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: undefined,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should hide proposal", () => {
@@ -405,7 +405,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should ignore ballots neuronIds that are not in neurons", () => {
@@ -601,7 +601,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hasMatchingProposals({
@@ -623,7 +623,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         hasMatchingProposals({
@@ -645,7 +645,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -1038,13 +1038,13 @@ describe("proposals-utils", () => {
           proposalsA: proposals,
           proposalsB: proposals.slice(1),
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         proposalsHaveSameIds({
           proposalsA: generateMockProposals(20).slice(10),
           proposalsB: proposals,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -1208,7 +1208,7 @@ describe("proposals-utils", () => {
           ...mockProposalInfo,
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds - 10000)),
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should be open for votes short period", () => {
@@ -1232,7 +1232,7 @@ describe("proposals-utils", () => {
           topic: Topic.ManageNeuron,
           proposalTimestampSeconds: BigInt(Math.round(nowSeconds - 3600 * 13)),
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should be open for votes quiet threshold", () => {
@@ -1278,7 +1278,7 @@ describe("proposals-utils", () => {
             Math.round(nowSeconds - 3600 * 24 * 5)
           ),
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -1060,7 +1060,7 @@ describe("sns-neuron utils", () => {
 
     it("returns false for NeuronInfo (nnsNeuron)", () => {
       const neuron: NeuronInfo = { ...mockNeuron };
-      expect(isSnsNeuron(neuron)).toBeFalsy();
+      expect(isSnsNeuron(neuron)).toBe(false);
     });
   });
 
@@ -1098,7 +1098,7 @@ describe("sns-neuron utils", () => {
         cached_neuron_stake_e8s: BigInt(0),
         maturity_e8s_equivalent: BigInt(0),
       };
-      expect(hasValidStake(neuron)).toBeFalsy();
+      expect(hasValidStake(neuron)).toBe(false);
     });
   });
 
@@ -1131,7 +1131,7 @@ describe("sns-neuron utils", () => {
           fee: 100n,
           neuronMinimumStake: 1000n,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -1161,7 +1161,7 @@ describe("sns-neuron utils", () => {
           fee: 100n,
           neuronMinimumStake: 1000n,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -1247,12 +1247,12 @@ describe("sns-neuron utils", () => {
         maturity_e8s_equivalent: BigInt(0),
       };
 
-      expect(hasEnoughMaturityToStake(neuron)).toBeFalsy();
+      expect(hasEnoughMaturityToStake(neuron)).toBe(false);
     });
 
     it("should return false when no neuron provided", () => {
-      expect(hasEnoughMaturityToStake(null)).toBeFalsy();
-      expect(hasEnoughMaturityToStake(undefined)).toBeFalsy();
+      expect(hasEnoughMaturityToStake(null)).toBe(false);
+      expect(hasEnoughMaturityToStake(undefined)).toBe(false);
     });
   });
 
@@ -1278,12 +1278,12 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
-      expect(hasStakedMaturity(neuron)).toBeFalsy();
+      expect(hasStakedMaturity(neuron)).toBe(false);
     });
 
     it("should return false when no neuron provided", () => {
-      expect(hasStakedMaturity(null)).toBeFalsy();
-      expect(hasStakedMaturity(undefined)).toBeFalsy();
+      expect(hasStakedMaturity(null)).toBe(false);
+      expect(hasStakedMaturity(undefined)).toBe(false);
     });
   });
 
@@ -1324,7 +1324,7 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         source_nns_neuron_id: [],
       };
-      expect(isCommunityFund(neuron)).toBeFalsy();
+      expect(isCommunityFund(neuron)).toBe(false);
     });
   });
 
@@ -1351,7 +1351,7 @@ describe("sns-neuron utils", () => {
           neuron,
           balanceE8s: BigInt(2),
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -358,17 +358,17 @@ describe("sns-utils", () => {
 
     it("returns false on unknown error", () => {
       const error = new Error("Fake the swap has already reached its target");
-      expect(isInternalRefreshBuyerTokensError(error)).toBeFalsy();
+      expect(isInternalRefreshBuyerTokensError(error)).toBe(false);
     });
 
     it("returns false on not error argument", () => {
-      expect(isInternalRefreshBuyerTokensError(null)).toBeFalsy();
-      expect(isInternalRefreshBuyerTokensError(undefined)).toBeFalsy();
+      expect(isInternalRefreshBuyerTokensError(null)).toBe(false);
+      expect(isInternalRefreshBuyerTokensError(undefined)).toBe(false);
       expect(
         isInternalRefreshBuyerTokensError(
           "The swap has already reached its target"
         )
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -393,17 +393,17 @@ sale_participants_count ${saleBuyerCount} 1677707139456
 
     it("returns false on unknown error", () => {
       const error = new Error("Fake the swap has already reached its target");
-      expect(isInternalRefreshBuyerTokensError(error)).toBeFalsy();
+      expect(isInternalRefreshBuyerTokensError(error)).toBe(false);
     });
 
     it("returns false on not error argument", () => {
-      expect(isInternalRefreshBuyerTokensError(null)).toBeFalsy();
-      expect(isInternalRefreshBuyerTokensError(undefined)).toBeFalsy();
+      expect(isInternalRefreshBuyerTokensError(null)).toBe(false);
+      expect(isInternalRefreshBuyerTokensError(undefined)).toBe(false);
       expect(
         isInternalRefreshBuyerTokensError(
           "The swap has already reached its target"
         )
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -34,13 +34,13 @@ describe("transactions-utils", () => {
           type: AccountTransactionType.Send,
           isReceive: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         showTransactionFee({
           type: AccountTransactionType.Mint,
           isReceive: true,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should be false for sent Mint and Burn", () => {
@@ -49,13 +49,13 @@ describe("transactions-utils", () => {
           type: AccountTransactionType.Mint,
           isReceive: false,
         })
-      ).toBeFalsy();
+      ).toBe(false);
       expect(
         showTransactionFee({
           type: AccountTransactionType.Burn,
           isReceive: false,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
 
     it("should be true for Sent", () => {
@@ -213,7 +213,7 @@ describe("transactions-utils", () => {
         .e8s as bigint;
 
       expect(type).toBe(transactionType(mockSentToSubAccountTransaction));
-      expect(isReceive).toBeFalsy();
+      expect(isReceive).toBe(false);
       expect(isSend).toBeTruthy();
       expect(from).toBe(mockMainAccount.identifier);
       expect(to).toBe(mockSubAccount.identifier);
@@ -248,7 +248,7 @@ describe("transactions-utils", () => {
       expect(type).toBe(
         transactionType(mockReceivedFromMainAccountTransaction)
       );
-      expect(isSend).toBeFalsy();
+      expect(isSend).toBe(false);
       expect(isReceive).toBeTruthy();
       expect(from).toBe(mockMainAccount.identifier);
       expect(to).toBe(mockSubAccount.identifier);
@@ -287,7 +287,7 @@ describe("transactions-utils", () => {
           fee: TokenAmount.fromE8s({ amount: fee, token: ICPToken }),
         }).toE8s()
       );
-      expect(isSend).toBeFalsy();
+      expect(isSend).toBe(false);
       expect(isReceive).toBeTruthy();
     });
   });
@@ -381,8 +381,8 @@ describe("transactions-utils", () => {
     });
 
     it("should not be network Btc", () => {
-      expect(isTransactionNetworkBtc(TransactionNetwork.ICP)).toBeFalsy();
-      expect(isTransactionNetworkBtc(TransactionNetwork.ICP)).toBeFalsy();
+      expect(isTransactionNetworkBtc(TransactionNetwork.ICP)).toBe(false);
+      expect(isTransactionNetworkBtc(TransactionNetwork.ICP)).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -44,14 +44,14 @@ describe("universes-utils", () => {
           universe: "not used here",
           path: AppPath.Neurons,
         })
-      ).toBeFalsy();
+      ).toBe(false);
 
       expect(
         pathSupportsCkBTC({
           universe: "not used here",
           path: AppPath.Proposal,
         })
-      ).toBeFalsy();
+      ).toBe(false);
     });
   });
 
@@ -61,7 +61,7 @@ describe("universes-utils", () => {
     });
 
     it("returns true if nns dapp principal", () => {
-      expect(isUniverseNns(Principal.from("aaaaa-aa"))).toBeFalsy();
+      expect(isUniverseNns(Principal.from("aaaaa-aa"))).toBe(false);
     });
   });
 
@@ -79,11 +79,11 @@ describe("universes-utils", () => {
     });
 
     it("returns false if not ckBTC canister id", () => {
-      expect(isUniverseCkBTC(OWN_CANISTER_ID)).toBeFalsy();
+      expect(isUniverseCkBTC(OWN_CANISTER_ID)).toBe(false);
     });
 
     it("returns false if not ckBTC canister id text", () => {
-      expect(isUniverseCkBTC(OWN_CANISTER_ID.toText())).toBeFalsy();
+      expect(isUniverseCkBTC(OWN_CANISTER_ID.toText())).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -112,7 +112,7 @@ describe("utils", () => {
     });
 
     it("should return false if undefined", () => {
-      expect(isDefined(undefined)).toBeFalsy();
+      expect(isDefined(undefined)).toBe(false);
     });
   });
 

--- a/frontend/src/tests/utils/neurons-modal.test-utils.ts
+++ b/frontend/src/tests/utils/neurons-modal.test-utils.ts
@@ -34,7 +34,7 @@ export const enterAmount = async (
   const icpAmount = "10";
   const input = container.querySelector(AMOUNT_INPUT_SELECTOR);
   input && fireEvent.input(input, { target: { value: icpAmount } });
-  await waitFor(() => expect(nextButton?.hasAttribute("disabled")).toBeFalsy());
+  await waitFor(() => expect(nextButton?.hasAttribute("disabled")).toBe(false));
 
   fireEvent.click(nextButton);
 

--- a/frontend/src/tests/utils/transaction-modal.test.utils.ts
+++ b/frontend/src/tests/utils/transaction-modal.test.utils.ts
@@ -56,7 +56,7 @@ export const testTransferReviewTokens = async (params: TestTransferTokens) => {
   const participateButton = getByTestId("transaction-button-next");
 
   await waitFor(() =>
-    expect(participateButton?.hasAttribute("disabled")).toBeFalsy()
+    expect(participateButton?.hasAttribute("disabled")).toBe(false)
   );
 
   fireEvent.click(participateButton);


### PR DESCRIPTION
# Motivation

When using `.toBeFalsy()` it's not clear whether we actually expect `false` or another value like `0` or `undefined`.

# Changes

1. Replace `.toBeFalsy()` in `frontend/src/tests/lib/stores/accounts.store.spec.ts` with `.toBe(undefined)`.
2. Replace every other instance of `toBeFalsy()` with `.toBe(false)`.

# Tests

`npm run test`