### PR TITLE
Put coreutils front of path on mac

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -66,7 +66,9 @@ mkdir -p "$USER_BIN"
 NEW_TERMINAL_NEEDED=false
 append_to_profile() {
   printf '\n%s\n' "$1" >>"$USER_PROFILE"
+  set +eu
   . "$USER_PROFILE"
+  set -eu
   NEW_TERMINAL_NEEDED=true
 }
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -101,9 +101,16 @@ install_brew_maybe() {
   }
 }
 
+check_coreutils() {
+  : Checks that everything we need from coreutils is installed
+  for command in sha256sum date; do
+    "$command" --version | grep 'GNU coreutils' || return 1
+  done
+}
 install_coreutils_darwin() {
   echo "Installing coreutils..."
   brew install coreutils
+  append_to_profile "export PATH=\"/opt/homebrew/opt/coreutils/libexec/gnubin:\$PATH\""
 }
 install_coreutils_linux() {
   echo "Installing coreutils..."
@@ -285,7 +292,7 @@ install_brew_maybe
 command -v wget || "install_wget_$OS"
 command -v curl || "install_curl_$OS"
 is_docker_installed || install_docker
-command -v sha256sum || "install_coreutils_$OS"
+check_coreutils || "install_coreutils_$OS"
 command -v sponge || "install_moreutils_$OS"
 command -v jq || "install_jq_$OS"
 command -v yq || "install_yq_$OS"


### PR DESCRIPTION
# Motivation
On M1 macs (and possibly Intel as well) coreutils tools may be installed but not front-of-path.  This can cause undefined behaviour, when ancient apple tools are invoked instead.

# Changes
* Check that tools such as date use the coreutils versions, and if not install coreutils (as before) and put the coreutils front of path.

# Tests
* None.  Can someone with an M1 mac test please?