### PR TITLE
Verify aggregator patch files in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -201,8 +201,15 @@ jobs:
           dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Check config script
         run: bash -x ./config.test
+  sns-aggregator-patches:
+    name: SNS aggregator patches
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Recreate and compare patches
+        run: scripts/mk_nns_patch.test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -206,6 +206,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install didc
+        run: |
+          USER_BIN="$HOME/.local/bin"
+          mkdir -p "$USER_BIN"
+          echo "$USER_BIN" >> $GITHUB_PATH
+          curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-linux64 | install -m 755 /dev/stdin "$USER_BIN/didc"
+      - name: Check didc
+        run: command -v didc
       - name: Recreate and compare patches
         run: scripts/mk_nns_patch.test
   checks-pass:

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -8,6 +8,7 @@ index 85a991cff..c1812a9a5 100644
  
 +
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct GenericNervousSystemFunction {
    pub  validator_canister_id: Option<candid::Principal>,
 @@ -21,7 +22,7 @@ pub struct GenericNervousSystemFunction {
  

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -8,7 +8,6 @@ index 85a991cff..c1812a9a5 100644
  
 +
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct GenericNervousSystemFunction {
    pub  validator_canister_id: Option<candid::Principal>,
 @@ -21,7 +22,7 @@ pub struct GenericNervousSystemFunction {
  

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{ ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,11 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | \
+    sed -E 's/^(struct|enum|type) /pub &/;
+            s@^use .*@// &@;
+            s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
+            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/[[:<:]]Deserialize[[:>:]]/&, Serialize, Clone, Debug/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/([{ ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 ##########################
 # Hjelpe meg!

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/g;s/^use .*/\/\/ &/g;s/\<Deserialize\>/&, Serialize, Clone, Debug/g;s/^  [a-z].*:/  pub&/g;s/^( *pub ) *pub /\1/g'
+  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/;s@^use .*@// &@;s/[[:<:]]Deserialize[[:>:]]/&, Serialize, Clone, Debug/;s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (

--- a/scripts/mk_nns_patch.sh
+++ b/scripts/mk_nns_patch.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+ALL_CANISTERS="$(ls "$GIT_ROOT/declarations")"
 
 ##########################
 # Hjelpe meg!
@@ -8,12 +11,15 @@ print_help() {
   cat <<-EOF
     Makes a patch file for a rust file from local customizations.
 
-	Usage: $(basename "$0") <CANISTER_NAME>
+	Usage: $(basename "$0") [ <CANISTER_NAME> ]
 	takes inputs:
 	  <CANISTER_NAME>.did
 	  <CANISTER_NAME>.rs (must be committed as it will be changed)
 	creates:
 	  <CANISTER_NAME>.patch
+
+	If no <CANISTER_NAME> is given, the script is run once for each of:
+	$ALL_CANISTERS
 
 	EOF
 }
@@ -22,10 +28,14 @@ print_help() {
   exit 0
 }
 
-##########################
-# Get working dir and args
-##########################
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ -z "${1:-}" ]]; then
+  for CANISTER_NAME in $ALL_CANISTERS; do
+    "$0" "$CANISTER_NAME"
+  done
+  exit 0
+fi
+
+
 CANISTER_NAME="$1"
 
 RUST_PATH="${GIT_ROOT}/rs/sns_aggregator/src/types/ic_${CANISTER_NAME}.rs"

--- a/scripts/mk_nns_patch.sh
+++ b/scripts/mk_nns_patch.sh
@@ -44,7 +44,7 @@ cd "$GIT_ROOT"
 
 rm -f "${PATCH_PATH}"
 scripts/did2rs.sh "$CANISTER_NAME"
-git diff -R "${RUST_PATH}" >"${PATCH_PATH}"
+git -c core.abbrev=9 diff -R "${RUST_PATH}" >"${PATCH_PATH}"
 if test -s "${PATCH_PATH}"; then
   git add "${PATCH_PATH}"
 else

--- a/scripts/mk_nns_patch.sh
+++ b/scripts/mk_nns_patch.sh
@@ -35,7 +35,6 @@ if [[ -z "${1:-}" ]]; then
   exit 0
 fi
 
-
 CANISTER_NAME="$1"
 
 RUST_PATH="${GIT_ROOT}/rs/sns_aggregator/src/types/ic_${CANISTER_NAME}.rs"

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -11,7 +11,7 @@ fi
 
 scripts/mk_nns_patch.sh
 
-if ! git diff --exit-code; then
+if ! git diff --staged --exit-code; then
   echo "FAILED: Patch files should be updated to reflect current differences."
   echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
   git reset --hard HEAD

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -14,7 +14,7 @@ scripts/mk_nns_patch.sh
 if ! git diff --staged --exit-code; then
   echo "FAILED: Patch files should be updated to reflect current differences."
   echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
-  git reset --hard HEAD
+  git reset --hard HEAD > /dev/null
   exit 1
 fi
 

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -11,7 +11,7 @@ fi
 
 scripts/mk_nns_patch.sh
 
-if [ "$(git status --porcelain)" != "" ]; then
+if git diff --exit-code; then
   echo "FAILED: Patch files should be updated to reflect current differences."
   echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
   git reset --hard HEAD

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOP_DIR="$(git rev-parse --show-toplevel)"
+cd "$TOP_DIR"
+
+if [ "$(git status --porcelain)" != "" ]; then
+  echo "$0 should only be run on a clean branch."
+  exit 1
+fi
+
+scripts/mk_nns_patch.sh
+
+if [ "$(git status --porcelain)" != "" ]; then
+  echo "FAILED: Patch files should be updated to reflect current differences."
+  echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
+  git reset --hard HEAD
+  exit 1
+fi
+
+echo "SUCCESS: Patch files are unchanged."

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -11,7 +11,7 @@ fi
 
 scripts/mk_nns_patch.sh
 
-if git diff --exit-code; then
+if ! git diff --exit-code; then
   echo "FAILED: Patch files should be updated to reflect current differences."
   echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
   git reset --hard HEAD

--- a/scripts/mk_nns_patch.test
+++ b/scripts/mk_nns_patch.test
@@ -14,7 +14,7 @@ scripts/mk_nns_patch.sh
 if ! git diff --staged --exit-code; then
   echo "FAILED: Patch files should be updated to reflect current differences."
   echo "Run 'scripts/mk_nns_patch.sh' to update patch files."
-  git reset --hard HEAD > /dev/null
+  git reset --hard HEAD >/dev/null
   exit 1
 fi
 


### PR DESCRIPTION
# Motivation

We generate files with rust types from import `.did` files and apply some changes to them.
The changes are in patch files.
If people make manual changes, the patch files are might not be usable anymore.

# Changes

1. Change `scripts/mk_nns_patch.sh` to allow running without arguments to apply to all canisters.
2. Make sure the `git diff` command always uses the same abbreviation length for hashes to get consistent output.
3. Add `scripts/mk_nns_patch.test` that verifies that the patch files are what they would be when the update script is run.
4. Run the test from CI.
5. Remove a few `set -x` to make scripts less verbose.

# Tests

This is what a failed run looks like:
https://github.com/dfinity/nns-dapp/actions/runs/4960612014/jobs/8876323282
The output ends with:
```
FAILED: Patch files should be updated to reflect current differences.
Run 'scripts/mk_nns_patch.sh' to update patch files.
Error: Process completed with exit code 1.```