### PR TITLE
Build Web Workers ESM

### DIFF
--- a/frontend/src/lib/worker-api/canisters.worker-api.ts
+++ b/frontend/src/lib/worker-api/canisters.worker-api.ts
@@ -4,11 +4,8 @@ import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
 import type { CanisterActorParams } from "$lib/types/worker";
 import { mapCanisterId } from "$lib/utils/canisters.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import {
-  HttpAgentWorker,
-  getManagementCanisterWorker,
-} from "$lib/worker-utils/canister.worker-utils";
 import type { ManagementCanisterRecord } from "@dfinity/agent";
+import { getManagementCanister, HttpAgent } from "@dfinity/agent";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
 
 export const queryCanisterDetails = async ({
@@ -49,7 +46,7 @@ const canisters = async ({
 }: CanisterActorParams): Promise<{
   icMgtService: ManagementCanisterRecord;
 }> => {
-  const agent = new HttpAgentWorker({
+  const agent = new HttpAgent({
     identity,
     host,
   });
@@ -58,7 +55,7 @@ const canisters = async ({
     await agent.fetchRootKey();
   }
 
-  const icMgtService = getManagementCanisterWorker({ agent });
+  const icMgtService = getManagementCanister({ agent });
 
   return { icMgtService };
 };

--- a/frontend/src/lib/worker-utils/canister.worker-utils.ts
+++ b/frontend/src/lib/worker-utils/canister.worker-utils.ts
@@ -1,14 +1,6 @@
 import type { CanisterId } from "$lib/types/canister";
 import type { CanisterActorParams } from "$lib/types/worker";
-/**
- * HTTP-Agent explicit CJS import for compatibility with web worker - avoid Error [RollupError]: Unexpected token (Note that you need plugins to import files that are not JavaScript)
- */
-import { HttpAgent, getManagementCanister } from "@dfinity/agent/lib/cjs/index";
-
-export {
-  HttpAgent as HttpAgentWorker,
-  getManagementCanister as getManagementCanisterWorker,
-};
+import { HttpAgent } from "@dfinity/agent";
 
 export interface CreateCanisterWorkerParams {
   canisterId: CanisterId;

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -4,7 +4,7 @@ import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
 
-jest.mock("@dfinity/agent/lib/cjs/index");
+jest.mock("@dfinity/agent");
 
 describe("canisters-worker-api", () => {
   const response: CanisterStatusResponse = {
@@ -24,7 +24,7 @@ describe("canisters-worker-api", () => {
 
   beforeEach(async () => {
     jest.resetAllMocks();
-    const module = await import("@dfinity/agent/lib/cjs/index");
+    const module = await import("@dfinity/agent");
     module.HttpAgent = MockHttpAgent;
     module.getManagementCanister = jest.fn().mockReturnValue({
       canister_status: async () => response,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -109,6 +109,9 @@ const config: UserConfig = {
       },
     },
   },
+  worker: {
+    format: "es",
+  },
 };
 
 export default config;


### PR DESCRIPTION
# Motivation

Web Workers ES modules are required to build easily  #2639 and are now supported by all browsers.

# Changes

- active ESM for Web Workers
- drop explicit usage of agent-js CJS
