### PR TITLE
Sns proposal layout title

### DIFF
--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -22,6 +22,8 @@
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSnsProposalStore } from "../derived/debug.derived";
   import { isUniverseNns } from "$lib/utils/universe.utils";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { i18n } from "$lib/stores/i18n";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -147,6 +149,13 @@
       setProposal(undefined);
     }
   };
+
+  // Update layout title
+  $: layoutTitleStore.set(
+    `${$i18n.proposal_detail.title}${
+      nonNullish(proposalIdText) ? ` ${proposalIdText}` : ""
+    }`
+  );
 
   // The `update` function cares about the necessary data to be refetched.
   $: universeIdText, proposalIdText, $snsNeuronsStore, update();

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -7,6 +7,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { layoutTitleStore } from "$lib/stores/layout.store";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import { mockAuthStoreNoIdentitySubscribe } from "$tests/mocks/auth.store.mock";
@@ -91,6 +92,26 @@ describe("SnsProposalDetail", () => {
       expect(await po.hasSummarySection()).toBe(true);
       expect(await po.hasSystemInfoSection()).toBe(true);
       expect(await po.getSkeletonDetails().isPresent()).toBe(false);
+    });
+
+    it("should update layout title text", async () => {
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [proposalId],
+      });
+      fakeSnsGovernanceApi.pause();
+
+      const spyOnSetTitle = jest.spyOn(layoutTitleStore, "set");
+      const proposalIdText = proposalId.id.toString();
+      render(SnsProposalDetail, {
+        props: {
+          proposalIdText,
+        },
+      });
+
+      expect(spyOnSetTitle).toHaveBeenCalledTimes(1);
+      expect(spyOnSetTitle).toHaveBeenCalledWith(`Proposal ${proposalIdText}`);
     });
 
     it("should render the name of the nervous function as title", async () => {


### PR DESCRIPTION
# Motivation

Update the page layout title with selected sns proposal. Similar to nns proposal details page.

# Changes

- update the layout title.

# Tests

- update should be called on page render

# Screenshots

![Screen Recording 2023-06-14 at 10 37 05](https://github.com/dfinity/nns-dapp/assets/98811342/912c7fe8-5c69-40f9-a85d-238356f2beed)

