### PR TITLE
Gix 1197 optimise sns parameters loading for neurons

### DIFF
--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -33,11 +33,6 @@
   ): Promise<void> => {
     if (selectedProjectCanisterId !== undefined) {
       loading = true;
-
-      // params.minimum_stake_amount needs for checking neurons balance (checkNeuronsSubaccounts)
-      // TODO(GIX-1197): extract that logic in a service and have a test that check that loadSnsParameters is indeed called before the calls?
-      await loadSnsParameters(selectedProjectCanisterId);
-
       await Promise.all([
         syncSnsNeurons(selectedProjectCanisterId),
         syncSnsAccounts({ rootCanisterId: selectedProjectCanisterId }),

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -7,7 +7,6 @@ import {
 import { MAX_NEURONS_SUBACCOUNTS } from "$lib/constants/sns-neurons.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import {
   getSnsNeuronIdAsHexString,
   needsRefresh,
@@ -15,14 +14,12 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
-import type { SnsNervousSystemParameters } from "@dfinity/sns";
 import {
   neuronSubaccount,
   type SnsNeuron,
   type SnsNeuronId,
 } from "@dfinity/sns";
-import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
-import { get } from "svelte/store";
+import { fromNullable } from "@dfinity/utils";
 
 const loadNeuron = async ({
   rootCanisterId,
@@ -288,21 +285,14 @@ const checkNeurons = async ({
 export const checkSnsNeuronBalances = async ({
   rootCanisterId,
   neurons,
+  neuronMinimumStake,
 }: {
   rootCanisterId: Principal;
   neurons: SnsNeuron[];
+  neuronMinimumStake: bigint;
 }): Promise<void> => {
   // TODO: Check neurons controlled by linked HW?
   const identity = await getAuthenticatedIdentity();
-
-  // TODO(Maks): refactor using `getSnsParametersFromStore` https://dfinity.atlassian.net/browse/GIX-1178
-  const neuronMinimumStake = fromDefinedNullable(
-    (
-      get(snsParametersStore)?.[rootCanisterId.toText()]
-        ?.parameters as SnsNervousSystemParameters
-    ).neuron_minimum_stake_e8s ?? [0n]
-  );
-
   const unvisitedNeurons = await checkNeuronsSubaccounts({
     identity,
     rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -10,7 +10,6 @@ import {
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
-import { loadSnsParameters } from "$lib/services/sns-parameters.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
@@ -45,7 +44,7 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 
 jest.mock("$lib/services/sns-parameters.services", () => {
   return {
-    loadSnsParameters: jest.fn().mockReturnValue(undefined),
+    loadSnsParameters: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -95,7 +94,6 @@ describe("SnsNeurons", () => {
     it("should subscribe to store and call services to set up data", async () => {
       render(SnsNeurons);
       await waitFor(() => expect(authStoreMock).toHaveBeenCalled());
-      await waitFor(() => expect(loadSnsParameters).toHaveBeenCalled());
       await waitFor(() => expect(syncSnsAccounts).toBeCalled());
       await waitFor(() => expect(syncSnsNeurons).toBeCalled());
     });

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -8,25 +8,13 @@ import {
   neuronNeedsRefresh,
 } from "$lib/services/sns-neurons-check-balances.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
-import {
-  mockSnsNeuron,
-  snsNervousSystemParametersMock,
-} from "$tests/mocks/sns-neurons.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { neuronSubaccount, type SnsNeuronId } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-neurons-check-balances-services", () => {
-  beforeEach(() => {
-    snsParametersStore.setParameters({
-      rootCanisterId: mockPrincipal,
-      certified: true,
-      parameters: snsNervousSystemParametersMock,
-    });
-  });
-
   describe("checkSnsNeuronBalances", () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -56,6 +44,7 @@ describe("sns-neurons-check-balances-services", () => {
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
+        neuronMinimumStake: 100000000n,
       });
 
       await waitFor(() => expect(spyNeuronBalance).toBeCalled());
@@ -94,6 +83,7 @@ describe("sns-neurons-check-balances-services", () => {
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
+        neuronMinimumStake: 100000000n,
       });
 
       await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
@@ -130,6 +120,7 @@ describe("sns-neurons-check-balances-services", () => {
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
+        neuronMinimumStake: 100000000n,
       });
 
       await waitFor(() => expect(spyRefreshNeuron).toBeCalled());


### PR DESCRIPTION
# Motivation

Optimise sns parameters loading:
1. Implement parallel loading of parameters alongside SNS neurons.
2. Make it more robust to not forget to load params before neurons.

[Jira task](https://dfinity.atlassian.net/browse/GIX-1197)

# Changes

- move `loadSnsParameters` to be inside `syncSnsNeurons`

# Tests

- should call loadSnsParameters when parameters are not in store
- should skip loadSnsParameters call when parameters are in store
