### PR TITLE
Move AdditionalInfoReviewPo to ParticipateSwapModalPo

### DIFF
--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -138,7 +138,7 @@ describe("ParticipateSwapModal", () => {
       const review = po.getTransactionReviewPo();
       expect(await review.isSendButtonEnabled()).toBe(false);
 
-      await review.clickCheckbox();
+      await po.getAdditionalInfoReviewPo().clickCheckbox();
       expect(await review.isSendButtonEnabled()).toBe(true);
 
       await sendAndExpectParticipation(review);
@@ -206,7 +206,7 @@ describe("ParticipateSwapModal", () => {
       const review = po.getTransactionReviewPo();
       expect(await review.isSendButtonEnabled()).toBe(false);
 
-      await review.clickCheckbox();
+      await po.getAdditionalInfoReviewPo().clickCheckbox();
       expect(await review.isSendButtonEnabled()).toBe(true);
 
       await sendAndExpectParticipation(review);
@@ -229,7 +229,7 @@ describe("ParticipateSwapModal", () => {
         const review = po.getTransactionReviewPo();
         expect(await review.isSendButtonEnabled()).toBe(false);
 
-        await review.clickCheckbox();
+        await po.getAdditionalInfoReviewPo().clickCheckbox();
         expect(await review.isSendButtonEnabled()).toBe(true);
 
         await sendAndExpectParticipation(review);
@@ -247,7 +247,7 @@ describe("ParticipateSwapModal", () => {
         const review = po.getTransactionReviewPo();
         expect(await review.isSendButtonEnabled()).toBe(false);
 
-        await review.clickCheckbox();
+        await po.getAdditionalInfoReviewPo().clickCheckbox();
         expect(await review.isSendButtonEnabled()).toBe(true);
 
         await sendAndExpectParticipation(review);

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -1,4 +1,5 @@
 import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.page-object";
+import { AdditionalInfoReviewPo } from "$tests/page-objects/AdditionalInfoReview.page-object";
 import { InProgressPo } from "$tests/page-objects/InProgress.page-object";
 import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -16,6 +17,10 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
     return AdditionalInfoFormPo.under(this.root);
   }
 
+  getAdditionalInfoReviewPo(): AdditionalInfoReviewPo {
+    return AdditionalInfoReviewPo.under(this.root);
+  }
+
   getInProgressPo(): InProgressPo {
     return InProgressPo.under(this.root);
   }
@@ -28,8 +33,7 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
     const formPo = this.getTransactionFormPo();
     await formPo.enterAmount(amount);
     await formPo.clickContinue();
-    const review = this.getTransactionReviewPo();
-    await review.clickCheckbox();
-    await review.clickSend();
+    await this.getAdditionalInfoReviewPo().clickCheckbox();
+    await this.getTransactionReviewPo().clickSend();
   }
 }

--- a/frontend/src/tests/page-objects/TransactionReview.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionReview.page-object.ts
@@ -1,4 +1,3 @@
-import { AdditionalInfoReviewPo } from "$tests/page-objects/AdditionalInfoReview.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -8,10 +7,6 @@ export class TransactionReviewPo extends BasePageObject {
 
   static under(element: PageObjectElement): TransactionReviewPo {
     return new TransactionReviewPo(element.byTestId(TransactionReviewPo.TID));
-  }
-
-  getAdditionalInfoReviewPo(): AdditionalInfoReviewPo {
-    return AdditionalInfoReviewPo.under(this.root);
   }
 
   getSendButtonPo(): ButtonPo {
@@ -36,9 +31,5 @@ export class TransactionReviewPo extends BasePageObject {
 
   clickSend(): Promise<void> {
     return this.getSendButtonPo().click();
-  }
-
-  clickCheckbox(): Promise<void> {
-    return this.getAdditionalInfoReviewPo().clickCheckbox();
   }
 }


### PR DESCRIPTION
# Motivation

The `AdditionalInfoReview` component is specific to the `ParticipateSwapModal` component and the `TransactionReview` component is more generic.
But the `AdditionalInfoReviewPo` getter is currently defined inside `TransactionReviewPo`

# Changes

Move `getAdditionalInfoReviewPo` from `frontend/src/tests/page-objects/TransactionReview.page-object.ts` to `frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts`.

# Tests

Existing tests still pass.
