### PR TITLE
Fix: Point to icp0.io not icp0.app

### DIFF
--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -216,9 +216,9 @@ const cspConnectSrc = () => {
     "${{SNS_AGGREGATOR_URL}}",
     // TODO: solve with a worker
     // Used for the metrics of OC launch
-    "https://2hx64-daaaa-aaaaq-aaana-cai.raw.ic0.app",
+    "https://2hx64-daaaa-aaaaq-aaana-cai.raw.icp0.io",
     // Used for the metrics of Sonic launch.
-    "https://24scz-zyaaa-aaaaq-aaapq-cai.raw.ic0.app",
+    "https://7hi6i-7iaaa-aaaaq-aaaqq-cai.raw.icp0.io",
   ];
 
   if (isAggregatorCanisterUrlDefined) {

--- a/frontend/src/lib/api/sns-swap-metrics.api.ts
+++ b/frontend/src/lib/api/sns-swap-metrics.api.ts
@@ -10,7 +10,7 @@ export const querySnsSwapMetrics = async ({
 
   try {
     // TODO: switch to a metrics canister. Otherwise not testable on testnet.
-    const url = `https://${swapCanisterId.toText()}.raw.ic0.app/metrics`;
+    const url = `https://${swapCanisterId.toText()}.raw.ic0.io/metrics`;
     const response = await fetch(url);
 
     if (!response.ok) {


### PR DESCRIPTION
# Motivation

Link to get metrics is in the domain icp0.io not icp0.app now.

# Changes

* Change metrics api endpoint.
* Change CSP to use new endpoint.
* Change the canister id in the Sonic CSP. It was using the governance canister, and it should be the swap canister.

# Tests

No new functionality
