### PR TITLE
E2E: Use test step to follow progress when headless

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -1,6 +1,6 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
@@ -11,7 +11,8 @@ test("Test accounts requirements", async ({ page, context }) => {
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
-  // The user has a main account
+  step("The user has a main account");
+
   const mainAccountName = "Main";
   const nnsAccountsPo = appPo.getAccountsPo().getNnsAccountsPo();
   expect(
@@ -19,7 +20,7 @@ test("Test accounts requirements", async ({ page, context }) => {
     mainAccountName
   );
 
-  // AU002: The user MUST be able to create an additional account
+  step("AU002: The user MUST be able to create an additional account");
   const subAccountName = "My second account";
   await nnsAccountsPo.addAccount(subAccountName);
 
@@ -32,7 +33,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   // TODO: Fix the accounts store and remove this line.
   await expect(page.getByTestId("account-card")).toHaveCount(2);
 
-  // AU001: The user MUST be able to see a list of all their accounts
+  step("AU001: The user MUST be able to see a list of all their accounts");
   const accountNames = async () => await nnsAccountsPo.getAccountNames();
   expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
 
@@ -43,7 +44,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   // Get some ICP to be able to transfer
   await appPo.getTokens(20);
 
-  // AU004: The user MUST be able to transfer funds
+  step("AU004: The user MUST be able to transfer funds");
   expect(await nnsAccountsPo.getAccountBalance(mainAccountName)).toEqual(
     "20.00"
   );
@@ -66,7 +67,9 @@ test("Test accounts requirements", async ({ page, context }) => {
   );
   expect(await nnsAccountsPo.getAccountBalance(subAccountName)).toEqual("5.00");
 
-  // AU005: The user MUST be able to see the transactions of a specific account
+  step(
+    "AU005: The user MUST be able to see the transactions of a specific account"
+  );
   const mainAccountAddress = await nnsAccountsPo.getAccountAddress(
     mainAccountName
   );

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,6 +1,6 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
@@ -11,6 +11,7 @@ test("Test SNS governance", async ({ page, context }) => {
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
+  step("Navigate to SNS universe");
   const snsUniverseCards = await appPo
     .getSelectUniverseListPo()
     .getSnsUniverseCards();
@@ -22,6 +23,7 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(snsProjectName).toMatch(/[A-Z]{5}/);
 
   await snsUniverseCard.click();
+  step("Acquire tokens");
   await appPo.getTokens(20);
 
   expect(
@@ -32,6 +34,7 @@ test("Test SNS governance", async ({ page, context }) => {
       .getBalance()
   ).toEqual("20.00");
 
+  step("Stake a neuron");
   await appPo.goToNeurons();
   await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
   expect(
@@ -44,7 +47,7 @@ test("Test SNS governance", async ({ page, context }) => {
   const formattedStake = "5.00";
   await appPo.getNeuronsPo().getSnsNeuronsFooterPo().stakeNeuron(stake);
 
-  // SN001: User can see the list of neurons
+  step("SN001: User can see the list of neurons");
   await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
   const neuronCards = await appPo
     .getNeuronsPo()
@@ -54,13 +57,13 @@ test("Test SNS governance", async ({ page, context }) => {
   const neuronCard = neuronCards[0];
   expect(await neuronCard.getStake()).toEqual(formattedStake);
 
-  // SN002: User can see the details of a neuron
+  step("SN002: User can see the details of a neuron");
   await neuronCard.click();
   const neuronDetail = appPo.getNeuronDetailPo().getSnsNeuronDetailPo();
   expect(await neuronDetail.getTitle()).toBe(snsProjectName);
   expect(await neuronDetail.getStake()).toBe(formattedStake);
 
-  // SN003: User can add a hotkey
+  step("SN003: User can add a hotkey");
   const hotkeyPrincipal =
     "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
   await neuronDetail.addHotkey(hotkeyPrincipal);

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -1,7 +1,7 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import type { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
@@ -12,7 +12,7 @@ test("Test SNS participation", async ({ page, context }) => {
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
-  // Get some ICP to participate in the sale.
+  step("Get some ICP to participate in the sale");
   await appPo
     .getAccountsPo()
     .getNnsAccountsPo()
@@ -20,9 +20,9 @@ test("Test SNS participation", async ({ page, context }) => {
     .waitFor();
   await appPo.getTokens(20);
 
+  step("D001: User can see the list of open sales");
   await appPo.goToLaunchpad();
 
-  // D001: User can see the list of open sales
   await appPo.getLaunchpadPo().getOpenProjectsPo().waitForContentLoaded();
   const openProjects: ProjectCardPo[] = await appPo
     .getLaunchpadPo()
@@ -30,7 +30,7 @@ test("Test SNS participation", async ({ page, context }) => {
     .getProjectCardPos();
   expect(openProjects.length).toBe(1);
 
-  // D002: User can see the list of successful sales
+  step("D002: User can see the list of successful sales");
   await appPo.getLaunchpadPo().getCommittedProjectsPo().waitForContentLoaded();
   const committedProjects: ProjectCardPo[] = await appPo
     .getLaunchpadPo()
@@ -38,7 +38,7 @@ test("Test SNS participation", async ({ page, context }) => {
     .getProjectCardPos();
   expect(committedProjects.length).toBeGreaterThan(1);
 
-  // D003: User can see the details of one sale
+  step("D003: User can see the details of one sale");
   const snsProjectName = await openProjects[0].getProjectName();
   await openProjects[0].click();
   const projectDetail = appPo.getProjectDetailPo();
@@ -48,12 +48,12 @@ test("Test SNS participation", async ({ page, context }) => {
   expect(await projectDetail.getTokenSymbol()).not.toBe("");
   expect(await projectDetail.getStatus()).toBe("Accepting Participation");
 
-  // D004: User can participate in a sale
+  step("D004: User can participate in a sale");
   expect(await projectDetail.hasCommitmentAmount()).toBe(false);
   await projectDetail.participate({ amount: 5, acceptConditions: true });
   expect(await projectDetail.getCommitmentAmount()).toBe("5.00");
 
-  // D005: User can increase the participation in a sale
+  step("D005: User can increase the participation in a sale");
   await projectDetail.participate({ amount: 8, acceptConditions: true });
   expect(await projectDetail.getCommitmentAmount()).toBe("13.00");
 });

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -1,6 +1,6 @@
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
 
-let resolvePreviousStep: () => {
+let resolvePreviousStep = () => {
   /* this function will be replaced at each step */
 };
 let previousStep = undefined;

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -1,6 +1,8 @@
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
 
-let resolvePreviousStep = () => {};
+let resolvePreviousStep: () => {
+  /* this function will be replaced at each step */
+};
 let previousStep = undefined;
 
 export const step = async (description: string) => {

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -6,6 +6,7 @@ let resolvePreviousStep = () => {
 let previousStep = undefined;
 
 export const step = async (description: string) => {
+  // We won't resolve the last step but Playwright doesn't mind.
   resolvePreviousStep();
   await previousStep;
   previousStep = test.step(description, () => {


### PR DESCRIPTION
# Motivation

If a test uses `test.step` you can see the name of the step in the terminal when running a headless e2e test.
The intended way to do this is to put all the code for a step inside a closure passed to `test.step()` but this makes the code hard to read and prevents sharing constants created in one step to another step.

# Changes

1. Add a utility function that lets you call `test.step` without passing a closure. It simulates that all the code until the next call to `step()` runs inside the passed closure.
2. Use `step()` inside existing e2e tests to make it easy to follow progress.

# Tests

Tested by running `npm run test-e2e` and observing the result in the terminal.

<img width="1263" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/7263ebac-22dd-4d9d-ae5f-ff6e3cbb4801">


