### PR TITLE
Upload aggregator assets

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -38,10 +38,10 @@ jobs:
         run: find ${{ matrix.BUILD_NAME }}-out -type f | xargs sha256sum
       - name: 'Record the git commit and any tags'
         run: git log | head -n1 > ${{ matrix.BUILD_NAME }}-out/commit.txt
-      - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
+      - name: 'Upload ${{ matrix.BUILD_NAME }} nns-dapp wasm module'
         uses: actions/upload-artifact@v3
         with:
-          name: NNS ${{ matrix.BUILD_NAME }} wasm module and arguments
+          name: nns-dapp for ${{ matrix.BUILD_NAME }}
           path: |
             ${{ matrix.BUILD_NAME }}-out/commit.txt
             ${{ matrix.BUILD_NAME }}-out/nns-dapp.wasm
@@ -49,6 +49,13 @@ jobs:
             ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-${{ matrix.DFX_NETWORK }}.bin
             ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
+      - name: 'Upload ${{ matrix.BUILD_NAME }} sns_aggregator'
+        uses: actions/upload-artifact@v3
+        with:
+          name: sns_aggregator for ${{ matrix.BUILD_NAME }}
+          path: |
+            ${{ matrix.BUILD_NAME }}-out/sns_aggregator.wasm
+            ${{ matrix.BUILD_NAME }}-out/sns_aggregator_dev.wasm
       - name: Release
         uses: ./.github/actions/release_nns_dapp
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -49,7 +49,7 @@ jobs:
             ${{ matrix.BUILD_NAME }}-out/nns-dapp-arg-${{ matrix.DFX_NETWORK }}.bin
             ${{ matrix.BUILD_NAME }}-out/frontend-config.sh
             ${{ matrix.BUILD_NAME }}-out/deployment-config.json
-      - name: 'Upload ${{ matrix.BUILD_NAME }} sns_aggregator'
+      - name: 'Upload ${{ matrix.BUILD_NAME }} sns_aggregator wasm module'
         uses: actions/upload-artifact@v3
         with:
           name: sns_aggregator for ${{ matrix.BUILD_NAME }}


### PR DESCRIPTION
# Motivation
The `sns_aggregator` built in the docker-build workflow is not available for download.  Having it would be convenient when making releases.

# Changes
- Add a separate upload for sns artefacts, including the dev and prod sns_aggregator wasms.
- Rename the nns-dapp upload to make naming consistent across the two uploads and minimize confusion.

# Tests
See CI, there are assets:
![Screenshot from 2023-05-27 10-42-45](https://github.com/dfinity/nns-dapp/assets/5982633/b350f2de-f935-4ed6-a99d-7d6318135793)

I have checked manually that the zip file contents are as expected.