### PR TITLE
Refactor Cjs import and common functions in a dedicated utils

### DIFF
--- a/frontend/src/lib/api/canisters.api.cjs.ts
+++ b/frontend/src/lib/api/canisters.api.cjs.ts
@@ -3,12 +3,9 @@ import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management
 import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
 import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-management.types";
 import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import { HttpAgentCjs, getManagementCanisterCjs } from "$lib/utils/cjs.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity, ManagementCanisterRecord } from "@dfinity/agent";
-/**
- * HTTP-Agent explicit CJS import for compatibility with web worker - avoid "window undefined" issues
- */
-import { getManagementCanister, HttpAgent } from "@dfinity/agent/lib/cjs/index";
 import { Principal } from "@dfinity/principal";
 
 export const queryCanisterDetails = async ({
@@ -48,7 +45,7 @@ const canisters = async (
 ): Promise<{
   icMgtService: ManagementCanisterRecord;
 }> => {
-  const agent = new HttpAgent({
+  const agent = new HttpAgentCjs({
     identity,
     host: HOST,
   });
@@ -57,7 +54,7 @@ const canisters = async (
     await agent.fetchRootKey();
   }
 
-  const icMgtService = getManagementCanister({ agent });
+  const icMgtService = getManagementCanisterCjs({ agent });
 
   return { icMgtService };
 };

--- a/frontend/src/lib/api/tvl.api.cjs.ts
+++ b/frontend/src/lib/api/tvl.api.cjs.ts
@@ -1,15 +1,14 @@
 import { TVLCanister } from "$lib/canisters/tvl/tvl.canister";
 import type { TvlResult } from "$lib/canisters/tvl/tvl.types";
 import { TVL_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { HOST } from "$lib/constants/environment.constants";
+import {
+  createCanisterCjs,
+  type CreateCanisterCjsParams,
+} from "$lib/utils/cjs.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import { isNullish } from "@dfinity/utils";
-/**
- * HTTP-Agent explicit CJS import for compatibility with web worker - avoid Error [RollupError]: Unexpected token (Note that you need plugins to import files that are not JavaScript)
- */
-import { HttpAgent } from "@dfinity/agent/lib/cjs/index";
 
 export const queryTVL = async ({
   identity,
@@ -35,20 +34,19 @@ export const queryTVL = async ({
   return result;
 };
 
-const canister = async ({
+const canister = ({
   identity,
   canisterId,
 }: {
   identity: Identity;
   canisterId: Principal;
-}): Promise<TVLCanister> => {
-  const agent = new HttpAgent({
+}): Promise<TVLCanister> =>
+  createCanisterCjs<TVLCanister>({
     identity,
-    host: HOST,
-  });
-
-  return TVLCanister.create({
-    agent,
     canisterId,
+    create: ({ agent, canisterId }: CreateCanisterCjsParams) =>
+      TVLCanister.create({
+        agent,
+        canisterId,
+      }),
   });
-};

--- a/frontend/src/lib/utils/cjs.utils.ts
+++ b/frontend/src/lib/utils/cjs.utils.ts
@@ -1,0 +1,38 @@
+import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+
+/**
+ * HTTP-Agent explicit CJS import for compatibility with web worker - avoid Error [RollupError]: Unexpected token (Note that you need plugins to import files that are not JavaScript)
+ */
+import { HttpAgent, getManagementCanister } from "@dfinity/agent/lib/cjs/index";
+
+export {
+  HttpAgent as HttpAgentCjs,
+  getManagementCanister as getManagementCanisterCjs,
+};
+
+export interface CreateCanisterCjsParams {
+  agent: HttpAgent;
+  canisterId: Principal;
+}
+
+export const createCanisterCjs = async <T>({
+  identity,
+  canisterId,
+  create,
+}: {
+  identity: Identity;
+  create: (params: CreateCanisterCjsParams) => T;
+} & Pick<CreateCanisterCjsParams, "canisterId">): Promise<T> => {
+  const agent = new HttpAgent({
+    identity,
+    host: HOST,
+  });
+
+  if (FETCH_ROOT_KEY) {
+    await agent.fetchRootKey();
+  }
+
+  return create({ agent, canisterId });
+};


### PR DESCRIPTION
# Motivation

Refactor (move) Cjs dedicated import and common functions in a specific utils.

That way we spare the duplicate code and we make the functions also available for upcoming workers such as in #2639.

# Changes

- move import (and rexport)  `"@dfinity/agent/lib/cjs/index"` to `cjs.utils`
- move a common `createCanisterCjs` to `cjs.utils`
- add the `if fetch_root_key then fetch_root_key` to that create function
