### PR TITLE
fix: make participation button tooltip to be on top of the button

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -82,6 +82,7 @@
             <Tooltip
               id="sns-project-participate-button-tooltip"
               text={$i18n.sns_project_detail.max_user_commitment_reached}
+              top={true}
             >
               <button
                 class="primary"
@@ -93,6 +94,7 @@
             <Tooltip
               id="sns-project-participate-button-tooltip"
               text={$i18n.sns_project_detail.not_eligible_to_participate}
+              top={true}
             >
               <button
                 class="primary"
@@ -139,6 +141,12 @@
     align-items: stretch;
     justify-content: center;
     padding: var(--padding-2x);
+
+    // To make the button inside the tooltip work the same way as the button w/o a tooltip
+    :global(.tooltip-target) {
+      display: flex;
+      flex-direction: column;
+    }
 
     @include media.min-width(medium) {
       align-items: center;

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -138,10 +138,7 @@
     &.top {
       bottom: unset;
       top: calc(-1 * var(--padding));
-      transform: translate(
-        var(--tooltip-transform-x, var(--tooltip-transform-x-default)),
-        -100%
-      );
+      transform: translate(-50%, -100%);
     }
 
     pointer-events: none;


### PR DESCRIPTION
# Motivation

Change the participation tooltip position to see 100% of its content.

# Changes

- display tooltip on top
- update the button size on mobile in tooltip

# Screenshot

# Mobile
![Screen Recording 2023-05-25 at 15 14 14](https://github.com/dfinity/nns-dapp/assets/98811342/0c61dbb5-9298-4f22-843c-28fa3bf02208)

## Desktop
<img width="1440" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/df9685b4-dcdb-4efe-8e41-dbf4f88fd9e5">
