### PR TITLE
Always reload account and transactions on "Refresh balance"

### DIFF
--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -1,6 +1,5 @@
 import { getCkBTCAccount } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getWithdrawalAccount as getWithdrawalAccountServices } from "$lib/services/ckbtc-minter.services";
 import type { CkBTCBTCWithdrawalAccount } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
@@ -84,11 +83,7 @@ export const getCkBTCWithdrawalAccount = async ({
 
   // We have to load the withdrawal account with an update call.
   // If we never have loaded it, we return a empty account as result of the not certified (query) call to indicate we are about to load the data.
-  if (
-    FORCE_CALL_STRATEGY !== "query" &&
-    !certified &&
-    isNullish(storedWithdrawalAccount?.account.identifier)
-  ) {
+  if (!certified && isNullish(storedWithdrawalAccount?.account.identifier)) {
     return {
       type: "withdrawalAccount",
     };

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -181,7 +181,7 @@ export const updateBalance = async ({
 
     return { success: false, err };
   } finally {
-    // We reload in any case because the user might hit "Refresh balance" in the UI thinking the feature is meant to relad the account and transactions, not confirming the BTC -> ckBTC
+    // We reload in any case because the user might hit "Refresh balance" in the UI thinking the feature is meant to reload the account and transactions even though it is actually meant to confirm the conversion of BTC -> ckBTC
     await reload?.();
 
     stopBusy("update-ckbtc-balance");

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -157,8 +157,6 @@ export const updateBalance = async ({
       new Promise((resolve) => setTimeout(resolve, time));
     await delay(deferReload ? 4000 : 0);
 
-    await reload?.();
-
     toastsSuccess({
       labelKey: "ckbtc.ckbtc_balance_updated",
     });
@@ -183,6 +181,9 @@ export const updateBalance = async ({
 
     return { success: false, err };
   } finally {
+    // We reload in any case because the user might hit "Refresh balance" in the UI thinking the feature is meant to relad the account and transactions, not confirming the BTC -> ckBTC
+    await reload?.();
+
     stopBusy("update-ckbtc-balance");
   }
 };

--- a/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-withdrawal-accounts.services.ts
@@ -7,13 +7,19 @@ import {
 } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import type { UniverseCanisterId } from "$lib/types/universe";
 
+/**
+ * To load the withdrawal account we use QUERY+UPDATE strategy. Because the withdrawal account can only be fetched with an UPDATE call at the moment, we fake a static QUERY call.
+ * That way we can display a spinner information in the UI while the account is loading.
+ *
+ * We use `queryAndUpdate` because it integrates thighly with the dapp core and also in case a QUERY call would be made available in the future.
+ */
 export const loadCkBTCWithdrawalAccount = async ({
   universeId,
 }: {
   universeId: UniverseCanisterId;
 }): Promise<void> => {
   return queryAndUpdate<CkBTCBTCWithdrawalAccount, unknown>({
-    strategy: FORCE_CALL_STRATEGY,
+    strategy: "query_and_update",
     request: ({ certified, identity }) =>
       getCkBTCWithdrawalAccount({ identity, certified, universeId }),
     onLoad: ({ response: account, certified }) =>

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -103,6 +103,24 @@ describe("ckbtc-minter-services", () => {
       await waitFor(() => expect(spyReload).toBeCalled());
     });
 
+    it("should reload after update balance even if update balance is on error", async () => {
+      jest.spyOn(minterApi, "updateBalance").mockImplementation(async () => {
+        throw new MinterAlreadyProcessingError();
+      });
+
+      const spyReload = jest.fn();
+
+      const err = new ApiErrorKey(en.error__ckbtc.already_process);
+
+      const result = await services.updateBalance({
+        ...params,
+        reload: spyReload,
+      });
+
+      await waitFor(() => expect(spyReload).toBeCalled());
+      expect(result).toEqual({ success: false, err });
+    });
+
     it("should start and stop busy", async () => {
       const startBusySpy = jest
         .spyOn(busyStore, "startBusy")


### PR DESCRIPTION
# Motivation

We reload in any case because the user might hit "Refresh balance" in the UI thinking the feature is meant to reload the account and transactions even though it is actually meant to confirm the conversion of BTC -> ckBTC

In addition this PR integrates #2535 to reuse pseudo query and update call to load the withdrawal account.

# Changes

- always reload regardless if `updateBalance` ends in error or success
