### PR TITLE
Get to know Web Workers sync status in UI

### DIFF
--- a/frontend/src/lib/derived/sync.derived.ts
+++ b/frontend/src/lib/derived/sync.derived.ts
@@ -1,0 +1,26 @@
+import {
+  syncStore,
+  type SyncStore,
+  type SyncStoreData,
+} from "$lib/stores/sync.store";
+import type { SyncState } from "$lib/types/sync";
+import { derived } from "svelte/store";
+
+/**
+ * A derived store for the sync status that returns a global status.
+ * If any sync is in error, it returns error. Likewise for progress and idle.
+ */
+export const syncOverallStatusStore = derived<SyncStore, SyncState>(
+  syncStore,
+  ({ transactions, balances }: SyncStoreData) => {
+    if (transactions === "error" || balances === "error") {
+      return "error";
+    }
+
+    if (transactions === "in_progress" || balances === "in_progress") {
+      return "in_progress";
+    }
+
+    return "idle";
+  }
+);

--- a/frontend/src/lib/stores/sync.store.ts
+++ b/frontend/src/lib/stores/sync.store.ts
@@ -1,0 +1,42 @@
+import type { SyncState } from "$lib/types/sync";
+import type { Readable } from "svelte/store";
+import { writable } from "svelte/store";
+
+export type SyncStoreDataKey = "balances" | "transactions";
+
+export type SyncStoreData = Record<SyncStoreDataKey, SyncState>;
+
+export interface SyncStore extends Readable<SyncStoreData> {
+  setState: (data: { key: SyncStoreDataKey; state: SyncState }) => void;
+  reset: () => void;
+}
+
+/**
+ * A store that holds the current status of the synchronization status of the jobs performed in Web Workers.
+ */
+const initSyncStore = (): SyncStore => {
+  const INITIAL_STATE: SyncStoreData = {
+    balances: "idle",
+    transactions: "idle",
+  } as const;
+
+  const { subscribe, update, set } = writable<SyncStoreData>(INITIAL_STATE);
+
+  return {
+    subscribe,
+
+    setState({ key, state }: { key: SyncStoreDataKey; state: SyncState }) {
+      update((currentState: SyncStoreData) => ({
+        ...currentState,
+        [key]: state,
+      }));
+    },
+
+    // For test purpose only
+    reset: () => {
+      set(INITIAL_STATE);
+    },
+  };
+};
+
+export const syncStore = initSyncStore();

--- a/frontend/src/lib/types/sync.ts
+++ b/frontend/src/lib/types/sync.ts
@@ -1,0 +1,1 @@
+export type SyncState = "idle" | "in_progress" | "error";

--- a/frontend/src/tests/lib/derived/sync.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sync.derived.spec.ts
@@ -1,0 +1,88 @@
+import { syncOverallStatusStore } from "$lib/derived/sync.derived";
+import { syncStore } from "$lib/stores/sync.store";
+import { get } from "svelte/store";
+
+describe("sync.derived", () => {
+  beforeEach(() => syncStore.reset());
+
+  it("should be idle per default", () => {
+    const store = get(syncOverallStatusStore);
+    expect(store).toEqual("idle");
+  });
+
+  it("should be in_progress", () => {
+    syncStore.setState({
+      key: "balances",
+      state: "in_progress",
+    });
+
+    const store = get(syncOverallStatusStore);
+    expect(store).toEqual("in_progress");
+
+    syncStore.setState({
+      key: "transactions",
+      state: "in_progress",
+    });
+
+    const store1 = get(syncOverallStatusStore);
+    expect(store1).toEqual("in_progress");
+
+    syncStore.setState({
+      key: "balances",
+      state: "idle",
+    });
+
+    const store2 = get(syncOverallStatusStore);
+    expect(store2).toEqual("in_progress");
+
+    syncStore.setState({
+      key: "transactions",
+      state: "idle",
+    });
+
+    const store3 = get(syncOverallStatusStore);
+    expect(store3).toEqual("idle");
+  });
+
+  it("should be error", () => {
+    syncStore.setState({
+      key: "balances",
+      state: "error",
+    });
+
+    const store = get(syncOverallStatusStore);
+    expect(store).toEqual("error");
+
+    syncStore.setState({
+      key: "transactions",
+      state: "error",
+    });
+
+    const store1 = get(syncOverallStatusStore);
+    expect(store1).toEqual("error");
+
+    syncStore.setState({
+      key: "balances",
+      state: "in_progress",
+    });
+
+    const store2 = get(syncOverallStatusStore);
+    expect(store2).toEqual("error");
+
+    syncStore.setState({
+      key: "balances",
+      state: "idle",
+    });
+
+    const store3 = get(syncOverallStatusStore);
+    expect(store3).toEqual("error");
+
+    syncStore.setState({
+      key: "transactions",
+      state: "idle",
+    });
+
+    const store4 = get(syncOverallStatusStore);
+    expect(store4).toEqual("idle");
+  });
+});

--- a/frontend/src/tests/lib/stores/sync.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sync.store.spec.ts
@@ -1,0 +1,55 @@
+import { syncStore } from "$lib/stores/sync.store";
+import { get } from "svelte/store";
+
+describe("sync.store", () => {
+  beforeEach(() => syncStore.reset());
+
+  const data = {
+    balances: "idle",
+    transactions: "idle",
+  };
+
+  it("should set sync status", () => {
+    syncStore.setState({
+      key: "balances",
+      state: "in_progress",
+    });
+
+    const store = get(syncStore);
+
+    expect(store).toEqual({
+      ...data,
+      balances: "in_progress",
+    });
+
+    syncStore.setState({
+      key: "transactions",
+      state: "in_progress",
+    });
+
+    const store1 = get(syncStore);
+
+    expect(store1).toEqual({
+      ...data,
+      balances: "in_progress",
+      transactions: "in_progress",
+    });
+
+    syncStore.setState({
+      key: "balances",
+      state: "idle",
+    });
+
+    const store2 = get(syncStore);
+
+    expect(store2).toEqual({
+      ...data,
+      transactions: "in_progress",
+    });
+  });
+
+  it("should be idle per default", () => {
+    const store = get(syncStore);
+    expect(store).toEqual(data);
+  });
+});


### PR DESCRIPTION
# Motivation

It will be useful in the future, notably for #2639, to display an information in the UI to the users about the status of the Web Workers synchronization. Notably displaying a small hint like a spinner when work is in progress.

This PR introduces a store that contains such information for upcoming workers of #2639 and also improve the timer utils to transmit the information

# Changes

- new `sync.store` and `sync.derived`
- add `postMessage` in timer utils to transmit the sync status to the UI
