### PR TITLE
Fix Sns proposal reload with correct ID but NNS as universe

### DIFF
--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -21,9 +21,11 @@
   import { snsProposalIdString } from "$lib/utils/sns-proposals.utils";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSnsProposalStore } from "../derived/debug.derived";
+  import { isUniverseNns } from "$lib/utils/universe.utils";
 
   export let proposalIdText: string | undefined | null = undefined;
 
+  // TODO: why using $pageStore.universe and not $selectedUniverseIdStore as in other components and routes?
   let universeId: Principal;
   $: universeId = Principal.fromText($pageStore.universe);
 
@@ -111,7 +113,8 @@
     if (
       nonNullish(proposalIdText) &&
       nonNullish(universeIdText) &&
-      nonNullish(universeCanisterId)
+      nonNullish(universeCanisterId) &&
+      !isUniverseNns(universeCanisterId)
     ) {
       try {
         updating = true;

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -114,6 +114,7 @@
       nonNullish(proposalIdText) &&
       nonNullish(universeIdText) &&
       nonNullish(universeCanisterId) &&
+      // TODO: improve testing to ensure reloadProposal is not called
       !isUniverseNns(universeCanisterId)
     ) {
       try {

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -159,14 +159,8 @@ describe("SnsProposalDetail", () => {
         return expect(path).toEqual(AppPath.Proposals);
       });
     });
-  });
 
-  describe("nns universe", () => {
-    beforeEach(() => {
-      page.mock({ data: { universe: OWN_CANISTER_ID.toText() } });
-    });
-
-    it("should not render content once proposal is loaded if incorrect universe", async () => {
+    it("should not render content if universe changes to Nns", async () => {
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
@@ -174,7 +168,7 @@ describe("SnsProposalDetail", () => {
       });
       fakeSnsGovernanceApi.pause();
 
-      const { container } = render(SnsProposalDetail, {
+      const { container, rerender } = render(SnsProposalDetail, {
         props: {
           proposalIdText: proposalId.id.toString(),
         },
@@ -186,6 +180,11 @@ describe("SnsProposalDetail", () => {
       expect(await po.isContentLoaded()).toBe(false);
 
       fakeSnsGovernanceApi.resume();
+      await waitFor(async () => expect(await po.isContentLoaded()).toBe(true));
+
+      page.mock({ data: { universe: OWN_CANISTER_ID.toText() } });
+
+      rerender(SnsProposalDetail);
       await waitFor(async () => expect(await po.isContentLoaded()).toBe(false));
     });
   });

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -157,7 +157,7 @@ describe("SnsProposalDetail", () => {
       });
     });
 
-    it.only("should not render content if universe changes to Nns", async () => {
+    it("should not render content if universe changes to Nns", async () => {
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
@@ -10,8 +11,8 @@ import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsProposalDetailPo } from "$tests/page-objects/SnsProposalDetail.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { render, waitFor } from "@testing-library/svelte";
@@ -36,13 +37,16 @@ describe("SnsProposalDetail", () => {
     return SnsProposalDetailPo.under(new JestPageObjectElement(container));
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreNoIdentitySubscribe);
+  });
+
   describe("not logged in", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      jest.spyOn(console, "error").mockImplementation(() => undefined);
-      jest
-        .spyOn(authStore, "subscribe")
-        .mockImplementation(mockAuthStoreNoIdentitySubscribe);
       page.mock({ data: { universe: rootCanisterId.toText() } });
     });
 
@@ -154,6 +158,35 @@ describe("SnsProposalDetail", () => {
         const { path } = get(pageStore);
         return expect(path).toEqual(AppPath.Proposals);
       });
+    });
+  });
+
+  describe("nns universe", () => {
+    beforeEach(() => {
+      page.mock({ data: { universe: OWN_CANISTER_ID.toText() } });
+    });
+
+    it("should not render content once proposal is loaded if incorrect universe", async () => {
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [proposalId],
+      });
+      fakeSnsGovernanceApi.pause();
+
+      const { container } = render(SnsProposalDetail, {
+        props: {
+          proposalIdText: proposalId.id.toString(),
+        },
+      });
+      const po = SnsProposalDetailPo.under(
+        new JestPageObjectElement(container)
+      );
+      expect(await po.getSkeletonDetails().isPresent()).toBe(true);
+      expect(await po.isContentLoaded()).toBe(false);
+
+      fakeSnsGovernanceApi.resume();
+      await waitFor(async () => expect(await po.isContentLoaded()).toBe(false));
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -37,16 +37,13 @@ describe("SnsProposalDetail", () => {
     return SnsProposalDetailPo.under(new JestPageObjectElement(container));
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreNoIdentitySubscribe);
-  });
-
   describe("not logged in", () => {
     beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest
+        .spyOn(authStore, "subscribe")
+        .mockImplementation(mockAuthStoreNoIdentitySubscribe);
       page.mock({ data: { universe: rootCanisterId.toText() } });
     });
 
@@ -160,7 +157,7 @@ describe("SnsProposalDetail", () => {
       });
     });
 
-    it("should not render content if universe changes to Nns", async () => {
+    it.only("should not render content if universe changes to Nns", async () => {
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
@@ -184,7 +181,12 @@ describe("SnsProposalDetail", () => {
 
       page.mock({ data: { universe: OWN_CANISTER_ID.toText() } });
 
-      rerender(SnsProposalDetail);
+      rerender({
+        props: {
+          proposalIdText: proposalId.id.toString(),
+        },
+      });
+
       await waitFor(async () => expect(await po.isContentLoaded()).toBe(false));
     });
   });


### PR DESCRIPTION
# Motivation

When navigating from a Sns proposal detail to a Nns universe, such as for example the launchpad, the reload feature is triggered again with the same Id but with the a universe Id extracted from the route that is Nns.

# Changes

- add a check to load the Sns proposal only if not Nns
- added a `TODO` to use another source of information to load the universe

# Screenshot

I found the issue with a breakpoint in the browser.

<img width="1536" alt="Capture d’écran 2023-06-08 à 07 33 01" src="https://github.com/dfinity/nns-dapp/assets/16886711/3ab1820c-3771-4c24-968e-57bdd68f6e3d">

