### PR TITLE
One wasm to rule them all

### DIFF
--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -20,7 +20,7 @@ runs:
         cd "${{ inputs.assets_dir }}"
         daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
         cp nns-dapp.wasm "$daily_build_name"
-        artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
+        artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name" nns-dapp-arg-mainnet.did nns-dapp-arg-mainnet.bin nns-dapp-arg-local.did nns-dapp-arg-local.bin)
         ls -l "${artefacts[@]}"
         for tag in $(git tag --points-at HEAD) ; do
           : Creates or updates a release for the tag

--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -20,7 +20,7 @@ runs:
         cd "${{ inputs.assets_dir }}"
         daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm"
         cp nns-dapp.wasm "$daily_build_name"
-        artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name" nns-dapp-arg-mainnet.did nns-dapp-arg-mainnet.bin nns-dapp-arg-local.did nns-dapp-arg-local.bin)
+        artefacts=(nns-dapp.wasm sns_aggregator.wasm sns_aggregator_dev.wasm assets.tar.xz "$daily_build_name")
         ls -l "${artefacts[@]}"
         for tag in $(git tag --points-at HEAD) ; do
           : Creates or updates a release for the tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,6 +290,16 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out-mainnet
+      - name: Get nns-dapp_local
+        uses: actions/download-artifact@v3
+        with:
+          name: nns-dapp_local
+          path: out-local
+      - name: Get sns_aggregator
+        uses: actions/download-artifact@v3
+        with:
+          name: sns_aggregator
+          path: out-local
       - name: Get sns_aggregator_dev
         uses: actions/download-artifact@v3
         with:
@@ -299,7 +309,7 @@ jobs:
         run: |
           set -x
           ls -l
-          artefacts="sns_aggregator_dev.wasm"
+          artefacts="sns_aggregator_dev.wasm sns_aggregator.wasm nns-dapp.wasm"
           networks=(mainnet local)
           for network in "${networks[@]}" ; do
             ls -l "out-$network"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,8 +269,47 @@ jobs:
         working-directory: e2e-tests
         run: |
           rm -rf screenshots
+  network_independent_wasm:
+    name: "Same wasms for mainnet and local"
+    needs: build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v3
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build wasms
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            DFX_NETWORK=mainnet
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=cached-stage
+          # Exports the artefacts from the final stage
+          outputs: ./out-mainnet
+      - name: Get sns_aggregator_dev
+        uses: actions/download-artifact@v3
+        with:
+          name: sns_aggregator_dev
+          path: out-local
+      - name: Compare wasms
+        run: |
+          set -x
+          ls -l
+          artefacts="sns_aggregator_dev.wasm"
+          networks=(mainnet local)
+          for network in "${networks[@]}" ; do
+            ls -l "out-$network"
+            (cd "out-$network" && sha256sum "${artefacts[@]}" ; ) > "${network}_hashes.txt"
+          done
+          diff local_hashes.txt mainnet_hashes.txt  || {
+            echo "ERROR: wasm hashes differ between mainnet and local."
+          }
   build-pass:
-    needs: ["build", "test-playwright-e2e", "test-rest"]
+    needs: ["build", "test-playwright-e2e", "test-rest", "network_independent_wasm"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,8 @@ jobs:
         with:
           name: nns-dapp_local
           path: out-local
+      - name: Remove _local suffix
+        run: mv out-local/nns-dapp_local.wasm out-local/nns-dapp.wasm
       - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
           networks=(mainnet local)
           for network in "${networks[@]}" ; do
             ls -l "out-$network"
-            (cd "out-$network" && sha256sum "${artefacts[@]}" ; ) > "${network}_hashes.txt"
+            (cd "out-$network" && sha256sum ${artefacts[@]} ; ) > "${network}_hashes.txt"
           done
           diff local_hashes.txt mainnet_hashes.txt  || {
             echo "ERROR: wasm hashes differ between mainnet and local."


### PR DESCRIPTION
# Motivation
The wasm we have on mainnet should be identical to the one used on local networks.  Let's test that.

# Changes
- Add a test that compares wasm builds for mainnet and local.

# Notes
- There is a separate issue of whether all parts of the code are using the dynamic configuration passed in with arguments.  That is not covered in this PR.
- There is  a question of where the test should live. I am personally of the opinion that we should build the wasm once, then use that one wasm across many tests.  Why?  Why waste CPU cycles repeating work?  That means that we should not have separate e2e and testing workflows but rather one workflow with separate jobs inside it.

# Tests
See above.