### PR TITLE
Feat: Swap Metrics util

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -14,6 +14,7 @@
   import type { SnsSwapDerivedState, SnsParams } from "@dfinity/sns";
   import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
   import { nonNullish } from "@dfinity/utils";
+  import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
@@ -41,10 +42,10 @@
   });
 
   let saleBuyerCount: number | undefined;
-  $: saleBuyerCount =
-    $projectDetailStore?.summary?.rootCanisterId &&
-    $snsSwapMetricsStore[$projectDetailStore?.summary?.rootCanisterId.toText()]
-      ?.saleBuyerCount;
+  $: saleBuyerCount = swapSaleBuyerCount({
+    rootCanisterId: $projectDetailStore?.summary?.rootCanisterId,
+    swapMetrics: $snsSwapMetricsStore,
+  });
 </script>
 
 {#if nonNullish(saleBuyerCount)}

--- a/frontend/src/lib/utils/sns-swap.utils.ts
+++ b/frontend/src/lib/utils/sns-swap.utils.ts
@@ -1,0 +1,14 @@
+import type { SnsSwapMetricsStoreData } from "$lib/stores/sns-swap-metrics.store";
+import type { Principal } from "@dfinity/principal";
+
+export const swapSaleBuyerCount = ({
+  swapMetrics,
+  rootCanisterId,
+}: {
+  swapMetrics: SnsSwapMetricsStoreData;
+  rootCanisterId: Principal | undefined;
+}): number | undefined => {
+  return rootCanisterId === undefined
+    ? undefined
+    : swapMetrics?.[rootCanisterId.toText()]?.saleBuyerCount;
+};

--- a/frontend/src/tests/lib/utils/sns-swap.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-swap.utils.spec.ts
@@ -1,0 +1,57 @@
+import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { Principal } from "@dfinity/principal";
+
+describe("sns-swap utils", () => {
+  describe("swapSaleBuyerCount", () => {
+    it("should return undefined if rootCanisterId or metrics are not defined", () => {
+      expect(
+        swapSaleBuyerCount({
+          rootCanisterId: undefined,
+          swapMetrics: undefined,
+        })
+      ).toBeUndefined();
+      expect(
+        swapSaleBuyerCount({ rootCanisterId: undefined, swapMetrics: null })
+      ).toBeUndefined();
+      expect(
+        swapSaleBuyerCount({
+          rootCanisterId: mockPrincipal,
+          swapMetrics: undefined,
+        })
+      ).toBeUndefined();
+      expect(
+        swapSaleBuyerCount({ rootCanisterId: mockPrincipal, swapMetrics: null })
+      ).toBeUndefined();
+      expect(
+        swapSaleBuyerCount({
+          rootCanisterId: undefined,
+          swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
+        })
+      ).toBeUndefined();
+    });
+
+    it("should return undefined if root canister id is not in the metrics store", () => {
+      expect(
+        swapSaleBuyerCount({
+          rootCanisterId: Principal.fromText(
+            "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+          ),
+          swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
+        })
+      ).toBeUndefined();
+    });
+
+    it("should return sale count of the selected root canister id", () => {
+      const saleCount = 100;
+      expect(
+        swapSaleBuyerCount({
+          rootCanisterId: mockPrincipal,
+          swapMetrics: {
+            [mockPrincipal.toText()]: { saleBuyerCount: saleCount },
+          },
+        })
+      ).toBe(saleCount);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to use the data from the derived state instead of getting the swap buyer count from the metrics from the raw endpoint.

Not all SNSes support the new field in the derived state with the count or buyers.

This PR: Prepare the util that will select the buyers count either from current swap metrics store or from derived state.

# Changes

* New sns-swap util `swapSaleBuyerCount`.
* Use the new util in `ProjectCommitment.svelte` component.

# Tests

* Add tests for new sns-swap util `swapSaleBuyerCount`