### PR TITLE
Take FORCE_CALL_STRATEGY into account getCkBTCWithdrawalAccount

### DIFF
--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -1,5 +1,6 @@
 import { getCkBTCAccount } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getWithdrawalAccount as getWithdrawalAccountServices } from "$lib/services/ckbtc-minter.services";
 import type { CkBTCBTCWithdrawalAccount } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
@@ -83,7 +84,11 @@ export const getCkBTCWithdrawalAccount = async ({
 
   // We have to load the withdrawal account with an update call.
   // If we never have loaded it, we return a empty account as result of the not certified (query) call to indicate we are about to load the data.
-  if (!certified && isNullish(storedWithdrawalAccount?.account.identifier)) {
+  if (
+    FORCE_CALL_STRATEGY !== "query" &&
+    !certified &&
+    isNullish(storedWithdrawalAccount?.account.identifier)
+  ) {
     return {
       type: "withdrawalAccount",
     };


### PR DESCRIPTION
# Motivation

During the SNS swap we rely on just query calls to be prepared for heavy load.
The getCkBTCWithdrawalAccount code assumed that there will always be an update response, even though we apply the value of FORCE_CALL_STRATEGY when making the call here:
https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts#:~:text=strategy:%20FORCE_CALL_STRATEGY

# Changes

Check the value of FORCE_CALL_STRATEGY before assuming there will be an update call, in `getCkBTCWithdrawalAccount`.

# Tests

Manually verified that there isn't an infinite spinner for "Checking for incomplete BTC transfers".
Will add unit test separately.