### PR TITLE
Feat: Support SNS pagination

### DIFF
--- a/frontend/src/lib/constants/sns.constants.ts
+++ b/frontend/src/lib/constants/sns.constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_SNS_LOGO = "/assets/sns-logo-default.svg";
 export const AGGREGATOR_CANISTER_VERSION = "v1";
-export const AGGREGATOR_CANISTER_PATH = "/sns/list/page/0/slow.json";
+export const AGGREGATOR_PAGE_SIZE = 10;
 export const SALE_PARTICIPATION_RETRY_SECONDS = 2;
 export const WATCH_SALE_STATE_EVERY_MILLISECONDS = 10_000;

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -7,12 +7,13 @@ describe("sns-aggregator api", () => {
     afterEach(() => {
       jest.resetAllMocks();
     });
-    it("should fetch json", async () => {
+    it("should fetch json once if less than 10 SNSes", async () => {
       const mockFetch = jest.fn();
+      const [_first, ...rest] = aggregatedSnses;
       mockFetch.mockReturnValueOnce(
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve(aggregatedSnses),
+          json: () => Promise.resolve(rest),
         })
       );
       global.fetch = mockFetch;
@@ -20,14 +21,42 @@ describe("sns-aggregator api", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
       );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should fetch next page if there are 10 SNSes", async () => {
+      const mockFetch = jest.fn();
+      mockFetch
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(aggregatedSnses),
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([aggregatedSnses[0]]),
+          })
+        );
+      global.fetch = mockFetch;
+      await querySnsProjects();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/1/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("should convert response", async () => {
       const mockFetch = jest.fn();
-      mockFetch.mockReturnValueOnce(
+      const [first, ..._rest] = aggregatedSnses;
+      mockFetch.mockReturnValue(
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve(aggregatedSnses),
+          json: () => Promise.resolve([first]),
         })
       );
       global.fetch = mockFetch;

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -1,6 +1,6 @@
 import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
-import aggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
+import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 
 describe("sns-aggregator api", () => {
   describe("querySnsProjects", () => {
@@ -9,11 +9,11 @@ describe("sns-aggregator api", () => {
     });
     it("should fetch json once if less than 10 SNSes", async () => {
       const mockFetch = jest.fn();
-      const [_first, ...rest] = aggregatedSnses;
+      const [_first, ...nineSnses] = tenAggregatedSnses;
       mockFetch.mockReturnValueOnce(
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve(rest),
+          json: () => Promise.resolve(nineSnses),
         })
       );
       global.fetch = mockFetch;
@@ -30,13 +30,13 @@ describe("sns-aggregator api", () => {
         .mockReturnValueOnce(
           Promise.resolve({
             ok: true,
-            json: () => Promise.resolve(aggregatedSnses),
+            json: () => Promise.resolve(tenAggregatedSnses),
           })
         )
         .mockReturnValueOnce(
           Promise.resolve({
             ok: true,
-            json: () => Promise.resolve([aggregatedSnses[0]]),
+            json: () => Promise.resolve([tenAggregatedSnses[0]]),
           })
         );
       global.fetch = mockFetch;
@@ -52,16 +52,16 @@ describe("sns-aggregator api", () => {
 
     it("should convert response", async () => {
       const mockFetch = jest.fn();
-      const [first, ..._rest] = aggregatedSnses;
       mockFetch.mockReturnValue(
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve([first]),
+          json: () => Promise.resolve([tenAggregatedSnses[0]]),
         })
       );
       global.fetch = mockFetch;
       const snses = await querySnsProjects();
       const sns = snses.find(({ index }) => index === aggregatorSnsMock.index);
+      // TODO: Make clear that aggregatorSnsMock is the first in the list of aggregated SNSes
       expect(sns).toEqual(aggregatorSnsMock);
     });
   });


### PR DESCRIPTION
# Motivation

We only fetch one page of the SNS aggregator.

When there are more than 10 SNSes, the latest never appear.

# Changes

* Get the next page if the SNS Aggregator returns 10 SNSes.

# Tests

* Test the new functionality of the sns aggregator api.
