### PR TITLE
Cleanup: Sunset nns-dapp_local.wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,11 @@ jobs:
         uses: ./.github/actions/build_nns_dapp
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Rename nns-dapp.wasm.gz for upload
-        run: cp out/nns-dapp.wasm.gz out/nns-dapp_local.wasm.gz
-      - name: 'Upload nns-dapp_local wasm module'
+      - name: 'Upload nns-dapp wasm module'
         uses: actions/upload-artifact@v3
         with:
-          name: nns-dapp_local
-          path: out/nns-dapp_local.wasm.gz
+          name: nns-dapp
+          path: out/nns-dapp.wasm.gz
           retention-days: 3
       - name: 'Upload sns_aggregator wasm module'
         uses: actions/upload-artifact@v3
@@ -50,10 +48,10 @@ jobs:
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
-      - name: Get nns-dapp_local
+      - name: Get nns-dapp
         uses: actions/download-artifact@v3
         with:
-          name: nns-dapp_local
+          name: nns-dapp
       - name: Get sns_aggregator_dev
         uses: actions/download-artifact@v3
         with:
@@ -64,7 +62,7 @@ jobs:
           # Version from 2023-06-06 with dfx v 0.14.1
           snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
-          nns_dapp_wasm: 'nns-dapp_local.wasm.gz'
+          nns_dapp_wasm: 'nns-dapp.wasm.gz'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
       - name: Generate .env configuration for Playwright end-to-end tests
         run: |
@@ -104,10 +102,10 @@ jobs:
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
-      - name: Get nns-dapp_local
+      - name: Get nns-dapp
         uses: actions/download-artifact@v3
         with:
-          name: nns-dapp_local
+          name: nns-dapp
       - name: Get sns_aggregator
         uses: actions/download-artifact@v3
         with:
@@ -122,7 +120,7 @@ jobs:
           # Version from 2023-06-06 with dfx v0.14.1
           snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
           snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
-          nns_dapp_wasm: 'nns-dapp_local.wasm.gz'
+          nns_dapp_wasm: 'nns-dapp.wasm.gz'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
       - name: Add go and SNS scripts to the path
         run: |
@@ -178,14 +176,12 @@ jobs:
           } >&2
       - name: Check that metadata is present
         run: |
-          # dfx-wasm-metadata-add.test expects nns-dapp.wasm.gz
-          cp nns-dapp_local.wasm.gz nns-dapp.wasm.gz
           scripts/dfx-wasm-metadata-add.test --verbose
       - name: Basic downgrade-upgrade test
         run: |
           git fetch --depth 1 origin tag prod
           if git diff tags/prod rs/backend | grep -q .
-          then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_local.wasm.gz
+          then ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp.wasm.gz
           else echo "Skipping test as there are no relevant code changes"
           fi
       - name: Release
@@ -193,8 +189,8 @@ jobs:
           for tag in $(git tag --points-at HEAD) ; do
             : Creates or updates a release for the tag
             if gh release view "$tag"
-            then gh release upload --repo dfinity/nns-dapp --clobber "$tag" nns-dapp_local.wasm.gz || true
-            else gh release create --title "Release for tags/$tag" --draft --notes "Build artefacts from tag: $tag" "$tag" nns-dapp_local.wasm.gz
+            then gh release upload --repo dfinity/nns-dapp --clobber "$tag" nns-dapp.wasm.gz || true
+            else gh release create --title "Release for tags/$tag" --draft --notes "Build artefacts from tag: $tag" "$tag" nns-dapp.wasm.gz
             fi
             : If the tag is for a proposal or nightly, make it public
             [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
@@ -225,7 +221,7 @@ jobs:
           SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count
         run: |
-          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp_local.wasm.gz --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
+          dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp.wasm.gz --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
           postinstall_instructions="$(scripts/backend/get_upgrade_instructions)"
           echo "Installation consumed ${postinstall_instructions} instructions."
           echo "Cycles consumed are instructions * some factor that depends on subnet.  There is no guarantee that that formula will not change."
@@ -295,15 +291,15 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out-mainnet
-      - name: Get nns-dapp_local
+      - name: Get nns-dapp
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3
         with:
-          name: nns-dapp_local
+          name: nns-dapp
           path: out-local
       - name: Remove _local suffix
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        run: mv out-local/nns-dapp_local.wasm.gz out-local/nns-dapp.wasm.gz
+        run: mv out-local/nns-dapp.wasm.gz out-local/nns-dapp.wasm.gz
       - name: Get sns_aggregator
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3

--- a/scripts/dfx-software-nd-cache
+++ b/scripts/dfx-software-nd-cache
@@ -26,5 +26,4 @@ LOCAL_ND_WASM="$(jq -r '.canisters["nns-dapp"].wasm' dfx.json)"
 
 : "Put the wasm into the cache, for use by 'dfx nns install'"
 mkdir -p "$DFX_WASMS_DIR"
-cp "$LOCAL_ND_WASM" nns-dapp_local.wasm.gz
-cp nns-dapp_local.wasm "$DFX_WASMS_DIR"
+cp "$LOCAL_ND_WASM" "$DFX_WASMS_DIR"

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -32,7 +32,7 @@ get_current_wasm() {
 }
 
 get_prod_wasm() {
-  curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_local.wasm.gz >"$PROD_WASM"
+  curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp.wasm.gz >"$PROD_WASM"
 }
 
 # Installs the current build of nns-dapp


### PR DESCRIPTION
# Motivation
*  The nns-dapp wasm used to be different depending on which network it was deployed to.  So we had a `_local` build for use on localhost and CI.
* Then the wasm was the same for all networks, but we retained `_local` to avoid breaking workflows.
* The time has come to sunset _local.

# Changes
* Transition all remaining references to `nns-dapp_local.wasm` to `nns-dapp.wasm`

# Tests
* None.  Existing functionality should be unaffected.
* Third parties who haven't yet transitioned to the universal build will have to do so now.