### PR TITLE
Bump snsdemo commit in workflows

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -32,8 +32,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Apr 4 2023 with xz compressed state
-          ref: '8160f742e10fbd1ac89549a5880ae047ff8f290d'
+          # Version from 2023-05-24 with longer retries to install dfx
+          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Apr 4 2023 with xz compressed state
-          ref: '8160f742e10fbd1ac89549a5880ae047ff8f290d'
+          # Version from 2023-05-24 with longer retries to install dfx
+          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -192,8 +192,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from Apr 4 2023 with xz compressed state
-          ref: '8160f742e10fbd1ac89549a5880ae047ff8f290d'
+          # Version from 2023-05-24 with longer retries to install dfx
+          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Motivation

`dfx` often fails to install on CI because it gets the install script from a canister which updates often.
The script that downloads the install script comes from snsdemo and has been changed to retry for longer.

# Changes

Use a newer snsdemo commit for `actions/checkout@v3` in CI workflows.

# Tests

CI