### PR TITLE
Separate out code for inserting a tarball

### DIFF
--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -359,14 +359,23 @@ pub fn insert_asset_into_state<S: Into<String> + Clone>(state: &State, path: S, 
 
 /// Adds the files bundled in the wasm to the state.
 ///
+/// Note: Used both in init and post_upgrade
+pub fn init_assets() {
+    let compressed = include_bytes!("../../../assets.tar.xz").to_vec();
+    insert_tar_xz(compressed);
+}
+
+/// Adds an xz compressed tarball of assets to the state.
+///
 /// - Adds the files to `state.assets`.
 /// - Signs the given path and all alternate paths for the given asset.
 ///
-/// Note: Used both in init and post_upgrade
-pub fn init_assets() {
+/// Note: The vec is mutated during decompression, so pass by reference is inefficient
+///       as it would force the data to be copied into a new vector, even when the
+///       original is no longer needed.
+pub fn insert_tar_xz(compressed: Vec<u8>) {
     dfn_core::api::print("Inserting assets...");
     let mut num_assets = 0;
-    let compressed = include_bytes!("../../../assets.tar.xz").to_vec();
     let mut decompressed = Vec::new();
     lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
     let mut tar: tar::Archive<&[u8]> = tar::Archive::new(decompressed.as_ref());


### PR DESCRIPTION
# Motivation
We would like to upload asset tarballs.  The code for adding a tarball of assets already exists, it just needs to be decoupled from `init()`.

# Changes
- Separate the code for installing an assets tarball from the assets baked into the binary.

# Tests
None; existing tests should suffice.