### PR TITLE
Chore: Refactor Participate Button with status helper

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -91,6 +91,7 @@
             </Tooltip>
             <!-- TODO: GIX-1553 Add disabled-not-eligible -->
           {:else}
+            <!-- This is the "enabled" and "disabled-not-eligible" case -->
             <button
               on:click={openModal}
               class="primary participate"

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,6 +1,6 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import { getDeniedCountries } from "$lib/getters/sns-summary";
-import type { CountryCode } from "$lib/types/location";
+import type { Country } from "$lib/types/location";
 import type {
   SnsSummary,
   SnsSummarySwap,
@@ -264,7 +264,7 @@ export const validParticipation = ({
   return { valid: true };
 };
 
-type ParticipationButtonStatus =
+export type ParticipationButtonStatus =
   | "disabled-max-participation"
   | "disabled-not-eligible"
   | "disabled-not-open"
@@ -321,7 +321,7 @@ export const participateButtonStatus = ({
   swapCommitment: SnsSwapCommitment | undefined | null;
   loggedIn: boolean;
   ticket: SnsSwapTicket | undefined | null;
-  userCountry: CountryCode | undefined | Error;
+  userCountry: Country | Error | "not loaded";
 }): ParticipationButtonStatus => {
   if (!loggedIn) {
     return "logged-out";
@@ -359,11 +359,11 @@ export const participateButtonStatus = ({
       return "enabled";
     }
 
-    if (userCountry === undefined) {
+    if (userCountry === "not loaded") {
       return "loading";
     }
 
-    if (projectDeniedCountries.includes(userCountry)) {
+    if (projectDeniedCountries.includes(userCountry.isoCode)) {
       return "disabled-not-eligible";
     }
   }

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -26,6 +26,8 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { renderContextCmp, snsTicketMock } from "$tests/mocks/sns.mock";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
@@ -156,6 +158,22 @@ describe("ParticipateButton", () => {
       expect(queryByTestId("sns-project-participate-button")).toBeNull();
     });
 
+    it("should display a spinner while fetching user commitment", async () => {
+      snsTicketsStore.setNoTicket(rootCanisterIdMock);
+
+      const { queryByTestId, getByTestId } = renderContextCmp({
+        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        swapCommitment: undefined,
+        Component: ParticipateButton,
+      });
+
+      await waitFor(() =>
+        expect(getByTestId("connecting_sale_canister")).not.toBeNull()
+      );
+
+      expect(queryByTestId("sns-project-participate-button")).toBeNull();
+    });
+
     it("should display spinner and hide button when there is loading ticket", async () => {
       const { queryByTestId, getByTestId, container } = renderContextCmp({
         summary: summaryForLifecycle(SnsSwapLifecycle.Open),
@@ -217,10 +235,11 @@ describe("ParticipateButton", () => {
       await waitFor(() => expect(button.getAttribute("disabled")).toBeNull());
     });
 
-    it("should disable button if user has committed max already", () => {
+    it("should disable button if user has committed max already", async () => {
       const mock = mockSnsFullProject.swapCommitment as SnsSwapCommitment;
+      snsTicketsStore.setNoTicket(mock.rootCanisterId);
 
-      const { queryByTestId } = renderContextCmp({
+      const { queryByTestId, container } = renderContextCmp({
         summary: summaryForLifecycle(SnsSwapLifecycle.Open),
         swapCommitment: {
           rootCanisterId: mock.rootCanisterId,
@@ -237,6 +256,9 @@ describe("ParticipateButton", () => {
         "sns-project-participate-button"
       ) as HTMLButtonElement;
       expect(button.getAttribute("disabled")).not.toBeNull();
+
+      const tooltipPo = new TooltipPo(new JestPageObjectElement(container));
+      expect(await tooltipPo.getText()).toBe("Maximum commitment reached");
     });
   });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -87,7 +87,10 @@ describe("ProjectStatusSection", () => {
     const { rootCanisterId } = summary;
     const { queryByTestId } = renderContextCmp({
       summary,
-      swapCommitment: undefined,
+      swapCommitment: {
+        rootCanisterId,
+        myCommitment: undefined,
+      },
       Component: ProjectStatusSection,
     });
     expect(

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -997,7 +997,7 @@ describe("project-utils", () => {
         loggedIn: false,
         summary,
         swapCommitment: userNoCommitment,
-        userCountry: undefined,
+        userCountry: "not loaded",
         ticket: null,
       });
       expect(expected).toBe("logged-out");
@@ -1009,7 +1009,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: undefined,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("loading");
@@ -1018,7 +1018,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: null,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("loading");
@@ -1027,7 +1027,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary: null,
           swapCommitment: userNoCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("loading");
@@ -1036,7 +1036,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary: undefined,
           swapCommitment: userNoCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("loading");
@@ -1048,7 +1048,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: userNoCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: undefined,
         })
       ).toBe("loading");
@@ -1057,7 +1057,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: userNoCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: testTicket,
         })
       ).toBe("loading");
@@ -1069,7 +1069,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary: notOpenSummary,
           swapCommitment: userNoCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("disabled-not-open");
@@ -1091,7 +1091,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: userMaxCommitment,
-          userCountry: "CH",
+          userCountry: { isoCode: "CH" },
           ticket: null,
         })
       ).toBe("disabled-max-participation");
@@ -1105,7 +1105,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary,
           swapCommitment: userNoCommitment,
-          userCountry: undefined,
+          userCountry: "not loaded",
           ticket: null,
         })
       ).toBe("enabled");
@@ -1134,7 +1134,7 @@ describe("project-utils", () => {
             loggedIn: true,
             summary,
             swapCommitment: userNoCommitment,
-            userCountry: "CH",
+            userCountry: { isoCode: "CH" },
             ticket: null,
           })
         ).toBe("disabled-not-eligible");
@@ -1146,7 +1146,7 @@ describe("project-utils", () => {
             loggedIn: true,
             summary,
             swapCommitment: userNoCommitment,
-            userCountry: undefined,
+            userCountry: "not loaded",
             ticket: null,
           })
         ).toBe("loading");
@@ -1170,7 +1170,7 @@ describe("project-utils", () => {
             loggedIn: true,
             summary,
             swapCommitment: userNoCommitment,
-            userCountry: "SP",
+            userCountry: { isoCode: "SP" },
             ticket: null,
           })
         ).toBe("enabled");


### PR DESCRIPTION
# Motivation

The status of the Participate Button is becoming complex.

In this PR, we use the helper to get the participation button status in the ParticipateButton component.

Not in this PR, manage the new scenarios with restricted countries.

# Changes

* ParticipateButton, use the button status from the helper instead of other variables to render and not render.
* Change the type of the `userCountry` in util `participateButtonStatus`.

# Tests

* Add new test case for "loading" in ParticipateButton spec file.
* Fix tests for participateButtonStatus after refactor.
* One test in ParticipateButton was broken and was passing for the wrong reasons. I fixed it and added an extra expect to ensure the scenario is the expected one.
* Fix one text in ProjectStatusSection. No commitment means loading state, not present. Earlier, this case was not covered in the button.
