### PR TITLE
GIX-1437 E2E: Increase participation

### DIFF
--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -54,5 +54,6 @@ test("Test SNS participation", async ({ page, context }) => {
   expect(await projectDetail.getCommitmentAmount()).toBe("5.00");
 
   // D005: User can increase the participation in a sale
-  // TODO
+  await projectDetail.participate({ amount: 8, acceptConditions: true });
+  expect(await projectDetail.getCommitmentAmount()).toBe("13.00");
 });


### PR DESCRIPTION
# Motivation

Finishing the swap participation end-to-end test.

# Changes

In `frontend/src/tests/e2e/sns-participation.spec.ts` test that the user can increase swap participation after participating for the first time.

# Tests

`npm run test-e2e`
