### PR TITLE
Fix proposal navigation visibility during voting

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -36,7 +36,7 @@
     voteRegistrationStore: VoteRegistrationStoreData;
   }): bigint[] => {
     const proposalIds =
-      $filteredProposals.proposals?.map(({ id }) => id as bigint) || [];
+      proposalStore.proposals?.map(({ id }) => id as bigint) || [];
     const proposalIdsInRegistrations = (
       voteRegistrationStore.registrations[OWN_CANISTER_ID_TEXT] ?? []
     ).map(({ proposalIdString }) => BigInt(proposalIdString));

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -13,43 +13,14 @@
   import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
   import { filteredProposals } from "$lib/derived/proposals.derived";
   import { navigateToProposal } from "$lib/utils/proposals.utils";
-  import {
-    voteRegistrationStore,
-    type VoteRegistrationStoreData,
-  } from "$lib/stores/vote-registration.store";
-  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-  import type { ProposalsStore } from "$lib/stores/proposals.store";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
   );
 
-  // The proposal that is currently in vote registration process is not included in the filtered proposals list,
-  // since it should not be available for voting.
-  // But this shouldn't prevent user from navigating to it.
-  // Here we are adding this proposal to the list of proposals, so that the navigation block is not hidden for it.
-  const collectProposalIds = ({
-    proposalStore,
-    voteRegistrationStore,
-  }: {
-    proposalStore: ProposalsStore;
-    voteRegistrationStore: VoteRegistrationStoreData;
-  }): bigint[] => {
-    const proposalIds =
-      proposalStore.proposals?.map(({ id }) => id as bigint) || [];
-    const proposalIdsInRegistrations = (
-      voteRegistrationStore.registrations[OWN_CANISTER_ID_TEXT] ?? []
-    ).map(({ proposalIdString }) => BigInt(proposalIdString));
-
-    // return unique proposal ids
-    return Array.from(new Set([...proposalIds, ...proposalIdsInRegistrations]));
-  };
-
   let proposalIds: bigint[] | undefined;
-  $: proposalIds = collectProposalIds({
-    proposalStore: $filteredProposals,
-    voteRegistrationStore: $voteRegistrationStore,
-  });
+  $: proposalIds =
+    $filteredProposals.proposals?.map(({ id }) => id as bigint) ?? [];
 </script>
 
 {#if $store?.proposal?.id !== undefined}

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -19,8 +19,7 @@
   );
 
   let proposalIds: bigint[] | undefined;
-  $: proposalIds =
-    $filteredProposals.proposals?.map(({ id }) => id as bigint) ?? [];
+  $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
 </script>
 
 {#if $store?.proposal?.id !== undefined}

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -13,13 +13,43 @@
   import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
   import { filteredProposals } from "$lib/derived/proposals.derived";
   import { navigateToProposal } from "$lib/utils/proposals.utils";
+  import {
+    voteRegistrationStore,
+    type VoteRegistrationStoreData,
+  } from "$lib/stores/vote-registration.store";
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import type { ProposalsStore } from "$lib/stores/proposals.store";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
   );
 
+  // The proposal that is currently in vote registration process is not included in the filtered proposals list,
+  // since it should not be available for voting.
+  // But this shouldn't prevent user from navigating to it.
+  // Here we are adding this proposal to the list of proposals, so that the navigation block is not hidden for it.
+  const collectProposalIds = ({
+    proposalStore,
+    voteRegistrationStore,
+  }: {
+    proposalStore: ProposalsStore;
+    voteRegistrationStore: VoteRegistrationStoreData;
+  }): bigint[] => {
+    const proposalIds =
+      $filteredProposals.proposals?.map(({ id }) => id as bigint) || [];
+    const proposalIdsInRegistrations = (
+      voteRegistrationStore.registrations[OWN_CANISTER_ID_TEXT] ?? []
+    ).map(({ proposalIdString }) => BigInt(proposalIdString));
+
+    // return unique proposal ids
+    return Array.from(new Set([...proposalIds, ...proposalIdsInRegistrations]));
+  };
+
   let proposalIds: bigint[] | undefined;
-  $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
+  $: proposalIds = collectProposalIds({
+    proposalStore: $filteredProposals,
+    voteRegistrationStore: $voteRegistrationStore,
+  });
 </script>
 
 {#if $store?.proposal?.id !== undefined}

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -7,20 +7,23 @@
   export let proposalIds: bigint[] = [];
   export let selectProposal: (proposalId: bigint) => void;
 
+  let sortedProposalIds: bigint[];
+  $: sortedProposalIds = [...proposalIds].sort((a, b) => Number(b - a));
+
   let currentProposalIndex: number;
-  $: currentProposalIndex = proposalIds.indexOf(currentProposalId);
+  $: currentProposalIndex = sortedProposalIds.indexOf(currentProposalId);
 
   let previousId: bigint | undefined;
   $: previousId =
     currentProposalIndex === -1
       ? undefined
-      : proposalIds[currentProposalIndex - 1];
+      : sortedProposalIds[currentProposalIndex - 1];
 
   let nextId: bigint | undefined;
   $: nextId =
     currentProposalIndex === -1
       ? undefined
-      : proposalIds[currentProposalIndex + 1];
+      : sortedProposalIds[currentProposalIndex + 1];
 
   const selectPrevious = () => {
     assertNonNullish(previousId);
@@ -32,7 +35,7 @@
   };
 </script>
 
-{#if proposalIds.length > 1}
+{#if sortedProposalIds.length > 1}
   <div role="toolbar" data-tid="proposal-nav">
     <button
       class="ghost"

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -10,20 +10,14 @@
   let sortedProposalIds: bigint[];
   $: sortedProposalIds = [...proposalIds].sort((a, b) => Number(b - a));
 
-  let currentProposalIndex: number;
-  $: currentProposalIndex = sortedProposalIds.indexOf(currentProposalId);
-
   let previousId: bigint | undefined;
-  $: previousId =
-    currentProposalIndex === -1
-      ? undefined
-      : sortedProposalIds[currentProposalIndex - 1];
+  // use `as bigint[]` to avoid TS error (type T | undefined is not assignable to type bigint | undefined)
+  $: previousId = ([...sortedProposalIds].reverse() as bigint[]).find(
+    (id) => id > currentProposalId
+  );
 
   let nextId: bigint | undefined;
-  $: nextId =
-    currentProposalIndex === -1
-      ? undefined
-      : sortedProposalIds[currentProposalIndex + 1];
+  $: nextId = sortedProposalIds.find((id) => id < currentProposalId);
 
   const selectPrevious = () => {
     assertNonNullish(previousId);

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -7,17 +7,15 @@
   export let proposalIds: bigint[] = [];
   export let selectProposal: (proposalId: bigint) => void;
 
-  let sortedProposalIds: bigint[];
-  $: sortedProposalIds = [...proposalIds].sort((a, b) => Number(b - a));
-
   let previousId: bigint | undefined;
+  // TODO: switch to findLast() once it's available
   // use `as bigint[]` to avoid TS error (type T | undefined is not assignable to type bigint | undefined)
-  $: previousId = ([...sortedProposalIds].reverse() as bigint[]).find(
+  $: previousId = ([...proposalIds].reverse() as bigint[]).find(
     (id) => id > currentProposalId
   );
 
   let nextId: bigint | undefined;
-  $: nextId = sortedProposalIds.find((id) => id < currentProposalId);
+  $: nextId = proposalIds.find((id) => id < currentProposalId);
 
   const selectPrevious = () => {
     assertNonNullish(previousId);
@@ -29,7 +27,7 @@
   };
 </script>
 
-{#if sortedProposalIds.length > 1}
+{#if proposalIds.length > 1}
   <div role="toolbar" data-tid="proposal-nav">
     <button
       class="ghost"

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -58,6 +58,17 @@ describe("ProposalNavigation", () => {
       expect(await po.isPreviousButtonHidden()).toBe(false);
     });
 
+    it("should be visible even when the current proposal is not in the list", async () => {
+      const po = renderComponent({
+        currentProposalId: 10n,
+        proposalIds: [20n, 0n],
+        selectProposal: jest.fn(),
+      });
+
+      expect(await po.isNextButtonHidden()).toBe(false);
+      expect(await po.isPreviousButtonHidden()).toBe(false);
+    });
+
     it("should disable previous button when it's selected", async () => {
       const po = renderComponent({
         currentProposalId: 1n,

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -84,29 +84,29 @@ describe("ProposalNavigation", () => {
   it("should emmit next click", async () => {
     const selectProposalSpy = jest.fn();
     const po = renderComponent({
-      currentProposalId: 1n,
-      proposalIds: [2n, 1n, 0n],
+      currentProposalId: 2n,
+      proposalIds: [4n, 3n, 2n, 1n, 0n],
       selectProposal: selectProposalSpy,
     });
 
     await po.clickNext();
 
     expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-    expect(selectProposalSpy).toHaveBeenCalledWith(0n);
+    expect(selectProposalSpy).toHaveBeenCalledWith(1n);
   });
 
   it("should emmit previous click", async () => {
     const selectProposalSpy = jest.fn();
     const po = renderComponent({
-      currentProposalId: 1n,
-      proposalIds: [2n, 1n, 0n],
+      currentProposalId: 2n,
+      proposalIds: [4n, 3n, 2n, 1n, 0n],
       selectProposal: selectProposalSpy,
     });
 
     await po.clickPrevious();
 
     expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-    expect(selectProposalSpy).toHaveBeenCalledWith(2n);
+    expect(selectProposalSpy).toHaveBeenCalledWith(3n);
   });
 
   it("should emit with right arguments for non-consecutive ids", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -39,7 +39,7 @@ describe("ProposalNavigation", () => {
     it("should render buttons", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [0n, 1n, 2n],
+        proposalIds: [2n, 1n, 0n],
         selectProposal: jest.fn(),
       });
 
@@ -50,7 +50,7 @@ describe("ProposalNavigation", () => {
     it("should enable both buttons", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [0n, 1n, 2n],
+        proposalIds: [2n, 1n, 0n],
         selectProposal: jest.fn(),
       });
 
@@ -61,7 +61,7 @@ describe("ProposalNavigation", () => {
     it("should disable previous button when it's selected", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [0n, 1n],
+        proposalIds: [1n, 0n],
         selectProposal: jest.fn(),
       });
 
@@ -72,7 +72,7 @@ describe("ProposalNavigation", () => {
     it("should disable next when it's selected", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [1n, 2n],
+        proposalIds: [2n, 1n],
         selectProposal: jest.fn(),
       });
 
@@ -85,7 +85,7 @@ describe("ProposalNavigation", () => {
     const selectProposalSpy = jest.fn();
     const po = renderComponent({
       currentProposalId: 1n,
-      proposalIds: [0n, 1n, 2n],
+      proposalIds: [2n, 1n, 0n],
       selectProposal: selectProposalSpy,
     });
 
@@ -99,7 +99,7 @@ describe("ProposalNavigation", () => {
     const selectProposalSpy = jest.fn();
     const po = renderComponent({
       currentProposalId: 1n,
-      proposalIds: [0n, 1n, 2n],
+      proposalIds: [2n, 1n, 0n],
       selectProposal: selectProposalSpy,
     });
 

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -61,7 +61,7 @@ describe("ProposalNavigation", () => {
     it("should disable previous button when it's selected", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [1n, 2n],
+        proposalIds: [0n, 1n],
         selectProposal: jest.fn(),
       });
 
@@ -72,7 +72,7 @@ describe("ProposalNavigation", () => {
     it("should disable next when it's selected", async () => {
       const po = renderComponent({
         currentProposalId: 1n,
-        proposalIds: [0n, 1n],
+        proposalIds: [1n, 2n],
         selectProposal: jest.fn(),
       });
 
@@ -93,7 +93,7 @@ describe("ProposalNavigation", () => {
       await po.clickNext();
 
       expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-      expect(selectProposalSpy).toHaveBeenCalledWith(2n);
+      expect(selectProposalSpy).toHaveBeenCalledWith(0n);
     });
 
     it("should emmit previous click", async () => {
@@ -107,7 +107,7 @@ describe("ProposalNavigation", () => {
       await po.clickPrevious();
 
       expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-      expect(selectProposalSpy).toHaveBeenCalledWith(0n);
+      expect(selectProposalSpy).toHaveBeenCalledWith(2n);
     });
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -108,4 +108,18 @@ describe("ProposalNavigation", () => {
     expect(selectProposalSpy).toHaveBeenCalledTimes(1);
     expect(selectProposalSpy).toHaveBeenCalledWith(2n);
   });
+
+  it("should emit with right arguments for non-consecutive ids", async () => {
+    const selectProposalSpy = jest.fn();
+    const po = renderComponent({
+      currentProposalId: 13n,
+      proposalIds: [99n, 17n, 13n, 4n, 2n, 1n, 0n],
+      selectProposal: selectProposalSpy,
+    });
+
+    await po.clickPrevious();
+    expect(selectProposalSpy).toHaveBeenLastCalledWith(17n);
+    await po.clickNext();
+    expect(selectProposalSpy).toHaveBeenLastCalledWith(4n);
+  });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -133,4 +133,18 @@ describe("ProposalNavigation", () => {
     await po.clickNext();
     expect(selectProposalSpy).toHaveBeenLastCalledWith(4n);
   });
+
+  it("should emit with right arguments even when the current id is not in the list", async () => {
+    const selectProposalSpy = jest.fn();
+    const po = renderComponent({
+      currentProposalId: 9n,
+      proposalIds: [99n, 17n, 13n, 4n, 2n, 1n, 0n],
+      selectProposal: selectProposalSpy,
+    });
+
+    await po.clickPrevious();
+    expect(selectProposalSpy).toHaveBeenLastCalledWith(13n);
+    await po.clickNext();
+    expect(selectProposalSpy).toHaveBeenLastCalledWith(4n);
+  });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -108,18 +108,4 @@ describe("ProposalNavigation", () => {
     expect(selectProposalSpy).toHaveBeenCalledTimes(1);
     expect(selectProposalSpy).toHaveBeenCalledWith(2n);
   });
-
-  it("should work also w/ not sorted proposalIds list", async () => {
-    const selectProposalSpy = jest.fn();
-    const po = renderComponent({
-      currentProposalId: 3n,
-      proposalIds: [5n, 2n, 3n, 0n, 1n, 4n],
-      selectProposal: selectProposalSpy,
-    });
-
-    await po.clickPrevious();
-    expect(selectProposalSpy).toHaveBeenCalledWith(4n);
-    await po.clickNext();
-    expect(selectProposalSpy).toHaveBeenCalledWith(2n);
-  });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -81,33 +81,45 @@ describe("ProposalNavigation", () => {
     });
   });
 
-  describe("action", () => {
-    it("should emmit next click", async () => {
-      const selectProposalSpy = jest.fn();
-      const po = renderComponent({
-        currentProposalId: 1n,
-        proposalIds: [0n, 1n, 2n],
-        selectProposal: selectProposalSpy,
-      });
-
-      await po.clickNext();
-
-      expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-      expect(selectProposalSpy).toHaveBeenCalledWith(0n);
+  it("should emmit next click", async () => {
+    const selectProposalSpy = jest.fn();
+    const po = renderComponent({
+      currentProposalId: 1n,
+      proposalIds: [0n, 1n, 2n],
+      selectProposal: selectProposalSpy,
     });
 
-    it("should emmit previous click", async () => {
-      const selectProposalSpy = jest.fn();
-      const po = renderComponent({
-        currentProposalId: 1n,
-        proposalIds: [0n, 1n, 2n],
-        selectProposal: selectProposalSpy,
-      });
+    await po.clickNext();
 
-      await po.clickPrevious();
+    expect(selectProposalSpy).toHaveBeenCalledTimes(1);
+    expect(selectProposalSpy).toHaveBeenCalledWith(0n);
+  });
 
-      expect(selectProposalSpy).toHaveBeenCalledTimes(1);
-      expect(selectProposalSpy).toHaveBeenCalledWith(2n);
+  it("should emmit previous click", async () => {
+    const selectProposalSpy = jest.fn();
+    const po = renderComponent({
+      currentProposalId: 1n,
+      proposalIds: [0n, 1n, 2n],
+      selectProposal: selectProposalSpy,
     });
+
+    await po.clickPrevious();
+
+    expect(selectProposalSpy).toHaveBeenCalledTimes(1);
+    expect(selectProposalSpy).toHaveBeenCalledWith(2n);
+  });
+
+  it("should work also w/ not sorted proposalIds list", async () => {
+    const selectProposalSpy = jest.fn();
+    const po = renderComponent({
+      currentProposalId: 3n,
+      proposalIds: [5n, 2n, 3n, 0n, 1n, 4n],
+      selectProposal: selectProposalSpy,
+    });
+
+    await po.clickPrevious();
+    expect(selectProposalSpy).toHaveBeenCalledWith(4n);
+    await po.clickNext();
+    expect(selectProposalSpy).toHaveBeenCalledWith(2n);
   });
 });


### PR DESCRIPTION
# Motivation

Fix the missing proposal navigation buttons during a vote registration.
Sns fix will be implemented in another pr.

# Changes

- Combine the ids for navigation component from available for voting proposal ids and currently in voting process.
- ProposalNavigation cares about the ids order and sorts them (because the combined list).

# Tests

- ProposalNavigation sorts the ids
- The issue itself could be better addressed by an end-to-end test to ensure that the navigation is functioning properly even during the registration process.

# Screenshots

![Screen Recording 2023-06-15 at 15 42 07](https://github.com/dfinity/nns-dapp/assets/98811342/a34f68b4-6d6a-4cef-8d4a-a7305b82dcd6)

