### PR TITLE
Clean up ParticipateSwapModal.spec.ts

### DIFF
--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -194,7 +194,7 @@ describe("ParticipateSwapModal", () => {
       expect(await form.isContinueButtonEnabled()).toBe(true);
     });
 
-    describe("when user has participated", () => {
+    describe("when user has existing swap commitment", () => {
       it("should move to the last step, enable button when accepting terms and call participate in swap service", async () => {
         const po = await renderEnter10ICPAndNext(
           mockSnsFullProject.swapCommitment

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -29,7 +29,8 @@ import {
 import { renderModalContextWrapper } from "$tests/mocks/modal.mock";
 import {
   createSummary,
-  mockSnsFullProject,
+  mockSwapCommitment,
+  createBuyersState,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
@@ -194,10 +195,13 @@ describe("ParticipateSwapModal", () => {
       expect(await form.isContinueButtonEnabled()).toBe(true);
     });
 
-    describe("when user has existing swap commitment", () => {
+    describe("when user has non-zero swap commitment", () => {
       it("should move to the last step, enable button when accepting terms and call participate in swap service", async () => {
         const po = await renderEnter10ICPAndNext(
-          mockSnsFullProject.swapCommitment
+          {
+            ...mockSwapCommitment,
+            myCommitment: createBuyersState(BigInt(25 * 100000000)),
+          }
         );
 
         const review = po.getTransactionReviewPo();

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -28,9 +28,9 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import { renderModalContextWrapper } from "$tests/mocks/modal.mock";
 import {
+  createBuyersState,
   createSummary,
   mockSwapCommitment,
-  createBuyersState,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
@@ -197,12 +197,10 @@ describe("ParticipateSwapModal", () => {
 
     describe("when user has non-zero swap commitment", () => {
       it("should move to the last step, enable button when accepting terms and call participate in swap service", async () => {
-        const po = await renderEnter10ICPAndNext(
-          {
-            ...mockSwapCommitment,
-            myCommitment: createBuyersState(BigInt(25 * 100000000)),
-          }
-        );
+        const po = await renderEnter10ICPAndNext({
+          ...mockSwapCommitment,
+          myCommitment: createBuyersState(BigInt(25 * 100000000)),
+        });
 
         const review = po.getTransactionReviewPo();
         expect(await review.isSendButtonEnabled()).toBe(false);


### PR DESCRIPTION
# Motivation

`ParticipateSwapModal.spec.ts` has some redundant test and some tests that don't appear to make sense anymore.

I was very confused trying to figure this out so please review carefully.

# Changes

1. Remove redundant test. See review comments.
2. Change "when user has participated" to "when user has existing swap commitment" for clarity.
3. Move cleanup to the top level `beforeEach`.
4. Resolve the `queryAccounts` results explicitly to make the test that the accounts dropdown is absent until accounts are loaded less brittle.
5. In the test "loads accounts with query only", actually verify that the corresponding update calls aren't made.

# Tests

Verified that if update calls are made, the "query only" test does indeed fail.
