### PR TITLE
Script to split assets into several tarballs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -219,8 +219,15 @@ jobs:
         run: command -v didc
       - name: Recreate and compare patches
         run: scripts/mk_nns_patch.test
+  asset-chunking-works:
+    name: Asset chunking works
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test chunking
+        run: scripts/nns-dapp/split-assets.test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/scripts/nns-dapp/split-assets
+++ b/scripts/nns-dapp/split-assets
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+	
+	Splits an assets tarball into several smaller tarballs.
+
+	- Note: The files in each tarball are complete, so each tarball can be uploaded
+	        to a canister independently.  Theer is no need to collect all the
+	        tarballs ion the canister and then install them together.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=a long=assets desc="The assets.tar.xz to split" variable=ORIGINAL_ASSETS_TAR_XZ default="out/assets.tar.xz"
+clap.define short=o long=out desc="The output directory; a subdirectory 'chunks' will be created and populated." variable=OUTPUT_DIR default="out"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+ORIGINAL_ASSETS_TAR_XZ="$(realpath "$ORIGINAL_ASSETS_TAR_XZ")"
+test -d "$OUTPUT_DIR" || {
+  echo "ERROR: The output directory should exist: '$OUTPUT_DIR'"
+  exit 1
+} >&2
+rm -fr "$OUTPUT_DIR/chunks"
+
+NUM_CHUNKS=2
+WORKDIR="$(mktemp -d)"
+
+(
+  : Unpack the assets
+  cd "$WORKDIR"
+  mkdir assets
+  cd assets
+  tar -Jxf "$ORIGINAL_ASSETS_TAR_XZ"
+)
+
+# Prints paths of assets in the tarball
+list_assets() {
+  (
+    cd "$WORKDIR/assets"
+    find . -type f
+  )
+}
+# Prints absolute paths to chunk manifests.
+# Each manifest contains a list of assets.
+list_manifests() {
+  find "$WORKDIR/chunk_names" -type f
+}
+
+FILES_PER_CHUNK="$(
+  num_files="$(list_assets | wc -l)"
+  echo $(((num_files + NUM_CHUNKS - 1) / NUM_CHUNKS))
+)"
+
+(
+  : Decide which files should go in every chunk
+  cd "$WORKDIR"
+  mkdir chunk_names
+  cd chunk_names
+  list_assets | split -l "$FILES_PER_CHUNK"
+  : "Note: This creates manifest files containing at most FILES_PER_CHUNK lines, each line being the path of an asset."
+  : "      The manifests can be listed with list_manifests"
+  ACTUAL_NUM_CHUNKS="$(list_manifests | wc -l)"
+  ((ACTUAL_NUM_CHUNKS == NUM_CHUNKS)) || ((NUM_CHUNKS > "$(list_assets | wc -l)")) || {
+    echo "ERROR: The actual number of chunks should be as requested:"
+    echo "  EXPECTED: $NUM_CHUNKS"
+    echo "  ACTUAL:   $ACTUAL_NUM_CHUNKS"
+    exit 1
+  } >&2
+)
+
+(
+  : Make chunks
+  cd "$WORKDIR"
+  mkdir chunks
+  cd assets
+  list_manifests | while read chunk_manifest; do
+    chunk_name="$WORKDIR/chunks/assets.$(basename "$chunk_manifest").tar.xz"
+    tar cJf "$chunk_name" -T "$chunk_manifest"
+  done
+)
+
+mv "$WORKDIR/chunks" "$OUTPUT_DIR"
+rm -fr "$WORKDIR" # TODO: Delete on exit

--- a/scripts/nns-dapp/split-assets
+++ b/scripts/nns-dapp/split-assets
@@ -9,8 +9,8 @@ print_help() {
 	Splits an assets tarball into several smaller tarballs.
 
 	- Note: The files in each tarball are complete, so each tarball can be uploaded
-	        to a canister independently.  Theer is no need to collect all the
-	        tarballs ion the canister and then install them together.
+	        to a canister independently.  There is no need to collect all the
+	        tarballs in the canister and then install them together.
 	EOF
 }
 

--- a/scripts/nns-dapp/split-assets
+++ b/scripts/nns-dapp/split-assets
@@ -80,7 +80,7 @@ FILES_PER_CHUNK="$(
   cd "$WORKDIR"
   mkdir chunks
   cd assets
-  list_manifests | while read chunk_manifest; do
+  list_manifests | while read -r chunk_manifest; do
     chunk_name="$WORKDIR/chunks/assets.$(basename "$chunk_manifest").tar.xz"
     tar cJf "$chunk_name" -T "$chunk_manifest"
   done

--- a/scripts/nns-dapp/split-assets
+++ b/scripts/nns-dapp/split-assets
@@ -82,7 +82,15 @@ FILES_PER_CHUNK="$(
   cd assets
   list_manifests | while read -r chunk_manifest; do
     chunk_name="$WORKDIR/chunks/assets.$(basename "$chunk_manifest").tar.xz"
-    tar cJf "$chunk_name" -T "$chunk_manifest"
+    tar cJ \
+      --mtime='2021-05-07 17:00Z' \
+      --sort=name \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=ustar \
+      -f "$chunk_name" \
+      -T "$chunk_manifest"
   done
 )
 

--- a/scripts/nns-dapp/split-assets.test
+++ b/scripts/nns-dapp/split-assets.test
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 tarfile_contents() {
   # Tarfile contents, excluding directories
   tar -Jtf "$1" | grep -vE '/$'
+}
+
+canonical_tar_filenames() {
+  # Omit the leading ./ if present.
+  # Sort the filenames
+  sed -r 's#^./##g' | sort
 }
 
 (
@@ -20,7 +28,7 @@ tarfile_contents() {
   scripts/nns-dapp/split-assets --assets "${original}" --out "$chunks_dir"
 
   : "Check that the list of files is the same"
-  diff <(tarfile_contents "$original" | sort) <(find "$chunks_dir" -type f | while read -r line; do tarfile_contents "$line"; done | sort) || {
+  diff <(tarfile_contents "$original" | canonical_tar_filenames) <(find "$chunks_dir" -type f | while read -r line; do tarfile_contents "$line"; done | canonical_tar_filenames) || {
     echo "ERROR: The list of files present in the chunks should be the same as that in the original, without duplicates or omissions."
     echo "Original:   $original"
     echo "Chunks dir: $chunks_dir"
@@ -29,9 +37,9 @@ tarfile_contents() {
 
   : "Check that the file contents are the same"
   original_unpacked="$(mktemp -d ,original-assets-XXXXXX)"
-  tar -Jxf out/assets.tar.xz -C "$original_unpacked"
+  tar -Jxf "$original" -C "$original_unpacked"
   chunks_unpacked="$(mktemp -d ,chunked-assets-XXXXXX)"
-  find out/chunks/ -type f -printf '%p\n' | xargs -I{} tar -Jxf {} -C "$chunks_unpacked"
+  find "$chunks_dir" -type f -printf '%p\n' | xargs -I{} tar -Jxf {} -C "$chunks_unpacked"
   diff --recursive "$original_unpacked" "$chunks_unpacked" || {
     echo "ERROR: The contents of the chunked tarballs should match the contents of the original tarball"
     echo "Unpacked original: $original_unpacked"

--- a/scripts/nns-dapp/split-assets.test
+++ b/scripts/nns-dapp/split-assets.test
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+PATH="$SOURCE_DIR:$PATH"
+
+print_help() {
+  cat <<-EOF
+
+	Verifies that the ${0%.test} command behaves as advertised.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+cd "$SOURCE_DIR/.."
 
 tarfile_contents() {
   # Tarfile contents, excluding directories

--- a/scripts/nns-dapp/split-assets.test
+++ b/scripts/nns-dapp/split-assets.test
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+tarfile_contents() {
+  # Tarfile contents, excluding directories
+  tar -Jtf "$1" | grep -vE '/$'
+}
+
+(
+  echo "Chunks should contain all the original files"
+
+  : "Get or create a .tar.xz file"
+  original="$(mktemp ,original-XXXXXX)"
+  if test -e out/assets.tar.xz; then
+    cp out/assets.tar.xz "$toy_assets"
+  else
+    tar -cJf "$original" frontend
+  fi
+
+  : "Chunk the original"
+  chunks_dir="$(mktemp -d ,chunks-XXXXXX)"
+  scripts/nns-dapp/split-assets --assets "${original}" --out "$chunks_dir"
+
+  : "Check that the list of files is the same"
+  diff <(tarfile_contents "$original" | sort) <(find "$chunks_dir" -type f | while read line; do tarfile_contents "$line"; done | sort) || {
+    echo "ERROR: The list of files present in the chunks should be the same as that in the original, without duplicates or omissions."
+    echo "Original:   $original"
+    echo "Chunks dir: $chunks_dir"
+    exit 1
+  } >&2
+
+  : "Check that the file contents are the same"
+  original_unpacked="$(mktemp -d ,original-assets-XXXXXX)"
+  tar -Jxf out/assets.tar.xz -C "$original_unpacked"
+  chunks_unpacked="$(mktemp -d ,chunked-assets-XXXXXX)"
+  find out/chunks/ -type f | xargs -I{} tar -Jxf {} -C "$chunks_unpacked"
+  diff --recursive "$original_unpacked" "$chunks_unpacked" || {
+    echo "ERROR: The contents of the chunked tarballs should match the contents of the original tarball"
+    echo "Unpacked original: $original_unpacked"
+    echo "Unpacked chunks:   $chunks_unpacked"
+    exit 1
+  } >&2
+
+  : "Clean up"
+  rm -fr "$original" "$chunks_dir" "$original_unpacked" "$chunks_unpacked"
+)
+
+echo "$(basename "$0") PASSED"

--- a/scripts/nns-dapp/split-assets.test
+++ b/scripts/nns-dapp/split-assets.test
@@ -10,7 +10,7 @@ tarfile_contents() {
   : "Get or create a .tar.xz file"
   original="$(mktemp ,original-XXXXXX)"
   if test -e out/assets.tar.xz; then
-    cp out/assets.tar.xz "$toy_assets"
+    cp out/assets.tar.xz "$original"
   else
     tar -cJf "$original" frontend
   fi
@@ -20,7 +20,7 @@ tarfile_contents() {
   scripts/nns-dapp/split-assets --assets "${original}" --out "$chunks_dir"
 
   : "Check that the list of files is the same"
-  diff <(tarfile_contents "$original" | sort) <(find "$chunks_dir" -type f | while read line; do tarfile_contents "$line"; done | sort) || {
+  diff <(tarfile_contents "$original" | sort) <(find "$chunks_dir" -type f | while read -r line; do tarfile_contents "$line"; done | sort) || {
     echo "ERROR: The list of files present in the chunks should be the same as that in the original, without duplicates or omissions."
     echo "Original:   $original"
     echo "Chunks dir: $chunks_dir"
@@ -31,7 +31,7 @@ tarfile_contents() {
   original_unpacked="$(mktemp -d ,original-assets-XXXXXX)"
   tar -Jxf out/assets.tar.xz -C "$original_unpacked"
   chunks_unpacked="$(mktemp -d ,chunked-assets-XXXXXX)"
-  find out/chunks/ -type f | xargs -I{} tar -Jxf {} -C "$chunks_unpacked"
+  find out/chunks/ -type f -printf '%p\n' | xargs -I{} tar -Jxf {} -C "$chunks_unpacked"
   diff --recursive "$original_unpacked" "$chunks_unpacked" || {
     echo "ERROR: The contents of the chunked tarballs should match the contents of the original tarball"
     echo "Unpacked original: $original_unpacked"

--- a/scripts/nns-dapp/split-assets.test
+++ b/scripts/nns-dapp/split-assets.test
@@ -33,6 +33,9 @@ canonical_tar_filenames() {
   echo "Chunks should contain all the original files"
 
   : "Get or create a .tar.xz file"
+  # Note: Any .tar.xz file will do.  If we happen to have the assets.tar.xz around, we use that,
+  # otherwise we create a .tar.xz from the contents of the frontend dir.  We could equally use
+  # any other directory or .tar.xz as long as it contains at least two files.
   original="$(mktemp ,original-XXXXXX)"
   if test -e out/assets.tar.xz; then
     cp out/assets.tar.xz "$original"


### PR DESCRIPTION
# Motivation
The assets are too large to upload as a single tarball.

# Changes
- Add a command to split `assets.tar.xz` into smaller `.tar.xz` files.

# Tests
- A test is included and is exercised in CI.