### PR TITLE
Fix: Voting after SNS proposal has closed

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,9 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Deprecated
 #### Removed
 #### Fixed
+
+* Enable voting for proposals that are decided but still accepting votes.
+
 #### Security
 #### Not Published
 

--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -22,7 +22,7 @@
   import {
     snsNeuronToVotingNeuron,
     snsProposalIdString,
-    snsProposalOpen,
+    snsProposalAcceptingVotes,
   } from "$lib/utils/sns-proposals.utils";
   import {
     getSnsNeuronIdAsHexString,
@@ -82,7 +82,7 @@
     $voteRegistrationStore,
     (visible =
       voteRegistration !== undefined ||
-      (votableNeurons.length > 0 && snsProposalOpen(proposal)));
+      (votableNeurons.length > 0 && snsProposalAcceptingVotes(proposal)));
 
   let neuronsReady = false;
   $: neuronsReady =

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -351,8 +351,9 @@ export const snsProposalIdString = (proposal: SnsProposalData): string =>
 export const snsProposalId = (proposal: SnsProposalData): bigint =>
   fromDefinedNullable(proposal.id).id;
 
-export const snsProposalOpen = (proposal: SnsProposalData): boolean =>
-  proposal.decided_timestamp_seconds === 0n;
+export const snsProposalAcceptingVotes = (proposal: SnsProposalData): boolean =>
+  snsRewardStatus(proposal) ===
+  SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES;
 
 /**
  * Returns the voting power of a neuron for a proposal.

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -3,6 +3,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
+  type SnsBallot,
   type SnsProposalData,
   type SnsProposalId,
   type SnsTally,
@@ -125,10 +126,14 @@ export const createSnsProposal = ({
   status,
   rewardStatus,
   proposalId,
+  ballots = [],
+  createdAt = BigInt(12313123),
 }: {
   status: SnsProposalDecisionStatus;
   rewardStatus?: SnsProposalRewardStatus;
   proposalId: bigint;
+  ballots?: Array<[string, SnsBallot]>;
+  createdAt?: bigint;
 }): SnsProposalData => {
   const id: [SnsProposalId] = [{ id: proposalId }];
   switch (status) {
@@ -139,6 +144,8 @@ export const createSnsProposal = ({
           id,
           latest_tally: [acceptedTally],
           decided_timestamp_seconds: BigInt(0),
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
         },
         rewardStatus,
       });
@@ -151,6 +158,8 @@ export const createSnsProposal = ({
           decided_timestamp_seconds: BigInt(11223),
           executed_timestamp_seconds: BigInt(0),
           failed_timestamp_seconds: BigInt(0),
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
         },
         rewardStatus,
       });
@@ -163,6 +172,8 @@ export const createSnsProposal = ({
           decided_timestamp_seconds: BigInt(11223),
           executed_timestamp_seconds: BigInt(0),
           failed_timestamp_seconds: BigInt(112231320),
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
         },
         rewardStatus,
       });
@@ -175,6 +186,8 @@ export const createSnsProposal = ({
           decided_timestamp_seconds: BigInt(11223),
           executed_timestamp_seconds: BigInt(112231320),
           failed_timestamp_seconds: BigInt(0),
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
         },
         rewardStatus,
       });
@@ -187,6 +200,18 @@ export const createSnsProposal = ({
           decided_timestamp_seconds: BigInt(11223),
           executed_timestamp_seconds: BigInt(0),
           failed_timestamp_seconds: BigInt(0),
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
+        },
+        rewardStatus,
+      });
+    default:
+      return addRewardStatusData({
+        proposal: {
+          ...mockSnsProposal,
+          id,
+          ballots,
+          proposal_creation_timestamp_seconds: createdAt,
         },
         rewardStatus,
       });


### PR DESCRIPTION
# Motivation

Users couldn't vote on proposals that were decided (executed, or failed, ...) but still accepting proposals.

# Changes

* Fix logic in `snsProposalOpen` to check the reward status of the proposal.
* Rename `snsProposalOpen` to `snsProposalAcceptingVotes` to more accurately describe what it does.

# Tests

* Add two new params to `createSnsProposal`: ballots and created at.
* Change test for `snsProposalOpen` and add more test cases.
* Add test case in SnsVotingCard to replicate the issue and make it pass.
