### PR TITLE
Feat: Store data utils and type

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -5,3 +5,5 @@ export enum StoreLocalStorageKey {
   BitcoinConvertBlockIndexes = "nnsBitcoinConvertBlockIndexes",
   SnsProposalFilters = "nnsSnsProposalFilters",
 }
+
+export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/stores/user-country.store.ts
+++ b/frontend/src/lib/stores/user-country.store.ts
@@ -1,12 +1,13 @@
 import type { Country } from "$lib/types/location";
 import { derived, writable } from "svelte/store";
+import type { StoreData } from "../types/store";
 
 /**
  * - Not Loaded: "not loaded"
  * - Error: Error
  * - Success: Country
  */
-type UserCountryStore = Country | Error | "not loaded";
+type UserCountryStore = StoreData<Country>;
 
 // Stores the user's country code
 export const userCountryStore = writable<UserCountryStore>("not loaded");

--- a/frontend/src/lib/stores/user-country.store.ts
+++ b/frontend/src/lib/stores/user-country.store.ts
@@ -1,20 +1,16 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { Country } from "$lib/types/location";
+import type { StoreData } from "$lib/types/store";
 import { derived, writable } from "svelte/store";
-import type { StoreData } from "../types/store";
 
-/**
- * - Not Loaded: "not loaded"
- * - Error: Error
- * - Success: Country
- */
 type UserCountryStore = StoreData<Country>;
 
 // Stores the user's country code
-export const userCountryStore = writable<UserCountryStore>("not loaded");
+export const userCountryStore = writable<UserCountryStore>(NOT_LOADED);
 
 export const isUserCountryLoadedStore = derived(
   userCountryStore,
-  ($userCountry) => $userCountry !== "not loaded"
+  ($userCountry) => $userCountry !== NOT_LOADED
 );
 export const isUserCountryErrorStore = derived(
   userCountryStore,

--- a/frontend/src/lib/types/store.ts
+++ b/frontend/src/lib/types/store.ts
@@ -1,0 +1,1 @@
+export type StoreData<T> = T | Error | "not loaded";

--- a/frontend/src/lib/types/store.ts
+++ b/frontend/src/lib/types/store.ts
@@ -1,1 +1,8 @@
-export type StoreData<T> = T | Error | "not loaded";
+import type { NOT_LOADED } from "$lib/constants/stores.constants";
+
+/**
+ * - Not Loaded: NOT_LOADED
+ * - Error: Error
+ * - Success: T
+ */
+export type StoreData<T> = T | Error | typeof NOT_LOADED;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,3 +1,4 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import { getDeniedCountries } from "$lib/getters/sns-summary";
 import type { Country } from "$lib/types/location";
@@ -6,6 +7,7 @@ import type {
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
+import type { StoreData } from "$lib/types/store";
 import type { TokenAmount } from "@dfinity/nns";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
 import { isNullish, nonNullish } from "@dfinity/utils";
@@ -321,7 +323,7 @@ export const participateButtonStatus = ({
   swapCommitment: SnsSwapCommitment | undefined | null;
   loggedIn: boolean;
   ticket: SnsSwapTicket | undefined | null;
-  userCountry: Country | Error | "not loaded";
+  userCountry: StoreData<Country>;
 }): ParticipationButtonStatus => {
   if (!loggedIn) {
     return "logged-out";
@@ -359,7 +361,7 @@ export const participateButtonStatus = ({
       return "enabled";
     }
 
-    if (userCountry === "not loaded") {
+    if (userCountry === NOT_LOADED) {
       return "loading";
     }
 

--- a/frontend/src/lib/utils/store.utils.ts
+++ b/frontend/src/lib/utils/store.utils.ts
@@ -1,4 +1,5 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { StoreData } from "$lib/types/store";
 
 export const isStoreData = <T>(storeData: StoreData<T>): storeData is T =>
-  storeData !== "not loaded" && !(storeData instanceof Error);
+  storeData !== NOT_LOADED && !(storeData instanceof Error);

--- a/frontend/src/lib/utils/store.utils.ts
+++ b/frontend/src/lib/utils/store.utils.ts
@@ -1,0 +1,4 @@
+import type { StoreData } from "$lib/types/store";
+
+export const isStoreData = <T>(storeData: StoreData<T>): storeData is T =>
+  storeData !== "not loaded" && !(storeData instanceof Error);

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -49,7 +50,7 @@ describe("ParticipateButton", () => {
       });
       snsTicketsStore.reset();
       jest.clearAllMocks();
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
     });
 
     it("should render a text to increase participation", () => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -9,6 +9,7 @@ import * as snsMetricsApi from "$lib/api/sns-swap-metrics.api";
 import * as snsApi from "$lib/api/sns.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
@@ -80,7 +81,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
     snsQueryStore.reset();
     snsSwapCommitmentsStore.reset();
     snsSwapMetricsStore.reset();
-    userCountryStore.set("not loaded");
+    userCountryStore.set(NOT_LOADED);
 
     jest.clearAllTimers();
     const now = Date.now();
@@ -343,7 +344,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
             true
           );
 
-          expect(get(userCountryStore)).toBe("not loaded");
+          expect(get(userCountryStore)).toBe(NOT_LOADED);
         });
 
         it("should show enabled button after getting user country", async () => {

--- a/frontend/src/tests/lib/services/user-country.services.spec.ts
+++ b/frontend/src/tests/lib/services/user-country.services.spec.ts
@@ -1,4 +1,5 @@
 import * as locationApi from "$lib/api/location.api";
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { loadUserCountry } from "$lib/services/user-country.services";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
@@ -16,10 +17,10 @@ describe("location services", () => {
 
   describe("loadUserLocation", () => {
     beforeEach(() => {
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
     });
     it("should set the location store to api response", async () => {
-      expect(get(userCountryStore)).toBe("not loaded");
+      expect(get(userCountryStore)).toBe(NOT_LOADED);
 
       const countryCode = "CH";
       jest
@@ -32,7 +33,7 @@ describe("location services", () => {
     });
 
     it("should set the location store to error if api fails", async () => {
-      expect(get(userCountryStore)).toBe("not loaded");
+      expect(get(userCountryStore)).toBe(NOT_LOADED);
 
       jest
         .spyOn(locationApi, "queryUserCountryLocation")

--- a/frontend/src/tests/lib/stores/user-country.store.spec.ts
+++ b/frontend/src/tests/lib/stores/user-country.store.spec.ts
@@ -1,3 +1,4 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import {
   isUserCountryErrorStore,
   isUserCountryLoadedStore,
@@ -7,7 +8,7 @@ import { get } from "svelte/store";
 
 describe("userCountryStore", () => {
   beforeEach(() => {
-    userCountryStore.set("not loaded");
+    userCountryStore.set(NOT_LOADED);
   });
 
   describe("userCountryStore", () => {
@@ -24,11 +25,11 @@ describe("userCountryStore", () => {
 
   describe("isUserCountryLoadedStore", () => {
     beforeEach(() => {
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
     });
 
     it("should return false when the location is 'not loaded'", () => {
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
       expect(get(isUserCountryLoadedStore)).toBe(false);
     });
 
@@ -43,7 +44,7 @@ describe("userCountryStore", () => {
 
   describe("isUserCountryErrorStore", () => {
     beforeEach(() => {
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
     });
 
     it("should return true when the location is an error", () => {
@@ -55,7 +56,7 @@ describe("userCountryStore", () => {
       userCountryStore.set({ isoCode: "CH" });
       expect(get(isUserCountryErrorStore)).toEqual(false);
 
-      userCountryStore.set("not loaded");
+      userCountryStore.set(NOT_LOADED);
       expect(get(isUserCountryErrorStore)).toEqual(false);
     });
   });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,3 +1,4 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -1047,7 +1048,7 @@ describe("project-utils", () => {
         loggedIn: false,
         summary,
         swapCommitment: userNoCommitment,
-        userCountry: "not loaded",
+        userCountry: NOT_LOADED,
         ticket: null,
       });
       expect(expected).toBe("logged-out");
@@ -1153,7 +1154,7 @@ describe("project-utils", () => {
           loggedIn: true,
           summary: summaryNoRestricted,
           swapCommitment: userNoCommitment,
-          userCountry: "not loaded",
+          userCountry: NOT_LOADED,
           ticket: null,
         })
       ).toBe("enabled");
@@ -1187,7 +1188,7 @@ describe("project-utils", () => {
             loggedIn: true,
             summary: summaryUsRestricted,
             swapCommitment: userNoCommitment,
-            userCountry: "not loaded",
+            userCountry: NOT_LOADED,
             ticket: null,
           })
         ).toBe("loading");

--- a/frontend/src/tests/lib/utils/store.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/store.utils.spec.ts
@@ -1,12 +1,14 @@
 import { isStoreData } from "$lib/utils/store.utils";
 
-describe("isStoreData", () => {
-  it("should return false if data is error or not loaded", () => {
-    expect(isStoreData("not loaded")).toBe(false);
-    expect(isStoreData(new Error())).toBe(false);
-  });
+describe("store utils", () => {
+  describe("isStoreData", () => {
+    it("should return false if data is error or not loaded", () => {
+      expect(isStoreData("not loaded")).toBe(false);
+      expect(isStoreData(new Error())).toBe(false);
+    });
 
-  it("should return true if data is error or not loaded", () => {
-    expect(isStoreData({ data: [] })).toBe(true);
+    it("should return true if data is error or not loaded", () => {
+      expect(isStoreData({ data: [] })).toBe(true);
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/store.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/store.utils.spec.ts
@@ -1,16 +1,17 @@
+import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { isStoreData } from "$lib/utils/store.utils";
 
 describe("store utils", () => {
   describe("isStoreData", () => {
     it("should return false if data is error or not loaded", () => {
-      expect(isStoreData("not loaded")).toBe(false);
+      expect(isStoreData(NOT_LOADED)).toBe(false);
       expect(isStoreData(new Error())).toBe(false);
     });
 
     it("should return true if data is error nor 'not loaded'", () => {
       expect(isStoreData({ data: [] })).toBe(true);
-      // It can also be a string
       expect(isStoreData("successful")).toBe(true);
+      expect(isStoreData(Symbol("test"))).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/store.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/store.utils.spec.ts
@@ -1,0 +1,12 @@
+import { isStoreData } from "$lib/utils/store.utils";
+
+describe("isStoreData", () => {
+  it("should return false if data is error or not loaded", () => {
+    expect(isStoreData("not loaded")).toBe(false);
+    expect(isStoreData(new Error())).toBe(false);
+  });
+
+  it("should return true if data is error or not loaded", () => {
+    expect(isStoreData({ data: [] })).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/utils/store.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/store.utils.spec.ts
@@ -7,8 +7,10 @@ describe("store utils", () => {
       expect(isStoreData(new Error())).toBe(false);
     });
 
-    it("should return true if data is error or not loaded", () => {
+    it("should return true if data is error nor 'not loaded'", () => {
       expect(isStoreData({ data: [] })).toBe(true);
+      // It can also be a string
+      expect(isStoreData("successful")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want stores to hold the error, loading and success states.

This PR: Introduces a type that should be used by the stores and a helper to convert the type to the success type.

The type is already used in the useCountryStore.

The util will be used in the util from PR #2700 [swapSaleBuyerCount](https://github.com/dfinity/nns-dapp/pull/2700/files#diff-aa44a48b94ac01459ed5ebb708a264a70bbd0b1c1afc4616da02d00053131738R4)

# Changes

* New type `StoreData`.
* Use new type in `userCountryStore`.
* New store util `isStoreData`. Not used yet, only tested.

# Tests

* New test file for new store util `isStoreData`.
