### PR TITLE
GIX-1553: Disable button user restricted country

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -89,7 +89,17 @@
                 disabled>{$i18n.sns_project_detail.participate}</button
               >
             </Tooltip>
-            <!-- TODO: GIX-1553 Add disabled-not-eligible -->
+          {:else if buttonStatus === "disabled-not-eligible"}
+            <Tooltip
+              id="sns-project-participate-button-tooltip"
+              text={$i18n.sns_project_detail.not_eligible_to_participate}
+            >
+              <button
+                class="primary"
+                data-tid="sns-project-participate-button"
+                disabled>{$i18n.sns_project_detail.participate}</button
+              >
+            </Tooltip>
           {:else}
             <!-- This is the "enabled" and "disabled-not-eligible" case -->
             <button

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,5 +1,7 @@
 import type { CountryCode } from "$lib/types/location";
 import type { SnsSummary } from "$lib/types/sns";
+import { fromNullable } from "@dfinity/utils";
 
-// TODO: GIX-1545 Implement this function
-export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] => [];
+export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] =>
+  fromNullable(fromNullable(_summary.swap.init)?.restricted_countries ?? [])
+    ?.iso_codes ?? [];

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -650,6 +650,7 @@
     "completed": "Completed",
     "sale_end": "Swap End",
     "max_user_commitment_reached": "Maximum commitment reached",
+    "not_eligible_to_participate": "You are not eligible to participate in this swap.",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",
     "sign_in": "Sign in to participate"
   },

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -676,6 +676,7 @@ interface I18nSns_project_detail {
   completed: string;
   sale_end: string;
   max_user_commitment_reached: string;
+  not_eligible_to_participate: string;
   getting_sns_open_ticket: string;
   sign_in: string;
 }

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -260,6 +260,36 @@ describe("ParticipateButton", () => {
       const tooltipPo = new TooltipPo(new JestPageObjectElement(container));
       expect(await tooltipPo.getText()).toBe("Maximum commitment reached");
     });
+
+    it("should disable button if user is from a restricted country", async () => {
+      const userCountry = "CH";
+      // TODO: GIX-1545 Remove mock and create a summary with deny list
+      jest
+        .spyOn(summaryGetters, "getDeniedCountries")
+        .mockReturnValue([userCountry]);
+      userCountryStore.set({ isoCode: userCountry });
+      const mock = mockSnsFullProject.swapCommitment as SnsSwapCommitment;
+      snsTicketsStore.setNoTicket(mock.rootCanisterId);
+
+      const { queryByTestId, container } = renderContextCmp({
+        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        swapCommitment: {
+          rootCanisterId: mock.rootCanisterId,
+          myCommitment: undefined,
+        },
+        Component: ParticipateButton,
+      });
+
+      const button = queryByTestId(
+        "sns-project-participate-button"
+      ) as HTMLButtonElement;
+      expect(button.getAttribute("disabled")).not.toBeNull();
+
+      const tooltipPo = new TooltipPo(new JestPageObjectElement(container));
+      expect(await tooltipPo.getText()).toBe(
+        "You are not eligible to participate in this swap."
+      );
+    });
   });
 
   describe("not signed in", () => {


### PR DESCRIPTION
# Motivation

SNS projects can restrict swap participation based on the user's country.

# Changes

* Handle the button status "disabled-not-eligible" in the ParticipateButton.
* Implement the `getDeniedCountries` getter helper.

# Tests

* Add test case in ParticipateButton.spec
