### PR TITLE
E2E: Accept conditions in participation test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Get test environment
         run: |
-          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/release-2023-04-27/snsdemo_snapshot_ubuntu-22.04.tar.xz > state.tar.xz
+          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz > state.tar.xz
           dfx-snapshot-restore --snapshot state.tar.xz --verbose
           dfx identity use snsdemo8
           dfx-sns-demo-healthcheck

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -52,6 +52,7 @@ test("Test SNS participation", async ({ page, context }) => {
   expect(await projectDetail.hasCommitmentAmount()).toBe(false);
   await projectDetail.participate({ amount: 5 });
   expect(await projectDetail.getCommitmentAmount()).toBe("5.00");
+  expect(true).toBe(false);
 
   // D005: User can increase the participation in a sale
   // TODO

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -50,9 +50,8 @@ test("Test SNS participation", async ({ page, context }) => {
 
   // D004: User can participate in a sale
   expect(await projectDetail.hasCommitmentAmount()).toBe(false);
-  await projectDetail.participate({ amount: 5 });
+  await projectDetail.participate({ amount: 5, acceptConditions: true });
   expect(await projectDetail.getCommitmentAmount()).toBe("5.00");
-  expect(true).toBe(false);
 
   // D005: User can increase the participation in a sale
   // TODO

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -437,7 +437,10 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           );
 
           expect(await projectDetail.hasCommitmentAmount()).toBe(false);
-          await projectDetail.participate({ amount: amountICP });
+          await projectDetail.participate({
+            amount: amountICP,
+            acceptConditions: false,
+          });
           expect(await projectDetail.getCommitmentAmount()).toBe(
             formattedAmountICP
           );

--- a/frontend/src/tests/page-objects/ParticipateButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateButton.page-object.ts
@@ -13,10 +13,13 @@ export class ParticipateButtonPo extends BasePageObject {
     return ParticipateSwapModalPo.under(this.root);
   }
 
-  async participate({ amount }: { amount: number }): Promise<void> {
+  async participate(params: {
+    amount: number;
+    acceptConditions: boolean;
+  }): Promise<void> {
     await this.getButton().click();
     const modal = this.getParticipateSwapModalPo();
-    await modal.participate({ amount });
+    await modal.participate(params);
     await modal.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -31,10 +31,10 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
 
   async participate({
     amount,
-    acceptConditions = false,
+    acceptConditions,
   }: {
     amount: number;
-    acceptConditions?: boolean | undefined;
+    acceptConditions: boolean;
   }): Promise<void> {
     const formPo = this.getTransactionFormPo();
     await formPo.enterAmount(amount);

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -32,6 +32,7 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
   async participate({ amount }: { amount: number }): Promise<void> {
     const formPo = this.getTransactionFormPo();
     await formPo.enterAmount(amount);
+    await this.getAdditionalInfoFormPo().toggleConditionsAccepted();
     await formPo.clickContinue();
     await this.getAdditionalInfoReviewPo().clickCheckbox();
     await this.getTransactionReviewPo().clickSend();

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -29,10 +29,19 @@ export class ParticipateSwapModalPo extends TransactionModalPo {
     return this.getInProgressPo().isPresent();
   }
 
-  async participate({ amount }: { amount: number }): Promise<void> {
+  async participate({
+    amount,
+    acceptConditions = false,
+  }: {
+    amount: number;
+    acceptConditions?: boolean | undefined;
+  }): Promise<void> {
     const formPo = this.getTransactionFormPo();
     await formPo.enterAmount(amount);
-    await this.getAdditionalInfoFormPo().toggleConditionsAccepted();
+    const info = this.getAdditionalInfoFormPo();
+    if (await info.hasConditions()) {
+      await info.toggleConditionsAccepted();
+    }
     await formPo.clickContinue();
     await this.getAdditionalInfoReviewPo().clickCheckbox();
     await this.getTransactionReviewPo().clickSend();

--- a/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
@@ -50,8 +50,11 @@ export class ProjectDetailPo extends BasePageObject {
     return this.getProjectStatusSectionPo().hasCommitmentAmount();
   }
 
-  participate({ amount }: { amount: number }): Promise<void> {
-    return this.getProjectStatusSectionPo().participate({ amount });
+  participate(params: {
+    amount: number;
+    acceptConditions: boolean;
+  }): Promise<void> {
+    return this.getProjectStatusSectionPo().participate(params);
   }
 
   waitForContentLoaded(): Promise<void> {

--- a/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
@@ -29,8 +29,11 @@ export class ProjectStatusSectionPo extends BasePageObject {
     return this.getProjectStatusPo().getStatus();
   }
 
-  participate({ amount }: { amount: number }): Promise<void> {
-    return this.getParticipateButtonPo().participate({ amount });
+  participate(params: {
+    amount: number;
+    acceptConditions: boolean;
+  }): Promise<void> {
+    return this.getParticipateButtonPo().participate(params);
   }
 
   getCommitmentAmount(): Promise<string> {

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -49,6 +49,7 @@ export class TransactionFormPo extends BasePageObject {
   }): Promise<void> {
     await this.getSelectDestinationAddressPo().selectAccount(accountName);
     await this.enterAmount(amount);
+    await this.getAdditionalInfoFormPo().toggleConditionsAccepted();
     await this.clickContinue();
   }
 }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -49,7 +49,6 @@ export class TransactionFormPo extends BasePageObject {
   }): Promise<void> {
     await this.getSelectDestinationAddressPo().selectAccount(accountName);
     await this.enterAmount(amount);
-    await this.getAdditionalInfoFormPo().toggleConditionsAccepted();
     await this.clickContinue();
   }
 }


### PR DESCRIPTION
# Motivation

Testing the SNS `confirmation_test` end-to-end.

# Changes

1. Use a new snsdemo snapshot in CI, which includes an SNS with `confirmation_text`.
2. Add `acceptConditions: boolean` parameters to `participate` method of relevant page objects.
3. Set `acceptConditions: true` in `frontend/src/tests/e2e/sns-participation.spec.ts`
4. Set `acceptConditions: false` in `frontend/src/tests/lib/pages/ProjectDetail.spec.ts`

# Tests

Only tests are changed in the PR.
