### PR TITLE
Chore: Enable split HW controlled neuron

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
@@ -8,10 +8,8 @@
     ageMultiplier,
     dissolveDelayMultiplier,
     formatVotingPower,
-    isNeuronControllableByUser,
     formattedStakedMaturity,
   } from "$lib/utils/neuron.utils";
-  import { accountsStore } from "$lib/stores/accounts.store";
   import {
     Html,
     KeyValuePairInfo,
@@ -27,12 +25,6 @@
   import { onIntersection } from "$lib/directives/intersection.directives";
 
   export let neuron: NeuronInfo;
-
-  let isControlledByUser: boolean;
-  $: isControlledByUser = isNeuronControllableByUser({
-    neuron,
-    mainAccount: $accountsStore.main,
-  });
 
   const updateLayoutTitle = ($event: Event) => {
     const {
@@ -98,9 +90,7 @@
 </div>
 
 <div class="buttons">
-  {#if isControlledByUser}
-    <SplitNnsNeuronButton {neuron} />
-  {/if}
+  <SplitNnsNeuronButton {neuron} />
 </div>
 
 <Separator />

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -13,6 +13,8 @@ export const SPAWN_VARIANCE_PERCENTAGE = 0.95;
 export const MIN_VERSION_STAKE_MATURITY_WORKAROUND = "2.0.7";
 // Version published in January 2023
 export const CANDID_PARSER_VERSION = "2.2.1";
+// Version published in February 2023
+export const SNS_SUPPORT_VERSION = "2.3.0";
 
 export const DISSOLVE_DELAY_MULTIPLIER = 1;
 export const AGE_MULTIPLIER = 0.25;

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -47,7 +47,7 @@
     startBusy({ initiator: "split-neuron" });
 
     const id = await splitNeuron({
-      neuronId: neuron.neuronId,
+      neuron,
       amount,
     });
     if (id !== undefined) {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
@@ -94,7 +94,7 @@ describe("NnsNeuronMetaInfoCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders split actions", () => {
+  it("renders actions", () => {
     // Each action button is tested separately
     const { queryByText } = render(NeuronContextActionsTest, {
       props: {
@@ -103,10 +103,19 @@ describe("NnsNeuronMetaInfoCard", () => {
       },
     });
 
+    expect(
+      queryByText(en.neuron_detail.increase_dissolve_delay)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByText(en.neuron_detail.start_dissolving)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByText(en.neuron_detail.increase_stake)
+    ).not.toBeInTheDocument();
     expect(queryByText(en.neuron_detail.split_neuron)).toBeInTheDocument();
   });
 
-  it("renders no actions if user is not controller", () => {
+  it("does not render specific actions if user is not controller", () => {
     const { queryByText } = render(NeuronContextActionsTest, {
       props: {
         neuron: {
@@ -129,7 +138,23 @@ describe("NnsNeuronMetaInfoCard", () => {
     expect(
       queryByText(en.neuron_detail.increase_stake)
     ).not.toBeInTheDocument();
-    expect(queryByText(en.neuron_detail.split_neuron)).not.toBeInTheDocument();
+  });
+
+  it("renders split neuron action if user is not controller", () => {
+    const { queryByText } = render(NeuronContextActionsTest, {
+      props: {
+        neuron: {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockFullNeuron,
+            controller: "not-controller",
+          },
+        },
+        testComponent: NnsNeuronMetaInfoCard,
+      },
+    });
+
+    expect(queryByText(en.neuron_detail.split_neuron)).toBeInTheDocument();
   });
 
   it("should render neuron age", () => {


### PR DESCRIPTION
# Motivation

In the ICP Ledger App version 2.3.0 it's enabled to split neurons.

Therefore, we should enable the UI in NNS Dapp as well.

# Changes

* "Split Neuron" button is always present. Also HW controlled neurons.
* Neuron service splitNeuron checks the controller of the neuron and the ledger app version before splitting
* New Ledger app version constant: 2.3.0

# Tests

* Test that "Split Neuron" button is present for HW controlled neurons.
* Test that neuron service split neurons checks ledger app version before continuing.
