### PR TITLE
Feat: Support derived_state field in SNS Aggregator

### DIFF
--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -10,6 +10,7 @@ import type {
 } from "@dfinity/ledger";
 import type {
   SnsFunctionType,
+  SnsGetDerivedStateResponse,
   SnsGetMetadataResponse,
   SnsNervousSystemFunction,
   SnsSwap,
@@ -61,6 +62,7 @@ export type CachedSns = {
    */
   icrc1_fee?: bigint;
   icrc1_total_supply: bigint;
+  derived_state: SnsGetDerivedStateResponse;
 };
 
 type CachedSnsMetadataDto = {
@@ -116,9 +118,9 @@ type CachedSnsSwapDto = {
 type CachedSnsSwapDerivedDto = {
   buyer_total_icp_e8s: number;
   sns_tokens_per_icp: number;
-  cf_participant_count: number | undefined;
-  direct_participant_count: number | undefined;
-  cf_neuron_count: number | undefined;
+  cf_participant_count: number | undefined | null;
+  direct_participant_count: number | undefined | null;
+  cf_neuron_count: number | undefined | null;
 };
 
 type CachedSnsTokenMetadataDto = [
@@ -147,6 +149,7 @@ type CachedSnsDto = {
   icrc1_metadata: CachedSnsTokenMetadataDto;
   icrc1_fee: [] | [number];
   icrc1_total_supply: number;
+  derived_state: CachedSnsSwapDerivedDto;
 };
 
 const convertOptionalNumToBigInt = (
@@ -261,6 +264,28 @@ const convertDerived = ({
     : [],
 });
 
+const convertDerivedToResponse = ({
+  sns_tokens_per_icp,
+  buyer_total_icp_e8s,
+  cf_participant_count,
+  direct_participant_count,
+  cf_neuron_count,
+}: CachedSnsSwapDerivedDto): SnsGetDerivedStateResponse => ({
+  sns_tokens_per_icp: toNullable(sns_tokens_per_icp),
+  buyer_total_icp_e8s: toNullable(
+    convertOptionalNumToBigInt(buyer_total_icp_e8s)
+  ),
+  cf_participant_count: nonNullish(cf_participant_count)
+    ? toNullable(BigInt(cf_participant_count))
+    : [],
+  direct_participant_count: nonNullish(direct_participant_count)
+    ? toNullable(BigInt(direct_participant_count))
+    : [],
+  cf_neuron_count: nonNullish(cf_neuron_count)
+    ? toNullable(BigInt(cf_neuron_count))
+    : [],
+});
+
 const convertIcrc1Metadata = (
   icrc1Metadata: CachedSnsTokenMetadataDto
 ): IcrcTokenMetadataResponse => {
@@ -285,6 +310,7 @@ const convertSnsData = ({
   icrc1_metadata,
   icrc1_fee,
   icrc1_total_supply,
+  derived_state,
 }: CachedSnsDto): CachedSns => ({
   index,
   canister_ids,
@@ -301,6 +327,7 @@ const convertSnsData = ({
   icrc1_metadata: convertIcrc1Metadata(icrc1_metadata),
   icrc1_fee: convertOptionalNumToBigInt(icrc1_fee[0]),
   icrc1_total_supply: BigInt(icrc1_total_supply),
+  derived_state: convertDerivedToResponse(derived_state),
 });
 
 const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -120,6 +120,14 @@ export const loadSnsProjects = async (): Promise<void> => {
           {} as TokensStoreData
         )
     );
+    cachedSnses.forEach(
+      ({ canister_ids: { root_canister_id }, derived_state }) => {
+        snsQueryStore.updateDerivedState({
+          rootCanisterId: root_canister_id,
+          derivedState: derived_state,
+        });
+      }
+    );
     // TODO: PENDING to be implemented, load SNS parameters.
   } catch (err) {
     // If aggregator canister fails, fallback to the old way

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -196,7 +196,7 @@ const initSnsQueryStore = (): SnsQueryStore => {
       const buyer_total_icp_e8s = fromNullable(
         derivedState.buyer_total_icp_e8s
       );
-      // We don't update the store if any of the derived state is undefined.
+      // We don't update the store if any of the derived state mandatory fields is undefined.
       if (
         sns_tokens_per_icp === undefined ||
         buyer_total_icp_e8s === undefined
@@ -204,11 +204,9 @@ const initSnsQueryStore = (): SnsQueryStore => {
         return;
       }
       const newDerivedState: SnsSwapDerivedState = {
+        ...derivedState,
         sns_tokens_per_icp,
         buyer_total_icp_e8s,
-        cf_participant_count: [],
-        direct_participant_count: [],
-        cf_neuron_count: [],
       };
       update((data: SnsQueryStoreData) => ({
         metadata: data?.metadata ?? [],

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -111,6 +111,7 @@ describe("SNS public services", () => {
       jest.spyOn(snsApi, "queryAllSnsMetadata").mockResolvedValue([]);
       jest.spyOn(snsApi, "querySnsSwapStates").mockResolvedValue([]);
     });
+
     it("loads sns stores with data", async () => {
       const spyQuerySnsProjects = jest
         .spyOn(aggregatorApi, "querySnsProjects")
@@ -174,6 +175,33 @@ describe("SNS public services", () => {
       expect(data).not.toBeUndefined();
       expect(data?.certified).toBeTruthy();
       expect(data?.totalSupply).toEqual(totalSupply);
+    });
+
+    it("loads derived state from property derived state", async () => {
+      jest
+        .spyOn(aggregatorApi, "querySnsProjects")
+        .mockImplementation(() => Promise.resolve([aggregatorSnsMock]));
+
+      await loadSnsProjects();
+
+      const queryStore = get(snsQueryStore);
+      const derivedState = queryStore.swaps[0]?.derived[0];
+      const expectedDerivedState = aggregatorSnsMock.derived_state;
+      expect(derivedState.buyer_total_icp_e8s).toBe(
+        expectedDerivedState.buyer_total_icp_e8s[0]
+      );
+      expect(derivedState.sns_tokens_per_icp).toBe(
+        expectedDerivedState.sns_tokens_per_icp[0]
+      );
+      expect(derivedState.cf_neuron_count[0]).toBe(
+        expectedDerivedState.cf_neuron_count[0]
+      );
+      expect(derivedState.cf_participant_count[0]).toBe(
+        expectedDerivedState.cf_participant_count[0]
+      );
+      expect(derivedState.direct_participant_count[0]).toBe(
+        expectedDerivedState.direct_participant_count[0]
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -279,9 +279,9 @@ describe("sns.store", () => {
       const updatedDerivedState: SnsGetDerivedStateResponse = {
         sns_tokens_per_icp: [updatedSnsTokensPerIcp],
         buyer_total_icp_e8s: [updatedBuyerTotalIcps],
-        cf_participant_count: [],
-        direct_participant_count: [],
-        cf_neuron_count: [],
+        cf_participant_count: [10n],
+        direct_participant_count: [100n],
+        cf_neuron_count: [11n],
       };
 
       const initStore = get(snsQueryStore);
@@ -301,6 +301,15 @@ describe("sns.store", () => {
       });
       expect(updatedState?.buyer_total_icp_e8s).toEqual(updatedBuyerTotalIcps);
       expect(updatedState?.sns_tokens_per_icp).toEqual(updatedSnsTokensPerIcp);
+      expect(updatedState?.cf_neuron_count).toEqual(
+        updatedDerivedState.cf_neuron_count
+      );
+      expect(updatedState?.direct_participant_count).toEqual(
+        updatedDerivedState.direct_participant_count
+      );
+      expect(updatedState?.cf_participant_count).toEqual(
+        updatedDerivedState.cf_participant_count
+      );
     });
 
     it("should NOT update the derived state if sns_tokens_per_icp undefined", () => {

--- a/frontend/src/tests/mocks/sns-aggregator.mock.json
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.json
@@ -115,7 +115,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 1100000000000
+    "icrc1_total_supply": 1100000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 2.0,
+      "buyer_total_icp_e8s": 100500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 4,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 10,
@@ -223,7 +230,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 1000000000000
+    "icrc1_total_supply": 1000000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 2.0,
+      "buyer_total_icp_e8s": 100500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 4,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 9,
@@ -331,7 +345,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 900000000000
+    "icrc1_total_supply": 900000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 1,
+      "buyer_total_icp_e8s": 100500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 4,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 8,
@@ -424,7 +445,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 800000000000
+    "icrc1_total_supply": 800000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 1,
+      "buyer_total_icp_e8s": 100500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 4,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 7,
@@ -532,7 +560,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 700000000000
+    "icrc1_total_supply": 700000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 2,
+      "buyer_total_icp_e8s": 200500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 4,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 6,
@@ -640,7 +675,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 600000000000
+    "icrc1_total_supply": 600000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 3,
+      "buyer_total_icp_e8s": 300500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 5,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 5,
@@ -733,7 +775,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 500000000000
+    "icrc1_total_supply": 500000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 6,
+      "buyer_total_icp_e8s": 300500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 50,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 4,
@@ -841,7 +890,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 400000000000
+    "icrc1_total_supply": 400000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 9,
+      "buyer_total_icp_e8s": 300500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 500,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 3,
@@ -949,7 +1005,14 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 300000000000
+    "icrc1_total_supply": 300000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 2.5,
+      "buyer_total_icp_e8s": 400500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 10,
+      "cf_neuron_count": 0
+    }
   },
   {
     "index": 2,
@@ -1057,6 +1120,13 @@
       ["icrc1:fee", { "Nat": [1000] }]
     ],
     "icrc1_fee": [1000],
-    "icrc1_total_supply": 200000000000
+    "icrc1_total_supply": 200000000000,
+    "derived_state": {
+      "sns_tokens_per_icp": 3,
+      "buyer_total_icp_e8s": 300500000010,
+      "cf_participant_count": 0,
+      "direct_participant_count": 20,
+      "cf_neuron_count": 0
+    }
   }
 ]

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -8,6 +8,7 @@ export const aggregatorTokenMock: IcrcTokenMetadata = {
   fee: BigInt(1000),
 };
 
+// It should match the converted response from sns-aggregator.mock.json with the same `index` value
 export const aggregatorSnsMock: CachedSns = {
   index: 11,
   canister_ids: {
@@ -150,6 +151,13 @@ export const aggregatorSnsMock: CachedSns = {
   ],
   icrc1_fee: aggregatorTokenMock.fee,
   icrc1_total_supply: BigInt(1100_000_000_000),
+  derived_state: {
+    sns_tokens_per_icp: [2.0],
+    buyer_total_icp_e8s: [100500000010n],
+    cf_participant_count: [0n],
+    direct_participant_count: [4n],
+    cf_neuron_count: [0n],
+  },
 };
 
 export const aggregatorSnsMockWith = ({


### PR DESCRIPTION
# Motivation

Use the new field `direct_participant_count` from derived state to display the number of participants of a swap instead of relying in the metrics raw endpoint.

In this PR: Use the SNS aggregator field derived_state which supports the latest properties.

# Changes

* Add `derived_state` to the type of the SNS Aggregator resposne.
* Convert the type of the aggregator to the type needed by the snsQueryStore.
* Update the snsQueryStore with the value in the field `derived_state` from the aggregator.
* Fix the method `updateDerivedState` of the snsQueryStore that was ignoring the new fields.

# Tests

* Add new field to the sns aggregator response mocks and converted mock.
* Test that the new field is used to update the snsQueryStore in the sns service.
* Check also the new fields in the tests for `updateDerivedState` in snsQueryStore test file
