### PR TITLE
Bump ic-js and gix-cmp for semver

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.7-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-22.1.tgz",
-      "integrity": "sha512-Nrvqc77cLCWG+HiFp7yBrnpNNHgIWQkkQ/39H3Xn6MR3NyQQXULWBljFzLBZ/AgPzyvhxxXHnWF818Qb71zOoA==",
+      "version": "0.0.7-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-26.1.tgz",
+      "integrity": "sha512-My7ie9ytRmhxT4Y8WzAINiaz6xpueH8rUTHYrMlOc9FiGLOq3aunC/n8dXtiJR+Zc/gdW85aRdW3Yzvb5E9vEg==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.14-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-22.1.tgz",
-      "integrity": "sha512-RGPhO/cdSHdMtjLFjNNxeOUUkmmmv621Rn79gmGm1wegxjavlkUOnvKCzDUTTGEqGUQVCqzbj1ynWH4jxx8+fQ==",
+      "version": "0.0.14-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-26.1.tgz",
+      "integrity": "sha512-ZLhZheb9nfTL4NBTJv1TWXj16H4ROzBfNb0SHwdf3FKSgPNhrLkYw41QkFXLFJ638GBxbuxkuicFL8UkooMmZg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-06",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-06.tgz",
-      "integrity": "sha512-vSeq/EB84BkigV+gusPQrIhnN28Mjo/Etx2jBKSIL5nUdzP9a1R80JWHDeIo6e/tbdVZZhQERQUgk6TPZTrmNA==",
+      "version": "2.6.0-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-26.1.tgz",
+      "integrity": "sha512-JJzsNxTlQ7tGh8DW+0Cl0aSoMIznJrAakhKF5Kh/DXx/FX1+fVfy3xIv5MoFm2THXqziow7pu052PhRhKnLfjA==",
       "dependencies": {
         "dompurify": "^3.0.3",
         "html5-qrcode": "^2.3.8",
@@ -775,9 +775,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.4-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-22.1.tgz",
-      "integrity": "sha512-PyCLIrxdQCyCsFKgVOSJRrBnRmVTogrM4rILFBpN9DkcFTRAD0mY029k8WQqYNRzbd+BRyC+Khlu60GCZvxPrg==",
+      "version": "0.0.4-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-26.1.tgz",
+      "integrity": "sha512-LsFNFmbwSLC0D/YT7GA2cr/s56y34vMi6yDk5NjbIskAS9A8S80PGpJDhzW+7Ed1eC/sxZnvKBrEvYgjeQf/KA==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.11-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-22.1.tgz",
-      "integrity": "sha512-TegXgThdi6RIKndyX0kRNLh3m/PWvJhIXsXdxG7TqyppiaL6pWPQg7Q40R2FgcTYL93fyYwj101z3v8VuKIVHA==",
+      "version": "0.0.11-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-26.1.tgz",
+      "integrity": "sha512-KQc2RoqihUn28BGI7U8tfGyfKj9RAEjH//2XkgnoSsWjgz7I8BVlsfq5vBRc8fERFKJ4wnwFEiGZlNGshwYLzg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.3-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-22.1.tgz",
-      "integrity": "sha512-PfHQHfvqiPvniYY7TDURsWWaf66cZJGHpBEa/eHl3/eRHDY/aMxvCFWCf2cKnrpKTMP78WRWbX1dGNA+KoMNDg==",
+      "version": "0.16.3-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-26.1.tgz",
+      "integrity": "sha512-Wl5ClF/WrF34+wjVhu99JcVzRMP98nT/gdAdigqWDK5eoTQXDHWCD6tuZh+/K0SeheLTa7LzuN8xyRbOyV7MTw==",
       "dependencies": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.4-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-22.1.tgz",
-      "integrity": "sha512-jbLJMDqjMF9n9PInt/fkr7W83TiY9hQIhfOePhCd5j+NXMaPyRvxC+BpLGZhPh0GiAzwzWfcZHaVJpVvpI+wzQ==",
+      "version": "0.0.4-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-26.1.tgz",
+      "integrity": "sha512-bFlfb/WgExruxg73nKLY9SmqDoZkGIl8Ibw+bZZ4F7lW04BNTlD1l4cIYyKFqZn1yxnVIYxCE8uI5D72EtZJtQ==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.18-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-22.1.tgz",
-      "integrity": "sha512-zFH8VvJGSFBlGUwcpBUkPibRIJrbJQ9Gu2Azl/CUWLGvqddFUMks3rjrz4f4s423hidi0kqzecUD52R+MzSMgQ==",
+      "version": "0.0.18-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-26.1.tgz",
+      "integrity": "sha512-USqmaoS/xqWfqhwZMlU3z/wKWJCZw3ROLSUS0fAgD5wqdSj/QUO6r5KqfIiFXhWXPYlR7hm+AoGNobDSU5ProA==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.18-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-22.1.tgz",
-      "integrity": "sha512-Aa+Eu489EJEKa8pusOBbA/0AD3HBBzsGu3FtyQI79J8B26v20qgiMbM6cOUQcnbz6O9fiRoe/y1jVZbh7T1/oA==",
+      "version": "0.0.18-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-26.1.tgz",
+      "integrity": "sha512-soLZBoyLlPTytCFQf8jyztsQUnm3qNn+zMNlN4h9n23xNe3tiCoXwDWmbNN+MqxUQngXhAU2YD/mCeKU1KDX/Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9979,9 +9979,9 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.7-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-22.1.tgz",
-      "integrity": "sha512-Nrvqc77cLCWG+HiFp7yBrnpNNHgIWQkkQ/39H3Xn6MR3NyQQXULWBljFzLBZ/AgPzyvhxxXHnWF818Qb71zOoA==",
+      "version": "0.0.7-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-26.1.tgz",
+      "integrity": "sha512-My7ie9ytRmhxT4Y8WzAINiaz6xpueH8rUTHYrMlOc9FiGLOq3aunC/n8dXtiJR+Zc/gdW85aRdW3Yzvb5E9vEg==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -9989,15 +9989,15 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.14-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-22.1.tgz",
-      "integrity": "sha512-RGPhO/cdSHdMtjLFjNNxeOUUkmmmv621Rn79gmGm1wegxjavlkUOnvKCzDUTTGEqGUQVCqzbj1ynWH4jxx8+fQ==",
+      "version": "0.0.14-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-26.1.tgz",
+      "integrity": "sha512-ZLhZheb9nfTL4NBTJv1TWXj16H4ROzBfNb0SHwdf3FKSgPNhrLkYw41QkFXLFJ638GBxbuxkuicFL8UkooMmZg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-06",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-06.tgz",
-      "integrity": "sha512-vSeq/EB84BkigV+gusPQrIhnN28Mjo/Etx2jBKSIL5nUdzP9a1R80JWHDeIo6e/tbdVZZhQERQUgk6TPZTrmNA==",
+      "version": "2.6.0-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-26.1.tgz",
+      "integrity": "sha512-JJzsNxTlQ7tGh8DW+0Cl0aSoMIznJrAakhKF5Kh/DXx/FX1+fVfy3xIv5MoFm2THXqziow7pu052PhRhKnLfjA==",
       "requires": {
         "dompurify": "^3.0.3",
         "html5-qrcode": "^2.3.8",
@@ -10005,9 +10005,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.4-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-22.1.tgz",
-      "integrity": "sha512-PyCLIrxdQCyCsFKgVOSJRrBnRmVTogrM4rILFBpN9DkcFTRAD0mY029k8WQqYNRzbd+BRyC+Khlu60GCZvxPrg==",
+      "version": "0.0.4-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-26.1.tgz",
+      "integrity": "sha512-LsFNFmbwSLC0D/YT7GA2cr/s56y34vMi6yDk5NjbIskAS9A8S80PGpJDhzW+7Ed1eC/sxZnvKBrEvYgjeQf/KA==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10025,24 +10025,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.11-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-22.1.tgz",
-      "integrity": "sha512-TegXgThdi6RIKndyX0kRNLh3m/PWvJhIXsXdxG7TqyppiaL6pWPQg7Q40R2FgcTYL93fyYwj101z3v8VuKIVHA==",
+      "version": "0.0.11-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-26.1.tgz",
+      "integrity": "sha512-KQc2RoqihUn28BGI7U8tfGyfKj9RAEjH//2XkgnoSsWjgz7I8BVlsfq5vBRc8fERFKJ4wnwFEiGZlNGshwYLzg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.3-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-22.1.tgz",
-      "integrity": "sha512-PfHQHfvqiPvniYY7TDURsWWaf66cZJGHpBEa/eHl3/eRHDY/aMxvCFWCf2cKnrpKTMP78WRWbX1dGNA+KoMNDg==",
+      "version": "0.16.3-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-26.1.tgz",
+      "integrity": "sha512-Wl5ClF/WrF34+wjVhu99JcVzRMP98nT/gdAdigqWDK5eoTQXDHWCD6tuZh+/K0SeheLTa7LzuN8xyRbOyV7MTw==",
       "requires": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.4-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-22.1.tgz",
-      "integrity": "sha512-jbLJMDqjMF9n9PInt/fkr7W83TiY9hQIhfOePhCd5j+NXMaPyRvxC+BpLGZhPh0GiAzwzWfcZHaVJpVvpI+wzQ==",
+      "version": "0.0.4-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-26.1.tgz",
+      "integrity": "sha512-bFlfb/WgExruxg73nKLY9SmqDoZkGIl8Ibw+bZZ4F7lW04BNTlD1l4cIYyKFqZn1yxnVIYxCE8uI5D72EtZJtQ==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10057,17 +10057,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.18-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-22.1.tgz",
-      "integrity": "sha512-zFH8VvJGSFBlGUwcpBUkPibRIJrbJQ9Gu2Azl/CUWLGvqddFUMks3rjrz4f4s423hidi0kqzecUD52R+MzSMgQ==",
+      "version": "0.0.18-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-26.1.tgz",
+      "integrity": "sha512-USqmaoS/xqWfqhwZMlU3z/wKWJCZw3ROLSUS0fAgD5wqdSj/QUO6r5KqfIiFXhWXPYlR7hm+AoGNobDSU5ProA==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.18-next-2023-06-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-22.1.tgz",
-      "integrity": "sha512-Aa+Eu489EJEKa8pusOBbA/0AD3HBBzsGu3FtyQI79J8B26v20qgiMbM6cOUQcnbz6O9fiRoe/y1jVZbh7T1/oA==",
+      "version": "0.0.18-next-2023-06-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-26.1.tgz",
+      "integrity": "sha512-soLZBoyLlPTytCFQf8jyztsQUnm3qNn+zMNlN4h9n23xNe3tiCoXwDWmbNN+MqxUQngXhAU2YD/mCeKU1KDX/Q==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Fix semver vulnerable to Regular Expression Denial of Service [CVE-2022-25883](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw).

# PRs

- [x] https://github.com/dfinity/ic-js/pull/365
- [x] https://github.com/dfinity/gix-components/pull/223

# Changes

- bump ic-js and gix-cmp