### PR TITLE
Fix: Update dissolve delay for almost 8 years neurons

### DIFF
--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -11,6 +11,7 @@
   import DayInput from "$lib/components/ui/DayInput.svelte";
   import { daysToDuration } from "$lib/utils/date.utils";
   import type { NeuronState, TokenAmount } from "@dfinity/nns";
+  import { SECONDS_IN_DAY } from "$lib/constants/constants";
 
   export let neuronState: NeuronState;
   export let neuronDissolveDelaySeconds: bigint;
@@ -41,31 +42,27 @@
 
   let disableUpdate: boolean;
   $: disableUpdate =
-    delayInDays < secondsToDays(minProjectDelayInSeconds) ||
-    delayInDays <= minDelayInDays ||
-    delayInDays > maxDelayInDays;
+    delayInSeconds < minProjectDelayInSeconds ||
+    delayInSeconds <= minDelayInSeconds ||
+    delayInSeconds > maxDelayInSeconds;
 
-  const updateDelays = () => {
-    if (delayInDays < minDelayInDays) {
-      delayInDays = minDelayInDays;
+  const keepDelaysInBounds = () => {
+    if (delayInSeconds < minDelayInSeconds) {
+      delayInSeconds = minDelayInSeconds;
     }
 
-    if (delayInDays > maxDelayInDays) {
-      delayInDays = maxDelayInDays;
+    if (delayInSeconds > maxDelayInSeconds) {
+      delayInSeconds = maxDelayInSeconds;
     }
-
-    delayInSeconds = daysToSeconds(delayInDays);
   };
   const setMin = () => {
-    delayInDays = Math.max(
-      minDelayInDays + 1,
-      secondsToDays(minProjectDelayInSeconds)
+    delayInSeconds = Math.max(
+      minDelayInSeconds + SECONDS_IN_DAY,
+      minProjectDelayInSeconds
     );
-    updateDelays();
   };
   const setMax = () => {
-    delayInDays = maxDelayInDays;
-    updateDelays();
+    delayInSeconds = maxDelayInSeconds;
   };
   const updateInputError = () => {
     if (delayInDays > maxDelayInDays) {
@@ -83,7 +80,7 @@
   const goToConfirmation = () => dispatch("nnsConfirmDelay");
 </script>
 
-<div class="wrapper" data-tid="set-dissolve-delay">
+<div class="wrapper" data-tid="set-dissolve-delay-component">
   <div>
     <p class="label">{$i18n.neurons.neuron_id}</p>
     <slot name="neuron-id" />
@@ -136,9 +133,9 @@
       <InputRange
         ariaLabel={$i18n.neuron_detail.dissolve_delay_range}
         min={0}
-        max={maxDelayInDays}
-        bind:value={delayInDays}
-        handleInput={updateDelays}
+        max={maxDelayInSeconds}
+        bind:value={delayInSeconds}
+        handleInput={keepDelaysInBounds}
       />
       <div class="details">
         <div>

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import SetDissolveDelay from "$lib/components/neurons/SetDissolveDelay.svelte";
+import {
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_HALF_YEAR,
+} from "$lib/constants/constants";
+import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ICPToken, NeuronState, TokenAmount } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+
+describe("SetDissolveDelay", () => {
+  describe("current dissolve delay is Max - (less than a day in seconds)", () => {
+    it("should enable button if user clicks Max button", async () => {
+      const neuronDissolveDelaySeconds = SECONDS_IN_EIGHT_YEARS - 10;
+      const { container } = render(SetDissolveDelay, {
+        props: {
+          neuronState: NeuronState.Locked,
+          neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+          neuronStake: TokenAmount.fromE8s({
+            amount: BigInt(200_000_000),
+            token: ICPToken,
+          }),
+          delayInSeconds: neuronDissolveDelaySeconds,
+          minDelayInSeconds: neuronDissolveDelaySeconds,
+          minProjectDelayInSeconds: SECONDS_IN_HALF_YEAR,
+          maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+          calculateVotingPower: () => 0,
+          minDissolveDelayDescription: "",
+        },
+      });
+      const po = SetDissolveDelayPo.under(new JestPageObjectElement(container));
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+      await po.clickMax();
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/lib/components/neurons/SetNnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetNnsDissolveDelay.spec.ts
@@ -14,6 +14,6 @@ describe("SetNnsDissolveDelay", () => {
         delayInSeconds: 0,
       },
     });
-    expect(getByTestId("set-dissolve-delay")).toBeInTheDocument();
+    expect(getByTestId("set-dissolve-delay-component")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -5,7 +5,6 @@
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import IncreaseDissolveDelayModal from "$lib/modals/neurons/IncreaseDissolveDelayModal.svelte";
 import { updateDelay } from "$lib/services/neurons.services";
-import { secondsToDays } from "$lib/utils/date.utils";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { NeuronInfo } from "@dfinity/nns";
@@ -60,7 +59,7 @@ describe("IncreaseDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: secondsToDays(SECONDS_IN_YEAR * 2) },
+        target: { value: SECONDS_IN_YEAR * 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(
@@ -87,9 +86,10 @@ describe("IncreaseDissolveDelayModal", () => {
   });
 
   it("should not be able to change dissolve delay below current value", async () => {
+    const currentNeuronDissoveDelay = SECONDS_IN_YEAR;
     const editableNeuron = {
       ...mockNeuron,
-      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+      dissolveDelaySeconds: BigInt(currentNeuronDissoveDelay),
     };
     const { container } = await renderIncreaseDelayModal(editableNeuron);
 
@@ -103,7 +103,7 @@ describe("IncreaseDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: secondsToDays(SECONDS_IN_YEAR / 2) },
+        target: { value: currentNeuronDissoveDelay / 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(
@@ -115,7 +115,7 @@ describe("IncreaseDissolveDelayModal", () => {
     );
     inputRange &&
       (await waitFor(() =>
-        expect(inputRange.value).toBe(String(secondsToDays(SECONDS_IN_YEAR)))
+        expect(inputRange.value).toBe(String(currentNeuronDissoveDelay))
       ));
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/StakeNeuronModal.spec.ts
@@ -16,7 +16,6 @@ import {
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import { secondsToDays } from "$lib/utils/date.utils";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
 import {
   mockAccountDetails,
@@ -238,7 +237,7 @@ describe("StakeNeuronModal", () => {
       const FIVE_MONTHS = 60 * 60 * 24 * 30 * 5;
       inputRange &&
         (await fireEvent.input(inputRange, {
-          target: { value: secondsToDays(FIVE_MONTHS) },
+          target: { value: FIVE_MONTHS },
         }));
 
       const updateDelayButton = container.querySelector(
@@ -327,7 +326,7 @@ describe("StakeNeuronModal", () => {
       const ONE_YEAR = 60 * 60 * 24 * 365;
       inputRange &&
         (await fireEvent.input(inputRange, {
-          target: { value: secondsToDays(ONE_YEAR) },
+          target: { value: ONE_YEAR },
         }));
 
       const goToConfirmDelayButton = container.querySelector(
@@ -489,7 +488,7 @@ describe("StakeNeuronModal", () => {
       const ONE_YEAR = 60 * 60 * 24 * 365;
       inputRange &&
         (await fireEvent.input(inputRange, {
-          target: { value: secondsToDays(ONE_YEAR) },
+          target: { value: ONE_YEAR },
         }));
 
       const goToConfirmDelayButton = container.querySelector(

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -111,7 +111,7 @@ describe("IncreaseSnsDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: Math.round(secondsToDays(SECONDS_IN_YEAR * 2)) },
+        target: { value: SECONDS_IN_YEAR * 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -19,4 +19,8 @@ export class ButtonPo extends SimpleBasePageObject {
   click(): Promise<void> {
     return this.root.click();
   }
+
+  async isDisabled(): Promise<boolean> {
+    return (await this.root.getAttribute("disabled")) !== null;
+  }
 }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,0 +1,29 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ButtonPo } from "./Button.page-object";
+
+export class SetDissolveDelayPo extends BasePageObject {
+  private static readonly TID = "set-dissolve-delay-component";
+
+  static under(element: PageObjectElement): SetDissolveDelayPo {
+    return new SetDissolveDelayPo(element.byTestId(SetDissolveDelayPo.TID));
+  }
+
+  getUpdateButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "go-confirm-delay-button",
+    });
+  }
+
+  getMaxButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "max-button",
+    });
+  }
+
+  clickMax(): Promise<void> {
+    return this.getMaxButtonPo().click();
+  }
+}


### PR DESCRIPTION
# Motivation

Neurons with dissolve delay of almost 8 years (8 years - some seconds) could not update the dissolve delay to 8 years.

The issue was raised in the forum: https://forum.dfinity.org/t/peculiar-issue-7-years-and-365-days-neuron/19910?u=diegop

# Changes

The fix is to move the range input, max and min buttons to use seconds instead of days.

Main changes:
* SetDissolveDelay component uses seconds instead of days.

# Tests

* Add a test for the specific bug in SetDissolveDelay.spec.ts
* Change tests that were using the range in days to use the range in seconds.
* New SetDissolveDelay page object.
