### PR TITLE
Parse build run conslusion instead of using --status of gh

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -39,6 +39,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Removed
 - Deleted the now empty `docker-build` and `aggregator` GitHub workflows.
 #### Fixed
+- Script to download WASM from CI no longer relies on broken `gh --status` flag.
 #### Security
 
 ## Proposal 123245

--- a/scripts/nns-dapp/get-ci-build-run
+++ b/scripts/nns-dapp/get-ci-build-run
@@ -22,7 +22,7 @@ source "$(clap.build)"
 
 COMMIT="$(git rev-parse "$COMMIT")"
 
-ci_build_run_id="$(gh run list --workflow "$WORKFLOW_NAME" --limit "$LIMIT" --status success --json databaseId,headSha | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit)' | jq -r '.databaseId' | tail -1)"
+ci_build_run_id="$(gh run list --workflow "$WORKFLOW_NAME" --limit "$LIMIT" --json databaseId,headSha,conclusion | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit and .conclusion == "success")' | jq -r '.databaseId' | tail -1)"
 
 if ! [ "$ci_build_run_id" ]; then
   (


### PR DESCRIPTION
# Motivation

We have a script that downloads the WASM from CI. It uses `gh` to get a successful run by using `--status success`. This was working before but at commit `8ac5bef5427b0e3b003794fd2545eb9fd92cee83` it does not find any runs. But if I remove the flag, I do see runs that are successful.

# Changes

Instead of using the `--status success` flag of `gh`. Parse the `.conclusion` field of the result to find the successful runs.

# Tests

This was found because `scripts/nns-dapp/download-ci-wasm.test` was failing so the test was working.
The test passed on this PR: https://github.com/dfinity/nns-dapp/actions/runs/5399373231/jobs/9806423017?pr=2775

# Todos

- [x] Add entry to changelog (if necessary).
