### PR TITLE
Delay ckBTC account and transactions reload

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -7,8 +7,6 @@
   export let reload: () => Promise<void>;
   export let inline = false;
 
-  // Exposed for test purpose - i.e. we do not test with a delayed call
-
   // TODO(GIX-1320): ckBTC - update_balance is an happy path, improve UX once track_balance implemented
   const updateBalance = async () =>
     await updateBalanceService({

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -12,7 +12,7 @@
     await updateBalanceService({
       minterCanisterId,
       reload,
-      deferReload: true
+      deferReload: true,
     });
 </script>
 

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -8,14 +8,13 @@
   export let inline = false;
 
   // Exposed for test purpose - i.e. we do not test with a delayed call
-  export let deferReload = true;
 
   // TODO(GIX-1320): ckBTC - update_balance is an happy path, improve UX once track_balance implemented
   const updateBalance = async () =>
     await updateBalanceService({
       minterCanisterId,
       reload,
-      deferReload,
+      deferReload: true,
     });
 </script>
 

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -7,12 +7,15 @@
   export let reload: () => Promise<void>;
   export let inline = false;
 
+  // Exposed for test purpose - i.e. we do not test with a delayed call
+  export let deferReload = true;
+
   // TODO(GIX-1320): ckBTC - update_balance is an happy path, improve UX once track_balance implemented
   const updateBalance = async () =>
     await updateBalanceService({
       minterCanisterId,
       reload,
-      deferReload: true,
+      deferReload,
     });
 </script>
 

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -12,6 +12,7 @@
     await updateBalanceService({
       minterCanisterId,
       reload,
+      deferReload: true
     });
 </script>
 

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -137,9 +137,11 @@ export const depositFee = async ({
 export const updateBalance = async ({
   minterCanisterId,
   reload,
+  deferReload = false
 }: {
   minterCanisterId: CanisterId;
   reload: (() => Promise<void>) | undefined;
+  deferReload?: boolean;
 }): Promise<{ success: boolean; err?: CkBTCErrorKey | unknown }> => {
   startBusy({
     initiator: "update-ckbtc-balance",
@@ -149,6 +151,9 @@ export const updateBalance = async ({
 
   try {
     await updateBalanceAPI({ identity, canisterId: minterCanisterId });
+
+    const delay = (time: number) => new Promise((resolve) => setTimeout(resolve, time));
+    await delay(deferReload ? 6000 : 0);
 
     await reload?.();
 

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -137,7 +137,7 @@ export const depositFee = async ({
 export const updateBalance = async ({
   minterCanisterId,
   reload,
-  deferReload = false
+  deferReload = false,
 }: {
   minterCanisterId: CanisterId;
   reload: (() => Promise<void>) | undefined;
@@ -152,7 +152,8 @@ export const updateBalance = async ({
   try {
     await updateBalanceAPI({ identity, canisterId: minterCanisterId });
 
-    const delay = (time: number) => new Promise((resolve) => setTimeout(resolve, time));
+    const delay = (time: number) =>
+      new Promise((resolve) => setTimeout(resolve, time));
     await delay(deferReload ? 6000 : 0);
 
     await reload?.();

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -152,9 +152,10 @@ export const updateBalance = async ({
   try {
     await updateBalanceAPI({ identity, canisterId: minterCanisterId });
 
+    // Workaround. Ultimately we want to poll to update balance and list of transactions
     const delay = (time: number) =>
       new Promise((resolve) => setTimeout(resolve, time));
-    await delay(deferReload ? 6000 : 0);
+    await delay(deferReload ? 4000 : 0);
 
     await reload?.();
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -93,8 +93,8 @@ describe("CkBTCWalletActions", () => {
 
     await fireEvent.click(button as HTMLButtonElement);
 
-    // wait for 6 seconds
-    await advanceTime(6000);
+    // wait for 4 seconds
+    await advanceTime(4000);
 
     await waitFor(() => expect(spyReload).toHaveBeenCalled());
   });

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import en from "$tests/mocks/i18n.mock";
+import { advanceTime } from "$tests/utils/timers.test-utils";
 import { waitFor } from "@testing-library/dom";
 import { fireEvent, render } from "@testing-library/svelte";
 import { page } from "../../../../../__mocks__/$app/stores";
@@ -19,6 +20,8 @@ jest.mock("$lib/api/ckbtc-minter.api", () => ({
 }));
 
 describe("CkBTCWalletActions", () => {
+  const now = Date.now();
+
   beforeAll(() => {
     page.mock({
       data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
@@ -26,10 +29,12 @@ describe("CkBTCWalletActions", () => {
     });
   });
 
+  beforeEach(() => jest.useFakeTimers().setSystemTime(now));
+  afterEach(jest.clearAllTimers);
+
   const props = {
     minterCanisterId: CKTESTBTC_MINTER_CANISTER_ID,
     reload: () => Promise.resolve(),
-    deferReload: false,
   };
 
   it("should render action", () => {
@@ -82,9 +87,14 @@ describe("CkBTCWalletActions", () => {
       },
     });
 
+    expect(spyReload).not.toHaveBeenCalled();
+
     const button = getByTestId("manual-refresh-balance");
 
-    fireEvent.click(button as HTMLButtonElement);
+    await fireEvent.click(button as HTMLButtonElement);
+
+    // wait for 6 seconds
+    await advanceTime(6000);
 
     await waitFor(() => expect(spyReload).toHaveBeenCalled());
   });

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -29,6 +29,7 @@ describe("CkBTCWalletActions", () => {
   const props = {
     minterCanisterId: CKTESTBTC_MINTER_CANISTER_ID,
     reload: () => Promise.resolve(),
+    deferReload: false,
   };
 
   it("should render action", () => {


### PR DESCRIPTION
# Motivation

The `index` canister needs 30sec or so and soon less to populate new transaction but still, takes a bit of time. That's why after a "ckBTC refresh balance" currently only the balance is updated and not the list of transactions.

In the future we will fetch the list of transactions and balance from the index but, it isn't there yet. Likewise we plan to implement some crontab refresh but it's tasky.

That's why this PR just adds a bit of delay.

# Changes

- delay call of `reload` function in `updateBalance` of few seconds
