### PR TITLE
Enable simulating merge hotkey neurons

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -460,16 +460,8 @@ export const simulateMergeNeurons = async ({
     });
 
     const accounts = get(accountsStore);
-    if (
-      isNeuronControlledByHardwareWallet({ neuron: targetNeuron, accounts })
-    ) {
-      // Simulating is not yet supported for HW controlled neurons.
-      return undefined;
-    }
 
-    const identity: Identity = await getIdentityOfControllerByNeuronId(
-      targetNeuronId
-    );
+    const identity: Identity = await getAuthenticatedIdentity();
 
     return await governanceApiService.simulateMergeNeurons({
       sourceNeuronId,

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -454,12 +454,10 @@ export const simulateMergeNeurons = async ({
   targetNeuronId: NeuronId;
 }): Promise<NeuronInfo | undefined> => {
   try {
-    const { targetNeuron } = await checkCanBeMerged({
+    await checkCanBeMerged({
       sourceNeuronId,
       targetNeuronId,
     });
-
-    const accounts = get(accountsStore);
 
     const identity: Identity = await getAuthenticatedIdentity();
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -990,7 +990,7 @@ describe("neurons-services", () => {
       expect(spyMergeNeurons).not.toBeCalled();
     });
 
-    it("should not simulate merging neurons if HW controlled", async () => {
+    it("should simulate merging neurons if HW controlled", async () => {
       accountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
@@ -1022,7 +1022,7 @@ describe("neurons-services", () => {
         targetNeuronId: neuron2.neuronId,
       });
 
-      expect(spySimulateMergeNeurons).not.toBeCalled();
+      expect(spySimulateMergeNeurons).toBeCalledTimes(1);
       expect(spyMergeNeurons).not.toBeCalled();
     });
   });


### PR DESCRIPTION
# Motivation

Simulating merging hotkey-controlled neurons is now supported by the governance canister and I tested it with a snapshot based on the latest ic commit.

# Changes

1. Remove the check that a neuron is not hardware wallet controlled.
2. Use the authenticated identity instead of the controller identity.
3. Updated the test accordingly.

# Tests

1. Unit test is updated in the PR.
2. Tested manually with the latest backend canisters that it works.
