### PR TITLE
Query and update for ckBTC withdrawal account

### DIFF
--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -1,6 +1,5 @@
 import { getCkBTCAccount } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getWithdrawalAccount as getWithdrawalAccountServices } from "$lib/services/ckbtc-minter.services";
 import type { CkBTCBTCWithdrawalAccount } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
@@ -84,11 +83,7 @@ export const getCkBTCWithdrawalAccount = async ({
 
   // We have to load the withdrawal account with an update call.
   // If we never have loaded it, we return a empty account as result of the not certified (query) call to indicate we are about to load the data.
-  if (
-    FORCE_CALL_STRATEGY !== "query" &&
-    !certified &&
-    isNullish(storedWithdrawalAccount?.account.identifier)
-  ) {
+  if (!certified && isNullish(storedWithdrawalAccount?.account.identifier)) {
     return {
       type: "withdrawalAccount",
     };

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -7,13 +7,16 @@ import {
 } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import type { UniverseCanisterId } from "$lib/types/universe";
 
+/**
+ * To load the withdrawal account we use QUERY+UPDATE strategy. As there is not QUERY option provided by the canister we fake a static result instead.
+ * That way we can display a spinner information in the UI while the account is loading.
+ */
 export const loadCkBTCWithdrawalAccount = async ({
   universeId,
 }: {
   universeId: UniverseCanisterId;
 }): Promise<void> => {
   return queryAndUpdate<CkBTCBTCWithdrawalAccount, unknown>({
-    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getCkBTCWithdrawalAccount({ identity, certified, universeId }),
     onLoad: ({ response: account, certified }) =>

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -8,7 +8,7 @@ import {
 import type { UniverseCanisterId } from "$lib/types/universe";
 
 /**
- * To load the withdrawal account we use QUERY+UPDATE strategy. As there is not QUERY option provided by the canister we fake a static result instead.
+ * To load the withdrawal account we use QUERY+UPDATE strategy. Because the withdrawal account can only be fetched with an UPDATE call at the moment, we fake a static QUERY call.
  * That way we can display a spinner information in the UI while the account is loading.
  */
 export const loadCkBTCWithdrawalAccount = async ({

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -10,6 +10,8 @@ import type { UniverseCanisterId } from "$lib/types/universe";
 /**
  * To load the withdrawal account we use QUERY+UPDATE strategy. Because the withdrawal account can only be fetched with an UPDATE call at the moment, we fake a static QUERY call.
  * That way we can display a spinner information in the UI while the account is loading.
+ *
+ * We use `queryAndUpdate` because it integrates thighly with the dapp core and also in case a QUERY call would be made available in the future.
  */
 export const loadCkBTCWithdrawalAccount = async ({
   universeId,

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -17,6 +17,7 @@ export const loadCkBTCWithdrawalAccount = async ({
   universeId: UniverseCanisterId;
 }): Promise<void> => {
   return queryAndUpdate<CkBTCBTCWithdrawalAccount, unknown>({
+    strategy: "query_and_update",
     request: ({ certified, identity }) =>
       getCkBTCWithdrawalAccount({ identity, certified, universeId }),
     onLoad: ({ response: account, certified }) =>


### PR DESCRIPTION
# Motivation

Always use (fake) QUERY + (real) UPDATE for ckBTC to retrieve withdrawal account even if the stategy is set to query.

# Changes

- remove usage of strategy (that should have not been there in first place, copy/paste are bad)
- remove fix that handles strategy
