### PR TITLE
GIX-1566 Remove min/max info from participation form

### DIFF
--- a/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
+++ b/frontend/src/lib/components/sale/AdditionalInfoForm.svelte
@@ -1,18 +1,9 @@
 <script lang="ts">
-  import type { TokenAmount } from "@dfinity/nns";
-  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-  import IcpText from "$lib/components/ic/ICPText.svelte";
   import { nonNullish } from "@dfinity/utils";
   import { Checkbox } from "@dfinity/gix-components";
-  import { KeyValuePair } from "@dfinity/gix-components";
-  import { i18n } from "$lib/stores/i18n";
 
   export let conditionsToAccept: string | undefined = undefined;
   export let areConditionsAccepted = false;
-
-  export let userHasParticipated: boolean;
-  export let minCommitment: TokenAmount;
-  export let maxCommitment: TokenAmount;
 </script>
 
 <div data-tid="additional-info-form-component" class="additional-info">
@@ -26,28 +17,9 @@
       <span data-tid="conditions">{conditionsToAccept}</span>
     </Checkbox>
   {/if}
-
-  {#if userHasParticipated}
-    <p class="right">
-      {$i18n.sns_project_detail.max_left}
-      <AmountDisplay singleLine amount={maxCommitment} />
-    </p>
-  {:else}
-    <KeyValuePair>
-      <IcpText slot="key" amount={minCommitment}>
-        <span class="description">{$i18n.core.min}</span>
-      </IcpText>
-      <IcpText slot="value" amount={maxCommitment}>
-        <span class="description">{$i18n.core.max}</span>
-      </IcpText>
-    </KeyValuePair>
-  {/if}
 </div>
 
 <style lang="scss">
-  p {
-    margin: 0;
-  }
   .additional-info {
     --checkbox-label-order: 1;
     --padding: var(--padding-2x);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -648,7 +648,6 @@
     "status_completed": "Status",
     "completed": "Completed",
     "sale_end": "Swap End",
-    "max_left": "max left",
     "max_user_commitment_reached": "Maximum commitment reached",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",
     "sign_in": "Sign in to participate"

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -11,7 +11,6 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsParams } from "@dfinity/sns";
   import {
     currentUserMaxCommitment,
     hasUserParticipatedToSwap,
@@ -83,11 +82,6 @@
       }
     : undefined;
 
-  let params: SnsParams;
-  $: ({
-    swap: { params },
-  } = summary);
-
   let currentStep: WizardStep | undefined;
   let title: string | undefined;
   $: title =
@@ -98,23 +92,6 @@
       : currentStep?.name === "Progress"
       ? $i18n.sns_sale.participation_in_progress
       : $i18n.accounts.review_transaction;
-
-  let maxCommitment: TokenAmount;
-  $: maxCommitment = TokenAmount.fromE8s({
-    amount: currentUserMaxCommitment({
-      summary,
-      swapCommitment,
-    }),
-    token: ICPToken,
-  });
-
-  let minCommitment: TokenAmount;
-  $: minCommitment = TokenAmount.fromE8s({
-    amount: userHasParticipatedToSwap
-      ? BigInt(0)
-      : params.min_participant_icp_e8s,
-    token: ICPToken,
-  });
 
   let accepted: boolean;
 
@@ -214,11 +191,7 @@
       >{title ?? $i18n.sns_project_detail.participate}</svelte:fragment
     >
     <div class="additional-info" slot="additional-info-form">
-      <AdditionalInfoForm
-        {minCommitment}
-        {maxCommitment}
-        userHasParticipated={userHasParticipatedToSwap}
-      />
+      <AdditionalInfoForm />
     </div>
     <div class="additional-info" slot="additional-info-review">
       <AdditionalInfoReview bind:accepted />

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -674,7 +674,6 @@ interface I18nSns_project_detail {
   status_completed: string;
   completed: string;
   sale_end: string;
-  max_left: string;
   max_user_commitment_reached: string;
   getting_sns_open_ticket: string;
   sign_in: string;

--- a/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
+++ b/frontend/src/tests/lib/components/sale/AdditionalInfoFormTest.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import AdditionalInfoForm from "$lib/components/sale/AdditionalInfoForm.svelte";
-  import { ICPToken, TokenAmount } from "@dfinity/nns";
   import type { Writable } from "svelte/store";
 
   export let conditionsToAccept: string | undefined;
@@ -9,22 +8,6 @@
 
   $: areConditionsAcceptedStore &&
     areConditionsAcceptedStore.set(areConditionsAccepted);
-
-  const minCommitment = TokenAmount.fromString({
-    amount: "1.00",
-    token: ICPToken,
-  });
-  const maxCommitment = TokenAmount.fromString({
-    amount: "1000.00",
-    token: ICPToken,
-  });
-  const userHasParticipated = false;
 </script>
 
-<AdditionalInfoForm
-  {minCommitment}
-  {maxCommitment}
-  {userHasParticipated}
-  bind:areConditionsAccepted
-  {conditionsToAccept}
-/>
+<AdditionalInfoForm bind:areConditionsAccepted {conditionsToAccept} />


### PR DESCRIPTION
# Motivation

https://dfinity.atlassian.net/browse/GIX-1566

This information is already available on the project details.
Removing it will make space for the confirmation checkbox.

# Changes

1. Remove min/max info from `frontend/src/lib/components/sale/AdditionalInfoForm.svelte`
2. Remove related props from the component.
3. Remove passing the props from the parent component.
4. Remove the data from the parent component.
5. Remove the now unused i18n labels.

# Tests

Sadly no tests failed so this was untested.
Now that it's gone it no longer needs to be tested.

I did a quick manual inspection that the form still looks fine for both initial participation and increasing participation.
