### PR TITLE
GIX-1543: Remove getDeniedCountries mock

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
-import * as summaryGetters from "$lib/getters/sns-summary";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -17,6 +16,7 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
+  createSummary,
   createTransferableAmount,
   mockSnsFullProject,
   mockSnsParams,
@@ -49,8 +49,6 @@ describe("ParticipateButton", () => {
       });
       snsTicketsStore.reset();
       jest.clearAllMocks();
-      // TODO: GIX-1545 Remove mock and create a summary accordingly
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue([]);
       userCountryStore.set("not loaded");
     });
 
@@ -187,11 +185,13 @@ describe("ParticipateButton", () => {
     });
 
     it("should display spinner while loading location if project has restricted countries and user has no ticket", async () => {
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
+      const summary = createSummary({
+        lifecycle: SnsSwapLifecycle.Open,
+        restrictedCountries: ["US"],
+      });
       snsTicketsStore.setNoTicket(rootCanisterIdMock);
       const { queryByTestId, getByTestId, container } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        summary,
         swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
         Component: ParticipateButton,
       });
@@ -202,13 +202,15 @@ describe("ParticipateButton", () => {
     });
 
     it("should not display spinner if project has restricted countries, user location is loaded and user has no open ticket", async () => {
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
+      const summary = createSummary({
+        lifecycle: SnsSwapLifecycle.Open,
+        restrictedCountries: ["US"],
+      });
       userCountryStore.set({ isoCode: "US" });
       snsTicketsStore.setNoTicket(rootCanisterIdMock);
 
       const { queryByTestId } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        summary,
         swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
         Component: ParticipateButton,
       });
@@ -237,12 +239,14 @@ describe("ParticipateButton", () => {
 
     it("should enable button if from a non-restricted country", async () => {
       snsTicketsStore.setNoTicket(rootCanisterIdMock);
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["CH"]);
+      const summary = createSummary({
+        lifecycle: SnsSwapLifecycle.Open,
+        restrictedCountries: ["CH"],
+      });
       userCountryStore.set({ isoCode: "US" });
 
       const { queryByTestId } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        summary,
         swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
         Component: ParticipateButton,
       });
@@ -282,16 +286,16 @@ describe("ParticipateButton", () => {
 
     it("should disable button if user is from a restricted country", async () => {
       const userCountry = "CH";
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest
-        .spyOn(summaryGetters, "getDeniedCountries")
-        .mockReturnValue([userCountry]);
+      const summary = createSummary({
+        lifecycle: SnsSwapLifecycle.Open,
+        restrictedCountries: [userCountry],
+      });
       userCountryStore.set({ isoCode: userCountry });
       const mock = mockSnsFullProject.swapCommitment as SnsSwapCommitment;
       snsTicketsStore.setNoTicket(mock.rootCanisterId);
 
       const { queryByTestId, container } = renderContextCmp({
-        summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+        summary,
         swapCommitment: {
           rootCanisterId: mock.rootCanisterId,
           myCommitment: undefined,

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -29,8 +29,11 @@ import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
-import { mockInit } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import {
+  snsResponseFor,
+  snsResponsesForLifecycle,
+} from "$tests/mocks/sns-response.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -330,26 +333,16 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         });
 
         it("should load user's country if non-empty deny list", async () => {
-          const responses = snsResponsesForLifecycle({
-            lifecycles: [SnsSwapLifecycle.Open],
+          const rootCanisterId = principal(1);
+          const response = snsResponseFor({
+            principal: rootCanisterId,
+            lifecycle: SnsSwapLifecycle.Open,
             certified: true,
+            restrictedCountries: ["US"],
           });
-          const swap = responses[1][0].swap[0];
-          responses[1][0].swap = [
-            {
-              ...swap,
-              init: [
-                {
-                  ...mockInit,
-                  restricted_countries: [{ iso_codes: ["US"] }],
-                },
-              ],
-            },
-          ];
-          const rootCanisterId = responses[0][0].rootCanisterId;
-          snsQueryStore.setData(responses);
+          snsQueryStore.setData(response);
 
-          render(ProjectDetail, { rootCanisterId });
+          render(ProjectDetail, { rootCanisterId: rootCanisterId.toText() });
 
           // TODO: Use fake for locationApi and test that button is disabled initially and enabled after location is loaded.
           expect(locationApi.queryUserCountryLocation).toBeCalled();

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -11,7 +11,6 @@ import * as snsApi from "$lib/api/sns.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { pageStore } from "$lib/derived/page.derived";
-import * as summaryGetters from "$lib/getters/sns-summary";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
 import { accountsStore } from "$lib/stores/accounts.store";
@@ -30,6 +29,7 @@ import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import { mockInit } from "$tests/mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
@@ -324,20 +324,34 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         });
 
         it("should not load user's country if no deny list", async () => {
-          // TODO: GIX-1545 Create a summary without deny list
           render(ProjectDetail, props);
 
           expect(locationApi.queryUserCountryLocation).not.toBeCalled();
         });
 
         it("should load user's country if non-empty deny list", async () => {
-          // TODO: GIX-1545 Remove mock and create a summary with deny list
-          jest
-            .spyOn(summaryGetters, "getDeniedCountries")
-            .mockReturnValue(["US"]);
+          const responses = snsResponsesForLifecycle({
+            lifecycles: [SnsSwapLifecycle.Open],
+            certified: true,
+          });
+          const swap = responses[1][0].swap[0];
+          responses[1][0].swap = [
+            {
+              ...swap,
+              init: [
+                {
+                  ...mockInit,
+                  restricted_countries: [{ iso_codes: ["US"] }],
+                },
+              ],
+            },
+          ];
+          const rootCanisterId = responses[0][0].rootCanisterId;
+          snsQueryStore.setData(responses);
 
-          render(ProjectDetail, props);
+          render(ProjectDetail, { rootCanisterId });
 
+          // TODO: Use fake for locationApi and test that button is disabled initially and enabled after location is loaded.
           expect(locationApi.queryUserCountryLocation).toBeCalled();
         });
       });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,5 +1,4 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import * as summaryGetters from "$lib/getters/sns-summary";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
@@ -19,6 +18,7 @@ import {
 } from "$lib/utils/projects.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
+  createSummary,
   createTransferableAmount,
   mockSnsFullProject,
   mockSnsParams,
@@ -32,6 +32,15 @@ import { ICPToken, TokenAmount } from "@dfinity/nns";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
 
 describe("project-utils", () => {
+  const summaryUsRestricted: SnsSummary = createSummary({
+    lifecycle: SnsSwapLifecycle.Open,
+    restrictedCountries: ["US"],
+  });
+  const summaryNoRestricted: SnsSummary = createSummary({
+    lifecycle: SnsSwapLifecycle.Open,
+    restrictedCountries: [],
+  });
+
   describe("filter", () => {
     it("should filter by status", () => {
       expect(
@@ -279,8 +288,6 @@ describe("project-utils", () => {
   describe("userCountryIsNeeded", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue(["US"]);
     });
 
     it("country not needed", () => {
@@ -317,7 +324,10 @@ describe("project-utils", () => {
     it("country not needed if sale is not open", () => {
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Unspecified),
+          summary: createSummary({
+            lifecycle: SnsSwapLifecycle.Unspecified,
+            restrictedCountries: ["US"],
+          }),
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -325,7 +335,10 @@ describe("project-utils", () => {
 
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Pending),
+          summary: createSummary({
+            lifecycle: SnsSwapLifecycle.Pending,
+            restrictedCountries: ["US"],
+          }),
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -333,7 +346,10 @@ describe("project-utils", () => {
 
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
+          summary: createSummary({
+            lifecycle: SnsSwapLifecycle.Committed,
+            restrictedCountries: ["US"],
+          }),
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -341,7 +357,10 @@ describe("project-utils", () => {
 
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Aborted),
+          summary: createSummary({
+            lifecycle: SnsSwapLifecycle.Aborted,
+            restrictedCountries: ["US"],
+          }),
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -351,7 +370,7 @@ describe("project-utils", () => {
     it("country is needed", () => {
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          summary: summaryUsRestricted,
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -359,11 +378,9 @@ describe("project-utils", () => {
     });
 
     it("country not needed if empty list of denied countries", () => {
-      // TODO: GIX-1545 Remove mock and create a summary with deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue([]);
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          summary: summaryNoRestricted,
           swapCommitment: mockSwapCommitment,
           loggedIn: true,
         })
@@ -373,7 +390,7 @@ describe("project-utils", () => {
     it("country not needed if not logged in", () => {
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          summary: summaryUsRestricted,
           swapCommitment: mockSwapCommitment,
           loggedIn: false,
         })
@@ -383,7 +400,7 @@ describe("project-utils", () => {
     it("country is not needed if max user commitment is reached", () => {
       expect(
         userCountryIsNeeded({
-          summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+          summary: summaryUsRestricted,
           swapCommitment: {
             rootCanisterId: mockSwapCommitment.rootCanisterId,
             myCommitment: {
@@ -1131,12 +1148,10 @@ describe("project-utils", () => {
     });
 
     it("returns 'enabled' if there are no restricted countries", () => {
-      // TODO: GIX-1545 Remove mock and create a summary with empty deny list
-      jest.spyOn(summaryGetters, "getDeniedCountries").mockReturnValue([]);
       expect(
         participateButtonStatus({
           loggedIn: true,
-          summary,
+          summary: summaryNoRestricted,
           swapCommitment: userNoCommitment,
           userCountry: "not loaded",
           ticket: null,
@@ -1154,20 +1169,13 @@ describe("project-utils", () => {
     });
 
     describe("when project has a restricted countries list", () => {
-      beforeEach(() => {
-        // TODO: GIX-1545 Remove mock and create a summary with deny list
-        jest
-          .spyOn(summaryGetters, "getDeniedCountries")
-          .mockReturnValue(["CH"]);
-      });
-
       it("returns 'disabled-not-eligible' if user is in a restricted country", () => {
         expect(
           participateButtonStatus({
             loggedIn: true,
-            summary,
+            summary: summaryUsRestricted,
             swapCommitment: userNoCommitment,
-            userCountry: { isoCode: "CH" },
+            userCountry: { isoCode: "US" },
             ticket: null,
           })
         ).toBe("disabled-not-eligible");
@@ -1177,7 +1185,7 @@ describe("project-utils", () => {
         expect(
           participateButtonStatus({
             loggedIn: true,
-            summary,
+            summary: summaryUsRestricted,
             swapCommitment: userNoCommitment,
             userCountry: "not loaded",
             ticket: null,
@@ -1189,7 +1197,7 @@ describe("project-utils", () => {
         expect(
           participateButtonStatus({
             loggedIn: true,
-            summary,
+            summary: summaryUsRestricted,
             swapCommitment: userNoCommitment,
             userCountry: new Error("Failed to get user country"),
             ticket: null,
@@ -1201,7 +1209,7 @@ describe("project-utils", () => {
         expect(
           participateButtonStatus({
             loggedIn: true,
-            summary,
+            summary: summaryUsRestricted,
             swapCommitment: userNoCommitment,
             userCountry: { isoCode: "SP" },
             ticket: null,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -20,8 +20,10 @@ import {
   type SnsSwap,
   type SnsSwapBuyerState,
   type SnsSwapDerivedState,
+  type SnsSwapInit,
   type SnsTransferableAmount,
 } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export const mockProjectSubscribe =
@@ -96,6 +98,24 @@ export const mockSnsParams: SnsParams = {
   max_participant_icp_e8s: BigInt(5000000000),
   min_icp_e8s: BigInt(1500 * 100000000),
   sale_delay_seconds: [],
+};
+
+export const mockInit: SnsSwapInit = {
+  sns_root_canister_id:
+    "vxi5c-ydsws-tmett-fndw6-7qwga-thtxc-epwtj-st3wy-jc464-muowb-eqe",
+  fallback_controller_principal_ids: [],
+  neuron_minimum_stake_e8s: [100_000_000n],
+  confirmation_text: [],
+  nns_governance_canister_id:
+    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe",
+  transaction_fee_e8s: [10_000n],
+  icp_ledger_canister_id:
+    "2lwez-knpss-xe26y-sqpx3-7m5ev-gbqwb-ogdk4-af53j-r7fed-k5df4-uqe",
+  sns_ledger_canister_id:
+    "nv24n-kslcc-636yn-hazy3-t2zgj-fsrkg-2uhfm-vumlm-vqolw-6ciai-tae",
+  sns_governance_canister_id:
+    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe",
+  restricted_countries: [],
 };
 
 export const mockSwap: SnsSummarySwap = {
@@ -237,6 +257,29 @@ export const summaryForLifecycle = (
     lifecycle,
   },
 });
+
+export const createSummary = ({
+  lifecycle,
+  restrictedCountries,
+}: {
+  lifecycle: SnsSwapLifecycle;
+  restrictedCountries: string[] | undefined;
+}): SnsSummary => {
+  const init: SnsSwapInit = {
+    ...mockInit,
+    restricted_countries: nonNullish(restrictedCountries)
+      ? [{ iso_codes: restrictedCountries }]
+      : [],
+  };
+  const summary = summaryForLifecycle(lifecycle);
+  return {
+    ...summary,
+    swap: {
+      ...summary.swap,
+      init: [init],
+    },
+  };
+};
 
 export const mockQueryMetadataResponse: SnsGetMetadataResponse = {
   url: [`https://my.url/`],

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -6,9 +6,10 @@ import type {
   SnsSwapDerivedState,
   SnsSwapLifecycle,
 } from "@dfinity/sns";
-import { toNullable } from "@dfinity/utils";
+import { nonNullish, toNullable } from "@dfinity/utils";
 import {
   mockDerived,
+  mockInit,
   mockQueryMetadata,
   principal,
   summaryForLifecycle,
@@ -33,10 +34,12 @@ export const snsResponseFor = ({
   principal,
   lifecycle,
   certified = false,
+  restrictedCountries,
 }: {
   principal: Principal;
   lifecycle: SnsSwapLifecycle;
   certified?: boolean;
+  restrictedCountries?: string[];
 }): [QuerySnsMetadata[], QuerySnsSwapState[]] => [
   [
     {
@@ -50,7 +53,17 @@ export const snsResponseFor = ({
       rootCanisterId: principal.toText(),
       swapCanisterId: swapCanisterIdMock,
       governanceCanisterId: governanceCanisterIdMock,
-      swap: swapToQuerySwap(summaryForLifecycle(lifecycle).swap),
+      swap: swapToQuerySwap({
+        ...summaryForLifecycle(lifecycle).swap,
+        init: [
+          {
+            ...mockInit,
+            restricted_countries: nonNullish(restrictedCountries)
+              ? [{ iso_codes: restrictedCountries }]
+              : [],
+          },
+        ],
+      }),
       derived: [mockDerived] as [SnsSwapDerivedState],
       certified,
     },


### PR DESCRIPTION
# Motivation

Remove mocking the getter `getDeniedCountries` in tests.

Instead, create a swap summary with the desired state.

# Changes

* New mockInit.
* New helper createSummary to create a swap summary data based on lifecycle and restricted countries.
* Remove the `jest.spyOn(summaryGetters, "getDeniedCountries")` and instead build a swap summary.

# Tests

All are test changes.