### PR TITLE
Reduce warnings

### DIFF
--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -70,7 +70,7 @@ fn post_upgrade(args: Option<CanisterArguments>) {
     STATE.with(|s| {
         let bytes = stable::get();
         let new_state = State::decode(bytes).unwrap_or_else(|e| {
-            trap_with(&format!("Decoding stable memory failed. Error: {:?}", e));
+            trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
             unreachable!();
         });
 
@@ -89,9 +89,9 @@ pub fn http_request() {
     over(candid_one, assets::http_request);
 }
 
-/// Returns the user's account details if they have an account, else AccountNotFound.
+/// Returns the user's account details if they have an account, else `AccountNotFound`.
 ///
-/// The account details contain each of the AccountIdentifiers linked to the user's account. These
+/// The account details contain each of the `AccountIdentifier`s linked to the user's account. These
 /// include all accounts controlled by the user's principal directly and also any hardware wallet
 /// accounts they have registered.
 #[export_name = "canister_query get_account"]
@@ -122,9 +122,9 @@ fn add_account_impl() -> AccountIdentifier {
     AccountIdentifier::from(principal)
 }
 
-/// Returns a page of transactions for a given AccountIdentifier.
+/// Returns a page of transactions for a given `AccountIdentifier`.
 ///
-/// The AccountIdentifier must be linked to the caller's account, else an empty Vec will be
+/// The `AccountIdentifier` must be linked to the caller's account, else an empty Vec will be
 /// returned.
 #[export_name = "canister_query get_transactions"]
 pub fn get_transactions() {
@@ -222,7 +222,7 @@ fn detach_canister_impl(request: DetachCanisterRequest) -> DetachCanisterRespons
 
 #[export_name = "canister_update get_proposal_payload"]
 pub fn get_proposal_payload() {
-    over_async(candid_one, proposals::get_proposal_payload)
+    over_async(candid_one, proposals::get_proposal_payload);
 }
 
 #[export_name = "canister_update add_pending_notify_swap"]
@@ -296,10 +296,10 @@ pub fn add_stable_asset() {
                 insert_asset("/assets/canvaskit/canvaskit.js", Asset::new_stable(asset_bytes));
             }
             unknown_hash => {
-                dfn_core::api::trap_with(&format!("Unknown asset with hash {}", unknown_hash));
+                dfn_core::api::trap_with(&format!("Unknown asset with hash {unknown_hash}"));
             }
         }
-    })
+    });
 }
 
 #[derive(CandidType)]

--- a/rs/backend/src/metrics_encoder.rs
+++ b/rs/backend/src/metrics_encoder.rs
@@ -29,7 +29,7 @@ impl<W: io::Write> MetricsEncoder<W> {
     }
 
     fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
-        writeln!(self.writer, "# HELP {name} {typ}")?;
+        writeln!(self.writer, "# HELP {name} {help}")?;
         writeln!(self.writer, "# TYPE {name} {typ}")
     }
 

--- a/rs/backend/src/metrics_encoder.rs
+++ b/rs/backend/src/metrics_encoder.rs
@@ -29,8 +29,8 @@ impl<W: io::Write> MetricsEncoder<W> {
     }
 
     fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
-        writeln!(self.writer, "# HELP {} {}", name, help)?;
-        writeln!(self.writer, "# TYPE {} {}", name, typ)
+        writeln!(self.writer, "# HELP {name} {typ}")?;
+        writeln!(self.writer, "# TYPE {name} {typ}")
     }
 
     pub fn encode_single_value(&mut self, typ: &str, name: &str, value: f64, help: &str) -> io::Result<()> {

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -215,7 +215,7 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
 }
 
 fn debug<T: Debug>(value: T) -> String {
-    format!("{:?}", value)
+    format!("{value:?}")
 }
 
 mod def {
@@ -530,7 +530,7 @@ mod def {
     fn calculate_hash_string(bytes: &[u8]) -> String {
         let mut hash_string = String::with_capacity(64);
         for byte in calculate_hash(bytes) {
-            write!(hash_string, "{:02x}", byte).unwrap();
+            write!(hash_string, "{byte:02x}").unwrap();
         }
         hash_string
     }
@@ -538,7 +538,7 @@ mod def {
     fn format_bytes(bytes: &[u8]) -> String {
         let mut hash_string = String::with_capacity(64);
         for byte in bytes {
-            write!(hash_string, "{:02x}", byte).unwrap();
+            write!(hash_string, "{byte:02x}").unwrap();
         }
         hash_string
     }


### PR DESCRIPTION
# Motivation
Clippy, in pedantic mode, produces a lot of warnings.  It would be nice to reduce them.  Pedantic warnings can be useful but interesting lints are hidden by a mass of uninteresting warnings.

# Changes
- Address about 10% of pedantic warnings.

# Tests
None.  There is no change in functionality so existing CI should suffice.