### PR TITLE
Use big iron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash -euxlo pipefail {0}
 jobs:
   build:
-    runs-on: ubuntu-20.04-8-cores
+    runs-on: ubuntu-latest-m
     timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash -euxlo pipefail {0}
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-8-cores
     timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
   svelte-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-8-cores
     defaults:
       run:
         shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
   svelte-tests:
-    runs-on: ubuntu-20.04-8-cores
+    runs-on: ubuntu-latest-m
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
# Motivation
Some jobs in our workflow are quite slow.

# Changes
- Use large runners for the two jobs on the critical path:  The wasm build and the svelte tests.

# Tests
- See CI run times and compare with the normal run times.