### PR TITLE
Script to download wasm from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator_dev
-      - name: Test download CI wasm
-        run: |
-          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
-          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT" --expected-wasm nns-dapp.wasm.gz
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
@@ -142,6 +138,12 @@ jobs:
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Test download CI wasm
+        run: |
+          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
+          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Install command line HTML parser
         run: |
           go install github.com/ericchiang/pup@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,12 +138,6 @@ jobs:
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Test download CI wasm
-        run: |
-          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
-          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
-        env:
-          GH_TOKEN: ${{ github.token }}
       - name: Install command line HTML parser
         run: |
           go install github.com/ericchiang/pup@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sns_aggregator_dev
+      - name: Test download CI wasm
+        run: scripts/nns-dapp-download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,10 @@ jobs:
         with:
           name: sns_aggregator_dev
       - name: Test download CI wasm
-        run: scripts/nns-dapp/download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
+        run: |
+          git remote -v
+          git fetch origin main
+          scripts/nns-dapp/download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,9 +128,8 @@ jobs:
           name: sns_aggregator_dev
       - name: Test download CI wasm
         run: |
-          git remote -v
-          git fetch origin main
-          scripts/nns-dapp/download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
+          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
+          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT" --expected-wasm nns-dapp.wasm.gz
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           name: sns_aggregator_dev
       - name: Test download CI wasm
-        run: scripts/nns-dapp-download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
+        run: scripts/nns-dapp/download-ci-wasm.test --commit main --expected-wasm nns-dapp.wasm.gz
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -268,6 +268,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: docker-build prints help
         run: ./scripts/docker-build --help | grep -i usage
+  download-nns-dapp-ci-wasm:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download NNS-dapp CI wasm
+        run: |
+          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
+          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
+    env:
+      GH_TOKEN: ${{ github.token }}
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "mainnet-config-stability-test", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags"]
     if: ${{ always() }}

--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -40,7 +40,7 @@ if ! [ "$docker_build_run_id" ]; then
 fi
 
 tmp_dir="$(mktemp -d)"
-trap "rm -rf $tmp_dir" EXIT
+trap 'rm -rf $tmp_dir' EXIT
 gh run download "$docker_build_run_id" --dir "$tmp_dir"
 
 mkdir -p "$OUTPUT_DIR"
@@ -49,7 +49,7 @@ src_wasm_file="$(find "$tmp_dir" -name "$WASM_FILENAME")"
 
 if ! [ "$src_wasm_file" ]; then
   echo "No $WASM_FILENAME found in $tmp_dir" >&2
-  trap "echo Leaving $tmp_dir for debugging" EXIT
+  trap 'echo Leaving $tmp_dir for debugging' EXIT
   exit 1
 fi
 

--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+DEFAULT_WASM_FILENAME="nns-dapp.wasm"
+
+print_help() {
+  cat <<-EOF
+
+  Downloads the $DEFAULT_WASM_FILENAME for the given commit from GitHub CI.
+
+	EOF
+}
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=c long=commit desc="Commit to download wasm for" variable=COMMIT default="tags/release-candidate"
+clap.define short=d long=dir desc="Directory to put the wasm in" variable=OUTPUT_DIR default="$TOP_DIR/release/ci"
+clap.define short=l long=limit desc="--limit passed to gh run list" variable=LIMIT default="200"
+clap.define short=w long=wasm-filename desc="The name of the WASM file in the
+download" variable=WASM_FILENAME default="$DEFAULT_WASM_FILENAME"
+
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+COMMIT="$(git rev-parse "$COMMIT")"
+
+docker_build_run_id="$(gh run list --workflow "Docker build" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
+
+if ! [ "$docker_build_run_id" ]; then
+  (
+    echo "No successful Docker build run found for commit $COMMIT."
+    echo "If the commit is too new, the run may not have finished yet."
+    echo "If the commit is too old, increasing --limit (was $LIMIT) may help."
+  ) >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap "rm -rf $tmp_dir" EXIT
+gh run download "$docker_build_run_id" --dir "$tmp_dir"
+
+mkdir -p "$OUTPUT_DIR"
+dst_wasm_file="$OUTPUT_DIR/$WASM_FILENAME"
+src_wasm_file="$(find "$tmp_dir" -name "$WASM_FILENAME")"
+
+if ! [ "$src_wasm_file" ]; then
+  echo "No $WASM_FILENAME found in $tmp_dir" >&2
+  trap "echo Leaving $tmp_dir for debugging" EXIT
+  exit 1
+fi
+
+mv "$src_wasm_file" "$dst_wasm_file"
+
+sha256sum "$dst_wasm_file"

--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-DEFAULT_WASM_FILENAME="nns-dapp.wasm"
+DEFAULT_WASM_FILENAME="nns-dapp.wasm.gz"
+ARTIFACT_WORKFLOW="Build and test"
 
 print_help() {
   cat <<-EOF
@@ -28,7 +29,7 @@ source "$(clap.build)"
 
 COMMIT="$(git rev-parse "$COMMIT")"
 
-docker_build_run_id="$(gh run list --workflow "Docker build" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
+docker_build_run_id="$(gh run list --workflow "$ARTIFACT_WORKFLOW" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
 
 if ! [ "$docker_build_run_id" ]; then
   (
@@ -45,7 +46,7 @@ gh run download "$docker_build_run_id" --dir "$tmp_dir"
 
 mkdir -p "$OUTPUT_DIR"
 dst_wasm_file="$OUTPUT_DIR/$WASM_FILENAME"
-src_wasm_file="$(find "$tmp_dir" -name "$WASM_FILENAME")"
+src_wasm_file="$(find "$tmp_dir" -name "$WASM_FILENAME" | head -1)"
 
 if ! [ "$src_wasm_file" ]; then
   echo "No $WASM_FILENAME found in $tmp_dir" >&2

--- a/scripts/nns-dapp/download-ci-wasm.test
+++ b/scripts/nns-dapp/download-ci-wasm.test
@@ -7,7 +7,8 @@ WASM_FILENAME="nns-dapp.wasm.gz"
 print_help() {
   cat <<-EOF
 
-  Test scripts/nns-dapp/download-ci-wasm
+  Test that scripts/nns-dapp/download-ci-wasm downloads what appears to be a
+  gzipped nns-dapp wasm file.
 
 	EOF
 }
@@ -16,7 +17,6 @@ print_help() {
 source "$SOURCE_DIR/../clap.bash"
 # Define options
 clap.define short=c long=commit desc="Commit to download wasm for" variable=COMMIT default="main"
-clap.define short=w long=expected-wasm desc="Expected wasm for comparison" variable=EXPECTED_WASM_FILE default="./$WASM_FILENAME"
 
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
@@ -26,8 +26,10 @@ COMMIT="$(git rev-parse "$COMMIT")"
 tmp_dir="$(mktemp -d)"
 "$SOURCE_DIR/download-ci-wasm" --commit "$COMMIT" --dir "$tmp_dir"
 
-if ! diff "$EXPECTED_WASM_FILE" "$tmp_dir/$WASM_FILENAME"; then
+if ! wasm-nm -je <(gunzip <tmp/nns-dapp.wasm.gz) | grep get_account; then
+  echo "ERROR: Downloaded file is not an nns-dapp wasm file"
   exit 1
 fi
 
-echo "SUCCESS: Correct wasm was downloaded"
+echo "PASSED"
+rm -rf "$tmp_dir"

--- a/scripts/nns-dapp/download-ci-wasm.test
+++ b/scripts/nns-dapp/download-ci-wasm.test
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+WASM_FILENAME="nns-dapp.wasm.gz"
+
+print_help() {
+  cat <<-EOF
+
+  Test scripts/nns-dapp/download-ci-wasm
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=c long=commit desc="Commit to download wasm for" variable=COMMIT default="main"
+clap.define short=w long=expected-wasm desc="Expected wasm for comparison" variable=EXPECTED_WASM_FILE default="./$WASM_FILENAME"
+
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+COMMIT="$(git rev-parse "$COMMIT")"
+
+tmp_dir="$(mktemp -d)"
+"$SOURCE_DIR/download-ci-wasm" --commit "$COMMIT" --dir "$tmp_dir"
+
+if ! diff "$EXPECTED_WASM_FILE" "$tmp_dir/$WASM_FILENAME"; then
+  exit 1
+fi
+
+echo "SUCCESS: Correct wasm was downloaded"

--- a/scripts/nns-dapp/download-ci-wasm.test
+++ b/scripts/nns-dapp/download-ci-wasm.test
@@ -26,8 +26,8 @@ COMMIT="$(git rev-parse "$COMMIT")"
 tmp_dir="$(mktemp -d)"
 "$SOURCE_DIR/download-ci-wasm" --commit "$COMMIT" --dir "$tmp_dir"
 
-if ! wasm-nm -je <(gunzip <tmp/nns-dapp.wasm.gz) | grep get_account; then
-  echo "ERROR: Downloaded file is not an nns-dapp wasm file"
+if ! file "$tmp_dir/$WASM_FILENAME" | grep gzip; then
+  echo "ERROR: Downloaded file is not a gzipped file" >&2
   exit 1
 fi
 


### PR DESCRIPTION
# Motivation

We want to make the release a less manual process.
One of the steps in the release process is to download the WASM from CI.

# Changes

Add a script to download the nns-dapp WASM from CI.

# Tests

Ran the script, also with wrong commit and wrong filename to exercise the error code paths.

Added a test which checks that the downloaded file is a gzip file.
