### PR TITLE
Fix: Screen Title in HW when staking two neurons

### DIFF
--- a/frontend/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/ledger.services.spec.ts
@@ -14,6 +14,7 @@ import {
   getLedgerIdentity,
   listNeuronsHardwareWallet,
   registerHardwareWallet,
+  resetIdentitiesCachedForTesting,
   showAddressAndPubKeyOnHardwareWallet,
 } from "$lib/services/ledger.services";
 import { authStore } from "$lib/stores/auth.store";
@@ -45,6 +46,7 @@ describe("ledger-services", () => {
   const mockLedgerIdentity: MockLedgerIdentity = new MockLedgerIdentity();
 
   beforeEach(() => {
+    resetIdentitiesCachedForTesting();
     jest.clearAllMocks();
   });
 
@@ -208,6 +210,18 @@ describe("ledger-services", () => {
       expect(principalToAccountIdentifier(identity.getPrincipal())).toEqual(
         mockLedgerIdentifier
       );
+    });
+
+    it("should cache ledger identity", async () => {
+      const identity1 = await getLedgerIdentity(mockLedgerIdentifier);
+
+      expect(identity1).not.toBeNull();
+      expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+
+      const identity2 = await getLedgerIdentity(mockLedgerIdentifier);
+
+      expect(identity2).toBe(identity1);
+      expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
     });
 
     it("should throw an error if identifier does not match", async () => {

--- a/frontend/src/tests/lib/services/ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/ledger.services.spec.ts
@@ -26,6 +26,7 @@ import {
   mockGetIdentity,
   mockIdentity,
   mockIdentityErrorMsg,
+  mockPrincipal,
   resetIdentity,
   setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
@@ -44,6 +45,10 @@ import { mock } from "jest-mock-extended";
 describe("ledger-services", () => {
   const callback = jest.fn();
   const mockLedgerIdentity: MockLedgerIdentity = new MockLedgerIdentity();
+  const ledgerPrincipal2 = mockPrincipal;
+  const mockLedgerIdentity2: MockLedgerIdentity = new MockLedgerIdentity({
+    principal: ledgerPrincipal2,
+  });
 
   beforeEach(() => {
     resetIdentitiesCachedForTesting();
@@ -212,7 +217,7 @@ describe("ledger-services", () => {
       );
     });
 
-    it("should cache ledger identity", async () => {
+    it("should cache ledger identity for same identifier", async () => {
       const identity1 = await getLedgerIdentity(mockLedgerIdentifier);
 
       expect(identity1).not.toBeNull();
@@ -222,6 +227,29 @@ describe("ledger-services", () => {
 
       expect(identity2).toBe(identity1);
       expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not return cached ledger identity for different account", async () => {
+      jest
+        .spyOn(LedgerIdentity, "create")
+        .mockImplementationOnce(
+          async (): Promise<LedgerIdentity> => mockLedgerIdentity
+        )
+        .mockImplementationOnce(
+          async (): Promise<LedgerIdentity> => mockLedgerIdentity2
+        );
+
+      const identity1 = await getLedgerIdentity(mockLedgerIdentifier);
+
+      expect(identity1).not.toBeNull();
+      expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+
+      const identity2 = await getLedgerIdentity(
+        principalToAccountIdentifier(ledgerPrincipal2)
+      );
+
+      expect(identity2).not.toBe(identity1);
+      expect(LedgerIdentity.create).toHaveBeenCalledTimes(2);
     });
 
     it("should throw an error if identifier does not match", async () => {

--- a/frontend/src/tests/mocks/ledger.identity.mock.ts
+++ b/frontend/src/tests/mocks/ledger.identity.mock.ts
@@ -1,6 +1,7 @@
 import { LEDGER_DEFAULT_DERIVE_PATH } from "$lib/constants/ledger.constants";
 import { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { Secp256k1PublicKey } from "$lib/keys/secp256k1";
+import type { Principal } from "@dfinity/principal";
 import type { ResponseVersion } from "@zondax/ledger-icp";
 
 export const fromHexString = (hexString: string): ArrayBuffer => {
@@ -23,11 +24,13 @@ export const mockLedgerIdentifier =
 
 type MockIdentityOptions = {
   version?: ResponseVersion;
+  principal?: Principal;
 };
 // eslint-disable-next-line
 // @ts-ignore: test file
 export class MockLedgerIdentity extends LedgerIdentity {
-  constructor({ version }: MockIdentityOptions = {}) {
+  private readonly principal: Principal;
+  constructor({ version, principal }: MockIdentityOptions = {}) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - we do not use the service for mocking purpose
     super(
@@ -37,6 +40,10 @@ export class MockLedgerIdentity extends LedgerIdentity {
 
     if (version !== undefined) {
       this.getVersion = () => Promise.resolve(version);
+    }
+
+    if (principal !== undefined) {
+      this.getPrincipal = () => principal;
     }
   }
 


### PR DESCRIPTION
# Motivation

The user was getting "Send ICP" in the HW screen instead of "Stake Neuron" if they were staking two neurons in a row without refreshing the page.

Problem: The agent from `createAgent` is cache. Therefore it was using the identity from the first staking. Yet, the service to stake a neuron was getting a new identity and setting the flag to stake neuron in that identity.

# Changes

* Cache the ledger identity.

# Tests

* Add a test to the ledger service to check that the identity is cached.
