### PR TITLE
Feat: Add Min Participants to Project Detail Page

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -74,9 +74,9 @@
     <span slot="key">{$i18n.sns_project_detail.total_tokens} </span>
     <AmountDisplay slot="value" amount={snsTokens} singleLine />
   </KeyValuePair>
-  <KeyValuePair>
+  <KeyValuePair testId="project-swap-min-participants">
     <span slot="key">{$i18n.sns_project_detail.min_participants} </span>
-    <span slot="value" data-tid="project-swap-min-participants"
+    <span slot="value"
       >{formatNumber(params.min_participants, {
         minFraction: 0,
         maxFraction: 0,

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -16,6 +16,7 @@
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { nonNullish } from "@dfinity/utils";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import { formatNumber } from "$lib/utils/format.utils";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
@@ -72,6 +73,15 @@
   <KeyValuePair>
     <span slot="key">{$i18n.sns_project_detail.total_tokens} </span>
     <AmountDisplay slot="value" amount={snsTokens} singleLine />
+  </KeyValuePair>
+  <KeyValuePair>
+    <span slot="key">{$i18n.sns_project_detail.min_participants} </span>
+    <span slot="value" data-tid="project-swap-min-participants"
+      >{formatNumber(params.min_participants, {
+        minFraction: 0,
+        maxFraction: 0,
+      })}</span
+    >
   </KeyValuePair>
   <KeyValuePair>
     <span slot="key">{$i18n.sns_project_detail.min_commitment} </span>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -630,6 +630,7 @@
     "total_tokens_supply": "Total Supply",
     "min_commitment": "Minimum Commitment",
     "max_commitment": "Maximum Commitment",
+    "min_participants": "Minimum Participants",
     "current_overall_commitment": "Current Overall Commitment",
     "current_sale_buyer_count": "Current Total Participants",
     "min_commitment_goal": "Minimum Commitment Goal",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -656,6 +656,7 @@ interface I18nSns_project_detail {
   total_tokens_supply: string;
   min_commitment: string;
   max_commitment: string;
+  min_participants: string;
   current_overall_commitment: string;
   current_sale_buyer_count: string;
   min_commitment_goal: string;

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -39,8 +39,8 @@ describe("ProjectSwapDetails", () => {
     );
   });
 
-  it("should render min participants", () => {
-    const { getByTestId } = renderContextCmp({
+  it("should render min participants", async () => {
+    const { container } = renderContextCmp({
       summary: {
         ...mockSummary,
         swap: {
@@ -55,9 +55,9 @@ describe("ProjectSwapDetails", () => {
       Component: ProjectSwapDetails,
     });
 
-    const element = getByTestId("project-swap-min-participants");
+    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
-    expect(element.innerHTML).toEqual("1’430");
+    expect(await po.getMinParticipants()).toEqual("1’430");
   });
 
   it("should render min commitment", () => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -39,6 +39,27 @@ describe("ProjectSwapDetails", () => {
     );
   });
 
+  it("should render min participants", () => {
+    const { getByTestId } = renderContextCmp({
+      summary: {
+        ...mockSummary,
+        swap: {
+          ...mockSummary.swap,
+          params: {
+            ...mockSummary.swap.params,
+            min_participants: 1430,
+          },
+        },
+      },
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectSwapDetails,
+    });
+
+    const element = getByTestId("project-swap-min-participants");
+
+    expect(element.innerHTML).toEqual("1’430");
+  });
+
   it("should render min commitment", () => {
     const { container } = renderContextCmp({
       summary: mockSummary,

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -41,16 +41,7 @@ describe("ProjectSwapDetails", () => {
 
   it("should render min participants", async () => {
     const { container } = renderContextCmp({
-      summary: {
-        ...mockSummary,
-        swap: {
-          ...mockSummary.swap,
-          params: {
-            ...mockSummary.swap.params,
-            min_participants: 1430,
-          },
-        },
-      },
+      summary: createSummary({ minParticipants: 1430 }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectSwapDetails,
     });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -273,10 +273,12 @@ export const createSummary = ({
   lifecycle = SnsSwapLifecycle.Open,
   confirmationText = undefined,
   restrictedCountries = undefined,
+  minParticipants = 20,
 }: {
   lifecycle?: SnsSwapLifecycle;
   confirmationText?: string | undefined;
   restrictedCountries?: string[] | undefined;
+  minParticipants?: number;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -285,12 +287,17 @@ export const createSummary = ({
       ? [{ iso_codes: restrictedCountries }]
       : [],
   };
+  const params: SnsParams = {
+    ...mockSnsParams,
+    min_participants: minParticipants,
+  };
   const summary = summaryForLifecycle(lifecycle);
   return {
     ...summary,
     swap: {
       ...summary.swap,
       init: [init],
+      params,
     },
   };
 };

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -22,4 +22,11 @@ export class ProjectSwapDetailsPo extends BasePageObject {
       testId: "excluded-countries",
     });
   }
+
+  getMinParticipants(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "project-swap-min-participants",
+    }).getValueText();
+  }
 }


### PR DESCRIPTION
# Motivation

Add the minimum of participants needed for a Swap to pass in the Project Detail page.

# Changes

* Add one more KeyValuePair in the ProjectSwapDetails with the value of `min_participants`.

# Tests

* Add a test case for the new value rendered.
