### PR TITLE
Fix sed command in scripts/did2rs.sh

### DIFF
--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{ ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,11 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | \
+    sed -E 's/^(struct|enum|type) /pub &/;
+            s@^use .*@// &@;
+            s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
+            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/[[:<:]]Deserialize[[:>:]]/&, Serialize, Clone, Debug/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{ ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/g;s/^use .*/\/\/ &/g;s/\<Deserialize\>/&, Serialize, Clone, Debug/g;s/^  [a-z].*:/  pub&/g;s/^( *pub ) *pub /\1/g'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/[[:<:]]Deserialize[[:>:]]/&, Serialize, Clone, Debug/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | \
+  didc bind "${DID_PATH}" --target rs |
     sed -E 's/^(struct|enum|type) /pub &/;
             s@^use .*@// &@;
             s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;


### PR DESCRIPTION
# Motivation

`sed` works slightly differently on Mac vs. Linux.
`sed` on Mac doesn't support `\<` and `\>` as word boundary.
`[[:<:]]` and `[[:>:]]` work on Mac but not on Linux.



# Changes

1. In the `sed` command in `scripts/did2rs.sh`, instead of using word boundaries, expect specific characters.
2. Remove the `g` modifiers because they mean "multiple times per line" but each of these substitutions happens once per line.
3. Use @ instead of / in one of the substitutions to limit escaping.

# Tests

Ran `scripts/mk_nns_patch.sh` and checked that no patch files were changed.
Without the fix, that script results in much longer patch files on Mac.
