### PR TITLE
Page objects in MergeNeuronsModal.spec.ts

### DIFF
--- a/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -51,14 +51,14 @@
   };
 </script>
 
-<div class="wrapper">
+<div class="wrapper" data-tid="confirm-neurons-merge-component">
   <h3>{$i18n.neurons.merge_neurons_modal_title_2}</h3>
 
-  <NnsNeuronInfo neuron={sourceNeuron} />
+  <NnsNeuronInfo neuron={sourceNeuron} testId="source-neuron-info" />
 
   <h3>{$i18n.neurons.merge_neurons_modal_into}</h3>
 
-  <NnsNeuronInfo neuron={targetNeuron} />
+  <NnsNeuronInfo neuron={targetNeuron} testId="target-neuron-info" />
 
   <div class="additional-text">
     <p class="description">

--- a/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
@@ -8,7 +8,7 @@
   import { Html } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
 
-  export let testId: string = "nns-neuron-info-component";
+  export let testId = "nns-neuron-info-component";
   export let neuron: NeuronInfo;
 </script>
 

--- a/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { neuronStake } from "$lib/utils/neuron.utils";
   import { formatToken } from "$lib/utils/token.utils";
@@ -7,23 +8,26 @@
   import { Html } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
 
+  export let testId: string = "nns-neuron-info-component";
   export let neuron: NeuronInfo;
 </script>
 
-<div>
-  <p class="label">{$i18n.neurons.neuron_id}</p>
-  <p class="value">{neuron.neuronId}</p>
-</div>
+<TestIdWrapper {testId}>
+  <div>
+    <p class="label">{$i18n.neurons.neuron_id}</p>
+    <p data-tid="neuron-id" class="value">{neuron.neuronId}</p>
+  </div>
 
-<div>
-  <p class="label">{$i18n.neurons.neuron_balance}</p>
-  <p>
-    <Html
-      text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
-        $amount: valueSpan(
-          formatToken({ value: neuronStake(neuron), detailed: true })
-        ),
-      })}
-    />
-  </p>
-</div>
+  <div>
+    <p class="label">{$i18n.neurons.neuron_balance}</p>
+    <p>
+      <Html
+        text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
+          $amount: valueSpan(
+            formatToken({ value: neuronStake(neuron), detailed: true })
+          ),
+        })}
+      />
+    </p>
+  </div>
+</TestIdWrapper>

--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -52,7 +52,7 @@
   $: isMaxSelection = selectedNeuronIds.length >= MAX_NEURONS_MERGED;
 </script>
 
-<div class="wrapper legacy">
+<div class="wrapper legacy" data-tid="select-neurons-to-merge-component">
   <p>{$i18n.neurons.merge_neurons_select_info}</p>
   <ul class="items">
     {#each neurons as { neuron, selected, mergeable, messageKey } (neuron.neuronId)}

--- a/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/MergeNeuronsModal.svelte
@@ -60,7 +60,13 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<WizardModal
+  testId="merge-neurons-modal-component"
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+>
   <svelte:fragment slot="title"
     >{currentStep?.title ??
       $i18n.neurons.merge_neurons_modal_title}</svelte:fragment

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -1,4 +1,3 @@
-import type { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 
 // This should not be used directly but rather as a base class for specific

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -1,0 +1,24 @@
+import type { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+
+// This should not be used directly but rather as a base class for specific
+// card components.
+export class CardPo extends BasePageObject {
+  async hasClass(className: string): Promise<boolean> {
+    const classNames = (await this.root.getAttribute("class")).split(" ");
+    return classNames.includes(className);
+  }
+
+  async isSelected(): Promise<boolean> {
+    //console.log('dskloetx CardPo root', (this.root as JestPageObjectElement).element.outerHTML);
+    return this.hasClass("selected");
+  }
+
+  async isHighlighted(): Promise<boolean> {
+    return this.hasClass("highlighted");
+  }
+
+  async isDisabled(): Promise<boolean> {
+    return this.hasClass("disabled");
+  }
+}

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 
-// This should not be used directly but rather as a base class for specific
+// CardPo should not be used directly but rather as a base class for specific
 // card components.
 export class CardPo extends BasePageObject {
   async hasClass(className: string): Promise<boolean> {
@@ -9,7 +9,6 @@ export class CardPo extends BasePageObject {
   }
 
   async isSelected(): Promise<boolean> {
-    //console.log('dskloetx CardPo root', (this.root as JestPageObjectElement).element.outerHTML);
     return this.hasClass("selected");
   }
 

--- a/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
@@ -1,0 +1,33 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { NnsNeuronInfoPo } from "$tests/page-objects/NnsNeuronInfo.page-object";
+import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ConfirmNeuronsMergePo extends BasePageObject {
+  static readonly TID = "confirm-neurons-merge-component";
+
+  static under(element: PageObjectElement): ConfirmNeuronsMergePo {
+    return new ConfirmNeuronsMergePo(element.byTestId(ConfirmNeuronsMergePo.TID));
+  }
+
+  getSourceNeuronInfoPo(): NnsNeuronInfoPo {
+    return NnsNeuronInfoPo.under({element: this.root, testId: "source-neuron-info"});
+  }
+
+  getTargetNeuronInfoPo(): NnsNeuronInfoPo {
+    return NnsNeuronInfoPo.under({element: this.root, testId: "target-neuron-info"});
+  }
+
+  getConfirmMergeButtonPo(): ButtonPo {
+    return this.getButton("confirm-merge-neurons-button");
+  }
+
+  getSourceNeuronId(): Promise<string> {
+    return this.getSourceNeuronInfoPo().getNeuronId();
+  }
+
+  getTargetNeuronId(): Promise<string> {
+    return this.getTargetNeuronInfoPo().getNeuronId();
+  }
+}

--- a/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
@@ -1,6 +1,5 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { NnsNeuronInfoPo } from "$tests/page-objects/NnsNeuronInfo.page-object";
-import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,15 +7,23 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
   static readonly TID = "confirm-neurons-merge-component";
 
   static under(element: PageObjectElement): ConfirmNeuronsMergePo {
-    return new ConfirmNeuronsMergePo(element.byTestId(ConfirmNeuronsMergePo.TID));
+    return new ConfirmNeuronsMergePo(
+      element.byTestId(ConfirmNeuronsMergePo.TID)
+    );
   }
 
   getSourceNeuronInfoPo(): NnsNeuronInfoPo {
-    return NnsNeuronInfoPo.under({element: this.root, testId: "source-neuron-info"});
+    return NnsNeuronInfoPo.under({
+      element: this.root,
+      testId: "source-neuron-info",
+    });
   }
 
   getTargetNeuronInfoPo(): NnsNeuronInfoPo {
-    return NnsNeuronInfoPo.under({element: this.root, testId: "target-neuron-info"});
+    return NnsNeuronInfoPo.under({
+      element: this.root,
+      testId: "target-neuron-info",
+    });
   }
 
   getConfirmMergeButtonPo(): ButtonPo {

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -1,6 +1,5 @@
 import { ConfirmNeuronsMergePo } from "$tests/page-objects/ConfirmNeuronsMerge.page-object";
 import { SelectNeuronsToMergePo } from "$tests/page-objects/SelectNeuronsToMerge.page-object";
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -1,0 +1,25 @@
+import { ConfirmNeuronsMergePo } from "$tests/page-objects/ConfirmNeuronsMerge.page-object";
+import { SelectNeuronsToMergePo } from "$tests/page-objects/SelectNeuronsToMerge.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class MergeNeuronsModalPo extends BasePageObject {
+  static readonly TID = "merge-neurons-modal-component";
+
+  static under(element: PageObjectElement): MergeNeuronsModalPo {
+    return new MergeNeuronsModalPo(element.byTestId(MergeNeuronsModalPo.TID));
+  }
+
+  getSelectNeuronsToMergePo(): SelectNeuronsToMergePo {
+    return SelectNeuronsToMergePo.under(this.root);
+  }
+
+  getConfirmNeuronsMergePo(): ConfirmNeuronsMergePo {
+    return ConfirmNeuronsMergePo.under(this.root);
+  }
+
+  getTitle(): Promise<string> {
+    return this.getText("modal-title");
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronCardContainer.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronCardContainer.page-object.ts
@@ -1,0 +1,10 @@
+import { CardPo } from "$tests/page-objects/Card.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronCardContainerPo extends CardPo {
+  private static readonly TID = "neuron-card";
+
+  static under(element: PageObjectElement): NeuronCardContainerPo {
+    return new NeuronCardContainerPo(element.byTestId(NeuronCardContainerPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronCardContainer.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronCardContainer.page-object.ts
@@ -5,6 +5,8 @@ export class NeuronCardContainerPo extends CardPo {
   private static readonly TID = "neuron-card";
 
   static under(element: PageObjectElement): NeuronCardContainerPo {
-    return new NeuronCardContainerPo(element.byTestId(NeuronCardContainerPo.TID));
+    return new NeuronCardContainerPo(
+      element.byTestId(NeuronCardContainerPo.TID)
+    );
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { NeuronCardContainerPo } from "$tests/page-objects/NeuronCardContainer.page-object";
 import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronCardPo extends BasePageObject {
@@ -17,7 +18,23 @@ export class NnsNeuronCardPo extends BasePageObject {
     return NnsNeuronCardTitlePo.under(this.root);
   }
 
+  getNeuronCardContainerPo(): NeuronCardContainerPo {
+    return NeuronCardContainerPo.under(this.root);
+  }
+
   getNeuronId(): Promise<string> {
     return this.getCardTitlePo().getNeuronId();
+  }
+
+  click(): Promise<void> {
+    return this.getNeuronCardContainerPo().click();
+  }
+
+  isSelected(): Promise<boolean> {
+    return this.getNeuronCardContainerPo().isSelected();
+  }
+
+  isDisabled(): Promise<boolean> {
+    return this.getNeuronCardContainerPo().isDisabled();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
@@ -1,12 +1,13 @@
-import type { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronInfoPo extends BasePageObject {
-  static under({element, testId}: {
-  element: PageObjectElement;
-  testId: string;
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
   }): NnsNeuronInfoPo {
     return new NnsNeuronInfoPo(element.byTestId(testId));
   }

--- a/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
@@ -1,0 +1,17 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsNeuronInfoPo extends BasePageObject {
+  static under({element, testId}: {
+  element: PageObjectElement;
+  testId: string;
+  }): NnsNeuronInfoPo {
+    return new NnsNeuronInfoPo(element.byTestId(testId));
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getText("neuron-id");
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { CardPo } from "$tests/page-objects/Card.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ProjectCardPo extends BasePageObject {
+export class ProjectCardPo extends CardPo {
   private static readonly TID = "project-card-component";
 
   static async allUnder(element: PageObjectElement): Promise<ProjectCardPo[]> {
@@ -16,10 +16,5 @@ export class ProjectCardPo extends BasePageObject {
 
   getProjectName(): Promise<string> {
     return this.getText("project-name");
-  }
-
-  async isHighlighted(): Promise<boolean> {
-    const classNames = await this.root.getAttribute("class");
-    return classNames.includes("highlighted");
   }
 }

--- a/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
@@ -7,9 +7,11 @@ export class SelectNeuronsToMergePo extends BasePageObject {
   static readonly TID = "select-neurons-to-merge-component";
 
   static under(element: PageObjectElement): SelectNeuronsToMergePo {
-    return new SelectNeuronsToMergePo(element.byTestId(SelectNeuronsToMergePo.TID));
+    return new SelectNeuronsToMergePo(
+      element.byTestId(SelectNeuronsToMergePo.TID)
+    );
   }
-  
+
   getNnsNeuronCardPos(): Promise<NnsNeuronCardPo[]> {
     return NnsNeuronCardPo.allUnder(this.root);
   }

--- a/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
@@ -1,0 +1,20 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SelectNeuronsToMergePo extends BasePageObject {
+  static readonly TID = "select-neurons-to-merge-component";
+
+  static under(element: PageObjectElement): SelectNeuronsToMergePo {
+    return new SelectNeuronsToMergePo(element.byTestId(SelectNeuronsToMergePo.TID));
+  }
+  
+  getNnsNeuronCardPos(): Promise<NnsNeuronCardPo[]> {
+    return NnsNeuronCardPo.allUnder(this.root);
+  }
+
+  getConfirmSelectionButtonPo(): ButtonPo {
+    return this.getButton("merge-neurons-confirm-selection-button");
+  }
+}

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -79,7 +79,9 @@ export class JestPageObjectElement implements PageObjectElement {
 
   async isPresent(): Promise<boolean> {
     const { rootElement, fullSelector } = this.getRootAndFullSelector();
-    this.element = rootElement.querySelector(fullSelector);
+    if (fullSelector !== ":scope") {
+      this.element = rootElement.querySelector(fullSelector);
+    }
     return nonNullish(this.element);
   }
 


### PR DESCRIPTION
# Motivation

I'm planning to make changes to `MergeNeuronsModal.svelte` so cleaning up the test so it's easier to add tests later.
In particular, migrating the test to using page objects.

# Changes

1. Added several page objects.
2. Also added `CardPo` which serves as a base class for other card page objects. And use it for new `NeuronCardContainerPo` and existing `ProjectCardPo` which is otherwise unrelated to this PR.
3. Added test IDs to make components accessible to page objects.
4. Change `frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts` to use page objects.
5. Also use a top-level `beforeEach` instead of a nested `afterEach`.
6. And fixed an issue in `JestPageObjectElement.isPreset()` because it only worked for descendant elements. `:scope` is a selector referring to the element itself but apparently only works when followed by descendant selectors.

# Tests

`npm run test`

Manually checked that the modified components look normal.
