### PR TITLE
E2E: Remove race condition work-around

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -23,15 +23,6 @@ test("Test accounts requirements", async ({ page, context }) => {
   const subAccountName = "My second account";
   await nnsAccountsPo.addAccount(subAccountName);
 
-  // Workaround for the following scenario:
-  // 1. query result from initAccounts makes the main account card visible
-  // 2. query result from syncAccounts from addSubAccount makes the subaccount
-  //    card visible.
-  // 3. update result from initAccounts hides the subaccount card.
-  // 4. update result from syncAccount makes the subaccount card visible again.
-  // TODO: Fix the accounts store and remove this line.
-  await expect(page.getByTestId("account-card")).toHaveCount(2);
-
   // AU001: The user MUST be able to see a list of all their accounts
   const accountNames = await nnsAccountsPo.getAccountNames();
   expect(accountNames).toEqual([mainAccountName, subAccountName]);


### PR DESCRIPTION
# Motivation

We used to have a race condition in the accounts store when an update result for an old queryAndUpdate overwrites a query result for a newer queryAndUpdate.
This should be fixed by https://github.com/dfinity/nns-dapp/pull/2445

# Changes

Remove the work-around in frontend/src/tests/e2e/accounts.spec.ts that is no longer necessary.

# Tests

Deployed nns-dapp locally and ran:
`CI=true npm run test-e2e -- account --repeat-each 20 --workers 20`
All 20 passed.
