### PR TITLE
Expose Sns index canister ID

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -143,7 +143,12 @@ export const querySnsSwapState = async ({
 
   const {
     swapState,
-    canisterIds: { swapCanisterId, governanceCanisterId, ledgerCanisterId },
+    canisterIds: {
+      swapCanisterId,
+      governanceCanisterId,
+      ledgerCanisterId,
+      indexCanisterId,
+    },
   }: SnsWrapper = await wrapper({
     rootCanisterId,
     identity,
@@ -161,6 +166,7 @@ export const querySnsSwapState = async ({
     swapCanisterId,
     governanceCanisterId,
     ledgerCanisterId,
+    indexCanisterId,
     swap,
     derived,
     certified,

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -70,6 +70,7 @@ export const loadSnsProjects = async (): Promise<void> => {
         ledgerCanisterId: Principal.fromText(
           sns.canister_ids.ledger_canister_id
         ),
+        indexCanisterId: Principal.fromText(sns.canister_ids.index_canister_id),
         swap: toNullable(sns.swap_state.swap),
         derived: toNullable(sns.swap_state.derived),
       })),

--- a/frontend/src/lib/types/sns.query.ts
+++ b/frontend/src/lib/types/sns.query.ts
@@ -23,6 +23,7 @@ export type QuerySnsSwapState = QuerySns & {
   swapCanisterId: Principal;
   governanceCanisterId: Principal;
   ledgerCanisterId: Principal;
+  indexCanisterId: Principal;
   swap: [] | [SnsSwap];
   derived: [] | [SnsSwapDerivedState];
 };

--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -45,8 +45,10 @@ export interface SnsSummary {
   swapCanisterId: Principal;
   // Used to show destination when staking sns neurons.
   governanceCanisterId: Principal;
-  // Used to observe accounts' balance and transactions
+  // Used to observe accounts' balance
   ledgerCanisterId: Principal;
+  // Used to observe accounts' transactions
+  indexCanisterId: Principal;
 
   /**
    * The metadata of the Sns project (title, description, etc.)

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -38,6 +38,7 @@ type OptionalSummary = QuerySns & {
   swapCanisterId?: Principal;
   governanceCanisterId?: Principal;
   ledgerCanisterId?: Principal;
+  indexCanisterId?: Principal;
 };
 
 type ValidSummary = Required<Omit<OptionalSummary, "swap">> & {
@@ -155,6 +156,7 @@ export const mapAndSortSnsQueryToSummaries = ({
         swapCanisterId: swapState?.swapCanisterId,
         governanceCanisterId: swapState?.governanceCanisterId,
         ledgerCanisterId: swapState?.ledgerCanisterId,
+        indexCanisterId: swapState?.indexCanisterId,
         swap: mapOptionalSwap(swapData),
         derived: fromNullable(swapState?.derived ?? []),
       };
@@ -169,6 +171,7 @@ export const mapAndSortSnsQueryToSummaries = ({
       entry.swapCanisterId !== undefined &&
       entry.governanceCanisterId !== undefined &&
       entry.ledgerCanisterId !== undefined &&
+      entry.indexCanisterId !== undefined &&
       entry.derived !== undefined &&
       entry.metadata !== undefined &&
       entry.token !== undefined

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -60,6 +60,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,
@@ -84,6 +85,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [],
             certified: true,
@@ -103,6 +105,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -130,6 +133,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -154,6 +158,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [mockQuerySwap],
             derived: [mockDerived],
             certified: true,
@@ -178,6 +183,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,
@@ -197,6 +203,7 @@ describe("sns-utils", () => {
             swapCanisterId: Principal.fromText("aaaaa-aa"),
             governanceCanisterId: Principal.fromText("aaaaa-aa"),
             ledgerCanisterId: Principal.fromText("aaaaa-aa"),
+            indexCanisterId: Principal.fromText("aaaaa-aa"),
             swap: [
               {
                 ...mockQuerySwap,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -48,6 +48,9 @@ export const principal = (index: number): Principal =>
     Principal.fromText(
       "vxi5c-ydsws-tmett-fndw6-7qwga-thtxc-epwtj-st3wy-jc464-muowb-eqe"
     ),
+    Principal.fromText(
+      "4etav-nasrq-uvswa-iqsll-6spts-ryhsl-e4yf6-xtycj-4sxvp-ciay5-yae"
+    ),
   ][index];
 
 export const createTransferableAmount = (
@@ -173,6 +176,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapCanisterId: principal(3),
     governanceCanisterId: principal(2),
     ledgerCanisterId: principal(1),
+    indexCanisterId: principal(4),
     metadata: mockMetadata,
     token: mockToken,
     swap: mockSwap,
@@ -183,6 +187,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapCanisterId: principal(2),
     governanceCanisterId: principal(3),
     ledgerCanisterId: principal(0),
+    indexCanisterId: principal(4),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAClSURBVHgB7dqxDYMwEEBRE2UET5I6icQUzMgc9EziHUAuqLElS+if/iuoruAXyCeL6fufjxTMuz5KKbeDOee0rXtq8Vs+TbM9cy3vWNX3fKWAjKIwisIoipBRU9iNYuTp3zM7eu6a9ZuiMIrCKAqjKNwoek711nuPkXPXrN8UhVEURlEYReFG4R3Fg4yiMIrCKAo3Cgr/o6AwisIoCqMojKIIuSadjJ5VyRrmqP4AAAAASUVORK5CYII=",
       name: "Pac-Man",
@@ -203,6 +208,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapCanisterId: principal(1),
     governanceCanisterId: principal(3),
     ledgerCanisterId: principal(0),
+    indexCanisterId: principal(4),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACjSURBVHgB7dkxDkRAGEDh32ZPsuWWWy+JQ4gzimPolUpXIXMCM4nmjfcVqglegT+j+Xf9EZV5p8MyrZcL2/EX+7BFjs/8zVpbsi7nHpN0n6+okFEURlEYRVFlVPP4iaLkq37npFB6bZ8pCqMojKIwisKJomSP4s5zukcRvig4jKIwisKJgsK/HhRGURhFYRSFEwWFEwWFURRGURhFYRRFlWPSCah/Vck0pRWfAAAAAElFTkSuQmCC",
       name: "Super Mario",
@@ -223,6 +229,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapCanisterId: principal(0),
     governanceCanisterId: principal(2),
     ledgerCanisterId: principal(1),
+    indexCanisterId: principal(4),
     metadata: {
       logo: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZkxCsJAFAUTETyAexcbEfZSHsJLBcTGu6wHsFK3SL0/EIvZzBSpHj87gYXHz3i+5M/QGfv6OB2mZvD5zqHcnC2lNHMppb+8ezd0iFIUlKKgFIUupcbNN4rpeB0i5Ndt1ZnRefNM7xQFpSgoRUEpCv02ijX3CZXoTmFJLnLGSj2nd4qCUhSUoqAUBXcUSxrF497O/j6ofz2iKEVBKQpKUbBRUHBHQUEpCkpRUIqCUhS6rElfBK1VyaWjTNYAAAAASUVORK5CYII=",
       name: "Donkey Kong",

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -16,6 +16,7 @@ import {
 } from "./sns-projects.mock";
 import {
   governanceCanisterIdMock,
+  indexCanisterIdMock,
   ledgerCanisterIdMock,
   swapCanisterIdMock,
 } from "./sns.api.mock";
@@ -58,6 +59,7 @@ export const snsResponseFor = ({
       swapCanisterId: swapCanisterIdMock,
       governanceCanisterId: governanceCanisterIdMock,
       ledgerCanisterId: ledgerCanisterIdMock,
+      indexCanisterId: indexCanisterIdMock,
       swap: swapToQuerySwap({
         ...summaryForLifecycle(lifecycle).swap,
         init: [


### PR DESCRIPTION
# Motivation

Expose Sns index canister ID for PR #2639 and generally speaking because in the future we will be able to fetch the balance of an account using the index canister as well (not just the ledger).

# PRs

- [ ] https://github.com/dfinity/ic-js/pull/343

# Changes

- export `ledgerCanisterId` in SnsSummary (as we already did for swap, governance and ledger)
- bump ic-js

# Tests

Similar approach as discussed in #2642
