### PR TITLE
feat: maturityLastDistribution util

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -15,6 +15,7 @@
     isNeuronControllable,
     formattedStakedMaturity,
     formattedTotalMaturity,
+    maturityLastDistribution,
   } from "$lib/utils/neuron.utils";
   import { accountsStore } from "$lib/stores/accounts.store";
   import Separator from "$lib/components/ui/Separator.svelte";
@@ -67,8 +68,9 @@
             <span slot="value"
               >{secondsToDate(
                 Number(
-                  $nnsLatestRewardEventStore.rewardEvent
-                    .actual_timestamp_seconds
+                  maturityLastDistribution(
+                    $nnsLatestRewardEventStore.rewardEvent
+                  )
                 )
               )}</span
             >

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -31,7 +31,6 @@ import {
 } from "@dfinity/gix-components";
 import {
   NeuronState,
-  RewardEvent,
   Topic,
   Vote,
   ineligibleNeurons,
@@ -43,6 +42,7 @@ import {
   type NeuronInfo,
   type ProposalId,
   type ProposalInfo,
+  type RewardEvent,
 } from "@dfinity/nns";
 import type { SnsVote } from "@dfinity/sns";
 import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -859,3 +859,23 @@ export const filterIneligibleNnsNeurons = ({
         ? "since"
         : "short",
   }));
+
+export const maturityLastDistribution = ({
+  distributed_e8s_equivalent,
+  total_available_e8s_equivalent,
+  actual_timestamp_seconds,
+  rounds_since_last_distribution,
+}: RewardEvent): bigint => {
+  // Rewards were distributed that round, so the timestamp is correct
+  if (distributed_e8s_equivalent === total_available_e8s_equivalent) {
+    return actual_timestamp_seconds;
+  }
+
+  // When there was a reward event, but no rewards were distributed (because of a rollover)
+  return (
+    actual_timestamp_seconds -
+    (fromNullable(rounds_since_last_distribution) ?? 0n) *
+      BigInt(SECONDS_IN_DAY)
+  );
+};
+

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1,5 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
+  SECONDS_IN_DAY,
   SECONDS_IN_EIGHT_YEARS,
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_HALF_YEAR,
@@ -30,6 +31,7 @@ import {
 } from "@dfinity/gix-components";
 import {
   NeuronState,
+  RewardEvent,
   Topic,
   Vote,
   ineligibleNeurons,
@@ -43,7 +45,7 @@ import {
   type ProposalInfo,
 } from "@dfinity/nns";
 import type { SnsVote } from "@dfinity/sns";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
 import type { SvelteComponent } from "svelte";
 import {
   getAccountByPrincipal,
@@ -878,4 +880,3 @@ export const maturityLastDistribution = ({
       BigInt(SECONDS_IN_DAY)
   );
 };
-

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -271,6 +271,7 @@ describe("NnsNeuronMaturityCard", () => {
         actual_timestamp_seconds: BigInt(
           new Date("1992-05-22T21:00:00").getTime() / 1000
         ),
+        rounds_since_last_distribution: [3n] as [bigint],
       };
       nnsLatestRewardEventStore.setLatestRewardEvent({
         rewardEvent,
@@ -288,7 +289,7 @@ describe("NnsNeuronMaturityCard", () => {
         new JestPageObjectElement(container)
       );
 
-      expect(await po.getLastDistributionMaturity()).toEqual("May 22, 1992");
+      expect(await po.getLastDistributionMaturity()).toEqual("May 19, 1992");
       expect(await po.getLastDistributionMaturityDescription()).toEqual(
         "On a day with no settled proposals, no rewards are distributed; rather rewards will roll over to the following day. The last distribution date is the last time rewards were distributed. Learn more"
       );

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -36,6 +36,7 @@ describe("NeuronDetail", () => {
   };
   const rewardEvent = {
     ...mockRewardEvent,
+    rounds_since_last_distribution: [3n] as [bigint],
     actual_timestamp_seconds: BigInt(
       new Date("1992-05-22T21:00:00").getTime() / 1000
     ),
@@ -135,7 +136,7 @@ describe("NeuronDetail", () => {
     const po = NnsNeuronDetailPo.under(new JestPageObjectElement(container));
 
     expect(await po.getMaturityCardPo().getLastDistributionMaturity()).toEqual(
-      "May 22, 1992"
+      "May 19, 1992"
     );
   });
 });

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -79,7 +79,11 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
-  didc bind "${DID_PATH}" --target rs | sed -E 's/^(struct|enum|type) /pub &/g;s/^use .*/\/\/ &/g;s/\<Deserialize\>/&, Serialize, Clone, Debug/g;s/^  [a-z].*:/  pub&/g;s/^( *pub ) *pub /\1/g'
+  didc bind "${DID_PATH}" --target rs |
+    sed -E 's/^(struct|enum|type) /pub &/;
+            s@^use .*@// &@;
+            s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
+            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (


### PR DESCRIPTION
# Motivation

Fix the issue that in case of rollover rounds the last reward distribution date was displayed wrong. 
[Discussions](https://dfinity.slack.com/archives/C01S03NBM7S/p1683906720696299)

# Changes

- util function `maturityLastDistribution`

# Tests

- maturityLastDistribution
