### PR TITLE
feat: remove desktop related logic to make medium viewport work more …

### DIFF
--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -68,35 +68,13 @@ export class AppPo extends BasePageObject {
   }
 
   async openMenu(): Promise<void> {
-    // On large viewports, the menu is always open, but on smaller windows, we
-    // need to click the menu toggle to open the menu. So we check if the menu toggle is
-    // there and wait for the menu to open if necessary.
-
-    // If the header isn't loaded yet, it looks like the menu toggle isn't
-    // there but it's just not there *yet*.
-    await this.waitForHeaderLoaded();
-    const isTogglePresent = await this.getMenuTogglePo().isPresent();
-    if (isTogglePresent) {
-      const backdrop = this.getBackdropPo();
-      if (await backdrop.isPresent()) {
-        throw Error("Menu is already open");
-      }
-      await this.toggleMenu();
-      await backdrop.waitFor();
-    }
+    await this.toggleMenu();
+    await this.getBackdropPo().waitFor();
   }
 
   async closeMenu(): Promise<void> {
-    // Whether the menu needs to be closed depends on the size of the viewport.
-    const isTogglePresent = await this.getMenuTogglePo().isPresent();
-    if (isTogglePresent) {
-      const backdrop = this.getBackdropPo();
-      if (!(await backdrop.isPresent())) {
-        throw Error("Menu is already closed");
-      }
-      await this.toggleMenu();
-      await backdrop.waitForAbsent();
-    }
+    await this.toggleMenu();
+    await this.getBackdropPo().waitForAbsent();
   }
 
   async goToNeurons(): Promise<void> {
@@ -119,8 +97,9 @@ export class AppPo extends BasePageObject {
     await this.closeMenu();
   }
 
-  goBack(): Promise<void> {
-    return this.getButton("back").click();
+  async goBack(): Promise<void> {
+    await this.getButton("back").click();
+    await this.getButton("back").waitForAbsent();
   }
 
   waitForNotBusy(): Promise<void> {

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -63,10 +63,6 @@ export class AppPo extends BasePageObject {
     return this.getMenuTogglePo().click();
   }
 
-  waitForHeaderLoaded(): Promise<void> {
-    return this.root.byTestId("header-component").waitFor();
-  }
-
   async openMenu(): Promise<void> {
     await this.toggleMenu();
     await this.getBackdropPo().waitFor();


### PR DESCRIPTION
# Motivation

To improve e2e reliability the extra logic to decide which menu is used was removed (currently all the e2e tests run in medium viewport).

# Changes

- toggle and wait for open/close menu actions.
- remove `waitForHeaderLoaded` function.
