### PR TITLE
E2E: Add SNS neuron hotkey

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -61,6 +61,9 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(await neuronDetail.getStake()).toBe(formattedStake);
 
   // SN003: User can add a hotkey
+  const hotkeyPrincipal =
+    "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
+  await neuronDetail.addHotkey(hotkeyPrincipal);
 
   // SN004: User can remove a hotkey
 

--- a/frontend/src/tests/page-objects/AddSnsHotkeyModal.page-object.ts
+++ b/frontend/src/tests/page-objects/AddSnsHotkeyModal.page-object.ts
@@ -1,0 +1,15 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class AddSnsHotkeyModalPo extends BasePageObject {
+  private static readonly TID = "add-hotkey-neuron-modal";
+
+  static under(element: PageObjectElement): AddSnsHotkeyModalPo {
+    return new AddSnsHotkeyModalPo(element.byTestId(AddSnsHotkeyModalPo.TID));
+  }
+
+  async addHotkey(principal: string): Promise<void> {
+    await this.getTextInput().typeText(principal);
+    await this.click("add-principal-button");
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -1,4 +1,4 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { AddSnsHotkeyModalPo } from "$tests/page-objects/AddSnsHotkeyModal.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsIncreaseStakeNeuronModalPo } from "$tests/page-objects/SnsIncreaseStakeNeuronModal.page-object";
 import { SnsNeuronFollowingCardPo } from "$tests/page-objects/SnsNeuronFollowingCard.page-object";
@@ -7,6 +7,7 @@ import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.pag
 import { SnsNeuronMaturityCardPo } from "$tests/page-objects/SnsNeuronMaturityCard.page-object";
 import { SnsNeuronMetaInfoCardPo } from "$tests/page-objects/SnsNeuronMetaInfoCard.page-object";
 import { SummaryPo } from "$tests/page-objects/Summary.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronDetailPo extends BasePageObject {
@@ -65,5 +66,17 @@ export class SnsNeuronDetailPo extends BasePageObject {
   async increaseStake(amount: number): Promise<void> {
     await this.getStakeCardPo().getIncreaseStakeButtonPo().click();
     await this.getIncreaseStakeModalPo().increase(amount);
+  }
+
+  getAddSnsHotkeyModalPo(): AddSnsHotkeyModalPo {
+    return AddSnsHotkeyModalPo.under(this.root);
+  }
+
+  async addHotkey(principal: string): Promise<void> {
+    await this.getHotkeysCardPo().clickAddHotkey();
+    const modal = this.getAddSnsHotkeyModalPo();
+    await modal.waitFor();
+    await modal.addHotkey(principal);
+    await modal.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
@@ -9,4 +9,8 @@ export class SnsNeuronHotkeysCardPo extends BasePageObject {
       element.byTestId(SnsNeuronHotkeysCardPo.TID)
     );
   }
+
+  clickAddHotkey(): Promise<void> {
+    return this.click("add-hotkey-button");
+  }
 }


### PR DESCRIPTION
# Motivation

Continuing with SNS end-to-end coverage.

# Changes

1. Add a hotkey to an SNS neuron in `frontend/src/tests/e2e/sns-governance.spec.ts`.
2. Add missing page object functionality.

# Tests

`npm run test-e2e`
