### PR TITLE
Fix: npm run build

### DIFF
--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -17,6 +17,7 @@
   import { ICPToken, type Token } from "@dfinity/nns";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
 
   let visible = false;
   let transferring = false;
@@ -75,7 +76,9 @@
   let tokenBalanceE8s = 0n;
   $: selectedProjectId,
     (async () => {
-      tokenBalanceE8s = await getTestBalance(selectedProjectId);
+      if (isBrowser) {
+        tokenBalanceE8s = await getTestBalance(selectedProjectId);
+      }
     })();
 
   // If the test account balance is 0, don't show a button that won't work. Show the ICP token instead.

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -76,7 +76,7 @@
   let tokenBalanceE8s = 0n;
   $: selectedProjectId,
     (async () => {
-      // This was executed at build time and it depends on `window` to convert string to AccountIdentifier.
+      // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
       if (isBrowser) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -76,6 +76,7 @@
   let tokenBalanceE8s = 0n;
   $: selectedProjectId,
     (async () => {
+      // This was executed at build time and it depends on `window` to convert string to AccountIdentifier.
       if (isBrowser) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }


### PR DESCRIPTION
# Motivation

`npm run build` is broken.

The problem: Code that depends on `window` was executed at build time.

Ideally: That component should not be executed at build time.

Workaround: Check whether the environment is the browser before calling the problematic code.

# Changes

* Check whether we're in the browser in `GetTokens` before getting the balance of the test account.

# Tests

This component is not tested because it's used only in testnets or loca environments.
