### PR TITLE
GIX-1642: Hide unavailable buttons when vesting

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -15,6 +15,7 @@
     hasPermissionToDisburse,
     hasPermissionToDissolve,
     isCommunityFund,
+    isVesting,
   } from "$lib/utils/sns-neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { NeuronState } from "@dfinity/nns";
@@ -39,7 +40,8 @@
     hasPermissionToDissolve({
       neuron,
       identity: $authStore.identity,
-    });
+    }) &&
+    !isVesting(neuron);
 
   let allowedToDisburse: boolean;
   $: allowedToDisburse =
@@ -47,7 +49,8 @@
     hasPermissionToDisburse({
       neuron,
       identity: $authStore.identity,
-    });
+    }) &&
+    !isVesting(neuron);
 
   let canDissolve = false;
   $: canDissolve =

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -9,6 +9,7 @@
     getSnsNeuronIdAsHexString,
     getSnsNeuronState,
     hasPermissionToSplit,
+    isVesting,
   } from "$lib/utils/sns-neuron.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import type { E8s, NeuronState, Token } from "@dfinity/nns";
@@ -47,7 +48,8 @@
     hasPermissionToSplit({
       neuron,
       identity: $authStore.identity,
-    });
+    }) &&
+    !isVesting(neuron);
 
   const updateLayoutTitle = ($event: Event) => {
     const {
@@ -68,7 +70,7 @@
 
 <TestIdWrapper testId="sns-neuron-meta-info-card-component">
   {#if nonNullish(neuron) && nonNullish(neuronState)}
-    <div class="content-cell-details">
+    <div class="content-cell-details" data-tid="sns-neuron-meta-info-content">
       <KeyValuePair>
         <SnsNeuronCardTitle
           tagName="h3"

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -1,5 +1,11 @@
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_HOUR,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
 import type { ProjectNeuronStore } from "$lib/stores/sns-neurons.store";
 import type { SnsParameters } from "$lib/stores/sns-parameters.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";
 import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -8,6 +14,7 @@ import {
   type SnsNervousSystemParameters,
   type SnsNeuron,
 } from "@dfinity/sns";
+import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 import { mockIdentity } from "./auth.store.mock";
@@ -19,42 +26,58 @@ export const createMockSnsNeuron = ({
   stake = BigInt(1_000_000_000),
   id,
   state,
+  permissions = [],
+  vesting,
 }: {
   stake?: bigint;
   id: number[];
   state?: NeuronState;
-}): SnsNeuron => ({
-  id: [{ id: arrayOfNumberToUint8Array(id) }],
-  permissions: [],
-  source_nns_neuron_id: [],
-  maturity_e8s_equivalent: BigInt(1),
-  cached_neuron_stake_e8s: stake,
-  created_timestamp_seconds: BigInt(
-    Math.floor(Date.now() / 1000 - mockSnsNeuronTimestampSeconds)
-  ),
-  staked_maturity_e8s_equivalent: [BigInt(2)],
-  auto_stake_maturity: [],
-  aging_since_timestamp_seconds: BigInt(100),
-  voting_power_percentage_multiplier: BigInt(1),
-  dissolve_state:
-    state === undefined
-      ? []
-      : [
-          state === NeuronState.Dissolving
-            ? {
-                WhenDissolvedTimestampSeconds: BigInt(
-                  Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
-                ),
-              }
-            : {
-                DissolveDelaySeconds: BigInt(Math.floor(3600 * 24 * 365 * 2)),
-              },
-        ],
-  followees: [],
-  neuron_fees_e8s: BigInt(0),
-  vesting_period_seconds: [],
-  disburse_maturity_in_progress: [],
-});
+  permissions?: NeuronPermission[];
+  // `undefined` means no vesting at all (default)
+  // `true` means is still vesting
+  // `false` means vesting period has passed
+  vesting?: boolean;
+}): SnsNeuron => {
+  // Neurons are in Locked state if vesting
+  if (vesting) {
+    state = NeuronState.Locked;
+  }
+  return {
+    id: [{ id: arrayOfNumberToUint8Array(id) }],
+    permissions,
+    source_nns_neuron_id: [],
+    maturity_e8s_equivalent: BigInt(1),
+    cached_neuron_stake_e8s: stake,
+    created_timestamp_seconds: BigInt(nowInSeconds() - SECONDS_IN_DAY),
+    staked_maturity_e8s_equivalent: [BigInt(2)],
+    auto_stake_maturity: [],
+    aging_since_timestamp_seconds: BigInt(100),
+    voting_power_percentage_multiplier: BigInt(1),
+    dissolve_state:
+      state === undefined
+        ? []
+        : [
+            state === NeuronState.Dissolving
+              ? {
+                  WhenDissolvedTimestampSeconds: BigInt(
+                    Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
+                  ),
+                }
+              : {
+                  DissolveDelaySeconds: BigInt(Math.floor(3600 * 24 * 365 * 2)),
+                },
+          ],
+    followees: [],
+    neuron_fees_e8s: BigInt(0),
+    vesting_period_seconds:
+      vesting === undefined
+        ? []
+        : vesting
+        ? [BigInt(SECONDS_IN_MONTH)]
+        : [BigInt(SECONDS_IN_HOUR)],
+    disburse_maturity_in_progress: [],
+  };
+};
 
 export const mockSnsNeuronId = {
   id: arrayOfNumberToUint8Array([1, 5, 3, 9, 9, 3, 2]),

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -2,6 +2,7 @@ import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ButtonPo } from "./Button.page-object";
 
 export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-meta-info-card-component";
@@ -10,6 +11,21 @@ export class SnsNeuronMetaInfoCardPo extends BasePageObject {
     return new SnsNeuronMetaInfoCardPo(
       element.byTestId(SnsNeuronMetaInfoCardPo.TID)
     );
+  }
+
+  isContentLoaded(): Promise<boolean> {
+    return this.root.byTestId("sns-neuron-meta-info-content").isPresent();
+  }
+
+  getSplitButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "split-neuron-button",
+    });
+  }
+
+  hasSplitButton(): Promise<boolean> {
+    return this.getSplitButtonPo().isPresent();
   }
 
   getNeuronAgePo(): SnsNeuronAgePo {

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -1,8 +1,8 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
 
 export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   static readonly TID = "sns-neuron-meta-info-card-component";


### PR DESCRIPTION
# Motivation

SNS neurons for developers might have a vesting period. During this vesting period, the functionality of the neuron is limited.

UI should not show unavailable functionality. Therefore, the following buttons are hidden during the vesting period:
* Increase Dissolve Delay
* Start or Stop Dissolving
* Disburse
* Split

# Changes

* In `SnsNeuronInfoStake` use `isVesting` for `allowedToDissolve` and `allowedToDisburse`.
* In `SnsNeuronMetaInfoCard` use `isVesting` for `allowedToSplit`.

# Tests

* Extend `createMockSnsNeuron` to return neuron with vesting configuration.
* Extend `SnsNeuronMetaInfoCardPo` to check the Split button.
* Add test case for the hidden buttons during vesting in `SnsNeuronInfoStake`.
* Add test case for the hidden buttons during vesting in `SnsNeuronMetaInfoCard`.
