### PR TITLE
DO NOT MERGE: New initialization in canistersStore

### DIFF
--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -1,7 +1,6 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { accountsStore } from "$lib/stores/accounts.store";
-import { canistersStore } from "$lib/stores/canisters.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -97,12 +96,12 @@ export const debugSnsProposalStore = (
 export const initDebugStore = () =>
   derived(
     [
+      // TODO: Add canisters store
       // TODO (L2-611): anonymize wallet id and neuron ids
       busyStore,
       accountsStore,
       neuronsStore,
       knownNeuronsStore,
-      canistersStore,
       proposalsStore,
       proposalsFiltersStore,
       votingNeuronSelectStore,
@@ -129,7 +128,6 @@ export const initDebugStore = () =>
       $accountsStore,
       $neuronsStore,
       $knownNeuronsStore,
-      $canistersStore,
       $proposalsStore,
       $proposalsFiltersStore,
       $votingNeuronSelectStore,
@@ -155,7 +153,6 @@ export const initDebugStore = () =>
       accounts: $accountsStore,
       neurons: $neuronsStore,
       knownNeurons: $knownNeuronsStore,
-      canisters: $canistersStore,
       proposals: $proposalsStore,
       proposalsFilters: $proposalsFiltersStore,
       votingNeuronSelect: $votingNeuronSelectStore,

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -8,7 +8,10 @@
     listCanisters,
   } from "$lib/services/canisters.services";
   import { i18n } from "$lib/stores/i18n";
-  import { canistersStore } from "$lib/stores/canisters.store";
+  import {
+    initCanistersStore,
+    type CanistersStore,
+  } from "$lib/stores/canisters.store";
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
   import { SkeletonText, busy, Island } from "@dfinity/gix-components";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
@@ -35,12 +38,17 @@
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
   import { emit } from "$lib/utils/events.utils";
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
+  import { authStore } from "$lib/stores/auth.store";
 
   // BEGIN: loading and navigation
 
   // TODO: checking if ready is similar to what's done in <ProposalDetail /> for the neurons.
   // Therefore we can probably refactor this to generic function.
 
+  let canistersStore: undefined | CanistersStore;
+  $: canistersStore = initCanistersStore($authStore.identity);
+
+  // TODO: Remove this part
   const canistersStoreReady = (): boolean => {
     // We consider the canisters store as ready if it has been initialized once.
     if (canistersReady) {
@@ -48,7 +56,7 @@
     }
 
     // At the moment we load the stores with query only.
-    return $canistersStore.canisters !== undefined;
+    return $canistersStore?.canisters !== undefined;
   };
 
   let canistersReady = false;

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -3,10 +3,7 @@
   import type { Principal } from "@dfinity/principal";
   import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { AppPath } from "$lib/constants/routes.constants";
-  import {
-    getCanisterDetails,
-    listCanisters,
-  } from "$lib/services/canisters.services";
+  import { getCanisterDetails } from "$lib/services/canisters.services";
   import { i18n } from "$lib/stores/i18n";
   import {
     initCanistersStore,
@@ -39,6 +36,7 @@
   import { emit } from "$lib/utils/events.utils";
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
   import { authStore } from "$lib/stores/auth.store";
+  import { nonNullish } from "@dfinity/utils";
 
   // BEGIN: loading and navigation
 
@@ -47,26 +45,6 @@
 
   let canistersStore: undefined | CanistersStore;
   $: canistersStore = initCanistersStore($authStore.identity);
-
-  // TODO: Remove this part
-  const canistersStoreReady = (): boolean => {
-    // We consider the canisters store as ready if it has been initialized once.
-    if (canistersReady) {
-      return true;
-    }
-
-    // At the moment we load the stores with query only.
-    return $canistersStore?.canisters !== undefined;
-  };
-
-  let canistersReady = false;
-  $: $canistersStore, (canistersReady = canistersStoreReady());
-
-  onMount(async () => {
-    if (!canistersStoreReady()) {
-      await listCanisters({ clearBeforeQuery: false });
-    }
-  });
 
   const goBack = (): Promise<void> => goto(AppPath.Canisters);
 
@@ -132,8 +110,8 @@
 
   $: canisterId,
     selectedCanister,
-    canistersReady,
     (async () => {
+      const canistersReady = nonNullish($canistersStore?.canisters);
       // When detaching, this is also executed but there is no `canisterId`.
       if (!canistersReady || canisterId === undefined) {
         return;

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { onMount, setContext } from "svelte";
+  import { setContext } from "svelte";
   import type { Principal } from "@dfinity/principal";
   import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { AppPath } from "$lib/constants/routes.constants";
   import { getCanisterDetails } from "$lib/services/canisters.services";
   import { i18n } from "$lib/stores/i18n";
   import {
-    initCanistersStore,
+    getOrCreateCanistersStore,
     type CanistersStore,
   } from "$lib/stores/canisters.store";
   import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
@@ -44,7 +44,7 @@
   // Therefore we can probably refactor this to generic function.
 
   let canistersStore: undefined | CanistersStore;
-  $: canistersStore = initCanistersStore($authStore.identity);
+  $: canistersStore = getOrCreateCanistersStore($authStore.identity);
 
   const goBack = (): Promise<void> => goto(AppPath.Canisters);
 

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -4,7 +4,10 @@
   import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import { listCanisters } from "$lib/services/canisters.services";
-  import { canistersStore } from "$lib/stores/canisters.store";
+  import {
+    initCanistersStore,
+    type CanistersStore,
+  } from "$lib/stores/canisters.store";
   import { AppPath } from "$lib/constants/routes.constants";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import CanisterCard from "$lib/components/canisters/CanisterCard.svelte";
@@ -19,8 +22,12 @@
   import { pageStore } from "$lib/derived/page.derived";
   import Summary from "$lib/components/summary/Summary.svelte";
   import PrincipalText from "$lib/components/summary/PrincipalText.svelte";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let referrerPath: AppPath | undefined = undefined;
+
+  let canistersStore: undefined | CanistersStore;
+  $: canistersStore = initCanistersStore($authStore.identity);
 
   const loadCanisters = async () => {
     try {
@@ -39,7 +46,7 @@
     const reload = reloadRouteData({
       expectedPreviousPath: AppPath.Canister,
       effectivePreviousPath: referrerPath,
-      currentData: $canistersStore.canisters,
+      currentData: $canistersStore?.canisters,
     });
 
     if (!reload) {
@@ -58,9 +65,9 @@
     );
 
   let loading: boolean;
-  $: loading = $canistersStore.canisters === undefined;
+  $: loading = $canistersStore?.canisters === undefined;
   let noCanisters: boolean;
-  $: noCanisters = !loading && $canistersStore.canisters?.length === 0;
+  $: noCanisters = !loading && $canistersStore?.canisters?.length === 0;
 
   type ModalKey = "CreateCanister" | "LinkCanister";
   let modal: ModalKey | undefined = undefined;
@@ -74,7 +81,7 @@
   </Summary>
 
   <div class="card-grid">
-    {#each $canistersStore.canisters ?? [] as canister (canister.canister_id)}
+    {#each $canistersStore?.canisters ?? [] as canister (canister.canister_id)}
       <CanisterCard
         role="link"
         ariaLabel={$i18n.canisters.aria_label_canister_card}

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -29,19 +29,6 @@
   let canistersStore: undefined | CanistersStore;
   $: canistersStore = initCanistersStore($authStore.identity);
 
-  const loadCanisters = async () => {
-    try {
-      await listCanisters({
-        clearBeforeQuery: true,
-      });
-    } catch (err: unknown) {
-      toastsError({
-        labelKey: "error.list_canisters",
-        err,
-      });
-    }
-  };
-
   onMount(async () => {
     const reload = reloadRouteData({
       expectedPreviousPath: AppPath.Canister,
@@ -52,8 +39,6 @@
     if (!reload) {
       return;
     }
-
-    await loadCanisters();
   });
 
   const goToCanisterDetails = (canisterId: CanisterId) => async () =>

--- a/frontend/src/lib/pages/Canisters.svelte
+++ b/frontend/src/lib/pages/Canisters.svelte
@@ -2,10 +2,8 @@
   import Footer from "$lib/components/layout/Footer.svelte";
   import { onMount } from "svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { listCanisters } from "$lib/services/canisters.services";
   import {
-    initCanistersStore,
+    getOrCreateCanistersStore,
     type CanistersStore,
   } from "$lib/stores/canisters.store";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -27,7 +25,7 @@
   export let referrerPath: AppPath | undefined = undefined;
 
   let canistersStore: undefined | CanistersStore;
-  $: canistersStore = initCanistersStore($authStore.identity);
+  $: canistersStore = getOrCreateCanistersStore($authStore.identity);
 
   onMount(async () => {
     const reload = reloadRouteData({

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -14,7 +14,7 @@ import type {
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { canistersStore } from "$lib/stores/canisters.store";
+import { initCanistersStore } from "$lib/stores/canisters.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { LedgerErrorMessage } from "$lib/types/ledger.errors";
@@ -27,8 +27,9 @@ import {
 } from "$lib/utils/error.utils";
 import { ICPToken, TokenAmount } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
 import { getAccountIdentity, loadBalance } from "./accounts.services";
-import { getAuthenticatedIdentity } from "./auth.services";
+import { getAuthenticatedIdentity, getCurrentIdentity } from "./auth.services";
 import { queryAndUpdate } from "./utils.services";
 
 export const listCanisters = async ({
@@ -36,6 +37,11 @@ export const listCanisters = async ({
 }: {
   clearBeforeQuery?: boolean;
 }) => {
+  const identity = getCurrentIdentity();
+  const canistersStore = initCanistersStore(identity);
+  if (isNullish(canistersStore)) {
+    return;
+  }
   if (clearBeforeQuery === true) {
     canistersStore.setCanisters({ canisters: undefined, certified: true });
   }

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -14,7 +14,7 @@ import type {
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { initCanistersStore } from "$lib/stores/canisters.store";
+import { getOrCreateCanistersStore } from "$lib/stores/canisters.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { LedgerErrorMessage } from "$lib/types/ledger.errors";
@@ -38,7 +38,7 @@ export const listCanisters = async ({
   clearBeforeQuery?: boolean;
 }) => {
   const identity = getCurrentIdentity();
-  const canistersStore = initCanistersStore(identity);
+  const canistersStore = getOrCreateCanistersStore(identity);
   if (isNullish(canistersStore)) {
     return;
   }

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -14,7 +14,7 @@ import type {
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { getOrCreateCanistersStore } from "$lib/stores/canisters.store";
+import { getOrCreateFullCanistersStore } from "$lib/stores/canisters.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
 import { LedgerErrorMessage } from "$lib/types/ledger.errors";
@@ -38,7 +38,7 @@ export const listCanisters = async ({
   clearBeforeQuery?: boolean;
 }) => {
   const identity = getCurrentIdentity();
-  const canistersStore = getOrCreateCanistersStore(identity);
+  const canistersStore = getOrCreateFullCanistersStore(identity);
   if (isNullish(canistersStore)) {
     return;
   }

--- a/frontend/src/lib/stores/canisters.store.ts
+++ b/frontend/src/lib/stores/canisters.store.ts
@@ -16,7 +16,11 @@ export interface CanistersStore extends Readable<CanistersStoreData> {
   setCanisters(data: CanistersStoreData): void;
 }
 
-const stores: Record<string, CanistersStore> = {};
+let stores: Record<string, CanistersStore> = {};
+
+export const resetCanistersStoresCacheForTesting = () => {
+  stores = {};
+};
 
 const loadCanistersFactory =
   (identity: Identity) => (set: (data: CanistersStoreData) => void) => {
@@ -49,7 +53,7 @@ const loadCanistersFactory =
  *
  * TODO: Error and loading states
  */
-export const initCanistersStore = (
+export const getOrCreateCanistersStore = (
   identity: Identity | undefined | null
 ): CanistersStore | undefined => {
   if (isNullish(identity)) {

--- a/frontend/src/lib/stores/canisters.store.ts
+++ b/frontend/src/lib/stores/canisters.store.ts
@@ -1,29 +1,51 @@
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { writable } from "svelte/store";
+import type { Identity } from "@dfinity/agent";
+import { isNullish } from "@dfinity/utils";
+import { writable, type Readable } from "svelte/store";
 
-export interface CanistersStore {
+export interface CanistersStoreData {
   canisters: CanisterInfo[] | undefined;
   certified: boolean | undefined;
 }
+
+export interface CanistersStore extends Readable<CanistersStoreData> {
+  setCanisters(data: CanistersStoreData): void;
+}
+
+const stores: Record<string, CanistersStore> = {};
 
 /**
  * A store that contains the canisters of the users
  *
  * - setCanisters: replace the current list of canisters with a new list (can be the effective list of canisters or empty)
+ *
+ * TODO: Error and loading states
  */
-const initCanistersStore = () => {
-  const { subscribe, set } = writable<CanistersStore>({
+export const initCanistersStore = (
+  identity: Identity | undefined | null
+): CanistersStore | undefined => {
+  if (isNullish(identity)) {
+    return;
+  }
+  const storeKey = identity.getPrincipal().toText();
+  if (stores[storeKey]) {
+    return stores[storeKey];
+  }
+
+  const { subscribe, set } = writable<CanistersStoreData>({
     canisters: undefined,
     certified: undefined,
   });
 
-  return {
+  const store = {
     subscribe,
 
-    setCanisters({ canisters, certified }: CanistersStore) {
+    setCanisters({ canisters, certified }: CanistersStoreData) {
       set({ canisters, certified });
     },
   };
-};
 
-export const canistersStore = initCanistersStore();
+  stores[storeKey] = store;
+
+  return store;
+};

--- a/frontend/src/lib/utils/canisters.utils.ts
+++ b/frontend/src/lib/utils/canisters.utils.ts
@@ -3,7 +3,7 @@ import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canis
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { ONE_TRILLION } from "$lib/constants/icp.constants";
 import type { AuthStoreData } from "$lib/stores/auth.store";
-import type { CanistersStore } from "$lib/stores/canisters.store";
+import type { CanistersStoreData } from "$lib/stores/canisters.store";
 import { i18n } from "$lib/stores/i18n";
 import type { CanisterId } from "$lib/types/canister";
 import { Principal } from "@dfinity/principal";
@@ -12,12 +12,14 @@ import { formatNumber } from "./format.utils";
 
 export const getCanisterFromStore = ({
   canisterId,
-  canistersStore: { canisters },
+  canistersStore,
 }: {
   canisterId: string | undefined | null;
-  canistersStore: CanistersStore;
+  canistersStore: CanistersStoreData | undefined;
 }): CanisterInfo | undefined =>
-  canisters?.find(({ canister_id }) => canister_id.toText() === canisterId);
+  canistersStore?.canisters?.find(
+    ({ canister_id }) => canister_id.toText() === canisterId
+  );
 
 export const formatCyclesToTCycles = (cycles: bigint): string =>
   formatNumber(Number(cycles) / Number(ONE_TRILLION), {

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -6,6 +6,8 @@ import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import type { Identity } from "@dfinity/agent";
 import { tick } from "svelte";
 
 describe("api-utils", () => {
@@ -36,6 +38,28 @@ describe("api-utils", () => {
           });
 
         expect(call).rejects.toThrowError();
+      });
+
+      it("should use the identity passed", async () => {
+        const request = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve({ certified: true }));
+        const onLoad = jest.fn();
+        const onError = jest.fn();
+        const identity = mockIdentity;
+
+        await queryAndUpdate<number, unknown>({
+          request,
+          onLoad,
+          onError,
+          identity,
+        });
+
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(request).toHaveBeenCalledWith({
+          certified: true,
+          identity,
+        });
       });
     });
 
@@ -236,6 +260,30 @@ describe("api-utils", () => {
         });
 
         expect(log).toBeCalled();
+      });
+
+      it("should use the identity passed", async () => {
+        const request = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve({ certified: true }));
+        const onLoad = jest.fn();
+        const onError = jest.fn();
+        const identity = {
+          getPrincipal: () => principal(2),
+        } as unknown as Identity;
+
+        await queryAndUpdate<number, unknown>({
+          request,
+          onLoad,
+          onError,
+          identity,
+        });
+
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(request).toHaveBeenCalledWith({
+          certified: false,
+          identity,
+        });
       });
     });
   });

--- a/frontend/src/tests/lib/stores/canisters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/canisters.store.spec.ts
@@ -1,28 +1,109 @@
-import { canistersStore } from "$lib/stores/canisters.store";
+/**
+ * @jest-environment jsdom
+ */
+
+import * as canistersApi from "$lib/api/canisters.api";
+import {
+  getOrCreateCanistersStore,
+  resetCanistersStoresCacheForTesting,
+} from "$lib/stores/canisters.store";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisters } from "$tests/mocks/canisters.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+jest.mock("$lib/api/canisters.api");
+
 describe("canisters-store", () => {
+  blockAllCallsTo(["$lib/api/canisters.api"]);
+
+  beforeEach(() => {
+    resetCanistersStoresCacheForTesting();
+    jest.clearAllMocks();
+  });
+
   describe("canistersStore", () => {
-    it("should set canisters", () => {
+    it("should load canisters from api", async () => {
+      jest
+        .spyOn(canistersApi, "queryCanisters")
+        .mockResolvedValue(mockCanisters);
+      const canistersStore = getOrCreateCanistersStore(mockIdentity);
+
+      let canisters = undefined;
+      canistersStore.subscribe((storeData) => {
+        canisters = storeData.canisters;
+      });
+
+      expect(canisters).toBeUndefined();
+      await runResolvedPromises();
+
+      // Update + query call
+      expect(canistersApi.queryCanisters).toBeCalledTimes(2);
+
+      expect(canisters).toEqual(mockCanisters);
+    });
+
+    it("should load once for two calls for same identity", async () => {
+      jest
+        .spyOn(canistersApi, "queryCanisters")
+        .mockResolvedValue(mockCanisters);
+      const canistersStore = getOrCreateCanistersStore(mockIdentity);
+
+      let canisters;
+      canistersStore.subscribe((storeData) => {
+        canisters = storeData.canisters;
+      });
+
+      await waitFor(() => expect(canisters).toEqual(mockCanisters));
+
+      // Update + query call
+      expect(canistersApi.queryCanisters).toBeCalledTimes(2);
+
+      const canistersStore2 = getOrCreateCanistersStore(mockIdentity);
+
+      let canisters2;
+      canistersStore2.subscribe((storeData) => {
+        canisters2 = storeData.canisters;
+      });
+
+      expect(canisters2).toEqual(mockCanisters);
+
+      expect(canistersApi.queryCanisters).toBeCalledTimes(2);
+    });
+
+    it("should set canisters", async () => {
+      jest.spyOn(canistersApi, "queryCanisters").mockResolvedValue([]);
+      const canistersStore = getOrCreateCanistersStore(mockIdentity);
+
+      await runResolvedPromises();
+
+      await waitFor(() => expect(get(canistersStore).canisters).toEqual([]));
+
       canistersStore.setCanisters({
         canisters: mockCanisters,
         certified: true,
       });
 
-      const store = get(canistersStore);
-      expect(store.canisters).toEqual(mockCanisters);
+      expect(get(canistersStore).canisters).toEqual(mockCanisters);
     });
 
-    it("should reset canisters", () => {
+    it("should reset canisters", async () => {
+      jest.spyOn(canistersApi, "queryCanisters").mockResolvedValue([]);
+      const canistersStore = getOrCreateCanistersStore(mockIdentity);
+
+      await runResolvedPromises();
+
+      await waitFor(() => expect(get(canistersStore).canisters).toEqual([]));
+
       canistersStore.setCanisters({
         canisters: mockCanisters,
         certified: true,
       });
       canistersStore.setCanisters({ canisters: undefined, certified: true });
 
-      const store = get(canistersStore);
-      expect(store.canisters).toBeUndefined();
+      expect(get(canistersStore).canisters).toBeUndefined();
     });
   });
 });

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -7,7 +7,7 @@ import {
   CKBTC_INDEX_CANISTER_ID,
   CKBTC_MINTER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import type { CanistersStore } from "$lib/stores/canisters.store";
+import type { CanistersStoreData } from "$lib/stores/canisters.store";
 import type { SelectCanisterDetailsStore } from "$lib/types/canister-detail.context";
 import { Principal } from "@dfinity/principal";
 import { writable, type Subscriber } from "svelte/store";
@@ -49,7 +49,7 @@ export const mockCanisterDetails: CanisterDetails = {
 };
 
 export const mockCanistersStoreSubscribe = (
-  run: Subscriber<CanistersStore>
+  run: Subscriber<CanistersStoreData>
 ): (() => void) => {
   run({ canisters: mockCanisters, certified: true });
 


### PR DESCRIPTION
# Motivation

This is a draft of how the new store initialization pattern could look like.

If we like the idea, I can implement it in multiple smaller PRs.

The difference from what we discussed is in passing the identity when creating the store. This was the easiest way I found to use the identity in the start function without accessing global state.

# Changes

Main changes
* Do not initialize the store in canisters.store.ts.
* Initialize the canistersStore where it's used. In the Canisters and CanisterDetail pages as well as in the service.
* Use the start function of the stores to load the data with query and update.
* Remove the call to `listCanisters` on mounting of Canisters and CanisterDetail page.

Minor changes:
* Add a new `identity` parameter to `queryAndUpdate`.

# Tests

This is just a draft PR to discuss a new pattern.
