### PR TITLE
Display "Select NNS" instead of "Select Token" on proposals

### DIFF
--- a/frontend/src/lib/derived/title-token-selector.derived.ts
+++ b/frontend/src/lib/derived/title-token-selector.derived.ts
@@ -9,8 +9,8 @@ export const titleTokenSelectorStore = derived(
   ([$i18n, page]) =>
     isSelectedPath({
       currentPath: page.path,
-      paths: [AppPath.Neurons, AppPath.Neuron],
+      paths: [AppPath.Accounts, AppPath.Wallet],
     })
-      ? $i18n.universe.select_nervous_system
-      : $i18n.universe.select_token
+      ? $i18n.universe.select_token
+      : $i18n.universe.select_nervous_system
 );

--- a/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/title-token-selector.derived.spec.ts
@@ -30,7 +30,7 @@ describe("title token selector derived store", () => {
       routeId: AppPath.Proposals,
     });
     const $store3 = get(titleTokenSelectorStore);
-    expect($store3).toEqual(en.universe.select_token);
+    expect($store3).toEqual(en.universe.select_nervous_system);
   });
 
   it("should return select nervous system text if path is related to neurons", () => {

--- a/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
+++ b/frontend/src/tests/lib/modals/universe/SelectUniverseModal.spec.ts
@@ -35,7 +35,7 @@ describe("SelectUniverseModal", () => {
 
     expect(
       getByTestId("select-universe-modal-title")?.textContent ?? ""
-    ).toEqual(en.universe.select_token);
+    ).toEqual(en.universe.select_nervous_system);
   });
 
   it("should navigate", async () => {


### PR DESCRIPTION
# Motivation

In universe selector, on the proposal tab, display "Select Network Nervous System" instead of "Select Token"
