### PR TITLE
GIX-1555 Show conditions to accept if confirmation_text is present

### DIFF
--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -5,3 +5,8 @@ import { fromNullable } from "@dfinity/utils";
 export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] =>
   fromNullable(fromNullable(_summary.swap.init)?.restricted_countries ?? [])
     ?.iso_codes ?? [];
+
+export const getConditionsToAccept = (
+  summary: SnsSummary
+): string | undefined =>
+  fromNullable(fromNullable(summary.swap.init)?.confirmation_text || []);

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -7,6 +7,7 @@
     onDestroy,
     onMount,
   } from "svelte";
+  import { getConditionsToAccept } from "$lib/getters/sns-summary";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
@@ -64,6 +65,9 @@
   $: userHasParticipatedToSwap = hasUserParticipatedToSwap({
     swapCommitment,
   });
+
+  let conditionsToAccept: string | undefined;
+  $: conditionsToAccept = getConditionsToAccept(summary);
 
   let destinationAddress: string | undefined;
   $: (async () => {
@@ -192,7 +196,7 @@
       >{title ?? $i18n.sns_project_detail.participate}</svelte:fragment
     >
     <div class="additional-info" slot="additional-info-form">
-      <AdditionalInfoForm />
+      <AdditionalInfoForm {conditionsToAccept} />
     </div>
     <div class="additional-info" slot="additional-info-review">
       <AdditionalInfoReview bind:accepted />

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -23,7 +23,7 @@ import {
   type SnsSwapInit,
   type SnsTransferableAmount,
 } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
+import { nonNullish, toNullable } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export const mockProjectSubscribe =
@@ -259,14 +259,17 @@ export const summaryForLifecycle = (
 });
 
 export const createSummary = ({
-  lifecycle,
-  restrictedCountries,
+  lifecycle = SnsSwapLifecycle.Open,
+  confirmationText = undefined,
+  restrictedCountries = undefined,
 }: {
-  lifecycle: SnsSwapLifecycle;
-  restrictedCountries: string[] | undefined;
+  lifecycle?: SnsSwapLifecycle;
+  confirmationText?: string | undefined;
+  restrictedCountries?: string[] | undefined;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
+    confirmation_text: toNullable(confirmationText),
     restricted_countries: nonNullish(restrictedCountries)
       ? [{ iso_codes: restrictedCountries }]
       : [],

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -1,3 +1,4 @@
+import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.page-object";
 import { InProgressPo } from "$tests/page-objects/InProgress.page-object";
 import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -9,6 +10,10 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
     return new ParticipateSwapModalPo(
       element.byTestId(ParticipateSwapModalPo.TID)
     );
+  }
+
+  getAdditionalInfoFormPo(): AdditionalInfoFormPo {
+    return AdditionalInfoFormPo.under(this.root);
   }
 
   getInProgressPo(): InProgressPo {


### PR DESCRIPTION
# Motivation

We want to allow SNS creators to specify conditions that have to be accepted by swap participants.
For this purpose there is a field `confirmation_text` in the swap summary.

This PR only displays the confirmation text and checkbox.
It does not yet require that the checkbox is checked or send the confirmation text in the refresh buyer tokens request.

# Changes

1. In `frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte` pass the `confirmation_text` from the summary to the `AdditionalInfoForm` component.
2. Add a convenience getter in `frontend/src/lib/getters/sns-summary.ts`
3. Add 2 tests to verify that the text is rendered if and only if it's present in the summary.
4. Add `renderSwapModalPo` in the test, convenient for the case where the test only needs the po, and use it in existing tests.
5. Make all the params of `createSummary` optional and add `confirmationText` as one more parameter of it.
6. Add `getAdditionalInfoFormPo` to `ParticipateSwapModalPo`.

# Tests

1. Included in the PR.
2. Tested manually that the text renders only when the field is set.
