### PR TITLE
sns proposals navigation

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -11,13 +11,30 @@
   import SkeletonDetails from "$lib/components/ui/SkeletonDetails.svelte";
   import NnsProposalProposerActionsEntry from "./NnsProposalProposerActionsEntry.svelte";
   import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
+  import { filteredProposals } from "$lib/derived/proposals.derived";
+  import { goto } from "$app/navigation";
+  import { buildProposalUrl } from "$lib/utils/navigation.utils";
+  import { pageStore } from "$lib/derived/page.derived";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
   );
+
+  const navigate = async ({ detail: proposalId }) => {
+    await goto(
+      buildProposalUrl({
+        universe: $pageStore.universe,
+        proposalId,
+      })
+    );
+  };
 </script>
 
-<ProposalNavigation proposalInfo={$store.proposal} />
+<ProposalNavigation
+  proposalIdString={`${$store?.proposal?.id}`}
+  proposalIds={$filteredProposals.proposals.map(({ id }) => `${id}`)}
+  on:nnsNavigation={navigate}
+/>
 
 {#if $store?.proposal !== undefined}
   <div class="content-grid" data-tid="proposal-details-grid">

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { IconWest, IconEast } from "@dfinity/gix-components";
-  import { uiProposals } from "$lib/derived/proposals.derived";
   import { createEventDispatcher, onDestroy } from "svelte";
   import { i18n } from "$lib/stores/i18n";
 
@@ -26,7 +25,7 @@
       const index =
         proposalIdString === undefined
           ? undefined
-          : proposalIdString && proposalIds?.indexOf(proposalIdString);
+          : proposalIds?.indexOf(proposalIdString);
 
       if (proposalIds === undefined || index === undefined || index < 0) {
         reset();
@@ -39,14 +38,14 @@
 
   onDestroy(reset);
 
-  let lastProposal: boolean;
-  $: lastProposal =
+  let singleProposal: boolean;
+  $: singleProposal =
     proposalIdString !== undefined &&
     nextIdString === undefined &&
     previousIdString === undefined;
 </script>
 
-{#if $uiProposals.proposals.length > 0 && !lastProposal}
+{#if proposalIdString && !singleProposal}
   <div role="toolbar">
     <button
       class="ghost"

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -43,19 +43,26 @@
     proposalIdString !== undefined &&
     nextIdString === undefined &&
     previousIdString === undefined;
+
+  let prevDisabled = true;
+  $: prevDisabled =
+    proposalIdString !== undefined && previousIdString === undefined;
+
+  let nextDisabled = true;
+  $: nextDisabled =
+    proposalIdString !== undefined && nextIdString === undefined;
 </script>
 
 {#if proposalIdString && !singleProposal}
-  <div role="toolbar">
+  <div role="toolbar" data-tid="proposal-nav">
     <button
       class="ghost"
       type="button"
       aria-label={$i18n.proposal_detail.newer}
+      aria-hidden={prevDisabled ? true : undefined}
       on:click={previous}
-      class:hidden={proposalIdString !== undefined &&
-        previousIdString === undefined}
-      disabled={proposalIdString !== undefined &&
-        previousIdString === undefined}
+      class:hidden={prevDisabled}
+      disabled={prevDisabled}
       data-tid="proposal-nav-previous"
     >
       <IconWest />
@@ -66,10 +73,10 @@
       class="ghost"
       type="button"
       aria-label={$i18n.proposal_detail.older}
+      aria-hidden={nextDisabled ? true : undefined}
       on:click={next}
-      class:hidden={proposalIdString !== undefined &&
-        nextIdString === undefined}
-      disabled={proposalIdString !== undefined && nextIdString === undefined}
+      class:hidden={nextDisabled}
+      disabled={nextDisabled}
       data-tid="proposal-nav-next"
     >
       {$i18n.proposal_detail.older_short}

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { buildProposalsUrl } from "$lib/utils/navigation.utils";
+  import {
+    buildProposalsUrl,
+    buildProposalUrl,
+  } from "$lib/utils/navigation.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { getSnsProposalById } from "$lib/services/$public/sns-proposals.services";
   import type { SnsProposalData, SnsProposalId } from "@dfinity/sns";
@@ -18,9 +21,14 @@
   import { loadSnsParameters } from "$lib/services/sns-parameters.services";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
-  import { snsProposalIdString } from "$lib/utils/sns-proposals.utils";
+  import {
+    snsProposalIdString,
+    sortSnsProposalsById,
+  } from "$lib/utils/sns-proposals.utils";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSnsProposalStore } from "../derived/debug.derived";
+  import ProposalNavigation from "$lib/components/proposal-detail/ProposalNavigation.svelte";
+  import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposals.derived";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -146,7 +154,27 @@
 
   // The `update` function cares about the necessary data to be refetched.
   $: universeIdText, proposalIdText, $snsNeuronsStore, update();
+
+  let sortedProposalIdStrings: string[] | undefined;
+  $: sortedProposalIdStrings = sortSnsProposalsById(
+    $snsFilteredProposalsStore[universeIdText]?.proposals
+  )?.map(snsProposalIdString);
+
+  const navigate = async ({ detail: proposalId }) => {
+    await goto(
+      buildProposalUrl({
+        universe: $pageStore.universe,
+        proposalId,
+      })
+    );
+  };
 </script>
+
+<ProposalNavigation
+  proposalIdString={proposalIdText}
+  proposalIds={sortedProposalIdStrings}
+  on:nnsNavigation={navigate}
+/>
 
 <div class="content-grid" data-tid="sns-proposal-details-grid">
   {#if !updating && nonNullish(proposal) && nonNullish(universeCanisterId)}

--- a/frontend/src/tests/page-objects/ProposalNavigation.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalNavigation.page-object.ts
@@ -1,0 +1,20 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProposalNavigationPo extends BasePageObject {
+  private static readonly TID = "proposal-nav";
+
+  static under(element: PageObjectElement): ProposalNavigationPo {
+    return new ProposalNavigationPo(element.byTestId(ProposalNavigationPo.TID));
+  }
+
+  getNextButtonPo = () => this.getButton("proposal-nav-next");
+  getPreviousButtonPo = () => this.getButton("proposal-nav-previous");
+  isNextButtonHidden = async () =>
+    (await this.getNextButtonPo().root.getAttribute("aria-hidden")) === "true";
+  isPreviousButtonHidden = async () =>
+    (await this.getPreviousButtonPo().root.getAttribute("aria-hidden")) ===
+    "true";
+  clickNextProposal = () => this.getNextButtonPo().click();
+  clickPreviousProposal = () => this.getPreviousButtonPo().click();
+}


### PR DESCRIPTION
# Motivation

Add sns proposal navigation from proposal details page (same as nns version).

# Changes

- refactor `ProposalNavigation` component to work only w/ ids
- add `ProposalNavigation` to the sns details page

# Tests

- `ProposalNavigation` functionality
