### PR TITLE
gzip without timestamp

### DIFF
--- a/scripts/dfx-wasm-metadata-add
+++ b/scripts/dfx-wasm-metadata-add
@@ -76,7 +76,7 @@ rm "$WITH_COMMIT"
 
 ZIPPED="${DFX_CANISTER_WASM}.gz"
 if ((IS_ZIPPED == 0)); then
-  gzip <"${WITH_DID}" >"$ZIPPED"
+  gzip -n <"${WITH_DID}" >"$ZIPPED"
 else
   cat <"${WITH_DID}" >"$ZIPPED"
 fi


### PR DESCRIPTION
# Motivation

Unless you pass `-n`, `gzip` adds a timestamp, making the result not reproducible.

# Changes

Add `-n` to `gzip` in `scripts/dfx-wasm-metadata-add`

# Tests

Before:
```
$ cp nns-dapp.wasm-without-meta nns-dapp.wasm && scripts/dfx-wasm-metadata-add --canister_name nns-dapp --wasm nns-dapp.wasm && sha256sum nns-dapp.wasm
2e1de8f235b1e2be9282cbdfaf7de4cba139d72f7e29eff94875f305f0f6a3ae  nns-dapp.wasm

$ cp nns-dapp.wasm-without-meta nns-dapp.wasm && scripts/dfx-wasm-metadata-add --canister_name nns-dapp --wasm nns-dapp.wasm && sha256sum nns-dapp.wasm
57a40e9170dd27b539de22cbf96e3c79ea7afd0d7cb1dc3f430870deb47cac27  nns-dapp.wasm
```

After:
```
$ cp nns-dapp.wasm-without-meta nns-dapp.wasm && scripts/dfx-wasm-metadata-add --canister_name nns-dapp --wasm nns-dapp.wasm && sha256sum nns-dapp.wasm
df36c91cec159495d569bfa6430c52a00bc61371428d6866422017e989db6eb7  nns-dapp.wasm

$ cp nns-dapp.wasm-without-meta nns-dapp.wasm && scripts/dfx-wasm-metadata-add --canister_name nns-dapp --wasm nns-dapp.wasm && sha256sum nns-dapp.wasm
df36c91cec159495d569bfa6430c52a00bc61371428d6866422017e989db6eb7  nns-dapp.wasm
```
