### PR TITLE
Fix: steps not needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,10 +290,10 @@ jobs:
           then echo "dockerfile_changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Set up docker buildx
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: docker/setup-buildx-action@v2
       - name: Build wasms
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -305,28 +305,28 @@ jobs:
           # Exports the artefacts from the final stage
           outputs: ./out-mainnet
       - name: Get nns-dapp_local
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: nns-dapp_local
           path: out-local
       - name: Remove _local suffix
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         run: mv out-local/nns-dapp_local.wasm out-local/nns-dapp.wasm
       - name: Get sns_aggregator
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator
           path: out-local
       - name: Get sns_aggregator_dev
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator_dev
           path: out-local
       - name: Compare wasms
-        if: needs.dockerfile_changed.outputs.dockerfile_changed == 'true'
+        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         run: |
           set -x
           ls -l

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use this with
+# Use this with:
 #
 # docker build . -t nns-dapp
 # container_id=$(docker create nns-dapp no-op)


### PR DESCRIPTION
# Motivation
The code that runs on dockerfile change never runs.  This is because the wrong namespace is used for the github variable.

# Changes
- `s/needs/steps/g`

# Tests
- No run with no change to the dockerfile:
![Screenshot from 2023-06-16 06-24-46](https://github.com/dfinity/nns-dapp/assets/5982633/ced8ffe9-9b8b-49b3-8c66-c046ed677628)

- Run with a trivial change to the dockerfile: 
![Screenshot from 2023-06-16 06-33-57](https://github.com/dfinity/nns-dapp/assets/5982633/48d81984-5bf2-4789-9f9a-54beecc6271a)
