### PR TITLE
Fix reproducibility by not explicitly importing cjs modules from agent-js in esm

### DIFF
--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -17,7 +17,7 @@
   import { ICPToken, type Token } from "@dfinity/nns";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
-  import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
+  import { browser } from "$app/environment";
 
   let visible = false;
   let transferring = false;
@@ -77,7 +77,7 @@
   $: selectedProjectId,
     (async () => {
       // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
-      if (isBrowser) {
+      if (browser) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }
     })();

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -1,6 +1,5 @@
 import { getEnvVars } from "$lib/utils/env-vars.utils";
-import { addRawToUrl, isLocalhost } from "$lib/utils/env.utils";
-import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
+import { addRawToUrl, isBrowser, isLocalhost } from "$lib/utils/env.utils";
 
 const envVars = getEnvVars();
 

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -1,4 +1,4 @@
-import { isBrowser } from "@dfinity/auth-client/lib/cjs/storage";
+import { isBrowser } from "$lib/utils/env.utils";
 import { isNullish } from "@dfinity/utils";
 
 const localDevelopment = import.meta.env.DEV;

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -1,5 +1,17 @@
 import { NNS_IC_ORG_ALTERNATIVE_ORIGIN } from "$lib/constants/origin.constants";
 
+/**
+ * To be use when Rollup fails to resolve import "$app/environment". This can happen because we manually define chunks and SvelteKit is not entirely resilient to bundler reordering.
+ * Example of SvelteKit issue: https://github.com/sveltejs/kit/pull/9808
+ *
+ * Stacktrace of the `npm run build` error that can lead to use `isBrowser` instead of `browser`:
+ *
+ * [vite:worker] [vite]: Rollup failed to resolve import "__sveltekit/environment" from "/.../nns-dapp/frontend/node_modules/@sveltejs/kit/src/runtime/app/environment.js".
+ * This is most likely unintended because it can break your application at runtime.
+ * If you do want to externalize this module explicitly add it to `build.rollupOptions.external`
+ */
+export const isBrowser = typeof window !== "undefined";
+
 export const isNnsAlternativeOrigin = (): boolean => {
   const {
     location: { origin },


### PR DESCRIPTION
# Motivation

@dskloetd figured out that our frontend reproducibility issue started with PR #2377. After having a look at the PR we noticed it introduced an explicit import of a CJS module of agent-js within the code that is bundled with ESM. As I suspected that our issue was linked to pollyfying the Node modules for the browser, we replaced the import by inline code and as a result, the reproducibility was improved.

Using the `./script/test-reproducibility` script, on my machine, I am now able to run 100 successful check in a row.

# Changes

- remove explicit CJS `import`
- use SvelteKit `browser` information when possible
- when not (see PR for explanation) use a custom `isBrowser` information

