### PR TITLE
Build wasm without assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,32 @@ RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
 ARG COMMIT
 RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name nns-dapp --verbose
 
+# Title: Image to build the nns-dapp backend.
+FROM builder AS build_nnsdapp_without_assets
+SHELL ["bash", "-c"]
+COPY ./rs/backend /build/rs/backend
+COPY ./scripts/nns-dapp/test-exports /build/scripts/nns-dapp/test-exports
+COPY ./scripts/clap.bash /build/scripts/clap.bash
+COPY ./build-backend.sh /build/
+COPY ./build-rs.sh /build/
+COPY ./Cargo.toml /build/
+COPY ./Cargo.lock /build/
+COPY ./dfx.json /build/
+WORKDIR /build
+RUN tar -cJf assets.tar.xz -T /dev/null
+# We need to make sure that the rebuild happens if the code has changed.
+# - Docker checks whether the filesystem or command line have changed, so it will
+#   run if there are code changes and skip otherwise.  Perfect.
+# - However cargo _may_ then look at the mtime and decide that no, or only minimal,
+#   rebuilding is necessary due to the potentially recent dependency building step above.
+#   Cargo checks whether the mtime of some code is newer than its last build, like
+#   it's 1974, unlike bazel that uses checksums.
+# So we update the timestamps of the root code files.
+# Old canisters use src/main.rs, new ones use src/lib.rs.  We update the timestamps on all that exist.
+# We don't wish to update the code from main.rs to lib.rs and then have builds break.
+RUN touch --no-create rs/backend/src/main.rs rs/backend/src/lib.rs
+RUN ./build-backend.sh
+
 # Title: Image to build the sns aggregator, used to increase performance and reduce load.
 # Args: None.
 #       The SNS aggregator needs to know the canister ID of the
@@ -189,6 +215,7 @@ COPY --from=configurator /build/nns-dapp-arg* /
 # Note: The frontend/.env is kept for use with test deployments only.
 COPY --from=configurator /build/frontend/.env /frontend-config.sh
 COPY --from=build_nnsdapp /build/nns-dapp.wasm /
+COPY --from=build_nnsdapp_without_assets /build/nns-dapp.wasm /nns-dapp_noassets.wasm
 COPY --from=build_nnsdapp /build/assets.tar.xz /
 COPY --from=build_frontend /build/sourcemaps.tar.xz /
 COPY --from=build_aggregate /build/sns_aggregator.wasm /

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,7 @@ RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
 ARG COMMIT
 RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name nns-dapp --verbose
 
-# Title: Image to build the nns-dapp backend.
+# Title: Image to build the nns-dapp backend without assets.
 FROM builder AS build_nnsdapp_without_assets
 SHELL ["bash", "-c"]
 COPY ./rs/backend /build/rs/backend
@@ -168,6 +168,7 @@ COPY ./Cargo.toml /build/
 COPY ./Cargo.lock /build/
 COPY ./dfx.json /build/
 WORKDIR /build
+# Create an empty assets tarfile.
 RUN tar -cJf assets.tar.xz -T /dev/null
 # We need to make sure that the rebuild happens if the code has changed.
 # - Docker checks whether the filesystem or command line have changed, so it will
@@ -181,6 +182,11 @@ RUN tar -cJf assets.tar.xz -T /dev/null
 # We don't wish to update the code from main.rs to lib.rs and then have builds break.
 RUN touch --no-create rs/backend/src/main.rs rs/backend/src/lib.rs
 RUN ./build-backend.sh
+COPY ./scripts/dfx-wasm-metadata-add /build/scripts/dfx-wasm-metadata-add
+# TODO: Move this to the apt install at the beginning of this file.
+RUN apt-get update -yq && apt-get install -yqq --no-install-recommends file
+ARG COMMIT
+RUN scripts/dfx-wasm-metadata-add --commit "$COMMIT" --canister_name nns-dapp --verbose
 
 # Title: Image to build the sns aggregator, used to increase performance and reduce load.
 # Args: None.


### PR DESCRIPTION
# Motivation
Deploying to an application subnet requires installing the wasm without assets, then installing assets afterwards.

# Changes
Add a new docker build stage that builds the nns-dapp wasm with an empty assets tarfile.

# Tests
None.  This should be tested in combination with the chunk uploading PR, once merged.