### PR TITLE
Fix: Forever loading participation button

### DIFF
--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -273,7 +273,8 @@
 
     // TODO: Improve cancellatoin of actions onDestroy
     // The polling was triggered by `restoreSnsSaleParticipation` call and needs to be canceled explicitly.
-    cancelPollGetOpenTicket();
+    // TODO: Reenable https://dfinity.atlassian.net/browse/GIX-1574
+    // cancelPollGetOpenTicket();
 
     // Hide toasts when moving away from the page
     hidePollingToast();

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -33,7 +33,6 @@
   import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
   import SaleInProgressModal from "$lib/modals/sns/sale/SaleInProgressModal.svelte";
   import {
-    cancelPollGetOpenTicket,
     hidePollingToast,
     restoreSnsSaleParticipation,
   } from "$lib/services/sns-sale.services";


### PR DESCRIPTION
# Motivation

Users in the phone that access the Project Detail through the Launchpad sometimes had the participation button always loading.

The problem is that the BottomSheet component triggers two mount and unmounts.

Issue to investigate this further: https://dfinity.atlassian.net/browse/GIX-1574

# Changes

* Do not cancel polling getting the open ticket when ProjectDetail is destroyed.

# Tests

There are no tests that checked that the polling was cancelled.
