### PR TITLE
fix: update the ic-admin download link

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -217,7 +217,7 @@ install_ic_admin_linux() {
   chmod +x "$USER_BIN/ic-admin"
 }
 install_ic_admin_darwin() {
-  curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/ic-admin.gz" | gunzip >"$USER_BIN/ic-admin"
+  curl "https://download.dfinity.systems/ic/${IC_COMMIT}/openssl-static-binaries/x86_64-darwin/ic-admin.gz" | gunzip >"$USER_BIN/ic-admin"
   chmod +x "$USER_BIN/ic-admin"
   # shellcheck disable=SC2016
   command -v ic-admin ||


### PR DESCRIPTION
# Motivation

Fix the `ic-admin` setup. The darwin link was outdated (screenshot).

# Changes

- change the download path.

# Screenshot

*Broken link*
<img width="981" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/9d003536-ac3c-4bee-a213-444b79bbfab2">


