### PR TITLE
chore: update FORCE_CALL_STRATEGY missing cases

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -39,6 +39,7 @@
   } from "$lib/utils/neuron.utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 
   export let proposalInfo: ProposalInfo;
 
@@ -103,7 +104,9 @@
     }
 
     return (
-      $neuronsStore.neurons !== undefined && $neuronsStore.certified === true
+      $neuronsStore.neurons !== undefined &&
+      ($neuronsStore.certified === true ||
+        ($neuronsStore.certified === false && FORCE_CALL_STRATEGY === "query"))
     );
   };
 

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -35,6 +35,7 @@
   import Summary from "$lib/components/summary/Summary.svelte";
   import { listNeurons } from "$lib/services/neurons.services";
   import { loadLatestRewardEvent } from "$lib/services/nns-reward-event.services";
+  import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 
   export let neuronIdText: string | undefined | null;
 
@@ -70,7 +71,9 @@
       $neuronsStore.neurons !== undefined &&
       // After neuron staking the query (not certified) call can return the outdated neuron list
       // so if the neuron is undefined it's more reliable to wait for the update call.
-      $neuronsStore.certified === true &&
+      ($neuronsStore.certified === true ||
+        ($neuronsStore.certified === false &&
+          FORCE_CALL_STRATEGY === "query")) &&
       $pageStore.path === AppPath.Neuron
     ) {
       toastsError({

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -26,6 +26,7 @@
   import { authStore } from "$lib/stores/auth.store";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 
   export let referrerPath: AppPath | undefined = undefined;
   // It's exported so that we can test the value
@@ -133,7 +134,10 @@
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches
-    if ($filteredProposals.certified === false) {
+    if (
+      $filteredProposals.certified === false &&
+      FORCE_CALL_STRATEGY !== "query"
+    ) {
       if (loading) nothingFound = false;
       return;
     }

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -249,7 +249,10 @@ export const loadProposal = async ({
     console.error(erroneusResponse);
 
     const skipUpdateErrorHandling =
-      silentUpdateErrorMessages === true && erroneusResponse.certified === true;
+      silentUpdateErrorMessages === true &&
+      (erroneusResponse.certified === true ||
+        (erroneusResponse.certified === false &&
+          FORCE_CALL_STRATEGY === "query"));
 
     if (silentErrorMessages !== true && !skipUpdateErrorHandling) {
       const details = errorToString(erroneusResponse?.error);

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -458,7 +458,10 @@ export const pollAccounts = async (certified = true) => {
   // Skip if accounts are already loaded and certified
   // `certified` might be `undefined` if not yet loaded.
   // Therefore, we compare with `true`.
-  if (accounts.certified === true) {
+  if (
+    accounts.certified === true ||
+    (accounts.certified === false && FORCE_CALL_STRATEGY === "query")
+  ) {
     return;
   }
 

--- a/frontend/src/lib/services/sns-parameters.services.ts
+++ b/frontend/src/lib/services/sns-parameters.services.ts
@@ -17,7 +17,11 @@ export const loadSnsParameters = async (
 ): Promise<void> => {
   const storeData = get(snsParametersStore);
   // Do not load if already loaded and certified
-  if (storeData[rootCanisterId.toText()]?.certified === true) {
+  if (
+    storeData[rootCanisterId.toText()]?.certified === true ||
+    (storeData[rootCanisterId.toText()]?.certified === false &&
+      FORCE_CALL_STRATEGY === "query")
+  ) {
     return;
   }
   await queryAndUpdate<SnsNervousSystemParameters, unknown>({


### PR DESCRIPTION
# Motivation

Make `certified` responses logic respect `FORCE_CALL_STRATEGY`.

# Changes

- replace `response.certified === true` with `response.certified === true || (response.certified === false && FORCE_CALL_STRATEGY === "query")`
