### PR TITLE
Unit test for ckBTC FORCE_CALL_STRATEGY fix

### DIFF
--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -7,6 +7,7 @@ import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 import localStorageMock from "./src/tests/mocks/local-storage.mock";
 import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
+import { mockedConstants } from "./src/tests/utils/mockable-constants.test-utils";
 
 // Mock SubtleCrypto to test @dfinity/auth-client
 const crypto = new SubtleCrypto();
@@ -49,14 +50,7 @@ jest.mock("./src/lib/utils/env-vars.utils.ts", () => ({
   }),
 }));
 
-jest.mock("./src/lib/constants/mockable.constants.ts", () => ({
-  DEV: false,
-  ENABLE_METRICS: false,
-  FORCE_CALL_STRATEGY: undefined,
-  IS_TEST_ENV: true,
-  QR_CODE_RENDERED_DEFAULT_STATE: true,
-  ENABLE_QR_CODE_READER: false,
-}));
+jest.mock("./src/lib/constants/mockable.constants.ts", () => mockedConstants);
 
 global.localStorage = localStorageMock;
 

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -7,7 +7,10 @@ import { TextDecoder, TextEncoder } from "util";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 import localStorageMock from "./src/tests/mocks/local-storage.mock";
 import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
-import { mockedConstants } from "./src/tests/utils/mockable-constants.test-utils";
+import {
+  mockedConstants,
+  setDefaultTestConstants,
+} from "./src/tests/utils/mockable-constants.test-utils";
 
 // Mock SubtleCrypto to test @dfinity/auth-client
 const crypto = new SubtleCrypto();
@@ -51,6 +54,14 @@ jest.mock("./src/lib/utils/env-vars.utils.ts", () => ({
 }));
 
 jest.mock("./src/lib/constants/mockable.constants.ts", () => mockedConstants);
+setDefaultTestConstants({
+  DEV: false,
+  ENABLE_METRICS: false,
+  FORCE_CALL_STRATEGY: undefined,
+  IS_TEST_ENV: true,
+  QR_CODE_RENDERED_DEFAULT_STATE: true,
+  ENABLE_QR_CODE_READER: false,
+});
 
 global.localStorage = localStorageMock;
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -14,9 +14,9 @@ export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 // When the QR code is rendered (draw), it triggers an event that is replicated to a property to get to know if the QR code has been or not rendered.
 // We use a constant / environment variable that way, we can mock it to `true` for test purpose.
 // Jest has trouble loading the QR-code dependency and because the QR-code content is anyway covered by e2e snapshot testing in gix-cmp.
-export const QR_CODE_RENDERED_DEFAULT_STATE: boolean = false;
+export const QR_CODE_RENDERED_DEFAULT_STATE = false;
 
 // Here too, Jest has trouble loading the QR-code reader dependency asynchronously (`await import ("")`).
 // npm run test leads to error -> segmentation fault  npm run test src/tests/lib/modals/transaction/TransactionModal.spec.ts
 // That's why we use a constant / environment variable that way, we can mock it to `false` for test purpose.
-export const ENABLE_QR_CODE_READER: boolean = true;
+export const ENABLE_QR_CODE_READER = true;

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -1,6 +1,7 @@
 // These are constants that can have a different value during tests but which are not set with the arguments passed to the canister.
 // Tests can override these constants by setting them on the mockedConstants
 // object in frontend/src/tests/utils/mockable-constants.test-utils.ts
+// Their default values during unit tests are defined in jest-setup.ts.
 
 export const DEV = import.meta.env.DEV;
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -1,4 +1,7 @@
 // These are constants that can have a different value during tests but which are not set with the arguments passed to the canister.
+// Tests can override these constants by setting them on the mockedConstants
+// object in frontend/src/tests/utils/mockable-constants.test-utils.ts
+
 export const DEV = import.meta.env.DEV;
 
 // Disable TVL or transaction rate warning locally because that information is not crucial when we develop
@@ -11,9 +14,9 @@ export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 // When the QR code is rendered (draw), it triggers an event that is replicated to a property to get to know if the QR code has been or not rendered.
 // We use a constant / environment variable that way, we can mock it to `true` for test purpose.
 // Jest has trouble loading the QR-code dependency and because the QR-code content is anyway covered by e2e snapshot testing in gix-cmp.
-export const QR_CODE_RENDERED_DEFAULT_STATE = false;
+export const QR_CODE_RENDERED_DEFAULT_STATE: boolean = false;
 
 // Here too, Jest has trouble loading the QR-code reader dependency asynchronously (`await import ("")`).
 // npm run test leads to error -> segmentation fault  npm run test src/tests/lib/modals/transaction/TransactionModal.spec.ts
 // That's why we use a constant / environment variable that way, we can mock it to `false` for test purpose.
-export const ENABLE_QR_CODE_READER = true;
+export const ENABLE_QR_CODE_READER: boolean = true;

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -33,7 +33,7 @@ export const loadCkBTCWithdrawalAccount = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (!certified && FORCE_CALL_STRATEGY !== "query") {
+      if (!certified) {
         return;
       }
 

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -1,4 +1,3 @@
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getCkBTCWithdrawalAccount } from "$lib/services/ckbtc-accounts-loader.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import {

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -18,18 +18,11 @@ import {
   mockCkBTCWithdrawalIcrcAccount,
   mockCkBTCWithdrawalIdentifier,
 } from "$tests/mocks/ckbtc-accounts.mock";
-import {
-  mockedConstants,
-  resetMockedConstants,
-} from "$tests/utils/mockable-constants.test-utils";
 import { TokenAmount } from "@dfinity/nns";
 import { waitFor } from "@testing-library/svelte";
 
 describe("ckbtc-accounts-loader-services", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    resetMockedConstants();
-  });
+  afterEach(() => jest.clearAllMocks());
 
   describe("getCkBTCAccounts", () => {
     it("should call get CkBTC account", async () => {
@@ -164,26 +157,6 @@ describe("ckbtc-accounts-loader-services", () => {
           expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
             identity: params.identity,
             certified: true,
-            canisterId: params.universeId,
-            ...mockCkBTCWithdrawalIcrcAccount,
-            type: "withdrawalAccount",
-          });
-        });
-
-        it("should return withdrawal account with forced query calls", async () => {
-          mockedConstants.FORCE_CALL_STRATEGY = "query";
-
-          const result = await getCkBTCWithdrawalAccount({
-            ...params,
-            certified: false,
-          });
-
-          expect(result.identifier).toEqual(mockCkBTCWithdrawalIdentifier);
-          expect(result.balance.toE8s()).toEqual(mockAccountBalance.toE8s());
-
-          expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
-            identity: params.identity,
-            certified: false,
             canisterId: params.universeId,
             ...mockCkBTCWithdrawalIcrcAccount,
             type: "withdrawalAccount",

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -18,11 +18,18 @@ import {
   mockCkBTCWithdrawalIcrcAccount,
   mockCkBTCWithdrawalIdentifier,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockedConstants,
+  resetMockedConstants,
+} from "$tests/utils/mockable-constants.test-utils";
 import { TokenAmount } from "@dfinity/nns";
 import { waitFor } from "@testing-library/svelte";
 
 describe("ckbtc-accounts-loader-services", () => {
-  afterEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockedConstants();
+  });
 
   describe("getCkBTCAccounts", () => {
     it("should call get CkBTC account", async () => {
@@ -157,6 +164,26 @@ describe("ckbtc-accounts-loader-services", () => {
           expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
             identity: params.identity,
             certified: true,
+            canisterId: params.universeId,
+            ...mockCkBTCWithdrawalIcrcAccount,
+            type: "withdrawalAccount",
+          });
+        });
+
+        it("should return withdrawal account with forced query calls", async () => {
+          mockedConstants.FORCE_CALL_STRATEGY = "query";
+
+          const result = await getCkBTCWithdrawalAccount({
+            ...params,
+            certified: false,
+          });
+
+          expect(result.identifier).toEqual(mockCkBTCWithdrawalIdentifier);
+          expect(result.balance.toE8s()).toEqual(mockAccountBalance.toE8s());
+
+          expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
+            identity: params.identity,
+            certified: false,
             canisterId: params.universeId,
             ...mockCkBTCWithdrawalIcrcAccount,
             type: "withdrawalAccount",

--- a/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
@@ -1,7 +1,3 @@
-import {
-  mockedConstants,
-  resetMockedConstants,
-} from "$tests/utils/mockable-constants.test-utils";
 import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
@@ -11,6 +7,10 @@ import {
   mockCkBTCWithdrawalAccount,
   mockCkBTCWithdrawalIcrcAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockedConstants,
+  resetMockedConstants,
+} from "$tests/utils/mockable-constants.test-utils";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
@@ -1,3 +1,7 @@
+import {
+  mockedConstants,
+  resetMockedConstants,
+} from "$tests/utils/mockable-constants.test-utils";
 import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
@@ -13,6 +17,7 @@ import { get } from "svelte/store";
 describe("ckbtc-withdrawal-accounts.services", () => {
   describe("loadCkBTCWithdrawalAccount", () => {
     beforeEach(() => {
+      resetMockedConstants();
       jest.clearAllMocks();
       ckBTCWithdrawalAccountsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
@@ -26,6 +31,30 @@ describe("ckbtc-withdrawal-accounts.services", () => {
       });
 
     it("should call api.getCkBTCAccount and load neurons in store", async () => {
+      const spyGetCkBTCAccount = jest
+        .spyOn(ledgerApi, "getCkBTCAccount")
+        .mockResolvedValue(mockCkBTCWithdrawalAccount);
+
+      await loadCkBTCWithdrawalAccount({
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      await tick();
+
+      expect(spyGetCkBTCAccount).toHaveBeenCalled();
+
+      expect(spyGetWithdrawalAccount).toHaveBeenCalled();
+
+      const store = get(ckBTCWithdrawalAccountsStore);
+
+      expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).not.toBeUndefined();
+      expect(
+        store[CKBTC_UNIVERSE_CANISTER_ID.toText()].account.identifier
+      ).toEqual(mockCkBTCWithdrawalAccount.identifier);
+    });
+
+    it("should not be affected by FORCE_CALL_STRATEGY", async () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
       const spyGetCkBTCAccount = jest
         .spyOn(ledgerApi, "getCkBTCAccount")
         .mockResolvedValue(mockCkBTCWithdrawalAccount);

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -1,0 +1,19 @@
+// Values used during unit testing for the constants in
+// frontend/src/lib/constants/mockable.constants.ts
+
+const defaultTestConstants = {
+  DEV: false,
+  ENABLE_METRICS: false,
+  FORCE_CALL_STRATEGY: undefined,
+  IS_TEST_ENV: true,
+  QR_CODE_RENDERED_DEFAULT_STATE: true,
+  ENABLE_QR_CODE_READER: false,
+};
+
+export const mockedConstants = { ...defaultTestConstants };
+
+export const resetMockedConstants = () => {
+  Object.keys(mockedConstants).forEach((key) => {
+    mockedConstants[key] = defaultTestConstants[key];
+  });
+};

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -1,19 +1,30 @@
 // Values used during unit testing for the constants in
 // frontend/src/lib/constants/mockable.constants.ts
 
-const defaultTestConstants = {
-  DEV: false,
-  ENABLE_METRICS: false,
-  FORCE_CALL_STRATEGY: undefined,
-  IS_TEST_ENV: true,
-  QR_CODE_RENDERED_DEFAULT_STATE: true,
-  ENABLE_QR_CODE_READER: false,
-};
+import type * as mockableConstants from "$lib/constants/mockable.constants";
 
-export const mockedConstants = { ...defaultTestConstants };
+type MockableConstantsKey = keyof typeof mockableConstants;
+type MockableConstants = { [K in MockableConstantsKey]: unknown };
+
+// Default values are set from jest-setup.ts:
+let defaultTestConstants: MockableConstants;
+
+export const mockedConstants: MockableConstants = {
+  DEV: undefined,
+  ENABLE_METRICS: undefined,
+  FORCE_CALL_STRATEGY: undefined,
+  IS_TEST_ENV: undefined,
+  QR_CODE_RENDERED_DEFAULT_STATE: undefined,
+  ENABLE_QR_CODE_READER: undefined,
+};
 
 export const resetMockedConstants = () => {
   Object.keys(mockedConstants).forEach((key) => {
     mockedConstants[key] = defaultTestConstants[key];
   });
+};
+
+export const setDefaultTestConstants = (constants: MockableConstants) => {
+  defaultTestConstants = constants;
+  resetMockedConstants();
 };


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/2536 fixed a loading ckBTC withdrawal accounts by no longer taking `FORCE_CALL_STRATEGY` into account when loading those accounts.
But it did not add a unit test for that fix.
This PR adds the unit test.

# Changes

1. Add a util to make mockable constants mockable per individual test.
2. Add a test which sets `FORCE_CALL_STRATEGY` to `"query"` and verifies that withdrawal accounts are still loaded. (It duplicates the test above it with the only difference being `FORCE_CALL_STRATEGY = "query"`.)
3. Remove a check on `FORCE_CALL_STRATEGY` in the error handler since it's now irrelevant.

# Tests

Unit test is added.
I also verified that the test fails without the `FORCE_CALL_STRATEGY` change from https://github.com/dfinity/nns-dapp/pull/2536.