### PR TITLE
Rename close listeners

### DIFF
--- a/frontend/src/lib/utils/before-unload.utils.ts
+++ b/frontend/src/lib/utils/before-unload.utils.ts
@@ -5,22 +5,22 @@ const onBeforeUnload = ($event: BeforeUnloadEvent) => {
   return ($event.returnValue = "Are you sure you want to exit?");
 };
 
-const addSyncBeforeUnload = () => {
+const addBeforeUnload = () => {
   window.addEventListener("beforeunload", onBeforeUnload, { capture: true });
 };
 
-const removeSyncBeforeUnload = () => {
+const removeBeforeUnload = () => {
   window.removeEventListener("beforeunload", onBeforeUnload, { capture: true });
 };
 
-export const syncBeforeUnload = (dirty: boolean) => {
+export const confirmCloseApp = (dirty: boolean) => {
   if (!browser) {
     return;
   }
 
   if (dirty) {
-    addSyncBeforeUnload();
+    addBeforeUnload();
   } else {
-    removeSyncBeforeUnload();
+    removeBeforeUnload();
   }
 };

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
-  import { syncBeforeUnload } from "$lib/utils/before-unload.utils";
+  import { confirmCloseApp } from "$lib/utils/before-unload.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { onMount } from "svelte";
   import { Toasts, BusyScreen } from "@dfinity/gix-components";
@@ -13,7 +13,7 @@
 
   onMount(async () => await Promise.all([initAppAuth(), initAppPublicData()]));
 
-  $: syncBeforeUnload(
+  $: confirmCloseApp(
     voteRegistrationActive(
       $voteRegistrationStore.registrations[OWN_CANISTER_ID_TEXT] ?? []
     )


### PR DESCRIPTION
# Motivation

Listeners were probably copied a long time ago from Papyrs that's why they mention "sync...". 
We can rename those to be more generic.
