### PR TITLE
SNS: display excluded country codes

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { ICPToken, TokenAmount } from "@dfinity/nns";
+  import { getDeniedCountries } from "$lib/getters/sns-summary";
   import type { SnsSummary } from "$lib/types/sns";
   import { getContext } from "svelte";
+  import type { CountryCode } from "$lib/types/location";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
@@ -19,13 +21,16 @@
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
+  // type safety validation is done in ProjectDetail component
+  let summary: SnsSummary;
+  $: summary = $projectDetailStore.summary as SnsSummary;
+
   let params: SnsParams;
   let token: IcrcTokenMetadata;
-  // type safety validation is done in ProjectDetail component
   $: ({
     swap: { params },
     token,
-  } = $projectDetailStore.summary as SnsSummary);
+  } = summary);
 
   let minCommitmentIcp: TokenAmount;
   $: minCommitmentIcp = TokenAmount.fromE8s({
@@ -46,6 +51,15 @@
 
   let snsTotalTokenSupply: TokenAmount | undefined | null;
   $: snsTotalTokenSupply = $projectDetailStore.totalTokensSupply;
+
+  let deniedCountryCodes: CountryCode[];
+  $: deniedCountryCodes = getDeniedCountries(summary);
+
+  let hasDeniedCountries: boolean;
+  $: hasDeniedCountries = deniedCountryCodes.length > 0;
+
+  let formattedDeniedCountryCodes: string;
+  $: formattedDeniedCountryCodes = deniedCountryCodes.join(", ");
 </script>
 
 <TestIdWrapper testId="project-swap-details-component">
@@ -75,4 +89,10 @@
       tagName="span"
     />
   </KeyValuePair>
+  {#if hasDeniedCountries}
+    <KeyValuePair>
+      <span slot="key">{$i18n.sns_project_detail.persons_excluded} </span>
+      <span slot="value">{formattedDeniedCountryCodes}</span>
+    </KeyValuePair>
+  {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -654,6 +654,7 @@
     "status_completed": "Status",
     "completed": "Completed",
     "sale_end": "Swap End",
+    "persons_excluded": "Persons Excluded",
     "max_user_commitment_reached": "Maximum commitment reached",
     "not_eligible_to_participate": "You are not eligible to participate in this swap.",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -680,6 +680,7 @@ interface I18nSns_project_detail {
   status_completed: string;
   completed: string;
   sale_end: string;
+  persons_excluded: string;
   max_user_commitment_reached: string;
   not_eligible_to_participate: string;
   getting_sns_open_ticket: string;


### PR DESCRIPTION
# Motivation

Making it clear who is not eligible in an SNS swap.

# Changes

Display "Persons Excluded: <country code>" in `ProjectSwapDetails.svelte`.

<img width="802" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/6ce721ca-62e5-4c26-99b8-c9f292d4814e">

# Tests

Tested manually with and without restricted_countries and with multiple.

Unit test will be added in next PR.
