### PR TITLE
Fix some setup issues on a new M1 installation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -31,7 +31,7 @@ That is why we are providing a `./config.sh` script that generate the above envi
 To run the dapp against canisters deployed locally on a simulated IC network, use the steps below, or run `./scripts/dev-local.sh` which guides you through these steps
 
 - Make sure you have a clean local replica running with `dfx start --clean`. This will stay running so use a separate terminal for this.
-- Deploy the Nns backend canisters locally with `dfx nns install`
+- Deploy the NNS backend canisters locally with `dfx nns install`
 - From the last line of output of `dfx nns install` note down the value url for `nns-dapp`
 - Run `DFX_NETWORK=local ./config.sh` to populate the `./frontend/.env` file.
 - Manually edit the `./frontend/.env` and replace `null` with the nns-dapp canister id from the url you noted down before.

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -83,7 +83,7 @@ get_binary() {
   OS="$(uname)"
   case "$OS" in
   Darwin)
-    curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl "https://download.dfinity.systems/ic/${IC_COMMIT}/openssl-static-binaries/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     ;;
   Linux)
     curl "https://download.dfinity.systems/ic/${IC_COMMIT}/release/${FILENAME}.gz" | gunzip >"$TMP_FILE"

--- a/e2e-tests/scripts/nns-canister-download
+++ b/e2e-tests/scripts/nns-canister-download
@@ -83,7 +83,7 @@ get_binary() {
   OS="$(uname)"
   case "$OS" in
   Darwin)
-    curl "https://download.dfinity.systems/ic/${IC_COMMIT}/openssl-static-binaries/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
+    curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/${FILENAME}.gz" | gunzip >"$TMP_FILE"
     ;;
   Linux)
     curl "https://download.dfinity.systems/ic/${IC_COMMIT}/release/${FILENAME}.gz" | gunzip >"$TMP_FILE"

--- a/scripts/setup
+++ b/scripts/setup
@@ -280,7 +280,7 @@ install_brew_maybe
 command -v wget || "install_wget_$OS"
 command -v curl || "install_curl_$OS"
 is_docker_installed || install_docker
-command -v sha256sum || "install_coreutils_$OS"
+command -v sha256sum && command -v realpath || "install_coreutils_$OS"
 command -v sponge || "install_moreutils_$OS"
 command -v jq || "install_jq_$OS"
 command -v yq || "install_yq_$OS"

--- a/scripts/setup
+++ b/scripts/setup
@@ -229,7 +229,7 @@ install_sns_linux() {
   chmod +x "$USER_BIN/sns"
 }
 install_sns_darwin() {
-  curl "https://download.dfinity.systems/ic/${IC_COMMIT}/nix-release/x86_64-darwin/sns.gz" | gunzip >"$USER_BIN/sns"
+  curl "https://download.dfinity.systems/ic/${IC_COMMIT}/openssl-static-binaries/x86_64-darwin/sns.gz" | gunzip >"$USER_BIN/sns"
   chmod +x "$USER_BIN/sns"
   # shellcheck disable=SC2016
   command -v sns ||
@@ -280,7 +280,7 @@ install_brew_maybe
 command -v wget || "install_wget_$OS"
 command -v curl || "install_curl_$OS"
 is_docker_installed || install_docker
-command -v realpath || "install_coreutils_$OS"
+command -v sha256sum || "install_coreutils_$OS"
 command -v sponge || "install_moreutils_$OS"
 command -v jq || "install_jq_$OS"
 command -v yq || "install_yq_$OS"

--- a/scripts/setup
+++ b/scripts/setup
@@ -280,7 +280,7 @@ install_brew_maybe
 command -v wget || "install_wget_$OS"
 command -v curl || "install_curl_$OS"
 is_docker_installed || install_docker
-command -v sha256sum && command -v realpath || "install_coreutils_$OS"
+command -v sha256sum || "install_coreutils_$OS"
 command -v sponge || "install_moreutils_$OS"
 command -v jq || "install_jq_$OS"
 command -v yq || "install_yq_$OS"


### PR DESCRIPTION
# Motivation

I tried to build outside of Docker on my M1 and required a few interventions. This is only a partial list of the issues I discovered with @dskloetd help, but I'll make another PR once I test some more.

# Changes

- `sns` binary url for Darwin was wrong
- `realpath` on my M1 exists on `/bin` so `./setup` didn't `brew install coreutils`, so I changed the condition to `sha256sum`

# Tests

Manual tests
