### PR TITLE
Update IC commit

### DIFF
--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -28,7 +28,10 @@ type By = variant {
   NeuronId : record {};
 };
 type CanisterStatusResultV2 = record {
+  controller : principal;
   status : CanisterStatusType;
+  freezing_threshold : nat;
+  balance : vec record { vec nat8; nat };
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
@@ -96,6 +99,7 @@ type Command_2 = variant {
 type Configure = record { operation : opt Operation };
 type DefaultFollowees = record { followees : vec record { nat64; Followees } };
 type DefiniteCanisterSettingsArgs = record {
+  controller : principal;
   freezing_threshold : nat;
   controllers : vec principal;
   memory_allocation : nat;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -5,6 +5,7 @@ type Timestamp = nat64;
 // Number of nanoseconds between two [Timestamp]s.
 type Duration = nat64;
 type Tokens = nat;
+type TxIndex = nat;
 
 type Account = record {
     owner : principal;
@@ -37,7 +38,7 @@ type TransferResult = variant {
 };
 
 // The value returned from the [icrc1_metadata] endpoint.
-type Value = variant {
+type MetadataValue = variant {
     Nat : nat;
     Int : int;
     Text : text;
@@ -51,7 +52,7 @@ type InitArgs = record {
     transfer_fee : nat64;
     token_symbol : text;
     token_name : text;
-    metadata : vec record { text; Value };
+    metadata : vec record { text; MetadataValue };
     initial_balances : vec record { Account; nat64 };
     archive_options : record {
         num_blocks_to_archive : nat64;
@@ -68,7 +69,7 @@ type ChangeFeeCollector = variant {
 };
 
 type UpgradeArgs = record {
-    metadata : opt vec record { text; Value };
+    metadata : opt vec record { text; MetadataValue };
     token_symbol : opt text;
     token_name : opt text;
     transfer_fee : opt nat64;
@@ -80,15 +81,196 @@ type LedgerArg = variant {
     Upgrade: opt UpgradeArgs;
 };
 
+type GetTransactionsRequest = record {
+    // The index of the first tx to fetch.
+    start : TxIndex;
+    // The number of transactions to fetch.
+    length : nat;
+};
+
+type GetTransactionsResponse = record {
+    // The total number of transactions in the log.
+    log_length : nat;
+
+    // List of transaction that were available in the ledger when it processed the call.
+    //
+    // The transactions form a contiguous range, with the first transaction having index
+    // [first_index] (see below), and the last transaction having index
+    // [first_index] + len(transactions) - 1.
+    //
+    // The transaction range can be an arbitrary sub-range of the originally requested range.
+    transactions : vec Transaction;
+
+    // The index of the first transaction in [transactions].
+    // If the transaction vector is empty, the exact value of this field is not specified.
+    first_index : TxIndex;
+
+    // Encoding of instructions for fetching archived transactions whose indices fall into the
+    // requested range.
+    //
+    // For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
+    // of the originally requested transaction range.
+    archived_transactions : vec record {
+        // The index of the first archived transaction you can fetch using the [callback].
+        start : TxIndex;
+
+        // The number of transactions you can fetch using the callback.
+        length : nat;
+
+        // The function you should call to fetch the archived transactions.
+        // The range of the transaction accessible using this function is given by [from]
+        // and [len] fields above.
+        callback : QueryArchiveFn;
+    };
+};
+
+
+// A prefix of the transaction range specified in the [GetTransactionsRequest] request.
+type TransactionRange = record {
+    // A prefix of the requested transaction range.
+    // The index of the first transaction is equal to [GetTransactionsRequest.from].
+    //
+    // Note that the number of transactions might be less than the requested
+    // [GetTransactionsRequest.length] for various reasons, for example:
+    //
+    // 1. The query might have hit the replica with an outdated state
+    //    that doesn't have the whole range yet.
+    // 2. The requested range is too large to fit into a single reply.
+    //
+    // NOTE: the list of transactions can be empty if:
+    //
+    // 1. [GetTransactionsRequest.length] was zero.
+    // 2. [GetTransactionsRequest.from] was larger than the last transaction known to
+    //    the canister.
+    transactions : vec Transaction;
+};
+
+// A function for fetching archived transaction.
+type QueryArchiveFn = func (GetTransactionsRequest) -> (TransactionRange) query;
+
+type Transaction = record {
+     kind : text;
+     mint : opt record {
+         amount : nat;
+         to : Account;
+         memo : opt blob;
+         created_at_time : opt nat64;
+     };
+     burn : opt record {
+         amount : nat;
+         from : Account;
+         memo : opt blob;
+         created_at_time : opt nat64;
+     };
+     transfer : opt record {
+         amount : nat;
+         from : Account;
+         to : Account;
+         memo : opt blob;
+         created_at_time : opt nat64;
+         fee : opt nat;
+     };
+     timestamp : nat64;
+};
+
+type Value = variant { 
+    Blob : blob; 
+    Text : text; 
+    Nat : nat;
+    Nat64: nat64; 
+    Int : int;
+    Array : vec Value; 
+    Map : Map; 
+};
+
+type Map = vec record { text; Value };
+
+type Block = Value;
+
+type GetBlocksArgs = record {
+    // The index of the first block to fetch.
+    start : BlockIndex;
+    // Max number of blocks to fetch.
+    length : nat;
+};
+
+// A prefix of the block range specified in the [GetBlocksArgs] request.
+type BlockRange = record {
+    // A prefix of the requested block range.
+    // The index of the first block is equal to [GetBlocksArgs.start].
+    //
+    // Note that the number of blocks might be less than the requested
+    // [GetBlocksArgs.length] for various reasons, for example:
+    //
+    // 1. The query might have hit the replica with an outdated state
+    //    that doesn't have the whole range yet.
+    // 2. The requested range is too large to fit into a single reply.
+    //
+    // NOTE: the list of blocks can be empty if:
+    //
+    // 1. [GetBlocksArgs.length] was zero.
+    // 2. [GetBlocksArgs.start] was larger than the last block known to
+    //    the canister.
+    blocks : vec Block;
+};
+
+// A function for fetching archived blocks.
+type QueryBlockArchiveFn = func (GetBlocksArgs) -> (BlockRange) query;
+
+// The result of a "get_blocks" call.
+type GetBlocksResponse = record {
+    // The index of the first block in "blocks".
+    // If the blocks vector is empty, the exact value of this field is not specified.
+    first_index : BlockIndex;
+
+    // The total number of blocks in the chain.
+    // If the chain length is positive, the index of the last block is `chain_len - 1`.
+    chain_length : nat64;
+
+    // System certificate for the hash of the latest block in the chain.
+    // Only present if `get_blocks` is called in a non-replicated query context.
+    certificate : opt blob;
+
+    // List of blocks that were available in the ledger when it processed the call.
+    //
+    // The blocks form a contiguous range, with the first block having index
+    // [first_block_index] (see below), and the last block having index
+    // [first_block_index] + len(blocks) - 1.
+    //
+    // The block range can be an arbitrary sub-range of the originally requested range.
+    blocks : vec Block;
+
+    // Encoding of instructions for fetching archived blocks.
+    archived_blocks : vec record {
+        // The index of the first archived block.
+        start : BlockIndex;
+
+        // The number of blocks that can be fetched.
+        length : nat;
+
+        // Callback to fetch the archived blocks.
+        callback : QueryBlockArchiveFn;
+    };
+};
+
+// Certificate for the block at `block_index`.
+type DataCertificate = record {
+    certificate : opt blob;
+    hash_tree : blob;
+};
+
 service : (ledger_arg : LedgerArg) -> {
     icrc1_name : () -> (text) query;
     icrc1_symbol : () -> (text) query;
     icrc1_decimals : () -> (nat8) query;
-    icrc1_metadata : () -> (vec record { text; Value }) query;
+    icrc1_metadata : () -> (vec record { text; MetadataValue }) query;
     icrc1_total_supply : () -> (Tokens) query;
     icrc1_fee : () -> (Tokens) query;
     icrc1_minting_account : () -> (opt Account) query;
     icrc1_balance_of : (Account) -> (Tokens) query;
     icrc1_transfer : (TransferArg) -> (TransferResult);
     icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
+    get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
+    get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;  
+    get_data_certificate : () -> (DataCertificate) query;    
 }

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -18,6 +18,7 @@ type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
+type Countries = record { iso_codes : vec text };
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -28,6 +29,9 @@ type DefiniteCanisterSettingsArgs = record {
 type DerivedState = record {
   sns_tokens_per_icp : float32;
   buyer_total_icp_e8s : nat64;
+  cf_participant_count : opt nat64;
+  direct_participant_count : opt nat64;
+  cf_neuron_count : opt nat64;
 };
 type DirectInvestment = record { buyer_principal : text };
 type Err = record { description : opt text; error_type : opt int32 };
@@ -58,6 +62,9 @@ type GetBuyersTotalResponse = record { buyers_total : nat64 };
 type GetDerivedStateResponse = record {
   sns_tokens_per_icp : opt float64;
   buyer_total_icp_e8s : opt nat64;
+  cf_participant_count : opt nat64;
+  direct_participant_count : opt nat64;
+  cf_neuron_count : opt nat64;
 };
 type GetInitResponse = record { init : opt Init };
 type GetLifecycleResponse = record {
@@ -79,6 +86,7 @@ type Init = record {
   icp_ledger_canister_id : text;
   sns_ledger_canister_id : text;
   sns_governance_canister_id : text;
+  restricted_countries : opt Countries;
 };
 type InvalidUserAmount = record {
   min_amount_icp_e8s_included : nat64;
@@ -150,7 +158,10 @@ type Possibility = variant {
 };
 type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
 type Possibility_2 = variant { Ok : record {}; Err : CanisterCallError };
-type RefreshBuyerTokensRequest = record { buyer : text };
+type RefreshBuyerTokensRequest = record {
+  confirmation_text : opt text;
+  buyer : text;
+};
 type RefreshBuyerTokensResponse = record {
   icp_accepted_participation_e8s : nat64;
   icp_ledger_account_balance_e8s : nat64;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,6 +1,7 @@
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
+type Countries = record { iso_codes : vec text };
 type DeployNewSnsRequest = record { sns_init_payload : opt SnsInitPayload };
 type DeployNewSnsResponse = record {
   subnet_id : opt principal;
@@ -99,6 +100,7 @@ type SnsInitPayload = record {
   reward_rate_transition_duration_seconds : opt nat64;
   token_name : opt text;
   proposal_reject_cost_e8s : opt nat64;
+  restricted_countries : opt Countries;
 };
 type SnsUpgrade = record {
   next_version : opt SnsVersion;

--- a/dfx.json
+++ b/dfx.json
@@ -695,7 +695,7 @@
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2022-11-17",
-        "IC_COMMIT": "10779a35b683eb991777bfdffda94145d33759db"
+        "IC_COMMIT": "26b480f775222265f4369bc485d502a140f15564"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 66418e9ff..92c48c6f4 100644
+index d1acc5d98..25b9ba676 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -11,6 +11,7 @@ use ic_cdk::api::call::CallResult;
@@ -72,7 +72,7 @@ index 66418e9ff..92c48c6f4 100644
  pub struct GetMetadataResponse {
    pub  url: Option<String>,
    pub  logo: Option<String>,
-@@ -513,7 +514,7 @@ pub struct GetSnsInitializationParametersResponse {
+@@ -517,7 +518,7 @@ pub struct GetSnsInitializationParametersResponse {
    pub  sns_initialization_parameters: String,
  }
  
@@ -81,7 +81,7 @@ index 66418e9ff..92c48c6f4 100644
  pub struct ListNervousSystemFunctionsResponse {
    pub  reserved_ids: Vec<u64>,
    pub  functions: Vec<NervousSystemFunction>,
-@@ -585,17 +586,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
+@@ -589,17 +590,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
  pub enum Command_1 {
    Error(GovernanceError),
    Split(SplitResponse),

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -481,6 +481,7 @@ pub enum CanisterStatusType { stopped, stopping, running }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettingsArgs {
+  pub  controller: candid::Principal,
   pub  freezing_threshold: candid::Nat,
   pub  controllers: Vec<candid::Principal>,
   pub  memory_allocation: candid::Nat,
@@ -489,7 +490,10 @@ pub struct DefiniteCanisterSettingsArgs {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResultV2 {
+  pub  controller: candid::Principal,
   pub  status: CanisterStatusType,
+  pub  freezing_threshold: candid::Nat,
+  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
   pub  memory_size: candid::Nat,
   pub  cycles: candid::Nat,
   pub  settings: DefiniteCanisterSettingsArgs,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index fc5913ad6..53c430ccd 100644
+index 8b7243de1..8588d3891 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -4,7 +4,7 @@

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 8b7243de1..8588d3891 100644
+index 8b7243de1..f5baada32 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -4,7 +4,7 @@
@@ -11,3 +11,37 @@ index 8b7243de1..8588d3891 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
+@@ -81,14 +81,14 @@ pub type Block = Box<Value>;
+ pub struct BlockRange { blocks: Vec<Block> }
+ 
+ pub type QueryBlockArchiveFn = candid::Func;
+-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
++#[derive(CandidType, Deserialize)]
+ pub struct GetBlocksResponse_archived_blocks_inner {
+   pub  callback: QueryBlockArchiveFn,
+   pub  start: BlockIndex,
+   pub  length: candid::Nat,
+ }
+ 
+-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
++#[derive(CandidType, Deserialize)]
+ pub struct GetBlocksResponse {
+   pub  certificate: Option<Vec<u8>>,
+   pub  first_index: BlockIndex,
+@@ -143,14 +143,14 @@ pub struct Transaction {
+ pub struct TransactionRange { transactions: Vec<Transaction> }
+ 
+ pub type QueryArchiveFn = candid::Func;
+-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
++#[derive(CandidType, Deserialize)]
+ pub struct GetTransactionsResponse_archived_transactions_inner {
+   pub  callback: QueryArchiveFn,
+   pub  start: TxIndex,
+   pub  length: candid::Nat,
+ }
+ 
+-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
++#[derive(CandidType, Deserialize)]
+ pub struct GetTransactionsResponse {
+   pub  first_index: TxIndex,
+   pub  log_length: candid::Nat,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -81,14 +81,14 @@ pub type Block = Box<Value>;
 pub struct BlockRange { blocks: Vec<Block> }
 
 pub type QueryBlockArchiveFn = candid::Func;
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse_archived_blocks_inner {
   pub  callback: QueryBlockArchiveFn,
   pub  start: BlockIndex,
   pub  length: candid::Nat,
 }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
   pub  certificate: Option<Vec<u8>>,
   pub  first_index: BlockIndex,
@@ -143,14 +143,14 @@ pub struct Transaction {
 pub struct TransactionRange { transactions: Vec<Transaction> }
 
 pub type QueryArchiveFn = candid::Func;
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse_archived_transactions_inner {
   pub  callback: QueryArchiveFn,
   pub  start: TxIndex,
   pub  length: candid::Nat,
 }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
   pub  first_index: TxIndex,
   pub  log_length: candid::Nat,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -12,7 +12,12 @@ use ic_cdk::api::call::CallResult;
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Value { Int(candid::Int), Nat(candid::Nat), Blob(Vec<u8>), Text(String) }
+pub enum MetadataValue {
+  Int(candid::Int),
+  Nat(candid::Nat),
+  Blob(Vec<u8>),
+  Text(String),
+}
 
 pub type Subaccount = Vec<u8>;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -25,7 +30,7 @@ pub enum ChangeFeeCollector { SetTo(Account), Unset }
 pub struct UpgradeArgs {
   pub  token_symbol: Option<String>,
   pub  transfer_fee: Option<u64>,
-  pub  metadata: Option<Vec<(String,Value,)>>,
+  pub  metadata: Option<Vec<(String,MetadataValue,)>>,
   pub  change_fee_collector: Option<ChangeFeeCollector>,
   pub  token_name: Option<String>,
 }
@@ -44,7 +49,7 @@ pub struct InitArgs_archive_options {
 pub struct InitArgs {
   pub  token_symbol: String,
   pub  transfer_fee: u64,
-  pub  metadata: Vec<(String,Value,)>,
+  pub  metadata: Vec<(String,MetadataValue,)>,
   pub  minting_account: Account,
   pub  initial_balances: Vec<(Account,u64,)>,
   pub  fee_collector_account: Option<Account>,
@@ -54,6 +59,106 @@ pub struct InitArgs {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum LedgerArg { Upgrade(Option<UpgradeArgs>), Init(InitArgs) }
+
+pub type BlockIndex = candid::Nat;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetBlocksArgs { start: BlockIndex, length: candid::Nat }
+
+pub type Map = Vec<(String,Box<Value>,)>;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub enum Value {
+  Int(candid::Int),
+  Map(Map),
+  Nat(candid::Nat),
+  Nat64(u64),
+  Blob(Vec<u8>),
+  Text(String),
+  Array(Vec<Box<Value>>),
+}
+
+pub type Block = Box<Value>;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct BlockRange { blocks: Vec<Block> }
+
+pub type QueryBlockArchiveFn = candid::Func;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetBlocksResponse_archived_blocks_inner {
+  pub  callback: QueryBlockArchiveFn,
+  pub  start: BlockIndex,
+  pub  length: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetBlocksResponse {
+  pub  certificate: Option<Vec<u8>>,
+  pub  first_index: BlockIndex,
+  pub  blocks: Vec<Block>,
+  pub  chain_length: u64,
+  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct DataCertificate { certificate: Option<Vec<u8>>, hash_tree: Vec<u8> }
+
+pub type TxIndex = candid::Nat;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetTransactionsRequest { start: TxIndex, length: candid::Nat }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Transaction_burn_inner {
+  pub  from: Account,
+  pub  memo: Option<Vec<u8>>,
+  pub  created_at_time: Option<u64>,
+  pub  amount: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Transaction_mint_inner {
+  pub  to: Account,
+  pub  memo: Option<Vec<u8>>,
+  pub  created_at_time: Option<u64>,
+  pub  amount: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Transaction_transfer_inner {
+  pub  to: Account,
+  pub  fee: Option<candid::Nat>,
+  pub  from: Account,
+  pub  memo: Option<Vec<u8>>,
+  pub  created_at_time: Option<u64>,
+  pub  amount: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Transaction {
+  pub  burn: Option<Transaction_burn_inner>,
+  pub  kind: String,
+  pub  mint: Option<Transaction_mint_inner>,
+  pub  timestamp: u64,
+  pub  transfer: Option<Transaction_transfer_inner>,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct TransactionRange { transactions: Vec<Transaction> }
+
+pub type QueryArchiveFn = candid::Func;
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetTransactionsResponse_archived_transactions_inner {
+  pub  callback: QueryArchiveFn,
+  pub  start: TxIndex,
+  pub  length: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetTransactionsResponse {
+  pub  first_index: TxIndex,
+  pub  log_length: candid::Nat,
+  pub  transactions: Vec<Transaction>,
+  pub  archived_transactions: Vec<
+    GetTransactionsResponse_archived_transactions_inner
+  >,
+}
 
 pub type Tokens = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -70,7 +175,6 @@ pub struct TransferArg {
   pub  amount: Tokens,
 }
 
-pub type BlockIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum TransferError {
   GenericError{ message: String, error_code: candid::Nat },
@@ -88,6 +192,18 @@ pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
 
 pub struct SERVICE(candid::Principal);
 impl SERVICE{
+  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
+    (GetBlocksResponse,)
+  > { ic_cdk::call(self.0, "get_blocks", (arg0,)).await }
+  pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
+    ic_cdk::call(self.0, "get_data_certificate", ()).await
+  }
+  pub async fn get_transactions(
+    &self,
+    arg0: GetTransactionsRequest,
+  ) -> CallResult<(GetTransactionsResponse,)> {
+    ic_cdk::call(self.0, "get_transactions", (arg0,)).await
+  }
   pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
     ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
   }
@@ -97,9 +213,9 @@ impl SERVICE{
   pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
     ic_cdk::call(self.0, "icrc1_fee", ()).await
   }
-  pub async fn icrc1_metadata(&self) -> CallResult<(Vec<(String,Value,)>,)> {
-    ic_cdk::call(self.0, "icrc1_metadata", ()).await
-  }
+  pub async fn icrc1_metadata(&self) -> CallResult<
+    (Vec<(String,MetadataValue,)>,)
+  > { ic_cdk::call(self.0, "icrc1_metadata", ()).await }
   pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
     ic_cdk::call(self.0, "icrc1_minting_account", ()).await
   }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index a8b595640..ab7f0122d 100644
+index a8b595640..0bb086fa1 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-@@ -4,7 +4,7 @@
+@@ -4,17 +4,17 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -11,8 +11,11 @@ index a8b595640..ab7f0122d 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -14,7 +14,7 @@ use ic_cdk::api::call::CallResult;
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+ // use ic_cdk::api::call::CallResult;
+ 
+-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
++#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
  pub struct Countries { iso_codes: Vec<String> }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index bab509dc1..4fe931d81 100644
+index a8b595640..ab7f0122d 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-@@ -4,14 +4,14 @@
+@@ -4,7 +4,7 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -11,15 +11,16 @@ index bab509dc1..4fe931d81 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
- // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
- // use ic_cdk::api::call::CallResult;
+@@ -14,7 +14,7 @@ use ic_cdk::api::call::CallResult;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Countries { iso_codes: Vec<String> }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
  pub struct Init {
    pub  sns_root_canister_id: String,
    pub  fallback_controller_principal_ids: Vec<String>,
-@@ -75,7 +75,7 @@ pub struct SettleCommunityFundParticipationResult {
+@@ -79,7 +79,7 @@ pub struct SettleCommunityFundParticipationResult {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -28,7 +29,7 @@ index bab509dc1..4fe931d81 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SetModeCallResult { possibility: Option<Possibility_2> }
-@@ -210,13 +210,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
+@@ -217,13 +217,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_sale_parameters_arg0 {}
  
@@ -44,12 +45,9 @@ index bab509dc1..4fe931d81 100644
  pub struct Params {
    pub  min_participant_icp_e8s: u64,
    pub  neuron_basket_construction_parameters: Option<
-@@ -287,10 +287,10 @@ pub struct Swap {
+@@ -302,8 +302,8 @@ pub struct DerivedState {
+   pub  cf_neuron_count: Option<u64>,
  }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct DerivedState { sns_tokens_per_icp: f32, buyer_total_icp_e8s: u64 }
-+pub struct DerivedState { pub sns_tokens_per_icp: f32, pub buyer_total_icp_e8s: u64 }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 -pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
@@ -14,7 +14,7 @@ use ic_cdk::api::call::CallResult;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Countries { iso_codes: Vec<String> }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Init {
   pub  sns_root_canister_id: String,
   pub  fallback_controller_principal_ids: Vec<String>,
@@ -302,8 +302,8 @@ pub struct DerivedState {
   pub  cf_neuron_count: Option<u64>,
 }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListCommunityFundParticipantsRequest {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -11,7 +11,7 @@ use ic_cdk::api::call::CallResult;
 // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Countries { iso_codes: Vec<String> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -4,14 +4,17 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize};
+use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Countries { iso_codes: Vec<String> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Init {
   pub  sns_root_canister_id: String,
   pub  fallback_controller_principal_ids: Vec<String>,
@@ -22,6 +25,7 @@ pub struct Init {
   pub  icp_ledger_canister_id: String,
   pub  sns_ledger_canister_id: String,
   pub  sns_governance_canister_id: String,
+  pub  restricted_countries: Option<Countries>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -161,6 +165,9 @@ pub struct get_derived_state_arg0 {}
 pub struct GetDerivedStateResponse {
   pub  sns_tokens_per_icp: Option<f64>,
   pub  buyer_total_icp_e8s: Option<u64>,
+  pub  cf_participant_count: Option<u64>,
+  pub  direct_participant_count: Option<u64>,
+  pub  cf_neuron_count: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -287,10 +294,16 @@ pub struct Swap {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DerivedState { pub sns_tokens_per_icp: f32, pub buyer_total_icp_e8s: u64 }
+pub struct DerivedState {
+  pub  sns_tokens_per_icp: f32,
+  pub  buyer_total_icp_e8s: u64,
+  pub  cf_participant_count: Option<u64>,
+  pub  direct_participant_count: Option<u64>,
+  pub  cf_neuron_count: Option<u64>,
+}
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
-pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListCommunityFundParticipantsRequest {
@@ -357,7 +370,10 @@ pub struct OpenRequest {
 pub struct open_ret0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct RefreshBuyerTokensRequest { buyer: String }
+pub struct RefreshBuyerTokensRequest {
+  pub  confirmation_text: Option<String>,
+  pub  buyer: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RefreshBuyerTokensResponse {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 3c6424bb1..e0e932720 100644
+index 01542946c..043be43a0 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 @@ -4,7 +4,7 @@
@@ -11,7 +11,7 @@ index 3c6424bb1..e0e932720 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -169,7 +169,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+@@ -173,7 +173,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}
  
@@ -20,7 +20,7 @@ index 3c6424bb1..e0e932720 100644
  pub struct DeployedSns {
    pub  root_canister_id: Option<candid::Principal>,
    pub  governance_canister_id: Option<candid::Principal>,
-@@ -179,7 +179,7 @@ pub struct DeployedSns {
+@@ -183,7 +183,7 @@ pub struct DeployedSns {
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -68,6 +68,9 @@ pub enum InitialTokenDistribution {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct Countries { iso_codes: Vec<String> }
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsInitPayload {
   pub  url: Option<String>,
   pub  max_dissolve_delay_seconds: Option<u64>,
@@ -91,6 +94,7 @@ pub struct SnsInitPayload {
   pub  reward_rate_transition_duration_seconds: Option<u64>,
   pub  token_name: Option<String>,
   pub  proposal_reject_cost_e8s: Option<u64>,
+  pub  restricted_countries: Option<Countries>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/scripts/mk_nns_types.sh
+++ b/scripts/mk_nns_types.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 ##########################
 # Hjelpe meg!
@@ -20,6 +20,7 @@ print_help() {
 
 cd "$(dirname "$(realpath "$0")")"
 GIT_ROOT="$(git rev-parse --show-toplevel)"
+failed_output=""
 for CANISTER_NAME in sns_ledger sns_governance sns_root sns_swap sns_wasm; do
   export CANISTER_NAME
   DID_PATH="${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did"
@@ -27,5 +28,15 @@ for CANISTER_NAME in sns_ledger sns_governance sns_root sns_swap sns_wasm; do
     cd "$GIT_ROOT"
     cp "$(jq '.canisters[env.CANISTER_NAME].candid' dfx.json)" "$DID_PATH"
   )
-  ./did2rs.sh "${CANISTER_NAME}"
+  if output=$(./did2rs.sh "${CANISTER_NAME}"); then
+    echo "$output"
+  else
+    failed_output="${failed_output}${output}"
+  fi
 done
+
+if [[ "$failed_output" != "" ]]; then
+  echo "Failed on some canisters:"
+  echo "$failed_output"
+  exit 1
+fi

--- a/scripts/mk_nns_types.sh
+++ b/scripts/mk_nns_types.sh
@@ -36,7 +36,9 @@ for CANISTER_NAME in sns_ledger sns_governance sns_root sns_swap sns_wasm; do
 done
 
 if [[ "$failed_output" != "" ]]; then
-  echo "Failed on some canisters:"
-  echo "$failed_output"
+  {
+    echo "Failed on some canisters:"
+    echo "$failed_output"
+  } >&2
   exit 1
 fi

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -45,7 +45,7 @@ source "$(clap.build)"
   did_curl sns_root /rs/sns/root/canister/root.did
   did_curl sns_swap /rs/sns/swap/canister/swap.did
   did_curl sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
-  did_curl sns_ledger /rs/rosetta-api/icrc1/ledger/icrc1.did
+  did_curl sns_ledger /rs/rosetta-api/icrc1/ledger/ledger.did
 }
 
 : "Derive Rust types from candid interfaces"


### PR DESCRIPTION
# Motivation

We need to access the `restricted_countries` [field in the SNS init params](https://github.com/dfinity/ic/blob/master/rs/sns/swap/canister/swap.did#:~:text=restricted_countries) to be able to apply geo restriction.
We will access it through the sns_aggregator so it needs to be aware of the field.
The field was added in commit [c5f7c8b...](https://github.com/dfinity/ic/commit/c5f7c8b15223e3a93d456bc0bf43af7662fc802b).
A *published* commit after it, is 26b480f775222265f4369bc485d502a140f15564.

The file `/rs/rosetta-api/icrc1/ledger/icrc1.did` was replaced by `/rs/rosetta-api/icrc1/ledger/ledger.did` according to [this slack thread](https://dfinity.slack.com/archives/C01AVALTNSH/p1684230727167909).

Previously, `scripts/mk_nns_types.sh` would stop applying patches as soon as one of the patches fails to apply.

When running `scripts/update_ic_commit`, 2 hunks of `rs/sns_aggregator/src/types/ic_sns_swap.patch` failed to apply:
```
@@ -4,14 +4,14 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Init {
   pub  sns_root_canister_id: String,
   pub  fallback_controller_principal_ids: Vec<String>,
@@ -290,10 +290,10 @@
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DerivedState { sns_tokens_per_icp: f32, buyer_total_icp_e8s: u64 }
+pub struct DerivedState { pub sns_tokens_per_icp: f32, pub buyer_total_icp_e8s: u64 }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListCommunityFundParticipantsRequest {
```

The corresponding bits in `rs/sns_aggregator/src/types/ic_sns_swap.rs` are:
```
#![allow(non_camel_case_types)]
#![allow(dead_code)]

use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
use ic_cdk::api::call::CallResult;
// This is an experimental feature to generate Rust binding from Candid.
// You may want to manually adjust some of the types.
// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
// use ic_cdk::api::call::CallResult;

#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
pub struct Countries { iso_codes: Vec<String> }
```
and
```
}

#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
pub struct DerivedState {
  pub  sns_tokens_per_icp: f32,
  pub  buyer_total_icp_e8s: u64,
  pub  cf_participant_count: Option<u64>,
  pub  direct_participant_count: Option<u64>,
  pub  cf_neuron_count: Option<u64>,
}

#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }

#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
pub struct ListCommunityFundParticipantsRequest {
```

I have no idea why the first hunk failed to apply. I just applied the changes manually.

The changes to `DerivedState` failed to apply because it now has more fields (and takes up multiple lines). But those changes were to make the field public and the script does that automatically for multiline structs, so I didn't need to do anything manually there.

The changes to `GetStateResponse` failed to apply simply because they were in the same hunk. So I had to manually add `Default` to the `#derive` macro and make the fields `pub`.

# Changes

1. Changed `scripts/update_ic_commit` to use `/rs/rosetta-api/icrc1/ledger/ledger.did` instead of `/rs/rosetta-api/icrc1/ledger/icrc1.did`.
2. Fixed `scripts/mk_nns_types.sh` to continue applying patches after one of the patches fails to apply.
3. Updated commit, did files and rust types with `scripts/update_ic_commit --ic_commit 26b480f775222265f4369bc485d502a140f15564`.
4. Manually fixed `rs/sns_aggregator/src/types/ic_sns_swap.rs` for the patch hunks that failed to apply.
5. Updated patch files with `scripts/mk_nns_patch.sh`.
6. Manually added `PartialEq` to `Countries` in `ic_sns_swap.rs` and removed `, Serialize, Clone, Debug` (which was added by `scripts/did2rs.sh`) from `GetBlocksResponse_archived_blocks_inner`, `GetBlocksResponse`, `GetTransactionsResponse_archived_transactions_inner` and `GetTransactionsResponse` in `ic_sns_ledger.rs` to make the `sns_aggregator` compile again.
7. Updated patch files again with `scripts/mk_nns_patch.sh`.

# Tests

1. I locally installed the sns_aggregator and verified that the `restricted_countries ` field is present in its `slow.json` response (with value `null`).
2. I manually test that locally the Launchpad and ProjectDetail page work fine while using the sns_aggregator.