### PR TITLE
vite ignore comment in import of marked

### DIFF
--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -57,7 +57,7 @@ export const renderer = (marked: Marked): Renderer => {
  */
 export const markdownToHTML = async (text: string): Promise<string> => {
   const url = "/assets/libs/marked.min.js";
-  const { marked }: { marked: Marked } = await import(url);
+  const { marked }: { marked: Marked } = await import(/* @vite-ignore */ url);
   return marked(text, {
     renderer: renderer(marked),
   });


### PR DESCRIPTION
# Motivation

Resolve warning:

> /Users/daviddalbusco/projects/dfinity/nns-dapp/frontend/src/lib/utils/html.utils.ts
> 19 |  export const markdownToHTML = async (text) => {
> 20 |    const url = "/assets/libs/marked.min.js";
> 21 |    const { marked } = await import(url);
>    |                                    ^
> 22 |    return marked(text, {
> 23 |      renderer: renderer(marked)
> The above dynamic import cannot be analyzed by Vite.
> See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

