### PR TITLE
Don't require a config field in the network

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -24,6 +24,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 - A script to get the WASM hash from the GitHub CI build log.
 #### Changed
+- Made per-network configuration in dfx.json optional.
 - Consolidated the `docker-build` and `aggregator` GitHub workflows into the `build` workflow, to reuse the build artefacts and so reduce network load on the runners.
 #### Deprecated
 #### Removed

--- a/config.sh
+++ b/config.sh
@@ -131,7 +131,7 @@ local_deployment_data="$(
 : "- replace OWN_CANISTER_ID"
 : "- construct ledger and governance canister URLs"
 json=$(HOST=$(dfx-canister-url --network "$DFX_NETWORK" --type api) jq -s --sort-keys '
-  (.[0].defaults.network.config // {}) * .[1] * .[0].networks[env.DFX_NETWORK].config |
+  (.[0].defaults.network.config // {}) * .[1] * (.[0].networks[env.DFX_NETWORK].config // {}) |
   .DFX_NETWORK = env.DFX_NETWORK |
   . as $config |
   .HOST=env.HOST |


### PR DESCRIPTION
# Motivation
The nns-dapp config script currently relies on a network config entry being present in dfx.json.  The network config in dfx.json is not always present for all networks, and is indeed deprecated so will be removed entirely.

# Changes
- Make per-network config optional.

# Tests
- The config script works exactly as before if there is a config entry, which there is for prod.
- For local deployments, CI should suffice.

# Todos

- [x] Add entry to changelog (if necessary).
