### PR TITLE
GIX-1584: Build env var being used in worker

### DIFF
--- a/frontend/jest-resolver.cjs
+++ b/frontend/jest-resolver.cjs
@@ -1,0 +1,13 @@
+const url = require("url");
+
+// Needed to resolve imports from the worker
+// Reference: https://github.com/vitejs/vite/discussions/5552#discussioncomment-1617341
+module.exports = (request, options) => {
+  // Remove any query parameters in the request path
+  // (e.g. ?worker, which Vite uses for worker imports)
+  if (request.includes("?")) {
+    return options.defaultResolver(url.parse(request).pathname, options);
+  }
+
+  return options.defaultResolver(request, options);
+};

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -29,6 +29,7 @@ module.exports = {
     "@dfinity/gix-components":
       "<rootDir>/node_modules/@dfinity/gix-components/dist",
   },
+  resolver: "<rootDir>/jest-resolver.cjs",
   setupFiles: ["fake-indexeddb/auto"],
   testPathIgnorePatterns: ["<rootDir>/src/tests/e2e/"],
 };

--- a/frontend/src/lib/api/canisters.api.cjs.ts
+++ b/frontend/src/lib/api/canisters.api.cjs.ts
@@ -2,7 +2,6 @@ import { toCanisterDetails } from "$lib/canisters/ic-management/converters";
 import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
 import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
 import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-management.types";
-import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
 import { HttpAgentCjs, getManagementCanisterCjs } from "$lib/utils/cjs.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity, ManagementCanisterRecord } from "@dfinity/agent";
@@ -11,13 +10,13 @@ import { Principal } from "@dfinity/principal";
 export const queryCanisterDetails = async ({
   identity,
   canisterId,
-  host = HOST,
-  fetchRootKey = FETCH_ROOT_KEY,
+  host,
+  fetchRootKey,
 }: {
   identity: Identity;
   canisterId: string;
-  host?: string;
-  fetchRootKey?: boolean;
+  host: string;
+  fetchRootKey: boolean;
 }): Promise<CanisterDetails> => {
   logWithTimestamp(`Getting canister ${canisterId} details call...`);
   const {

--- a/frontend/src/lib/api/canisters.api.cjs.ts
+++ b/frontend/src/lib/api/canisters.api.cjs.ts
@@ -11,14 +11,18 @@ import { Principal } from "@dfinity/principal";
 export const queryCanisterDetails = async ({
   identity,
   canisterId,
+  host = HOST,
+  fetchRootKey = FETCH_ROOT_KEY,
 }: {
   identity: Identity;
   canisterId: string;
+  host?: string;
+  fetchRootKey?: boolean;
 }): Promise<CanisterDetails> => {
   logWithTimestamp(`Getting canister ${canisterId} details call...`);
   const {
     icMgtService: { canister_status },
-  } = await canisters(identity);
+  } = await canisters({ identity, host, fetchRootKey });
 
   try {
     const canister_id = Principal.fromText(canisterId);
@@ -40,17 +44,23 @@ export const queryCanisterDetails = async ({
   }
 };
 
-const canisters = async (
-  identity: Identity
-): Promise<{
+const canisters = async ({
+  identity,
+  host,
+  fetchRootKey,
+}: {
+  identity: Identity;
+  host: string;
+  fetchRootKey: boolean;
+}): Promise<{
   icMgtService: ManagementCanisterRecord;
 }> => {
   const agent = new HttpAgentCjs({
     identity,
-    host: HOST,
+    host,
   });
 
-  if (FETCH_ROOT_KEY) {
+  if (fetchRootKey) {
     await agent.fetchRootKey();
   }
 

--- a/frontend/src/lib/services/worker-cycles.services.ts
+++ b/frontend/src/lib/services/worker-cycles.services.ts
@@ -1,17 +1,14 @@
-import type {
-  PostMessageDataRequestCycles,
-  PostMessageDataResponseCycles,
-} from "$lib/types/post-message.canister";
+import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import type { PostMessageDataResponseCycles } from "$lib/types/post-message.canister";
 import type { PostMessage } from "$lib/types/post-messages";
 
 export type CyclesCallback = (data: PostMessageDataResponseCycles) => void;
 
 export interface CyclesWorker {
-  startCyclesTimer: (
-    params: {
-      callback: CyclesCallback;
-    } & PostMessageDataRequestCycles
-  ) => void;
+  startCyclesTimer: (params: {
+    callback: CyclesCallback;
+    canisterId: string;
+  }) => void;
   stopCyclesTimer: () => void;
 }
 
@@ -36,15 +33,16 @@ export const initCyclesWorker = async (): Promise<CyclesWorker> => {
   return {
     startCyclesTimer: ({
       callback,
-      ...rest
+      canisterId,
     }: {
       callback: CyclesCallback;
-    } & PostMessageDataRequestCycles) => {
+      canisterId: string;
+    }) => {
       cyclesCallback = callback;
 
       cyclesWorker.postMessage({
         msg: "nnsStartCyclesTimer",
-        data: { ...rest },
+        data: { canisterId, host: HOST, fetchRootKey: FETCH_ROOT_KEY },
       });
     },
     stopCyclesTimer: () => {

--- a/frontend/src/lib/services/worker-cycles.services.ts
+++ b/frontend/src/lib/services/worker-cycles.services.ts
@@ -1,14 +1,18 @@
 import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
-import type { PostMessageDataResponseCycles } from "$lib/types/post-message.canister";
+import type {
+  PostMessageDataRequestCycles,
+  PostMessageDataResponseCycles,
+} from "$lib/types/post-message.canister";
 import type { PostMessage } from "$lib/types/post-messages";
 
 export type CyclesCallback = (data: PostMessageDataResponseCycles) => void;
 
 export interface CyclesWorker {
-  startCyclesTimer: (params: {
-    callback: CyclesCallback;
-    canisterId: string;
-  }) => void;
+  startCyclesTimer: (
+    params: {
+      callback: CyclesCallback;
+    } & Pick<PostMessageDataRequestCycles, "canisterId">
+  ) => void;
   stopCyclesTimer: () => void;
 }
 

--- a/frontend/src/lib/services/worker-cycles.services.ts
+++ b/frontend/src/lib/services/worker-cycles.services.ts
@@ -33,7 +33,7 @@ export const initCyclesWorker = async (): Promise<CyclesWorker> => {
   return {
     startCyclesTimer: ({
       callback,
-      canisterId,
+      ...rest
     }: {
       callback: CyclesCallback;
       canisterId: string;
@@ -42,7 +42,7 @@ export const initCyclesWorker = async (): Promise<CyclesWorker> => {
 
       cyclesWorker.postMessage({
         msg: "nnsStartCyclesTimer",
-        data: { canisterId, host: HOST, fetchRootKey: FETCH_ROOT_KEY },
+        data: { ...rest, host: HOST, fetchRootKey: FETCH_ROOT_KEY },
       });
     },
     stopCyclesTimer: () => {

--- a/frontend/src/lib/types/post-message.canister.ts
+++ b/frontend/src/lib/types/post-message.canister.ts
@@ -1,10 +1,10 @@
 import type { CanisterSync } from "$lib/types/canister";
 import type {
   PostMessageData,
-  PostMessageFetchBase,
+  PostMessageDataActor,
 } from "$lib/types/post-messages";
 
-export interface PostMessageDataRequestCycles extends PostMessageFetchBase {
+export interface PostMessageDataRequestCycles extends PostMessageDataActor {
   canisterId: string;
 }
 

--- a/frontend/src/lib/types/post-message.canister.ts
+++ b/frontend/src/lib/types/post-message.canister.ts
@@ -1,7 +1,10 @@
 import type { CanisterSync } from "$lib/types/canister";
-import type { PostMessageData } from "$lib/types/post-messages";
+import type {
+  PostMessageData,
+  PostMessageFetchBase,
+} from "$lib/types/post-messages";
 
-export interface PostMessageDataRequestCycles extends PostMessageData {
+export interface PostMessageDataRequestCycles extends PostMessageFetchBase {
   canisterId: string;
 }
 

--- a/frontend/src/lib/types/post-messages.ts
+++ b/frontend/src/lib/types/post-messages.ts
@@ -14,6 +14,11 @@ export type PostMessageResponse =
 
 export type PostMessageData = object;
 
+export interface PostMessageFetchBase extends PostMessageData {
+  host: string;
+  fetchRootKey: boolean;
+}
+
 export interface PostMessage<T extends PostMessageData> {
   msg: PostMessageRequest | PostMessageResponse;
   data: T;

--- a/frontend/src/lib/types/post-messages.ts
+++ b/frontend/src/lib/types/post-messages.ts
@@ -14,7 +14,7 @@ export type PostMessageResponse =
 
 export type PostMessageData = object;
 
-export interface PostMessageFetchBase extends PostMessageData {
+export interface PostMessageDataActor extends PostMessageData {
   host: string;
   fetchRootKey: boolean;
 }

--- a/frontend/src/lib/workers/cycles.worker.ts
+++ b/frontend/src/lib/workers/cycles.worker.ts
@@ -33,12 +33,14 @@ onmessage = async ({
 
 const syncCanister = async ({
   identity,
-  data: { canisterId },
+  data: { canisterId, host, fetchRootKey },
 }: TimerWorkerUtilJobData<PostMessageDataRequestCycles>) => {
   try {
     const canisterInfo: CanisterDetails = await queryCanisterDetails({
       canisterId,
       identity,
+      host,
+      fetchRootKey,
     });
 
     syncCanisterData({

--- a/frontend/src/lib/workers/cycles.worker.ts
+++ b/frontend/src/lib/workers/cycles.worker.ts
@@ -33,14 +33,13 @@ onmessage = async ({
 
 const syncCanister = async ({
   identity,
-  data: { canisterId, host, fetchRootKey },
+  data,
 }: TimerWorkerUtilJobData<PostMessageDataRequestCycles>) => {
+  const { canisterId } = data;
   try {
     const canisterInfo: CanisterDetails = await queryCanisterDetails({
-      canisterId,
+      ...data,
       identity,
-      host,
-      fetchRootKey,
     });
 
     syncCanisterData({

--- a/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
@@ -38,7 +38,7 @@ describe("canisters-api.cjs", () => {
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id.toText(),
         host,
-        fetchRootKey: true,
+        fetchRootKey: false,
       });
 
       expect(result).toEqual({

--- a/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
@@ -33,9 +33,12 @@ describe("canisters-api.cjs", () => {
 
   describe("queryCanisterDetails", () => {
     it("should call IC Management Canister with canister id", async () => {
+      const host = "http://localhost:8000";
       const result = await queryCanisterDetails({
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id.toText(),
+        host,
+        fetchRootKey: true,
       });
 
       expect(result).toEqual({
@@ -50,20 +53,6 @@ describe("canisters-api.cjs", () => {
           computeAllocation: 5n,
         },
         moduleHash: undefined,
-      });
-    });
-
-    it("should use the host parameter", async () => {
-      const host = "http://localhost:8000";
-      await queryCanisterDetails({
-        identity: mockIdentity,
-        canisterId: mockCanisterDetails.id.toText(),
-        host,
-      });
-
-      expect(MockHttpAgent).toBeCalledWith({
-        host,
-        identity: mockIdentity,
       });
     });
   });

--- a/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.cjs.spec.ts
@@ -4,9 +4,9 @@ import type { CanisterStatusResponse } from "$lib/canisters/ic-management/ic-man
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
 
-jest.mock("@dfinity/agent/lib/cjs/index", () => {
-  class MockHttpAgent {}
+jest.mock("@dfinity/agent/lib/cjs/index");
 
+describe("canisters-api.cjs", () => {
   const response: CanisterStatusResponse = {
     status: { running: null },
     memory_size: BigInt(1000),
@@ -20,16 +20,16 @@ jest.mock("@dfinity/agent/lib/cjs/index", () => {
     module_hash: [],
   };
 
-  return {
-    HttpAgent: MockHttpAgent,
-    getManagementCanister: () => ({
-      canister_status: async () => response,
-    }),
-  };
-});
+  const MockHttpAgent = jest.fn();
 
-describe("canisters-api.cjs", () => {
-  afterAll(() => jest.resetAllMocks());
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    const module = await import("@dfinity/agent/lib/cjs/index");
+    module.HttpAgent = MockHttpAgent;
+    module.getManagementCanister = jest.fn().mockReturnValue({
+      canister_status: async () => response,
+    });
+  });
 
   describe("queryCanisterDetails", () => {
     it("should call IC Management Canister with canister id", async () => {
@@ -50,6 +50,20 @@ describe("canisters-api.cjs", () => {
           computeAllocation: 5n,
         },
         moduleHash: undefined,
+      });
+    });
+
+    it("should use the host parameter", async () => {
+      const host = "http://localhost:8000";
+      await queryCanisterDetails({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id.toText(),
+        host,
+      });
+
+      expect(MockHttpAgent).toBeCalledWith({
+        host,
+        identity: mockIdentity,
       });
     });
   });

--- a/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-cycles.services.spec.ts
@@ -1,0 +1,36 @@
+import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import { initCyclesWorker } from "$lib/services/worker-cycles.services";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+
+jest.mock("$lib/workers/cycles.worker?worker");
+
+describe("initCyclesWorker", () => {
+  const postMessage = jest.fn();
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await import("$lib/workers/cycles.worker?worker");
+    module.default = jest.fn().mockReturnValue({
+      postMessage,
+    });
+  });
+
+  it("starting sends post message with host and fetchRootKey", async () => {
+    const cyclesWorker = initCyclesWorker();
+
+    const callback = jest.fn();
+
+    (await cyclesWorker).startCyclesTimer({
+      callback,
+      canisterId: mockCanisterId.toText(),
+    });
+
+    expect(postMessage).toBeCalledWith({
+      msg: "nnsStartCyclesTimer",
+      data: {
+        canisterId: mockCanisterId.toText(),
+        host: HOST,
+        fetchRootKey: FETCH_ROOT_KEY,
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

As described in https://dfinity.atlassian.net/browse/GIX-1584 a build environment variables was being used instead of the one from the initialization.

The problem was that the workers can't access `window` and therefore do not have access to the initialization env vars.

Solution for now: Pass the parameter in the post message instead of accessing the env vars directly.

Food for thought: Should we substitute the variables in the JS files instead of setting them in HTML during canister installation and upgrade?

# Changes

* `queryCanisterDetails` expects two new optional params: `host` and `fetchRootKey`.
* PostMessage to the cycles worker includes `host` and `fetchRootKey`.
* Cycles service `initCyclesWorker` passes `host` and `fetchRootKey` in the post message to the worker.
* Cycles worker uses new params `host` and `fetchRootKey` when calling `queryCanisterDetails`.

# Tests

* New test case in `queryCanisterDetails` to check that new param is being used.
