### PR TITLE
Use fake governance API in MergeNeuronsModal.spec.ts

### DIFF
--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -11,7 +11,7 @@ import {
 } from "$tests/utils/module.test-utils";
 import type { Identity } from "@dfinity/agent";
 import type { KnownNeuron, NeuronInfo, RewardEvent } from "@dfinity/nns";
-import { isNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 
 const modulePath = "$lib/api/governance.api";
 const fakeFunctions = {
@@ -130,6 +130,9 @@ export const addNeuronWith = ({
   }
   if (controller) {
     neuron.fullNeuron.controller = controller;
+  }
+  if (nonNullish(getNeuron({ identity, neuronId: neuron.neuronId }))) {
+    throw new Error(`A neuron with id ${neuron.neuronId} already exists`);
   }
   getNeurons(identity).push(neuron);
 };

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -1,4 +1,7 @@
-import type { ApiQueryParams } from "$lib/api/governance.api";
+import type {
+  ApiMergeNeuronsParams,
+  ApiQueryParams,
+} from "$lib/api/governance.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
@@ -15,6 +18,7 @@ const fakeFunctions = {
   queryNeurons,
   queryKnownNeurons,
   queryLastestRewardEvent,
+  mergeNeurons,
 };
 
 //////////////////////////////////////////////
@@ -34,6 +38,17 @@ const getNeurons = (identity: Identity) => {
     neurons.set(key, neuronList);
   }
   return neuronList;
+};
+
+const getNeuron = ({
+  identity,
+  neuronId,
+}: {
+  identity: Identity;
+  neuronId: bigint;
+}): NeuronInfo | undefined => {
+  const neurons = getNeurons(identity);
+  return neurons.find((n) => n.neuronId === neuronId);
 };
 
 ////////////////////////
@@ -61,9 +76,29 @@ async function queryLastestRewardEvent({
   return mockRewardEvent;
 }
 
+async function mergeNeurons({
+  sourceNeuronId,
+  targetNeuronId,
+  identity,
+}: ApiMergeNeuronsParams): Promise<void> {
+  const sourceNeuron = getNeuron({ identity, neuronId: sourceNeuronId });
+  const targetNeuron = getNeuron({ identity, neuronId: targetNeuronId });
+  // This is extremely simplified, just good enough for the test to see that the
+  // merge happened.
+  targetNeuron.fullNeuron.cachedNeuronStake +=
+    sourceNeuron.fullNeuron.cachedNeuronStake;
+  sourceNeuron.fullNeuron.cachedNeuronStake = BigInt(0);
+}
+
 /////////////////////////////////
 // Functions to control the fake:
 /////////////////////////////////
+
+export type FakeNeuronParams = {
+  neuronId?: bigint;
+  controller?: string;
+  stake?: bigint;
+};
 
 const {
   pause,
@@ -77,16 +112,38 @@ const reset = () => {
   resetPaused();
 };
 
-export { pause, resume };
+export { pause, resume, getNeuron };
 
 export const addNeuronWith = ({
   identity = mockIdentity,
-  ...neuronParams
-}: { identity?: Identity } & Partial<NeuronInfo>) => {
-  getNeurons(identity).push({
-    ...mockNeuron,
-    ...neuronParams,
-  });
+  neuronId,
+  controller,
+  stake,
+}: { identity?: Identity } & Partial<FakeNeuronParams>) => {
+  const neuron = { ...mockNeuron, fullNeuron: { ...mockNeuron.fullNeuron } };
+  if (neuronId) {
+    neuron.neuronId = neuronId;
+    neuron.fullNeuron.id = neuronId;
+  }
+  if (stake) {
+    neuron.fullNeuron.cachedNeuronStake = stake;
+  }
+  if (controller) {
+    neuron.fullNeuron.controller = controller;
+  }
+  getNeurons(identity).push(neuron);
+};
+
+export const addNeurons = ({
+  identity = mockIdentity,
+  neurons,
+}: {
+  identity?: Identity;
+  neurons: FakeNeuronParams[];
+}) => {
+  for (const neuron of neurons) {
+    addNeuronWith({ identity, ...neuron });
+  }
 };
 
 // Call this inside a describe() block outside beforeEach() because it defines


### PR DESCRIPTION
# Motivation

I'll be making changes to this test when implementing the simulate merging neurons UI so now seems like a good time to change it from mocking the service and store to using a fake.

# Changes

In `frontend/src/tests/fakes/governance-api.fake.ts`:
1. Add `mergeNeurons`. It only adds the stakes together in the target neuron and sets the stake to 0 in the source neuron. This is very simplistic but should be good enough to verify in the test that neurons have been merged.
2. Add `getNeuron({identity, neuronId})` for use in the fake itself as well as in tests for convenience.
3. Allow setting the `stake` on neurons in the fake.
4. Add `addNeurons` to insert multiple fake neurons with a single call.

In `frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts`:
1. Create and use a test identity to make sure the authenticated identity, the controller of the neurons and the principal of the main account all align.
2. Insert neurons into the fake API instead of in the store.
3. Verify the result of the mergeNeurons call instead of only expecting `mergeNeurons` to be called on the service.


# Tests

Test only
