### PR TITLE
feat: updates logic for last maturity distribution time calculation

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -862,21 +862,21 @@ export const filterIneligibleNnsNeurons = ({
         : "short",
   }));
 
+/// Returns timestamp in seconds of last maturity distribution event
 export const maturityLastDistribution = ({
-  distributed_e8s_equivalent,
-  total_available_e8s_equivalent,
   actual_timestamp_seconds,
   rounds_since_last_distribution,
+  settled_proposals,
 }: RewardEvent): bigint => {
-  // Rewards were distributed that round, so the timestamp is correct
-  if (distributed_e8s_equivalent === total_available_e8s_equivalent) {
+  // Rewards were distributed that round (the most recent reward event was not a rollover), so the timestamp is correct
+  if (settled_proposals.length > 0) {
     return actual_timestamp_seconds;
   }
 
   // When there was a reward event, but no rewards were distributed (because of a rollover)
   return (
     actual_timestamp_seconds -
-    (fromNullable(rounds_since_last_distribution) ?? 0n) *
+    (fromNullable(rounds_since_last_distribution) ?? 1n) *
       BigInt(SECONDS_IN_DAY)
   );
 };

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1975,8 +1975,11 @@ describe("neuron-utils", () => {
       const testRewardEvent = {
         ...mockRewardEvent,
         actual_timestamp_seconds: 12234455555n,
-        distributed_e8s_equivalent: 100n,
-        total_available_e8s_equivalent: 100n,
+        settled_proposals: [
+          {
+            id: 0n,
+          },
+        ],
       } as RewardEvent;
       expect(maturityLastDistribution(testRewardEvent)).toEqual(12234455555n);
     });
@@ -1985,9 +1988,8 @@ describe("neuron-utils", () => {
       const testRewardEvent = {
         ...mockRewardEvent,
         actual_timestamp_seconds: 12234455555n,
-        distributed_e8s_equivalent: 100n,
-        total_available_e8s_equivalent: 200n,
         rounds_since_last_distribution: [3n],
+        settled_proposals: [],
       } as RewardEvent;
       const threeDays = BigInt(3 * SECONDS_IN_DAY);
       expect(maturityLastDistribution(testRewardEvent)).toEqual(


### PR DESCRIPTION
# Motivation

Update last maturity distribution calculation logic to be based no `settled_proposals` absence.

# Changes

- `maturityLastDistribution` logic

# Tests

- updated related tests
