### PR TITLE
Re-enable Firefox on Playwright tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ dotenv.config();
 export default defineConfig({
   testDir: "./src/tests/e2e",
   /* Maximum time one test can run for. */
-  timeout: 120 * 1000,
+  timeout: (process.env.CI ? 180 : 90) * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Let's not enable retries until we actually need them */
   retries: 0,
   /* Number of tests that can be run in parallel. */
-  workers: process.env.CI ? 3 : 20,
+  workers: process.env.CI ? 3 : 6,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Let's not enable retries until we actually need them */
   retries: 0,
   /* Number of tests that can be run in parallel. */
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 3 : 20,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,11 +48,10 @@ export default defineConfig({
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
-    // TODO: Enable Firefox when flakiness is fixed.
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'], channel: "firefox" },
-    // },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'], channel: "firefox" },
+    },
     // {
     //   name: "chromium",
     //   use: { ...devices["Desktop Chrome"] },


### PR DESCRIPTION
# Motivation

We disabled Firefox tests because the tests were flaky.
https://github.com/dfinity/nns-dapp/pull/2445 should have fixed most or all of the flakiness.
If the tests are flaky again, I'll investigate and disable if necessary.

# Changes

1. Enable Firefox in `frontend/playwright.config.ts`
2. Increase the timeout on CI because the tests are close to the limit. Lower the timeout on non-CI because CI machines are really quite slow compared to our development machines.
3. Set the number of workers for non-CI to 6 so all (now 6) tests can run in parallel by default. Apparently `undefined` defaults to 5 workers.

# Tests

`npm run test-e2e`
