### PR TITLE
Fix: Use ballot voting power in SNS proposals

### DIFF
--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -52,7 +52,7 @@
               SNS_NEURON_ID_DISPLAY_LENGTH
             )}
           </p>
-          <p class="vote-details">
+          <p class="vote-details" data-tid="my-votes-voting-power">
             <Value>{formatVotingPower(neuron.votingPower)}</Value>
             {#if voteIconMapper[neuron.vote]}
               <svelte:component this={voteIconMapper[neuron.vote]} />

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
@@ -42,6 +42,7 @@
           >
           <span
             class="voting-power value"
+            data-tid="voting-neuron-select-voting-power"
             aria-label={replacePlaceholders(
               $i18n.proposal_detail__vote.cast_vote_votingPower,
               {

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -31,6 +31,7 @@ import {
   nonNullish,
 } from "@dfinity/utils";
 import { nowInSeconds } from "./date.utils";
+import { ballotVotingPower } from "./sns-proposals.utils";
 import { bytesToHexString } from "./utils";
 
 export const sortSnsNeuronsByCreatedTimestamp = (
@@ -790,11 +791,9 @@ export const votedSnsNeurons = ({
 export const votedSnsNeuronDetails = ({
   neurons,
   proposal,
-  snsParameters,
 }: {
   neurons: SnsNeuron[];
   proposal: SnsProposalData;
-  snsParameters: SnsNervousSystemParameters;
 }): CompactNeuronInfo[] =>
   votedSnsNeurons({
     neurons,
@@ -802,12 +801,7 @@ export const votedSnsNeuronDetails = ({
   })
     .map((neuron) => ({
       idString: getSnsNeuronIdAsHexString(neuron),
-      votingPower: BigInt(
-        snsNeuronVotingPower({
-          neuron,
-          snsParameters,
-        })
-      ),
+      votingPower: ballotVotingPower({ proposal, neuron }),
       vote: getSnsNeuronVote({ neuron, proposal }),
     }))
     // Exclude the cases where the vote was not found.

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -5,16 +5,12 @@ import {
 } from "$lib/constants/sns-proposals.constants";
 import { i18n } from "$lib/stores/i18n";
 import type { VotingNeuron } from "$lib/types/proposals";
-import {
-  getSnsNeuronIdAsHexString,
-  snsNeuronVotingPower,
-} from "$lib/utils/sns-neuron.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import type { Vote } from "@dfinity/nns";
 import type {
   SnsAction,
   SnsBallot,
   SnsNervousSystemFunction,
-  SnsNervousSystemParameters,
   SnsNeuron,
   SnsNeuronId,
   SnsProposalData,
@@ -355,15 +351,31 @@ export const snsProposalIdString = (proposal: SnsProposalData): string =>
 export const snsProposalOpen = (proposal: SnsProposalData): boolean =>
   proposal.decided_timestamp_seconds === 0n;
 
+/**
+ * Returns the voting power of a neuron for a proposal.
+ */
+export const ballotVotingPower = ({
+  proposal,
+  neuron,
+}: {
+  proposal: SnsProposalData;
+  neuron: SnsNeuron;
+}): bigint =>
+  BigInt(
+    proposal.ballots.find(
+      ([ballotNeuronId]) => ballotNeuronId === getSnsNeuronIdAsHexString(neuron)
+    )?.[1].voting_power || 0
+  );
+
 export const snsNeuronToVotingNeuron = ({
   neuron,
-  snsParameters,
+  proposal,
 }: {
   neuron: SnsNeuron;
-  snsParameters: SnsNervousSystemParameters;
+  proposal: SnsProposalData;
 }): VotingNeuron => ({
   neuronIdString: getSnsNeuronIdAsHexString(neuron),
-  votingPower: BigInt(snsNeuronVotingPower({ neuron, snsParameters })),
+  votingPower: ballotVotingPower({ proposal, neuron }),
 });
 
 /** To have the logic in one place */

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -10,10 +10,7 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
-import {
-  createMockSnsNeuron,
-  snsNervousSystemParametersMock,
-} from "$tests/mocks/sns-neurons.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { NeuronState } from "@dfinity/nns";
 import type { SnsProposalData } from "@dfinity/sns";
@@ -71,7 +68,6 @@ describe("sns-vote-registration-services", () => {
       proposal,
       vote,
       updateProposalCallback: reloadProposalCallback,
-      snsParameters: snsNervousSystemParametersMock,
     });
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -2038,7 +2038,7 @@ describe("sns-neuron utils", () => {
           {
             vote: SnsVote.Yes,
             cast_timestamp_seconds: 0n,
-            voting_power: 321n,
+            voting_power: 324n,
           },
         ],
         [
@@ -2052,22 +2052,21 @@ describe("sns-neuron utils", () => {
       ],
     };
 
-    it("should return an sns neuron vote", () => {
+    it("should return an sns neuron vote with ballot voting power", () => {
       expect(
         votedSnsNeuronDetails({
           neurons: [testVotedNeuronA, testVotedNeuronB, testNotVotedNeuron],
           proposal: testProposal,
-          snsParameters: snsNervousSystemParametersMock,
         })
       ).toEqual([
         {
           idString: "010203",
-          votingPower: 0n,
+          votingPower: 324n,
           vote: Vote.Yes,
         },
         {
           idString: "010101",
-          votingPower: 0n,
+          votingPower: 321n,
           vote: Vote.No,
         },
       ]);


### PR DESCRIPTION
# Motivation

There was a bug where the voting power shows in the SNS proposals matched the voting power of the neuron, instead of the voting power of the ballot.

Voting power of a neuron for a proposal is set when the proposal is created. If the voting power of the neuron changes afterwards, it doesn't affect the voting power for earlier proposals.

# Changes

* New sns proposal util `ballotVotingPower` to get the voting power of a neuron for a specific proposal.
* Change the voting power calculation in the sns vote registration service `proposalAfterVote`.
* Change the voting power calculation in the sns neuron util `votedSnsNeuronDetails`.
* Change the voting power calculation in the sns proposal util `snsNeuronToVotingNeuron`.
* Remove the unused property `parameters` in the changed functions and in the dependencies where they are called.

# Tests

* Add two new cases in SnsVotingCard spec file to check that voting power comes from ballots.
* Edit the tests for the utils after change in calculation.
* New test for `ballotVotingPower` util.
