### PR TITLE
GIX-1555 Disable Continue until swap conditions are accepted

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -32,6 +32,7 @@
   export let canSelectSource: boolean;
   export let selectedDestinationAddress: string | undefined = undefined;
   export let amount: number | undefined = undefined;
+  export let disableContinue = false;
   export let token: Token;
   export let transactionFee: TokenAmount;
   // TODO: Handle min and max validations inline: https://dfinity.atlassian.net/browse/L2-798
@@ -66,6 +67,7 @@
 
   let disableButton: boolean;
   $: disableButton =
+    disableContinue ||
     selectedAccount === undefined ||
     amount === 0 ||
     amount === undefined ||

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -66,8 +66,13 @@
     swapCommitment,
   });
 
+  let areSwapConditionsAccepted: boolean = false;
   let conditionsToAccept: string | undefined;
   $: conditionsToAccept = getConditionsToAccept(summary);
+
+  let disableContinue = true;
+  $: disableContinue =
+    nonNullish(conditionsToAccept) && !areSwapConditionsAccepted;
 
   let destinationAddress: string | undefined;
   $: (async () => {
@@ -187,6 +192,7 @@
     on:nnsSubmit={participate}
     {validateAmount}
     {transactionInit}
+    {disableContinue}
     disableSubmit={!accepted || busy}
     skipHardwareWallets
     transactionFee={$mainTransactionFeeStoreAsToken}
@@ -196,7 +202,10 @@
       >{title ?? $i18n.sns_project_detail.participate}</svelte:fragment
     >
     <div class="additional-info" slot="additional-info-form">
-      <AdditionalInfoForm {conditionsToAccept} />
+      <AdditionalInfoForm
+        {conditionsToAccept}
+        bind:areConditionsAccepted={areSwapConditionsAccepted}
+      />
     </div>
     <div class="additional-info" slot="additional-info-review">
       <AdditionalInfoReview bind:accepted />

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -38,6 +38,7 @@
   export let currentStep: WizardStep | undefined = undefined;
   export let token: Token = ICPToken;
   export let transactionFee: TokenAmount;
+  export let disableContinue = false;
   export let disableSubmit = false;
   // Max amount accepted by the transaction without fees
   export let maxAmount: bigint | undefined = undefined;
@@ -114,6 +115,7 @@
       {rootCanisterId}
       {canSelectDestination}
       {canSelectSource}
+      {disableContinue}
       {transactionFee}
       {validateAmount}
       bind:selectedDestinationAddress

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -174,6 +174,26 @@ describe("ParticipateSwapModal", () => {
       const info = po.getAdditionalInfoFormPo();
       expect(await info.hasConditions()).toBe(false);
     });
+
+    it("should disable continue until conditions are accepted", async () => {
+      const confirmationText = "I confirm the text";
+      const po = await renderSwapModalPo({ confirmationText });
+      const info = po.getAdditionalInfoFormPo();
+      const form = po.getTransactionFormPo();
+      await form.enterAmount(10);
+      expect(await form.isContinueButtonEnabled()).toBe(false);
+      expect(await info.toggleConditionsAccepted());
+      expect(await form.isContinueButtonEnabled()).toBe(true);
+    });
+
+    it("should not disable continue if confirmation text is absent", async () => {
+      const confirmationText = undefined;
+      const po = await renderSwapModalPo({ confirmationText });
+      const info = po.getAdditionalInfoFormPo();
+      const form = po.getTransactionFormPo();
+      await form.enterAmount(10);
+      expect(await form.isContinueButtonEnabled()).toBe(true);
+    });
   });
 
   describe("when user has participated", () => {


### PR DESCRIPTION
# Motivation

When an SNS confirmation text is specified, we want to require that the conditions are accepted before a user can continue participating in the swap.

# Changes

1. Export, and pass on, a `disableContinue` prop on `TransactionModal` and `TransactionForm`.
2. In `frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte` set `disableContinue` to `true` iff `confirmation_text` is present and the checkbox is not checked.

# Tests

Added 2 tests to `frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts` for the case with and without confirmation_text.
