### PR TITLE
Update patches

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 102317cc..9e78cfd4 100644
+index 85a991cff..c1812a9a5 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -9,6 +9,7 @@ use ic_cdk::api::call::CallResult;
+@@ -11,6 +11,7 @@ use ic_cdk::api::call::CallResult;
  // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
  // use ic_cdk::api::call::CallResult;
  
@@ -10,7 +10,7 @@ index 102317cc..9e78cfd4 100644
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GenericNervousSystemFunction {
    pub  validator_canister_id: Option<candid::Principal>,
-@@ -19,7 +20,7 @@ pub struct GenericNervousSystemFunction {
+@@ -21,7 +22,7 @@ pub struct GenericNervousSystemFunction {
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum FunctionType {
@@ -19,7 +19,7 @@ index 102317cc..9e78cfd4 100644
    GenericNervousSystemFunction(GenericNervousSystemFunction),
  }
  
-@@ -180,12 +181,12 @@ pub enum Action {
+@@ -184,12 +185,12 @@ pub enum Action {
    ManageNervousSystemParameters(NervousSystemParameters),
    AddGenericNervousSystemFunction(NervousSystemFunction),
    RemoveGenericNervousSystemFunction(u64),
@@ -34,7 +34,7 @@ index 102317cc..9e78cfd4 100644
    ManageSnsMetadata(ManageSnsMetadata),
    ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
    Motion(Motion),
-@@ -256,8 +257,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
+@@ -261,8 +262,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum Operation {
    ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
@@ -45,7 +45,7 @@ index 102317cc..9e78cfd4 100644
    IncreaseDissolveDelay(IncreaseDissolveDelay),
    SetDissolveTimestamp(SetDissolveTimestamp),
  }
-@@ -278,7 +279,7 @@ pub struct FinalizeDisburseMaturity {
+@@ -283,7 +284,7 @@ pub struct FinalizeDisburseMaturity {
  pub struct MemoAndController { controller: Option<candid::Principal>, memo: u64 }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -54,7 +54,7 @@ index 102317cc..9e78cfd4 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ClaimOrRefresh { by: Option<By> }
-@@ -311,7 +312,7 @@ pub enum Command_2 {
+@@ -316,7 +317,7 @@ pub enum Command_2 {
    DisburseMaturity(DisburseMaturity),
    Configure(Configure),
    RegisterVote(RegisterVote),
@@ -63,7 +63,7 @@ index 102317cc..9e78cfd4 100644
    MakeProposal(Proposal),
    FinalizeDisburseMaturity(FinalizeDisburseMaturity),
    ClaimOrRefreshNeuron(ClaimOrRefresh),
-@@ -406,7 +407,7 @@ pub struct ClaimSwapNeuronsResponse {
+@@ -419,7 +420,7 @@ pub struct ClaimSwapNeuronsResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}
  
@@ -72,7 +72,7 @@ index 102317cc..9e78cfd4 100644
  pub struct GetMetadataResponse {
    pub  url: Option<String>,
    pub  logo: Option<String>,
-@@ -474,7 +475,7 @@ pub struct GetSnsInitializationParametersResponse {
+@@ -493,7 +494,7 @@ pub struct GetSnsInitializationParametersResponse {
    pub  sns_initialization_parameters: String,
  }
  
@@ -81,7 +81,7 @@ index 102317cc..9e78cfd4 100644
  pub struct ListNervousSystemFunctionsResponse {
    pub  reserved_ids: Vec<u64>,
    pub  functions: Vec<NervousSystemFunction>,
-@@ -546,17 +547,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
+@@ -565,17 +566,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
  pub enum Command_1 {
    Error(GovernanceError),
    Split(SplitResponse),

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,10 +1,10 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index de877575..72fe139e 100644
+index 003d885d6..4b9844b29 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -2,7 +2,7 @@
- #![allow(clippy::all)]
+@@ -4,7 +4,7 @@
  #![allow(non_camel_case_types)]
+ #![allow(dead_code)]
  
 -use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 +use crate::types::{CandidType, Deserialize, Serialize};

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,17 +1,17 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 14ebf6f6..7c74fb10 100644
+index d362af863..dc244c613 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -2,7 +2,7 @@
- #![allow(clippy::all)]
+@@ -4,7 +4,7 @@
  #![allow(non_camel_case_types)]
+ #![allow(dead_code)]
  
 -use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -82,7 +82,7 @@ pub struct GetSnsCanistersSummaryResponse {
+@@ -85,7 +85,7 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_sns_canisters_arg0 {}
  

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,17 +1,17 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index d0c9062d..3c3b67a3 100644
+index b895247fa..5cbd6c17e 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -2,7 +2,7 @@
- #![allow(clippy::all)]
+@@ -4,7 +4,7 @@
  #![allow(non_camel_case_types)]
+ #![allow(dead_code)]
  
 -use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -167,7 +167,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+@@ -168,7 +168,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}
  
@@ -20,7 +20,7 @@ index d0c9062d..3c3b67a3 100644
  pub struct DeployedSns {
    pub  root_canister_id: Option<candid::Principal>,
    pub  governance_canister_id: Option<candid::Principal>,
-@@ -177,7 +177,7 @@ pub struct DeployedSns {
+@@ -178,7 +178,7 @@ pub struct DeployedSns {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]


### PR DESCRIPTION
# Motivation
The patches are out of sync with the upstream types, possibly due to some manual changes.

# Changes
Update the patches by running:
```
ls declarations/ | xargs -I{} ./scripts/mk_nns_patch.sh {}
```

# Tests
See CI