### PR TITLE
Argument rendering test vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
 name = "nns-dapp"
 version = "2.0.34"
 dependencies = [
+ "anyhow",
  "base64 0.13.1",
  "candid",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,17 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fn-error-context"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,7 +3322,6 @@ dependencies = [
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "flate2",
- "fn-error-context",
  "futures",
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fn-error-context"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3333,7 @@ dependencies = [
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "flate2",
+ "fn-error-context",
  "futures",
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -56,3 +56,4 @@ regex = "1.7.1"
 [dev-dependencies]
 maplit = "1.0.2"
 anyhow = "1.0.68"
+fn-error-context = "0.2.0"

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -56,4 +56,3 @@ regex = "1.7.1"
 [dev-dependencies]
 maplit = "1.0.2"
 anyhow = "1.0.68"
-fn-error-context = "0.2.0"

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -55,3 +55,4 @@ regex = "1.7.1"
 
 [dev-dependencies]
 maplit = "1.0.2"
+anyhow = "1.0.68"

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -106,7 +106,7 @@ fn canister_arg_types(canister_id: Option<CanisterId>) -> IDLTypes {
     } else {
         vec![]
     };
-    IDLTypes{args}
+    IDLTypes { args }
 }
 
 fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
@@ -114,7 +114,11 @@ fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
         return "[]".to_owned();
     }
     // We support only one argument, for the time being.
-    let idl_type = arg_types.args.get(0).cloned().unwrap_or_else(|| IDLType::PrimT(PrimType::Null));
+    let idl_type = arg_types
+        .args
+        .get(0)
+        .cloned()
+        .unwrap_or_else(|| IDLType::PrimT(PrimType::Null));
 
     match Decode!(arg, IDLValue) {
         Ok(idl_value) => {
@@ -213,6 +217,7 @@ fn debug<T: Debug>(value: T) -> String {
 }
 
 mod def {
+    use crate::proposals::canister_arg_types;
     use crate::proposals::{decode_arg, Json};
     use candid::CandidType;
     use ic_base_types::{CanisterId, PrincipalId};
@@ -223,7 +228,6 @@ mod def {
     use serde::{Deserialize, Serialize};
     use std::convert::TryFrom;
     use std::fmt::Write;
-    use crate::proposals::canister_arg_types;
 
     // NNS function 1 - CreateSubnet
     // https://github.com/dfinity/ic/blob/0a729806f2fbc717f2183b07efac19f24f32e717/rs/registry/canister/src/mutations/do_create_subnet.rs#L248

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -3,7 +3,6 @@ use crate::proposals::decode_arg;
 use anyhow::Context;
 use candid::parser::types::{IDLType, IDLTypes};
 use candid::{IDLArgs, IDLProg};
-use fn_error_context::context;
 use std::str::FromStr;
 
 /// Sample argument and expected corresponding output.
@@ -150,7 +149,6 @@ fn args_should_be_parsed() {
     }
 }
 
-#[context("Test vector '{}' failed", test_vector.name)]
 fn arg_should_be_parsed(test_vector: &TestVector) -> anyhow::Result<()> {
     let TestVector {
         name,

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -1,9 +1,9 @@
 //! Tests for the argument parsing code.
-use anyhow::{Context};
-use candid::parser::types::{IDLType, IDLTypes};
-use fn_error_context::context;
 use crate::proposals::decode_arg;
-use candid::{IDLProg, IDLArgs};
+use anyhow::Context;
+use candid::parser::types::{IDLType, IDLTypes};
+use candid::{IDLArgs, IDLProg};
+use fn_error_context::context;
 use std::str::FromStr;
 
 /// Sample argument and expected corresponding output.
@@ -116,7 +116,7 @@ const TEST_VECTORS: [TestVector; 10] = [
 ];
 
 /// Extract the args field from a did types file.
-/// 
+///
 /// TODO: Move into idl2json
 fn arg_types_from_did(did: &str) -> anyhow::Result<IDLTypes> {
     let prog = IDLProg::from_str(&did).context("Failed to parse canister did file.")?;
@@ -143,19 +143,28 @@ fn arg_types_from_did_should_be_correct() {
 
 #[test]
 fn args_should_be_parsed() {
-   for test_vector in TEST_VECTORS {
-    arg_should_be_parsed(&test_vector).with_context(|| format!("Test vector '{}' failed", test_vector.name)).unwrap();
-   }
+    for test_vector in TEST_VECTORS {
+        arg_should_be_parsed(&test_vector)
+            .with_context(|| format!("Test vector '{}' failed", test_vector.name))
+            .unwrap();
+    }
 }
 
 #[context("Test vector '{}' failed", test_vector.name)]
 fn arg_should_be_parsed(test_vector: &TestVector) -> anyhow::Result<()> {
-    let TestVector { name, did, args, status_quo, .. } = *test_vector.clone();
-        let did: IDLTypes = arg_types_from_did(did).context("Test error: Failed to get args from candid interface description.")?;
-        let args_parsed: IDLArgs = IDLArgs::from_str(args).context("Test error: Failed to parse arg value")?;
-        let args_bytes = args_parsed.to_bytes().context("Failed to convert args to bytes")?;
-        let expected = status_quo;
-        let actual = decode_arg(&args_bytes, did); // Note: This does NOT match the current code.
-        assert_eq!(expected, actual, "Invalid conversion for test vector: {name}");
-        Ok(())
+    let TestVector {
+        name,
+        did,
+        args,
+        status_quo,
+        ..
+    } = *test_vector.clone();
+    let did: IDLTypes =
+        arg_types_from_did(did).context("Test error: Failed to get args from candid interface description.")?;
+    let args_parsed: IDLArgs = IDLArgs::from_str(args).context("Test error: Failed to parse arg value")?;
+    let args_bytes = args_parsed.to_bytes().context("Failed to convert args to bytes")?;
+    let expected = status_quo;
+    let actual = decode_arg(&args_bytes, did); // Note: This does NOT match the current code.
+    assert_eq!(expected, actual, "Invalid conversion for test vector: {name}");
+    Ok(())
 }

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -119,7 +119,7 @@ const TEST_VECTORS: [TestVector; 10] = [
 ///
 /// TODO: Move into idl2json
 fn arg_types_from_did(did: &str) -> anyhow::Result<IDLTypes> {
-    let prog = IDLProg::from_str(&did).context("Failed to parse canister did file.")?;
+    let prog = IDLProg::from_str(did).context("Failed to parse canister did file.")?;
     let service = prog.actor.context("Could not find service in did file.")?;
     if let IDLType::ClassT(args, _) = service {
         Ok(IDLTypes { args })
@@ -158,7 +158,7 @@ fn arg_should_be_parsed(test_vector: &TestVector) -> anyhow::Result<()> {
         args,
         status_quo,
         ..
-    } = *test_vector.clone();
+    } = *test_vector;
     let did: IDLTypes =
         arg_types_from_did(did).context("Test error: Failed to get args from candid interface description.")?;
     let args_parsed: IDLArgs = IDLArgs::from_str(args).context("Test error: Failed to parse arg value")?;

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -1,0 +1,78 @@
+//! Tests for the argument parsing code.
+
+/// Sample argument and expected corresponding output.
+struct TestVector{
+    /// Name of the test vector
+  name: &'static str,
+    /// Canister init arg type
+  ///
+  /// Note: May be provided internally, but may then be wrong if the schema changes.
+  ///
+  /// Note: May be provided by the proposer in future, if we use the .did included in the wasm metadata.
+  did: &'static str,
+  /// Canister init arg.
+  ///
+  /// Provided by the proposer.  May be invalid.
+  args: &'static str,
+  /// JSON or error message
+  ///
+  /// Note: We may want to always return a str, or a str and a list of warnings.
+  ///       E.g. if the arg does not match the schema, we might show the arg with a warning.
+  json: Result<&'static str, &'static str>,
+}
+
+/// The arg parsing behaviour we would like.
+const test_vectors: TestVector[6] = [
+  TestVector {
+      name: "No argument",
+    did: "service : () -> {}",
+    args: "()",
+    json: "[]"
+  },
+  TestVector {
+      name: "Optional argument omitted",
+    did: "service : (opt nat8) -> {}",
+    args: "()",
+    json: "[null]"
+  },
+  TestVector {
+      name: "Optional argument given as none",
+    did: "service : (opt nat8) -> {}",
+    args: "(none)",
+    json: "[null]"
+  },
+  TestVector {
+      name: "Optional argument provided",
+    did: "service : (opt nat8) -> {}",
+    args: "(opt 9)",
+    json: "[9]"
+  },
+  TestVector {
+      name: "Wrong argument type provided",
+      did: "service : (opt nat8) -> {}",
+    args: "(9)",
+    json: "[9]"
+  },
+  TestVector {
+      name: "Too many arguments provided",
+      did: "service : (opt nat8) -> {}",
+    args: "(opt 9, 11)",
+    json: "[9, 11]"
+  },
+  // TODO: Names in types are supported
+  // TODO: Decide how to handle the case when the type and data don't match
+  // TODO: Handle args that are not valid candid
+  // TODO: Decide what we want to show when the type itself is invalid
+];
+
+
+#[test]
+fn args_should_be_parsed() {
+    for TestVector{ name, did, arg, json } in test_vectors {
+      let did: IDLType = IDLType::from_str(did);
+      let args: IDLArgs = IDLArgs::from_str(args);
+      let expected = json;
+      let actual = decode_args(args, did); // Note: This does NOT match the current code.
+      assert_eq!(expected, actual, "Invalid conversion for test vector: {name}");
+    }
+}

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -1,6 +1,6 @@
 //! Tests for the argument parsing code.
 use anyhow::{Context, Result};
-use candid::parser::types::{IDLType, PrimType, IDLTypes};
+use candid::parser::types::{IDLType, IDLTypes, PrimType};
 use candid::IDLProg;
 use std::str::FromStr;
 
@@ -91,7 +91,7 @@ fn arg_types_from_did(did: &str) -> anyhow::Result<IDLTypes> {
     let prog = IDLProg::from_str(&did).context("Failed to parse canister did file.")?;
     let service = prog.actor.context("Could not find service in did file.")?;
     if let IDLType::ClassT(args, _) = service {
-        Ok(IDLTypes{args})
+        Ok(IDLTypes { args })
     } else {
         anyhow::bail!("Could not get arg for service")
     }
@@ -99,8 +99,8 @@ fn arg_types_from_did(did: &str) -> anyhow::Result<IDLTypes> {
 #[test]
 fn arg_types_from_did_should_be_correct() {
     let ok_test_vectors = vec![
-      ("service : (opt opt nat8, nat16) -> {}", "(opt opt nat8, nat16)"),
-      ("service : (opt opt nat8) -> {}", "(opt opt nat8)"),
+        ("service : (opt opt nat8, nat16) -> {}", "(opt opt nat8, nat16)"),
+        ("service : (opt opt nat8) -> {}", "(opt opt nat8)"),
     ];
     for (did, arg) in ok_test_vectors {
         let actual_arg = arg_types_from_did(did).expect("Failed to get arg");

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -1,78 +1,95 @@
 //! Tests for the argument parsing code.
 
 /// Sample argument and expected corresponding output.
-struct TestVector{
+struct TestVector {
     /// Name of the test vector
-  name: &'static str,
+    name: &'static str,
     /// Canister init arg type
-  ///
-  /// Note: May be provided internally, but may then be wrong if the schema changes.
-  ///
-  /// Note: May be provided by the proposer in future, if we use the .did included in the wasm metadata.
-  did: &'static str,
-  /// Canister init arg.
-  ///
-  /// Provided by the proposer.  May be invalid.
-  args: &'static str,
-  /// JSON or error message
-  ///
-  /// Note: We may want to always return a str, or a str and a list of warnings.
-  ///       E.g. if the arg does not match the schema, we might show the arg with a warning.
-  json: Result<&'static str, &'static str>,
+    ///
+    /// Note: May be provided internally, but may then be wrong if the schema changes.
+    ///
+    /// Note: May be provided by the proposer in future, if we use the .did included in the wasm metadata.
+    did: &'static str,
+    /// Canister init arg.
+    ///
+    /// Provided by the proposer.  May be invalid.
+    args: &'static str,
+    /// JSON or error message
+    ///
+    /// Note: We may want to always return a str, or a str and a list of warnings.
+    ///       E.g. if the arg does not match the schema, we might show the arg with a warning.
+    json: Result<&'static str, &'static str>,
 }
 
 /// The arg parsing behaviour we would like.
-const test_vectors: TestVector[6] = [
-  TestVector {
-      name: "No argument",
-    did: "service : () -> {}",
-    args: "()",
-    json: "[]"
-  },
-  TestVector {
-      name: "Optional argument omitted",
-    did: "service : (opt nat8) -> {}",
-    args: "()",
-    json: "[null]"
-  },
-  TestVector {
-      name: "Optional argument given as none",
-    did: "service : (opt nat8) -> {}",
-    args: "(none)",
-    json: "[null]"
-  },
-  TestVector {
-      name: "Optional argument provided",
-    did: "service : (opt nat8) -> {}",
-    args: "(opt 9)",
-    json: "[9]"
-  },
-  TestVector {
-      name: "Wrong argument type provided",
-      did: "service : (opt nat8) -> {}",
-    args: "(9)",
-    json: "[9]"
-  },
-  TestVector {
-      name: "Too many arguments provided",
-      did: "service : (opt nat8) -> {}",
-    args: "(opt 9, 11)",
-    json: "[9, 11]"
-  },
-  // TODO: Names in types are supported
-  // TODO: Decide how to handle the case when the type and data don't match
-  // TODO: Handle args that are not valid candid
-  // TODO: Decide what we want to show when the type itself is invalid
+const test_vectors: [TestVector; 6] = [
+    TestVector {
+        name: "No argument",
+        did: "service : () -> {}",
+        args: "()",
+        json: "[]",
+    },
+    TestVector {
+        name: "Optional argument omitted",
+        did: "service : (opt nat8) -> {}",
+        args: "()",
+        json: "[null]",
+    },
+    TestVector {
+        name: "Optional argument given as none",
+        did: "service : (opt nat8) -> {}",
+        args: "(none)",
+        json: "[null]",
+    },
+    TestVector {
+        name: "Optional argument provided",
+        did: "service : (opt nat8) -> {}",
+        args: "(opt 9)",
+        json: "[9]",
+    },
+    TestVector {
+        name: "Wrong argument type provided",
+        did: "service : (opt nat8) -> {}",
+        args: "(9)",
+        json: "[9]",
+    },
+    TestVector {
+        name: "Too many arguments provided",
+        did: "service : (opt nat8) -> {}",
+        args: "(opt 9, 11)",
+        json: "[9, 11]",
+    },
+    TestVector {
+        name: "Argument with multiple values",
+        did: "service : (opt nat8, nat16) -> {}",
+        args: "(opt 8, 10)",
+        json: "[8, 10]",
+    },
+    TestVector {
+        name: "Argument with multiple values v2",
+        did: "service : (opt nat8, nat16) -> {}",
+        args: "(none, 10)",
+        json: "[null, 10]",
+    },
+    TestVector {
+        name: "Argument with multiple values v3",
+        did: "service : (opt opt nat8, nat16) -> {}",
+        args: "(opt none, 10)",
+        json: "[null, 10]",
+    },
+    // TODO: Names in types are supported
+    // TODO: Decide how to handle the case when the type and data don't match
+    // TODO: Handle args that are not valid candid
+    // TODO: Decide what we want to show when the type itself is invalid
 ];
-
 
 #[test]
 fn args_should_be_parsed() {
-    for TestVector{ name, did, arg, json } in test_vectors {
-      let did: IDLType = IDLType::from_str(did);
-      let args: IDLArgs = IDLArgs::from_str(args);
-      let expected = json;
-      let actual = decode_args(args, did); // Note: This does NOT match the current code.
-      assert_eq!(expected, actual, "Invalid conversion for test vector: {name}");
+    for TestVector { name, did, arg, json } in test_vectors {
+        let did: IDLType = IDLType::from_str(did);
+        let args: IDLArgs = IDLArgs::from_str(args);
+        let expected = json;
+        let actual = decode_args(args, did); // Note: This does NOT match the current code.
+        assert_eq!(expected, actual, "Invalid conversion for test vector: {name}");
     }
 }

--- a/rs/backend/src/proposals/tests/args.rs
+++ b/rs/backend/src/proposals/tests/args.rs
@@ -31,7 +31,7 @@ struct TestVector {
 }
 
 /// The arg parsing behaviour we would like.
-const TEST_VECTORS: [TestVector; 9] = [
+const TEST_VECTORS: [TestVector; 10] = [
     TestVector {
         name: "No argument",
         did: "service : () -> {}",
@@ -96,6 +96,20 @@ const TEST_VECTORS: [TestVector; 9] = [
         status_quo: "[null]",
     },
     // TODO: Names in types are supported
+    TestVector {
+        name: "Argument with multiple values v3",
+        did: "
+        type Config = record {
+            update_interval_ms : nat64;
+            fast_interval_ms : nat64;
+          };
+          
+        service : (opt Config) -> {}",
+        args: "(opt record{update_interval_ms = 999; fast_interval_ms = 100;})",
+        json: "[{\"update_interval_ms\": 999, \"fast_interval_ms\": 100}]",
+        status_quo: "[{\"2_344_481_514\":\"999\",\"3_143_647_229\":\"100\"}]",
+    },
+    // TODO: Check serialization when arguments are provided with annotation.
     // TODO: Decide how to handle the case when the type and data don't match
     // TODO: Handle args that are not valid candid
     // TODO: Decide what we want to show when the type itself is invalid

--- a/rs/backend/src/proposals/tests/mod.rs
+++ b/rs/backend/src/proposals/tests/mod.rs
@@ -2,6 +2,7 @@ use crate::proposals::tests::payloads::get_payloads;
 use crate::proposals::transform_payload_to_json;
 
 mod payloads;
+mod args;
 
 #[test]
 fn payload_deserialization() {

--- a/rs/backend/src/proposals/tests/mod.rs
+++ b/rs/backend/src/proposals/tests/mod.rs
@@ -1,7 +1,6 @@
 use crate::proposals::tests::payloads::get_payloads;
 use crate::proposals::transform_payload_to_json;
 
-mod args;
 mod payloads;
 
 #[test]

--- a/rs/backend/src/proposals/tests/mod.rs
+++ b/rs/backend/src/proposals/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::proposals::tests::payloads::get_payloads;
 use crate::proposals::transform_payload_to_json;
 
+mod args;
 mod payloads;
 
 #[test]

--- a/rs/backend/src/proposals/tests/mod.rs
+++ b/rs/backend/src/proposals/tests/mod.rs
@@ -1,8 +1,8 @@
 use crate::proposals::tests::payloads::get_payloads;
 use crate::proposals::transform_payload_to_json;
 
-mod payloads;
 mod args;
+mod payloads;
 
 #[test]
 fn payload_deserialization() {


### PR DESCRIPTION
# Motivation
Argument rendering is currently imperfect.  It has no tests, though, making it hard to evaluate improvements.

# Changes
- Add tests for argument rendering.
  - The test vector includes both the current behaviour and the value that we would probably like.  A PR that makes the actual and desired values align more closely is potentially a good thing.
- Split the argument rendering function into two parts, for more comprehensive testing.

# Tests
- This PR provides almost nothing but tests.