### PR TITLE
Use the public URL as the staging host

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -186,7 +186,7 @@
     },
     "staging": {
       "config": {
-        "HOST": "https://nnsdapp.testnet.dfinity.network",
+        "HOST": "https://nnsdapp.dfinity.network",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_VOTING": false,
           "ENABLE_SNS_AGGREGATOR": true,


### PR DESCRIPTION
# Motivation
This is publicly accessible, so can be used for reviews of a release candidate:

https://ptid5-maaaa-aaaaa-aacnq-cai.nnsdapp.dfinity.network/

This is not:

https://ptid5-maaaa-aaaaa-aacnq-cai.nnsdapp.testnet.dfinity.network/

The release SOP actually states that the testnet needs to be removed and I was shown how to edit dfx to remove the testnet.

We actually never need the `testnet` in that URL.

# Changes
* Remove `testnet` from the staging URL.

# Tests
* Deployments to staging already have this change applied manually.