### PR TITLE
GIX-1637: Show Vesting Period in SNS Neuron

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -26,6 +26,7 @@
   import SplitSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import SnsNeuronVestingPeriodRemaining from "./SnsNeuronVestingPeriodRemaining.svelte";
 
   export let parameters: SnsNervousSystemParameters;
   export let token: Token;
@@ -81,6 +82,8 @@
       <SnsNeuronAge {neuron} />
 
       <SnsNeuronStateRemainingTime {neuron} inline={false} />
+
+      <SnsNeuronVestingPeriodRemaining {neuron} />
 
       <div class="buttons">
         {#if allowedToSplit}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVestingPeriodRemaining.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVestingPeriodRemaining.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { SnsNeuron } from "@dfinity/sns";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import { KeyValuePair } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { secondsToDuration } from "$lib/utils/date.utils";
+  import { isVesting, vestingInSeconds } from "$lib/utils/sns-neuron.utils";
+
+  export let neuron: SnsNeuron;
+</script>
+
+<TestIdWrapper testId="sns-vesting-period-remaining-component">
+  {#if isVesting(neuron)}
+    <KeyValuePair testId="sns-neuron-vesting-period">
+      <span class="label" slot="key">{$i18n.neurons.vestion_period}</span>
+      <span class="value" slot="value">
+        {secondsToDuration(vestingInSeconds(neuron))}
+      </span>
+    </KeyValuePair>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -286,6 +286,7 @@
     "inline_remaining": "$duration remaining",
     "remaining": "Remaining",
     "age": "Age",
+    "vestion_period": "Remaining vesting period",
     "aria_label_neuron_card": "Go to neuron details",
     "neuron_id": "Neuron ID",
     "neuron_balance": "Balance",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -296,6 +296,7 @@ interface I18nNeurons {
   inline_remaining: string;
   remaining: string;
   age: string;
+  vestion_period: string;
   aria_label_neuron_card: string;
   neuron_id: string;
   neuron_balance: string;

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -842,3 +842,32 @@ export const snsNeuronsToIneligibleNeuronData = ({
       identity,
     }),
   }));
+
+/**
+ * Returns whether the neuron is still vesting.
+ */
+export const isVesting = ({
+  created_timestamp_seconds,
+  vesting_period_seconds,
+}: SnsNeuron): boolean =>
+  nowInSeconds() <
+  Number(created_timestamp_seconds) +
+    Number(fromNullable(vesting_period_seconds) ?? 0n);
+
+/**
+ * Returns how long until the vesting period ends in seconds.
+ *
+ * If the vesting period has ended, returns 0.
+ */
+export const vestingInSeconds = ({
+  created_timestamp_seconds,
+  vesting_period_seconds,
+}: SnsNeuron): bigint =>
+  BigInt(
+    Math.max(
+      Number(created_timestamp_seconds) +
+        Number(fromNullable(vesting_period_seconds) ?? 0n) -
+        nowInSeconds(),
+      0
+    )
+  );

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -844,17 +844,6 @@ export const snsNeuronsToIneligibleNeuronData = ({
   }));
 
 /**
- * Returns whether the neuron is still vesting.
- */
-export const isVesting = ({
-  created_timestamp_seconds,
-  vesting_period_seconds,
-}: SnsNeuron): boolean =>
-  nowInSeconds() <
-  Number(created_timestamp_seconds) +
-    Number(fromNullable(vesting_period_seconds) ?? 0n);
-
-/**
  * Returns how long until the vesting period ends in seconds.
  *
  * If the vesting period has ended, returns 0.
@@ -871,3 +860,9 @@ export const vestingInSeconds = ({
       0
     )
   );
+
+/**
+ * Returns whether the neuron is still vesting.
+ */
+export const isVesting = (neuron: SnsNeuron): boolean =>
+  vestingInSeconds(neuron) > 0n;

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsNeuronMetaInfoCard from "$lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte";
-import { SECONDS_IN_MONTH } from "$lib/constants/constants";
+import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { dispatchIntersecting } from "$lib/directives/intersection.directives";
 import { authStore } from "$lib/stores/auth.store";
@@ -99,6 +99,23 @@ describe("SnsNeuronMetaInfoCard", () => {
     const { queryByTestId } = renderSnsNeuronCmp();
 
     expect(queryByTestId("split-neuron-button")).toBeNull();
+  });
+
+  it("should render vesting period if neuron still vesting", async () => {
+    const yesterday = BigInt(nowSeconds - SECONDS_IN_DAY);
+    const neuronWithPositiveAge: SnsNeuron = {
+      ...mockSnsNeuron,
+      created_timestamp_seconds: yesterday,
+      vesting_period_seconds: [BigInt(SECONDS_IN_MONTH)],
+    };
+
+    const { container } = renderSnsNeuronCmp([], neuronWithPositiveAge);
+
+    const po = SnsNeuronMetaInfoCardPo.under(
+      new JestPageObjectElement(container)
+    );
+
+    expect(await po.getVestingPeriod()).toBe("29 days, 10 hours");
   });
 
   it("should render neuron age if greater than 0", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVestingPeriodRemaining.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVestingPeriodRemaining.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronVestingPeriodRemaining from "$lib/components/sns-neuron-detail/SnsNeuronVestingPeriodRemaining.svelte";
+import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SnsNeuronVestingPeriodRemaining", () => {
+  const now = 1686806749421;
+  const nowSeconds = Math.floor(now / 1000);
+  const yesterday = BigInt(nowSeconds - SECONDS_IN_DAY);
+  const monthAgo = BigInt(nowSeconds - SECONDS_IN_MONTH);
+  const oneWeek = BigInt(SECONDS_IN_DAY * 7);
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(now);
+  });
+
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(SnsNeuronVestingPeriodRemaining, {
+      props: { neuron },
+    });
+
+    return SnsNeuronVestingPeriodRemainingPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render vesting period if still vesting", async () => {
+    const neuronVesting: SnsNeuron = {
+      ...mockSnsNeuron,
+      created_timestamp_seconds: yesterday,
+      vesting_period_seconds: [BigInt(SECONDS_IN_MONTH)],
+    };
+
+    const po = renderComponent(neuronVesting);
+
+    expect(await po.getVestingPeriod()).toBe("29 days, 10 hours");
+  });
+
+  it("should not render vesting period if no vesting value", async () => {
+    const neuronNoVesting: SnsNeuron = {
+      ...mockSnsNeuron,
+      created_timestamp_seconds: yesterday,
+      vesting_period_seconds: [],
+    };
+
+    const po = renderComponent(neuronNoVesting);
+
+    expect(await po.vestingPeriodIsPresent()).toBe(false);
+  });
+
+  it("should not render vesting period if vesting passed", async () => {
+    const neuronFinishedVesting: SnsNeuron = {
+      ...mockSnsNeuron,
+      created_timestamp_seconds: monthAgo,
+      vesting_period_seconds: [oneWeek],
+    };
+
+    const po = renderComponent(neuronFinishedVesting);
+
+    expect(await po.vestingPeriodIsPresent()).toBe(false);
+  });
+});

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -1,6 +1,7 @@
 import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsNeuronVestingPeriodRemainingPo } from "./SnsNeuronVestingPeriodRemaining.page-object";
 
 export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-meta-info-card-component";
@@ -21,5 +22,17 @@ export class SnsNeuronMetaInfoCardPo extends BasePageObject {
 
   hasNeuronAge(): Promise<boolean> {
     return this.getNeuronAgePo().ageIsPresent();
+  }
+
+  getVestingPeriodPo(): SnsNeuronVestingPeriodRemainingPo {
+    return SnsNeuronVestingPeriodRemainingPo.under(this.root);
+  }
+
+  getVestingPeriod(): Promise<string> {
+    return this.getVestingPeriodPo().getVestingPeriod();
+  }
+
+  hasVestingPeriod(): Promise<boolean> {
+    return this.getVestingPeriodPo().vestingPeriodIsPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -1,7 +1,7 @@
 import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
+import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsNeuronVestingPeriodRemainingPo } from "./SnsNeuronVestingPeriodRemaining.page-object";
 
 export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-meta-info-card-component";

--- a/frontend/src/tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object.ts
@@ -1,0 +1,28 @@
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsNeuronVestingPeriodRemainingPo extends BasePageObject {
+  static readonly TID = "sns-vesting-period-remaining-component";
+
+  static under(element: PageObjectElement): SnsNeuronVestingPeriodRemainingPo {
+    return new SnsNeuronVestingPeriodRemainingPo(
+      element.byTestId(SnsNeuronVestingPeriodRemainingPo.TID)
+    );
+  }
+
+  getKeyValuePairPo(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "sns-neuron-vesting-period",
+    });
+  }
+
+  getVestingPeriod(): Promise<string> {
+    return this.getKeyValuePairPo().getValueText();
+  }
+
+  vestingPeriodIsPresent(): Promise<boolean> {
+    return this.getKeyValuePairPo().isPresent();
+  }
+}


### PR DESCRIPTION
# Motivation

SNS neurons for developers might have a vesting period. During this vesting period, the functionality of the neuron is limited.

Therefore, the UI should tell the user how long is until the neuron will have it's full capability.

The UI might change. Product is looking into it but it shouldn't be very different. We can change after releasing the feature if needed.

# Changes

* New SnsNeuronVestingPeriodRemaining to render the vesting period if still active.
* Use the new component in the SnsNeuronMetaInfoCard.
* New sns neuron utils `isVesting` and `vestingInSeconds`.

# Tests

* Test the new component SnsNeuronVestingPeriodRemaining
* Add a test case in SnsNeuronMetaInfoCard
* Test new sns neuron utils.
