### PR TITLE
fix: back navigation from the launchpad proposal details page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   import Layout from "$lib/components/layout/Layout.svelte";
   import Content from "$lib/components/layout/Content.svelte";
-  import { goto } from "$app/navigation";
+  import { afterNavigate, goto } from "$app/navigation";
   import { proposalsPathStore } from "$lib/derived/paths.derived";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import type { Navigation } from "@sveltejs/kit";
+  import { referrerPathForNav } from "$lib/utils/page.utils";
 
-  const back = (): Promise<void> => goto($proposalsPathStore);
+  let referrerPath: AppPath | undefined = undefined;
+  afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
+
+  const back = (): Promise<void> =>
+    goto(
+      referrerPath === AppPath.Launchpad ? referrerPath : $proposalsPathStore
+    );
 </script>
 
 <Layout>


### PR DESCRIPTION
# Motivation

Resolve the problem related to the incorrect back navigation from the launchpad proposal details page, which currently directs users to the proposals page instead of the launchpad page.

# Changes

- add `referrerPath` based back navigation

# Tests

A way to include unit tests for this specific scenario was not found.

# Screenshots
| Before | After |
|--------|--------|
| ![Screen Recording 2023-05-19 at 11 25 41](https://github.com/dfinity/nns-dapp/assets/98811342/7382e63a-ca91-4a42-bc66-48a28ba37a87) | ![Screen Recording 2023-05-19 at 11 24 16](https://github.com/dfinity/nns-dapp/assets/98811342/315cfa29-5b5e-4767-b42c-ffc42b3e36d9) |


