### PR TITLE
Fix e2e tsconfig exclude

### DIFF
--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -1,5 +1,5 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
-import { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
+import type { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";

--- a/frontend/src/tests/e2e/tsconfig.json
+++ b/frontend/src/tests/e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "exclude": []
+}


### PR DESCRIPTION
# Motivation

`tsconfig.spec.json` exclude `e2e` tests which lead to editor not understand `paths`.

# Changes

- extend tsconfig for e2e and reset exclusion of `e2e` path
- add requested `type` (detected once `tsconfig` properly applied)

# Screenshot

<img width="1470" alt="Capture d’écran 2023-05-24 à 13 52 13" src="https://github.com/dfinity/nns-dapp/assets/16886711/855db195-2fdd-48de-bda9-38925005e07a">
