### PR TITLE
Unit test for 'Excluded Persons'

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -90,7 +90,7 @@
     />
   </KeyValuePair>
   {#if hasDeniedCountries}
-    <KeyValuePair>
+    <KeyValuePair testId="excluded-countries">
       <span slot="key">{$i18n.sns_project_detail.persons_excluded} </span>
       <span slot="value">{formattedDeniedCountryCodes}</span>
     </KeyValuePair>

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -8,13 +8,14 @@ import type { SnsSwapCommitment } from "$lib/types/sns";
 import { secondsToDate, secondsToTime } from "$lib/utils/date.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import {
+  createSummary,
   mockSnsFullProject,
   mockSnsParams,
   mockSummary,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ProjectSwapDetailsPo } from "$tests/page-objects/ProjectSwapDetails.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { TokenAmount } from "@dfinity/nns";
 
 describe("ProjectSwapDetails", () => {
@@ -109,5 +110,29 @@ describe("ProjectSwapDetails", () => {
     expect(await po.getTotalSupply()).toMatch(
       formatToken({ value: totalSupply })
     );
+  });
+
+  it("should not render restricted countries if absent", async () => {
+    const { container } = renderContextCmp({
+      summary: createSummary({ restrictedCountries: [] }),
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectSwapDetails,
+    });
+
+    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
+
+    expect(await po.getExcludedCountriesPo().isPresent()).toBe(false);
+  });
+
+  it("should render restricted countries", async () => {
+    const { container } = renderContextCmp({
+      summary: createSummary({ restrictedCountries: ["CH", "US"] }),
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectSwapDetails,
+    });
+
+    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
+
+    expect(await po.getExcludedCountriesPo().getValueText()).toBe("CH, US");
   });
 });

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -1,4 +1,5 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -13,5 +14,12 @@ export class ProjectSwapDetailsPo extends BasePageObject {
     return AmountDisplayPo.under(
       this.root.querySelector("[data-tid=sns-total-token-supply]")
     ).getAmount();
+  }
+
+  getExcludedCountriesPo(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "excluded-countries",
+    });
   }
 }


### PR DESCRIPTION
# Motivation

Was missing from https://github.com/dfinity/nns-dapp/pull/2653

# Changes

1. Test that excluded countries are rendered if present and not if not.

# Tests

unit test
