### PR TITLE
Chore: New Changelog setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG* merge=union

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,7 @@
 # Tests
 
 <!-- Please provide any information or screenshots about the tests that have been done -->
+
+# Todos
+
+- [ ] Add entry to changelog (if necessary).

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -8,13 +8,24 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 ## Unreleased
 
-### Added
-### Changed
-### Fixed
-### Security
-### Not Published
-### Removed
-### Deprecated
+### Application
+
+#### Added
+#### Changed
+#### Deprecated
+#### Removed
+#### Fixed
+#### Security
+#### Not Published
+
+### Operations
+
+#### Added
+#### Changed
+#### Deprecated
+#### Removed
+#### Fixed
+#### Security
 
 ## Proposal 123006
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -1,4 +1,20 @@
-# Changelog
+# Changelog NNS Dapp
+
+All notable changes to the NNS Dapp will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+The NNS Dapp is released through proposals in the Network Nervous System. Therefore, each proposal is documented below, following the relevant changes.
+
+## Unreleased
+
+### Added
+### Changed
+### Fixed
+### Security
+### Not Published
+### Removed
+### Deprecated
 
 ## Proposal 123006
 

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -1,0 +1,17 @@
+# Changelog SNS Aggregator
+
+All notable changes to the SNS Aggregator will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+The SNS Aggregator is released through proposals in the Network Nervous System. Therefore, each proposal is documented below, following the relevant changes.
+
+## Unreleased
+
+### Added
+### Changed
+### Fixed
+### Security
+### Not Published
+### Removed
+### Deprecated


### PR DESCRIPTION
# Motivation

Improve the release process. Creating the Changelog before the release is a lot of work. With some time spent on each PR by each author the Changelog can be kept up to date.

# Changes

* Add new section "Todos" in Github PR template.
* Rename current CHANGELOG.md to CHANGELOG-Nns_Dapp.md
* New file CHANGELOG-Sns_Aggregator.md
* New types of changes inside the CHANGELOG files.

# Tests

Only documentation changes.
