### PR TITLE
Fix: Do not try to get tokens if balance 0

### DIFF
--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -1,23 +1,29 @@
 import { HOST, IS_TESTNET } from "$lib/constants/environment.constants";
 import type { Account } from "$lib/types/account";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
+import { isUniverseNns } from "$lib/utils/universe.utils";
 import type { Identity } from "@dfinity/agent";
 import { HttpAgent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
 import { SnsGovernanceCanister, type SnsNeuronId } from "@dfinity/sns";
 import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import { createAgent } from "./agent.api";
 import { governanceCanister } from "./governance.api";
 import { initSns, wrapper } from "./sns-wrapper.api";
 
+export const testAccountPrincipal =
+  "jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe";
+export const testAccountAddress =
+  "5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087";
+
 const getTestAccountAgent = async (): Promise<HttpAgent> => {
   // Create an identity who's default ledger account is initialised with 10k ICP on the testnet, then use that
   // identity to send the current user some ICP to test things with.
-  // The identity's principal is jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe
-  // The identity's default ledger address is 5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087
+  // The identity's principal is ${testAccountPrincipal}
+  // The identity's default ledger address is ${testAccountAddress}
   const publicKey = "Uu8wv55BKmk9ZErr6OIt5XR1kpEGXcOSOC1OYzrAwuk=";
   const privateKey =
     "N3HB8Hh2PrWqhWH2Qqgr1vbU9T3gb1zgdBD8ZOdlQnVS7zC/nkEqaT1kSuvo4i3ldHWSkQZdw5I4LU5jOsDC6Q==";
@@ -33,6 +39,32 @@ const getTestAccountAgent = async (): Promise<HttpAgent> => {
   await agent.fetchRootKey();
 
   return agent;
+};
+
+export const getTestAccountBalance = async (
+  rootCanisterId: Principal
+): Promise<bigint> => {
+  assertTestnet();
+
+  const agent = await getTestAccountAgent();
+
+  if (isUniverseNns(rootCanisterId)) {
+    const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
+
+    return ledgerCanister.accountBalance({
+      accountIdentifier: AccountIdentifier.fromHex(testAccountAddress),
+    });
+  }
+
+  const { balance } = await initSns({
+    agent,
+    rootCanisterId,
+    certified: false,
+  });
+
+  return balance({
+    owner: Principal.fromText(testAccountPrincipal),
+  });
 };
 
 /*

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -40,7 +40,7 @@
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
       if (
         selectedProjectId.toText() === OWN_CANISTER_ID.toText() ||
-        tokenBalanceE8s === BigInt(0)
+        tokenBalanceE8s === 0n
       ) {
         await getICPs(inputValue);
       } else {
@@ -72,17 +72,16 @@
   $: invalidForm = inputValue === undefined || inputValue <= 0;
 
   // Check the balance of the test account in that universe.
-  let tokenBalanceE8s = BigInt(0);
+  let tokenBalanceE8s = 0n;
   $: selectedProjectId,
     (async () => {
       tokenBalanceE8s = await getTestBalance(selectedProjectId);
-      console.log("getting balance", tokenBalanceE8s);
     })();
 
   // If the test account balance is 0, don't show a button that won't work. Show the ICP token instead.
   let token: Token;
   $: token =
-    (tokenBalanceE8s === BigInt(0) ? ICPToken : $snsTokenSymbolSelectedStore) ??
+    (tokenBalanceE8s === 0n ? ICPToken : $snsTokenSymbolSelectedStore) ??
     ICPToken;
 </script>
 

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -12,7 +12,6 @@
   } from "$lib/services/dev.services";
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { get } from "svelte/store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { ICPToken, type Token } from "@dfinity/nns";

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -1,4 +1,8 @@
-import { acquireICPTs, acquireSnsTokens } from "$lib/api/dev.api";
+import {
+  acquireICPTs,
+  acquireSnsTokens,
+  getTestAccountBalance,
+} from "$lib/api/dev.api";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import type { AccountsStoreData } from "$lib/stores/accounts.store";
 import { accountsStore } from "$lib/stores/accounts.store";
@@ -10,6 +14,8 @@ import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { syncAccounts } from "./accounts.services";
 import { loadSnsAccounts } from "./sns-accounts.services";
+
+export const getTestBalance = getTestAccountBalance;
 
 export const getICPs = async (icps: number) => {
   const { main }: AccountsStoreData = get(accountsStore);


### PR DESCRIPTION
# Motivation

FOR TESTNET OR LOCAL ENVIRONMENT ONLY

Users tried to get tokens when the test account balance was 0.

Instead, revert to get ICPs if the balance for those tokens is 0.

# Changes

* New dev api "getTestAccountBalance" to get the balance of the test account.
* New dev services "getTestBalance" that uses "getTestAccountBalance" dev api.
* Use the new service in the GetTokens component to change the name of the button and get from different accounts dependeing on the balance.

# Tests

ONLY TESTNET AND LOCAL FEATURE
