### PR TITLE
Use binstall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,8 @@ jobs:
       - name: Install ic-wasm
         if: steps.cache-ic-wasm.outputs.cache-hit != 'true'
         run: |
-          cargo install "ic-wasm@${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}"
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm "ic-wasm@${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}"
           command -v ic-wasm || {
             echo "ERROR: Failed to install ic-wasm"
             exit 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -142,6 +142,7 @@ jobs:
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
           version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          # TODO: Make didc support binstall, then use binstall here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
@@ -166,6 +167,7 @@ jobs:
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
           version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          # TODO: Use binstall, once didc supports it.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
@@ -214,6 +216,7 @@ jobs:
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
           version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          # TODO: Use binstall, once didc supports it.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 ENV PATH=/cargo/bin:$PATH
 RUN cargo --version
 # Install IC CDK optimizer
+# TODO: Make ic-cdk-optimizer support binstall, then use cargo binstall --no-confirm ic-cdk-optimizer here.
 RUN curl -L --fail --retry 5 "https://github.com/dfinity/cdk-rs/releases/download/$(cat config/optimizer_version)/ic-cdk-optimizer-$(cat config/optimizer_version)-ubuntu-20.04.tar.gz" | gunzip | tar -x "ic-cdk-optimizer-$(cat config/optimizer_version)-ubuntu-20.04/ic-cdk-optimizer" --to-stdout | install -m755 /dev/stdin /usr/local/bin/ic-cdk-optimizer
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty
@@ -69,6 +70,7 @@ RUN mkdir -p rs/backend/src/bin rs/sns_aggregator/src && touch rs/backend/src/li
 WORKDIR /
 RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 RUN dfx --version
+# TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc"
 RUN didc --version
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall -V

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,9 @@ RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfin
 RUN dfx --version
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc"
 RUN didc --version
-RUN cargo install "wasm-nm@$(cat config/wasm_nm_version)" && command -v wasm-nm
-RUN cargo install "ic-wasm@$(cat config/ic_wasm_version)"
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall -V
+RUN cargo binstall --no-confirm "wasm-nm@$(cat config/wasm_nm_version)" && command -v wasm-nm
+RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && command -v ic-wasm
 
 # Title: Gets the deployment configuration
 # Args: Everything in the environment.  Ideally also ~/.config/dfx but that is inaccessible.

--- a/e2e-tests/scripts/nns-canister.Dockerfile
+++ b/e2e-tests/scripts/nns-canister.Dockerfile
@@ -6,7 +6,8 @@ RUN apt -yq update && \
     apt autoremove --purge -y && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
-RUN cargo install --version 0.3.2 ic-cdk-optimizer
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall -V
+RUN cargo binstall --no-confirm --version 0.3.2 ic-cdk-optimizer
 
 ARG IC_COMMIT
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -257,6 +257,7 @@ install_idl2json() {
 install_didc_linux() {
   local version
   version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  # TODO: Use binstall
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
 }
 install_didc_darwin() {

--- a/scripts/setup
+++ b/scripts/setup
@@ -158,6 +158,10 @@ install_rust() {
   append_to_profile 'export CARGO_BUILD_JOBS=2'
 }
 
+install_binstall() {
+  curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall -V
+}
+
 install_xz_darwin() {
   brew install xz
 }
@@ -174,7 +178,7 @@ install_tar_linux() {
 
 install_ic_cdk_optimizer() {
   # Nit: Needs rust to be in a working state.
-  cargo install --version 0.3.2 ic-cdk-optimizer
+  cargo binstall --no-confirm --version 0.3.2 ic-cdk-optimizer
 }
 
 is_docker_installed() {
@@ -265,7 +269,7 @@ install_didc_darwin() {
 }
 
 install_wasm_nm() {
-  cargo install wasm-nm@"$(jq -r .defaults.build.config.WASM_NM_VERSION dfx.json)"
+  cargo binstall --no-confirm wasm-nm@"$(jq -r .defaults.build.config.WASM_NM_VERSION dfx.json)"
 }
 
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
@@ -286,6 +290,7 @@ command -v jq || "install_jq_$OS"
 command -v yq || "install_yq_$OS"
 command -v npm || "install_npm_$OS"
 command -v cargo || install_rust
+cargo binstall -V || install_binstall
 command -v xz || "install_xz_$OS"
 . <(./build-config.sh)
 have_correct_dfx || install_dfx


### PR DESCRIPTION
# Motivation
`cargo install` builds from source, making it slow.  So we pre-build many tools and download the pre-built binaries.  Now we have the problem that we have a bunch of scripts to find available versions and install them by curl.  `cargo binstall` does that for us.  For the versions, it uses the list of versions published as rust crates.  And it installs pre-built binaries, if available, else builds from source.

Pros:
- Using `binstall` saves us from having to write a bunch of custom curl-based installers and version finders.

Cons:
- We have to install `binstall`
- We have to put our pre-built executables at standardized locations.
  - I have done this for `idl2json`, so `cargo binstall idl2json_cli` works.  It isn't that hard.
  - I have made a PR to support binstall for `ic-wasm`.

# Changes
- Change every `cargo install` to `cargo binstall --no-confirm`

# Tests
See CI