### PR TITLE
Feat: Change functionality empty NNS Proposal filters

### DIFF
--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -41,6 +41,7 @@ export const queryProposals = async ({
       limit: DEFAULT_LIST_PAGINATION_LIMIT,
       beforeProposal,
       excludeTopic:
+        // We want all topics if the filter is empty
         topics.length === 0
           ? []
           : enumsExclude<Topic>({

--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -40,10 +40,13 @@ export const queryProposals = async ({
     request: {
       limit: DEFAULT_LIST_PAGINATION_LIMIT,
       beforeProposal,
-      excludeTopic: enumsExclude<Topic>({
-        obj: Topic as unknown as Topic,
-        values: topics,
-      }),
+      excludeTopic:
+        topics.length === 0
+          ? []
+          : enumsExclude<Topic>({
+              obj: Topic as unknown as Topic,
+              values: topics,
+            }),
       includeRewardStatus: rewards,
       includeStatus: status,
     },

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -40,8 +40,7 @@ export const sortedProposals: Readable<ProposalsStore> = derived(
 // HACK:
 //
 // 1. the governance canister does not implement a filter to hide proposals where all neurons have voted or are ineligible.
-// 2. the governance canister interprets queries with empty filter (e.g. topics=[]) has "any" queries and returns proposals anyway. On the contrary, the Flutter app displays nothing if one filter is empty.
-// 3. the Flutter app does not simply display nothing when a filter is empty but re-filter the results provided by the backend.
+// 2. the app does not simply display nothing when a filter is empty but re-filter the results provided by the backend.
 //
 // In addition, we have implemented an "optimistic voting" feature.
 //

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -67,7 +67,6 @@ export const listProposals = async ({
 }): Promise<void> => {
   return findProposals({
     beforeProposal: undefined,
-    loadFinished,
     onLoad: ({ response: proposals, certified }) => {
       proposalsStore.setProposals({ proposals, certified });
 
@@ -98,7 +97,6 @@ export const listNextProposals = async ({
 }): Promise<void> =>
   findProposals({
     beforeProposal,
-    loadFinished,
     onLoad: ({ response: proposals, certified }) => {
       if (proposals.length === 0) {
         // There is no more proposals to fetch for the current filters.
@@ -120,32 +118,12 @@ const findProposals = async ({
   beforeProposal,
   onLoad,
   onError,
-  loadFinished,
 }: {
   beforeProposal: ProposalId | undefined;
   onLoad: QueryAndUpdateOnResponse<ProposalInfo[]>;
   onError: QueryAndUpdateOnError<unknown>;
-  loadFinished: (params: {
-    paginationOver: boolean;
-    certified: boolean | undefined;
-  }) => void;
 }): Promise<void> => {
   const filters: ProposalsFiltersStore = get(proposalsFiltersStore);
-
-  const { topics, rewards, status } = filters;
-
-  // The governance canister consider empty filters and an "any" query. Flutter on the contrary considers empty as empty.
-  // That's why we implement the same behavior and do not render any proposals if one of the filter is empty.
-  // This is covered by our utils "hideProposal" but to avoid glitch, like displaying a spinner appearing and disappearing for a while, we "just" do not query the canister and empty the store if one of the filter is empty.
-  if (topics.length === 0 || rewards.length === 0 || status.length === 0) {
-    proposalsStore.setProposals({ proposals: [], certified: undefined });
-
-    loadFinished({
-      paginationOver: true,
-      certified: undefined,
-    });
-    return;
-  }
 
   const validateResponses = (
     trustedProposals: ProposalInfo[],

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -131,9 +131,9 @@ const matchFilters = ({
   } = proposalInfo;
 
   return (
-    topics.includes(proposalTopic) &&
-    rewards.includes(rewardStatus) &&
-    status.includes(proposalStatus)
+    (topics.length === 0 || topics.includes(proposalTopic)) &&
+    (rewards.length === 0 || rewards.includes(rewardStatus)) &&
+    (status.length === 0 || status.includes(proposalStatus))
   );
 };
 

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -49,6 +49,29 @@ describe("proposals-api", () => {
 
       expect(spyListProposals).toHaveReturnedTimes(1);
     });
+
+    it("should call with no excluded topics if topics filter is empty", async () => {
+      await queryProposals({
+        beforeProposal: mockProposals[mockProposals.length - 1].id,
+        filters: {
+          ...DEFAULT_PROPOSALS_FILTERS,
+          topics: [],
+        },
+        identity: mockIdentity,
+        certified: true,
+      });
+
+      expect(spyListProposals).toHaveBeenCalledWith({
+        certified: true,
+        request: {
+          beforeProposal: mockProposals[mockProposals.length - 1].id,
+          excludeTopic: [],
+          includeRewardStatus: DEFAULT_PROPOSALS_FILTERS.rewards,
+          includeStatus: DEFAULT_PROPOSALS_FILTERS.status,
+          limit: 100,
+        },
+      });
+    });
   });
 
   describe("load", () => {

--- a/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
@@ -7,7 +7,6 @@ import {
   ProposalPayloadNotFoundError,
   ProposalPayloadTooLargeError,
 } from "$lib/canisters/nns-dapp/nns-dapp.errors";
-import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import {
   listNextProposals,
   listProposals,
@@ -283,8 +282,10 @@ describe("proposals-services", () => {
 
     afterAll(() => jest.clearAllMocks());
 
-    it("should not call the canister if empty filter", async () => {
+    it("should load proposals if filters are empty", async () => {
       proposalsFiltersStore.filterStatus([]);
+      proposalsFiltersStore.filterRewards([]);
+      proposalsFiltersStore.filterTopics([]);
 
       await listProposals({
         loadFinished: () => {
@@ -292,24 +293,12 @@ describe("proposals-services", () => {
         },
       });
 
-      expect(spyQueryProposals).not.toHaveBeenCalled();
-
-      proposalsFiltersStore.filterStatus(DEFAULT_PROPOSALS_FILTERS.status);
-    });
-
-    it("should reset the proposal store if empty filter", async () => {
-      proposalsFiltersStore.filterStatus([]);
-
-      await listProposals({
-        loadFinished: () => {
-          // do nothing here
-        },
-      });
+      expect(spyQueryProposals).toHaveBeenCalledTimes(1);
 
       const { proposals } = get(proposalsStore);
-      expect(proposals).toEqual([]);
+      expect(proposals).toEqual(mockProposals);
 
-      proposalsFiltersStore.filterStatus(DEFAULT_PROPOSALS_FILTERS.status);
+      proposalsFiltersStore.reset();
     });
   });
 

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -277,7 +277,7 @@ describe("proposals-utils", () => {
       ).toBeTruthy();
     });
 
-    it("should hide proposal if a filter is empty", () => {
+    it("should not hide proposal if a filter is empty", () => {
       expect(
         hideProposal({
           proposalInfo: proposalWithBallot({
@@ -291,7 +291,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeTruthy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -306,7 +306,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeTruthy();
+      ).toBe(false);
 
       expect(
         hideProposal({
@@ -321,7 +321,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBeTruthy();
+      ).toBe(false);
     });
 
     it("should hide proposal if does not match filter", () => {


### PR DESCRIPTION
# Motivation

Bring consistency in proposal filters.

Inconsistency: SNS filters showed all proposals if no filter was selected. Whereas NNS had a hack coming from flutter to not render any proposal if a filter was empty.

Solution: Along with product, we agreed to remove the legacy hack and consider no filter selected as "any". This is also the behavior of the backend endpoint.

# Changes

* Remove hack in `findProposals` proposal service that would set an empty store if a filter was empty.
* Change the behavior of the queryProposals api when the topics filter is empty.
* Change behavior of the `matchFilters` helper inside the proposal utils.

# Tests

* Add a test case for the `queryProposals` api new logic.
* Change the test case for the findProposals service.
* Change the test case for the `hide` proposal util.
