### PR TITLE
First version of simulate merge UI

### DIFF
--- a/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
@@ -20,7 +20,7 @@
 
   <div>
     <p class="label">{$i18n.neurons.neuron_balance}</p>
-    <p>
+    <p data-tid="balance">
       <Html
         text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
           $amount: valueSpan(

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -258,6 +258,7 @@
     "merge_neurons_modal_merge_button": "Merge Neurons",
     "merge_neurons_modal_title_2": "Merge neuron",
     "merge_neurons_modal_into": "into",
+    "expected_merge_result": "Expected merge result:",
     "set_dissolve_delay": "Set Dissolve Delay",
     "add_user_as_hotkey": "Add Principal to Hotkeys",
     "add_user_as_hotkey_message": "To see and manage this neuron in the NNS app, please add the NNS app as a hotkey.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -268,6 +268,7 @@ interface I18nNeurons {
   merge_neurons_modal_merge_button: string;
   merge_neurons_modal_title_2: string;
   merge_neurons_modal_into: string;
+  expected_merge_result: string;
   set_dissolve_delay: string;
   add_user_as_hotkey: string;
   add_user_as_hotkey_message: string;

--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -19,6 +19,7 @@ const fakeFunctions = {
   queryKnownNeurons,
   queryLastestRewardEvent,
   mergeNeurons,
+  simulateMergeNeurons,
 };
 
 //////////////////////////////////////////////
@@ -88,6 +89,27 @@ async function mergeNeurons({
   targetNeuron.fullNeuron.cachedNeuronStake +=
     sourceNeuron.fullNeuron.cachedNeuronStake;
   sourceNeuron.fullNeuron.cachedNeuronStake = BigInt(0);
+}
+
+async function simulateMergeNeurons({
+  sourceNeuronId,
+  targetNeuronId,
+  identity,
+}: ApiMergeNeuronsParams): Promise<NeuronInfo> {
+  const sourceNeuron = getNeuron({ identity, neuronId: sourceNeuronId });
+  const targetNeuron = getNeuron({ identity, neuronId: targetNeuronId });
+  // This is extremely simplified, just good enough for the test to see that the
+  // correct merge was simulated.
+  const mergedStake =
+    sourceNeuron.fullNeuron.cachedNeuronStake +
+    targetNeuron.fullNeuron.cachedNeuronStake;
+  return {
+    ...targetNeuron,
+    fullNeuron: {
+      ...targetNeuron.fullNeuron,
+      cachedNeuronStake: mergedStake,
+    },
+  };
 }
 
 /////////////////////////////////

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -3,11 +3,13 @@
  */
 
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
+import { mergeNeurons, simulateMergeNeurons } from "$lib/api/governance.api";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
 import { accountsStore } from "$lib/stores/accounts.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import type { Account } from "$lib/types/account";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
@@ -197,6 +199,106 @@ describe("MergeNeuronsModal", () => {
       expect(getStake(targetNeuron)).toBe(
         mergeableNeuron1.stake + mergeableNeuron2.stake
       );
+    });
+
+    it("should not simulate merging with feature disabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_SIMULATE_MERGE_NEURONS", false);
+
+      const po = await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        po,
+        neurons: mergeableNeurons,
+      });
+
+      await po
+        .getSelectNeuronsToMergePo()
+        .getConfirmSelectionButtonPo()
+        .click();
+
+      await runResolvedPromises();
+      expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
+        false
+      );
+      expect(
+        await po.getConfirmNeuronsMergePo().getMergedNeuronInfoPo().isPresent()
+      ).toBe(false);
+      expect(simulateMergeNeurons).not.toBeCalled();
+
+      // Make sure no actual merge happened either.
+      expect(mergeNeurons).not.toBeCalled();
+    });
+
+    it("should simulate merging with feature enabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_SIMULATE_MERGE_NEURONS", true);
+
+      const po = await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        po,
+        neurons: mergeableNeurons,
+      });
+
+      await po
+        .getSelectNeuronsToMergePo()
+        .getConfirmSelectionButtonPo()
+        .click();
+
+      await runResolvedPromises();
+      expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
+        true
+      );
+      const mergeNeuronInfo = po
+        .getConfirmNeuronsMergePo()
+        .getMergedNeuronInfoPo();
+      expect(await mergeNeuronInfo.isPresent()).toBe(true);
+      expect(await mergeNeuronInfo.getBalance()).toBe("46.00 ICP Stake");
+      // Just to show where the 46 is coming from:
+      expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(
+        BigInt(46 * E8S_PER_ICP)
+      );
+
+      // Make sure no actual merge happened.
+      expect(mergeNeurons).not.toBeCalled();
+    });
+
+    it("should show a skeleton card while simulating the merging", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_SIMULATE_MERGE_NEURONS", true);
+
+      const po = await renderMergeModal(mergeableNeurons);
+
+      await selectAndTestTwoNeurons({
+        po,
+        neurons: mergeableNeurons,
+      });
+
+      fakeGovernanceApi.pause();
+      await po
+        .getSelectNeuronsToMergePo()
+        .getConfirmSelectionButtonPo()
+        .click();
+
+      await runResolvedPromises();
+      expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
+        true
+      );
+      expect(
+        await po.getConfirmNeuronsMergePo().getSkeletonCardPo().isPresent()
+      ).toBe(true);
+      const mergeNeuronInfo = po
+        .getConfirmNeuronsMergePo()
+        .getMergedNeuronInfoPo();
+      expect(await mergeNeuronInfo.isPresent()).toBe(false);
+
+      fakeGovernanceApi.resume();
+      await runResolvedPromises();
+      expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
+        true
+      );
+      expect(
+        await po.getConfirmNeuronsMergePo().getSkeletonCardPo().isPresent()
+      ).toBe(false);
+      expect(await mergeNeuronInfo.isPresent()).toBe(true);
     });
   });
 

--- a/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
@@ -1,5 +1,6 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { NnsNeuronInfoPo } from "$tests/page-objects/NnsNeuronInfo.page-object";
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -26,6 +27,17 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
     });
   }
 
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
+  getMergedNeuronInfoPo(): NnsNeuronInfoPo {
+    return NnsNeuronInfoPo.under({
+      element: this.root,
+      testId: "merged-neuron-info",
+    });
+  }
+
   getConfirmMergeButtonPo(): ButtonPo {
     return this.getButton("confirm-merge-neurons-button");
   }
@@ -36,5 +48,9 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
 
   getTargetNeuronId(): Promise<string> {
     return this.getTargetNeuronInfoPo().getNeuronId();
+  }
+
+  hasMergeResultSection(): Promise<boolean> {
+    return this.root.byTestId("merge-result-section").isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronInfo.page-object.ts
@@ -15,4 +15,8 @@ export class NnsNeuronInfoPo extends BasePageObject {
   getNeuronId(): Promise<string> {
     return this.getText("neuron-id");
   }
+
+  getBalance(): Promise<string> {
+    return this.getText("balance");
+  }
 }


### PR DESCRIPTION
# Motivation

We want to show users the result of merging neurons before committing.
This PR just wires the results up to the UI but doesn't actually show much, just neuron ID and stake.
But having the scaffolding in place is useful when iterating.

# Changes

1. If `ENABLE_SIMULATE_MERGE_NEURONS` is enabled, simulate the merge in the `ConfirmNeuronsMerge` component.
2. Show a skeleton card while waiting for the result.
3. Show an `NnsNeuronInfo` component when the result is there.

# Tests

Unit tests:
1. simulateNeurons is not called when the feature is disabled.
2. merge result is show when the feature is enabled
3. skeleton card is shown while waiting
