### PR TITLE
Fix args verification in release template

### DIFF
--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -51,6 +51,17 @@ git checkout "$(git rev-parse tags/release-candidate)"
 ./scripts/docker-build
 sha256sum nns-dapp.wasm
 \`\`\`
+
+## Arguments Verification
+
+\`\`\`
+git fetch  # to ensure you have the latest changes.
+git checkout "$(git rev-parse tags/release-candidate)"
+DFX_NETWORK=${DFX_NETWORK} ./config.sh
+didc encode "\$(cat nns-dapp-arg-mainnet.did)"
+\`\`\`
+
+Compare the output with the \`arg_hex\` field below.
 EOF
 
 cat <<EOF >release/ROLLBACK.md
@@ -68,13 +79,16 @@ git checkout "$(git rev-parse tags/release-candidate)"
 sha256sum nns-dapp.wasm
 \`\`\`
 
-You may also want to verify the canister arguments.  In the proposal they are binary, which is not very readable. Docker
-provides both binary and text formats and you can verify that the text format corresponds to the binary in the proposal.
+## Arguments Verification
 
 \`\`\`
-sha256sum nns-dapp-arg-${DFX_NETWORK}.bin
-didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p | sha256sum
+git fetch  # to ensure you have the latest changes.
+git checkout "$(git rev-parse tags/release-candidate)"
+DFX_NETWORK=${DFX_NETWORK} ./config.sh
+didc encode "\$(cat nns-dapp-arg-mainnet.did)"
 \`\`\`
+
+Compare the output with the \`arg_hex\` field below.
 EOF
 
 ./config.sh

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -52,16 +52,15 @@ git checkout "$(git rev-parse tags/release-candidate)"
 sha256sum nns-dapp.wasm
 \`\`\`
 
-## Arguments Verification
+You may also want to verify the canister arguments.  In the proposal they are
+binary, which is not very readable. Docker provides both binary and text formats
+and you can verify that the text format corresponds to the binary \`arg_hex\`
+field in the proposal.
 
 \`\`\`
-git fetch  # to ensure you have the latest changes.
-git checkout "$(git rev-parse tags/release-candidate)"
-DFX_NETWORK=${DFX_NETWORK} ./config.sh
-didc encode "\$(cat nns-dapp-arg-mainnet.did)"
+cat nns-dapp-arg-${DFX_NETWORK}.did
+didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
 \`\`\`
-
-Compare the output with the \`arg_hex\` field below.
 EOF
 
 cat <<EOF >release/ROLLBACK.md
@@ -79,16 +78,15 @@ git checkout "$(git rev-parse tags/release-candidate)"
 sha256sum nns-dapp.wasm
 \`\`\`
 
-## Arguments Verification
+You may also want to verify the canister arguments.  In the proposal they are
+binary, which is not very readable. Docker provides both binary and text formats
+and you can verify that the text format corresponds to the binary \`arg_hex\`
+field in the proposal.
 
 \`\`\`
-git fetch  # to ensure you have the latest changes.
-git checkout "$(git rev-parse tags/release-candidate)"
-DFX_NETWORK=${DFX_NETWORK} ./config.sh
-didc encode "\$(cat nns-dapp-arg-mainnet.did)"
+cat nns-dapp-arg-${DFX_NETWORK}.did
+didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
 \`\`\`
-
-Compare the output with the \`arg_hex\` field below.
 EOF
 
 ./config.sh


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/2236 intended to add arguments verification instructions to the proposal template but it actually only added them to the rollback proposal template.

Also the instructions there suggest to check the sha256sum but the proposal payload contains the binary hex so I think it makes more sense to provide instructions to output that because that's what can actually be compared to the proposal payload, as displayed on the dashboard, for example.

# Changes

1. Change the instructions to output binary hex.
2. Copy the same instructions from `ROLLBACK.md` to `PROPOSAL.md`
3. For convenience, mention the `arg_hex` field in the proposal payload to compare to.

# Tests

Ran `scripts/nns-dapp/release-template` and checked the sections in `PROPOSAL.md`:
````
You may also want to verify the canister arguments.  In the proposal they are
binary, which is not very readable. Docker provides both binary and text formats
and you can verify that the text format corresponds to the binary `arg_hex`
field in the proposal.

```
cat nns-dapp-arg-mainnet.did
didc encode "$(cat nns-dapp-arg-mainnet.did)"
```
````
and `ROLLBACK.md`:
````
You may also want to verify the canister arguments.  In the proposal they are
binary, which is not very readable. Docker provides both binary and text formats
and you can verify that the text format corresponds to the binary `arg_hex`
field in the proposal.

```
cat nns-dapp-arg-mainnet.did
didc encode "$(cat nns-dapp-arg-mainnet.did)"
```