### PR TITLE
Feat: Disable functionality while vesting

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,8 +11,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 ### Application
 
 #### Added
-
-* Added a command to inspect canister upgrade proposals. (See: scripts/dfx-nns-proposal-args)
 #### Changed
 
 * Add vesting information in SNS neuron detail.
@@ -28,6 +26,9 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 - A script to get the WASM hash from the GitHub CI build log.
+
+* Added a command to inspect canister upgrade proposals. (See: scripts/dfx-nns-proposal-args)
+
 #### Changed
 - Consolidated the `docker-build` and `aggregator` GitHub workflows into the `build` workflow, to reuse the build artefacts and so reduce network load on the runners.
 #### Deprecated

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,8 +11,13 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 ### Application
 
 #### Added
+
 * Added a command to inspect canister upgrade proposals. (See: scripts/dfx-nns-proposal-args)
 #### Changed
+
+* Add vesting information in SNS neuron detail.
+* Disable functionality buttons while SNS neuron is vesting.
+
 #### Deprecated
 #### Removed
 #### Fixed

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -15,7 +15,6 @@
     hasPermissionToDisburse,
     hasPermissionToDissolve,
     isCommunityFund,
-    isVesting,
   } from "$lib/utils/sns-neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { NeuronState } from "@dfinity/nns";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -40,8 +40,7 @@
     hasPermissionToDissolve({
       neuron,
       identity: $authStore.identity,
-    }) &&
-    !isVesting(neuron);
+    });
 
   let allowedToDisburse: boolean;
   $: allowedToDisburse =
@@ -49,8 +48,7 @@
     hasPermissionToDisburse({
       neuron,
       identity: $authStore.identity,
-    }) &&
-    !isVesting(neuron);
+    });
 
   let canDissolve = false;
   $: canDissolve =
@@ -73,7 +71,7 @@
 
     <div class="buttons">
       {#if allowedToDissolve}
-        <IncreaseSnsDissolveDelayButton />
+        <IncreaseSnsDissolveDelayButton {neuron} />
       {/if}
       {#if isIncreaseStakeAllowed}
         <SnsIncreaseStakeButton />
@@ -81,7 +79,7 @@
       {#if neuronState === NeuronState.Dissolved && allowedToDisburse}
         <DisburseSnsButton />
       {:else if canDissolve}
-        <DissolveSnsNeuronButton {neuronState} />
+        <DissolveSnsNeuronButton {neuron} />
       {/if}
     </div>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte
@@ -76,7 +76,7 @@
         <SnsIncreaseStakeButton />
       {/if}
       {#if neuronState === NeuronState.Dissolved && allowedToDisburse}
-        <DisburseSnsButton />
+        <DisburseSnsButton {neuron} />
       {:else if canDissolve}
         <DissolveSnsNeuronButton {neuron} />
       {/if}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -49,8 +49,7 @@
     hasPermissionToSplit({
       neuron,
       identity: $authStore.identity,
-    }) &&
-    !isVesting(neuron);
+    });
 
   const updateLayoutTitle = ($event: Event) => {
     const {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -9,7 +9,6 @@
     getSnsNeuronIdAsHexString,
     getSnsNeuronState,
     hasPermissionToSplit,
-    isVesting,
   } from "$lib/utils/sns-neuron.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import type { E8s, NeuronState } from "@dfinity/nns";

--- a/frontend/src/lib/components/sns-neuron-detail/VestingTooltipWrapper.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/VestingTooltipWrapper.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { secondsToDuration } from "$lib/utils/date.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isVesting, vestingInSeconds } from "$lib/utils/sns-neuron.utils";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
+
+  export let neuron: SnsNeuron;
+</script>
+
+<TestIdWrapper testId="sns-neuron-vesting-tooltip-component">
+  {#if isVesting(neuron)}
+    <Tooltip
+      id="sns-neuron-vesting-tooltip"
+      text={replacePlaceholders(
+        $i18n.sns_neuron_detail.vesting_period_tooltip,
+        {
+          $remainingVesting: secondsToDuration(vestingInSeconds(neuron)),
+        }
+      )}
+    >
+      <slot />
+    </Tooltip>
+  {:else}
+    <slot />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/DisburseSnsButton.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
+  import { isVesting } from "$lib/utils/sns-neuron.utils";
+
+  export let neuron: SnsNeuron;
 </script>
 
-<button
-  class="secondary"
-  on:click={() => openSnsNeuronModal({ type: "disburse" })}
-  data-tid="disburse-button">{$i18n.neuron_detail.disburse}</button
->
+<VestingTooltipWrapper {neuron}>
+  <button
+    class="secondary"
+    disabled={isVesting(neuron)}
+    on:click={() => openSnsNeuronModal({ type: "disburse" })}
+    data-tid="disburse-button">{$i18n.neuron_detail.disburse}</button
+  >
+</VestingTooltipWrapper>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte
@@ -3,8 +3,13 @@
   import { i18n } from "$lib/stores/i18n";
   import { keyOf } from "$lib/utils/utils";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
+  import { getSnsNeuronState, isVesting } from "$lib/utils/sns-neuron.utils";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
 
-  export let neuronState: NeuronState;
+  export let neuron: SnsNeuron;
+  let neuronState: NeuronState;
+  $: neuronState = getSnsNeuronState(neuron);
 
   let isDissolving: boolean;
   let buttonKey: string;
@@ -14,9 +19,12 @@
   }
 </script>
 
-<button
-  on:click={() => openSnsNeuronModal({ type: "dissolve" })}
-  class="secondary"
-  data-tid="sns-dissolve-button"
-  >{keyOf({ obj: $i18n.neuron_detail, key: buttonKey })}</button
->
+<VestingTooltipWrapper {neuron}>
+  <button
+    on:click={() => openSnsNeuronModal({ type: "dissolve" })}
+    disabled={isVesting(neuron)}
+    class="secondary"
+    data-tid="sns-dissolve-button"
+    >{keyOf({ obj: $i18n.neuron_detail, key: buttonKey })}</button
+  >
+</VestingTooltipWrapper>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
+  import { isVesting } from "$lib/utils/sns-neuron.utils";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
+
+  export let neuron: SnsNeuron;
 </script>
 
-<button
-  class="primary"
-  data-tid="sns-increase-dissolve-delay"
-  on:click={() => openSnsNeuronModal({ type: "increase-dissolve-delay" })}
-  >{$i18n.neuron_detail.increase_dissolve_delay}</button
->
+<VestingTooltipWrapper {neuron}>
+  <button
+    class="primary"
+    disabled={isVesting(neuron)}
+    data-tid="sns-increase-dissolve-delay"
+    on:click={() => openSnsNeuronModal({ type: "increase-dissolve-delay" })}
+    >{$i18n.neuron_detail.increase_dissolve_delay}</button
+  >
+</VestingTooltipWrapper>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -2,7 +2,10 @@
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { isVesting, neuronCanBeSplit } from "$lib/utils/sns-neuron.utils";
+  import {
+    isVesting,
+    hasEnoughStakeToSplit,
+  } from "$lib/utils/sns-neuron.utils";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
   import { fromDefinedNullable } from "@dfinity/utils";
   import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
@@ -23,15 +26,15 @@
     parameters.neuron_minimum_stake_e8s
   );
 
-  let splittable: boolean;
-  $: splittable = neuronCanBeSplit({
+  let enoughStakeToSplit: boolean;
+  $: enoughStakeToSplit = hasEnoughStakeToSplit({
     neuron,
     fee: transactionFee,
     neuronMinimumStake,
   });
 </script>
 
-{#if splittable}
+{#if enoughStakeToSplit}
   <VestingTooltipWrapper {neuron}>
     <button
       class="secondary"

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { neuronCanBeSplit } from "$lib/utils/sns-neuron.utils";
+  import { isVesting, neuronCanBeSplit } from "$lib/utils/sns-neuron.utils";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
   import { fromDefinedNullable } from "@dfinity/utils";
   import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
@@ -11,6 +11,7 @@
   import { formatToken } from "$lib/utils/token.utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import type { Token } from "@dfinity/utils";
+  import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
@@ -31,11 +32,14 @@
 </script>
 
 {#if splittable}
-  <button
-    class="secondary"
-    on:click={() => openSnsNeuronModal({ type: "split-neuron" })}
-    data-tid="split-neuron-button">{$i18n.neuron_detail.split_neuron}</button
-  >
+  <VestingTooltipWrapper {neuron}>
+    <button
+      class="secondary"
+      disabled={isVesting(neuron)}
+      on:click={() => openSnsNeuronModal({ type: "split-neuron" })}
+      data-tid="split-neuron-button">{$i18n.neuron_detail.split_neuron}</button
+    >
+  </VestingTooltipWrapper>
 {:else}
   <Tooltip
     id="split-neuron-button"

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -60,7 +60,7 @@
       }
     )}
   >
-    <button class="secondary" disabled
+    <button class="secondary" data-tid="split-neuron-button" disabled
       >{$i18n.neuron_detail.split_neuron}</button
     >
   </Tooltip>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -675,6 +675,7 @@
   "sns_neuron_detail": {
     "header": "Neuron",
     "all_topics": "All topics",
+    "vesting_period_tooltip": "This function is not available during your vesting period. Vesting will last another $remainingVesting",
     "community_fund_section": "Neurons' Fund",
     "community_fund_section_description": "You are not the controller of the SNS neurons below. To facilitate bootstrapping the SNS DAO governance, the NNS treasury has temporarily granted hotkey access to you for voting and following. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
     "add_hotkey_info": "In order to use this neuron to vote from the corresponding dapp, you have to add your personal dapp ID as a hotkey here. Please refer to the instructions given by the corresponding dapp.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -703,6 +703,7 @@ interface I18nSns_sale {
 interface I18nSns_neuron_detail {
   header: string;
   all_topics: string;
+  vesting_period_tooltip: string;
   community_fund_section: string;
   community_fund_section_description: string;
   add_hotkey_info: string;

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -427,7 +427,7 @@ export const isEnoughAmountToSplit = ({
   neuronMinimumStake: E8s;
 }): boolean => amount >= neuronMinimumStake + fee;
 
-export const neuronCanBeSplit = ({
+export const hasEnoughStakeToSplit = ({
   neuron,
   fee,
   neuronMinimumStake,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
@@ -33,7 +33,7 @@
   });
 </script>
 
-<!-- We do this to avoid getting an "unknown propo passed" warning -->
+<!-- We do this to avoid getting an "unknown prop passed" warning -->
 {#if passPropNeuron}
   <svelte:component this={testComponent} {neuron} />
 {:else}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronContextTest.svelte
@@ -4,7 +4,7 @@
   import SnsNeuronModals from "$lib/modals/sns/neurons/SnsNeuronModals.svelte";
   import type {
     SelectedSnsNeuronContext,
-    type SelectedSnsNeuronStore,
+    SelectedSnsNeuronStore,
   } from "$lib/types/sns-neuron-detail.context";
   import { SELECTED_SNS_NEURON_CONTEXT_KEY } from "$lib/types/sns-neuron-detail.context";
   import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
@@ -14,6 +14,7 @@
   export let neuron: SnsNeuron | undefined;
   export let rootCanisterId: Principal | null;
   export let testComponent: typeof SvelteComponent;
+  export let passPropNeuron = false;
 
   export const neuronStore = writable<SelectedSnsNeuronStore>({
     selected: {
@@ -32,6 +33,11 @@
   });
 </script>
 
-<svelte:component this={testComponent} />
+<!-- We do this to avoid getting an "unknown propo passed" warning -->
+{#if passPropNeuron}
+  <svelte:component this={testComponent} {neuron} />
+{:else}
+  <svelte:component this={testComponent} />
+{/if}
 
 <SnsNeuronModals />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -78,23 +78,6 @@ describe("SnsNeuronInfoStake", () => {
     expect(await po.hasDisburseButton()).toBe(false);
   });
 
-  it("should not render disburse button if neuron is still vesting", async () => {
-    const neuron: SnsNeuron = createMockSnsNeuron({
-      permissions: allPermissions,
-      vesting: true,
-      id: [1],
-    });
-    const { container } = renderSelectedSnsNeuronContext({
-      Component: SnsNeuronInfoStake,
-      neuron,
-      reload: jest.fn(),
-    });
-    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
-
-    expect(await po.isContentLoaded()).toBe(true);
-    expect(await po.hasDisburseButton()).toBe(false);
-  });
-
   it("should render dissolve button", async () => {
     const neuron: SnsNeuron = {
       ...mockSnsNeuronWithPermissions([
@@ -130,11 +113,15 @@ describe("SnsNeuronInfoStake", () => {
     const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(await po.isContentLoaded()).toBe(true);
-    expect(await po.hasDissolveButton()).toBe(false);
+    expect(await po.getDisburseButtonPo().isDisabled()).toBe(false);
   });
 
-  it("should not render dissolve button if neuron is vesting", async () => {
-    const neuron = mockSnsNeuronWithPermissions([]);
+  it("should render disabled dissolve button if neuron is vesting", async () => {
+    const neuron: SnsNeuron = createMockSnsNeuron({
+      permissions: allPermissions,
+      vesting: true,
+      id: [1],
+    });
     const { container } = renderSelectedSnsNeuronContext({
       Component: SnsNeuronInfoStake,
       neuron,
@@ -143,7 +130,7 @@ describe("SnsNeuronInfoStake", () => {
     const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(await po.isContentLoaded()).toBe(true);
-    expect(await po.hasDissolveButton()).toBe(false);
+    expect(await po.getDissolveButtonPo().isDisabled()).toBe(true);
   });
 
   it("renders increase dissolve delay button", async () => {
@@ -173,7 +160,7 @@ describe("SnsNeuronInfoStake", () => {
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
   });
 
-  it("should not render increase dissolve delay button if neuron is vesting", async () => {
+  it("should render disabled increase dissolve delay button if neuron is vesting", async () => {
     const neuron: SnsNeuron = createMockSnsNeuron({
       permissions: allPermissions,
       vesting: true,
@@ -187,7 +174,7 @@ describe("SnsNeuronInfoStake", () => {
     const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(await po.isContentLoaded()).toBe(true);
-    expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
+    expect(await po.getIncreaseDissolveDelayButtonPo().isDisabled()).toBe(true);
   });
 
   it("should render increase state button if neuron doesn't belong to the Community Fund", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -20,6 +20,7 @@ import {
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
+import { NeuronState } from "@dfinity/nns";
 import {
   SnsNeuronPermissionType,
   SnsSwapLifecycle,
@@ -78,6 +79,24 @@ describe("SnsNeuronInfoStake", () => {
     expect(await po.hasDisburseButton()).toBe(false);
   });
 
+  it("should render disabled disburse button if neuron is still vesting", async () => {
+    const neuron: SnsNeuron = createMockSnsNeuron({
+      permissions: allPermissions,
+      vesting: true,
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronInfoStake,
+      neuron,
+      reload: jest.fn(),
+    });
+    const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
+
+    expect(await po.isContentLoaded()).toBe(true);
+    expect(await po.getDisburseButtonPo().isDisabled()).toBe(true);
+  });
+
   it("should render dissolve button", async () => {
     const neuron: SnsNeuron = {
       ...mockSnsNeuronWithPermissions([
@@ -113,7 +132,7 @@ describe("SnsNeuronInfoStake", () => {
     const po = SnsNeuronInfoStakePo.under(new JestPageObjectElement(container));
 
     expect(await po.isContentLoaded()).toBe(true);
-    expect(await po.getDisburseButtonPo().isDisabled()).toBe(false);
+    expect(await po.hasDissolveButton()).toBe(false);
   });
 
   it("should render disabled dissolve button if neuron is vesting", async () => {
@@ -121,6 +140,7 @@ describe("SnsNeuronInfoStake", () => {
       permissions: allPermissions,
       vesting: true,
       id: [1],
+      state: NeuronState.Locked,
     });
     const { container } = renderSelectedSnsNeuronContext({
       Component: SnsNeuronInfoStake,

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -107,7 +107,7 @@ describe("SnsNeuronMetaInfoCard", () => {
     expect(queryByTestId("split-neuron-button")).toBeNull();
   });
 
-  it("should hide split neuron button if neuron is vesting", async () => {
+  it("should render disabled split neuron button if neuron is vesting", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       vesting: true,
@@ -121,7 +121,7 @@ describe("SnsNeuronMetaInfoCard", () => {
       new JestPageObjectElement(container)
     );
 
-    expect(await po.getVestingPeriod()).toBe("29 days, 10 hours");
+    expect(await po.getSplitButtonPo().isDisabled()).toBe(true);
   });
 
   it("should render vesting period if neuron still vesting", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import VestingTooltipWrapper from "$lib/components/sns-neuron-detail/VestingTooltipWrapper.svelte";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { VestingTooltipWrapperPo } from "$tests/page-objects/VestingTooltipWrapper.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("VestingTooltipWrapper", () => {
+  const nonVestingNeuron = createMockSnsNeuron({
+    id: [1],
+    vesting: false,
+  });
+  const vestingNeuron = createMockSnsNeuron({
+    id: [1],
+    vesting: true,
+  });
+
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(VestingTooltipWrapper, {
+      props: {
+        neuron,
+      },
+    });
+
+    return VestingTooltipWrapperPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should not render tooltip if neuron is not vesting", async () => {
+    const po = renderComponent(nonVestingNeuron);
+
+    expect(await po.getTooltipPo().isPresent()).toBe(false);
+  });
+
+  it("should render tooltip if neuron is vesting", async () => {
+    const po = renderComponent(vestingNeuron);
+
+    expect(await po.getTooltipPo().isPresent()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
@@ -39,5 +39,8 @@ describe("VestingTooltipWrapper", () => {
     const po = renderComponent(vestingNeuron);
 
     expect(await po.getTooltipPo().isPresent()).toBe(true);
+    expect(await po.getTooltipPo().getText()).toBe(
+      "This function is not available during your vesting period. Vesting will last another 29 days, 10 hours"
+    );
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
@@ -6,7 +6,10 @@ import DisburseSnsButton from "$lib/components/sns-neuron-detail/actions/Disburs
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
-import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+} from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
@@ -28,10 +31,30 @@ describe("DisburseSnsButton", () => {
         neuron: mockSnsNeuron,
         rootCanisterId: mockPrincipal,
         testComponent: DisburseSnsButton,
+        passPropNeuron: true,
       },
     });
 
     expect(getByText(en.neuron_detail.disburse)).toBeInTheDocument();
+  });
+
+  it("renders disabled button when vesting", () => {
+    const vestingNeuron = createMockSnsNeuron({
+      id: [1],
+      vesting: true,
+    });
+    const { queryByTestId } = render(SnsNeuronContextTest, {
+      props: {
+        neuron: vestingNeuron,
+        rootCanisterId: mockPrincipal,
+        testComponent: DisburseSnsButton,
+        passPropNeuron: true,
+      },
+    });
+
+    expect(
+      queryByTestId("disburse-button").getAttribute("disabled")
+    ).not.toBeNull();
   });
 
   it("opens sns modal", async () => {
@@ -40,6 +63,7 @@ describe("DisburseSnsButton", () => {
         neuron: mockSnsNeuron,
         rootCanisterId: mockPrincipal,
         testComponent: DisburseSnsButton,
+        passPropNeuron: true,
       },
     });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -30,8 +30,10 @@ describe("DissolveSnsNeuronButton", () => {
   it("renders start dissolve message when neuron is locked", () => {
     const { getByText } = render(DissolveSnsNeuronButtonTest, {
       props: {
-        neuron: mockSnsNeuron,
-        neuronState: NeuronState.Locked,
+        neuron: createMockSnsNeuron({
+          id: [1],
+          state: NeuronState.Locked,
+        }),
       },
     });
 
@@ -41,19 +43,39 @@ describe("DissolveSnsNeuronButton", () => {
   it("renders stop dissolve message when neuron is dissolving", () => {
     const { getByText } = render(DissolveSnsNeuronButtonTest, {
       props: {
-        neuron: mockSnsNeuron,
-        neuronState: NeuronState.Dissolving,
+        neuron: createMockSnsNeuron({
+          id: [1],
+          state: NeuronState.Dissolving,
+        }),
       },
     });
 
     expect(getByText(en.neuron_detail.stop_dissolving)).toBeInTheDocument();
   });
 
+  it("is disabled while vesting", () => {
+    const { queryByTestId } = render(DissolveSnsNeuronButtonTest, {
+      props: {
+        neuron: createMockSnsNeuron({
+          id: [1],
+          vesting: true,
+          state: NeuronState.Locked,
+        }),
+      },
+    });
+
+    expect(queryByTestId("sns-dissolve-button").hasAttribute("disabled")).toBe(
+      true
+    );
+  });
+
   it("calls startDissolving action on click and LOCKED state", async () => {
     const { container, queryByTestId } = render(DissolveSnsNeuronButtonTest, {
       props: {
-        neuron: mockSnsNeuron,
-        neuronState: NeuronState.Locked,
+        neuron: createMockSnsNeuron({
+          id: [1],
+          state: NeuronState.Locked,
+        }),
       },
     });
 
@@ -82,7 +104,6 @@ describe("DissolveSnsNeuronButton", () => {
           id: [1, 2, 2, 9, 9, 3, 2],
           state: NeuronState.Dissolving,
         }),
-        neuronState: NeuronState.Dissolving,
       },
     });
 
@@ -109,7 +130,6 @@ describe("DissolveSnsNeuronButton", () => {
     const { container, queryByTestId } = render(DissolveSnsNeuronButtonTest, {
       props: {
         neuron: mockSnsNeuron,
-        neuronState: NeuronState.Dissolving,
         spy,
       },
     });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButtonTest.svelte
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButtonTest.svelte
@@ -4,16 +4,14 @@
   import SnsNeuronModals from "$lib/modals/sns/neurons/SnsNeuronModals.svelte";
   import type {
     SelectedSnsNeuronContext,
-    type SelectedSnsNeuronStore,
+    SelectedSnsNeuronStore,
   } from "$lib/types/sns-neuron-detail.context";
   import { SELECTED_SNS_NEURON_CONTEXT_KEY } from "$lib/types/sns-neuron-detail.context";
   import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
   import type { SnsNeuron } from "@dfinity/sns";
   import DissolveSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.svelte";
-  import { NeuronState } from "@dfinity/nns";
 
   export let neuron: SnsNeuron | undefined;
-  export let neuronState: NeuronState;
   export let spy: (() => void) | undefined = undefined;
 
   export const neuronStore = writable<SelectedSnsNeuronStore>({
@@ -31,6 +29,6 @@
   });
 </script>
 
-<DissolveSnsNeuronButton {neuronState} />
+<DissolveSnsNeuronButton {neuron} />
 
 <SnsNeuronModals />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -20,19 +20,13 @@ jest.mock("$lib/utils/modals.utils", () => ({
   openSnsNeuronModal: jest.fn(),
 }));
 
-let canBeSplit = true;
-jest.mock("$lib/utils/sns-neuron.utils", () => ({
-  ...jest.requireActual("$lib/utils/sns-neuron.utils"),
-  neuronCanBeSplit: () => canBeSplit,
-  minNeuronSplittable: () => 0n,
-}));
-
 describe("SplitSnsNeuronButton", () => {
   const transactionFee = 100n;
-  const neuronMinimumStake = 0n;
+  const neuronMinimumStake = 100_000_000n;
   const props = {
     neuron: {
       ...mockSnsNeuron,
+      stake: neuronMinimumStake * 2n,
     },
     parameters: {
       ...snsNervousSystemParametersMock,
@@ -89,18 +83,18 @@ describe("SplitSnsNeuronButton", () => {
   });
 
   it("should display tooltip and disabled button when neuron can't be split", async () => {
-    canBeSplit = false;
+    const { getByText, queryByTestId } = render(SplitSnsNeuronButton, {
+      props: {
+        ...props,
+        neuron: createMockSnsNeuron({
+          id: [1],
+          vesting: true,
+          stake: neuronMinimumStake - 10_000n,
+        }),
+      },
+    });
 
-    const { getByText, container, queryByTestId } = render(
-      SplitSnsNeuronButton,
-      {
-        props,
-      }
-    );
-
-    expect(queryByTestId("split-neuron-button")).toBeNull();
-
-    const button = container.querySelector("button");
+    const button = queryByTestId("split-neuron-button");
     expect(button).toBeInTheDocument();
     expect(button.hasAttribute("disabled")).toBeTruthy();
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -9,6 +9,7 @@ import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import {
+  createMockSnsNeuron,
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
@@ -53,6 +54,22 @@ describe("SplitSnsNeuronButton", () => {
     const button = getByTestId("split-neuron-button");
     expect(button).toBeInTheDocument();
     expect(button.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("should display disabled button when neuron is vesting", async () => {
+    const { getByTestId } = render(SplitSnsNeuronButton, {
+      props: {
+        ...props,
+        neuron: createMockSnsNeuron({
+          id: [1],
+          vesting: true,
+        }),
+      },
+    });
+
+    const button = getByTestId("split-neuron-button");
+    expect(button).toBeInTheDocument();
+    expect(button.hasAttribute("disabled")).toBe(true);
   });
 
   it("should open split neuron modal", async () => {

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -26,6 +26,7 @@ import {
   getSnsNeuronState,
   getSnsNeuronVote,
   hasEnoughMaturityToStake,
+  hasEnoughStakeToSplit,
   hasPermissionToDisburse,
   hasPermissionToDissolve,
   hasPermissionToSplit,
@@ -43,7 +44,6 @@ import {
   minNeuronSplittable,
   needsRefresh,
   neuronAge,
-  neuronCanBeSplit,
   nextMemo,
   snsNeuronVotingPower,
   snsNeuronsIneligibilityReasons,
@@ -1179,10 +1179,10 @@ describe("sns-neuron utils", () => {
     });
   });
 
-  describe("neuronCanBeSplit", () => {
+  describe("hasEnoughStakeToSplit", () => {
     it("returns true if enough", () => {
       expect(
-        neuronCanBeSplit({
+        hasEnoughStakeToSplit({
           neuron: {
             ...mockSnsNeuron,
             cached_neuron_stake_e8s: 2100n,
@@ -1196,7 +1196,7 @@ describe("sns-neuron utils", () => {
 
     it("returns false if not enough", () => {
       expect(
-        neuronCanBeSplit({
+        hasEnoughStakeToSplit({
           neuron: {
             ...mockSnsNeuron,
             cached_neuron_stake_e8s: 2099n,

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -38,10 +38,6 @@ export const createMockSnsNeuron = ({
   // `false` means vesting period has passed
   vesting?: boolean;
 }): SnsNeuron => {
-  // Neurons are in Locked state if vesting
-  if (vesting) {
-    state = NeuronState.Locked;
-  }
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
     permissions,
@@ -54,7 +50,7 @@ export const createMockSnsNeuron = ({
     aging_since_timestamp_seconds: BigInt(100),
     voting_power_percentage_multiplier: BigInt(1),
     dissolve_state:
-      state === undefined
+      state === undefined || state === NeuronState.Dissolved
         ? []
         : [
             state === NeuronState.Dissolving

--- a/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
+++ b/frontend/src/tests/page-objects/VestingTooltipWrapper.page-object.ts
@@ -1,0 +1,17 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TooltipPo } from "./Tooltip.page-object";
+
+export class VestingTooltipWrapperPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-vesting-tooltip-component";
+
+  static under(element: PageObjectElement): VestingTooltipWrapperPo {
+    return new VestingTooltipWrapperPo(
+      element.byTestId(VestingTooltipWrapperPo.TID)
+    );
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

Instead of hiding the unavailable functionality while neuron is vesting, we want to disable it and explain why it's disabled.

# Changes

* New component `VestingTooltipWrapper` that checks whether a neuron is vesting and renders only the child or the child wrapped in a tooltip.
* Use `VestingTooltipWrapper` in `IncreaseSnsDissolveDelayButton`
* Add new param `neuron` in `IncreaseSnsDissolveDelayButton`.
* Use `VestingTooltipWrapper` in `DissolveSnsNeuronButton`
* Use `VestingTooltipWrapper` in `SplitSnsNeuronButton`
* Add new param `neuron` in `DissolveSnsNeuronButton` instead of the neuronState.

# Tests

* Change test cases from expecting no button to a disabled button.
* Add test cases in the button components to check the tooltip is present when vesting.
* New page object for the new compoment `VestingTooltipWrapper`.
* Test new component `VestingTooltipWrapper`.
