### PR TITLE
Split and sort filename and hash in test script

### DIFF
--- a/frontend/scripts/test-reproducibility
+++ b/frontend/scripts/test-reproducibility
@@ -12,6 +12,9 @@ fi
 for ((n = 0; n < 100; n++)); do
   npm run build && find public -type f -exec sha256sum {} \; | awk '{print $2 " " $1}' | sort >"$DIR/sha256-batch${n}.txt"
 
+  # Save results for manual comparison
+  cp -r public "$DIR/public-batch${n}"
+
   if ((n > 0)); then
     previous=$((n - 1))
     file1="sha256-batch${n}.txt"

--- a/frontend/scripts/test-reproducibility
+++ b/frontend/scripts/test-reproducibility
@@ -13,7 +13,8 @@ for ((n = 0; n < 100; n++)); do
   npm run build && find public -type f -exec sha256sum {} \; | awk '{print $2 " " $1}' | sort >"$DIR/sha256-batch${n}.txt"
 
   # Save results for manual comparison
-  cp -r public "$DIR/public-batch${n}"
+  rm -r "$DIR/public-batch${n}" 2>/dev/null
+  mv public "$DIR/public-batch${n}"
 
   if ((n > 0)); then
     previous=$((n - 1))

--- a/frontend/scripts/test-reproducibility
+++ b/frontend/scripts/test-reproducibility
@@ -10,7 +10,7 @@ if [ ! -d "$DIR" ]; then
 fi
 
 for ((n = 0; n < 100; n++)); do
-  npm run build && find public -type f -exec sha256sum {} \; >"$DIR/sha256-batch${n}.txt"
+  npm run build && find public -type f -exec sha256sum {} \; | awk '{print $2 " " $1}' | sort >"$DIR/sha256-batch${n}.txt"
 
   if ((n > 0)); then
     previous=$((n - 1))


### PR DESCRIPTION
# Motivation

In `test-reproducibility` script, print filename first and sort entries. Makes easier to compare diffs.

Also save results for manual comparison.
