### PR TITLE
Fix: Issue with arguments in CMC proposal

### DIFF
--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -110,13 +110,17 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
         IDLType::PrimT(PrimType::Null)
     };
 
-    let idl_value = Decode!(arg, IDLValue).expect("Binary is not valid candid");
-    let options = Idl2JsonOptions {
-        bytes_as: Some(BytesFormat::Hex),
-        long_bytes_as: None,
-    };
-    let json_value = idl2json_with_weak_names(&idl_value, &idl_type, &options);
-    serde_json::to_string(&json_value).expect("Failed to serialize JSON")
+    match Decode!(arg, IDLValue) {
+        Ok(idl_value) => {
+            let options = Idl2JsonOptions {
+                bytes_as: Some(BytesFormat::Hex),
+                long_bytes_as: None,
+            };
+            let json_value = idl2json_with_weak_names(&idl_value, &idl_type, &options);
+            serde_json::to_string(&json_value).expect("Failed to serialize JSON")
+        }
+        Err(_) => "[]".to_owned()
+    }
 }
 
 // Check if the proposal has a payload, if yes, deserialize it then convert it to JSON.

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -119,7 +119,7 @@ fn decode_arg(arg: &[u8], canister_id: Option<CanisterId>) -> String {
             let json_value = idl2json_with_weak_names(&idl_value, &idl_type, &options);
             serde_json::to_string(&json_value).expect("Failed to serialize JSON")
         }
-        Err(_) => "[]".to_owned()
+        Err(_) => "[]".to_owned(),
     }
 }
 


### PR DESCRIPTION
# Motivation

CMC proposal had a proposal to upgrade using as argument `()`. This is not a valid argument for the nns-dapp serializer because the arguments must always be `opt <something>`. Yet, to install canisters, this is a valid argument.

We need to support this argument and not fail to show the payload.

# Changes

* Return an emtpy array json instead of an error if `Decode` fails.

# Tests

There are no tests for this. But it would be good to add a few. In another PR.
