### PR TITLE
Chore: Add Sonics SNS Gov canister to CSP

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -217,6 +217,8 @@ const cspConnectSrc = () => {
     // TODO: solve with a worker
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
+    // Used for the metrics of Sonic launch.
+    "https://23ten-uaaaa-aaaaq-aaapa-cai.raw.ic0.app",
   ];
 
   if (isAggregatorCanisterUrlDefined) {

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -218,7 +218,7 @@ const cspConnectSrc = () => {
     // Used for the metrics of OC launch
     "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
     // Used for the metrics of Sonic launch.
-    "https://23ten-uaaaa-aaaaq-aaapa-cai.raw.ic0.app",
+    "https://24scz-zyaaa-aaaaq-aaapq-cai.raw.ic0.app",
   ];
 
   if (isAggregatorCanisterUrlDefined) {


### PR DESCRIPTION
# Motivation

We get the number of participants from the metrics endpoint of SNS governance.

To do so, we need the endpoint in our CSP rules.

# Changes

* Add new endpoint to CSP rules.

# Tests

Only build changes
