### PR TITLE
Feat: Add Participate Button Status helper

### DIFF
--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,4 +1,5 @@
+import type { CountryCode } from "$lib/types/location";
 import type { SnsSummary } from "$lib/types/sns";
 
 // TODO: GIX-1545 Implement this function
-export const getDeniedCountries = (_summary: SnsSummary) => [];
+export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] => [];

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -278,9 +278,9 @@ type ParticipationButtonStatus =
  * There are 6 possible statuses:
  * - logged-out: the user is not logged in.
  * - loading: the status is not yet known. Any of the resources is stil being fetched.
- * - disabled-no-open: the project is not open.
+ * - disabled-not-open: the project is not open.
  * - disabled-max-participation: the user has already participated in the swap with the maximum per user and cannot participate again.
- * - disabled-no-eligible: the user is not eligible to participate in the swap. E.g. user location in the restricted countries list.
+ * - disabled-not-eligible: the user is not eligible to participate in the swap. E.g. user location in the restricted countries list.
  * - enabled: the user can participate in the swap.
  *
  * logged-out:

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -276,12 +276,12 @@ type ParticipationButtonStatus =
  * Returns the status of the Participate Button.
  *
  * There are 6 possible statuses:
- * - logged-out: the user is not logged in.
- * - loading: the status is not yet known. Any of the resources is stil being fetched.
- * - disabled-not-open: the project is not open.
- * - disabled-max-participation: the user has already participated in the swap with the maximum per user and cannot participate again.
- * - disabled-not-eligible: the user is not eligible to participate in the swap. E.g. user location in the restricted countries list.
- * - enabled: the user can participate in the swap.
+ * - logged-out
+ * - loading
+ * - disabled-not-open
+ * - disabled-max-participation
+ * - disabled-not-eligible
+ * - enabled
  *
  * logged-out:
  * - The user is not logged in.

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -962,7 +962,7 @@ describe("project-utils", () => {
     });
   });
 
-  describe.only("participateButtonStatus", () => {
+  describe("participateButtonStatus", () => {
     const summary: SnsSummary = {
       ...mockSnsFullProject.summary,
     };

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1063,7 +1063,7 @@ describe("project-utils", () => {
       ).toBe("loading");
     });
 
-    it("returns 'disabled-no-open' if project is not open", () => {
+    it("returns 'disabled-not-open' if project is not open", () => {
       expect(
         participateButtonStatus({
           loggedIn: true,
@@ -1072,7 +1072,7 @@ describe("project-utils", () => {
           userCountry: "CH",
           ticket: null,
         })
-      ).toBe("disabled-no-open");
+      ).toBe("disabled-not-open");
     });
 
     it("returns 'disabled-max-participation' if user already participated with max amount", () => {
@@ -1128,7 +1128,7 @@ describe("project-utils", () => {
           .mockReturnValue(["CH"]);
       });
 
-      it("returns 'disabled-no-eligible' if user is in a restricted country", () => {
+      it("returns 'disabled-not-eligible' if user is in a restricted country", () => {
         expect(
           participateButtonStatus({
             loggedIn: true,
@@ -1137,7 +1137,7 @@ describe("project-utils", () => {
             userCountry: "CH",
             ticket: null,
           })
-        ).toBe("disabled-no-eligible");
+        ).toBe("disabled-not-eligible");
       });
 
       it("returns 'loading' if no user country but restricted list is not empty", () => {


### PR DESCRIPTION
# Motivation

The status of the Participate Button is becoming complex.

To manage the complexity, in this PR, we add a helper function to encapsulate all the logic for the button status.

# Changes

* New project util `participateButtonStatus` and new type `ParticipationButtonStatus`.
* Change return type in `getDeniedCountries`

# Tests

* Test new util.
