### PR TITLE
Fix: metrics api fix

### DIFF
--- a/frontend/src/lib/api/sns-swap-metrics.api.ts
+++ b/frontend/src/lib/api/sns-swap-metrics.api.ts
@@ -10,7 +10,7 @@ export const querySnsSwapMetrics = async ({
 
   try {
     // TODO: switch to a metrics canister. Otherwise not testable on testnet.
-    const url = `https://${swapCanisterId.toText()}.raw.ic0.io/metrics`;
+    const url = `https://${swapCanisterId.toText()}.raw.icp0.io/metrics`;
     const response = await fetch(url);
 
     if (!response.ok) {


### PR DESCRIPTION
# Motivation

Fix the metrics api endpoint to get the number of participants.

# Changes

* Add a missing "p" in "ic0". It shuold be "icp0". Like in CSP rules.

# Tests

Only endpoit change.
