### PR TITLE
Feat: Use derived state for buyers count

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -45,6 +45,7 @@
   $: saleBuyerCount = swapSaleBuyerCount({
     rootCanisterId: $projectDetailStore?.summary?.rootCanisterId,
     swapMetrics: $snsSwapMetricsStore,
+    derivedState: derived,
   });
 </script>
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -177,7 +177,7 @@
   $: derivedStateHasBuyersCount = hasBuyersCount(
     $projectDetailStore?.summary?.derived
   );
-  let watchersSet = false;
+  let areWatchersSet = false;
 
   let unsubscribeWatchCommitment: () => void | undefined;
   let unsubscribeWatchMetrics: () => void | undefined;
@@ -185,7 +185,7 @@
     nonNullish(rootCanisterId) &&
     nonNullish(swapCanisterId) &&
     nonNullish(derivedStateHasBuyersCount) &&
-    !watchersSet
+    !areWatchersSet
   ) {
     // TODO: Remove once all SNS support the buyers count in derived state
     if (!derivedStateHasBuyersCount) {
@@ -195,7 +195,7 @@
         swapCanisterId,
         forceFetch: false,
       });
-      if (!derivedStateHasBuyersCount && enableOpenProjectWatchers) {
+      if (enableOpenProjectWatchers) {
         unsubscribeWatchMetrics?.();
         unsubscribeWatchMetrics = watchSnsMetrics({
           rootCanisterId: Principal.fromText(rootCanisterId),
@@ -205,7 +205,7 @@
     }
 
     if (enableOpenProjectWatchers) {
-      watchersSet = true;
+      areWatchersSet = true;
       unsubscribeWatchCommitment?.();
       unsubscribeWatchCommitment = watchSnsTotalCommitment({ rootCanisterId });
     }

--- a/frontend/src/lib/utils/sns-swap.utils.ts
+++ b/frontend/src/lib/utils/sns-swap.utils.ts
@@ -1,14 +1,30 @@
 import type { SnsSwapMetricsStoreData } from "$lib/stores/sns-swap-metrics.store";
 import type { Principal } from "@dfinity/principal";
+import type { SnsSwapDerivedState } from "@dfinity/sns";
+import { fromNullable, nonNullish } from "@dfinity/utils";
 
 export const swapSaleBuyerCount = ({
   swapMetrics,
   rootCanisterId,
+  derivedState: { direct_participant_count },
 }: {
   swapMetrics: SnsSwapMetricsStoreData;
   rootCanisterId: Principal | undefined;
+  derivedState: SnsSwapDerivedState;
 }): number | undefined => {
+  if (nonNullish(fromNullable(direct_participant_count))) {
+    return Number(fromNullable(direct_participant_count));
+  }
   return rootCanisterId === undefined
     ? undefined
     : swapMetrics?.[rootCanisterId.toText()]?.saleBuyerCount;
+};
+
+export const hasBuyersCount = (
+  derived: SnsSwapDerivedState | undefined | null
+): undefined | boolean => {
+  if (derived === undefined || derived === null) {
+    return undefined;
+  }
+  return nonNullish(fromNullable(derived.direct_participant_count));
 };

--- a/frontend/src/lib/utils/sns-swap.utils.ts
+++ b/frontend/src/lib/utils/sns-swap.utils.ts
@@ -20,6 +20,14 @@ export const swapSaleBuyerCount = ({
     : swapMetrics?.[rootCanisterId.toText()]?.saleBuyerCount;
 };
 
+/**
+ * Returns whether the derived state has a buyers count.
+ *
+ * It returns undefined if the derived state is undefined or null.
+ *
+ * If the field is not set, we want to trigger a call to the raw canister metrics.
+ * Therefore, we don't want to return `false` while the derived state is not present.
+ */
 export const hasBuyersCount = (
   derived: SnsSwapDerivedState | undefined | null
 ): undefined | boolean => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -8,6 +8,7 @@ import type { SnsSwapCommitment } from "$lib/types/sns";
 import { formatToken } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import {
+  createSummary,
   mockSnsFullProject,
   summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
@@ -32,16 +33,48 @@ describe("ProjectCommitment", () => {
     ).toEqual(`${formatToken({ value: summary.swap.params.min_icp_e8s })} ICP`);
   });
 
-  it("should render total participants", () => {
+  it("should render total participants from swap metrics", () => {
     snsSwapMetricsStore.setMetrics({
       rootCanisterId: mockSnsFullProject.swapCommitment.rootCanisterId,
       metrics: {
         saleBuyerCount,
       },
     });
+    const summaryWithuotBuyers = createSummary({
+      lifecycle: SnsSwapLifecycle.Open,
+      buyersCount: null,
+    });
 
     const { queryByTestId } = renderContextCmp({
-      summary,
+      summary: summaryWithuotBuyers,
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectCommitment,
+    });
+
+    const textContent: string =
+      queryByTestId("sns-project-current-sale-buyer-count")?.textContent ?? "";
+
+    expect(
+      textContent.includes(en.sns_project_detail.current_sale_buyer_count)
+    ).toBeTruthy();
+
+    expect(textContent.includes(`${saleBuyerCount}`)).toBeTruthy();
+  });
+
+  it("should render total participants from derived state", () => {
+    snsSwapMetricsStore.setMetrics({
+      rootCanisterId: mockSnsFullProject.swapCommitment.rootCanisterId,
+      metrics: {
+        saleBuyerCount: 0,
+      },
+    });
+    const summaryWithBuyersCount = createSummary({
+      lifecycle: SnsSwapLifecycle.Open,
+      buyersCount: BigInt(saleBuyerCount),
+    });
+
+    const { queryByTestId } = renderContextCmp({
+      summary: summaryWithBuyersCount,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectCommitment,
     });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -40,13 +40,13 @@ describe("ProjectCommitment", () => {
         saleBuyerCount,
       },
     });
-    const summaryWithuotBuyers = createSummary({
+    const summaryWithoutBuyers = createSummary({
       lifecycle: SnsSwapLifecycle.Open,
       buyersCount: null,
     });
 
     const { queryByTestId } = renderContextCmp({
-      summary: summaryWithuotBuyers,
+      summary: summaryWithoutBuyers,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectCommitment,
     });

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -31,6 +31,7 @@ import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   snsResponseFor,
   snsResponsesForLifecycle,
@@ -119,17 +120,18 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
     // TODO: Remove once all SNSes support buyers count in derived state
     describe("Open project without buyers count on derived state", () => {
-      const responses = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Open],
+      const rootCanisterId = mockCanisterId;
+      const response = snsResponseFor({
+        principal: rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Open,
+        directParticipantCount: [],
         certified: true,
       });
-      const rootCanisterId = responses[0][0].rootCanisterId;
       const props = {
-        rootCanisterId,
+        rootCanisterId: rootCanisterId.toText(),
       };
-      responses[1][0].derived[0].direct_participant_count = [];
       beforeEach(() => {
-        snsQueryStore.setData(responses);
+        snsQueryStore.setData(response);
       });
 
       it("should start watching swap metrics and stop on unmounting", async () => {
@@ -167,16 +169,18 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
     });
 
     describe("Open project with buyers count on derived state", () => {
-      const responses = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Open],
+      const rootCanisterId = mockCanisterId;
+      const response = snsResponseFor({
+        principal: rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Open,
+        directParticipantCount: [30n],
         certified: true,
       });
-      const rootCanisterId = responses[0][0].rootCanisterId;
       const props = {
-        rootCanisterId,
+        rootCanisterId: rootCanisterId.toText(),
       };
       beforeEach(() => {
-        snsQueryStore.setData(responses);
+        snsQueryStore.setData(response);
       });
 
       it("should NOT start watching swap metrics", async () => {
@@ -187,6 +191,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
         const retryDelay = WATCH_SALE_STATE_EVERY_MILLISECONDS;
         await advanceTime(retryDelay);
+        await runResolvedPromises();
 
         expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(0);
       });
@@ -239,17 +244,18 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
     // TODO: Remove once all SNSes support buyers count in derived state
     describe("Committed project without buyers in derived state", () => {
-      const responses = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Committed],
+      const rootCanisterId = mockCanisterId;
+      const response = snsResponseFor({
+        principal: rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        directParticipantCount: [],
         certified: true,
       });
-      const rootCanisterId = responses[0][0].rootCanisterId;
       const props = {
-        rootCanisterId,
+        rootCanisterId: rootCanisterId.toText(),
       };
-      responses[1][0].derived[0].direct_participant_count = [];
       beforeEach(() => {
-        snsQueryStore.setData(responses);
+        snsQueryStore.setData(response);
       });
 
       it("should query metrics but not watch them", async () => {
@@ -582,19 +588,20 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
     });
 
     describe("Committed project", () => {
-      const responses = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Committed],
+      const rootCanisterId = mockCanisterId;
+      const response = snsResponseFor({
+        principal: rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        directParticipantCount: [],
         certified: true,
       });
-      const rootCanisterId = responses[0][0].rootCanisterId;
       const props = {
-        rootCanisterId,
+        rootCanisterId: rootCanisterId.toText(),
       };
-      responses[1][0].derived[0].direct_participant_count = [];
       beforeEach(() => {
-        snsQueryStore.setData(responses);
+        snsQueryStore.setData(response);
         jest.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
-          rootCanisterId: Principal.fromText(rootCanisterId),
+          rootCanisterId,
           myCommitment: {
             icp: [],
           },
@@ -644,7 +651,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         });
       });
 
-      it("should NOT query metrics but not watch them", async () => {
+      it("should NOT query metrics nor watch them", async () => {
         const { queryByTestId } = render(ProjectDetail, props);
 
         expect(queryByTestId("sns-project-detail-status")).toBeInTheDocument();

--- a/frontend/src/tests/lib/utils/sns-swap.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-swap.utils.spec.ts
@@ -1,57 +1,120 @@
-import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
+import { hasBuyersCount, swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockDerived } from "$tests/mocks/sns-projects.mock";
 import { Principal } from "@dfinity/principal";
+import type { SnsSwapDerivedState } from "@dfinity/sns";
 
 describe("sns-swap utils", () => {
   describe("swapSaleBuyerCount", () => {
-    it("should return undefined if rootCanisterId or metrics are not defined", () => {
-      expect(
-        swapSaleBuyerCount({
-          rootCanisterId: undefined,
-          swapMetrics: undefined,
-        })
-      ).toBeUndefined();
-      expect(
-        swapSaleBuyerCount({ rootCanisterId: undefined, swapMetrics: null })
-      ).toBeUndefined();
-      expect(
-        swapSaleBuyerCount({
-          rootCanisterId: mockPrincipal,
-          swapMetrics: undefined,
-        })
-      ).toBeUndefined();
-      expect(
-        swapSaleBuyerCount({ rootCanisterId: mockPrincipal, swapMetrics: null })
-      ).toBeUndefined();
-      expect(
-        swapSaleBuyerCount({
-          rootCanisterId: undefined,
-          swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
-        })
-      ).toBeUndefined();
+    describe("derived state does NOT have buyers count", () => {
+      const derivedState: SnsSwapDerivedState = {
+        ...mockDerived,
+        direct_participant_count: [],
+      };
+      it("should return undefined if rootCanisterId or metrics are not defined", () => {
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: undefined,
+            swapMetrics: undefined,
+            derivedState,
+          })
+        ).toBeUndefined();
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: undefined,
+            swapMetrics: null,
+            derivedState,
+          })
+        ).toBeUndefined();
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: mockPrincipal,
+            swapMetrics: undefined,
+            derivedState,
+          })
+        ).toBeUndefined();
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: mockPrincipal,
+            swapMetrics: null,
+            derivedState,
+          })
+        ).toBeUndefined();
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: undefined,
+            swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
+            derivedState,
+          })
+        ).toBeUndefined();
+      });
+
+      it("should return undefined if root canister id is not in the metrics store", () => {
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: Principal.fromText(
+              "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+            ),
+            swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
+            derivedState,
+          })
+        ).toBeUndefined();
+      });
+
+      it("should return sale count of the selected root canister id", () => {
+        const saleCount = 100;
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: mockPrincipal,
+            swapMetrics: {
+              [mockPrincipal.toText()]: { saleBuyerCount: saleCount },
+            },
+            derivedState,
+          })
+        ).toBe(saleCount);
+      });
     });
 
-    it("should return undefined if root canister id is not in the metrics store", () => {
-      expect(
-        swapSaleBuyerCount({
-          rootCanisterId: Principal.fromText(
-            "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
-          ),
-          swapMetrics: { ["aaaaa-aa"]: { saleBuyerCount: 10 } },
-        })
-      ).toBeUndefined();
+    describe("derived state has buyers count", () => {
+      const participantsCount = 100;
+      const derivedState: SnsSwapDerivedState = {
+        ...mockDerived,
+        direct_participant_count: [BigInt(participantsCount)],
+      };
+      it("should return sale count of the derived store ignoring the swap metrics data", () => {
+        expect(
+          swapSaleBuyerCount({
+            rootCanisterId: mockPrincipal,
+            swapMetrics: {
+              [mockPrincipal.toText()]: { saleBuyerCount: 400 },
+            },
+            derivedState,
+          })
+        ).toBe(participantsCount);
+      });
+    });
+  });
+
+  describe("hasBuyersCount", () => {
+    const derivedWithBuyersCount: SnsSwapDerivedState = {
+      ...mockDerived,
+      direct_participant_count: [100n],
+    };
+    const derivedWithoutBuyersCount: SnsSwapDerivedState = {
+      ...mockDerived,
+      direct_participant_count: [],
+    };
+    it("should return undefined if derived state is undefined or null", () => {
+      expect(hasBuyersCount(undefined)).toBeUndefined();
+      expect(hasBuyersCount(null)).toBeUndefined();
     });
 
-    it("should return sale count of the selected root canister id", () => {
-      const saleCount = 100;
-      expect(
-        swapSaleBuyerCount({
-          rootCanisterId: mockPrincipal,
-          swapMetrics: {
-            [mockPrincipal.toText()]: { saleBuyerCount: saleCount },
-          },
-        })
-      ).toBe(saleCount);
+    it("should return true if derived state has buyers count", () => {
+      expect(hasBuyersCount(derivedWithBuyersCount)).toBe(true);
+    });
+
+    it("should return false if derived state has no buyers count", () => {
+      expect(hasBuyersCount(derivedWithoutBuyersCount)).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -274,11 +274,13 @@ export const createSummary = ({
   confirmationText = undefined,
   restrictedCountries = undefined,
   minParticipants = 20,
+  buyersCount = 300n,
 }: {
   lifecycle?: SnsSwapLifecycle;
   confirmationText?: string | undefined;
   restrictedCountries?: string[] | undefined;
   minParticipants?: number;
+  buyersCount?: bigint | null;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -291,6 +293,10 @@ export const createSummary = ({
     ...mockSnsParams,
     min_participants: minParticipants,
   };
+  const derived: SnsSwapDerivedState = {
+    ...mockDerived,
+    direct_participant_count: buyersCount === null ? [] : [buyersCount],
+  };
   const summary = summaryForLifecycle(lifecycle);
   return {
     ...summary,
@@ -299,6 +305,7 @@ export const createSummary = ({
       init: [init],
       params,
     },
+    derived,
   };
 };
 

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -40,11 +40,13 @@ export const snsResponseFor = ({
   lifecycle,
   certified = false,
   restrictedCountries,
+  directParticipantCount,
 }: {
   principal: Principal;
   lifecycle: SnsSwapLifecycle;
   certified?: boolean;
   restrictedCountries?: string[];
+  directParticipantCount?: [] | [bigint];
 }): [QuerySnsMetadata[], QuerySnsSwapState[]] => [
   [
     {
@@ -71,7 +73,13 @@ export const snsResponseFor = ({
           },
         ],
       }),
-      derived: [{ ...mockDerived }] as [SnsSwapDerivedState],
+      derived: [
+        {
+          ...mockDerived,
+          direct_participant_count:
+            directParticipantCount ?? mockDerived.direct_participant_count,
+        },
+      ] as [SnsSwapDerivedState],
       certified,
     },
   ],

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -71,7 +71,7 @@ export const snsResponseFor = ({
           },
         ],
       }),
-      derived: [mockDerived] as [SnsSwapDerivedState],
+      derived: [{ ...mockDerived }] as [SnsSwapDerivedState],
       certified,
     },
   ],


### PR DESCRIPTION
# Motivation

Use the new field `direct_participant_count` from derived state to display the number of participants of a swap instead of relying in the metrics raw endpoint.

In this PR: Use the new field from derived state `direct_participant_count` instead of relying in the metrics.

# Changes

* New util `hasBuyersCount` to check whether derived state supports new field.
* Do not watch raw metrics if derived_state supports new field.
* Extend swap util `swapSaleBuyerCount` with the derived state.
* Use the derived state in ProjectCommitment `swapSaleBuyerCount`.

# Tests

* Test new util `hasBuyersCount`.
* Add new test cases for `swapSaleBuyerCount` test util.
* Add test cases in ProjectDetail.
* Add test case in ProjectCommitment
