### PR TITLE
Display spinner on navigation after sign-in

### DIFF
--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -2,7 +2,7 @@
   import Banner from "$lib/components/header/Banner.svelte";
   import { onMount } from "svelte";
   import { initAppAuth } from "$lib/services/$public/app.services";
-  import { Layout, ContentBackdrop } from "@dfinity/gix-components";
+  import { Layout, ContentBackdrop, Spinner } from "@dfinity/gix-components";
   import LoginMenuItems from "$lib/components/login/LoginMenuItems.svelte";
   import LoginFooter from "$lib/components/login/LoginFooter.svelte";
   import LoginHeader from "$lib/components/login/LoginHeader.svelte";
@@ -41,6 +41,8 @@
   </Layout>
 
   <Warnings bringToastsForward />
+{:else}
+  <Spinner />
 {/if}
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

The navigation between login screen to main page can take some times on testnet and mainnet when the JS chunks and other resources have to be downloaded.

Because we have to hide the content of the login mask on navigation, the UI results as being rendered empty while it is loading.

As a bare minimial improvement, we can display a spinner while it's loading.

# Screenshots

Currently - fast network

![no_spinner_normal](https://github.com/dfinity/nns-dapp/assets/16886711/0ec44c68-f85d-4609-9c08-fe4040d972e5)

Currently - slow network

![no_spinner_slow](https://github.com/dfinity/nns-dapp/assets/16886711/a5e63eab-ff5e-4e9f-b270-0003e1080842)

PR - fast network

![spinner_normal_speed](https://github.com/dfinity/nns-dapp/assets/16886711/91c68ea3-6736-42a7-976f-97aebb07e6a6)

PR - slow network

![spinner_slow_3g](https://github.com/dfinity/nns-dapp/assets/16886711/a670049d-d5dc-4285-b328-bda9bd25e450)
