### PR TITLE
style: make participation button tooltip on top

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -82,6 +82,7 @@
             <Tooltip
               id="sns-project-participate-button-tooltip"
               text={$i18n.sns_project_detail.max_user_commitment_reached}
+              top={true}
             >
               <button
                 class="primary"
@@ -93,6 +94,7 @@
             <Tooltip
               id="sns-project-participate-button-tooltip"
               text={$i18n.sns_project_detail.not_eligible_to_participate}
+              top={true}
             >
               <button
                 class="primary"


### PR DESCRIPTION
# Motivation

Change participation button tooltip to make the whole tooltip content visible.

# Changes

- change tooltip position

# Screenshots

## Mobile
<img width="428" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a2688af8-47cb-4472-a6fd-9eddadb51e25">

## Desktop
<img width="460" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/6b55e30c-9b80-484d-acb1-c391a169d814">


