### PR TITLE
E2E: SN005: User can see the list of hotkeys of a neuron

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -62,15 +62,18 @@ test("Test SNS governance", async ({ page, context }) => {
   const neuronDetail = appPo.getNeuronDetailPo().getSnsNeuronDetailPo();
   expect(await neuronDetail.getTitle()).toBe(snsProjectName);
   expect(await neuronDetail.getStake()).toBe(formattedStake);
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
 
   step("SN003: User can add a hotkey");
   const hotkeyPrincipal =
     "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
   await neuronDetail.addHotkey(hotkeyPrincipal);
 
+  step("SN005: User can see the list of hotkeys of a neuron");
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([hotkeyPrincipal]);
+
   step("SN004: User can remove a hotkey");
   await neuronDetail.removeHotkey(hotkeyPrincipal);
   await appPo.waitForNotBusy();
-
-  // SN005: User can see the list of hotkeys of a neuron
+  expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
 });

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -83,4 +83,8 @@ export class SnsNeuronDetailPo extends BasePageObject {
   removeHotkey(principal: string): Promise<void> {
     return this.getHotkeysCardPo().removeHotkey(principal);
   }
+
+  getHotkeyPrincipals(): Promise<string[]> {
+    return this.getHotkeysCardPo().getHotkeyPrincipals();
+  }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
@@ -53,4 +53,9 @@ export class SnsNeuronHotkeysCardPo extends BasePageObject {
     const row = await this.getHotkeyRowPo(principal);
     return row.clickRemove();
   }
+
+  async getHotkeyPrincipals(): Promise<string[]> {
+    const rows = await this.getHotkeyRowPos();
+    return Promise.all(rows.map((row) => row.getPrincipal()));
+  }
 }


### PR DESCRIPTION
# Motivation

Adding more end-to-end test coverage.

# Changes

1. In `frontend/src/tests/e2e/sns-governance.spec.ts` check that the user can see the added hotkey.
2. Add page object functions.

# Tests

`npm run test-e2e`