### PR TITLE
Use standard tool for getting canister URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,9 +309,6 @@ jobs:
         with:
           name: nns-dapp
           path: out-local
-      - name: Remove _local suffix
-        if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        run: mv out-local/nns-dapp.wasm.gz out-local/nns-dapp.wasm.gz
       - name: Get sns_aggregator
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
         uses: actions/download-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,8 @@ RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && comma
 FROM builder AS configurator
 SHELL ["bash", "-c"]
 COPY dfx.json config.sh canister_ids.jso[n] /build/
+COPY scripts/dfx-canister-url /build/scripts/dfx-canister-url
+COPY scripts/clap.bash /build/scripts/clap.bash
 COPY .df[x]/ /build/.dfx
 WORKDIR /build
 ARG DFX_NETWORK=mainnet
@@ -103,6 +105,8 @@ RUN didc encode "$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p >nns-dapp-a
 FROM builder AS mainnet_configurator
 SHELL ["bash", "-c"]
 COPY dfx.json config.sh /build/
+COPY scripts/dfx-canister-url /build/scripts/dfx-canister-url
+COPY scripts/clap.bash /build/scripts/clap.bash
 WORKDIR /build
 RUN mkdir -p frontend
 ENV DFX_NETWORK=mainnet

--- a/config.sh
+++ b/config.sh
@@ -38,30 +38,10 @@ first_not_null() {
   echo "null"
 }
 
-static_host() {
-  first_not_null \
-    "$(jq -re '.networks[env.DFX_NETWORK].config.STATIC_HOST' dfx.json)" \
-    "$(jq -re '.networks[env.DFX_NETWORK].config.HOST' dfx.json)"
-}
-
 api_host() {
   first_not_null \
     "$(jq -re '.networks[env.DFX_NETWORK].config.API_HOST' dfx.json)" \
     "$(jq -re '.networks[env.DFX_NETWORK].config.HOST' dfx.json)"
-}
-
-# Gets the static content URL for a canister based on its ID.
-# Uses the STATIC_HOST to create the URL, which is appropriate to fetch static content.
-canister_static_url_from_id() {
-  : "If we have a canister ID, insert it into HOST as a subdomain."
-  test -z "${1:-}" || { static_host | sed -E "s,^(https?://)?,&${1}.,g"; }
-}
-
-# Gets the api URL for a canister based on its ID.
-# Uses the API_HOST to create the URL, which is appropriate for Candid API calls.
-canister_api_url_from_id() {
-  : "If we have a canister ID, insert it into HOST as a subdomain."
-  test -z "${1:-}" || { api_host | sed -E "s,^(https?://)?,&${1}.,g"; }
 }
 
 local_deployment_data="$(

--- a/config.sh
+++ b/config.sh
@@ -76,11 +76,8 @@ local_deployment_data="$(
 
   : "Try to find the internet_identity URL"
   : "- may be deployed locally"
-  IDENTITY_SERVICE_URL="$(
-    canister_static_url_from_id "$(dfx canister --network "$DFX_NETWORK" id internet_identity 2>/dev/null || true)"
-  )"
+  IDENTITY_SERVICE_URL="$(dfx-canister-url --network "$DFX_NETWORK" internet_identity)"
   export IDENTITY_SERVICE_URL
-  test -n "${IDENTITY_SERVICE_URL:-}" || unset IDENTITY_SERVICE_URL
 
   : "Get the SNS wasm canister ID, if it exists"
   : "- may be set as an env var"
@@ -92,11 +89,8 @@ local_deployment_data="$(
 
   : "Try to find the SNS aggregator URL"
   : "- may be deployed locally"
-  SNS_AGGREGATOR_URL="$(
-    canister_static_url_from_id "$(dfx canister --network "$DFX_NETWORK" id sns_aggregator 2>/dev/null || true)"
-  )"
+  SNS_AGGREGATOR_URL="$(dfx-canister-url --network "$DFX_NETWORK" sns_aggregator)"
   export SNS_AGGREGATOR_URL
-  test -n "${SNS_AGGREGATOR_URL:-}" || unset SNS_AGGREGATOR_URL
 
   : "Try to find the ckBTC canister IDs"
   CKBTC_LEDGER_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id ckbtc_ledger 2>/dev/null || true)"

--- a/config.sh
+++ b/config.sh
@@ -135,7 +135,7 @@ local_deployment_data="$(
 : "After assembling the configuration:"
 : "- replace OWN_CANISTER_ID"
 : "- construct ledger and governance canister URLs"
-json=$(HOST=$(api_host) jq -s --sort-keys '
+json=$(HOST=$(dfx-canister-url --network "$DFX_NETWORK" --type api) jq -s --sort-keys '
   (.[0].defaults.network.config // {}) * .[1] * .[0].networks[env.DFX_NETWORK].config |
   .DFX_NETWORK = env.DFX_NETWORK |
   . as $config |

--- a/config.sh
+++ b/config.sh
@@ -38,12 +38,6 @@ first_not_null() {
   echo "null"
 }
 
-api_host() {
-  first_not_null \
-    "$(jq -re '.networks[env.DFX_NETWORK].config.API_HOST' dfx.json)" \
-    "$(jq -re '.networks[env.DFX_NETWORK].config.HOST' dfx.json)"
-}
-
 local_deployment_data="$(
   set -euo pipefail
   : "Try to find the nns-dapp canister ID:"

--- a/config.sh
+++ b/config.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 
 : "Move into the repository root directory"
 pushd "$(dirname "${BASH_SOURCE[0]}")"
+export PATH="$PWD/scripts:$PATH"
 
 : "Scan environment:"
 test -n "$DFX_NETWORK" # Will fail if not defined.

--- a/dfx.json
+++ b/dfx.json
@@ -233,54 +233,33 @@
       "type": "persistent"
     },
     "nnsdapp": {
-      "config": {
-        "HOST": "https://nnsdapp.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"
       ],
       "type": "persistent"
     },
     "small14": {
-      "config": {
-        "HOST": "https://small14.testnet.dfinity.network"
-      },
-      "providers": [
-        "http://[2a00:fb01:400:42:5000:a4ff:fe4f:a75e]:8080"
-      ],
       "type": "persistent"
     },
     "small13": {
-      "config": {
-        "HOST": "https://small13.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:c6ff:fe29:bfba]:8080"
       ],
       "type": "persistent"
     },
     "small12": {
-      "config": {
-        "HOST": "https://small12.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:54ff:fef3:eb8]:8080"
       ],
       "type": "persistent"
     },
     "small11": {
-      "config": {
-        "HOST": "https://small11.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:eeff:feae:ab37]:8080"
       ],
       "type": "persistent"
     },
     "large02": {
-      "config": {
-        "HOST": "https://large02.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:78ff:fe1b:9a48]:8080",
         "http://[2001:4d78:40d:0:5000:60ff:fe26:5213]:8080",
@@ -294,18 +273,12 @@
       "type": "persistent"
     },
     "small09": {
-      "config": {
-        "HOST": "https://small09.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:d0ff:fe7c:bd3f]:8080"
       ],
       "type": "persistent"
     },
     "small06": {
-      "config": {
-        "HOST": "https://small06.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:caff:fed1:b2e7]:8080"
       ],
@@ -399,9 +372,6 @@
       "type": "ephemeral"
     },
     "large01": {
-      "config": {
-        "HOST": "https://large01.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:f6ff:fef6:c05a]:8080",
         "http://[2001:4d78:40d:0:5000:53ff:fe8a:5990]:8080",
@@ -415,9 +385,6 @@
       "type": "persistent"
     },
     "large03": {
-      "config": {
-        "HOST": "https://large03.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:bbff:fe41:e451]:8080",
         "http://[2001:4d78:40d:0:5000:4dff:fe0b:d6a2]:8080",
@@ -431,9 +398,6 @@
       "type": "persistent"
     },
     "large04": {
-      "config": {
-        "HOST": "https://large04.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:3dff:fe4b:2aa0]:8080",
         "http://[2001:4d78:40d:0:5000:67ff:fe59:7d35]:8080",
@@ -447,9 +411,6 @@
       "type": "persistent"
     },
     "large05": {
-      "config": {
-        "HOST": "https://large05.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:3dff:febf:9908]:8080",
         "http://[2001:4d78:40d:0:5000:27ff:fea7:a1fe]:8080",
@@ -463,9 +424,6 @@
       "type": "persistent"
     },
     "medium01": {
-      "config": {
-        "HOST": "https://medium01.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:fbff:feb9:875b]:8080",
         "http://[2602:fb2b:100:10:5000:1fff:fefb:ac01]:8080",
@@ -475,9 +433,6 @@
       "type": "persistent"
     },
     "medium02": {
-      "config": {
-        "HOST": "https://medium02.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:c6ff:fe7c:8ac6]:8080",
         "http://[2602:fb2b:100:10:5000:79ff:febf:fd27]:8080",
@@ -487,9 +442,6 @@
       "type": "persistent"
     },
     "medium03": {
-      "config": {
-        "HOST": "https://medium03.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:12ff:feec:cae3]:8080",
         "http://[2602:fb2b:100:10:5000:6dff:fe9f:3530]:8080",
@@ -499,9 +451,6 @@
       "type": "persistent"
     },
     "medium04": {
-      "config": {
-        "HOST": "https://medium04.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:d2ff:fe81:6264]:8080",
         "http://[2602:fb2b:100:10:5000:63ff:fec2:8dae]:8080",
@@ -511,9 +460,6 @@
       "type": "persistent"
     },
     "medium05": {
-      "config": {
-        "HOST": "https://medium05.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:e6ff:fe0b:eca2]:8080",
         "http://[2602:fb2b:100:10:5000:56ff:fe3b:a226]:8080",
@@ -523,9 +469,6 @@
       "type": "persistent"
     },
     "medium06": {
-      "config": {
-        "HOST": "https://medium06.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:ffff:fe9e:83e5]:8080",
         "http://[2602:fb2b:100:10:5000:bbff:fec3:69bc]:8080",
@@ -535,9 +478,6 @@
       "type": "persistent"
     },
     "medium07": {
-      "config": {
-        "HOST": "https://medium07.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:b4ff:fe50:57a0]:8080",
         "http://[2602:fb2b:100:10:5000:d8ff:feb4:2a30]:8080",
@@ -547,9 +487,6 @@
       "type": "persistent"
     },
     "medium08": {
-      "config": {
-        "HOST": "https://medium08.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:cdff:fe0f:4ff]:8080",
         "http://[2602:fb2b:100:10:5000:8cff:fe0e:1fae]:8080",
@@ -559,9 +496,6 @@
       "type": "persistent"
     },
     "medium09": {
-      "config": {
-        "HOST": "https://medium09.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:73ff:fe41:db8e]:8080",
         "http://[2602:fb2b:100:10:5000:d9ff:fe40:44be]:8080",
@@ -571,9 +505,6 @@
       "type": "persistent"
     },
     "medium10": {
-      "config": {
-        "HOST": "https://medium10.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2602:fb2b:100:10:5000:71ff:fe1a:cf99]:8080",
         "http://[2602:fb2b:100:10:5000:99ff:feeb:55a4]:8080",
@@ -583,90 +514,60 @@
       "type": "persistent"
     },
     "small01": {
-      "config": {
-        "HOST": "https://small01.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:c9ff:fe17:cc3a]:8080"
       ],
       "type": "persistent"
     },
     "small02": {
-      "config": {
-        "HOST": "https://small02.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:6aff:feed:6c6a]:8080"
       ],
       "type": "persistent"
     },
     "small03": {
-      "config": {
-        "HOST": "https://small03.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:45ff:fe8b:20f1]:8080"
       ],
       "type": "persistent"
     },
     "small04": {
-      "config": {
-        "HOST": "https://small04.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:3cff:fe45:6c61]:8080"
       ],
       "type": "persistent"
     },
     "small05": {
-      "config": {
-        "HOST": "https://small05.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:e6ff:fe0f:1a73]:8080"
       ],
       "type": "persistent"
     },
     "small07": {
-      "config": {
-        "HOST": "https://small07.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:fbff:fe8d:cb73]:8080"
       ],
       "type": "persistent"
     },
     "small08": {
-      "config": {
-        "HOST": "https://small08.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:c3ff:fe84:757]:8080"
       ],
       "type": "persistent"
     },
     "small10": {
-      "config": {
-        "HOST": "https://small10.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:18ff:fe0e:13f6]:8080"
       ],
       "type": "persistent"
     },
     "small15": {
-      "config": {
-        "HOST": "https://small15.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2a00:fb01:400:42:5000:59ff:feca:510b]:8080"
       ],
       "type": "persistent"
     },
     "benchmarklarge": {
-      "config": {
-        "HOST": "https://benchmarklarge.testnet.dfinity.network"
-      },
       "providers": [
         "http://[2607:f6f0:3004:1:5000:84ff:fede:d302]:8080",
         "http://[2001:4d78:40d:0:5000:8aff:febb:940]:8080",

--- a/scripts/dfx-canister-url
+++ b/scripts/dfx-canister-url
@@ -2,7 +2,6 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
-. "$SOURCE_DIR/versions.bash"
 
 print_help() {
   cat <<-"EOF"
@@ -23,6 +22,7 @@ print_help() {
 	{ "canisters": {
 	    "my_canister": {
 	      "url": { "ic": "https://my-custom-url.com" },
+	      "raw_url": { "ic": "https://my-custom-raw-url.com" },
 	      ...
 	    }
 	  }
@@ -63,23 +63,24 @@ URL_TYPES=(static api)
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=c long=canister desc="The canister name" variable=DFX_CANISTER
 clap.define short=t long=type desc="The canister type (options: ${URL_TYPES[*]})" variable=DFX_URL_TYPE default=static
+clap.define short=r long=raw desc="Provide a raw static URL" variable=DFX_RAW nargs=0 default=""
 clap.define short=o long=open desc="Open the URL in a browser" variable=DFX_OPEN nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 # Historically, the canister name was given as a positional argument.
 test -n "${DFX_CANISTER:-}" || (($# != 1)) || DFX_CANISTER="${1:-}"
-test -n "${DFX_CANISTER:-}" || {
-  echo "ERROR: Please specify a canister name"
-  : "TODO: Support canister IDs as well."
-  exit 1
-}
 
 # Sanity check the URL type
 printf '%s\0' "${URL_TYPES[@]}" | grep -Fxqz -- "$DFX_URL_TYPE" || {
   echo "ERROR: Unsupported URL type: '$DFX_URL_TYPE'"
   echo "       Valid options:"
   printf "       * %s\n" "${URL_TYPES[@]}"
+  exit 1
+} >&2
+[[ "${DFX_RAW:-}" != "true" ]] || [[ "$DFX_URL_TYPE" == "static" ]] || {
+  echo "ERROR:  As far as I know, there are no properly supported raw API URLs."
+  echo "        If you know otherwise, please share."
   exit 1
 } >&2
 
@@ -95,17 +96,11 @@ while ! test -e dfx.json; do
   }
 done
 
-# Some canisters have custom URLs, such as identity.ic0.app.
-if [[ "${DFX_URL_TYPE:-}" == "static" ]]; then
-  url="$(jq -r '.canisters[env.DFX_CANISTER].url[env.DFX_NETWORK] // ""' dfx.json)"
-else
-  url=""
-fi
-
-# Not found?
-# Each network also has a pattern for canister URLs of the form: https://CANISTER_ID.NETWORK_URL
+# Each network has a pattern for canister URLs of the forms:
+# - https://CANISTER_ID.NETWORK_URL
+# - https://CANISTER_ID.raw.NETWORK_URL
 canister_id() {
-  dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER"
+  dfx canister id --network "$DFX_NETWORK" "$DFX_CANISTER" 2>/dev/null || echo "$DFX_CANISTER"
 }
 inject_canister_id() {
   read -r root_url
@@ -114,37 +109,56 @@ inject_canister_id() {
   static)
     local CANISTER_ID
     CANISTER_ID="$(canister_id)"
-    printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}.,g"
+    # Raw may be inserted, except on localhost.
+    local RAW_PART
+    RAW_PART="${DFX_RAW:+.raw}"
+    [[ "$DFX_NETWORK" != "local" ]] || RAW_PART=""
+    printf "%s\n" "$root_url" | sed -E "s,^(https?://)?,&${CANISTER_ID}${RAW_PART:-}.,g"
     ;;
   *) printf "%s\n" "$root_url" ;;
   esac
 }
-
-# .. Maybe this is in production.  Prioritize this so that production builds are not easily affected by local configuration.
-test -n "$url" || {
-  if [[ "$DFX_NETWORK" == "ic" ]]; then
-    case "$DFX_URL_TYPE" in
-    static) url="https://$(canister_id).icp0.io" ;;
-    api) url="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
-    esac
-  fi
-}
-
-# ... The network URL may be in dfx.json or in the user's global network config, if it exists.
+# ... Network config may be in dfx.json (deprecated) or in the user's global network config, if it exists.
 GLOBAL_NETWORK_CONFIG_FILE="$HOME/.config/dfx/networks.json"
 network_config() {
   : "Getting the local and global network config..."
   jq '.networks // {}' dfx.json
   ! test -e "$GLOBAL_NETWORK_CONFIG_FILE" || cat "$GLOBAL_NETWORK_CONFIG_FILE"
 }
-test -n "${url:-}" || url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' | inject_canister_id || true)"
+network_url() {
+  local network_url
+  if [[ "$DFX_NETWORK" == "ic" ]]; then
+    case "$DFX_URL_TYPE" in
+    static) network_url="https://icp0.io" ;;
+    api) network_url="https://icp-api.io" ;; # Note: The canister ID is NOT provided as a subdomain and no web assets are served.
+    esac
+  fi
+  test -n "${network_url:-}" || network_url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' || true)"
+  test -n "${network_url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || network_url="http://localhost:8080"
+  test -n "${network_url}" || network_url="https://${DFX_NETWORK}.testnet.dfinity.network"
+  echo "${network_url:-}" | head -n1
+}
 
-# ... The network may be local
-test -n "${url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || url="$(echo "http://localhost:8080" | inject_canister_id)"
+canister_url() {
+  local url
+  # Some canisters have custom URLs, such as identity.ic0.app.
+  if [[ "${DFX_URL_TYPE:-}" == "static" ]]; then
+    key="${DFX_RAW:+raw_}url"
+    url="$(k="$key" jq -r '.canisters[env.DFX_CANISTER][env.k][env.DFX_NETWORK] // ""' dfx.json)"
+  else
+    url=""
+  fi
+  test -n "${url}" || url="$(network_url | inject_canister_id)"
+  echo "${url:-}"
+}
 
-# Last try:  Assume the network is a testnet.
-test -n "$url" || url="$(echo "https://${DFX_NETWORK}.testnet.dfinity.network" | inject_canister_id)"
+if test -n "${DFX_CANISTER:-}"; then
+  url="$(canister_url)"
+else
+  url="$(network_url)"
+fi
 
+# What to do with our hard won information.
 if [[ "${DFX_OPEN:-}" == "true" ]]; then
   command=xdg-open                                  # Uses Linux default browser
   command -v "$command" &>/dev/null || command=open # Uses mac default browser


### PR DESCRIPTION
# Motivation
Storing network configuration in dfx.json is deprecated.  Removing the network config from dfx.json requires, among other things, using the standard logic for how to calculate URLs.

# Changes
- Update `dfx-canister-url` to the latest version.  This is a command that gets URLs using the current IC policies.
- Compute URLs in the nns-dapp config using `dfx-canister-url`.
- Update the dockerfile to include `dfx-canister-url` where needed.

# Tests
- CI should check that the parameters have not changed for mainnet, and work for localhost.
- I checked manually that the config is unchanged for `benchmarklarge`.  I used the following one-liner but it's probably not very easy to follow.  The steps are:
  - On the feature branch and on main, set canister IDs as if all the canisters had been deployed.
  - Compute the config in both branches
  - Compare the configs and verify that they are the same.
```
network=benchmarklarge && for canister_name in tvl nns-dapp sns_aggregator ckbtc_ledger ckbtc_minter ckbtc_index internet_identity ; do  ( canister_id="$(cd ../../ && dfx canister id --network mainnet "$canister_name" || echo rdmx6-jaaaa-aaaaa-aaadq-cai)" ; for dir in . ../.. ; do pushd "$dir" ; dfx-canister-set-id --canister_id "$canister_id" --canister_name "$canister_name" --network "$network" ; DFX_NETWORK="$network" ./config.sh && mv deployment-config.json "network_configs/$network.json" ; popd ; done ) ; done && diff ../../network_configs/$network.json network_configs/$network.json
```