### PR TITLE
E2E: Remove SNS neuron hotkey

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -133,8 +133,8 @@
       {:else}
         <ul>
           {#each hotkeys as hotkey (hotkey)}
-            <li>
-              <Value>{hotkey}</Value>
+            <li data-tid="hotkey-row">
+              <Value testId="hotkey-principal">{hotkey}</Value>
               {#if canManageHotkeys}
                 <button
                   class="text"

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -68,7 +68,9 @@ test("Test SNS governance", async ({ page, context }) => {
     "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
   await neuronDetail.addHotkey(hotkeyPrincipal);
 
-  // SN004: User can remove a hotkey
+  step("SN004: User can remove a hotkey");
+  await neuronDetail.removeHotkey(hotkeyPrincipal);
+  await appPo.waitForNotBusy();
 
   // SN005: User can see the list of hotkeys of a neuron
 });

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -1,5 +1,6 @@
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { BackdropPo } from "$tests/page-objects/Backdrop.page-object";
+import { BusyScreenPo } from "$tests/page-objects/BusyScreen.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { LaunchpadPo } from "$tests/page-objects/Launchpad.page-object";
 import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
@@ -52,6 +53,10 @@ export class AppPo extends BasePageObject {
 
   getMenuTogglePo(): ButtonPo {
     return this.getButton("menu-toggle");
+  }
+
+  getBusyScreenPo(): ButtonPo {
+    return BusyScreenPo.under(this.root);
   }
 
   toggleMenu(): Promise<void> {
@@ -114,5 +119,9 @@ export class AppPo extends BasePageObject {
 
   goBack(): Promise<void> {
     return this.getButton("back").click();
+  }
+
+  waitForNotBusy(): Promise<void> {
+    return this.getBusyScreenPo().waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/BusyScreen.page-object.ts
+++ b/frontend/src/tests/page-objects/BusyScreen.page-object.ts
@@ -1,0 +1,10 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BusyScreenPo extends BasePageObject {
+  static readonly TID = "busy";
+
+  static under(element: PageObjectElement): BusyScreenPo {
+    return new BusyScreenPo(element.byTestId(BusyScreenPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -79,4 +79,8 @@ export class SnsNeuronDetailPo extends BasePageObject {
     await modal.addHotkey(principal);
     await modal.waitForAbsent();
   }
+
+  removeHotkey(principal: string): Promise<void> {
+    return this.getHotkeysCardPo().removeHotkey(principal);
+  }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
@@ -1,6 +1,26 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
+// The hotkey row does not have its own component so its PO doesn't not have its
+// own file.
+class HotkeyRowPo extends BasePageObject {
+  static readonly TID = "hotkey-row";
+
+  static async allUnder(element: PageObjectElement): Promise<HotkeyRowPo[]> {
+    return Array.from(await element.allByTestId(HotkeyRowPo.TID)).map(
+      (el) => new HotkeyRowPo(el)
+    );
+  }
+
+  getPrincipal(): Promise<string> {
+    return this.getText("hotkey-principal");
+  }
+
+  clickRemove(): Promise<void> {
+    return this.click("remove-hotkey-button");
+  }
+}
+
 export class SnsNeuronHotkeysCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-hotkeys-card-component";
 
@@ -10,7 +30,27 @@ export class SnsNeuronHotkeysCardPo extends BasePageObject {
     );
   }
 
+  getHotkeyRowPos(): Promise<HotkeyRowPo[]> {
+    return HotkeyRowPo.allUnder(this.root);
+  }
+
+  async getHotkeyRowPo(principal: string): Promise<HotkeyRowPo> {
+    const rows = await this.getHotkeyRowPos();
+    // This awaits sequentially but the number of hotkeys is probably small.
+    for (const row of rows) {
+      if ((await row.getPrincipal()) === principal) {
+        return row;
+      }
+    }
+    throw new Error(`Hotkey not found: ${principal}`);
+  }
+
   clickAddHotkey(): Promise<void> {
     return this.click("add-hotkey-button");
+  }
+
+  async removeHotkey(principal: string): Promise<void> {
+    const row = await this.getHotkeyRowPo(principal);
+    return row.clickRemove();
   }
 }


### PR DESCRIPTION
# Motivation

Continuing with SNS end-to-end test coverage.

# Changes

1. In `frontend/src/tests/e2e/sns-governance.spec.ts` remove the added hotkey.
2. Adding necessary `data-tid`s.
3. Add necessary page object functionality.

# Tests

`npm run test-e2e`