### PR TITLE
Bump didc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,11 +76,9 @@ COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
 RUN mkdir -p rs/backend/src/bin rs/sns_aggregator/src && touch rs/backend/src/lib.rs rs/sns_aggregator/src/lib.rs && echo 'fn main(){}' | tee rs/backend/src/main.rs > rs/backend/src/bin/nns-dapp-check-args.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -f target/wasm32-unknown-unknown/release/*wasm
 # Install dfx
 WORKDIR /
-RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-RUN dfx --version
+RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
-RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc"
-RUN didc --version
+RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc" && didc --version
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall -V
 RUN cargo binstall --no-confirm "wasm-nm@$(cat config/wasm_nm_version)" && command -v wasm-nm
 RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && command -v ic-wasm

--- a/dfx.json
+++ b/dfx.json
@@ -696,7 +696,7 @@
         "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.5",
         "OPTIMIZER_VERSION": "0.3.6",
-        "DIDC_VERSION": "2022-11-17",
+        "DIDC_VERSION": "2023-05-26",
         "IC_COMMIT": "26b480f775222265f4369bc485d502a140f15564"
       },
       "packtool": ""

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,16 +1,26 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index d1acc5d98..25b9ba676 100644
+index 28bc6ec98..fbcff33af 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -11,6 +11,7 @@ use ic_cdk::api::call::CallResult;
- // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
- // use ic_cdk::api::call::CallResult;
- 
+@@ -8,20 +8,21 @@ use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+ use ic_cdk::api::call::CallResult;
+ // This is an experimental feature to generate Rust binding from Candid.
+ // You may want to manually adjust some of the types.
+-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, Principal};
+-// use ic_cdk::api::call::CallResult as Result;
++// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
++// use ic_cdk::api::call::CallResult;
 +
+ 
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GenericNervousSystemFunction {
-   pub  validator_canister_id: Option<candid::Principal>,
-@@ -21,7 +22,7 @@ pub struct GenericNervousSystemFunction {
+-  pub  validator_canister_id: Option<Principal>,
+-  pub  target_canister_id: Option<Principal>,
++  pub  validator_canister_id: Option<candid::Principal>,
++  pub  target_canister_id: Option<candid::Principal>,
+   pub  validator_method_name: Option<String>,
+   pub  target_method_name: Option<String>,
+ }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum FunctionType {
@@ -19,6 +29,84 @@ index d1acc5d98..25b9ba676 100644
    GenericNervousSystemFunction(GenericNervousSystemFunction),
  }
  
+@@ -59,7 +60,7 @@ pub struct MaturityModulation {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct NeuronId { id: serde_bytes::ByteBuf }
++pub struct NeuronId { id: Vec<u8> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Followees { followees: Vec<NeuronId> }
+@@ -104,12 +105,12 @@ pub struct NervousSystemParameters {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Version {
+-  pub  archive_wasm_hash: serde_bytes::ByteBuf,
+-  pub  root_wasm_hash: serde_bytes::ByteBuf,
+-  pub  swap_wasm_hash: serde_bytes::ByteBuf,
+-  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
+-  pub  governance_wasm_hash: serde_bytes::ByteBuf,
+-  pub  index_wasm_hash: serde_bytes::ByteBuf,
++  pub  archive_wasm_hash: Vec<u8>,
++  pub  root_wasm_hash: Vec<u8>,
++  pub  swap_wasm_hash: Vec<u8>,
++  pub  ledger_wasm_hash: Vec<u8>,
++  pub  governance_wasm_hash: Vec<u8>,
++  pub  index_wasm_hash: Vec<u8>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -143,15 +144,15 @@ pub struct Ballot { vote: i32, cast_timestamp_seconds: u64, voting_power: u64 }
+ pub struct Tally { no: u64, yes: u64, total: u64, timestamp_seconds: u64 }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct RegisterDappCanisters { canister_ids: Vec<Principal> }
++pub struct RegisterDappCanisters { canister_ids: Vec<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
++pub struct Subaccount { subaccount: Vec<u8> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct TransferSnsTreasuryFunds {
+   pub  from_treasury: i32,
+-  pub  to_principal: Option<Principal>,
++  pub  to_principal: Option<candid::Principal>,
+   pub  to_subaccount: Option<Subaccount>,
+   pub  memo: Option<u64>,
+   pub  amount_e8s: u64,
+@@ -159,16 +160,16 @@ pub struct TransferSnsTreasuryFunds {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct UpgradeSnsControlledCanister {
+-  pub  new_canister_wasm: serde_bytes::ByteBuf,
++  pub  new_canister_wasm: Vec<u8>,
+   pub  mode: Option<i32>,
+-  pub  canister_id: Option<Principal>,
+-  pub  canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
++  pub  canister_id: Option<candid::Principal>,
++  pub  canister_upgrade_arg: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DeregisterDappCanisters {
+-  pub  canister_ids: Vec<Principal>,
+-  pub  new_controllers: Vec<Principal>,
++  pub  canister_ids: Vec<candid::Principal>,
++  pub  new_controllers: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -182,7 +183,7 @@ pub struct ManageSnsMetadata {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct ExecuteGenericNervousSystemFunction {
+   pub  function_id: u64,
+-  pub  payload: serde_bytes::ByteBuf,
++  pub  payload: Vec<u8>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 @@ -193,12 +194,12 @@ pub enum Action {
    ManageNervousSystemParameters(NervousSystemParameters),
    AddGenericNervousSystemFunction(NervousSystemFunction),
@@ -34,7 +122,19 @@ index d1acc5d98..25b9ba676 100644
    ManageSnsMetadata(ManageSnsMetadata),
    ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
    Motion(Motion),
-@@ -270,8 +271,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
+@@ -245,7 +246,10 @@ pub struct Split { memo: u64, amount_e8s: u64 }
+ pub struct Follow { function_id: u64, followees: Vec<NeuronId> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct Account { owner: Option<Principal>, subaccount: Option<Subaccount> }
++pub struct Account {
++  pub  owner: Option<candid::Principal>,
++  pub  subaccount: Option<Subaccount>,
++}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DisburseMaturity {
+@@ -267,8 +271,8 @@ pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum Operation {
    ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
@@ -45,8 +145,15 @@ index d1acc5d98..25b9ba676 100644
    IncreaseDissolveDelay(IncreaseDissolveDelay),
    SetDissolveTimestamp(SetDissolveTimestamp),
  }
-@@ -292,7 +293,7 @@ pub struct FinalizeDisburseMaturity {
- pub struct MemoAndController { controller: Option<candid::Principal>, memo: u64 }
+@@ -286,10 +290,13 @@ pub struct FinalizeDisburseMaturity {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct MemoAndController { controller: Option<Principal>, memo: u64 }
++pub struct MemoAndController {
++  pub  controller: Option<candid::Principal>,
++  pub  memo: u64,
++}
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 -pub enum By { MemoAndController(MemoAndController), NeuronId{} }
@@ -54,7 +161,23 @@ index d1acc5d98..25b9ba676 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ClaimOrRefresh { by: Option<By> }
-@@ -325,7 +326,7 @@ pub enum Command_2 {
+@@ -297,13 +304,13 @@ pub struct ClaimOrRefresh { by: Option<By> }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct RemoveNeuronPermissions {
+   pub  permissions_to_remove: Option<NeuronPermissionList>,
+-  pub  principal_id: Option<Principal>,
++  pub  principal_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct AddNeuronPermissions {
+   pub  permissions_to_add: Option<NeuronPermissionList>,
+-  pub  principal_id: Option<Principal>,
++  pub  principal_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -322,7 +329,7 @@ pub enum Command_2 {
    DisburseMaturity(DisburseMaturity),
    Configure(Configure),
    RegisterVote(RegisterVote),
@@ -63,7 +186,51 @@ index d1acc5d98..25b9ba676 100644
    MakeProposal(Proposal),
    FinalizeDisburseMaturity(FinalizeDisburseMaturity),
    ClaimOrRefreshNeuron(ClaimOrRefresh),
-@@ -443,7 +444,7 @@ pub struct GetMaturityModulationResponse {
+@@ -337,7 +344,7 @@ pub struct NeuronInFlightCommand { command: Option<Command_2>, timestamp: u64 }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct NeuronPermission {
+-  pub  principal: Option<Principal>,
++  pub  principal: Option<candid::Principal>,
+   pub  permission_type: Vec<i32>,
+ }
+ 
+@@ -375,7 +382,7 @@ pub struct Neuron {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Governance {
+-  pub  root_canister_id: Option<Principal>,
++  pub  root_canister_id: Option<candid::Principal>,
+   pub  id_to_nervous_system_functions: Vec<(u64,NervousSystemFunction,)>,
+   pub  metrics: Option<GovernanceCachedMetrics>,
+   pub  maturity_modulation: Option<MaturityModulation>,
+@@ -386,8 +393,8 @@ pub struct Governance {
+   pub  sns_initialization_parameters: String,
+   pub  latest_reward_event: Option<RewardEvent>,
+   pub  pending_version: Option<UpgradeInProgress>,
+-  pub  swap_canister_id: Option<Principal>,
+-  pub  ledger_canister_id: Option<Principal>,
++  pub  swap_canister_id: Option<candid::Principal>,
++  pub  ledger_canister_id: Option<candid::Principal>,
+   pub  proposals: Vec<(u64,ProposalData,)>,
+   pub  in_flight_commands: Vec<(String,NeuronInFlightCommand,)>,
+   pub  sns_metadata: Option<ManageSnsMetadata>,
+@@ -397,12 +404,12 @@ pub struct Governance {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct NeuronParameters {
+-  pub  controller: Option<Principal>,
++  pub  controller: Option<candid::Principal>,
+   pub  dissolve_delay_seconds: Option<u64>,
+   pub  source_nns_neuron_id: Option<u64>,
+   pub  stake_e8s: Option<u64>,
+   pub  followees: Vec<NeuronId>,
+-  pub  hotkey: Option<Principal>,
++  pub  hotkey: Option<candid::Principal>,
+   pub  neuron_id: Option<NeuronId>,
+ }
+ 
+@@ -440,7 +447,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}
  
@@ -72,7 +239,37 @@ index d1acc5d98..25b9ba676 100644
  pub struct GetMetadataResponse {
    pub  url: Option<String>,
    pub  logo: Option<String>,
-@@ -517,7 +518,7 @@ pub struct GetSnsInitializationParametersResponse {
+@@ -477,24 +484,24 @@ pub enum CanisterStatusType { stopped, stopping, running }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DefiniteCanisterSettingsArgs {
+-  pub  controller: Principal,
++  pub  controller: candid::Principal,
+   pub  freezing_threshold: candid::Nat,
+-  pub  controllers: Vec<Principal>,
++  pub  controllers: Vec<candid::Principal>,
+   pub  memory_allocation: candid::Nat,
+   pub  compute_allocation: candid::Nat,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct CanisterStatusResultV2 {
+-  pub  controller: Principal,
++  pub  controller: candid::Principal,
+   pub  status: CanisterStatusType,
+   pub  freezing_threshold: candid::Nat,
+-  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
++  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
+   pub  memory_size: candid::Nat,
+   pub  cycles: candid::Nat,
+   pub  settings: DefiniteCanisterSettingsArgs,
+   pub  idle_cycles_burned_per_day: candid::Nat,
+-  pub  module_hash: Option<serde_bytes::ByteBuf>,
++  pub  module_hash: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -514,7 +521,7 @@ pub struct GetSnsInitializationParametersResponse {
    pub  sns_initialization_parameters: String,
  }
  
@@ -81,7 +278,28 @@ index d1acc5d98..25b9ba676 100644
  pub struct ListNervousSystemFunctionsResponse {
    pub  reserved_ids: Vec<u64>,
    pub  functions: Vec<NervousSystemFunction>,
-@@ -589,17 +590,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
+@@ -522,7 +529,7 @@ pub struct ListNervousSystemFunctionsResponse {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct ListNeurons {
+-  pub  of_principal: Option<Principal>,
++  pub  of_principal: Option<candid::Principal>,
+   pub  limit: u32,
+   pub  start_page_at: Option<NeuronId>,
+ }
+@@ -562,10 +569,7 @@ pub enum Command {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct ManageNeuron {
+-  pub  subaccount: serde_bytes::ByteBuf,
+-  pub  command: Option<Command>,
+-}
++pub struct ManageNeuron { subaccount: Vec<u8>, command: Option<Command> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SplitResponse { created_neuron_id: Option<NeuronId> }
+@@ -592,17 +596,17 @@ pub struct DisburseResponse { transfer_block_height: u64 }
  pub enum Command_1 {
    Error(GovernanceError),
    Split(SplitResponse),
@@ -104,3 +322,100 @@ index d1acc5d98..25b9ba676 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -614,76 +618,75 @@ pub struct SetMode { mode: i32 }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct set_mode_ret0 {}
+ 
+-pub struct SERVICE(pub Principal);
+-impl SERVICE {
++pub struct SERVICE(pub candid::Principal);
++impl SERVICE{
+   pub async fn claim_swap_neurons(
+     &self,
+     arg0: ClaimSwapNeuronsRequest,
+-  ) -> Result<(ClaimSwapNeuronsResponse,)> {
++  ) -> CallResult<(ClaimSwapNeuronsResponse,)> {
+     ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
+   }
+   pub async fn fail_stuck_upgrade_in_progress(
+     &self,
+     arg0: fail_stuck_upgrade_in_progress_arg0,
+-  ) -> Result<(fail_stuck_upgrade_in_progress_ret0,)> {
++  ) -> CallResult<(fail_stuck_upgrade_in_progress_ret0,)> {
+     ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
+   }
+-  pub async fn get_build_metadata(&self) -> Result<(String,)> {
++  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
+     ic_cdk::call(self.0, "get_build_metadata", ()).await
+   }
+-  pub async fn get_latest_reward_event(&self) -> Result<(RewardEvent,)> {
++  pub async fn get_latest_reward_event(&self) -> CallResult<(RewardEvent,)> {
+     ic_cdk::call(self.0, "get_latest_reward_event", ()).await
+   }
+   pub async fn get_maturity_modulation(
+     &self,
+     arg0: get_maturity_modulation_arg0,
+-  ) -> Result<(GetMaturityModulationResponse,)> {
++  ) -> CallResult<(GetMaturityModulationResponse,)> {
+     ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
+   }
+-  pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> Result<
++  pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> CallResult<
+     (GetMetadataResponse,)
+   > { ic_cdk::call(self.0, "get_metadata", (arg0,)).await }
+-  pub async fn get_mode(&self, arg0: get_mode_arg0) -> Result<
++  pub async fn get_mode(&self, arg0: get_mode_arg0) -> CallResult<
+     (GetModeResponse,)
+   > { ic_cdk::call(self.0, "get_mode", (arg0,)).await }
+-  pub async fn get_nervous_system_parameters(&self, arg0: ()) -> Result<
++  pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<
+     (NervousSystemParameters,)
+   > { ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await }
+-  pub async fn get_neuron(&self, arg0: GetNeuron) -> Result<
++  pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<
+     (GetNeuronResponse,)
+   > { ic_cdk::call(self.0, "get_neuron", (arg0,)).await }
+-  pub async fn get_proposal(&self, arg0: GetProposal) -> Result<
++  pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<
+     (GetProposalResponse,)
+   > { ic_cdk::call(self.0, "get_proposal", (arg0,)).await }
+-  pub async fn get_root_canister_status(&self, arg0: ()) -> Result<
++  pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<
+     (CanisterStatusResultV2,)
+   > { ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await }
+   pub async fn get_running_sns_version(
+     &self,
+     arg0: get_running_sns_version_arg0,
+-  ) -> Result<(GetRunningSnsVersionResponse,)> {
++  ) -> CallResult<(GetRunningSnsVersionResponse,)> {
+     ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
+   }
+   pub async fn get_sns_initialization_parameters(
+     &self,
+     arg0: get_sns_initialization_parameters_arg0,
+-  ) -> Result<(GetSnsInitializationParametersResponse,)> {
++  ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
+     ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
+   }
+-  pub async fn list_nervous_system_functions(&self) -> Result<
++  pub async fn list_nervous_system_functions(&self) -> CallResult<
+     (ListNervousSystemFunctionsResponse,)
+   > { ic_cdk::call(self.0, "list_nervous_system_functions", ()).await }
+-  pub async fn list_neurons(&self, arg0: ListNeurons) -> Result<
++  pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<
+     (ListNeuronsResponse,)
+   > { ic_cdk::call(self.0, "list_neurons", (arg0,)).await }
+-  pub async fn list_proposals(&self, arg0: ListProposals) -> Result<
++  pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<
+     (ListProposalsResponse,)
+   > { ic_cdk::call(self.0, "list_proposals", (arg0,)).await }
+-  pub async fn manage_neuron(&self, arg0: ManageNeuron) -> Result<
++  pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<
+     (ManageNeuronResponse,)
+   > { ic_cdk::call(self.0, "manage_neuron", (arg0,)).await }
+-  pub async fn set_mode(&self, arg0: SetMode) -> Result<(set_mode_ret0,)> {
++  pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(set_mode_ret0,)> {
+     ic_cdk::call(self.0, "set_mode", (arg0,)).await
+   }
+ }
+-

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 28bc6ec98..fbcff33af 100644
+index 28bc6ec98..3c3a440de 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -8,20 +8,21 @@ use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
@@ -29,35 +29,7 @@ index 28bc6ec98..fbcff33af 100644
    GenericNervousSystemFunction(GenericNervousSystemFunction),
  }
  
-@@ -59,7 +60,7 @@ pub struct MaturityModulation {
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct NeuronId { id: serde_bytes::ByteBuf }
-+pub struct NeuronId { id: Vec<u8> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct Followees { followees: Vec<NeuronId> }
-@@ -104,12 +105,12 @@ pub struct NervousSystemParameters {
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct Version {
--  pub  archive_wasm_hash: serde_bytes::ByteBuf,
--  pub  root_wasm_hash: serde_bytes::ByteBuf,
--  pub  swap_wasm_hash: serde_bytes::ByteBuf,
--  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
--  pub  governance_wasm_hash: serde_bytes::ByteBuf,
--  pub  index_wasm_hash: serde_bytes::ByteBuf,
-+  pub  archive_wasm_hash: Vec<u8>,
-+  pub  root_wasm_hash: Vec<u8>,
-+  pub  swap_wasm_hash: Vec<u8>,
-+  pub  ledger_wasm_hash: Vec<u8>,
-+  pub  governance_wasm_hash: Vec<u8>,
-+  pub  index_wasm_hash: Vec<u8>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -143,15 +144,15 @@ pub struct Ballot { vote: i32, cast_timestamp_seconds: u64, voting_power: u64 }
+@@ -143,7 +144,7 @@ pub struct Ballot { vote: i32, cast_timestamp_seconds: u64, voting_power: u64 }
  pub struct Tally { no: u64, yes: u64, total: u64, timestamp_seconds: u64 }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -65,9 +37,8 @@ index 28bc6ec98..fbcff33af 100644
 +pub struct RegisterDappCanisters { canister_ids: Vec<candid::Principal> }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
-+pub struct Subaccount { subaccount: Vec<u8> }
- 
+ pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
+@@ -151,7 +152,7 @@ pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct TransferSnsTreasuryFunds {
    pub  from_treasury: i32,
@@ -76,17 +47,13 @@ index 28bc6ec98..fbcff33af 100644
    pub  to_subaccount: Option<Subaccount>,
    pub  memo: Option<u64>,
    pub  amount_e8s: u64,
-@@ -159,16 +160,16 @@ pub struct TransferSnsTreasuryFunds {
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -161,14 +162,14 @@ pub struct TransferSnsTreasuryFunds {
  pub struct UpgradeSnsControlledCanister {
--  pub  new_canister_wasm: serde_bytes::ByteBuf,
-+  pub  new_canister_wasm: Vec<u8>,
+   pub  new_canister_wasm: serde_bytes::ByteBuf,
    pub  mode: Option<i32>,
 -  pub  canister_id: Option<Principal>,
--  pub  canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
 +  pub  canister_id: Option<candid::Principal>,
-+  pub  canister_upgrade_arg: Option<Vec<u8>>,
+   pub  canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -95,15 +62,6 @@ index 28bc6ec98..fbcff33af 100644
 -  pub  new_controllers: Vec<Principal>,
 +  pub  canister_ids: Vec<candid::Principal>,
 +  pub  new_controllers: Vec<candid::Principal>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -182,7 +183,7 @@ pub struct ManageSnsMetadata {
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct ExecuteGenericNervousSystemFunction {
-   pub  function_id: u64,
--  pub  payload: serde_bytes::ByteBuf,
-+  pub  payload: Vec<u8>,
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -239,7 +197,7 @@ index 28bc6ec98..fbcff33af 100644
  pub struct GetMetadataResponse {
    pub  url: Option<String>,
    pub  logo: Option<String>,
-@@ -477,24 +484,24 @@ pub enum CanisterStatusType { stopped, stopping, running }
+@@ -477,16 +484,16 @@ pub enum CanisterStatusType { stopped, stopping, running }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct DefiniteCanisterSettingsArgs {
@@ -258,17 +216,7 @@ index 28bc6ec98..fbcff33af 100644
 +  pub  controller: candid::Principal,
    pub  status: CanisterStatusType,
    pub  freezing_threshold: candid::Nat,
--  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
-+  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
-   pub  memory_size: candid::Nat,
-   pub  cycles: candid::Nat,
-   pub  settings: DefiniteCanisterSettingsArgs,
-   pub  idle_cycles_burned_per_day: candid::Nat,
--  pub  module_hash: Option<serde_bytes::ByteBuf>,
-+  pub  module_hash: Option<Vec<u8>>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+   pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
 @@ -514,7 +521,7 @@ pub struct GetSnsInitializationParametersResponse {
    pub  sns_initialization_parameters: String,
  }
@@ -295,7 +243,7 @@ index 28bc6ec98..fbcff33af 100644
 -  pub  subaccount: serde_bytes::ByteBuf,
 -  pub  command: Option<Command>,
 -}
-+pub struct ManageNeuron { subaccount: Vec<u8>, command: Option<Command> }
++pub struct ManageNeuron { subaccount: serde_bytes::ByteBuf, command: Option<Command> }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SplitResponse { created_neuron_id: Option<NeuronId> }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -8,7 +8,7 @@ use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
 
@@ -290,7 +290,10 @@ pub struct FinalizeDisburseMaturity {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct MemoAndController { controller: Option<candid::Principal>, memo: u64 }
+pub struct MemoAndController {
+  pub  controller: Option<candid::Principal>,
+  pub  memo: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum By { MemoAndController(MemoAndController), NeuronId(EmptyRecord) }
@@ -581,7 +584,10 @@ pub struct ClaimOrRefreshResponse { refreshed_neuron_id: Option<NeuronId> }
 pub struct StakeMaturityResponse { maturity_e8s: u64, staked_maturity_e8s: u64 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct MergeMaturityResponse { merged_maturity_e8s: u64, new_stake_e8s: u64 }
+pub struct MergeMaturityResponse {
+  pub  merged_maturity_e8s: u64,
+  pub  new_stake_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DisburseResponse { transfer_block_height: u64 }
@@ -612,7 +618,7 @@ pub struct SetMode { mode: i32 }
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct set_mode_ret0 {}
 
-pub struct SERVICE(candid::Principal);
+pub struct SERVICE(pub candid::Principal);
 impl SERVICE{
   pub async fn claim_swap_neurons(
     &self,

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -60,7 +60,7 @@ pub struct MaturityModulation {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronId { id: Vec<u8> }
+pub struct NeuronId { id: serde_bytes::ByteBuf }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Followees { followees: Vec<NeuronId> }
@@ -105,12 +105,12 @@ pub struct NervousSystemParameters {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Version {
-  pub  archive_wasm_hash: Vec<u8>,
-  pub  root_wasm_hash: Vec<u8>,
-  pub  swap_wasm_hash: Vec<u8>,
-  pub  ledger_wasm_hash: Vec<u8>,
-  pub  governance_wasm_hash: Vec<u8>,
-  pub  index_wasm_hash: Vec<u8>,
+  pub  archive_wasm_hash: serde_bytes::ByteBuf,
+  pub  root_wasm_hash: serde_bytes::ByteBuf,
+  pub  swap_wasm_hash: serde_bytes::ByteBuf,
+  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
+  pub  governance_wasm_hash: serde_bytes::ByteBuf,
+  pub  index_wasm_hash: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -147,7 +147,7 @@ pub struct Tally { no: u64, yes: u64, total: u64, timestamp_seconds: u64 }
 pub struct RegisterDappCanisters { canister_ids: Vec<candid::Principal> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Subaccount { subaccount: Vec<u8> }
+pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransferSnsTreasuryFunds {
@@ -160,10 +160,10 @@ pub struct TransferSnsTreasuryFunds {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpgradeSnsControlledCanister {
-  pub  new_canister_wasm: Vec<u8>,
+  pub  new_canister_wasm: serde_bytes::ByteBuf,
   pub  mode: Option<i32>,
   pub  canister_id: Option<candid::Principal>,
-  pub  canister_upgrade_arg: Option<Vec<u8>>,
+  pub  canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -183,7 +183,7 @@ pub struct ManageSnsMetadata {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ExecuteGenericNervousSystemFunction {
   pub  function_id: u64,
-  pub  payload: Vec<u8>,
+  pub  payload: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -496,12 +496,12 @@ pub struct CanisterStatusResultV2 {
   pub  controller: candid::Principal,
   pub  status: CanisterStatusType,
   pub  freezing_threshold: candid::Nat,
-  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
+  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
   pub  memory_size: candid::Nat,
   pub  cycles: candid::Nat,
   pub  settings: DefiniteCanisterSettingsArgs,
   pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<Vec<u8>>,
+  pub  module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -569,7 +569,7 @@ pub enum Command {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ManageNeuron { subaccount: Vec<u8>, command: Option<Command> }
+pub struct ManageNeuron { subaccount: serde_bytes::ByteBuf, command: Option<Command> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SplitResponse { created_neuron_id: Option<NeuronId> }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 8b7243de1..f5baada32 100644
+index 8c26d1bf1..fb84e9739 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -4,7 +4,7 @@
+@@ -4,24 +4,24 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -11,13 +11,58 @@ index 8b7243de1..f5baada32 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -81,14 +81,14 @@ pub type Block = Box<Value>;
+-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, Principal};
+-// use ic_cdk::api::call::CallResult as Result;
++// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
++// use ic_cdk::api::call::CallResult;
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub enum MetadataValue {
+   Int(candid::Int),
+   Nat(candid::Nat),
+-  Blob(serde_bytes::ByteBuf),
++  Blob(Vec<u8>),
+   Text(String),
+ }
+ 
+-pub type Subaccount = serde_bytes::ByteBuf;
++pub type Subaccount = Vec<u8>;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct Account { owner: Principal, subaccount: Option<Subaccount> }
++pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub enum ChangeFeeCollector { SetTo(Account), Unset }
+@@ -42,7 +42,7 @@ pub struct InitArgs_archive_options {
+   pub  max_message_size_bytes: Option<u64>,
+   pub  cycles_for_archive_creation: Option<u64>,
+   pub  node_max_memory_size_bytes: Option<u64>,
+-  pub  controller_id: Principal,
++  pub  controller_id: candid::Principal,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -71,7 +71,7 @@ pub enum Value {
+   Map(Map),
+   Nat(candid::Nat),
+   Nat64(u64),
+-  Blob(serde_bytes::ByteBuf),
++  Blob(Vec<u8>),
+   Text(String),
+   Array(Vec<Box<Value>>),
+ }
+@@ -80,30 +80,25 @@ pub type Block = Box<Value>;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct BlockRange { blocks: Vec<Block> }
  
- pub type QueryBlockArchiveFn = candid::Func;
+-candid::define_function!(pub QueryBlockArchiveFn : (GetBlocksArgs) -> (
+-    BlockRange,
+-  ) query);
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetBlocksResponse_archived_blocks_item {
++pub type QueryBlockArchiveFn = candid::Func;
 +#[derive(CandidType, Deserialize)]
- pub struct GetBlocksResponse_archived_blocks_inner {
++pub struct GetBlocksResponse_archived_blocks_inner {
    pub  callback: QueryBlockArchiveFn,
    pub  start: BlockIndex,
    pub  length: candid::Nat,
@@ -26,15 +71,63 @@ index 8b7243de1..f5baada32 100644
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResponse {
-   pub  certificate: Option<Vec<u8>>,
+-  pub  certificate: Option<serde_bytes::ByteBuf>,
++  pub  certificate: Option<Vec<u8>>,
    pub  first_index: BlockIndex,
-@@ -143,14 +143,14 @@ pub struct Transaction {
+   pub  blocks: Vec<Block>,
+   pub  chain_length: u64,
+-  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_item>,
++  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct DataCertificate {
+-  pub  certificate: Option<serde_bytes::ByteBuf>,
+-  pub  hash_tree: serde_bytes::ByteBuf,
+-}
++pub struct DataCertificate { certificate: Option<Vec<u8>>, hash_tree: Vec<u8> }
+ 
+ pub type TxIndex = candid::Nat;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -112,7 +107,7 @@ pub struct GetTransactionsRequest { start: TxIndex, length: candid::Nat }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Transaction_burn_inner {
+   pub  from: Account,
+-  pub  memo: Option<serde_bytes::ByteBuf>,
++  pub  memo: Option<Vec<u8>>,
+   pub  created_at_time: Option<u64>,
+   pub  amount: candid::Nat,
+ }
+@@ -120,7 +115,7 @@ pub struct Transaction_burn_inner {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Transaction_mint_inner {
+   pub  to: Account,
+-  pub  memo: Option<serde_bytes::ByteBuf>,
++  pub  memo: Option<Vec<u8>>,
+   pub  created_at_time: Option<u64>,
+   pub  amount: candid::Nat,
+ }
+@@ -130,7 +125,7 @@ pub struct Transaction_transfer_inner {
+   pub  to: Account,
+   pub  fee: Option<candid::Nat>,
+   pub  from: Account,
+-  pub  memo: Option<serde_bytes::ByteBuf>,
++  pub  memo: Option<Vec<u8>>,
+   pub  created_at_time: Option<u64>,
+   pub  amount: candid::Nat,
+ }
+@@ -147,36 +142,34 @@ pub struct Transaction {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct TransactionRange { transactions: Vec<Transaction> }
  
- pub type QueryArchiveFn = candid::Func;
+-candid::define_function!(pub QueryArchiveFn : (GetTransactionsRequest) -> (
+-    TransactionRange,
+-  ) query);
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetTransactionsResponse_archived_transactions_item {
++pub type QueryArchiveFn = candid::Func;
 +#[derive(CandidType, Deserialize)]
- pub struct GetTransactionsResponse_archived_transactions_inner {
++pub struct GetTransactionsResponse_archived_transactions_inner {
    pub  callback: QueryArchiveFn,
    pub  start: TxIndex,
    pub  length: candid::Nat,
@@ -45,3 +138,93 @@ index 8b7243de1..f5baada32 100644
  pub struct GetTransactionsResponse {
    pub  first_index: TxIndex,
    pub  log_length: candid::Nat,
+   pub  transactions: Vec<Transaction>,
+   pub  archived_transactions: Vec<
+-    GetTransactionsResponse_archived_transactions_item
++    GetTransactionsResponse_archived_transactions_inner
+   >,
+ }
+ 
+ pub type Tokens = candid::Nat;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct icrc1_supported_standards_ret0_item { url: String, name: String }
++pub struct icrc1_supported_standards_ret0_inner { url: String, name: String }
+ 
+ pub type Timestamp = u64;
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct TransferArg {
+   pub  to: Account,
+   pub  fee: Option<Tokens>,
+-  pub  memo: Option<serde_bytes::ByteBuf>,
++  pub  memo: Option<Vec<u8>>,
+   pub  from_subaccount: Option<Subaccount>,
+   pub  created_at_time: Option<Timestamp>,
+   pub  amount: Tokens,
+@@ -197,46 +190,48 @@ pub enum TransferError {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
+ 
+-pub struct SERVICE(pub Principal);
+-impl SERVICE {
+-  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> Result<
++pub struct SERVICE(pub candid::Principal);
++impl SERVICE{
++  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
+     (GetBlocksResponse,)
+   > { ic_cdk::call(self.0, "get_blocks", (arg0,)).await }
+-  pub async fn get_data_certificate(&self) -> Result<(DataCertificate,)> {
++  pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
+     ic_cdk::call(self.0, "get_data_certificate", ()).await
+   }
+-  pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> Result<
+-    (GetTransactionsResponse,)
+-  > { ic_cdk::call(self.0, "get_transactions", (arg0,)).await }
+-  pub async fn icrc1_balance_of(&self, arg0: Account) -> Result<(Tokens,)> {
++  pub async fn get_transactions(
++    &self,
++    arg0: GetTransactionsRequest,
++  ) -> CallResult<(GetTransactionsResponse,)> {
++    ic_cdk::call(self.0, "get_transactions", (arg0,)).await
++  }
++  pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
+     ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
+   }
+-  pub async fn icrc1_decimals(&self) -> Result<(u8,)> {
++  pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
+     ic_cdk::call(self.0, "icrc1_decimals", ()).await
+   }
+-  pub async fn icrc1_fee(&self) -> Result<(Tokens,)> {
++  pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
+     ic_cdk::call(self.0, "icrc1_fee", ()).await
+   }
+-  pub async fn icrc1_metadata(&self) -> Result<
++  pub async fn icrc1_metadata(&self) -> CallResult<
+     (Vec<(String,MetadataValue,)>,)
+   > { ic_cdk::call(self.0, "icrc1_metadata", ()).await }
+-  pub async fn icrc1_minting_account(&self) -> Result<(Option<Account>,)> {
++  pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
+     ic_cdk::call(self.0, "icrc1_minting_account", ()).await
+   }
+-  pub async fn icrc1_name(&self) -> Result<(String,)> {
++  pub async fn icrc1_name(&self) -> CallResult<(String,)> {
+     ic_cdk::call(self.0, "icrc1_name", ()).await
+   }
+-  pub async fn icrc1_supported_standards(&self) -> Result<
+-    (Vec<icrc1_supported_standards_ret0_item>,)
++  pub async fn icrc1_supported_standards(&self) -> CallResult<
++    (Vec<icrc1_supported_standards_ret0_inner>,)
+   > { ic_cdk::call(self.0, "icrc1_supported_standards", ()).await }
+-  pub async fn icrc1_symbol(&self) -> Result<(String,)> {
++  pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
+     ic_cdk::call(self.0, "icrc1_symbol", ()).await
+   }
+-  pub async fn icrc1_total_supply(&self) -> Result<(Tokens,)> {
++  pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
+     ic_cdk::call(self.0, "icrc1_total_supply", ()).await
+   }
+-  pub async fn icrc1_transfer(&self, arg0: TransferArg) -> Result<
++  pub async fn icrc1_transfer(&self, arg0: TransferArg) -> CallResult<
+     (TransferResult,)
+   > { ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await }
+ }
+-

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 8c26d1bf1..fb84e9739 100644
+index 8c26d1bf1..4ee8d9890 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -4,24 +4,24 @@
+@@ -4,12 +4,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -18,15 +18,9 @@ index 8c26d1bf1..fb84e9739 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum MetadataValue {
-   Int(candid::Int),
-   Nat(candid::Nat),
--  Blob(serde_bytes::ByteBuf),
-+  Blob(Vec<u8>),
-   Text(String),
- }
+@@ -21,7 +21,7 @@ pub enum MetadataValue {
  
--pub type Subaccount = serde_bytes::ByteBuf;
-+pub type Subaccount = Vec<u8>;
+ pub type Subaccount = serde_bytes::ByteBuf;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 -pub struct Account { owner: Principal, subaccount: Option<Subaccount> }
 +pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
@@ -42,15 +36,6 @@ index 8c26d1bf1..fb84e9739 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -71,7 +71,7 @@ pub enum Value {
-   Map(Map),
-   Nat(candid::Nat),
-   Nat64(u64),
--  Blob(serde_bytes::ByteBuf),
-+  Blob(Vec<u8>),
-   Text(String),
-   Array(Vec<Box<Value>>),
- }
 @@ -80,30 +80,25 @@ pub type Block = Box<Value>;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct BlockRange { blocks: Vec<Block> }
@@ -71,8 +56,7 @@ index 8c26d1bf1..fb84e9739 100644
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResponse {
--  pub  certificate: Option<serde_bytes::ByteBuf>,
-+  pub  certificate: Option<Vec<u8>>,
+   pub  certificate: Option<serde_bytes::ByteBuf>,
    pub  first_index: BlockIndex,
    pub  blocks: Vec<Block>,
    pub  chain_length: u64,
@@ -85,38 +69,11 @@ index 8c26d1bf1..fb84e9739 100644
 -  pub  certificate: Option<serde_bytes::ByteBuf>,
 -  pub  hash_tree: serde_bytes::ByteBuf,
 -}
-+pub struct DataCertificate { certificate: Option<Vec<u8>>, hash_tree: Vec<u8> }
++pub struct DataCertificate { certificate: Option<serde_bytes::ByteBuf>, hash_tree: serde_bytes::ByteBuf }
  
  pub type TxIndex = candid::Nat;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -112,7 +107,7 @@ pub struct GetTransactionsRequest { start: TxIndex, length: candid::Nat }
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct Transaction_burn_inner {
-   pub  from: Account,
--  pub  memo: Option<serde_bytes::ByteBuf>,
-+  pub  memo: Option<Vec<u8>>,
-   pub  created_at_time: Option<u64>,
-   pub  amount: candid::Nat,
- }
-@@ -120,7 +115,7 @@ pub struct Transaction_burn_inner {
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct Transaction_mint_inner {
-   pub  to: Account,
--  pub  memo: Option<serde_bytes::ByteBuf>,
-+  pub  memo: Option<Vec<u8>>,
-   pub  created_at_time: Option<u64>,
-   pub  amount: candid::Nat,
- }
-@@ -130,7 +125,7 @@ pub struct Transaction_transfer_inner {
-   pub  to: Account,
-   pub  fee: Option<candid::Nat>,
-   pub  from: Account,
--  pub  memo: Option<serde_bytes::ByteBuf>,
-+  pub  memo: Option<Vec<u8>>,
-   pub  created_at_time: Option<u64>,
-   pub  amount: candid::Nat,
- }
-@@ -147,36 +142,34 @@ pub struct Transaction {
+@@ -147,29 +142,27 @@ pub struct Transaction {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct TransactionRange { transactions: Vec<Transaction> }
  
@@ -152,14 +109,6 @@ index 8c26d1bf1..fb84e9739 100644
  
  pub type Timestamp = u64;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct TransferArg {
-   pub  to: Account,
-   pub  fee: Option<Tokens>,
--  pub  memo: Option<serde_bytes::ByteBuf>,
-+  pub  memo: Option<Vec<u8>>,
-   pub  from_subaccount: Option<Subaccount>,
-   pub  created_at_time: Option<Timestamp>,
-   pub  amount: Tokens,
 @@ -197,46 +190,48 @@ pub enum TransferError {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -15,11 +15,11 @@ use ic_cdk::api::call::CallResult;
 pub enum MetadataValue {
   Int(candid::Int),
   Nat(candid::Nat),
-  Blob(Vec<u8>),
+  Blob(serde_bytes::ByteBuf),
   Text(String),
 }
 
-pub type Subaccount = Vec<u8>;
+pub type Subaccount = serde_bytes::ByteBuf;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
 
@@ -71,7 +71,7 @@ pub enum Value {
   Map(Map),
   Nat(candid::Nat),
   Nat64(u64),
-  Blob(Vec<u8>),
+  Blob(serde_bytes::ByteBuf),
   Text(String),
   Array(Vec<Box<Value>>),
 }
@@ -90,7 +90,7 @@ pub struct GetBlocksResponse_archived_blocks_inner {
 
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
-  pub  certificate: Option<Vec<u8>>,
+  pub  certificate: Option<serde_bytes::ByteBuf>,
   pub  first_index: BlockIndex,
   pub  blocks: Vec<Block>,
   pub  chain_length: u64,
@@ -98,7 +98,7 @@ pub struct GetBlocksResponse {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DataCertificate { certificate: Option<Vec<u8>>, hash_tree: Vec<u8> }
+pub struct DataCertificate { certificate: Option<serde_bytes::ByteBuf>, hash_tree: serde_bytes::ByteBuf }
 
 pub type TxIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -107,7 +107,7 @@ pub struct GetTransactionsRequest { start: TxIndex, length: candid::Nat }
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction_burn_inner {
   pub  from: Account,
-  pub  memo: Option<Vec<u8>>,
+  pub  memo: Option<serde_bytes::ByteBuf>,
   pub  created_at_time: Option<u64>,
   pub  amount: candid::Nat,
 }
@@ -115,7 +115,7 @@ pub struct Transaction_burn_inner {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction_mint_inner {
   pub  to: Account,
-  pub  memo: Option<Vec<u8>>,
+  pub  memo: Option<serde_bytes::ByteBuf>,
   pub  created_at_time: Option<u64>,
   pub  amount: candid::Nat,
 }
@@ -125,7 +125,7 @@ pub struct Transaction_transfer_inner {
   pub  to: Account,
   pub  fee: Option<candid::Nat>,
   pub  from: Account,
-  pub  memo: Option<Vec<u8>>,
+  pub  memo: Option<serde_bytes::ByteBuf>,
   pub  created_at_time: Option<u64>,
   pub  amount: candid::Nat,
 }
@@ -169,7 +169,7 @@ pub type Timestamp = u64;
 pub struct TransferArg {
   pub  to: Account,
   pub  fee: Option<Tokens>,
-  pub  memo: Option<Vec<u8>>,
+  pub  memo: Option<serde_bytes::ByteBuf>,
   pub  from_subaccount: Option<Subaccount>,
   pub  created_at_time: Option<Timestamp>,
   pub  amount: Tokens,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -8,7 +8,7 @@ use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -190,7 +190,7 @@ pub enum TransferError {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
 
-pub struct SERVICE(candid::Principal);
+pub struct SERVICE(pub candid::Principal);
 impl SERVICE{
   pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
     (GetBlocksResponse,)

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 66c2d6742..b1f6d7027 100644
+index 66c2d6742..eb29aeae2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -4,41 +4,41 @@
+@@ -4,37 +4,37 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -52,11 +52,6 @@ index 66c2d6742..b1f6d7027 100644
    pub  status: CanisterStatusType,
    pub  memory_size: candid::Nat,
    pub  settings: DefiniteCanisterSettings,
--  pub  module_hash: Option<serde_bytes::ByteBuf>,
-+  pub  module_hash: Option<Vec<u8>>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 @@ -47,7 +47,7 @@ pub struct GetSnsCanistersSummaryRequest { update_canister_list: Option<bool> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct DefiniteCanisterSettingsArgs {
@@ -66,14 +61,7 @@ index 66c2d6742..b1f6d7027 100644
    pub  memory_allocation: candid::Nat,
    pub  compute_allocation: candid::Nat,
  }
-@@ -59,13 +59,13 @@ pub struct CanisterStatusResultV2 {
-   pub  cycles: candid::Nat,
-   pub  settings: DefiniteCanisterSettingsArgs,
-   pub  idle_cycles_burned_per_day: candid::Nat,
--  pub  module_hash: Option<serde_bytes::ByteBuf>,
-+  pub  module_hash: Option<Vec<u8>>,
- }
- 
+@@ -65,7 +65,7 @@ pub struct CanisterStatusResultV2 {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct CanisterSummary {
    pub  status: Option<CanisterStatusResultV2>,

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index e429d5ccc..7afe0c605 100644
+index 66c2d6742..b1f6d7027 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -4,7 +4,7 @@
+@@ -4,41 +4,41 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -11,12 +11,179 @@ index e429d5ccc..7afe0c605 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -82,7 +82,7 @@ pub struct GetSnsCanistersSummaryResponse {
+-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, Principal};
+-// use ic_cdk::api::call::CallResult as Result;
++// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
++// use ic_cdk::api::call::CallResult;
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SnsRootCanister {
+-  pub  dapp_canister_ids: Vec<Principal>,
++  pub  dapp_canister_ids: Vec<candid::Principal>,
+   pub  testflight: bool,
+   pub  latest_ledger_archive_poll_timestamp_seconds: Option<u64>,
+-  pub  archive_canister_ids: Vec<Principal>,
+-  pub  governance_canister_id: Option<Principal>,
+-  pub  index_canister_id: Option<Principal>,
+-  pub  swap_canister_id: Option<Principal>,
+-  pub  ledger_canister_id: Option<Principal>,
++  pub  archive_canister_ids: Vec<candid::Principal>,
++  pub  governance_canister_id: Option<candid::Principal>,
++  pub  index_canister_id: Option<candid::Principal>,
++  pub  swap_canister_id: Option<candid::Principal>,
++  pub  ledger_canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct CanisterIdRecord { canister_id: Principal }
++pub struct CanisterIdRecord { canister_id: candid::Principal }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub enum CanisterStatusType { stopped, stopping, running }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct DefiniteCanisterSettings { controllers: Vec<Principal> }
++pub struct DefiniteCanisterSettings { controllers: Vec<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct CanisterStatusResult {
+-  pub  controller: Principal,
++  pub  controller: candid::Principal,
+   pub  status: CanisterStatusType,
+   pub  memory_size: candid::Nat,
+   pub  settings: DefiniteCanisterSettings,
+-  pub  module_hash: Option<serde_bytes::ByteBuf>,
++  pub  module_hash: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -47,7 +47,7 @@ pub struct GetSnsCanistersSummaryRequest { update_canister_list: Option<bool> }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DefiniteCanisterSettingsArgs {
+   pub  freezing_threshold: candid::Nat,
+-  pub  controllers: Vec<Principal>,
++  pub  controllers: Vec<candid::Principal>,
+   pub  memory_allocation: candid::Nat,
+   pub  compute_allocation: candid::Nat,
+ }
+@@ -59,13 +59,13 @@ pub struct CanisterStatusResultV2 {
+   pub  cycles: candid::Nat,
+   pub  settings: DefiniteCanisterSettingsArgs,
+   pub  idle_cycles_burned_per_day: candid::Nat,
+-  pub  module_hash: Option<serde_bytes::ByteBuf>,
++  pub  module_hash: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct CanisterSummary {
+   pub  status: Option<CanisterStatusResultV2>,
+-  pub  canister_id: Option<Principal>,
++  pub  canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -82,25 +82,25 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_sns_canisters_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct ListSnsCanistersResponse {
-   pub  root: Option<candid::Principal>,
-   pub  swap: Option<candid::Principal>,
+-  pub  root: Option<Principal>,
+-  pub  swap: Option<Principal>,
+-  pub  ledger: Option<Principal>,
+-  pub  index: Option<Principal>,
+-  pub  governance: Option<Principal>,
+-  pub  dapps: Vec<Principal>,
+-  pub  archives: Vec<Principal>,
++  pub  root: Option<candid::Principal>,
++  pub  swap: Option<candid::Principal>,
++  pub  ledger: Option<candid::Principal>,
++  pub  index: Option<candid::Principal>,
++  pub  governance: Option<candid::Principal>,
++  pub  dapps: Vec<candid::Principal>,
++  pub  archives: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct RegisterDappCanisterRequest { canister_id: Option<Principal> }
++pub struct RegisterDappCanisterRequest { canister_id: Option<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct register_dapp_canister_ret0 {}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct RegisterDappCanistersRequest { canister_ids: Vec<Principal> }
++pub struct RegisterDappCanistersRequest { canister_ids: Vec<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct register_dapp_canisters_ret0 {}
+@@ -108,7 +108,7 @@ pub struct register_dapp_canisters_ret0 {}
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SetDappControllersRequest {
+   pub  canister_ids: Option<RegisterDappCanistersRequest>,
+-  pub  controller_principal_ids: Vec<Principal>,
++  pub  controller_principal_ids: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -117,49 +117,48 @@ pub struct CanisterCallError { code: Option<i32>, description: String }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct FailedUpdate {
+   pub  err: Option<CanisterCallError>,
+-  pub  dapp_canister_id: Option<Principal>,
++  pub  dapp_canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SetDappControllersResponse { failed_updates: Vec<FailedUpdate> }
+ 
+-pub struct SERVICE(pub Principal);
+-impl SERVICE {
+-  pub async fn canister_status(&self, arg0: CanisterIdRecord) -> Result<
++pub struct SERVICE(pub candid::Principal);
++impl SERVICE{
++  pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
+     (CanisterStatusResult,)
+   > { ic_cdk::call(self.0, "canister_status", (arg0,)).await }
+-  pub async fn get_build_metadata(&self) -> Result<(String,)> {
++  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
+     ic_cdk::call(self.0, "get_build_metadata", ()).await
+   }
+   pub async fn get_sns_canisters_summary(
+     &self,
+     arg0: GetSnsCanistersSummaryRequest,
+-  ) -> Result<(GetSnsCanistersSummaryResponse,)> {
++  ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
+     ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
+   }
+   pub async fn list_sns_canisters(
+     &self,
+     arg0: list_sns_canisters_arg0,
+-  ) -> Result<(ListSnsCanistersResponse,)> {
++  ) -> CallResult<(ListSnsCanistersResponse,)> {
+     ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
+   }
+   pub async fn register_dapp_canister(
+     &self,
+     arg0: RegisterDappCanisterRequest,
+-  ) -> Result<(register_dapp_canister_ret0,)> {
++  ) -> CallResult<(register_dapp_canister_ret0,)> {
+     ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
+   }
+   pub async fn register_dapp_canisters(
+     &self,
+     arg0: RegisterDappCanistersRequest,
+-  ) -> Result<(register_dapp_canisters_ret0,)> {
++  ) -> CallResult<(register_dapp_canisters_ret0,)> {
+     ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
+   }
+   pub async fn set_dapp_controllers(
+     &self,
+     arg0: SetDappControllersRequest,
+-  ) -> Result<(SetDappControllersResponse,)> {
++  ) -> CallResult<(SetDappControllersResponse,)> {
+     ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
+   }
+ }
+-

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -8,7 +8,7 @@ use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -123,7 +123,7 @@ pub struct FailedUpdate {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDappControllersResponse { failed_updates: Vec<FailedUpdate> }
 
-pub struct SERVICE(candid::Principal);
+pub struct SERVICE(pub candid::Principal);
 impl SERVICE{
   pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
     (CanisterStatusResult,)

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -38,7 +38,7 @@ pub struct CanisterStatusResult {
   pub  status: CanisterStatusType,
   pub  memory_size: candid::Nat,
   pub  settings: DefiniteCanisterSettings,
-  pub  module_hash: Option<Vec<u8>>,
+  pub  module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -59,7 +59,7 @@ pub struct CanisterStatusResultV2 {
   pub  cycles: candid::Nat,
   pub  settings: DefiniteCanisterSettingsArgs,
   pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<Vec<u8>>,
+  pub  module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 79a9b463e..fd282f942 100644
+index 79a9b463e..b373161c8 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -4,17 +4,17 @@
@@ -61,7 +61,7 @@ index 79a9b463e..fd282f942 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct TransferableAmount {
-@@ -138,24 +138,24 @@ pub enum CanisterStatusType { stopped, stopping, running }
+@@ -138,16 +138,16 @@ pub enum CanisterStatusType { stopped, stopping, running }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct DefiniteCanisterSettingsArgs {
@@ -80,28 +80,16 @@ index 79a9b463e..fd282f942 100644
 +  pub  controller: candid::Principal,
    pub  status: CanisterStatusType,
    pub  freezing_threshold: candid::Nat,
--  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
-+  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
-   pub  memory_size: candid::Nat,
-   pub  cycles: candid::Nat,
-   pub  settings: DefiniteCanisterSettingsArgs,
-   pub  idle_cycles_burned_per_day: candid::Nat,
--  pub  module_hash: Option<serde_bytes::ByteBuf>,
-+  pub  module_hash: Option<Vec<u8>>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -190,8 +190,8 @@ pub struct get_open_ticket_arg0 {}
+   pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
+@@ -190,7 +190,7 @@ pub struct get_open_ticket_arg0 {}
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct Icrc1Account {
 -  pub  owner: Option<Principal>,
--  pub  subaccount: Option<serde_bytes::ByteBuf>,
 +  pub  owner: Option<candid::Principal>,
-+  pub  subaccount: Option<Vec<u8>>,
+   pub  subaccount: Option<serde_bytes::ByteBuf>,
  }
  
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 @@ -217,13 +217,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_sale_parameters_arg0 {}
@@ -118,24 +106,6 @@ index 79a9b463e..fd282f942 100644
  pub struct Params {
    pub  min_participant_icp_e8s: u64,
    pub  neuron_basket_construction_parameters: Option<
-@@ -245,7 +245,7 @@ pub struct GetSaleParametersResponse { params: Option<Params> }
- pub struct get_state_arg0 {}
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct NeuronId { id: serde_bytes::ByteBuf }
-+pub struct NeuronId { id: Vec<u8> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct NeuronAttributes {
-@@ -287,7 +287,7 @@ pub struct Swap {
-   pub  init: Option<Init>,
-   pub  purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
-   pub  lifecycle: i32,
--  pub  purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
-+  pub  purge_old_tickets_next_principal: Option<Vec<u8>>,
-   pub  buyers: Vec<(String,BuyerState,)>,
-   pub  params: Option<Params>,
-   pub  open_sns_token_swap_proposal_id: Option<u64>,
 @@ -302,11 +302,8 @@ pub struct DerivedState {
    pub  cf_neuron_count: Option<u64>,
  }
@@ -188,7 +158,7 @@ index 79a9b463e..fd282f942 100644
 -  pub  subaccount: Option<serde_bytes::ByteBuf>,
 -  pub  amount_icp_e8s: u64,
 -}
-+pub struct NewSaleTicketRequest { subaccount: Option<Vec<u8>>, amount_icp_e8s: u64 }
++pub struct NewSaleTicketRequest { subaccount: Option<serde_bytes::ByteBuf>, amount_icp_e8s: u64 }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct InvalidUserAmount {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index a8b595640..0bb086fa1 100644
+index 79a9b463e..fd282f942 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -4,17 +4,17 @@
@@ -11,8 +11,10 @@ index a8b595640..0bb086fa1 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
- // use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
- // use ic_cdk::api::call::CallResult;
+-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, Principal};
+-// use ic_cdk::api::call::CallResult as Result;
++// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
++// use ic_cdk::api::call::CallResult;
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -23,6 +25,24 @@ index a8b595640..0bb086fa1 100644
  pub struct Init {
    pub  sns_root_canister_id: String,
    pub  fallback_controller_principal_ids: Vec<String>,
+@@ -29,7 +29,7 @@ pub struct Init {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct ErrorRefundIcpRequest { source_principal_id: Option<Principal> }
++pub struct ErrorRefundIcpRequest { source_principal_id: Option<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Ok { block_height: Option<u64> }
+@@ -52,7 +52,7 @@ pub struct CanisterCallError { code: Option<i32>, description: String }
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct FailedUpdate {
+   pub  err: Option<CanisterCallError>,
+-  pub  dapp_canister_id: Option<Principal>,
++  pub  dapp_canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 @@ -79,7 +79,7 @@ pub struct SettleCommunityFundParticipationResult {
  }
  
@@ -32,6 +52,56 @@ index a8b595640..0bb086fa1 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SetModeCallResult { possibility: Option<Possibility_2> }
+@@ -107,7 +107,7 @@ pub struct FinalizeSwapResponse {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetBuyerStateRequest { principal_id: Option<Principal> }
++pub struct GetBuyerStateRequest { principal_id: Option<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct TransferableAmount {
+@@ -138,24 +138,24 @@ pub enum CanisterStatusType { stopped, stopping, running }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DefiniteCanisterSettingsArgs {
+-  pub  controller: Principal,
++  pub  controller: candid::Principal,
+   pub  freezing_threshold: candid::Nat,
+-  pub  controllers: Vec<Principal>,
++  pub  controllers: Vec<candid::Principal>,
+   pub  memory_allocation: candid::Nat,
+   pub  compute_allocation: candid::Nat,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct CanisterStatusResultV2 {
+-  pub  controller: Principal,
++  pub  controller: candid::Principal,
+   pub  status: CanisterStatusType,
+   pub  freezing_threshold: candid::Nat,
+-  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
++  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
+   pub  memory_size: candid::Nat,
+   pub  cycles: candid::Nat,
+   pub  settings: DefiniteCanisterSettingsArgs,
+   pub  idle_cycles_burned_per_day: candid::Nat,
+-  pub  module_hash: Option<serde_bytes::ByteBuf>,
++  pub  module_hash: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -190,8 +190,8 @@ pub struct get_open_ticket_arg0 {}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Icrc1Account {
+-  pub  owner: Option<Principal>,
+-  pub  subaccount: Option<serde_bytes::ByteBuf>,
++  pub  owner: Option<candid::Principal>,
++  pub  subaccount: Option<Vec<u8>>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 @@ -217,13 +217,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_sale_parameters_arg0 {}
@@ -48,14 +118,202 @@ index a8b595640..0bb086fa1 100644
  pub struct Params {
    pub  min_participant_icp_e8s: u64,
    pub  neuron_basket_construction_parameters: Option<
-@@ -302,8 +302,8 @@ pub struct DerivedState {
+@@ -245,7 +245,7 @@ pub struct GetSaleParametersResponse { params: Option<Params> }
+ pub struct get_state_arg0 {}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct NeuronId { id: serde_bytes::ByteBuf }
++pub struct NeuronId { id: Vec<u8> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct NeuronAttributes {
+@@ -287,7 +287,7 @@ pub struct Swap {
+   pub  init: Option<Init>,
+   pub  purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
+   pub  lifecycle: i32,
+-  pub  purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
++  pub  purge_old_tickets_next_principal: Option<Vec<u8>>,
+   pub  buyers: Vec<(String,BuyerState,)>,
+   pub  params: Option<Params>,
+   pub  open_sns_token_swap_proposal_id: Option<u64>,
+@@ -302,11 +302,8 @@ pub struct DerivedState {
    pub  cf_neuron_count: Option<u64>,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct GetStateResponse { swap: Option<Swap>, derived: Option<DerivedState> }
+-pub struct GetStateResponse {
+-  pub  swap: Option<Swap>,
+-  pub  derived: Option<DerivedState>,
+-}
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 +pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ListCommunityFundParticipantsRequest {
+@@ -320,36 +317,25 @@ pub struct ListCommunityFundParticipantsResponse {
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct ListDirectParticipantsRequest {
+-  pub  offset: Option<u32>,
+-  pub  limit: Option<u32>,
+-}
++pub struct ListDirectParticipantsRequest { offset: Option<u32>, limit: Option<u32> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct Participant {
+   pub  participation: Option<BuyerState>,
+-  pub  participant_id: Option<Principal>,
++  pub  participant_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct ListDirectParticipantsResponse { participants: Vec<Participant> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct ListSnsNeuronRecipesRequest {
+-  pub  offset: Option<u64>,
+-  pub  limit: Option<u32>,
+-}
++pub struct ListSnsNeuronRecipesRequest { offset: Option<u64>, limit: Option<u32> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct ListSnsNeuronRecipesResponse {
+-  pub  sns_neuron_recipes: Vec<SnsNeuronRecipe>,
+-}
++pub struct ListSnsNeuronRecipesResponse { sns_neuron_recipes: Vec<SnsNeuronRecipe> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct NewSaleTicketRequest {
+-  pub  subaccount: Option<serde_bytes::ByteBuf>,
+-  pub  amount_icp_e8s: u64,
+-}
++pub struct NewSaleTicketRequest { subaccount: Option<Vec<u8>>, amount_icp_e8s: u64 }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct InvalidUserAmount {
+@@ -398,88 +384,96 @@ pub struct RefreshBuyerTokensResponse {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct restore_dapp_controllers_arg0 {}
+ 
+-pub struct SERVICE(pub Principal);
+-impl SERVICE {
+-  pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> Result<
+-    (ErrorRefundIcpResponse,)
+-  > { ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await }
+-  pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> Result<
++pub struct SERVICE(pub candid::Principal);
++impl SERVICE{
++  pub async fn error_refund_icp(
++    &self,
++    arg0: ErrorRefundIcpRequest,
++  ) -> CallResult<(ErrorRefundIcpResponse,)> {
++    ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
++  }
++  pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<
+     (FinalizeSwapResponse,)
+   > { ic_cdk::call(self.0, "finalize_swap", (arg0,)).await }
+-  pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> Result<
++  pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<
+     (GetBuyerStateResponse,)
+   > { ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await }
+-  pub async fn get_buyers_total(&self, arg0: get_buyers_total_arg0) -> Result<
+-    (GetBuyersTotalResponse,)
+-  > { ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await }
++  pub async fn get_buyers_total(
++    &self,
++    arg0: get_buyers_total_arg0,
++  ) -> CallResult<(GetBuyersTotalResponse,)> {
++    ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
++  }
+   pub async fn get_canister_status(
+     &self,
+     arg0: get_canister_status_arg0,
+-  ) -> Result<(CanisterStatusResultV2,)> {
++  ) -> CallResult<(CanisterStatusResultV2,)> {
+     ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
+   }
+-  pub async fn get_derived_state(&self, arg0: get_derived_state_arg0) -> Result<
+-    (GetDerivedStateResponse,)
+-  > { ic_cdk::call(self.0, "get_derived_state", (arg0,)).await }
+-  pub async fn get_init(&self, arg0: get_init_arg0) -> Result<
++  pub async fn get_derived_state(
++    &self,
++    arg0: get_derived_state_arg0,
++  ) -> CallResult<(GetDerivedStateResponse,)> {
++    ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
++  }
++  pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<
+     (GetInitResponse,)
+   > { ic_cdk::call(self.0, "get_init", (arg0,)).await }
+-  pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> Result<
++  pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> CallResult<
+     (GetLifecycleResponse,)
+   > { ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await }
+-  pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> Result<
++  pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> CallResult<
+     (GetOpenTicketResponse,)
+   > { ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await }
+   pub async fn get_sale_parameters(
+     &self,
+     arg0: get_sale_parameters_arg0,
+-  ) -> Result<(GetSaleParametersResponse,)> {
++  ) -> CallResult<(GetSaleParametersResponse,)> {
+     ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
+   }
+-  pub async fn get_state(&self, arg0: get_state_arg0) -> Result<
++  pub async fn get_state(&self, arg0: get_state_arg0) -> CallResult<
+     (GetStateResponse,)
+   > { ic_cdk::call(self.0, "get_state", (arg0,)).await }
+   pub async fn list_community_fund_participants(
+     &self,
+     arg0: ListCommunityFundParticipantsRequest,
+-  ) -> Result<(ListCommunityFundParticipantsResponse,)> {
++  ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
+     ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
+   }
+   pub async fn list_direct_participants(
+     &self,
+     arg0: ListDirectParticipantsRequest,
+-  ) -> Result<(ListDirectParticipantsResponse,)> {
++  ) -> CallResult<(ListDirectParticipantsResponse,)> {
+     ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
+   }
+   pub async fn list_sns_neuron_recipes(
+     &self,
+     arg0: ListSnsNeuronRecipesRequest,
+-  ) -> Result<(ListSnsNeuronRecipesResponse,)> {
++  ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
+     ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
+   }
+-  pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> Result<
++  pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<
+     (NewSaleTicketResponse,)
+   > { ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await }
+   pub async fn notify_payment_failure(
+     &self,
+     arg0: notify_payment_failure_arg0,
+-  ) -> Result<(Ok_1,)> {
++  ) -> CallResult<(Ok_1,)> {
+     ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
+   }
+-  pub async fn open(&self, arg0: OpenRequest) -> Result<(open_ret0,)> {
++  pub async fn open(&self, arg0: OpenRequest) -> CallResult<(open_ret0,)> {
+     ic_cdk::call(self.0, "open", (arg0,)).await
+   }
+   pub async fn refresh_buyer_tokens(
+     &self,
+     arg0: RefreshBuyerTokensRequest,
+-  ) -> Result<(RefreshBuyerTokensResponse,)> {
++  ) -> CallResult<(RefreshBuyerTokensResponse,)> {
+     ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
+   }
+   pub async fn restore_dapp_controllers(
+     &self,
+     arg0: restore_dapp_controllers_arg0,
+-  ) -> Result<(SetDappControllersCallResult,)> {
++  ) -> CallResult<(SetDappControllersCallResult,)> {
+     ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
+   }
+ }
+-

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -150,12 +150,12 @@ pub struct CanisterStatusResultV2 {
   pub  controller: candid::Principal,
   pub  status: CanisterStatusType,
   pub  freezing_threshold: candid::Nat,
-  pub  balance: Vec<(Vec<u8>,candid::Nat,)>,
+  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
   pub  memory_size: candid::Nat,
   pub  cycles: candid::Nat,
   pub  settings: DefiniteCanisterSettingsArgs,
   pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<Vec<u8>>,
+  pub  module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -191,7 +191,7 @@ pub struct get_open_ticket_arg0 {}
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Icrc1Account {
   pub  owner: Option<candid::Principal>,
-  pub  subaccount: Option<Vec<u8>>,
+  pub  subaccount: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -245,7 +245,7 @@ pub struct GetSaleParametersResponse { params: Option<Params> }
 pub struct get_state_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronId { id: Vec<u8> }
+pub struct NeuronId { id: serde_bytes::ByteBuf }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronAttributes {
@@ -287,7 +287,7 @@ pub struct Swap {
   pub  init: Option<Init>,
   pub  purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
   pub  lifecycle: i32,
-  pub  purge_old_tickets_next_principal: Option<Vec<u8>>,
+  pub  purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
   pub  buyers: Vec<(String,BuyerState,)>,
   pub  params: Option<Params>,
   pub  open_sns_token_swap_proposal_id: Option<u64>,
@@ -335,7 +335,7 @@ pub struct ListSnsNeuronRecipesRequest { offset: Option<u64>, limit: Option<u32>
 pub struct ListSnsNeuronRecipesResponse { sns_neuron_recipes: Vec<SnsNeuronRecipe> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NewSaleTicketRequest { subaccount: Option<Vec<u8>>, amount_icp_e8s: u64 }
+pub struct NewSaleTicketRequest { subaccount: Option<serde_bytes::ByteBuf>, amount_icp_e8s: u64 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InvalidUserAmount {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -8,7 +8,7 @@ use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -384,7 +384,7 @@ pub struct RefreshBuyerTokensResponse {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct restore_dapp_controllers_arg0 {}
 
-pub struct SERVICE(candid::Principal);
+pub struct SERVICE(pub candid::Principal);
 impl SERVICE{
   pub async fn error_refund_icp(
     &self,

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 01542946c..043be43a0 100644
+index 4d2c3f61e..bf7b2ff79 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -4,7 +4,7 @@
+@@ -4,31 +4,31 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -11,16 +11,140 @@ index 01542946c..043be43a0 100644
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
-@@ -173,7 +173,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, Principal};
+-// use ic_cdk::api::call::CallResult as Result;
++// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
++// use ic_cdk::api::call::CallResult;
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SnsWasmCanisterInitPayload {
+-  pub  allowed_principals: Vec<Principal>,
++  pub  allowed_principals: Vec<candid::Principal>,
+   pub  access_controls_enabled: bool,
+-  pub  sns_subnet_ids: Vec<Principal>,
++  pub  sns_subnet_ids: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct SnsWasm { wasm: serde_bytes::ByteBuf, canister_type: i32 }
++pub struct SnsWasm { wasm: Vec<u8>, canister_type: i32 }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct AddWasmRequest { hash: serde_bytes::ByteBuf, wasm: Option<SnsWasm> }
++pub struct AddWasmRequest { hash: Vec<u8>, wasm: Option<SnsWasm> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SnsWasmError { message: String }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub enum Result { Error(SnsWasmError), Hash(serde_bytes::ByteBuf) }
++pub enum Result { Error(SnsWasmError), Hash(Vec<u8>) }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct AddWasmResponse { result: Option<Result> }
+@@ -38,7 +38,7 @@ pub struct TreasuryDistribution { total_e8s: u64 }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct NeuronDistribution {
+-  pub  controller: Option<Principal>,
++  pub  controller: Option<candid::Principal>,
+   pub  dissolve_delay_seconds: u64,
+   pub  memo: u64,
+   pub  stake_e8s: u64,
+@@ -102,16 +102,16 @@ pub struct DeployNewSnsRequest { sns_init_payload: Option<SnsInitPayload> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SnsCanisterIds {
+-  pub  root: Option<Principal>,
+-  pub  swap: Option<Principal>,
+-  pub  ledger: Option<Principal>,
+-  pub  index: Option<Principal>,
+-  pub  governance: Option<Principal>,
++  pub  root: Option<candid::Principal>,
++  pub  swap: Option<candid::Principal>,
++  pub  ledger: Option<candid::Principal>,
++  pub  index: Option<candid::Principal>,
++  pub  governance: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct DeployNewSnsResponse {
+-  pub  subnet_id: Option<Principal>,
++  pub  subnet_id: Option<candid::Principal>,
+   pub  error: Option<SnsWasmError>,
+   pub  canisters: Option<SnsCanisterIds>,
+ }
+@@ -120,21 +120,23 @@ pub struct DeployNewSnsResponse {
+ pub struct get_allowed_principals_arg0 {}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetAllowedPrincipalsResponse { allowed_principals: Vec<Principal> }
++pub struct GetAllowedPrincipalsResponse {
++  pub  allowed_principals: Vec<candid::Principal>,
++}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct SnsVersion {
+-  pub  archive_wasm_hash: serde_bytes::ByteBuf,
+-  pub  root_wasm_hash: serde_bytes::ByteBuf,
+-  pub  swap_wasm_hash: serde_bytes::ByteBuf,
+-  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
+-  pub  governance_wasm_hash: serde_bytes::ByteBuf,
+-  pub  index_wasm_hash: serde_bytes::ByteBuf,
++  pub  archive_wasm_hash: Vec<u8>,
++  pub  root_wasm_hash: Vec<u8>,
++  pub  swap_wasm_hash: Vec<u8>,
++  pub  ledger_wasm_hash: Vec<u8>,
++  pub  governance_wasm_hash: Vec<u8>,
++  pub  index_wasm_hash: Vec<u8>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct GetNextSnsVersionRequest {
+-  pub  governance_canister_id: Option<Principal>,
++  pub  governance_canister_id: Option<candid::Principal>,
+   pub  current_version: Option<SnsVersion>,
+ }
+ 
+@@ -145,10 +147,10 @@ pub struct GetNextSnsVersionResponse { next_version: Option<SnsVersion> }
+ pub struct get_sns_subnet_ids_arg0 {}
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetSnsSubnetIdsResponse { sns_subnet_ids: Vec<Principal> }
++pub struct GetSnsSubnetIdsResponse { sns_subnet_ids: Vec<candid::Principal> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+-pub struct GetWasmRequest { hash: serde_bytes::ByteBuf }
++pub struct GetWasmRequest { hash: Vec<u8> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct GetWasmResponse { wasm: Option<SnsWasm> }
+@@ -162,7 +164,7 @@ pub struct SnsUpgrade {
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct InsertUpgradePathEntriesRequest {
+   pub  upgrade_path: Vec<SnsUpgrade>,
+-  pub  sns_governance_canister_id: Option<Principal>,
++  pub  sns_governance_canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -171,23 +173,23 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct DeployedSns {
-   pub  root_canister_id: Option<candid::Principal>,
-   pub  governance_canister_id: Option<candid::Principal>,
-@@ -183,7 +183,7 @@ pub struct DeployedSns {
+-  pub  root_canister_id: Option<Principal>,
+-  pub  governance_canister_id: Option<Principal>,
+-  pub  index_canister_id: Option<Principal>,
+-  pub  swap_canister_id: Option<Principal>,
+-  pub  ledger_canister_id: Option<Principal>,
++  pub  root_canister_id: Option<candid::Principal>,
++  pub  governance_canister_id: Option<candid::Principal>,
++  pub  index_canister_id: Option<candid::Principal>,
++  pub  swap_canister_id: Option<candid::Principal>,
++  pub  ledger_canister_id: Option<candid::Principal>,
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -29,3 +153,112 @@ index 01542946c..043be43a0 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ListUpgradeStepsRequest {
+   pub  limit: u32,
+   pub  starting_at: Option<SnsVersion>,
+-  pub  sns_governance_canister_id: Option<Principal>,
++  pub  sns_governance_canister_id: Option<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -211,8 +213,8 @@ pub struct ListUpgradeStepsResponse { steps: Vec<ListUpgradeStep> }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct UpdateAllowedPrincipalsRequest {
+-  pub  added_principals: Vec<Principal>,
+-  pub  removed_principals: Vec<Principal>,
++  pub  added_principals: Vec<candid::Principal>,
++  pub  removed_principals: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+@@ -228,74 +230,73 @@ pub struct UpdateAllowedPrincipalsResponse {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct UpdateSnsSubnetListRequest {
+-  pub  sns_subnet_ids_to_add: Vec<Principal>,
+-  pub  sns_subnet_ids_to_remove: Vec<Principal>,
++  pub  sns_subnet_ids_to_add: Vec<candid::Principal>,
++  pub  sns_subnet_ids_to_remove: Vec<candid::Principal>,
+ }
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub struct UpdateSnsSubnetListResponse { error: Option<SnsWasmError> }
+ 
+-pub struct SERVICE(pub Principal);
+-impl SERVICE {
+-  pub async fn add_wasm(&self, arg0: AddWasmRequest) -> Result<
++pub struct SERVICE(pub candid::Principal);
++impl SERVICE{
++  pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
+     (AddWasmResponse,)
+   > { ic_cdk::call(self.0, "add_wasm", (arg0,)).await }
+-  pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> Result<
++  pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<
+     (DeployNewSnsResponse,)
+   > { ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await }
+   pub async fn get_allowed_principals(
+     &self,
+     arg0: get_allowed_principals_arg0,
+-  ) -> Result<(GetAllowedPrincipalsResponse,)> {
++  ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
+     ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+   }
+-  pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> Result<
++  pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<
+     (Vec<(String,String,)>,)
+   > { ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await }
+   pub async fn get_next_sns_version(
+     &self,
+     arg0: GetNextSnsVersionRequest,
+-  ) -> Result<(GetNextSnsVersionResponse,)> {
++  ) -> CallResult<(GetNextSnsVersionResponse,)> {
+     ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
+   }
+   pub async fn get_sns_subnet_ids(
+     &self,
+     arg0: get_sns_subnet_ids_arg0,
+-  ) -> Result<(GetSnsSubnetIdsResponse,)> {
++  ) -> CallResult<(GetSnsSubnetIdsResponse,)> {
+     ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
+   }
+-  pub async fn get_wasm(&self, arg0: GetWasmRequest) -> Result<
++  pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<
+     (GetWasmResponse,)
+   > { ic_cdk::call(self.0, "get_wasm", (arg0,)).await }
+   pub async fn insert_upgrade_path_entries(
+     &self,
+     arg0: InsertUpgradePathEntriesRequest,
+-  ) -> Result<(InsertUpgradePathEntriesResponse,)> {
++  ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
+     ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
+   }
+   pub async fn list_deployed_snses(
+     &self,
+     arg0: list_deployed_snses_arg0,
+-  ) -> Result<(ListDeployedSnsesResponse,)> {
++  ) -> CallResult<(ListDeployedSnsesResponse,)> {
+     ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
+   }
+   pub async fn list_upgrade_steps(
+     &self,
+     arg0: ListUpgradeStepsRequest,
+-  ) -> Result<(ListUpgradeStepsResponse,)> {
++  ) -> CallResult<(ListUpgradeStepsResponse,)> {
+     ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
+   }
+   pub async fn update_allowed_principals(
+     &self,
+     arg0: UpdateAllowedPrincipalsRequest,
+-  ) -> Result<(UpdateAllowedPrincipalsResponse,)> {
++  ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
+     ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
+   }
+   pub async fn update_sns_subnet_list(
+     &self,
+     arg0: UpdateSnsSubnetListRequest,
+-  ) -> Result<(UpdateSnsSubnetListResponse,)> {
++  ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
+     ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
+   }
+ }
+-

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 4d2c3f61e..bf7b2ff79 100644
+index 4d2c3f61e..a8fc475ec 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -4,31 +4,31 @@
+@@ -4,18 +4,18 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -26,22 +26,6 @@ index 4d2c3f61e..bf7b2ff79 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct SnsWasm { wasm: serde_bytes::ByteBuf, canister_type: i32 }
-+pub struct SnsWasm { wasm: Vec<u8>, canister_type: i32 }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct AddWasmRequest { hash: serde_bytes::ByteBuf, wasm: Option<SnsWasm> }
-+pub struct AddWasmRequest { hash: Vec<u8>, wasm: Option<SnsWasm> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SnsWasmError { message: String }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub enum Result { Error(SnsWasmError), Hash(serde_bytes::ByteBuf) }
-+pub enum Result { Error(SnsWasmError), Hash(Vec<u8>) }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct AddWasmResponse { result: Option<Result> }
 @@ -38,7 +38,7 @@ pub struct TreasuryDistribution { total_e8s: u64 }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -74,7 +58,7 @@ index 4d2c3f61e..bf7b2ff79 100644
    pub  error: Option<SnsWasmError>,
    pub  canisters: Option<SnsCanisterIds>,
  }
-@@ -120,21 +120,23 @@ pub struct DeployNewSnsResponse {
+@@ -120,7 +120,9 @@ pub struct DeployNewSnsResponse {
  pub struct get_allowed_principals_arg0 {}
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -85,19 +69,7 @@ index 4d2c3f61e..bf7b2ff79 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SnsVersion {
--  pub  archive_wasm_hash: serde_bytes::ByteBuf,
--  pub  root_wasm_hash: serde_bytes::ByteBuf,
--  pub  swap_wasm_hash: serde_bytes::ByteBuf,
--  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
--  pub  governance_wasm_hash: serde_bytes::ByteBuf,
--  pub  index_wasm_hash: serde_bytes::ByteBuf,
-+  pub  archive_wasm_hash: Vec<u8>,
-+  pub  root_wasm_hash: Vec<u8>,
-+  pub  swap_wasm_hash: Vec<u8>,
-+  pub  ledger_wasm_hash: Vec<u8>,
-+  pub  governance_wasm_hash: Vec<u8>,
-+  pub  index_wasm_hash: Vec<u8>,
- }
+@@ -134,7 +136,7 @@ pub struct SnsVersion {
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GetNextSnsVersionRequest {
@@ -106,7 +78,7 @@ index 4d2c3f61e..bf7b2ff79 100644
    pub  current_version: Option<SnsVersion>,
  }
  
-@@ -145,10 +147,10 @@ pub struct GetNextSnsVersionResponse { next_version: Option<SnsVersion> }
+@@ -145,7 +147,7 @@ pub struct GetNextSnsVersionResponse { next_version: Option<SnsVersion> }
  pub struct get_sns_subnet_ids_arg0 {}
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -114,11 +86,7 @@ index 4d2c3f61e..bf7b2ff79 100644
 +pub struct GetSnsSubnetIdsResponse { sns_subnet_ids: Vec<candid::Principal> }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct GetWasmRequest { hash: serde_bytes::ByteBuf }
-+pub struct GetWasmRequest { hash: Vec<u8> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct GetWasmResponse { wasm: Option<SnsWasm> }
+ pub struct GetWasmRequest { hash: serde_bytes::ByteBuf }
 @@ -162,7 +164,7 @@ pub struct SnsUpgrade {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct InsertUpgradePathEntriesRequest {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -8,7 +8,7 @@ use crate::types::{CandidType, Deserialize, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use ic_cdk::export::candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -237,7 +237,7 @@ pub struct UpdateSnsSubnetListRequest {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateSnsSubnetListResponse { error: Option<SnsWasmError> }
 
-pub struct SERVICE(candid::Principal);
+pub struct SERVICE(pub candid::Principal);
 impl SERVICE{
   pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
     (AddWasmResponse,)

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -19,16 +19,16 @@ pub struct SnsWasmCanisterInitPayload {
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SnsWasm { wasm: Vec<u8>, canister_type: i32 }
+pub struct SnsWasm { wasm: serde_bytes::ByteBuf, canister_type: i32 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct AddWasmRequest { hash: Vec<u8>, wasm: Option<SnsWasm> }
+pub struct AddWasmRequest { hash: serde_bytes::ByteBuf, wasm: Option<SnsWasm> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsWasmError { message: String }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result { Error(SnsWasmError), Hash(Vec<u8>) }
+pub enum Result { Error(SnsWasmError), Hash(serde_bytes::ByteBuf) }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct AddWasmResponse { result: Option<Result> }
@@ -126,12 +126,12 @@ pub struct GetAllowedPrincipalsResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsVersion {
-  pub  archive_wasm_hash: Vec<u8>,
-  pub  root_wasm_hash: Vec<u8>,
-  pub  swap_wasm_hash: Vec<u8>,
-  pub  ledger_wasm_hash: Vec<u8>,
-  pub  governance_wasm_hash: Vec<u8>,
-  pub  index_wasm_hash: Vec<u8>,
+  pub  archive_wasm_hash: serde_bytes::ByteBuf,
+  pub  root_wasm_hash: serde_bytes::ByteBuf,
+  pub  swap_wasm_hash: serde_bytes::ByteBuf,
+  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
+  pub  governance_wasm_hash: serde_bytes::ByteBuf,
+  pub  index_wasm_hash: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -150,7 +150,7 @@ pub struct get_sns_subnet_ids_arg0 {}
 pub struct GetSnsSubnetIdsResponse { sns_subnet_ids: Vec<candid::Principal> }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetWasmRequest { hash: Vec<u8> }
+pub struct GetWasmRequest { hash: serde_bytes::ByteBuf }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetWasmResponse { wasm: Option<SnsWasm> }


### PR DESCRIPTION
# Motivation
We are using an old `didc`.

# Changes
* Update didc version
* Make the dockerfile cache the didc installation only if it succeeds
* Adopt the following changes that come with the new didc:
  * More fields are pub - good.
  * Some generated comments have changed.
  * `Vec<u8>` is now represented as `BufBytes`.

# Tests
-Deploy to app subnet and compare with prod.
  - Ideally needs: https://github.com/dfinity/nns-dapp/pull/2711
  - Deployed manually  Compare one of the SNSs:
    - `diff <(curl https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io/v1/sns/root/67bll-riaaa-aaaaq-aaauq-cai/slow.json) <(curl https://3r4gx-wqaaa-aaaaq-aaaia-cai.ic0.app/v1/sns/root/67bll-riaaa-aaaaq-aaauq-cai/slow.json)`
    - Comparing all: `<(curl https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io/v1/sns/list/latest/slow.json | jq .) <(curl https://3r4gx-wqaaa-aaaaq-aaaia-cai.ic0.app/v1/sns/list/latest/slow.json | jq .)`