### PR TITLE
Icrc balance and transactions api for workers

### DIFF
--- a/frontend/src/lib/worker-api/icrc-index.worker-api.ts
+++ b/frontend/src/lib/worker-api/icrc-index.worker-api.ts
@@ -1,0 +1,67 @@
+import type {
+  GetTransactionsParams,
+  GetTransactionsResponse,
+} from "$lib/api/icrc-index.api";
+import type { CanisterId } from "$lib/types/canister";
+import type { CanisterActorParams } from "$lib/types/worker";
+import { mapCanisterId } from "$lib/utils/canisters.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
+import {
+  createCanisterWorker,
+  type CreateCanisterWorkerParams,
+} from "$lib/worker-utils/canister.worker-utils";
+import { IcrcIndexCanister } from "@dfinity/ledger";
+import { fromNullable } from "@dfinity/utils";
+
+export const getIcrcTransactions = async ({
+  identity,
+  indexCanisterId,
+  maxResults: max_results,
+  start,
+  account,
+  fetchRootKey,
+  host,
+}: Omit<GetTransactionsParams, "getTransactions" | "identity" | "canisterId"> &
+  CanisterActorParams & {
+    indexCanisterId: string;
+  }): Promise<GetTransactionsResponse> => {
+  const canister_id = mapCanisterId(indexCanisterId);
+
+  logWithTimestamp(
+    `Getting transactions from Index canister ID ${canister_id.toText()}...`
+  );
+
+  const { getTransactions } = await createCanister({
+    identity,
+    canisterId: canister_id,
+    fetchRootKey,
+    host,
+  });
+
+  const { oldest_tx_id, ...rest } = await getTransactions({
+    max_results,
+    start,
+    account,
+  });
+
+  logWithTimestamp(
+    `Getting transactions from Index canister ID ${canister_id.toText()} complete.`
+  );
+
+  return {
+    oldestTxId: fromNullable(oldest_tx_id),
+    ...rest,
+  };
+};
+
+const createCanister = (
+  params: CanisterActorParams & { canisterId: CanisterId }
+): Promise<IcrcIndexCanister> =>
+  createCanisterWorker<IcrcIndexCanister>({
+    ...params,
+    create: ({ agent, canisterId }: CreateCanisterWorkerParams) =>
+      IcrcIndexCanister.create({
+        agent,
+        canisterId: mapCanisterId(canisterId),
+      }),
+  });

--- a/frontend/src/lib/worker-api/icrc-ledger.worker-api.ts
+++ b/frontend/src/lib/worker-api/icrc-ledger.worker-api.ts
@@ -1,0 +1,56 @@
+import type { CanisterId } from "$lib/types/canister";
+import type { CanisterActorParams } from "$lib/types/worker";
+import { mapCanisterId } from "$lib/utils/canisters.utils";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
+import {
+  createCanisterWorker,
+  type CreateCanisterWorkerParams,
+} from "$lib/worker-utils/canister.worker-utils";
+import { IcrcLedgerCanister, type IcrcAccount } from "@dfinity/ledger";
+
+export const getIcrcBalance = async ({
+  identity,
+  certified,
+  account,
+  ledgerCanisterId,
+  fetchRootKey,
+  host,
+}: {
+  certified: boolean;
+  account: IcrcAccount;
+} & CanisterActorParams & {
+    ledgerCanisterId: string;
+  }): Promise<bigint> => {
+  const canister_id = mapCanisterId(ledgerCanisterId);
+
+  logWithTimestamp(
+    `Getting balance from Ledger canister ID ${canister_id.toText()}...`
+  );
+
+  const { balance } = await createCanister({
+    identity,
+    canisterId: canister_id,
+    fetchRootKey,
+    host,
+  });
+
+  const result = await balance({ certified, ...account });
+
+  logWithTimestamp(
+    `Getting balance from Ledger canister ID ${canister_id.toText()} complete.`
+  );
+
+  return result;
+};
+
+const createCanister = (
+  params: CanisterActorParams & { canisterId: CanisterId }
+): Promise<IcrcLedgerCanister> =>
+  createCanisterWorker<IcrcLedgerCanister>({
+    ...params,
+    create: ({ agent, canisterId }: CreateCanisterWorkerParams) =>
+      IcrcLedgerCanister.create({
+        agent,
+        canisterId: mapCanisterId(canisterId),
+      }),
+  });

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -1,0 +1,64 @@
+import { CKBTC_INDEX_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import { getIcrcTransactions } from "$lib/worker-api/icrc-index.worker-api";
+import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { IcrcIndexCanister, type IcrcTransaction } from "@dfinity/ledger";
+import mock from "jest-mock-extended/lib/Mock";
+
+describe("icrc-index.worker-api", () => {
+  const indexCanisterMock = mock<IcrcIndexCanister>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .spyOn(IcrcIndexCanister, "create")
+      .mockImplementation(() => indexCanisterMock);
+  });
+
+  const params = {
+    identity: mockIdentity,
+    account: {
+      owner: mockPrincipal,
+    },
+    maxResults: BigInt(10),
+    indexCanisterId: CKBTC_INDEX_CANISTER_ID.toText(),
+    host: HOST,
+    fetchRootKey: FETCH_ROOT_KEY,
+  };
+
+  const transaction = {
+    burn: [],
+  } as unknown as IcrcTransaction;
+
+  it("should returns transactions", async () => {
+    const id = BigInt(1);
+
+    const getTransactionsSpy =
+      indexCanisterMock.getTransactions.mockResolvedValue({
+        transactions: [{ transaction, id }],
+        oldest_tx_id: [],
+      });
+
+    const results = await getIcrcTransactions(params);
+
+    expect(results.transactions.length).toBeGreaterThan(0);
+
+    const transactionFound = results.transactions.find(
+      ({ id: tId }) => tId === id
+    );
+    expect(transactionFound).not.toBeUndefined();
+
+    expect(getTransactionsSpy).toBeCalled();
+  });
+
+  it("should bubble errors", () => {
+    indexCanisterMock.getTransactions.mockImplementation(async () => {
+      throw new Error();
+    });
+
+    const call = () => getIcrcTransactions(params);
+
+    expect(call).rejects.toThrowError();
+  });
+});

--- a/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
@@ -1,0 +1,51 @@
+import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
+import { getIcrcBalance } from "$lib/worker-api/icrc-ledger.worker-api";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { IcrcLedgerCanister } from "@dfinity/ledger";
+import mock from "jest-mock-extended/lib/Mock";
+
+describe("icrc-ledger.worker-api", () => {
+  const ledgerCanisterMock = mock<IcrcLedgerCanister>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .spyOn(IcrcLedgerCanister, "create")
+      .mockImplementation(() => ledgerCanisterMock);
+  });
+
+  const params = {
+    certified: true,
+    identity: mockIdentity,
+    ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID.toText(),
+    account: {
+      owner: mockIdentity.getPrincipal(),
+    },
+    host: HOST,
+    fetchRootKey: FETCH_ROOT_KEY,
+  };
+
+  it("should return balance", async () => {
+    const balance = BigInt(10_000_000);
+
+    const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
+
+    const balanceE8s = await getIcrcBalance(params);
+
+    expect(balanceE8s).toEqual(balance);
+
+    expect(balanceSpy).toBeCalled();
+  });
+
+  it("should bubble errors", () => {
+    ledgerCanisterMock.balance.mockImplementation(() =>
+      Promise.reject(new Error())
+    );
+
+    const call = () => getIcrcBalance(params);
+
+    expect(call).rejects.toThrowError();
+  });
+});


### PR DESCRIPTION
# Motivation

In #2639 we will need to fetch Icrc balances and transactions from workers, this PR provides specific API for it.

# Notes

In the future  we might be able to refactor the app to just use the same API for any UI and workers but, thought it's a first step.

# Changes

- new `icrc-index.worker-api` and `icrc-ledger.worker-api`
