### PR TITLE
E2E: Check linked account after page reload

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -33,8 +33,12 @@ test("Test accounts requirements", async ({ page, context }) => {
   await expect(page.getByTestId("account-card")).toHaveCount(2);
 
   // AU001: The user MUST be able to see a list of all their accounts
-  const accountNames = await nnsAccountsPo.getAccountNames();
-  expect(accountNames).toEqual([mainAccountName, subAccountName]);
+  const accountNames = async () => await nnsAccountsPo.getAccountNames();
+  expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
+
+  // The linked account should still be present after refresh
+  page.reload();
+  expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
 
   // Get some ICP to be able to transfer
   await appPo.getTokens(20);


### PR DESCRIPTION
# Motivation

I want to delete the old (non-Playwright) e2e tests, but before I do I want to make sure that everything they test is covered by the new Playwright e2e tests.

For the accounts related tests, the only thing the old e2e tests test that the new tests don't yet test, is that the linked account is still present after reloading the page.

# Changes

In `frontend/src/tests/e2e/accounts.spec.ts`, reload the page and check that the linked account is still there.

# Tests

`npm run test-e2e`
