### PR TITLE
Faster wasm network independence test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,15 +272,28 @@ jobs:
           rm -rf screenshots
   network_independent_wasm:
     name: "Same wasms for mainnet and local"
+    # Note: The dockerfile structure SHOULD guarantee that the network is not used in any wasm build commands.
+    #       As long as that holds, this test is not needed.
     needs: build
     runs-on: ubuntu-latest-m
     timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check dockerfile for changes
+        id: dockerfile_changed
+        run: |
+          common_parent_commit="$(git merge-base HEAD origin/main)"
+          if git diff "$common_parent_commit" Dockerfile | grep -q .
+          then echo "dockerfile_changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up docker buildx
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: docker/setup-buildx-action@v2
       - name: Build wasms
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -292,23 +305,28 @@ jobs:
           # Exports the artefacts from the final stage
           outputs: ./out-mainnet
       - name: Get nns-dapp_local
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: nns-dapp_local
           path: out-local
       - name: Remove _local suffix
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         run: mv out-local/nns-dapp_local.wasm out-local/nns-dapp.wasm
       - name: Get sns_aggregator
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator
           path: out-local
       - name: Get sns_aggregator_dev
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator_dev
           path: out-local
       - name: Compare wasms
+        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
         run: |
           set -x
           ls -l

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
   network_independent_wasm:
     name: "Same wasms for mainnet and local"
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest-m
     timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp


### PR DESCRIPTION
# Motivation
We have a test that checks that the wasm is the same, regardless of which network we are building for.  This test is commonly the last to finish in CI:

![Screenshot from 2023-06-15 09-43-37](https://github.com/dfinity/nns-dapp/assets/5982633/5d3b2eb4-97f2-4ad8-acdd-a8f759a9b123)

It would be nice if CI were to finish sooner.

# Changes
* That the wasm does not depend on the network is guaranteed by the fact that the network is not an input to any of the wasm build steps in the Dockerfile.  As such, it probably suffices to perform the check only if the dockerfile has changed.
* If the test needs to be performed, use a larger runner.

# Tests
* See CI