### PR TITLE
audit fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9123,9 +9123,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
@@ -16121,9 +16121,9 @@
       }
     },
     "vite": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
-      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.17.5",


### PR DESCRIPTION
# Motivation

<!-- Describe the motivation that lead to the PR -->

# Changes

`npm audit fix` to solve:
```
# npm audit report

vite  4.3.0 - 4.3.8
Severity: high
Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//) - https://github.com/advisories/GHSA-353f-5xf4-qw67
fix available via `npm audit fix`
node_modules/vite

1 high severity vulnerability
```