### PR TITLE
Icrc worker store

### DIFF
--- a/frontend/src/lib/types/icrc.ts
+++ b/frontend/src/lib/types/icrc.ts
@@ -1,3 +1,4 @@
+import type { AccountIdentifierText } from "$lib/types/account";
 import type { Token } from "@dfinity/nns";
 
 /**
@@ -8,3 +9,5 @@ export interface IcrcTokenMetadata extends Token {
   fee: bigint;
   // TODO: integrate "decimals" to replace ICP_DISPLAYED_DECIMALS_DETAILED
 }
+
+export type IcrcAccountIdentifierText = AccountIdentifierText;

--- a/frontend/src/lib/worker-stores/icrc.worker-store.ts
+++ b/frontend/src/lib/worker-stores/icrc.worker-store.ts
@@ -1,0 +1,40 @@
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
+
+export interface IcrcWorkerData {
+  accountIdentifier: IcrcAccountIdentifierText;
+  certified: boolean;
+}
+
+export type IcrcWorkerState<T extends IcrcWorkerData> = Record<
+  IcrcAccountIdentifierText,
+  T
+>;
+
+export class IcrcWorkerStore<T extends IcrcWorkerData> {
+  private readonly EMPTY_STATE: IcrcWorkerState<T> = {};
+  private _state: IcrcWorkerState<T> = this.EMPTY_STATE;
+
+  update(data: T[]) {
+    this._state = {
+      ...this._state,
+      ...data.reduce(
+        (acc, { accountIdentifier, ...rest }) => ({
+          ...acc,
+          [accountIdentifier]: {
+            accountIdentifier,
+            ...rest,
+          },
+        }),
+        {}
+      ),
+    };
+  }
+
+  reset() {
+    this._state = this.EMPTY_STATE;
+  }
+
+  get state(): IcrcWorkerState<T> {
+    return this._state;
+  }
+}

--- a/frontend/src/tests/lib/worker-stores/icrc.worker-store.spec.ts
+++ b/frontend/src/tests/lib/worker-stores/icrc.worker-store.spec.ts
@@ -1,0 +1,60 @@
+import {
+  IcrcWorkerStore,
+  type IcrcWorkerData,
+} from "$lib/worker-stores/icrc.worker-store";
+
+describe("icrc.worker-store", () => {
+  interface TestData extends IcrcWorkerData {
+    test: string;
+  }
+
+  let store: IcrcWorkerStore<TestData>;
+
+  beforeEach(() => (store = new IcrcWorkerStore<TestData>()));
+
+  it("should be empty per default", () => {
+    expect(Object.keys(store.state)).toHaveLength(0);
+  });
+
+  it("should update store", () => {
+    const data1 = { accountIdentifier: "1", certified: false, test: "test" };
+    store.update([data1]);
+    expect(store.state).toEqual({
+      [data1.accountIdentifier]: data1,
+    });
+
+    const data2 = { accountIdentifier: "1", certified: false, test: "test" };
+    store.update([data2]);
+    expect(store.state).toEqual({
+      [data1.accountIdentifier]: data1,
+      [data2.accountIdentifier]: data2,
+    });
+
+    store.update([data1]);
+    expect(store.state).toEqual({
+      [data1.accountIdentifier]: data1,
+      [data2.accountIdentifier]: data2,
+    });
+
+    store.update([{ ...data1, test: "testtest" }]);
+    expect(store.state).not.toEqual({
+      [data1.accountIdentifier]: { ...data1, test: "testtest" },
+      [data2.accountIdentifier]: data2,
+    });
+  });
+
+  it("should reset store", () => {
+    const data1 = { accountIdentifier: "1", certified: false, test: "test" };
+    store.update([data1]);
+    expect(Object.keys(store.state)).toHaveLength(1);
+
+    store.reset();
+    expect(Object.keys(store.state)).toHaveLength(0);
+
+    store.update([data1, { ...data1, accountIdentifier: "2" }]);
+    expect(Object.keys(store.state)).toHaveLength(2);
+
+    store.reset();
+    expect(Object.keys(store.state)).toHaveLength(0);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -80,6 +80,7 @@ const config: UserConfig = {
               "frontend/src/lib/utils",
               "frontend/src/lib/worker-api",
               "frontend/src/lib/worker-services",
+              "frontend/src/lib/worker-stores",
               "frontend/src/lib/worker-utils",
               "frontend/src/lib/workers",
             ].find((module) => folder.includes(module)) !== undefined


### PR DESCRIPTION
# Motivation

In few workers we need to hold some values in worker memory as in #2639 in which we need to keep track of ICRC balances and transactions.

That's why this PR introduces an ICRC store that can be use in worker.

# Changes

- new `IcrcWorkerStore` store
- new package `worker-store`
- add type for `IcrcAccountIdentifierText`, a `string`
