### PR TITLE
Fix: Navigate from SNS proposal to launchpad

### DIFF
--- a/frontend/src/lib/components/metrics/TotalValueLocked.svelte
+++ b/frontend/src/lib/components/metrics/TotalValueLocked.svelte
@@ -18,16 +18,15 @@
     });
 </script>
 
-{#if nonNullish(total) && total > 0}
-  <div
-    class="tvl"
-    transition:fade={{ duration: 125 }}
-    class:stacked={layout === "stacked"}
-  >
-    <span>{$i18n.metrics.tvl}</span>
-    <span data-tid="tvl-metric" class="total">${format(total)}</span>
-  </div>
-{/if}
+<!-- DO NOT use a Svelte transition. It caused issues with navigation -->
+<div
+  class="tvl"
+  class:visible={nonNullish(total) && total > 0}
+  class:stacked={layout === "stacked"}
+>
+  <span>{$i18n.metrics.tvl}</span>
+  <span data-tid="tvl-metric" class="total">${format(total ?? 0)}</span>
+</div>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
@@ -35,6 +34,15 @@
 
   .tvl {
     display: inline-block;
+
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 150ms, visibility 150ms;
+
+    &.visible {
+      visibility: visible;
+      opacity: 1;
+    }
 
     text-align: center;
 

--- a/frontend/src/lib/components/metrics/TotalValueLocked.svelte
+++ b/frontend/src/lib/components/metrics/TotalValueLocked.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { fade } from "svelte/transition";
   import { nonNullish } from "@dfinity/utils";
   import { metricsStore } from "$lib/stores/metrics.store";
   import { formatNumber } from "$lib/utils/format.utils";
@@ -23,6 +22,7 @@
   class="tvl"
   class:visible={nonNullish(total) && total > 0}
   class:stacked={layout === "stacked"}
+  data-tid="total-value-locked-component"
 >
   <span>{$i18n.metrics.tvl}</span>
   <span data-tid="tvl-metric" class="total">${format(total ?? 0)}</span>

--- a/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
+++ b/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
@@ -2,11 +2,9 @@
  * @jest-environment jsdom
  */
 
-import TotalValueLocked from "$lib/components/metrics/TotalValueLocked.svelte";
 import type { MetricsCallback } from "$lib/services/$public/worker-metrics.services";
 import { metricsStore } from "$lib/stores/metrics.store";
 import { render, waitFor } from "@testing-library/svelte";
-import { tick } from "svelte";
 import TotalValueLockedTest from "./TotalValueLockedTest.svelte";
 
 let metricsCallback: MetricsCallback | undefined;
@@ -55,14 +53,16 @@ describe("TotalValueLocked", () => {
   });
 
   it("should not render TVL on load", () => {
-    const { getByTestId } = render(TotalValueLocked);
-    expect(() => getByTestId("tvl-metric")).toThrow();
+    const { getByTestId } = render(TotalValueLockedTest);
+
+    expect(getByTestId("total-value-locked-component")).not.toBeVisible();
   });
 
   it("should not render TVL if response has zero metrics", async () => {
-    const { getByTestId } = render(TotalValueLocked);
+    const { getByTestId } = render(TotalValueLockedTest);
 
-    await tick();
+    // Wait for initialization of the callback
+    await waitFor(() => expect(metricsCallback).not.toBeUndefined());
 
     metricsCallback?.({
       metrics: {
@@ -70,6 +70,6 @@ describe("TotalValueLocked", () => {
       },
     });
 
-    await waitFor(() => expect(() => getByTestId("tvl-metric")).toThrow());
+    expect(getByTestId("total-value-locked-component")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
# Motivation

There was a bug when the user navigated from the SNS Proposal detail page to the launchpad. The user was redirected to the proposals page.

The issue is a problem with Svelte transitions in components that persist across routes. In our case the `TotalValueLocked.svelte`.

The fix was to use CSS transition instead of a Svelte transition in that component.

# Changes

* Remove Svelte transition in `TotalValueLocked` and use a CSS transition instead.

# Tests

* Fix tests after refactor.
