### PR TITLE
chore: Update II init type

### DIFF
--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -62,6 +62,8 @@ pub struct InternetIdentityInit {
     pub archive_config: Option<ArchiveConfig>,
     pub canister_creation_cycles_cost: Option<u64>,
     pub register_rate_limit: Option<RateLimitConfig>,
+    pub max_num_latest_delegation_origins: Option<u64>,
+    pub migrate_storage_to_memory_manager: Option<bool>,
 }
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct RateLimitConfig {


### PR DESCRIPTION
The init type has changed again. This PR updates the type, namely adds two fields to `InternetIdentityInit` (both `Option<bool>`):

-  `max_num_latest_delegation_origins` 
-   `migrate_storage_to_memory_manager` 

**Note**: I did not test this change, but just copied the types from the Internet Identity repo.
