### PR TITLE
feat: display a warning after sign-in for testing in mainnet

### DIFF
--- a/frontend/src/lib/components/warnings/DemoWarning.svelte
+++ b/frontend/src/lib/components/warnings/DemoWarning.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { IconWarning, Modal } from "@dfinity/gix-components";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+
+  let visible = false;
+  $: visible = $authSignedInStore && !acknowledged;
+
+  let acknowledged = false;
+
+  const close = () => (acknowledged = true);
+</script>
+
+<Modal bind:visible role="alert" on:nnsClose={close}>
+  <div class="title" slot="title"><IconWarning /> Warning</div>
+
+  <p>Welcome to the Testing Environment.</p>
+
+  <p>
+    Please note that you are currently using a <strong>test</strong> version of
+    NNS-dapp that operates on the Internet Computer <strong>mainnet</strong>.
+    Although it utilizes real data, it is intended solely for testing purposes.
+  </p>
+
+  <p>
+    We kindly remind you that the functionality and availability of this testing
+    dapp may change or even disappear at any time. Therefore, it is crucial to
+    refrain from relying on it for any production or critical activities.
+  </p>
+
+  <div class="custom-toolbar">
+    <button class="primary" on:click={close}
+      >I understand and want to continue</button
+    >
+  </div>
+</Modal>
+
+<style lang="scss">
+  .title {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--padding);
+  }
+
+  .custom-toolbar {
+    display: flex;
+    justify-content: center;
+    padding: var(--padding-2x) 0 var(--padding);
+  }
+</style>

--- a/frontend/src/lib/components/warnings/Warnings.svelte
+++ b/frontend/src/lib/components/warnings/Warnings.svelte
@@ -4,9 +4,11 @@
   import Metrics from "$lib/components/metrics/Metrics.svelte";
   import { Toasts } from "@dfinity/gix-components";
   import ConvertCkBTCToBtcWarning from "$lib/components/warnings/ConvertCkBTCToBtcWarning.svelte";
+  import DemoWarning from "$lib/components/warnings/DemoWarning.svelte";
 
   export let bringToastsForward = false;
   export let ckBTCWarnings = false;
+  export let demoWarning = false;
 </script>
 
 {#if ENABLE_METRICS}
@@ -21,6 +23,10 @@
 
 {#if ckBTCWarnings}
   <ConvertCkBTCToBtcWarning />
+{/if}
+
+{#if demoWarning}
+  <DemoWarning />
 {/if}
 
 <style lang="scss">

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -22,7 +22,7 @@
 
 <slot />
 
-<Warnings ckBTCWarnings />
+<Warnings ckBTCWarnings demoWarning  />
 
 <Toasts />
 <BusyScreen />


### PR DESCRIPTION
# Motivation

We aim to deploy on mainnet a version of NNS-dapp that is only meant for testing purpose. That's why we want to display a warning after sign-in.

# Changes

- new warning component that renders a modal after sign-in for the app pages (not login page)

# Screenshot
<img width="1536" alt="Capture d’écran 2023-05-24 à 15 16 24" src="https://github
<img width="1536" alt="Capture d’écran 2023-05-24 à 15 16 37" src="https://github.com/dfinity/nns-dapp/assets/16886711/b06f3ab4-60f2-4f9d-89ca-17e876e4e0f6">
.com/dfinity/nns-dapp/assets/16886711/521c279b-788c-4777-82e3-3ca638621908">


