### PR TITLE
Use arm64 instead of arm in the yq install URL

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -134,7 +134,7 @@ YQ_VERSION="4.33.1"
 install_yq_darwin() {
   echo "Installing yq..."
   tempfile="$(mktemp ,yq-XXXXXXXX)"
-  curl -Lf "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_${ARCH}" >"$tempfile"
+  curl -Lf "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_${ARCH/arm/arm64}" >"$tempfile"
   install -m 755 "$tempfile" "$USER_BIN/yq"
   rm "$tempfile"
 }


### PR DESCRIPTION
# Motivation

`scripts/setup` uses a URL to install `yq` that gives 404.
The correct URL uses `arm64` for the architecture instead of `arm`

# Changes

When constructing the URL to download `yq`, replace `arm` with `arm64`.

# Tests

Tested manually on an M1 Mac.