### PR TITLE
Fix: Users are not able to vote in sns proposal

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -45,6 +45,7 @@
   import IneligibleNeuronsCard from "$lib/components/proposal-detail/IneligibleNeuronsCard.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { authStore } from "$lib/stores/auth.store";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let proposal: SnsProposalData;
   export let reloadProposal: () => Promise<void>;
@@ -163,36 +164,40 @@
         );
 </script>
 
-<BottomSheet>
-  <div class="container" class:signedIn={$authSignedInStore}>
-    <SignInGuard>
-      {#if $sortedSnsUserNeuronsStore.length > 0}
-        {#if neuronsReady}
-          {#if visible}
-            <VotingConfirmationToolbar
-              {voteRegistration}
-              on:nnsConfirm={vote}
-            />
-          {/if}
+<TestIdWrapper testId="sns-voting-card-component">
+  <BottomSheet>
+    <div class="container" class:signedIn={$authSignedInStore}>
+      <SignInGuard>
+        {#if $sortedSnsUserNeuronsStore.length > 0}
+          {#if neuronsReady}
+            {#if visible}
+              <VotingConfirmationToolbar
+                {voteRegistration}
+                on:nnsConfirm={vote}
+              />
+            {/if}
 
-          <VotingNeuronSelect>
-            <VotingNeuronSelectList disabled={voteRegistration !== undefined} />
-            <MyVotes {neuronsVotedForProposal} />
-            <IneligibleNeuronsCard
-              {ineligibleNeurons}
-              {minSnsDissolveDelaySeconds}
-            />
-          </VotingNeuronSelect>
-        {:else}
-          <div class="loader">
-            <SpinnerText>{$i18n.proposal_detail.loading_neurons}</SpinnerText>
-          </div>
+            <VotingNeuronSelect>
+              <VotingNeuronSelectList
+                disabled={voteRegistration !== undefined}
+              />
+              <MyVotes {neuronsVotedForProposal} />
+              <IneligibleNeuronsCard
+                {ineligibleNeurons}
+                {minSnsDissolveDelaySeconds}
+              />
+            </VotingNeuronSelect>
+          {:else}
+            <div class="loader">
+              <SpinnerText>{$i18n.proposal_detail.loading_neurons}</SpinnerText>
+            </div>
+          {/if}
         {/if}
-      {/if}
-      <span slot="signin-cta">{$i18n.proposal_detail.sign_in}</span>
-    </SignInGuard>
-  </div>
-</BottomSheet>
+        <span slot="signin-cta">{$i18n.proposal_detail.sign_in}</span>
+      </SignInGuard>
+    </div>
+  </BottomSheet>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -32,6 +32,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { i18n } from "$lib/stores/i18n";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -165,15 +166,15 @@
     }`
   );
 
-  // The `update` function cares about the necessary data to be refetched.
-  $: universeIdText, proposalIdText, $snsNeuronsStore, update();
-
   let proposalIds: bigint[];
   $: proposalIds = nonNullish(universeIdText)
     ? sortSnsProposalsById(
         $snsFilteredProposalsStore[universeIdText]?.proposals
       )?.map(snsProposalId) ?? []
     : [];
+
+  // The `update` function cares about the necessary data to be refetched.
+  $: universeIdText, proposalIdText, $snsNeuronsStore, $authStore, update();
 </script>
 
 <TestIdWrapper testId="sns-proposal-details-grid">

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -4,6 +4,7 @@ import {
   IDENTITY_SERVICE_URL,
   OLD_MAINNET_IDENTITY_SERVICE_URL,
 } from "$lib/constants/identity.constants";
+import { IS_TEST_ENV } from "$lib/constants/mockable.constants";
 import { NNS_IC_APP_DERIVATION_ORIGIN } from "$lib/constants/origin.constants";
 import { createAuthClient } from "$lib/utils/auth.utils";
 import { isNnsAlternativeOrigin } from "$lib/utils/env.utils";
@@ -49,6 +50,7 @@ const getIdentityProvider = () => {
  */
 export interface AuthStore extends Readable<AuthStoreData> {
   sync: () => Promise<void>;
+  setForTesting: (identity: Identity) => void;
   signIn: (onError: (error?: string) => void) => Promise<void>;
   signOut: () => Promise<void>;
 }
@@ -60,6 +62,16 @@ const initAuthStore = (): AuthStore => {
 
   return {
     subscribe,
+
+    setForTesting: (identity: Identity | undefined | null) => {
+      if (!IS_TEST_ENV) {
+        throw new Error(
+          "This function should only be used in test environment"
+        );
+      }
+
+      set({ identity });
+    },
 
     sync: async () => {
       authClient = authClient ?? (await createAuthClient());

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -289,11 +289,13 @@ describe("SnsProposalDetail", () => {
         proposalId: proposalId.id,
       });
 
+      const proposalCreatedTimestamp = 33333n;
+
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
         ...proposal,
-        proposal_creation_timestamp_seconds: 33333n,
+        proposal_creation_timestamp_seconds: proposalCreatedTimestamp,
         ballots: [
           [
             getSnsNeuronIdAsHexString(mockSnsNeuron),
@@ -310,7 +312,7 @@ describe("SnsProposalDetail", () => {
         identity: mockIdentity,
         rootCanisterId,
         id: mockSnsNeuron.id,
-        created_timestamp_seconds: 111n,
+        created_timestamp_seconds: proposalCreatedTimestamp - 100n,
         permissions: [
           {
             principal: [mockIdentity.getPrincipal()],
@@ -337,7 +339,8 @@ describe("SnsProposalDetail", () => {
       authStore.setForTesting(mockIdentity);
       await runResolvedPromises();
 
-      await waitFor(async () => expect(await po.hasVotingToolbar()).toBe(true));
+      // await waitFor(async () => expect(await po.hasVotingToolbar()).toBe(true));
+      expect(await po.hasVotingToolbar()).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -282,6 +282,7 @@ describe("SnsProposalDetail", () => {
     it("show neurons that can vote", async () => {
       authStore.setForTesting(undefined);
 
+      const proposalCreatedTimestamp = 33333n;
       const proposal = createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
         rewardStatus:
@@ -289,7 +290,21 @@ describe("SnsProposalDetail", () => {
         proposalId: proposalId.id,
       });
 
-      const proposalCreatedTimestamp = 33333n;
+      fakeSnsGovernanceApi.addNeuronWith({
+        identity: mockIdentity,
+        rootCanisterId,
+        id: mockSnsNeuron.id,
+        // The neuron must have creation timestamp before the proposal
+        created_timestamp_seconds: proposalCreatedTimestamp - 100n,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from([
+              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
+            ]),
+          },
+        ],
+      });
 
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
@@ -305,21 +320,6 @@ describe("SnsProposalDetail", () => {
               cast_timestamp_seconds: 0n,
             },
           ],
-        ],
-      });
-
-      fakeSnsGovernanceApi.addNeuronWith({
-        identity: mockIdentity,
-        rootCanisterId,
-        id: mockSnsNeuron.id,
-        created_timestamp_seconds: proposalCreatedTimestamp - 100n,
-        permissions: [
-          {
-            principal: [mockIdentity.getPrincipal()],
-            permission_type: Int32Array.from([
-              SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE,
-            ]),
-          },
         ],
       });
 

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -334,7 +334,6 @@ describe("SnsProposalDetail", () => {
 
       expect(await po.hasVotingToolbar()).toBe(false);
 
-      // TODO: This doesn't trigger a rerender that would show the voting toolbar.
       authStore.setForTesting(mockIdentity);
       await runResolvedPromises();
 

--- a/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalDetail.page-object.ts
@@ -5,6 +5,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { ProposalSummarySectionPo } from "./ProposalSummarySection.page-object";
 import { SnsProposalPayloadSectionPo } from "./SnsProposalPayloadSection.page-object";
+import { SnsProposalVotingSectionPo } from "./SnsProposalVotingSection.page-object";
 
 export class SnsProposalDetailPo extends BasePageObject {
   private static readonly TID = "sns-proposal-details-grid";
@@ -53,5 +54,13 @@ export class SnsProposalDetailPo extends BasePageObject {
 
   hasSummarySection(): Promise<boolean> {
     return this.getSummarySectionPo().isPresent();
+  }
+
+  getSnsProposalVotingSectionPo(): SnsProposalVotingSectionPo {
+    return SnsProposalVotingSectionPo.under(this.root);
+  }
+
+  hasVotingToolbar(): Promise<boolean> {
+    return this.getSnsProposalVotingSectionPo().hasVotingToolbar();
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalVotingSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalVotingSection.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { VotesResultPo } from "$tests/page-objects/VotesResults.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsVotingCardPo } from "./SnsVotingCard.page-object";
 
 export class SnsProposalVotingSectionPo extends BasePageObject {
   private static readonly TID = "sns-proposal-voting-section-component";
@@ -17,5 +18,13 @@ export class SnsProposalVotingSectionPo extends BasePageObject {
 
   async getVotingsResultsPo(): Promise<VotesResultPo> {
     return VotesResultPo.under(this.root);
+  }
+
+  getSnsVotingCardPo(): SnsVotingCardPo {
+    return SnsVotingCardPo.under(this.root);
+  }
+
+  hasVotingToolbar(): Promise<boolean> {
+    return this.getSnsVotingCardPo().hasVotingToolbar();
   }
 }

--- a/frontend/src/tests/page-objects/SnsVotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsVotingCard.page-object.ts
@@ -1,0 +1,23 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { VotingConfirmationToolbarPo } from "./VotingConfirmationToolbar.page-object";
+
+export class SnsVotingCardPo extends BasePageObject {
+  private static readonly TID = "sns-voting-card-component";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): SnsVotingCardPo {
+    return new SnsVotingCardPo(element.byTestId(SnsVotingCardPo.TID));
+  }
+
+  getConfirmationToolbar(): VotingConfirmationToolbarPo {
+    return VotingConfirmationToolbarPo.under(this.root);
+  }
+
+  hasVotingToolbar(): Promise<boolean> {
+    return this.getConfirmationToolbar().isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/VotingConfirmationToolbar.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingConfirmationToolbar.page-object.ts
@@ -1,0 +1,16 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class VotingConfirmationToolbarPo extends BasePageObject {
+  private static readonly TID = "voting-confirmation-toolbar";
+
+  private constructor(root: PageObjectElement) {
+    super(root);
+  }
+
+  static under(element: PageObjectElement): VotingConfirmationToolbarPo {
+    return new VotingConfirmationToolbarPo(
+      element.byTestId(VotingConfirmationToolbarPo.TID)
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

User was not able to vote on SNS proposal if was logging in directly from the SNS proposal detail page.

Problem: The neurons were not fetched.

# Changes

* The `update` call in the SnsProposalDetail page depends on the `authStore`.

# Tests

Main test:
* New test case in SnsProposalDetail to simulate the bug.

Additional changes:
* SnsVotingCard page object.
* New method `setForTesting` in `authStore`. This allows to fake logging in in unit tests.
* New methods in SnsProposalDetail page object.
* New methods in SnsProposalVotingSection page object.
* New SnsVotingCard page object.
* New ConfirmationToolBar page object.
