### PR TITLE
No dirty flag

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -53,7 +53,6 @@ for file in "${assets[@]}"; do
 done
 
 COMMIT="$(git rev-parse HEAD)"
-[ -z "$(git status --untracked-files=no --porcelain)" ] || COMMIT="${COMMIT}-dirty"
 
 set -x
 DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
# Motivation
The commit added to the metadata wasm currently includes a `-dirty` suffix if any of the committed files is changed.  Unfortunately this means that the wasm hash can change, surprisingly, due to otherwise inconsequential changes.

The `-dirty` suffix does provide some protection against users thinking that one commit has been deployed, e.g. to a testnet, when actually the commit plus some changes has been deployed.  Even with the suffix there is a risk of uncommitted files causing a change, so the protection is not absolute.  However we have no evidence that this has actually been a problem but we do have evidence that the `-dirty` suffix has caused problems when testing builds.

# Changes
- Remove the `-dirty` suffix.

# Tests
I have run `docker-build` locally and verified that it builds.