### PR TITLE
Expose ledger canister id in sns summary

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -143,7 +143,7 @@ export const querySnsSwapState = async ({
 
   const {
     swapState,
-    canisterIds: { swapCanisterId, governanceCanisterId },
+    canisterIds: { swapCanisterId, governanceCanisterId, ledgerCanisterId },
   }: SnsWrapper = await wrapper({
     rootCanisterId,
     identity,
@@ -160,6 +160,7 @@ export const querySnsSwapState = async ({
     rootCanisterId,
     swapCanisterId,
     governanceCanisterId,
+    ledgerCanisterId,
     swap,
     derived,
     certified,

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -67,6 +67,9 @@ export const loadSnsProjects = async (): Promise<void> => {
         governanceCanisterId: Principal.fromText(
           sns.canister_ids.governance_canister_id
         ),
+        ledgerCanisterId: Principal.fromText(
+          sns.canister_ids.ledger_canister_id
+        ),
         swap: toNullable(sns.swap_state.swap),
         derived: toNullable(sns.swap_state.derived),
       })),

--- a/frontend/src/lib/types/sns.query.ts
+++ b/frontend/src/lib/types/sns.query.ts
@@ -22,6 +22,7 @@ export type QuerySnsMetadata = QuerySns & {
 export type QuerySnsSwapState = QuerySns & {
   swapCanisterId: Principal;
   governanceCanisterId: Principal;
+  ledgerCanisterId: Principal;
   swap: [] | [SnsSwap];
   derived: [] | [SnsSwapDerivedState];
 };

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -45,6 +45,8 @@ export interface SnsSummary {
   swapCanisterId: Principal;
   // Used to show destination when staking sns neurons.
   governanceCanisterId: Principal;
+  // Used to observe accounts' balance and transactions
+  ledgerCanisterId: Principal;
 
   /**
    * The metadata of the Sns project (title, description, etc.)

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -37,6 +37,7 @@ type OptionalSummary = QuerySns & {
   derived?: SnsSwapDerivedState;
   swapCanisterId?: Principal;
   governanceCanisterId?: Principal;
+  ledgerCanisterId?: Principal;
 };
 
 type ValidSummary = Required<Omit<OptionalSummary, "swap">> & {
@@ -153,6 +154,7 @@ export const mapAndSortSnsQueryToSummaries = ({
         token: mapOptionalToken(token),
         swapCanisterId: swapState?.swapCanisterId,
         governanceCanisterId: swapState?.governanceCanisterId,
+        ledgerCanisterId: swapState?.ledgerCanisterId,
         swap: mapOptionalSwap(swapData),
         derived: fromNullable(swapState?.derived ?? []),
       };
@@ -166,6 +168,7 @@ export const mapAndSortSnsQueryToSummaries = ({
       entry.swap.params !== undefined &&
       entry.swapCanisterId !== undefined &&
       entry.governanceCanisterId !== undefined &&
+      entry.ledgerCanisterId !== undefined &&
       entry.derived !== undefined &&
       entry.metadata !== undefined &&
       entry.token !== undefined

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -59,6 +59,7 @@ describe("sns-utils", () => {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,
@@ -82,6 +83,7 @@ describe("sns-utils", () => {
             rootCanisterId: "1234",
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [],
             certified: true,
@@ -100,6 +102,7 @@ describe("sns-utils", () => {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -126,6 +129,7 @@ describe("sns-utils", () => {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -149,6 +153,7 @@ describe("sns-utils", () => {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -172,6 +177,7 @@ describe("sns-utils", () => {
             rootCanisterId: mockSummary.rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,
@@ -190,6 +196,7 @@ describe("sns-utils", () => {
             rootCanisterId: mockSnsSummaryList[1].rootCanisterId.toText(),
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
+            ledgerCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -172,6 +172,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     rootCanisterId: principal(0),
     swapCanisterId: principal(3),
     governanceCanisterId: principal(2),
+    ledgerCanisterId: principal(1),
     metadata: mockMetadata,
     token: mockToken,
     swap: mockSwap,
@@ -181,6 +182,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     rootCanisterId: principal(1),
     swapCanisterId: principal(2),
     governanceCanisterId: principal(3),
+    ledgerCanisterId: principal(0),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAClSURBVHgB7dqxDYMwEEBRE2UET5I6icQUzMgc9EziHUAuqLElS+if/iuoruAXyCeL6fufjxTMuz5KKbeDOee0rXtq8Vs+TbM9cy3vWNX3fKWAjKIwisIoipBRU9iNYuTp3zM7eu6a9ZuiMIrCKAqjKNwoek711nuPkXPXrN8UhVEURlEYReFG4R3Fg4yiMIrCKAo3Cgr/o6AwisIoCqMojKIIuSadjJ5VyRrmqP4AAAAASUVORK5CYII=",
       name: "Pac-Man",
@@ -200,6 +202,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     rootCanisterId: principal(2),
     swapCanisterId: principal(1),
     governanceCanisterId: principal(3),
+    ledgerCanisterId: principal(0),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACjSURBVHgB7dkxDkRAGEDh32ZPsuWWWy+JQ4gzimPolUpXIXMCM4nmjfcVqglegT+j+Xf9EZV5p8MyrZcL2/EX+7BFjs/8zVpbsi7nHpN0n6+okFEURlEYRVFlVPP4iaLkq37npFB6bZ8pCqMojKIwisKJomSP4s5zukcRvig4jKIwisKJgsK/HhRGURhFYRSFEwWFEwWFURRGURhFYRRFlWPSCah/Vck0pRWfAAAAAElFTkSuQmCC",
       name: "Super Mario",
@@ -219,6 +222,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     rootCanisterId: principal(3),
     swapCanisterId: principal(0),
     governanceCanisterId: principal(2),
+    ledgerCanisterId: principal(1),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZkxCsJAFAUTETyAexcbEfZSHsJLBcTGu6wHsFK3SL0/EIvZzBSpHj87gYXHz3i+5M/QGfv6OB2mZvD5zqHcnC2lNHMppb+8ezd0iFIUlKKgFIUupcbNN4rpeB0i5Ndt1ZnRefNM7xQFpSgoRUEpCv02ijX3CZXoTmFJLnLGSj2nd4qCUhSUoqAUBXcUSxrF497O/j6ofz2iKEVBKQpKUbBRUHBHQUEpCkpRUIqCUhS6rElfBK1VyaWjTNYAAAAASUVORK5CYII=",
       name: "Donkey Kong",

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -14,7 +14,11 @@ import {
   principal,
   summaryForLifecycle,
 } from "./sns-projects.mock";
-import { governanceCanisterIdMock, swapCanisterIdMock } from "./sns.api.mock";
+import {
+  governanceCanisterIdMock,
+  ledgerCanisterIdMock,
+  swapCanisterIdMock,
+} from "./sns.api.mock";
 
 const swapToQuerySwap = (swap: SnsSummarySwap): [SnsSwap] => [
   {
@@ -53,6 +57,7 @@ export const snsResponseFor = ({
       rootCanisterId: principal.toText(),
       swapCanisterId: swapCanisterIdMock,
       governanceCanisterId: governanceCanisterIdMock,
+      ledgerCanisterId: ledgerCanisterIdMock,
       swap: swapToQuerySwap({
         ...summaryForLifecycle(lifecycle).swap,
         init: [


### PR DESCRIPTION
# Motivation

Regardless if Sns, ckBTC or ICP we want to be able to fetch balance and transactions uses the ICRC-1 ledger.

In Snses we generally use the "wrapper" to access the canister but, in the particular crontab feature #2639 we want to avoid the use of such object and use `@dfinity/ledger` library directly regardless of the context.

That is why we need to access the ledger canister Id of a Sns project.

# Changes

- export `ledgerCanisterId` in `SnsSummary` (as we already did for swap and governance)
