### PR TITLE
Use ckBTC info to display kyt fee

### DIFF
--- a/frontend/src/lib/api/ckbtc-minter.api.ts
+++ b/frontend/src/lib/api/ckbtc-minter.api.ts
@@ -122,27 +122,6 @@ export const estimateFee = async ({
   return result;
 };
 
-export const depositFee = async ({
-  identity,
-  canisterId,
-  ...rest
-}: {
-  identity: Identity;
-  canisterId: Principal;
-} & QueryParams): Promise<bigint> => {
-  logWithTimestamp("Bitcoin deposit fee: call...");
-
-  const {
-    canister: { getDepositFee },
-  } = await ckBTCMinterCanister({ identity, canisterId });
-
-  const result = await getDepositFee(rest);
-
-  logWithTimestamp("Bitcoin deposit fee: done");
-
-  return result;
-};
-
 export const minterInfo = async ({
   identity,
   canisterId,

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -8,11 +8,20 @@
   import type { Token } from "@dfinity/nns";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
+  import {
+    ckBTCInfoStore,
+    type CkBTCInfoStoreUniverseData,
+  } from "$lib/stores/ckbtc-info.store";
 
   export let amount: number | undefined = undefined;
   export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
-  export let kytEstimatedFee: bigint | undefined | null = undefined;
   export let universeId: UniverseCanisterId;
+
+  let infoData: CkBTCInfoStoreUniverseData | undefined = undefined;
+  $: infoData = $ckBTCInfoStore[universeId.toText()];
+
+  let kytEstimatedFee: bigint | undefined = undefined;
+  $: kytEstimatedFee = infoData?.info.kyt_fee;
 
   let bitcoinLabel: string;
   $: bitcoinLabel = isUniverseCkTESTBTC(universeId)

--- a/frontend/src/lib/components/accounts/BitcoinKYTFee.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinKYTFee.svelte
@@ -1,34 +1,20 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { debounce, nonNullish } from "@dfinity/utils";
-  import { depositFee as depositFeeService } from "$lib/services/ckbtc-minter.services";
-  import type { CanisterId } from "$lib/types/canister";
+  import { nonNullish } from "@dfinity/utils";
   import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
-  import type { TransactionNetwork } from "$lib/types/transaction";
-  import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
+  import {
+    ckBTCInfoStore,
+    type CkBTCInfoStoreUniverseData,
+  } from "$lib/stores/ckbtc-info.store";
+  import type { UniverseCanisterId } from "$lib/types/universe";
 
-  export let minterCanisterId: CanisterId;
-  export let selectedNetwork: TransactionNetwork | undefined = undefined;
+  export let universeId: UniverseCanisterId;
 
-  export let kytFee: bigint | undefined | null = undefined;
+  let infoData: CkBTCInfoStoreUniverseData | undefined = undefined;
+  $: infoData = $ckBTCInfoStore[universeId.toText()];
 
-  const loadKYTFee = async () => {
-    if (!isTransactionNetworkBtc(selectedNetwork)) {
-      kytFee = null;
-      return;
-    }
-
-    const callback = (fee: bigint | null) => (kytFee = fee);
-
-    await depositFeeService({
-      minterCanisterId,
-      callback,
-    });
-  };
-
-  const debounceEstimateFee = debounce(loadKYTFee);
-
-  $: selectedNetwork, (async () => debounceEstimateFee())();
+  let kytFee: bigint | undefined = undefined;
+  $: kytFee = infoData?.info.kyt_fee;
 </script>
 
 {#if nonNullish(kytFee)}

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -23,7 +23,6 @@
   import ReceiveSelectAccountDropdown from "$lib/components/accounts/ReceiveSelectAccountDropdown.svelte";
   import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
   import BitcoinKYTFee from "$lib/components/accounts/BitcoinKYTFee.svelte";
-  import { TransactionNetwork } from "$lib/types/transaction";
 
   export let data: CkBTCReceiveModalData;
 
@@ -153,12 +152,7 @@
 
       <svelte:fragment slot="additional-information">
         {#if bitcoin}
-          <BitcoinKYTFee
-            minterCanisterId={canisters.minterCanisterId}
-            selectedNetwork={ckTESTBTC
-              ? TransactionNetwork.BTC_TESTNET
-              : TransactionNetwork.BTC_MAINNET}
-          />
+          <BitcoinKYTFee {universeId} />
         {/if}
       </svelte:fragment>
     </ReceiveAddressQRCode>

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -66,7 +66,6 @@
       : TransactionNetwork.BTC_MAINNET
     : undefined;
   let bitcoinEstimatedFee: bigint | undefined | null = undefined;
-  let kytEstimatedFee: bigint | undefined | null = undefined;
 
   let currentStep: WizardStep | undefined;
 
@@ -200,17 +199,14 @@
       minterCanisterId={canisters.minterCanisterId}
       bind:bitcoinEstimatedFee
     />
-    <BitcoinKYTFee
-      {selectedNetwork}
-      minterCanisterId={canisters.minterCanisterId}
-      bind:kytFee={kytEstimatedFee}
-    />
+    {#if networkBtc}
+      <BitcoinKYTFee {universeId} />
+    {/if}
   </svelte:fragment>
   <svelte:fragment slot="received-amount">
     {#if networkBtc}
       <BitcoinEstimatedAmountReceived
         {bitcoinEstimatedFee}
-        {kytEstimatedFee}
         {universeId}
         amount={userAmount}
       />

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -1,5 +1,4 @@
 import {
-  depositFee as depositFeeAPI,
   estimateFee as estimateFeeAPI,
   getBTCAddress as getBTCAddressAPI,
   updateBalance as updateBalanceAPI,
@@ -95,42 +94,6 @@ export const estimateFee = async ({
       );
     },
     logMessage: "Getting Bitcoin estimated fee",
-  });
-};
-
-export const depositFee = async ({
-  minterCanisterId,
-  callback,
-}: {
-  minterCanisterId: CanisterId;
-  callback: (fee: bigint | null) => void;
-}): Promise<void> => {
-  return queryAndUpdate<bigint, unknown>({
-    request: ({ certified, identity }) =>
-      depositFeeAPI({
-        identity,
-        certified,
-        canisterId: minterCanisterId,
-      }),
-    onLoad: ({ response: fee }) => callback(fee),
-    onError: ({ error: err, certified }) => {
-      console.error(err);
-
-      // hide fee on any error
-      callback(null);
-
-      if (certified !== true) {
-        return;
-      }
-
-      toastsError(
-        toToastError({
-          err,
-          fallbackErrorLabelKey: "error__ckbtc.deposit_fee",
-        })
-      );
-    },
-    logMessage: "Getting Bitcoin deposit fee",
   });
 };
 

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -1,5 +1,4 @@
 import {
-  depositFee,
   estimateFee,
   getBTCAddress,
   getWithdrawalAccount,
@@ -169,31 +168,6 @@ describe("ckbtc-minter api", () => {
       });
 
       const call = () => estimateFee(feeParams);
-
-      expect(call).rejects.toThrowError();
-    });
-  });
-
-  describe("depositFee", () => {
-    it("returns deposit fee", async () => {
-      const expectedResult = 789n;
-
-      const depositFeeSpy =
-        minterCanisterMock.getDepositFee.mockResolvedValue(expectedResult);
-
-      const result = await depositFee(params);
-
-      expect(result).toEqual(expectedResult);
-
-      expect(depositFeeSpy).toBeCalled();
-    });
-
-    it("bubble errors", () => {
-      minterCanisterMock.getDepositFee.mockImplementation(async () => {
-        throw new Error();
-      });
-
-      const call = () => depositFee(params);
 
       expect(call).rejects.toThrowError();
     });

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -4,12 +4,18 @@
 
 import BitcoinEstimatedAmountReceived from "$lib/components/accounts/BitcoinEstimatedAmountReceived.svelte";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import { render } from "@testing-library/svelte";
 import en from "../../../mocks/i18n.mock";
 
 describe("BitcoinEstimatedAmountReceived", () => {
+  beforeEach(() => {
+    ckBTCInfoStore.reset();
+  });
+
   describe("should display zero as estimated received amount", () => {
     const zeroBtc = `${formatEstimatedFee(0n)} ${en.ckbtc.btc}`;
 
@@ -18,7 +24,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
         props: {
           amount: undefined,
           bitcoinEstimatedFee: undefined,
-          kytEstimatedFee: undefined,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
       });
@@ -32,7 +37,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
         props: {
           amount: undefined,
           bitcoinEstimatedFee: 1_000n,
-          kytEstimatedFee: 2_000n,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
       });
@@ -46,7 +50,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
         props: {
           amount: 10,
           bitcoinEstimatedFee: undefined,
-          kytEstimatedFee: undefined,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
       });
@@ -56,11 +59,19 @@ describe("BitcoinEstimatedAmountReceived", () => {
     });
 
     it("amount does not cover fee", () => {
+      ckBTCInfoStore.setInfo({
+        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        info: {
+          ...mockCkBTCMinterInfo,
+          kyt_fee: 5_000n,
+        },
+        certified: true,
+      });
+
       const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
         props: {
           amount: 0.0000099,
           bitcoinEstimatedFee: 5_000n,
-          kytEstimatedFee: 5_000n,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
       });
@@ -75,7 +86,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
       props: {
         amount: undefined,
         bitcoinEstimatedFee: undefined,
-        kytEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });
@@ -90,7 +100,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
       props: {
         amount: undefined,
         bitcoinEstimatedFee: undefined,
-        kytEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });
@@ -103,7 +112,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
       props: {
         amount: undefined,
         bitcoinEstimatedFee: undefined,
-        kytEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });
@@ -112,11 +120,19 @@ describe("BitcoinEstimatedAmountReceived", () => {
   });
 
   it("should display estimated received amount as zero if estimated btc fee not defined", () => {
+    ckBTCInfoStore.setInfo({
+      canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+      info: {
+        ...mockCkBTCMinterInfo,
+        kyt_fee: 1_000n,
+      },
+      certified: true,
+    });
+
     const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: 0.0099,
         bitcoinEstimatedFee: undefined,
-        kytEstimatedFee: 1_000n,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });
@@ -135,7 +151,6 @@ describe("BitcoinEstimatedAmountReceived", () => {
       props: {
         amount: 0.0099,
         bitcoinEstimatedFee: 1_000n,
-        kytEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });
@@ -150,11 +165,19 @@ describe("BitcoinEstimatedAmountReceived", () => {
   });
 
   it("should display estimated received amount", () => {
+    ckBTCInfoStore.setInfo({
+      canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+      info: {
+        ...mockCkBTCMinterInfo,
+        kyt_fee: 2_000n,
+      },
+      certified: true,
+    });
+
     const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: 0.0099,
         bitcoinEstimatedFee: 1_000n,
-        kytEstimatedFee: 2_000n,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
     });

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -10,6 +10,7 @@ import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.sv
 import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
 import * as services from "$lib/services/ckbtc-convert.services";
 import { authStore } from "$lib/stores/auth.store";
+import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TransactionNetwork } from "$lib/types/transaction";
@@ -24,6 +25,7 @@ import {
   mockCkBTCWithdrawalAccount,
   mockCkBTCWithdrawalIdentifier,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import {
@@ -74,6 +76,15 @@ describe("CkBTCTransactionModal", () => {
       universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
     });
 
+    ckBTCInfoStore.setInfo({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      info: {
+        ...mockCkBTCMinterInfo,
+        kyt_fee: 789n,
+      },
+      certified: true,
+    });
+
     page.mock({
       data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
       routeId: AppPath.Accounts,
@@ -82,8 +93,6 @@ describe("CkBTCTransactionModal", () => {
     jest
       .spyOn(minterApi, "estimateFee")
       .mockResolvedValue({ minter_fee: 123n, bitcoin_fee: 456n });
-
-    jest.spyOn(minterApi, "depositFee").mockResolvedValue(789n);
   });
 
   it("should transfer tokens", async () => {

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -320,37 +320,6 @@ describe("ckbtc-minter-services", () => {
     });
   });
 
-  describe("depositFee", () => {
-    it("should call deposit fee", async () => {
-      const result = 789n;
-
-      const spyDepositFee = jest
-        .spyOn(minterApi, "depositFee")
-        .mockResolvedValue(result);
-
-      const params = { certified: true };
-
-      const callback = jest.fn();
-
-      await services.depositFee({
-        callback,
-        minterCanisterId: CKBTC_MINTER_CANISTER_ID,
-      });
-
-      await waitFor(() =>
-        expect(spyDepositFee).toBeCalledWith({
-          identity: mockIdentity,
-          canisterId: CKBTC_MINTER_CANISTER_ID,
-          ...params,
-        })
-      );
-
-      expect(callback).toHaveBeenCalledWith(result);
-      // Query + Update
-      expect(callback).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe("getWithdrawalAccount", () => {
     it("should call get withdrawal account", async () => {
       const result: WithdrawalAccount = {


### PR DESCRIPTION
# Motivation

Use new ckBTC info fetched from minter to display the kyt fee.

# PRs

- [ ] https://github.com/dfinity/ic-js/pull/348
- [ ] #2682

# Changes

- deprecate `getDepositFee`
- bump ic-js that deprecates `getDepositFee` as well
- remove fetch to above API call in component and replace with usage of the store
