### PR TITLE
Fix: Min should not increase more than max

### DIFF
--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -60,9 +60,11 @@
       minDelayInSeconds + SECONDS_IN_DAY,
       minProjectDelayInSeconds
     );
+    keepDelaysInBounds();
   };
   const setMax = () => {
     delayInSeconds = maxDelayInSeconds;
+    keepDelaysInBounds();
   };
   const updateInputError = () => {
     if (delayInDays > maxDelayInDays) {


### PR DESCRIPTION
# Motivation

Clicking on "Min" when dissolve delay was adding 1 day even thought the disssolve delay was the maximum.

The button was anyway disabled, but the user could see "8 years and 1 day"

# Changes

* Check the bound of dissolve delay when using the "Min" and "Max" buttons.

# Tests

UI fix only.