### PR TITLE
Feat: Add "Select All" and "Clear" buttons to proposals filters

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,9 +11,12 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 ### Application
 
 #### Added
+
+* Add "Select All" and "Clear" selection in proposal filters.
+* Add vesting information in SNS neuron detail.
+
 #### Changed
 
-* Add vesting information in SNS neuron detail.
 * Disable functionality buttons while SNS neuron is vesting.
 
 #### Deprecated

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-27.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-27.2.tgz",
-      "integrity": "sha512-xRb2aEaaeLj+6c/X1AYXWcCK6qL67lbYvFWgCTNGcSWbgSxyv+4iZR2lwOqlVR4B292nQ3hQ83ce2vzKrQ3HnA==",
+      "version": "2.6.0-next-2023-06-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-28.tgz",
+      "integrity": "sha512-BzaCeAiRH8cHpQjKouI7dI8sxAU4sFkCTc4HrNTLGerKMTaqLLIsM3rksZawonbIKgbX/JMR56PeB9nor8XgXw==",
       "dependencies": {
         "dompurify": "^3.0.3",
         "html5-qrcode": "^2.3.8",
@@ -9995,9 +9995,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-27.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-27.2.tgz",
-      "integrity": "sha512-xRb2aEaaeLj+6c/X1AYXWcCK6qL67lbYvFWgCTNGcSWbgSxyv+4iZR2lwOqlVR4B292nQ3hQ83ce2vzKrQ3HnA==",
+      "version": "2.6.0-next-2023-06-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-28.tgz",
+      "integrity": "sha512-BzaCeAiRH8cHpQjKouI7dI8sxAU4sFkCTc4HrNTLGerKMTaqLLIsM3rksZawonbIKgbX/JMR56PeB9nor8XgXw==",
       "requires": {
         "dompurify": "^3.0.3",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -380,9 +380,13 @@
     "topics": "Topics",
     "rewards": "Reward Status",
     "status": "Proposal Status",
+    "filter_by_topics": "Filter by topic",
+    "filter_by_rewards": "Filter by reward status",
+    "filter_by_status": "Filter by proposal status",
     "hide_unavailable_proposals": "Show only proposals you can still vote for",
-    "check_all": "Check All",
-    "uncheck_all": "Uncheck All",
+    "check_all": "Select All",
+    "uncheck_all": "Clear",
+    "filter_by": "Filter by $field",
     "nothing_found": "No proposals found for the filters."
   },
   "canisters": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -381,6 +381,8 @@
     "rewards": "Reward Status",
     "status": "Proposal Status",
     "hide_unavailable_proposals": "Show only proposals you can still vote for",
+    "check_all": "Check All",
+    "uncheck_all": "Uncheck All",
     "nothing_found": "No proposals found for the filters."
   },
   "canisters": {

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { check } from "prettier";
+
   import { Modal, Spinner } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
   import { Checkbox } from "@dfinity/gix-components";
@@ -43,6 +45,15 @@
   const filter = () => {
     dispatch("nnsConfirm");
   };
+
+  let hasMoreHalfCheck: boolean;
+  $: hasMoreHalfCheck = isNullish(filters)
+    ? false
+    : filters.filter(({ checked }) => checked).length >= filters.length / 2;
+
+  const toggleAll = () => {
+    dispatch("nnsToggleAll", { check: !hasMoreHalfCheck });
+  };
 </script>
 
 {#if !loading}
@@ -51,6 +62,13 @@
 
     {#if filters}
       <div class="filters">
+        <div class="toggle-all-wrapper">
+          <button on:click={toggleAll}
+            >{hasMoreHalfCheck
+              ? $i18n.voting.uncheck_all
+              : $i18n.voting.check_all}</button
+          >
+        </div>
         {#each filters as { id, name, checked } (id)}
           <Checkbox inputId={id} {checked} on:nnsChange={() => onChange(id)}
             >{name}</Checkbox
@@ -80,5 +98,11 @@
 <style lang="scss">
   .filters {
     --checkbox-padding: var(--padding-2x) var(--padding) var(--padding-2x);
+  }
+
+  .toggle-all-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-bottom: var(--padding);
   }
 </style>

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { check } from "prettier";
-
   import { Modal, Spinner } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
   import { Checkbox } from "@dfinity/gix-components";

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -46,13 +46,12 @@
     dispatch("nnsConfirm");
   };
 
-  let hasMoreHalfCheck: boolean;
-  $: hasMoreHalfCheck = isNullish(filters)
-    ? false
-    : filters.filter(({ checked }) => checked).length >= filters.length / 2;
+  const selectAll = () => {
+    dispatch("nnsSelectAll");
+  };
 
-  const toggleAll = () => {
-    dispatch("nnsToggleAll", { check: !hasMoreHalfCheck });
+  const clearSelection = () => {
+    dispatch("nnsClearSelection");
   };
 </script>
 
@@ -60,15 +59,24 @@
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
     <slot slot="title" name="title" />
 
+    <div slot="sub-title" class="toggle-all-wrapper">
+      <p><slot name="filter-by" /></p>
+      <div>
+        <button
+          class="text"
+          data-tid="filter-modal-select-all"
+          on:click={selectAll}>{$i18n.voting.check_all}</button
+        >
+        <button
+          class="text"
+          data-tid="filter-modal-clear"
+          on:click={clearSelection}>{$i18n.voting.uncheck_all}</button
+        >
+      </div>
+    </div>
+
     {#if filters}
       <div class="filters">
-        <div class="toggle-all-wrapper">
-          <button on:click={toggleAll}
-            >{hasMoreHalfCheck
-              ? $i18n.voting.uncheck_all
-              : $i18n.voting.check_all}</button
-          >
-        </div>
         {#each filters as { id, name, checked } (id)}
           <Checkbox inputId={id} {checked} on:nnsChange={() => onChange(id)}
             >{name}</Checkbox
@@ -102,7 +110,8 @@
 
   .toggle-all-wrapper {
     display: flex;
-    justify-content: center;
-    margin-bottom: var(--padding);
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 var(--padding-2x);
   }
 </style>

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -112,12 +112,12 @@
     close();
   };
 
-  const toggleAll = ({
-    detail: { check },
-  }: CustomEvent<{
-    check: boolean;
-  }>) => {
-    selectedFilters = check ? filtersValues.map(({ value }) => value) : [];
+  const selectAll = () => {
+    selectedFilters = filtersValues.map(({ value }) => value);
+  };
+
+  const clear = () => {
+    selectedFilters = [];
   };
 </script>
 
@@ -126,10 +126,15 @@
   on:nnsClose={close}
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
-  on:nnsToggleAll={toggleAll}
+  on:nnsSelectAll={selectAll}
+  on:nnsClearSelection={clear}
   filters={filtersValues}
 >
   <span slot="title"
     >{keyOfOptional({ obj: $i18n.voting, key: category }) ?? ""}</span
+  >
+  <span slot="filter-by"
+    >{keyOfOptional({ obj: $i18n.voting, key: `filter_by_${category}` }) ??
+      ""}</span
   >
 </FilterModal>

--- a/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
+++ b/frontend/src/lib/modals/proposals/NnsProposalsFilterModal.svelte
@@ -111,6 +111,14 @@
 
     close();
   };
+
+  const toggleAll = ({
+    detail: { check },
+  }: CustomEvent<{
+    check: boolean;
+  }>) => {
+    selectedFilters = check ? filtersValues.map(({ value }) => value) : [];
+  };
 </script>
 
 <FilterModal
@@ -118,6 +126,7 @@
   on:nnsClose={close}
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
+  on:nnsToggleAll={toggleAll}
   filters={filtersValues}
 >
   <span slot="title"

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
@@ -44,12 +44,21 @@
       ...(filter.checked ? [] : [filter.value]),
     ];
   };
+
+  const toggleAll = ({
+    detail: { check },
+  }: CustomEvent<{
+    check: boolean;
+  }>) => {
+    selectedFilters = check ? filters.map(({ value }) => value) : [];
+  };
 </script>
 
 <FilterModal
   on:nnsClose
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
+  on:nnsToggleAll={toggleAll}
   filters={filtersValues}
 >
   <span slot="title">{$i18n.voting.rewards}</span>

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterRewardsModal.svelte
@@ -45,12 +45,12 @@
     ];
   };
 
-  const toggleAll = ({
-    detail: { check },
-  }: CustomEvent<{
-    check: boolean;
-  }>) => {
-    selectedFilters = check ? filters.map(({ value }) => value) : [];
+  const clear = () => {
+    selectedFilters = [];
+  };
+
+  const selectAll = () => {
+    selectedFilters = filters.map(({ value }) => value);
   };
 </script>
 
@@ -58,8 +58,10 @@
   on:nnsClose
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
-  on:nnsToggleAll={toggleAll}
+  on:nnsSelectAll={selectAll}
+  on:nnsClearSelection={clear}
   filters={filtersValues}
 >
   <span slot="title">{$i18n.voting.rewards}</span>
+  <span slot="filter-by">{$i18n.voting.filter_by_rewards}</span>
 </FilterModal>

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
@@ -45,12 +45,12 @@
     ];
   };
 
-  const toggleAll = ({
-    detail: { check },
-  }: CustomEvent<{
-    check: boolean;
-  }>) => {
-    selectedFilters = check ? filters.map(({ value }) => value) : [];
+  const clear = () => {
+    selectedFilters = [];
+  };
+
+  const selectAll = () => {
+    selectedFilters = filters.map(({ value }) => value);
   };
 </script>
 
@@ -58,8 +58,10 @@
   on:nnsClose
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
-  on:nnsToggleAll={toggleAll}
+  on:nnsSelectAll={selectAll}
+  on:nnsClearSelection={clear}
   filters={filtersValues}
 >
   <span slot="title">{$i18n.voting.status}</span>
+  <span slot="filter-by">{$i18n.voting.filter_by_status}</span>
 </FilterModal>

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterStatusModal.svelte
@@ -44,12 +44,21 @@
       ...(filter.checked ? [] : [filter.value]),
     ];
   };
+
+  const toggleAll = ({
+    detail: { check },
+  }: CustomEvent<{
+    check: boolean;
+  }>) => {
+    selectedFilters = check ? filters.map(({ value }) => value) : [];
+  };
 </script>
 
 <FilterModal
   on:nnsClose
   on:nnsConfirm={filter}
   on:nnsChange={onChange}
+  on:nnsToggleAll={toggleAll}
   filters={filtersValues}
 >
   <span slot="title">{$i18n.voting.status}</span>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -393,9 +393,13 @@ interface I18nVoting {
   topics: string;
   rewards: string;
   status: string;
+  filter_by_topics: string;
+  filter_by_rewards: string;
+  filter_by_status: string;
   hide_unavailable_proposals: string;
   check_all: string;
   uncheck_all: string;
+  filter_by: string;
   nothing_found: string;
 }
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -394,6 +394,8 @@ interface I18nVoting {
   rewards: string;
   status: string;
   hide_unavailable_proposals: string;
+  check_all: string;
+  uncheck_all: string;
   nothing_found: string;
 }
 

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -78,4 +78,30 @@ describe("FilterModal", () => {
     const button = queryByTestId("apply-filters");
     button && fireEvent.click(button);
   });
+
+  it("should trigger nnsSelectAll when select all button is clicked", (done) => {
+    const { queryByTestId, component } = render(FilterModal, {
+      props,
+    });
+
+    component.$on("nnsSelectAll", () => {
+      done();
+    });
+
+    const button = queryByTestId("filter-modal-select-all");
+    button && fireEvent.click(button);
+  });
+
+  it("should trigger nnsClearSelection when clear button is clicked", (done) => {
+    const { queryByTestId, component } = render(FilterModal, {
+      props,
+    });
+
+    component.$on("nnsClearSelection", () => {
+      done();
+    });
+
+    const button = queryByTestId("filter-modal-clear");
+    button && fireEvent.click(button);
+  });
 });

--- a/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/NnsProposalsFilterModal.spec.ts
@@ -97,4 +97,46 @@ describe("ProposalsFilterModal", () => {
 
     expect(selectedTopics).toEqual([...DEFAULT_PROPOSALS_FILTERS.topics, 1, 2]);
   });
+
+  it("should select all filters", async () => {
+    const { queryAllByTestId, queryByTestId } = render(ProposalsFilterModal, {
+      props,
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        false
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-select-all");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+  });
+
+  it("should clear all filters", async () => {
+    const { queryAllByTestId, queryByTestId } = render(ProposalsFilterModal, {
+      props,
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    const firstInput = inputs[0];
+    fireEvent.click(firstInput);
+    await waitFor(() => expect(firstInput.checked).toBe(true));
+
+    await clickByTestId(queryByTestId, "filter-modal-clear");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc || input.checked, false)).toBe(
+        false
+      )
+    );
+  });
 });

--- a/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterRewardsModal.spec.ts
@@ -108,4 +108,70 @@ describe("SnsFilterRewardsModal", () => {
 
     expect(statuses.filter(({ checked }) => checked).length).toEqual(2);
   });
+
+  it("should select all filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltersStore.setRewardStatus({
+      rootCanisterId: mockPrincipal,
+      rewardStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterRewardsModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        false
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-select-all");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+  });
+
+  it("should clearfilters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: true,
+    }));
+    snsFiltersStore.setRewardStatus({
+      rootCanisterId: mockPrincipal,
+      rewardStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterRewardsModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-clear");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc || input.checked, false)).toBe(
+        false
+      )
+    );
+  });
 });

--- a/frontend/src/tests/lib/modals/sns/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterStatusModal.spec.ts
@@ -109,4 +109,70 @@ describe("SnsFilterStatusModal", () => {
 
     expect(statuses.filter(({ checked }) => checked).length).toEqual(2);
   });
+
+  it("should select all filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltersStore.setDecisionStatus({
+      rootCanisterId: mockPrincipal,
+      decisionStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterStatusModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        false
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-select-all");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+  });
+
+  it("should clearfilters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: true,
+    }));
+    snsFiltersStore.setDecisionStatus({
+      rootCanisterId: mockPrincipal,
+      decisionStatus: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterStatusModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-clear");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc || input.checked, false)).toBe(
+        false
+      )
+    );
+  });
 });


### PR DESCRIPTION
# Motivation

Allow the user to easily select or clear all the proposal filters.

# Changes

* Upgrade gix-components which adds a new slot to Modal.
* FilterModal uses the new slot in the modal to add two buttons "Select All" and "Clear" which trigger two new events "nnsSelectAll" and "nnsClearSelection".
* Implement the two new events in NnsProposalsFiltersModal
* Implement the two new events in SnsFilterRewardsModal
* Implement the two new events in SnsFilterStatusModal

# Tests

* Test that FilterModal triggers two new events.
* Test that NnsProposalsFiltersModal selects all and clears selection.
* Test that SnsFilterRewardsModal selects all and clears selection.
* Test that SnsFilterStatuModal selects all and clears selection.

# Todos

- [ ] Add entry to changelog (if necessary).
