### PR TITLE
Split e2e test workflow

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -12,6 +12,9 @@ inputs:
   sns_aggregator:
     description: "The name of the sns_aggregator wasm to install"
     required: false
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -20,8 +20,7 @@ runs:
       with:
         repository: 'dfinity/snsdemo'
         path: 'snsdemo'
-        # Version from 2023-05-24 with longer retries to install dfx
-        ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+        ref: ${{ inputs.snsdemo_ref }}
     - name: Add snsdemo scripts to the path
       shell: bash
       run: |
@@ -38,3 +37,17 @@ runs:
         dfx-snapshot-restore --snapshot state.tar.xz --verbose
         dfx identity use snsdemo8
         dfx-sns-demo-healthcheck
+    - name: Install nns-dapp
+      if: ${{ inputs.nns_dapp_wasm }}
+      run: |
+        echo "Create the nns-dapp install argument:"
+        export DFX_NETWORK=local
+        ./config.sh
+        echo "Install:"
+        dfx canister install nns-dapp --wasm ${{ inputs.nnd_dapp_wasm }} --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
+    - name: Install sns_aggregator
+      if: ${{ inputs.sns_aggregator_wasm }}
+      run: |
+        dfx canister install sns_aggregator --wasm ${{ inputs.sns_aggregator_wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+        # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:
+        dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -1,0 +1,37 @@
+name: 'Start dfx snapshot'
+description: |
+  Start a local replica running against a given snapshot.
+  Optionally installs nns-dapp and sns_aggregator.
+inputs:
+  snapshot_url:
+    description: "The URL of the snapshot to download and install"
+    required: true
+  nns_dapp_wasm:
+    description: "The name of the nns-dapp wasm to install"
+    required: false
+  sns_aggregator:
+    description: "The name of the sns_aggregator wasm to install"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Get SNS scripts
+      uses: actions/checkout@v3
+      with:
+        repository: 'dfinity/snsdemo'
+        path: 'snsdemo'
+        # Version from 2023-05-24 with longer retries to install dfx
+        ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+    - name: Add snsdemo scripts to the path
+      run: |
+        echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+    - name: Install SNS script dependencies
+      run: |
+        dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
+        dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
+    - name: Get test environment
+      run: |
+        curl -fL --retry 5 ${{ inputs.snapshot_url }} > state.tar.xz
+        dfx-snapshot-restore --snapshot state.tar.xz --verbose
+        dfx identity use snsdemo8
+        dfx-sns-demo-healthcheck

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -50,6 +50,6 @@ runs:
       if: ${{ inputs.sns_aggregator_wasm }}
       shell: bash
       run: |
-        dfx canister install sns_aggregator --wasm ${{ inputs.sns_aggregator_wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
+        dfx canister install sns_aggregator --wasm ${{ inputs.sns_aggregator_wasm }} --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
         # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:
         dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -3,6 +3,9 @@ description: |
   Start a local replica running against a given snapshot.
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
+  snsdemo_ref:
+    description: "The commit at which to use the snsdemo scripts"
+    required: true
   snapshot_url:
     description: "The URL of the snapshot to download and install"
     required: true

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -12,9 +12,6 @@ inputs:
   sns_aggregator:
     description: "The name of the sns_aggregator wasm to install"
     required: false
-defaults:
-  run:
-    shell: bash -euxlo pipefail {0}
 runs:
   using: "composite"
   steps:
@@ -26,13 +23,16 @@ runs:
         # Version from 2023-05-24 with longer retries to install dfx
         ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
     - name: Add snsdemo scripts to the path
+      shell: bash
       run: |
         echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
     - name: Install SNS script dependencies
+      shell: bash
       run: |
         dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
         dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
     - name: Get test environment
+      shell: bash
       run: |
         curl -fL --retry 5 ${{ inputs.snapshot_url }} > state.tar.xz
         dfx-snapshot-restore --snapshot state.tar.xz --verbose

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -39,6 +39,7 @@ runs:
         dfx-sns-demo-healthcheck
     - name: Install nns-dapp
       if: ${{ inputs.nns_dapp_wasm }}
+      shell: bash
       run: |
         echo "Create the nns-dapp install argument:"
         export DFX_NETWORK=local
@@ -47,6 +48,7 @@ runs:
         dfx canister install nns-dapp --wasm ${{ inputs.nnd_dapp_wasm }} --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
     - name: Install sns_aggregator
       if: ${{ inputs.sns_aggregator_wasm }}
+      shell: bash
       run: |
         dfx canister install sns_aggregator --wasm ${{ inputs.sns_aggregator_wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
         # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -9,7 +9,7 @@ inputs:
   nns_dapp_wasm:
     description: "The name of the nns-dapp wasm to install"
     required: false
-  sns_aggregator:
+  sns_aggregator_wasm:
     description: "The name of the sns_aggregator wasm to install"
     required: false
 runs:
@@ -45,7 +45,7 @@ runs:
         export DFX_NETWORK=local
         ./config.sh
         echo "Install:"
-        dfx canister install nns-dapp --wasm ${{ inputs.nnd_dapp_wasm }} --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
+        dfx canister install nns-dapp --wasm ${{ inputs.nns_dapp_wasm }} --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
     - name: Install sns_aggregator
       if: ${{ inputs.sns_aggregator_wasm }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
           path: sns_aggregator.wasm
           retention-days: 3
   test:
+    needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,10 @@ jobs:
         with:
           name: sns_aggregator_dev
       - name: Start snapshot environment
+      - uses: actions/checkout@v3
         uses: ./.github/action/start_dfx_snapshot
         with:
-         snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
+          snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nns-dapp_local
-      - name: Rename nns-dapp.wasm for use
-        run: cp nns-dapp_local.wasm nns-dapp.wasm
-      - name: Get sns_aggregator
-        uses: actions/download-artifact@v3
-        with:
-          name: sns_aggregator
       - name: Get sns_aggregator_dev
         uses: actions/download-artifact@v3
         with:
@@ -79,7 +73,7 @@ jobs:
           # Version from 2023-05-24 with longer retries to install dfx
           snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
-          nns_dapp_wasm: 'nns-dapp.wasm'
+          nns_dapp_wasm: 'nns-dapp_local.wasm'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm'
       - name: Generate .env configuration for Playwright end-to-end tests
         run: |
@@ -123,8 +117,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nns-dapp_local
-      - name: Rename nns-dapp.wasm for use
-        run: cp nns-dapp_local.wasm nns-dapp.wasm
       - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:
@@ -139,7 +131,7 @@ jobs:
           # Version from 2023-05-24 with longer retries to install dfx
           snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
-          nns_dapp_wasm: 'nns-dapp.wasm'
+          nns_dapp_wasm: 'nns-dapp_local.wasm'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm'
       - name: Add go and SNS scripts to the path
         run: |
@@ -198,7 +190,7 @@ jobs:
         run: |
           git fetch --depth 1 origin tag prod
           if git diff tags/prod rs/backend | grep -q .
-          then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp.wasm
+          then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_local.wasm
           else echo "Skipping test as there are no relevant code changes"
           fi
       - name: Release
@@ -238,7 +230,7 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count
         run: |
-          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp.wasm --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
+          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp_local.wasm --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
           postinstall_instructions="$(scripts/backend/get_upgrade_instructions)"
           echo "Installation consumed ${postinstall_instructions} instructions."
           echo "Cycles consumed are instructions * some factor that depends on subnet.  There is no guarantee that that formula will not change."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,10 @@ jobs:
             exit 1
           } >&2
       - name: Check that metadata is present
-        run: scripts/dfx-wasm-metadata-add.test --verbose
+        run: |
+          # dfx-wasm-metadata-add.test expects nns-dapp.wasm
+          cp nns-dapp_local.wasm nns-dapp.wasm
+          scripts/dfx-wasm-metadata-add.test --verbose
       - name: Basic downgrade-upgrade test
         run: |
           git fetch --depth 1 origin tag prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,21 +76,15 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
+          # Version from 2023-05-24 with longer retries to install dfx
+          snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
+          nns_dapp_wasm: 'nns-dapp.wasm'
+          sns_aggregator_wasm: 'sns_aggregator_dev.wasm'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Install nns-dapp and sns_aggregator
-        run: |
-          echo "Create the nns-dapp install argument:"
-          export DFX_NETWORK=local
-          ./config.sh
-          echo "Install:"
-          dfx canister install nns-dapp --wasm nns-dapp.wasm --upgrade-unchanged --mode reinstall --yes --argument "$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
-          dfx canister install sns_aggregator --wasm sns_aggregator_dev.wasm --upgrade-unchanged --mode reinstall --yes --argument '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
-          # TODO: The argument above is not passed to the canister by dfx.  Fix (by asking the sdk team), then remove the following line:
-          dfx canister call sns_aggregator reconfigure '(opt record { update_interval_ms = 100; fast_interval_ms = 100; })'
       - name: Install command line HTML parser
         run: |
           go install github.com/ericchiang/pup@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nns-dapp_local
-          path: nns-dapp_local.wasm
       - name: Rename nns-dapp.wasm for use
         run: cp nns-dapp_local.wasm nns-dapp.wasm
       - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator
-          path: sns_aggregator.wasm
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
@@ -32,6 +32,34 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: .
+      - name: Rename nns-dapp.wasm for upload
+        run: cp nns-dapp.wasm nns-dapp_local.wasm
+      - name: 'Upload nns-dapp_local wasm module'
+        uses: actions/upload-artifact@v3
+        with:
+          name: nns-dapp_local
+          path: nns-dapp_local.wasm
+          retention-days: 3
+      - name: 'Upload sns_aggregator wasm module'
+        uses: actions/upload-artifact@v3
+        with:
+          name: sns_aggregator
+          path: sns_aggregator.wasm
+          retention-days: 3
+  test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - name: Get nns-dapp_local
+        uses: actions/download-artifact@v3
+        with:
+          name: nns-dapp_local
+          path: nns-dapp_local.wasm
+      - name: Get nns-dapp_local
+        uses: actions/download-artifact@v3
+        with:
+          name: sns_aggregator
+          path: sns_aggregator.wasm
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:
@@ -119,14 +147,6 @@ jobs:
           then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp.wasm
           else echo "Skipping test as there are no relevant code changes"
           fi
-      - name: Rename nns-dapp.wasm for upload
-        run: cp nns-dapp.wasm nns-dapp_local.wasm
-      - name: 'Upload nns-dapp_local wasm module'
-        uses: actions/upload-artifact@v3
-        with:
-          name: nns-dapp_local
-          path: nns-dapp_local.wasm
-          retention-days: 3
       - name: Release
         run: |
           for tag in $(git tag --points-at HEAD) ; do
@@ -230,7 +250,7 @@ jobs:
         run: |
           rm -rf screenshots
   build-pass:
-    needs: ["build"]
+    needs: ["build", "test"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,13 @@ jobs:
           name: nns-dapp_local
           path: nns-dapp_local.wasm
           retention-days: 3
-      - name: 'Upload sns_aggregator_dev wasm module'
+      - name: 'Upload sns_aggregator wasm module'
         uses: actions/upload-artifact@v3
         with:
-          name: sns_aggregator_dev
-          path: sns_aggregator_dev.wasm
+          name: sns_aggregator
+          path: |
+            sns_aggregator.wasm
+            sns_aggregator_dev.wasm
           retention-days: 3
   test:
     needs: build
@@ -59,10 +61,10 @@ jobs:
           name: nns-dapp_local
       - name: Rename nns-dapp.wasm for use
         run: cp nns-dapp_local.wasm nns-dapp.wasm
-      - name: Get sns_aggregator_dev
+      - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:
-          name: sns_aggregator_dev
+          name: sns_aggregator
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
         with:
           name: nns-dapp_local
           path: nns-dapp_local.wasm
-      - name: Get nns-dapp_local
+      - name: Rename nns-dapp.wasm for use
+        run: cp nns-dapp_local.wasm nns-dapp.wasm
+      - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,67 @@ jobs:
           name: sns_aggregator_dev
           path: sns_aggregator_dev.wasm
           retention-days: 3
-  test:
+  test-playwright-e2e:
+    needs: build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v3
+      - name: Get nns-dapp_local
+        uses: actions/download-artifact@v3
+        with:
+          name: nns-dapp_local
+      - name: Rename nns-dapp.wasm for use
+        run: cp nns-dapp_local.wasm nns-dapp.wasm
+      - name: Get sns_aggregator
+        uses: actions/download-artifact@v3
+        with:
+          name: sns_aggregator
+      - name: Get sns_aggregator_dev
+        uses: actions/download-artifact@v3
+        with:
+          name: sns_aggregator_dev
+      - name: Start snapshot environment
+        uses: ./.github/actions/start_dfx_snapshot
+        with:
+          # Version from 2023-05-24 with longer retries to install dfx
+          snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
+          nns_dapp_wasm: 'nns-dapp.wasm'
+          sns_aggregator_wasm: 'sns_aggregator_dev.wasm'
+      - name: Generate .env configuration for Playwright end-to-end tests
+        run: |
+          DFX_NETWORK=local ./config.sh
+      - name: Prepare for Playwright end-to-end tests
+        working-directory: frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps firefox
+      - name: Wait for aggregator to get all SNSs
+        run: |
+          set +x
+          for (( try=300; try>0; try-- )); do
+             num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
+             (( num_sns < 12)) || break
+             printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
+             sleep 2
+          done
+      - name: Run Playwright end-to-end tests
+        working-directory: frontend
+        run: npm run test-e2e
+      - name: Upload Playwright results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: playwright-failure-results
+          path: |
+            frontend/playwright-report/*
+            frontend/playwright-results/*
+          retention-days: 3
+      - name: Stop replica
+        run: dfx stop
+  test-rest:
     needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 40
@@ -154,35 +214,6 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate .env configuration for Playwright end-to-end tests
-        run: |
-          DFX_NETWORK=local ./config.sh
-      - name: Prepare for Playwright end-to-end tests
-        working-directory: frontend
-        run: |
-          npm ci
-          npx playwright install --with-deps firefox
-      - name: Wait for aggregator to get all SNSs
-        run: |
-          set +x
-          for (( try=300; try>0; try-- )); do
-             num_sns="$(for ((page=0; page<3; page++)) ; do { curl -fsS "http://$(dfx canister id sns_aggregator).localhost:8080/v1/sns/list/page/$page/slow.json" | jq length ; } 2>/dev/null || true ; done | awk '{i+=$1}END{print i}')"
-             (( num_sns < 12)) || break
-             printf "\r #SNS: % 4d   Tries remaining: %4d" "$num_sns" "$try"
-             sleep 2
-          done
-      - name: Run Playwright end-to-end tests
-        working-directory: frontend
-        run: npm run test-e2e
-      - name: Upload Playwright results
-        uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
-        with:
-          name: playwright-failure-results
-          path: |
-            frontend/playwright-report/*
-            frontend/playwright-results/*
-          retention-days: 3
       - name: Generate .env configuration for e2e-tests
         run: |
           DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,18 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: sns_aggregator
-          path: |
-            sns_aggregator.wasm
-            sns_aggregator_dev.wasm
+          path: sns_aggregator.wasm
+          retention-days: 3
+      - name: 'Upload sns_aggregator_dev wasm module'
+        uses: actions/upload-artifact@v3
+        with:
+          name: sns_aggregator_dev
+          path: sns_aggregator_dev.wasm
           retention-days: 3
   test:
     needs: build
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
@@ -65,27 +69,18 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator
-      - name: Get SNS scripts
-        uses: actions/checkout@v3
+      - name: Get sns_aggregator_dev
+        uses: actions/download-artifact@v3
         with:
-          repository: 'dfinity/snsdemo'
-          path: 'snsdemo'
-          # Version from 2023-05-24 with longer retries to install dfx
-          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          name: sns_aggregator_dev
+      - name: Start snapshot environment
+        uses: ./.github/action/start_dfx_snapshot
+        with:
+         snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Install SNS script dependencies
-        run: |
-          dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
-          dfx-software-idl2json-install --version "v$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
-      - name: Get test environment
-        run: |
-          curl -fL --retry 5 https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz > state.tar.xz
-          dfx-snapshot-restore --snapshot state.tar.xz --verbose
-          dfx identity use snsdemo8
-          dfx-sns-demo-healthcheck
       - name: Install nns-dapp and sns_aggregator
         run: |
           echo "Create the nns-dapp install argument:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,7 @@ jobs:
         with:
           name: sns_aggregator_dev
       - name: Start snapshot environment
-      - uses: actions/checkout@v3
-        uses: ./.github/action/start_dfx_snapshot
+        uses: ./.github/actions/start_dfx_snapshot
         with:
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-05-24/snsdemo_snapshot_ubuntu-22.04.tar.xz
       - name: Add go and SNS scripts to the path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           rm -rf screenshots
   build-pass:
-    needs: ["build", "test"]
+    needs: ["build", "test-playwright-e2e", "test-rest"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v3
       - name: Get nns-dapp_local
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,11 @@ jobs:
           name: nns-dapp_local
           path: nns-dapp_local.wasm
           retention-days: 3
-      - name: 'Upload sns_aggregator wasm module'
+      - name: 'Upload sns_aggregator_dev wasm module'
         uses: actions/upload-artifact@v3
         with:
-          name: sns_aggregator
-          path: sns_aggregator.wasm
+          name: sns_aggregator_dev
+          path: sns_aggregator_dev.wasm
           retention-days: 3
   test:
     needs: build
@@ -59,10 +59,10 @@ jobs:
           name: nns-dapp_local
       - name: Rename nns-dapp.wasm for use
         run: cp nns-dapp_local.wasm nns-dapp.wasm
-      - name: Get sns_aggregator
+      - name: Get sns_aggregator_dev
         uses: actions/download-artifact@v3
         with:
-          name: sns_aggregator
+          name: sns_aggregator_dev
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Motivation

Run tests in parallel to make CI faster.

# Changes

1. Split the `build` job into 3 jobs: `build`, `test-playwright-e2e` and `test-rest`
2. Create an action to download and install a snapshot and use it in bot test jobs.
3. Move uploading `nns-dapp.wasm` up to right after building.
4. Also upload both `sns_aggregator` wasms.
5. Download the wasms in both test jobs.
6. Add the new jobs to the `needs` of the last job.

# Tests

See CI
