### PR TITLE
Script to get hash from CI log

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 ### Operations
 
 #### Added
+- A script to get the WASM hash from the GitHub CI build log.
 #### Changed
 - Consolidated the `docker-build` and `aggregator` GitHub workflows into the `build` workflow, to reuse the build artefacts and so reduce network load on the runners.
 #### Deprecated

--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -3,7 +3,6 @@ set -euo pipefail
 
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 DEFAULT_WASM_FILENAME="nns-dapp.wasm.gz"
-ARTIFACT_WORKFLOW="Build and test"
 
 print_help() {
   cat <<-EOF
@@ -29,20 +28,11 @@ source "$(clap.build)"
 
 COMMIT="$(git rev-parse "$COMMIT")"
 
-docker_build_run_id="$(gh run list --workflow "$ARTIFACT_WORKFLOW" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
-
-if ! [ "$docker_build_run_id" ]; then
-  (
-    echo "No successful Docker build run found for commit $COMMIT."
-    echo "If the commit is too new, the run may not have finished yet."
-    echo "If the commit is too old, increasing --limit (was $LIMIT) may help."
-  ) >&2
-  exit 1
-fi
+ci_build_run_id="$("$SOURCE_DIR/get-ci-build-run" --commit "$COMMIT" --limit "$LIMIT")"
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf $tmp_dir' EXIT
-gh run download "$docker_build_run_id" --dir "$tmp_dir"
+gh run download "$ci_build_run_id" --dir "$tmp_dir"
 
 mkdir -p "$OUTPUT_DIR"
 dst_wasm_file="$OUTPUT_DIR/$WASM_FILENAME"

--- a/scripts/nns-dapp/download-ci-wasm.test
+++ b/scripts/nns-dapp/download-ci-wasm.test
@@ -31,5 +31,13 @@ if ! file "$tmp_dir/$WASM_FILENAME" | grep gzip; then
   exit 1
 fi
 
+expected_hash="$("$SOURCE_DIR/get-hash-from-ci-log" --commit "$COMMIT")"
+actual_hash="$(sha256sum "$tmp_dir/$WASM_FILENAME" | awk '{print $1}')"
+
+if [ "$expected_hash" != "$actual_hash" ]; then
+  echo "ERROR: Expected hash $expected_hash but got $actual_hash" >&2
+  exit 1
+fi
+
 echo "PASSED"
 rm -rf "$tmp_dir"

--- a/scripts/nns-dapp/get-ci-build-run
+++ b/scripts/nns-dapp/get-ci-build-run
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+WORKFLOW_NAME="Build and test"
+
+print_help() {
+  cat <<-EOF
+
+  Get the GitHub CI successful build run number for a commit.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=c long=commit desc="Commit to get build run for" variable=COMMIT default="tags/release-candidate"
+clap.define short=l long=limit desc="--limit passed to gh run list" variable=LIMIT default="200"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+COMMIT="$(git rev-parse "$COMMIT")"
+
+ci_build_run_id="$(gh run list --workflow "$WORKFLOW_NAME" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
+
+if ! [ "$ci_build_run_id" ]; then
+  (
+    echo "No successful $WORKFLOW_NAME run found for commit $COMMIT."
+    echo "If the commit is too new, the run may not have finished yet."
+    echo "If the commit is too old, increasing --limit (was $LIMIT) may help."
+  ) >&2
+  exit 1
+fi
+
+echo "$ci_build_run_id"

--- a/scripts/nns-dapp/get-hash-from-ci-log
+++ b/scripts/nns-dapp/get-hash-from-ci-log
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+DEFAULT_WASM_FILENAME="nns-dapp.wasm.gz"
+
+print_help() {
+  cat <<-EOF
+
+  Get the hash of a build artifact from GitHub CI log.
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=c long=commit desc="Commit to get hash for" variable=COMMIT default="tags/release-candidate"
+clap.define short=l long=limit desc="--limit passed to gh run list" variable=LIMIT default="200"
+clap.define short=f long=filename desc="The name of the file to get the hash for" variable=FILENAME default="$DEFAULT_WASM_FILENAME"
+
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+ci_build_run_id="$("$SOURCE_DIR/get-ci-build-run" --commit "$COMMIT" --limit "$LIMIT")"
+
+tmp_file=$(mktemp)
+
+gh run view "$ci_build_run_id" --log >"$tmp_file"
+# We don't escape filename so hopefully it doesn't contain any regex special
+# characters that interfere with the result.
+grep "out/$FILENAME$" "$tmp_file" | grep -o '[0-9a-f]\{64\}' | head -1
+
+rm "$tmp_file"


### PR DESCRIPTION
# Motivation

Trying to make the release a less manual process.
One of the steps in the release process is getting the WASM hash from the build log from CI.

# Changes

1. Add a script to get the WASM hash from the build log from CI.
2. Factor out common code to get the GitHub CI run number for a given commit.

# Tests

Changed `scripts/nns-dapp/download-ci-wasm.test` to verify that the hash of the downloaded file matches the hash from the log.

# Todos

- [x] Add entry to changelog (if necessary).
