### PR TITLE
Commit in metadata

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -24,6 +24,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=local
+            COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=local
+            COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,13 @@ jobs:
             # grep ... fails if the value is implausibly short.
             key="$key" jq -re '.[0][env.key]' nns_dapp_args_in_page.json | grep -E ...
           done
+      - name: Check that metadata is present
+        run: |
+          set +x
+          for canister in nns-dapp sns_aggregator ; do
+            dfx canister metadata --network ic nns-dapp git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}'
+            dfx canister metadata --network ic nns-dapp candid:service | tee /dev/stderr | grep service
+          done
       - name: Basic downgrade-upgrade test
         run: |
           git fetch --depth 1 origin tag prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
             # grep ... fails if the value is implausibly short.
             key="$key" jq -re '.[0][env.key]' nns_dapp_args_in_page.json | grep -E ...
           done
+      - name: Install ic-wasm
+        run: cargo install "ic-wasm@$(jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json)"
       - name: Check that metadata is present
         run: scripts/dfx-wasm-metadata-add.test
       - name: Basic downgrade-upgrade test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
         run: |
           set +x
           for canister in nns-dapp sns_aggregator ; do
-            dfx canister metadata --network ic nns-dapp git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}'
-            dfx canister metadata --network ic nns-dapp candid:service | tee /dev/stderr | grep service
+            dfx canister metadata --network local nns-dapp git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}'
+            dfx canister metadata --network local nns-dapp candid:service | tee /dev/stderr | grep service
           done
       - name: Basic downgrade-upgrade test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install ic-wasm
         run: cargo install "ic-wasm@$(jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json)"
       - name: Check that metadata is present
-        run: scripts/dfx-wasm-metadata-add.test
+        run: scripts/dfx-wasm-metadata-add.test --verbose
       - name: Basic downgrade-upgrade test
         run: |
           git fetch --depth 1 origin tag prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,12 +85,7 @@ jobs:
             key="$key" jq -re '.[0][env.key]' nns_dapp_args_in_page.json | grep -E ...
           done
       - name: Check that metadata is present
-        run: |
-          set +x
-          for canister in nns-dapp sns_aggregator ; do
-            dfx canister metadata --network local nns-dapp git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}'
-            dfx canister metadata --network local nns-dapp candid:service | tee /dev/stderr | grep service
-          done
+        run: scripts/dfx-wasm-metadata-add.test
       - name: Basic downgrade-upgrade test
         run: |
           git fetch --depth 1 origin tag prod

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -30,6 +30,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=${{ matrix.DFX_NETWORK }}
+            COMMIT=${{ github.sha }}
           no-cache: ${{ inputs.no_cache || false }}
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -36,6 +36,7 @@ jobs:
           file: Dockerfile
           build-args: |
             DFX_NETWORK=${{ inputs.network || 'local' }}
+            COMMIT=${{ github.sha }}
           no-cache: ${{ inputs.no_cache || false }}
           cache-from: type=gha,scope=cached-stage
           cache-to: type=gha,scope=cached-stage,mode=max

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,6 +40,8 @@ jobs:
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
           outputs: out
+          build-args:
+            COMMIT: ${{ github.sha }}
       - name: 'Record the git commit and any tags'
         if: steps.preflight.outputs.need_release == 'true'
         run: git log | head -n1 > out/commit.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_VERSION' dfx.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' dfx.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.WASM_NM_VERSION' dfx.json > config/wasm_nm_version
+RUN jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json > config/ic_wasm_version
 
 # This is the "builder", i.e. the base image used later to build the final code.
 FROM base as builder
@@ -71,6 +72,7 @@ RUN dfx --version
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc"
 RUN didc --version
 RUN cargo install "wasm-nm@$(cat config/wasm_nm_version)" && command -v wasm-nm
+RUN cargo install "ic-wasm@$(cat config/ic_wasm_version)"
 
 # Title: Gets the deployment configuration
 # Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
 RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
 ARG COMMIT
 RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose
+RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose --wasm sns_aggregator_dev.wasm
 
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,7 @@ COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
 # TODO: Move this to the apt install at the beginning of this file.
 RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
 ARG COMMIT
-RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator
+RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose
 
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,11 @@ WORKDIR /build
 # We don't wish to update the code from main.rs to lib.rs and then have builds break.
 RUN touch --no-create rs/backend/src/main.rs rs/backend/src/lib.rs
 RUN ./build-backend.sh
+COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
+# TODO: Move this to the apt install at the beginning of this file.
+RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
+ARG COMMIT
+RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name nns-dapp --verbose
 
 # Title: Image to build the sns aggregator, used to increase performance and reduce load.
 # Args: None.
@@ -159,6 +164,12 @@ RUN touch --no-create rs/sns_aggregator/src/main.rs rs/sns_aggregator/src/lib.rs
 RUN RUSTFLAGS="--cfg feature=\"reconfigurable\"" ./build-sns-aggregator.sh
 RUN mv sns_aggregator.wasm sns_aggregator_dev.wasm
 RUN ./build-sns-aggregator.sh
+COPY ./scripts/clap.bash /build/scripts/clap.bash
+COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
+# TODO: Move this to the apt install at the beginning of this file.
+RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
+ARG COMMIT
+RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator
 
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,8 +169,7 @@ COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
 # TODO: Move this to the apt install at the beginning of this file.
 RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
 ARG COMMIT
-RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose
-RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose --wasm sns_aggregator_dev.wasm
+RUN for wasm in sns_aggregator.wasm sns_aggregator_dev.wasm ; do scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose --wasm "$wasm" ; done
 
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,6 @@ RUN didc encode "$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p >nns-dapp-a
 
 # Title: Gets the mainnet config, used for builds
 # Args: None.  This is fixed and studiously avoids depending on variables such as DFX_NETWORK.
-# Note: This MUST NOT be used as an input for the frontend or wasm.
-#       The mainnet config is compiled in and may be overridden using deploy args.
 FROM builder AS mainnet_configurator
 SHELL ["bash", "-c"]
 COPY dfx.json config.sh /build/
@@ -99,6 +97,8 @@ RUN mkdir -p frontend
 ENV DFX_NETWORK=mainnet
 RUN ./config.sh
 RUN didc encode "$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p >nns-dapp-arg-${DFX_NETWORK}.bin
+COPY .git .git
+RUN git rev-parse HEAD > /config/git_commit
 
 # Title: Image to build the nns-dapp frontend.
 FROM builder AS build_frontend
@@ -142,8 +142,8 @@ RUN ./build-backend.sh
 COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
 # TODO: Move this to the apt install at the beginning of this file.
 RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
-ARG COMMIT
-RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name nns-dapp --verbose
+COPY --from=mainnet_configurator /config/git_commit /config/git_commit
+RUN scripts/dfx-wasm-metadata-add --commit "$(cat /config/git_commit)" --canister_name nns-dapp --verbose
 
 # Title: Image to build the sns aggregator, used to increase performance and reduce load.
 # Args: None.
@@ -168,8 +168,8 @@ COPY ./scripts/clap.bash /build/scripts/clap.bash
 COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
 # TODO: Move this to the apt install at the beginning of this file.
 RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
-ARG COMMIT
-RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name sns_aggregator --verbose
+COPY --from=mainnet_configurator /config/git_commit /config/git_commit
+RUN scripts/dfx-wasm-metadata-add --commit "$(cat /config/git_commit)" --canister_name sns_aggregator --verbose
 
 # Title: Image used to extract the final outputs from previous steps.
 FROM scratch AS scratch

--- a/dfx.json
+++ b/dfx.json
@@ -690,6 +690,7 @@
       "config": {
         "NODE_VERSION": "18.14.2",
         "WASM_NM_VERSION": "0.2.0",
+	"IC_WASM_VERSION": "0.3.6",
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",

--- a/dfx.json
+++ b/dfx.json
@@ -100,7 +100,7 @@
     },
     "sns_aggregator": {
       "build": [
-        "./scripts/docker-build"
+        "./build-sns-aggregator.sh"
       ],
       "candid": "rs/sns_aggregator/sns_aggregator.did",
       "wasm": "sns_aggregator.wasm",

--- a/dfx.json
+++ b/dfx.json
@@ -100,7 +100,7 @@
     },
     "sns_aggregator": {
       "build": [
-        "./build-sns-aggregator.sh"
+        "./scripts/docker-build"
       ],
       "candid": "rs/sns_aggregator/sns_aggregator.did",
       "wasm": "sns_aggregator.wasm",

--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -4,7 +4,7 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 print_help() {
-	cat <<-EOF
+  cat <<-EOF
 
 	Adds the git commit and API .did to canister wasm custom sections.
 	EOF
@@ -54,12 +54,16 @@ test -e "${DFX_CANISTER_DID}" || {
 test -n "${DFX_CANISTER_COMMIT:-}" || DFX_CANISTER_COMMIT="$(git rev-parse HEAD)"
 
 : Determine whether the wasm is zipped
-IS_ZIPPED="$( file "$DFX_CANISTER_WASM" | grep -q gzip ; echo $? )"
+IS_ZIPPED="$(
+  file "$DFX_CANISTER_WASM" | grep -q gzip
+  echo $?
+)"
 
 UNZIPPED="${DFX_CANISTER_WASM}.unzipped"
-if (( IS_ZIPPED == 0 ))
-then gunzip < "${DFX_CANISTER_WASM}" > "$UNZIPPED"
-else cat < "${DFX_CANISTER_WASM}" > "$UNZIPPED"
+if ((IS_ZIPPED == 0)); then
+  gunzip <"${DFX_CANISTER_WASM}" >"$UNZIPPED"
+else
+  cat <"${DFX_CANISTER_WASM}" >"$UNZIPPED"
 fi
 
 WITH_COMMIT="${DFX_CANISTER_WASM}.with_commit"
@@ -71,8 +75,9 @@ ic-wasm "$WITH_COMMIT" -o "$WITH_DID" metadata candid:service -f "$DFX_CANISTER_
 rm "$WITH_COMMIT"
 
 ZIPPED="${DFX_CANISTER_WASM}.gz"
-if (( IS_ZIPPED == 0 ))
-then gzip < "${WITH_DID}" > "$ZIPPED"
-else cat < "${WITH_DID}" > "$ZIPPED"
+if ((IS_ZIPPED == 0)); then
+  gzip <"${WITH_DID}" >"$ZIPPED"
+else
+  cat <"${WITH_DID}" >"$ZIPPED"
 fi
 mv "$ZIPPED" "$DFX_CANISTER_WASM"

--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+	cat <<-EOF
+
+	Adds the git commit and API .did to canister wasm custom sections.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=c long=commit desc="The commit; defaults to the current HEAD." variable=DFX_CANISTER_COMMIT
+clap.define short=N long=canister_name desc="The name of the canister (optional)" variable=DFX_CANISTER_NAME
+clap.define short=w long=wasm desc="The path to the wasm file (defaults to the path in dfx.json)" variable=DFX_CANISTER_WASM
+clap.define short=d long=did desc="The path to the interface definition (.did) file (defaults to the path in dfx.json)" variable=DFX_CANISTER_DID
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+test -z "$DFX_CANISTER_NAME" || export DFX_CANISTER_NAME
+
+: "Find the wasm file"
+test -n "${DFX_CANISTER_WASM:-}" || DFX_CANISTER_WASM="$(jq -r '.canisters[env.DFX_CANISTER_NAME].wasm // ""')"
+test -n "${DFX_CANISTER_WASM:-}" || {
+  echo "ERROR: Unable to determine the path to the wasm file."
+  echo "       Please either:"
+  echo "         Use --wasm PATH_TO_WASM"
+  echo "         or use --canister_name NAME and ensure that the wasm is specified in dfx.json"
+  exit 1
+} >&2
+test -e "${DFX_CANISTER_WASM}" || {
+  echo "ERROR: There should be a wasm file at: '$DFX_CANISTER_WASM'"
+  exit 1
+} >&2
+
+: "Find the candid file"
+test -n "${DFX_CANISTER_DID:-}" || DFX_CANISTER_DID="$(jq -r '.canisters[env.DFX_CANISTER_NAME].candid // ""')"
+test -n "${DFX_CANISTER_DID:-}" || {
+  echo "ERROR: Unable to determine the path to the candid file."
+  echo "       Please either:"
+  echo "         Use --wasm PATH_TO_WASM"
+  echo "         or use --canister_name NAME and ensure that the candid is specified in dfx.json"
+  exit 1
+} >&2
+test -e "${DFX_CANISTER_DID}" || {
+  echo "ERROR: There should be a candid file at: '$DFX_CANISTER_DID'"
+  exit 1
+} >&2
+
+: "Find the commit"
+test -n "${DFX_CANISTER_COMMIT:-}" || DFX_CANISTER_COMMIT="$(git rev-parse HEAD)"
+
+: Determine whether the wasm is zipped
+IS_ZIPPED="$( file "$DFX_CANISTER_WASM" | grep -q gzip ; echo $? )"
+
+UNZIPPED="${DFX_CANISTER_WASM}.unzipped"
+if (( IS_ZIPPED == 0 ))
+then gunzip < "${DFX_CANISTER_WASM}" > "$UNZIPPED"
+else cat < "${DFX_CANISTER_WASM}" > "$UNZIPPED"
+fi
+
+WITH_COMMIT="${DFX_CANISTER_WASM}.with_commit"
+ic-wasm "$UNZIPPED" -o "$WITH_COMMIT" metadata git_commit_id -d"$DFX_CANISTER_COMMIT" -v public
+rm "$UNZIPPED"
+
+WITH_DID="${DFX_CANISTER_WASM}.with_did"
+ic-wasm "$WITH_COMMIT" -o "$WITH_DID" metadata candid:service -f "$DFX_CANISTER_DID" -v public
+rm "$WITH_COMMIT"
+
+ZIPPED="${DFX_CANISTER_WASM}.gz"
+if (( IS_ZIPPED == 0 ))
+then gzip < "${WITH_DID}" > "$ZIPPED"
+else cat < "${WITH_DID}" > "$ZIPPED"
+fi
+mv "$ZIPPED" "$DFX_CANISTER_WASM"

--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -23,7 +23,7 @@ source "$(clap.build)"
 test -z "$DFX_CANISTER_NAME" || export DFX_CANISTER_NAME
 
 : "Find the wasm file"
-test -n "${DFX_CANISTER_WASM:-}" || DFX_CANISTER_WASM="$(jq -r '.canisters[env.DFX_CANISTER_NAME].wasm // ""')"
+test -n "${DFX_CANISTER_WASM:-}" || DFX_CANISTER_WASM="$(jq -r '.canisters[env.DFX_CANISTER_NAME].wasm // ""' dfx.json)"
 test -n "${DFX_CANISTER_WASM:-}" || {
   echo "ERROR: Unable to determine the path to the wasm file."
   echo "       Please either:"
@@ -37,7 +37,7 @@ test -e "${DFX_CANISTER_WASM}" || {
 } >&2
 
 : "Find the candid file"
-test -n "${DFX_CANISTER_DID:-}" || DFX_CANISTER_DID="$(jq -r '.canisters[env.DFX_CANISTER_NAME].candid // ""')"
+test -n "${DFX_CANISTER_DID:-}" || DFX_CANISTER_DID="$(jq -r '.canisters[env.DFX_CANISTER_NAME].candid // ""' dfx.json)"
 test -n "${DFX_CANISTER_DID:-}" || {
   echo "ERROR: Unable to determine the path to the candid file."
   echo "       Please either:"

--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -41,7 +41,7 @@ test -n "${DFX_CANISTER_DID:-}" || DFX_CANISTER_DID="$(jq -r '.canisters[env.DFX
 test -n "${DFX_CANISTER_DID:-}" || {
   echo "ERROR: Unable to determine the path to the candid file."
   echo "       Please either:"
-  echo "         Use --wasm PATH_TO_WASM"
+  echo "         Use --did PATH_TO_CANDID"
   echo "         or use --canister_name NAME and ensure that the candid is specified in dfx.json"
   exit 1
 } >&2

--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -67,7 +67,7 @@ else
 fi
 
 WITH_COMMIT="${DFX_CANISTER_WASM}.with_commit"
-ic-wasm "$UNZIPPED" -o "$WITH_COMMIT" metadata git_commit_id -d"$DFX_CANISTER_COMMIT" -v public
+ic-wasm "$UNZIPPED" -o "$WITH_COMMIT" metadata git_commit_id -d "$DFX_CANISTER_COMMIT" -v public
 rm "$UNZIPPED"
 
 WITH_DID="${DFX_CANISTER_WASM}.with_did"

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -28,10 +28,7 @@ source "$(clap.build)"
       exit 1
     }
     dfx canister metadata "$canister" candid:service | tee /dev/stderr | grep service: || {
-      echo "ERROR: This "
+      echo "ERROR: The $canister candid:service metadata should contain a service definition."
     }
-  done
-
-  for canister in nns-dapp sns_aggregator; do
   done
 )

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -18,19 +18,19 @@ clap.define short=o long=offline desc="Don't test deployed canisters" variable=O
 source "$(clap.build)"
 
 check_commit() {
-    stdin="$(cat)"
-    echo "$stdin" | grep -qE '[a-fA-F0-9]{40}' || {
-      echo "ERROR: The $canister git_commit_id metadata should include a git commit."
-      echo "  ACTUAL: '$stdin'"
-      exit 1
-    }
+  stdin="$(cat)"
+  echo "$stdin" | grep -qE '[a-fA-F0-9]{40}' || {
+    echo "ERROR: The $canister git_commit_id metadata should include a git commit."
+    echo "  ACTUAL: '$stdin'"
+    exit 1
+  }
 }
-check_service(){
-    stdin="$(cat)"
-    echo "$stdin" | grep -qw service || {
-      echo "ERROR: The $canister candid:service metadata should contain a service definition."
-      exit 1
-    }
+check_service() {
+  stdin="$(cat)"
+  echo "$stdin" | grep -qw service || {
+    echo "ERROR: The $canister candid:service metadata should contain a service definition."
+    exit 1
+  }
 }
 
 (
@@ -38,26 +38,27 @@ check_service(){
   for canister in nns-dapp sns_aggregator; do
     wasm="$(c="$canister" jq -r '.canisters[env.c].wasm' dfx.json)"
     test -e "$wasm" || {
-       echo "ERROR: Please build the wasms before running this test."
-       exit 1
+      echo "ERROR: Please build the wasms before running this test."
+      exit 1
     }
-    gunzip < "$wasm" > "$wasm.unzipped"
+    gunzip <"$wasm" >"$wasm.unzipped"
     ic-wasm "$wasm.unzipped" metadata git_commit_id | check_commit
     ic-wasm "$wasm.unzipped" metadata candid:service | check_service
+    rm "$wasm.unzipped"
   done
 )
 
 [[ "${OFFLINE:-}" == "true" ]] ||
-(
-  echo "It should be possible to query metadata from the sns_aggregator and nns-dapp canisters"
-  for canister in nns-dapp sns_aggregator; do
-    dfx canister status "$canister" || {
-      echo "ERROR: Please deploy the $canister to the local network before running this test"
-      exit 1
-    }
-    dfx canister metadata "$canister" git_commit_id | check_commit
-    dfx canister metadata "$canister" candid:service | check_service
-  done
-)
+  (
+    echo "It should be possible to query metadata from the sns_aggregator and nns-dapp canisters"
+    for canister in nns-dapp sns_aggregator; do
+      dfx canister status "$canister" || {
+        echo "ERROR: Please deploy the $canister to the local network before running this test"
+        exit 1
+      }
+      dfx canister metadata "$canister" git_commit_id | check_commit
+      dfx canister metadata "$canister" candid:service | check_service
+    done
+  )
 
 echo "$(basename "$0") PASSED"

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -65,6 +65,8 @@ check_service() {
         echo "ERROR: Please deploy the $canister to the local network before running this test"
         exit 1
       }
+      : "Make sure that the correct wasm is deployed."
+      dfx-canister-check-wasm-hash --canister "$canister"
       dfx canister metadata "$canister" git_commit_id | check_commit
       dfx canister metadata "$canister" candid:service | check_service
     done

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -6,7 +6,11 @@ PATH="$SOURCE_DIR:$PATH"
 print_help() {
   cat <<-EOF
 
-	Verifies that the git commit and service definition are available from deployed canisters.
+	Verifies that the git commit and service definition are available in wasms and from
+	deployed canisters.
+
+	This test requires that the canisters are deployed to localhost.  It neither starts,
+	stops, nor in any other way modifies the local network.
 	EOF
 }
 

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Verifies that the git commit and service definition are available from deployed canisters.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+(
+  echo "It should be possible to query metadata from the sns_aggregator and nns-dapp canisters"
+  for canister in nns-dapp sns_aggregator; do
+    dfx canister status "$canister" || {
+      echo "ERROR: Please deploy the $canister to the local network before running this test"
+      exit 1
+    }
+    dfx canister metadata "$canister" git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}' || {
+      echo "ERROR: The $canister git_commit_id metadata should include a git commit."
+      exit 1
+    }
+    dfx canister metadata "$canister" candid:service | tee /dev/stderr | grep service: || {
+      echo "ERROR: This "
+    }
+  done
+
+  for canister in nns-dapp sns_aggregator; do
+  done
+)

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -17,9 +17,10 @@ clap.define short=o long=offline desc="Don't test deployed canisters" variable=O
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+COMMIT="$(git rev-parse HEAD)"
 check_commit() {
   stdin="$(cat)"
-  echo "$stdin" | grep -qE '[a-fA-F0-9]{40}' || {
+  echo "$stdin" | grep -qw "$COMMIT" || {
     echo "ERROR: The $canister git_commit_id metadata should include a git commit."
     echo "  ACTUAL: '$stdin'"
     exit 1

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -23,6 +23,8 @@ source "$(clap.build)"
 
 COMMIT="$(git rev-parse HEAD)"
 check_commit() {
+  set -x
+  local stdin
   stdin="$(cat)"
   echo "$stdin" | grep -qw "$COMMIT" || {
     echo "ERROR: The $canister git_commit_id metadata should include a git commit."
@@ -32,6 +34,7 @@ check_commit() {
   }
 }
 check_service() {
+  local stdin
   stdin="$(cat)"
   echo "$stdin" | grep -qw service || {
     echo "ERROR: The $canister candid:service metadata should contain a service definition."

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -26,7 +26,8 @@ check_commit() {
   stdin="$(cat)"
   echo "$stdin" | grep -qw "$COMMIT" || {
     echo "ERROR: The $canister git_commit_id metadata should include a git commit."
-    echo "  ACTUAL: '$stdin'"
+    echo "  EXPECTED: '$COMMIT'"
+    echo "  ACTUAL:   '$stdin'"
     exit 1
   }
 }

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -26,7 +26,7 @@ check_commit() {
   set -x
   local stdin
   stdin="$(cat)"
-  echo "$stdin" | grep -qw "$COMMIT" || {
+  grep -qw "$COMMIT" <(echo "$stdin") || {
     echo "ERROR: The $canister git_commit_id metadata should include a git commit."
     echo "  EXPECTED: '$COMMIT'"
     echo "  ACTUAL:   '$stdin'"
@@ -36,7 +36,7 @@ check_commit() {
 check_service() {
   local stdin
   stdin="$(cat)"
-  echo "$stdin" | grep -qw service || {
+  grep -qw service <(echo "$stdin") || {
     echo "ERROR: The $canister candid:service metadata should contain a service definition."
     exit 1
   }

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -66,7 +66,6 @@ check_service() {
         exit 1
       }
       : "Make sure that the correct wasm is deployed."
-      dfx-canister-check-wasm-hash --canister "$canister"
       dfx canister metadata "$canister" git_commit_id | check_commit
       dfx canister metadata "$canister" candid:service | check_service
     done

--- a/scripts/dfx-wasm-metadata-add.test
+++ b/scripts/dfx-wasm-metadata-add.test
@@ -13,9 +13,41 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
+clap.define short=o long=offline desc="Don't test deployed canisters" variable=OFFLINE nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+check_commit() {
+    stdin="$(cat)"
+    echo "$stdin" | grep -qE '[a-fA-F0-9]{40}' || {
+      echo "ERROR: The $canister git_commit_id metadata should include a git commit."
+      echo "  ACTUAL: '$stdin'"
+      exit 1
+    }
+}
+check_service(){
+    stdin="$(cat)"
+    echo "$stdin" | grep -qw service || {
+      echo "ERROR: The $canister candid:service metadata should contain a service definition."
+      exit 1
+    }
+}
+
+(
+  echo "Canister wasms should have commit id and service definitions in their metadata"
+  for canister in nns-dapp sns_aggregator; do
+    wasm="$(c="$canister" jq -r '.canisters[env.c].wasm' dfx.json)"
+    test -e "$wasm" || {
+       echo "ERROR: Please build the wasms before running this test."
+       exit 1
+    }
+    gunzip < "$wasm" > "$wasm.unzipped"
+    ic-wasm "$wasm.unzipped" metadata git_commit_id | check_commit
+    ic-wasm "$wasm.unzipped" metadata candid:service | check_service
+  done
+)
+
+[[ "${OFFLINE:-}" == "true" ]] ||
 (
   echo "It should be possible to query metadata from the sns_aggregator and nns-dapp canisters"
   for canister in nns-dapp sns_aggregator; do
@@ -23,12 +55,9 @@ source "$(clap.build)"
       echo "ERROR: Please deploy the $canister to the local network before running this test"
       exit 1
     }
-    dfx canister metadata "$canister" git_commit_id | tee /dev/stderr | grep -E '[a-fA-F0-9]{64}' || {
-      echo "ERROR: The $canister git_commit_id metadata should include a git commit."
-      exit 1
-    }
-    dfx canister metadata "$canister" candid:service | tee /dev/stderr | grep service: || {
-      echo "ERROR: The $canister candid:service metadata should contain a service definition."
-    }
+    dfx canister metadata "$canister" git_commit_id | check_commit
+    dfx canister metadata "$canister" candid:service | check_service
   done
 )
+
+echo "$(basename "$0") PASSED"

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -73,11 +73,15 @@ for file in "${assets[@]}"; do
   rm -f "$file"
 done
 
+COMMIT="$(git rev-parse HEAD)"
+[ -z "$(git status --untracked-files=no --porcelain)" ] || COMMIT="${COMMIT}-dirty"
+
 set -x
 DOCKER_BUILDKIT=1 docker build \
   --target scratch \
   "$PROGRESS" \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
+  --build-arg COMMIT="$COMMIT" \
   -t "$image_name" \
   -o "$OUTDIR" . \
   "${@+${@}}"


### PR DESCRIPTION
# Motivation
Requests from the nns & testing teams to publish the commit of our canisters.  In fact, it is becoming common to publish both the commit and the API did file so we cover both on both canisters.  Four with one stroke.

# Changes
* Created a new command to add metadata.  This is NOT in the canister build command so that the canister build can be cached, and commits that do not affect a canister wasm don't cause a rebuild just because the commit has changed.
* Created a test for the command
* Called the command in the dockerfile
* Created a test for deployments from the docker build

# Tests
* Tests are included.  See CI for the results.