### PR TITLE
Remove deprecated ICRC ledger calls

### DIFF
--- a/frontend/src/lib/api/ckbtc-ledger.api.ts
+++ b/frontend/src/lib/api/ckbtc-ledger.api.ts
@@ -31,13 +31,12 @@ export const getCkBTCAccount = async ({
   logWithTimestamp("Getting ckBTC account: call...");
 
   const {
-    canister: { metadata, balance },
+    canister: { balance },
   } = await ckBTCLedgerCanister({ identity, canisterId });
 
   const callParams = {
     certified,
     getBalance: balance,
-    getMetadata: metadata,
   };
 
   const account = await getIcrcAccount({

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -30,29 +30,14 @@ export const getIcrcAccount = async ({
   certified,
   type,
   getBalance,
-  getMetadata: ledgerMetadata,
 }: {
   type: AccountType;
   getBalance: (params: BalanceParams) => Promise<IcrcTokens>;
-  /**
-   * TODO: integrate ckBTC fee
-   * @deprecated metadata should not be called here and token should not be interpreted per account because it is the same token for all accounts
-   */
-  getMetadata: (params: QueryParams) => Promise<IcrcTokenMetadataResponse>;
 } & IcrcAccount &
   QueryParams): Promise<Account> => {
   const account = { owner, subaccount };
 
-  const [balanceE8s, metadata] = await Promise.all([
-    getBalance({ ...account, certified }),
-    ledgerMetadata({ certified }),
-  ]);
-
-  const projectToken = mapOptionalToken(metadata);
-
-  if (projectToken === undefined) {
-    throw new LedgerErrorKey("error.icrc_token_load");
-  }
+  const balanceE8s = await getBalance({ ...account, certified });
 
   return {
     identifier: encodeIcrcAccount(account),

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -24,7 +24,7 @@ export const getSnsAccounts = async ({
   // TODO: Support subaccounts
   logWithTimestamp("Getting sns accounts: call...");
 
-  const { balance: getBalance, ledgerMetadata: getMetadata } = await wrapper({
+  const { balance: getBalance } = await wrapper({
     identity,
     rootCanisterId: rootCanisterId.toText(),
     certified,
@@ -35,7 +35,6 @@ export const getSnsAccounts = async ({
     type: "main",
     certified,
     getBalance,
-    getMetadata,
   });
 
   logWithTimestamp("Getting sns accounts: done");

--- a/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
@@ -24,7 +24,7 @@ describe("ckbtc-ledger api", () => {
   afterAll(() => jest.clearAllMocks());
 
   describe("getCkBTCAccount", () => {
-    it("returns main account with balance and token metadata", async () => {
+    it("returns main account with balance", async () => {
       const balance = BigInt(10_000_000);
 
       const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
@@ -44,7 +44,7 @@ describe("ckbtc-ledger api", () => {
       expect(balanceSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no balance", () => {
       ledgerCanisterMock.balance.mockImplementation(() =>
         Promise.reject(new Error())
       );

--- a/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
@@ -25,12 +25,9 @@ describe("ckbtc-ledger api", () => {
 
   describe("getCkBTCAccount", () => {
     it("returns main account with balance and token metadata", async () => {
-      const metadataSpy = ledgerCanisterMock.metadata.mockResolvedValue(
-        mockQueryTokenResponse
-      );
-      const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(
-        BigInt(10_000_000)
-      );
+      const balance = BigInt(10_000_000);
+
+      const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
 
       const account = await getCkBTCAccount({
         certified: true,
@@ -42,14 +39,15 @@ describe("ckbtc-ledger api", () => {
 
       expect(account).not.toBeUndefined();
 
-      expect(account?.balanceE8s).toEqual(BigInt(10_000_000));
+      expect(account?.balanceE8s).toEqual(balance);
 
       expect(balanceSpy).toBeCalled();
-      expect(metadataSpy).toBeCalled();
     });
 
     it("throws an error if no token", () => {
-      ledgerCanisterMock.metadata.mockResolvedValue([]);
+      ledgerCanisterMock.balance.mockImplementation(() =>
+        Promise.reject(new Error())
+      );
 
       const call = () =>
         getCkBTCAccount({

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -33,7 +33,7 @@ describe("icrc-ledger api", () => {
       expect(balanceSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no balance", () => {
       const balanceSpy = async () => {
         throw new Error();
       };

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -11,17 +11,14 @@ import {
 
 describe("icrc-ledger api", () => {
   describe("getIcrcMainAccount", () => {
-    const balanceSpy = jest.fn().mockResolvedValue(BigInt(10_000_000));
-
     it("returns main account with balance and project token metadata", async () => {
-      const metadataSpy = jest.fn().mockResolvedValue(mockQueryTokenResponse);
+      const balanceSpy = jest.fn().mockResolvedValue(BigInt(10_000_000));
 
       const account = await getIcrcAccount({
         certified: true,
         owner: mockIdentity.getPrincipal(),
         type: "main",
         getBalance: balanceSpy,
-        getMetadata: metadataSpy,
       });
 
       expect(account).not.toBeUndefined();
@@ -34,11 +31,10 @@ describe("icrc-ledger api", () => {
       expect(account.type).toEqual("main");
 
       expect(balanceSpy).toBeCalled();
-      expect(metadataSpy).toBeCalled();
     });
 
     it("throws an error if no token", () => {
-      const metadataSpy = async () => {
+      const balanceSpy = async () => {
         throw new Error();
       };
 
@@ -48,7 +44,6 @@ describe("icrc-ledger api", () => {
           owner: mockIdentity.getPrincipal(),
           type: "main",
           getBalance: balanceSpy,
-          getMetadata: metadataSpy,
         });
 
       expect(call).rejects.toThrowError();

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -13,7 +13,6 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
 jest.mock("$lib/proxy/api.import.proxy");
 const mainBalance = BigInt(10_000_000);
-const balanceSpy = jest.fn().mockResolvedValue(mainBalance);
 const fee = BigInt(10_000);
 const transactionFeeSpy = jest.fn().mockResolvedValue(fee);
 const transferSpy = jest.fn().mockResolvedValue(BigInt(10));
@@ -24,6 +23,12 @@ const setMetadataSuccess = () => (metadataReturn = mockQueryTokenResponse);
 const metadataSpy = jest
   .fn()
   .mockImplementation(() => Promise.resolve(metadataReturn));
+
+let balanceReturn = Promise.resolve(mainBalance);
+const setBalanceError = () => (balanceReturn = Promise.reject(new Error()));
+const setBalanceSuccess = () => (balanceReturn = Promise.resolve(mainBalance));
+const balanceSpy = jest.fn().mockImplementation(() => balanceReturn);
+
 jest.mock("$lib/api/sns-wrapper.api", () => {
   return {
     wrapper: () => ({
@@ -40,7 +45,10 @@ describe("sns-ledger api", () => {
     beforeEach(() => {
       setMetadataSuccess();
     });
+
     it("returns main account with balance and project token metadata", async () => {
+      setBalanceSuccess();
+
       const accounts = await getSnsAccounts({
         certified: true,
         identity: mockIdentity,
@@ -55,11 +63,11 @@ describe("sns-ledger api", () => {
       expect(main?.balanceE8s).toEqual(mainBalance);
 
       expect(balanceSpy).toBeCalled();
-      expect(metadataSpy).toBeCalled();
     });
 
     it("throws an error if no token", () => {
-      setMetadataError();
+      setBalanceError();
+
       const call = () =>
         getSnsAccounts({
           certified: true,

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -41,6 +41,11 @@ jest.mock("$lib/api/sns-wrapper.api", () => {
 });
 
 describe("sns-ledger api", () => {
+  beforeEach(() => {
+    setMetadataSuccess();
+    setBalanceSuccess();
+  });
+
   describe("getSnsAccounts", () => {
     beforeEach(() => {
       setMetadataSuccess();

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -70,7 +70,7 @@ describe("sns-ledger api", () => {
       expect(balanceSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no balance", () => {
       setBalanceError();
 
       const call = () =>
@@ -129,7 +129,7 @@ describe("sns-ledger api", () => {
       expect(metadataSpy).toBeCalled();
     });
 
-    it("throws an error if no token", () => {
+    it("throws an error if no token metadata", () => {
       setMetadataError();
       const call = () =>
         getSnsToken({


### PR DESCRIPTION
# Motivation

Because we have replaced the balance of the `Account` in Token by the inherited value in E8s (PR #2594), we can remove the calls that were added to fetch the metadata.

In other word we can spare not required query+update calls to ICRC-1 ledgers.

