### PR TITLE
feat: icrc-accounts.store update

### DIFF
--- a/frontend/src/lib/stores/icrc-accounts.store.ts
+++ b/frontend/src/lib/stores/icrc-accounts.store.ts
@@ -18,6 +18,10 @@ export interface IcrcAccountsStore extends Readable<IcrcAccountStoreData> {
     accounts: IcrcAccounts;
     universeId: UniverseCanisterId;
   }) => void;
+  update: (params: {
+    accounts: IcrcAccounts;
+    universeId: UniverseCanisterId;
+  }) => void;
   reset: () => void;
 }
 
@@ -43,6 +47,29 @@ const initIcrcAccountsStore = (): IcrcAccountsStore => {
       update((currentState: IcrcAccountStoreData) => ({
         ...currentState,
         [universeId.toText()]: accounts,
+      }));
+    },
+
+    update: ({
+      accounts: { accounts, certified },
+      universeId,
+    }: {
+      accounts: IcrcAccounts;
+      universeId: UniverseCanisterId;
+    }) => {
+      update((currentState: IcrcAccountStoreData) => ({
+        ...currentState,
+        [universeId.toText()]: {
+          accounts: [
+            ...(currentState[universeId.toText()]?.accounts ?? []).filter(
+              ({ identifier }) =>
+                accounts.find(({ identifier: i }) => identifier === i) ===
+                undefined
+            ),
+            ...accounts,
+          ],
+          certified,
+        },
       }));
     },
 

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -1,7 +1,12 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockSnsMainAccount,
+  mockSnsSubAccount,
+} from "$tests/mocks/sns-accounts.mock";
 import { get } from "svelte/store";
 
 describe("icrc Accounts store", () => {
@@ -42,5 +47,42 @@ describe("icrc Accounts store", () => {
     expect(
       accountsInStore[CKBTC_UNIVERSE_CANISTER_ID.toText()]
     ).toBeUndefined();
+  });
+
+  it("should update accounts for a project", () => {
+    const accounts: Account[] = [mockSnsMainAccount, mockSnsSubAccount];
+    icrcAccountsStore.set({
+      accounts: {
+        accounts,
+        certified: true,
+      },
+      universeId: mockPrincipal,
+    });
+
+    const accountsInStore = get(icrcAccountsStore);
+    expect(accountsInStore[mockPrincipal.toText()]).toEqual({
+      accounts,
+      certified: true,
+    });
+
+    const updateSnsSubAccount = {
+      ...mockSnsSubAccount,
+      balanceE8s: 123n,
+    };
+
+    icrcAccountsStore.update({
+      accounts: {
+        accounts: [updateSnsSubAccount],
+        certified: true,
+      },
+      universeId: mockPrincipal,
+    });
+
+    const updatedStore = get(icrcAccountsStore);
+
+    expect(updatedStore[mockPrincipal.toText()]).toEqual({
+      accounts: [mockSnsMainAccount, updateSnsSubAccount],
+      certified: true,
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Add an `update` feature to `icrc-accounts` which can be use to update accounts when those are refreshed by a worker.
