### PR TITLE
Test: Refactor AuthStore into services

### DIFF
--- a/frontend/src/lib/components/common/SignIn.svelte
+++ b/frontend/src/lib/components/common/SignIn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { authStore } from "$lib/stores/auth.store";
+  import { signIn as signInService } from "$lib/services/auth.services";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import { Spinner } from "@dfinity/gix-components";
@@ -14,7 +14,7 @@
         err,
       });
 
-    await authStore.signIn(onError);
+    await signInService(onError);
   };
 
   let disabled = true;

--- a/frontend/src/lib/components/header/LoginIconOnly.svelte
+++ b/frontend/src/lib/components/header/LoginIconOnly.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { IconLogin } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutAuthReady } from "$lib/stores/layout.store";
+  import { signIn as signInService } from "$lib/services/auth.services";
 
   // TODO: Same code as in SignIn.svelte maybe we can refactore
   const signIn = async () => {
@@ -13,7 +13,7 @@
         err,
       });
 
-    await authStore.signIn(onError);
+    await signInService(onError);
   };
 </script>
 

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -4,8 +4,10 @@ import {
   loadSnsProjects,
   loadSnsSummaries,
 } from "$lib/services/$public/sns.services";
-import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
-import { authStore } from "$lib/stores/auth.store";
+import {
+  displayAndCleanLogoutMsg,
+  syncAuth,
+} from "$lib/services/auth.services";
 import { ENABLE_SNS_AGGREGATOR } from "$lib/stores/feature-flags.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -34,7 +36,7 @@ export const initAppPublicData = (): Promise<
 
 const syncAuthStore = async () => {
   try {
-    await authStore.sync();
+    await syncAuth();
   } catch (err) {
     toastsError({ labelKey: "error.auth_sync", err });
   }

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -1,14 +1,4 @@
-import { resetAgents } from "$lib/api/agent.api";
-import {
-  AUTH_SESSION_DURATION,
-  IDENTITY_SERVICE_URL,
-  OLD_MAINNET_IDENTITY_SERVICE_URL,
-} from "$lib/constants/identity.constants";
-import { NNS_IC_APP_DERIVATION_ORIGIN } from "$lib/constants/origin.constants";
-import { createAuthClient } from "$lib/utils/auth.utils";
-import { isNnsAlternativeOrigin } from "$lib/utils/env.utils";
 import type { Identity } from "@dfinity/agent";
-import type { AuthClient } from "@dfinity/auth-client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
@@ -16,91 +6,32 @@ export interface AuthStoreData {
   identity: Identity | undefined | null;
 }
 
-// We have to keep the authClient object in memory because calling the `authClient.login` feature should be triggered by a user interaction without any async callbacks call before calling `window.open` to open II
-// @see agent-js issue [#618](https://github.com/dfinity/agent-js/pull/618)
-let authClient: AuthClient | undefined | null;
-
-const getIdentityProvider = () => {
-  // If we are in mainnet in the old domain, we use the old identity provider.
-  if (location.host === "nns.ic0.app") {
-    return OLD_MAINNET_IDENTITY_SERVICE_URL;
-  }
-
-  return IDENTITY_SERVICE_URL;
-};
-
 /**
- * A store to handle authentication and the identity of the user.
+ * A store to store the identity of the user.
  *
- * - sync: query auth-client to get the status of the authentication
- * a. if authenticated only, set identity in the global state
- * b. if not authenticated, set null in store
- *
- * the sync function is performed when the app boots and on any change in the local storage (see <Guard/>)
- *
- * note: auth-client is initialized with an anonymous principal. By querying "isAuthenticated", the library checks for a valid chain and also that the principal is not anonymous.
- *
- * - signIn: log in method flow. started with a user interaction ("click on a button")
- *
- * - signOut: call auth-client log out and set null in the store. started with a user interaction ("click on a button")
- *
- * note: clearing idb auth keys does not happen in the state management but afterwards in its caller function (see <Logout/>)
- *
+ * The flows are managed in the auth services.
  */
 export interface AuthStore extends Readable<AuthStoreData> {
-  sync: () => Promise<void>;
-  signIn: (onError: (error?: string) => void) => Promise<void>;
-  signOut: () => Promise<void>;
+  setIdentity: (identity: Identity | undefined | null) => void;
+  setNoIdentity: () => void;
 }
 
 const initAuthStore = (): AuthStore => {
-  const { subscribe, set, update } = writable<AuthStoreData>({
+  const { subscribe, update } = writable<AuthStoreData>({
     identity: undefined,
   });
 
   return {
     subscribe,
 
-    sync: async () => {
-      authClient = authClient ?? (await createAuthClient());
-      const isAuthenticated = await authClient.isAuthenticated();
-
-      set({
-        identity: isAuthenticated ? authClient.getIdentity() : null,
-      });
+    setIdentity: (identity: Identity | undefined | null) => {
+      update((state: AuthStoreData) => ({
+        ...state,
+        identity,
+      }));
     },
 
-    signIn: async (onError: (error?: string) => void) => {
-      authClient = authClient ?? (await createAuthClient());
-
-      await authClient?.login({
-        identityProvider: getIdentityProvider(),
-        ...(isNnsAlternativeOrigin() && {
-          derivationOrigin: NNS_IC_APP_DERIVATION_ORIGIN,
-        }),
-        maxTimeToLive: AUTH_SESSION_DURATION,
-        onSuccess: () => {
-          update((state: AuthStoreData) => ({
-            ...state,
-            identity: authClient?.getIdentity(),
-          }));
-        },
-        onError,
-      });
-    },
-
-    signOut: async () => {
-      const client: AuthClient = authClient ?? (await createAuthClient());
-
-      await client.logout();
-
-      resetAgents();
-
-      // We currently do not have issue because the all screen is reloaded after sign-out.
-      // But, if we wouldn't, then agent-js auth client would not be able to process next sign-in if object would be still in memory with previous partial information. That's why we reset it.
-      // This fix a "sign in -> sign out -> sign in again" flow without window reload.
-      authClient = null;
-
+    setNoIdentity: () => {
       update((state: AuthStoreData) => ({
         ...state,
         identity: null,


### PR DESCRIPTION
# Motivation

Simplify the auth store. Refactor the functionality into services instead of having asynchronous functionality in the store.

Follow the same pattern as the other stores, which use methods to only store and manipulate data.

# Changes

* New auth services `signIn` and `syncAuth` that substitute `AuthStore.signIn` and `AuthStore.sync`.
* Move logic from `AuthStore.signOut` to auth service `logout`.

# Tests

PENDING in case this approach is approved by the team.
