### PR TITLE
Bump snsdemo

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -33,8 +33,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from 2023-05-24 with longer retries to install dfx
-          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          # Version from 2023-06-06 with dfx v0.14.1
+          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
-          # Version from 2023-05-24 with longer retries to install dfx
-          snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          # Version from 2023-06-06 with dfx v 0.14.1
+          snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
           nns_dapp_wasm: 'nns-dapp_local.wasm'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm'
@@ -128,8 +128,8 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
-          # Version from 2023-05-24 with longer retries to install dfx
-          snsdemo_ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          # Version from 2023-06-06 with dfx v0.14.1
+          snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
           nns_dapp_wasm: 'nns-dapp_local.wasm'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -194,8 +194,8 @@ jobs:
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from 2023-05-24 with longer retries to install dfx
-          ref: '94a006c4a4b77d7153071dee74d80939a22c835e'
+          # Version from 2023-06-06 with dfx v0.14.1
+          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
       - name: Add SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Motivation
`sns_demo` and `nns-dapp` now both use dfx v 0.14.1.

# Changes
- Update the snsdemo commit.

# Tests
See CI