### PR TITLE
Update IC commit

### DIFF
--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -28,10 +28,7 @@ type By = variant {
   NeuronId : record {};
 };
 type CanisterStatusResultV2 = record {
-  controller : principal;
   status : CanisterStatusType;
-  freezing_threshold : nat;
-  balance : vec record { vec nat8; nat };
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
@@ -99,7 +96,6 @@ type Command_2 = variant {
 type Configure = record { operation : opt Operation };
 type DefaultFollowees = record { followees : vec record { nat64; Followees } };
 type DefiniteCanisterSettingsArgs = record {
-  controller : principal;
   freezing_threshold : nat;
   controllers : vec principal;
   memory_allocation : nat;
@@ -145,6 +141,9 @@ type GenericNervousSystemFunction = record {
   validator_method_name : opt text;
   target_method_name : opt text;
 };
+type GetMaturityModulationResponse = record {
+  maturity_modulation : opt MaturityModulation;
+};
 type GetMetadataResponse = record {
   url : opt text;
   logo : opt text;
@@ -167,6 +166,7 @@ type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
   metrics : opt GovernanceCachedMetrics;
+  maturity_modulation : opt MaturityModulation;
   mode : int32;
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
@@ -229,6 +229,10 @@ type ManageSnsMetadata = record {
   name : opt text;
   description : opt text;
 };
+type MaturityModulation = record {
+  current_basis_points : opt int32;
+  updated_at_timestamp_seconds : opt nat64;
+};
 type MemoAndController = record { controller : opt principal; memo : nat64 };
 type MergeMaturity = record { percentage_to_merge : nat32 };
 type MergeMaturityResponse = record {
@@ -261,6 +265,7 @@ type NervousSystemParameters = record {
   max_age_bonus_percentage : opt nat64;
   neuron_grantable_permissions : opt NeuronPermissionList;
   voting_rewards_parameters : opt VotingRewardsParameters;
+  maturity_modulation_disabled : opt bool;
   max_number_of_principals_per_neuron : opt nat64;
 };
 type Neuron = record {
@@ -343,6 +348,7 @@ type RemoveNeuronPermissions = record {
 type Result = variant { Error : GovernanceError; Neuron : Neuron };
 type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
 type RewardEvent = record {
+  rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
   distributed_e8s_equivalent : nat64;
@@ -381,6 +387,7 @@ type UpgradeInProgress = record {
 };
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : vec nat8;
+  mode : opt int32;
   canister_id : opt principal;
   canister_upgrade_arg : opt vec nat8;
 };
@@ -401,7 +408,10 @@ type VotingRewardsParameters = record {
 type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
 service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
+  fail_stuck_upgrade_in_progress : (record {}) -> (record {});
   get_build_metadata : () -> (text) query;
+  get_latest_reward_event : () -> (RewardEvent) query;
+  get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
   get_metadata : (record {}) -> (GetMetadataResponse) query;
   get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -47,6 +47,7 @@ type Value = variant {
 // The initialization parameters of the Ledger
 type InitArgs = record {
     minting_account : Account;
+    fee_collector_account : opt Account;
     transfer_fee : nat64;
     token_symbol : text;
     token_name : text;
@@ -62,11 +63,16 @@ type InitArgs = record {
     };
 };
 
+type ChangeFeeCollector = variant {
+    Unset; SetTo: Account;
+};
+
 type UpgradeArgs = record {
     metadata : opt vec record { text; Value };
     token_symbol : opt text;
     token_name : opt text;
     transfer_fee : opt nat64;
+    change_fee_collector : opt ChangeFeeCollector;
 };
 
 type LedgerArg = variant {

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -4,13 +4,11 @@ type CanisterStatusResult = record {
   controller : principal;
   status : CanisterStatusType;
   memory_size : nat;
+  settings : DefiniteCanisterSettings;
   module_hash : opt vec nat8;
 };
 type CanisterStatusResultV2 = record {
-  controller : principal;
-  status : CanisterStatusType_1;
-  freezing_threshold : nat;
-  balance : vec record { vec nat8; nat };
+  status : CanisterStatusType;
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
@@ -18,13 +16,12 @@ type CanisterStatusResultV2 = record {
   module_hash : opt vec nat8;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type CanisterStatusType_1 = variant { stopped; stopping; running };
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
+type DefiniteCanisterSettings = record { controllers : vec principal };
 type DefiniteCanisterSettingsArgs = record {
-  controller : principal;
   freezing_threshold : nat;
   controllers : vec principal;
   memory_allocation : nat;

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -73,6 +73,7 @@ type Init = record {
   sns_root_canister_id : text;
   fallback_controller_principal_ids : vec text;
   neuron_minimum_stake_e8s : opt nat64;
+  confirmation_text : opt text;
   nns_governance_canister_id : text;
   transaction_fee_e8s : opt nat64;
   icp_ledger_canister_id : text;
@@ -198,8 +199,10 @@ type Ticket = record {
   amount_icp_e8s : nat64;
 };
 type TransferableAmount = record {
+  transfer_fee_paid_e8s : opt nat64;
   transfer_start_timestamp_seconds : nat64;
   amount_e8s : nat64;
+  amount_transferred_e8s : opt nat64;
   transfer_success_timestamp_seconds : nat64;
 };
 service : (Init) -> {

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -84,6 +84,7 @@ type SnsInitPayload = record {
   token_symbol : opt text;
   final_reward_rate_basis_points : opt nat64;
   neuron_minimum_stake_e8s : opt nat64;
+  confirmation_text : opt text;
   logo : opt text;
   name : opt text;
   initial_voting_period_seconds : opt nat64;

--- a/dfx.json
+++ b/dfx.json
@@ -695,7 +695,7 @@
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2022-11-17",
-        "IC_COMMIT": "aebee24076c67a57ff638d9eb9fe4a1d7561850d"
+        "IC_COMMIT": "10779a35b683eb991777bfdffda94145d33759db"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 85a991cff..c1812a9a5 100644
+index 66418e9ff..92c48c6f4 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -11,6 +11,7 @@ use ic_cdk::api::call::CallResult;
@@ -19,7 +19,7 @@ index 85a991cff..c1812a9a5 100644
    GenericNervousSystemFunction(GenericNervousSystemFunction),
  }
  
-@@ -184,12 +185,12 @@ pub enum Action {
+@@ -193,12 +194,12 @@ pub enum Action {
    ManageNervousSystemParameters(NervousSystemParameters),
    AddGenericNervousSystemFunction(NervousSystemFunction),
    RemoveGenericNervousSystemFunction(u64),
@@ -34,7 +34,7 @@ index 85a991cff..c1812a9a5 100644
    ManageSnsMetadata(ManageSnsMetadata),
    ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
    Motion(Motion),
-@@ -261,8 +262,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
+@@ -270,8 +271,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum Operation {
    ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
@@ -45,7 +45,7 @@ index 85a991cff..c1812a9a5 100644
    IncreaseDissolveDelay(IncreaseDissolveDelay),
    SetDissolveTimestamp(SetDissolveTimestamp),
  }
-@@ -283,7 +284,7 @@ pub struct FinalizeDisburseMaturity {
+@@ -292,7 +293,7 @@ pub struct FinalizeDisburseMaturity {
  pub struct MemoAndController { controller: Option<candid::Principal>, memo: u64 }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -54,7 +54,7 @@ index 85a991cff..c1812a9a5 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ClaimOrRefresh { by: Option<By> }
-@@ -316,7 +317,7 @@ pub enum Command_2 {
+@@ -325,7 +326,7 @@ pub enum Command_2 {
    DisburseMaturity(DisburseMaturity),
    Configure(Configure),
    RegisterVote(RegisterVote),
@@ -63,7 +63,7 @@ index 85a991cff..c1812a9a5 100644
    MakeProposal(Proposal),
    FinalizeDisburseMaturity(FinalizeDisburseMaturity),
    ClaimOrRefreshNeuron(ClaimOrRefresh),
-@@ -419,7 +420,7 @@ pub struct ClaimSwapNeuronsResponse {
+@@ -443,7 +444,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}
  
@@ -72,7 +72,7 @@ index 85a991cff..c1812a9a5 100644
  pub struct GetMetadataResponse {
    pub  url: Option<String>,
    pub  logo: Option<String>,
-@@ -493,7 +494,7 @@ pub struct GetSnsInitializationParametersResponse {
+@@ -513,7 +514,7 @@ pub struct GetSnsInitializationParametersResponse {
    pub  sns_initialization_parameters: String,
  }
  
@@ -81,7 +81,7 @@ index 85a991cff..c1812a9a5 100644
  pub struct ListNervousSystemFunctionsResponse {
    pub  reserved_ids: Vec<u64>,
    pub  functions: Vec<NervousSystemFunction>,
-@@ -565,17 +566,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
+@@ -585,17 +586,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
  pub enum Command_1 {
    Error(GovernanceError),
    Split(SplitResponse),

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 003d885d6..4b9844b29 100644
+index fc5913ad6..53c430ccd 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -4,7 +4,7 @@

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -14,17 +14,21 @@ use ic_cdk::api::call::CallResult;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Value { Int(candid::Int), Nat(candid::Nat), Blob(Vec<u8>), Text(String) }
 
+pub type Subaccount = Vec<u8>;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub enum ChangeFeeCollector { SetTo(Account), Unset }
+
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpgradeArgs {
   pub  token_symbol: Option<String>,
   pub  transfer_fee: Option<u64>,
   pub  metadata: Option<Vec<(String,Value,)>>,
+  pub  change_fee_collector: Option<ChangeFeeCollector>,
   pub  token_name: Option<String>,
 }
-
-pub type Subaccount = Vec<u8>;
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InitArgs_archive_options {
@@ -43,6 +47,7 @@ pub struct InitArgs {
   pub  metadata: Vec<(String,Value,)>,
   pub  minting_account: Account,
   pub  initial_balances: Vec<(Account,u64,)>,
+  pub  fee_collector_account: Option<Account>,
   pub  archive_options: InitArgs_archive_options,
   pub  token_name: String,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index d362af863..dc244c613 100644
+index e429d5ccc..7afe0c605 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
 @@ -4,7 +4,7 @@
@@ -11,7 +11,7 @@ index d362af863..dc244c613 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -85,7 +85,7 @@ pub struct GetSnsCanistersSummaryResponse {
+@@ -82,7 +82,7 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_sns_canisters_arg0 {}
  

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -30,10 +30,14 @@ pub struct CanisterIdRecord { canister_id: candid::Principal }
 pub enum CanisterStatusType { stopped, stopping, running }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct DefiniteCanisterSettings { controllers: Vec<candid::Principal> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResult {
   pub  controller: candid::Principal,
   pub  status: CanisterStatusType,
   pub  memory_size: candid::Nat,
+  pub  settings: DefiniteCanisterSettings,
   pub  module_hash: Option<Vec<u8>>,
 }
 
@@ -41,11 +45,7 @@ pub struct CanisterStatusResult {
 pub struct GetSnsCanistersSummaryRequest { update_canister_list: Option<bool> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum CanisterStatusType_1 { stopped, stopping, running }
-
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettingsArgs {
-  pub  controller: candid::Principal,
   pub  freezing_threshold: candid::Nat,
   pub  controllers: Vec<candid::Principal>,
   pub  memory_allocation: candid::Nat,
@@ -54,10 +54,7 @@ pub struct DefiniteCanisterSettingsArgs {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResultV2 {
-  pub  controller: candid::Principal,
-  pub  status: CanisterStatusType_1,
-  pub  freezing_threshold: candid::Nat,
-  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
+  pub  status: CanisterStatusType,
   pub  memory_size: candid::Nat,
   pub  cycles: candid::Nat,
   pub  settings: DefiniteCanisterSettingsArgs,

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 857000679..321ccf5ea 100644
+index bab509dc1..4fe931d81 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -4,14 +4,14 @@
@@ -19,7 +19,7 @@ index 857000679..321ccf5ea 100644
  pub struct Init {
    pub  sns_root_canister_id: String,
    pub  fallback_controller_principal_ids: Vec<String>,
-@@ -74,7 +74,7 @@ pub struct SettleCommunityFundParticipationResult {
+@@ -75,7 +75,7 @@ pub struct SettleCommunityFundParticipationResult {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -28,7 +28,7 @@ index 857000679..321ccf5ea 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SetModeCallResult { possibility: Option<Possibility_2> }
-@@ -207,13 +207,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
+@@ -210,13 +210,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_sale_parameters_arg0 {}
  
@@ -44,7 +44,7 @@ index 857000679..321ccf5ea 100644
  pub struct Params {
    pub  min_participant_icp_e8s: u64,
    pub  neuron_basket_construction_parameters: Option<
-@@ -284,10 +284,10 @@ pub struct Swap {
+@@ -287,10 +287,10 @@ pub struct Swap {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -16,6 +16,7 @@ pub struct Init {
   pub  sns_root_canister_id: String,
   pub  fallback_controller_principal_ids: Vec<String>,
   pub  neuron_minimum_stake_e8s: Option<u64>,
+  pub  confirmation_text: Option<String>,
   pub  nns_governance_canister_id: String,
   pub  transaction_fee_e8s: Option<u64>,
   pub  icp_ledger_canister_id: String,
@@ -106,8 +107,10 @@ pub struct GetBuyerStateRequest { principal_id: Option<candid::Principal> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransferableAmount {
+  pub  transfer_fee_paid_e8s: Option<u64>,
   pub  transfer_start_timestamp_seconds: u64,
   pub  amount_e8s: u64,
+  pub  amount_transferred_e8s: Option<u64>,
   pub  transfer_success_timestamp_seconds: u64,
 }
 

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index b895247fa..5cbd6c17e 100644
+index 3c6424bb1..e0e932720 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 @@ -4,7 +4,7 @@
@@ -11,7 +11,7 @@ index b895247fa..5cbd6c17e 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -168,7 +168,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+@@ -169,7 +169,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}
  
@@ -20,7 +20,7 @@ index b895247fa..5cbd6c17e 100644
  pub struct DeployedSns {
    pub  root_canister_id: Option<candid::Principal>,
    pub  governance_canister_id: Option<candid::Principal>,
-@@ -178,7 +178,7 @@ pub struct DeployedSns {
+@@ -179,7 +179,7 @@ pub struct DeployedSns {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -76,6 +76,7 @@ pub struct SnsInitPayload {
   pub  token_symbol: Option<String>,
   pub  final_reward_rate_basis_points: Option<u64>,
   pub  neuron_minimum_stake_e8s: Option<u64>,
+  pub  confirmation_text: Option<String>,
   pub  logo: Option<String>,
   pub  name: Option<String>,
   pub  initial_voting_period_seconds: Option<u64>,


### PR DESCRIPTION
# Motivation

We need to access the `confirmation_text` [field in the SNS init params](https://github.com/dfinity/ic/blob/master/rs/sns/swap/canister/swap.did#:~:text=confirmation_text%20:%20opt%20text;) to show it in the UI.
We will access it through the sns_aggregator so it needs to be aware of the field.
The field was added in commit [3d4752b...](https://github.com/dfinity/ic/commit/3d4752b2a717334006a5e35330a132b08f890ffc).
The first *published* commit after it, according to snsdemo/bin/dfx-software-ic-latest is 10779a35b683eb991777bfdffda94145d33759db.

# Changes

1. Updated commit, did files and rust types with `scripts/update_ic_commit --ic_commit 10779a35b683eb991777bfdffda94145d33759db`.
2. Updated patch files with `scripts/mk_nns_patch.sh`.

I did not make any manual changes.
Since I did not make manual changes, there shouldn't be any meaningful changes in the patch files but updating them will prevent too much drift in the line numbers which could eventually stop them from working.
And also to prevent people making manual changes without updating the patch files, updating them is required since https://github.com/dfinity/nns-dapp/pull/2508.

# Tests

1. I locally installed the sns_aggregator and verified that the `confirmation_text` field is present in its `slow.json` response (value with `null`).
2. I manually test that locally the Launchpad and ProjectDetail page work fine while using the sns_aggregator.