### PR TITLE
Use standard arg parsing for docker-build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: docker-build prints help
-        run: ./scripts/docker-build --help | grep Usage
+        run: ./scripts/docker-build --help | grep -i usage
       - name: docker-build complains about garbage
         run: |
           { ./scripts/docker-build safdashfdkj || true ; } |& grep 'ERROR: Unsupported flag:'

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -97,7 +97,12 @@ jobs:
         run: ./scripts/docker-build --help | grep -i usage
       - name: docker-build complains about garbage
         run: |
-          { ./scripts/docker-build safdashfdkj || true ; } |& grep -i error
+          { ./scripts/docker-build safdashfdkj || true ; } 2>,stderr
+          grep -qi error ,stderr || {
+            echo "ERROR: Expected to see an error message in:"
+            cat ,stderr
+            exit 1
+          }
   docker-build:
     needs: assets
     runs-on: ubuntu-20.04

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -97,7 +97,7 @@ jobs:
         run: ./scripts/docker-build --help | grep -i usage
       - name: docker-build complains about garbage
         run: |
-          { ./scripts/docker-build safdashfdkj || true ; } |& grep 'ERROR: Unsupported flag:'
+          { ./scripts/docker-build safdashfdkj || true ; } |& grep -i error
   docker-build:
     needs: assets
     runs-on: ubuntu-20.04

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -95,14 +95,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: docker-build prints help
         run: ./scripts/docker-build --help | grep -i usage
-      - name: docker-build complains about garbage
-        run: |
-          { ./scripts/docker-build safdashfdkj || true ; } 2>,stderr
-          grep -qi error ,stderr || {
-            echo "ERROR: Expected to see an error message in:"
-            cat ,stderr
-            exit 1
-          }
   docker-build:
     needs: assets
     runs-on: ubuntu-20.04

--- a/scripts/clap.bash
+++ b/scripts/clap.bash
@@ -132,6 +132,7 @@ while [ \$# -ne 0 ]; do
                         usage
                         exit 0;;
 		--verbose)
+			CLAP_VERBOSE=true
 			set -x;;
 		--)
 			break ;;

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,61 +1,40 @@
 #!/usr/bin/env bash
-# vim: ft=bash
-# Build nns-dapp.wasm inside docker. This outputs a single file, nns-dapp.wasm,
-# in the top-level directory.
-
 set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
-SCRIPTS_DIR="$(pwd)"
-
-cd "$SCRIPTS_DIR/.."
-
-# Note: This script is intended to be extremely robust and work on many platforms
-#       so we parse arguments manually rather than using a clever, feature-rich but
-#       fragile general purpose argument parser.
 print_help() {
-  cat <<-EOF
-	Builds the nns-dapp wasm and artifacts in docker.
+  cat <<-"EOF"
 
-	Usage: $(basename "$0") [--network <network>] [--verbose] [--help] [-- <docker flags>]
+	Build nns-dapp.wasm inside docker. This creates:
+	- An "out" directory in the project directory containing all build artefacts.
+	  Note: If the "out" directory already exists, it will be deleted and replaced.
+	- The following artefacts are also added to the project directory:
+	  - assets.tar.xz
+	  - nns-dapp.wasm
+	  - sns_aggregator.wasm
+	  - "nns-dapp-arg-${DFX_NETWORK}.did"
+	  - "nns-dapp-arg-${DFX_NETWORK}.bin"
 
-	<docker flags>
-	  Any flags that are to be passed on to Docker.  A common example is --no-cache.
-	  A full list is here: https://docs.docker.com/engine/reference/commandline/build/#options
 	EOF
 }
-DFX_NETWORK=${DFX_NETWORK:-mainnet}
-PROGRESS="--progress=auto"
-while (($# > 0)); do
-  arg="$1"
-  shift 1
-  case "$arg" in
-  --network)
-    DFX_NETWORK="$1"
-    shift 1
-    ;;
-  --verbose)
-    PROGRESS="--progress=plain"
-    ;;
-  --help)
-    print_help
-    exit 0
-    ;;
-  --)
-    break
-    ;;
-  *)
-    {
-      echo "ERROR: Unsupported flag: '$arg'"
-      print_help
-    } >&2
-    exit 1
-    ;;
-  esac
-done
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="mainnet"
+clap.define short=t long=target desc="The target in the docker file" variable=DFX_TARGET default="scratch"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
 
 echo "DFX_NETWORK: $DFX_NETWORK"
 echo "PWD: $PWD"
+
+if [[ "${CLAP_VERBOSE:-}" == "true" ]]; then
+  PROGRESS="--progress=plain"
+else
+  PROGRESS="--progress=auto"
+fi
 
 image_name="nns-dapp-$DFX_NETWORK"
 


### PR DESCRIPTION
# Motivation
Consistency.  I would like to add another flag but feel as if I am reinventing the wheel when modifying the docker-build arguments.  So why not use the standard argument parser in docker-build?

# Changes
- Use standard argument parsing in `docker-build`
- Surface the `--verbose` flag in the `clap.bash` environment variables, so that it can be used to make the docker output verbose, as before.

# Tests
See CI.  I have also used it locally.