### PR TITLE
Chore: Enable query updates

### DIFF
--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -4,7 +4,7 @@ export const DEV = import.meta.env.DEV;
 // Disable TVL or transaction rate warning locally because that information is not crucial when we develop
 export const ENABLE_METRICS = !DEV;
 
-export const FORCE_CALL_STRATEGY: "query" | undefined = undefined;
+export const FORCE_CALL_STRATEGY: "query" | undefined = "query";
 
 export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 

--- a/frontend/src/lib/services/known-neurons.services.ts
+++ b/frontend/src/lib/services/known-neurons.services.ts
@@ -1,4 +1,5 @@
 import { governanceApiService } from "$lib/api-services/governance.api-service";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { KnownNeuron } from "@dfinity/nns";
@@ -6,6 +7,7 @@ import { queryAndUpdate } from "./utils.services";
 
 export const listKnownNeurons = (): Promise<void> => {
   return queryAndUpdate<KnownNeuron[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: (options) => governanceApiService.queryKnownNeurons(options),
     onLoad: ({ response: neurons }) => knownNeuronsStore.setNeurons(neurons),
     onError: ({ error: err, certified, identity }) => {

--- a/frontend/src/lib/services/nns-reward-event.services.ts
+++ b/frontend/src/lib/services/nns-reward-event.services.ts
@@ -1,10 +1,12 @@
 import { governanceApiService } from "$lib/api-services/governance.api-service";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import type { RewardEvent } from "@dfinity/nns";
 import { queryAndUpdate } from "./utils.services";
 
 export const loadLatestRewardEvent = (): Promise<void> => {
   return queryAndUpdate<RewardEvent, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: (options) => governanceApiService.queryLastestRewardEvent(options),
     onLoad: ({ response: rewardEvent, certified }) => {
       nnsLatestRewardEventStore.setLatestRewardEvent({


### PR DESCRIPTION
# Motivation

We want a good UX for the upcoming swap. Therefore, we enable using only query to request data.

# Changes

* Add the flag in two calls: known neurons and latest reward event.
* Set `FORCE_CALL_STRATEGY` to `"query"`.

# Tests

Not applicable.
