### PR TITLE
clean: Didc version in setup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,7 +141,8 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-linux64 | install -m 755 /dev/stdin "$USER_BIN/didc"
+          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
       - name: Run the ic_commit code generator
@@ -164,7 +165,8 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-linux64 | install -m 755 /dev/stdin "$USER_BIN/didc"
+          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
       - name: Install dfx
@@ -211,7 +213,8 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-linux64 | install -m 755 /dev/stdin "$USER_BIN/didc"
+          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
       - name: Recreate and compare patches

--- a/scripts/setup
+++ b/scripts/setup
@@ -251,11 +251,13 @@ install_idl2json() {
 }
 
 install_didc_linux() {
-  local version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  local version
+  version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
 }
 install_didc_darwin() {
-  local version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  local version
+  version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
   tempfile="$(mktemp ,didc-XXXXXXXX)"
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-macos" >"$tempfile"
   install -m 755 "$tempfile" "$USER_BIN/didc"

--- a/scripts/setup
+++ b/scripts/setup
@@ -251,11 +251,13 @@ install_idl2json() {
 }
 
 install_didc_linux() {
-  curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-linux64 | install -m 755 /dev/stdin "$USER_BIN/didc"
+  local version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
 }
 install_didc_darwin() {
+  local version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
   tempfile="$(mktemp ,didc-XXXXXXXX)"
-  curl -Lf https://github.com/dfinity/candid/releases/download/2022-11-17/didc-macos >"$tempfile"
+  curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-macos" >"$tempfile"
   install -m 755 "$tempfile" "$USER_BIN/didc"
   rm "$tempfile"
 }


### PR DESCRIPTION
# Motivation
The didc version was not always taken from dfx.json.  While the versions were all correct, updating the version in dfx.json would have caused them to go out of sync.

# Changes
- Always get the didc version from dfx.json

# Tests
- See CI for the changes to github actions.
- I have run the local development setup script locally