### PR TITLE
Fix lint warning Type '(value: unknown) => void' is not assignable to type '() => void'.

### DIFF
--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -10,7 +10,7 @@ export const step = async (description: string) => {
   resolvePreviousStep();
   await previousStep;
   previousStep = test.step(description, () => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       resolvePreviousStep = resolve;
     });
   });


### PR DESCRIPTION
# Motivation

Fix in `e2e.test-utils`:

> TS2322: Type '(value: unknown) => void' is not assignable to type '() => void'.

