### PR TITLE
Refresh balances periodically on Sns accounts

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
@@ -19,14 +19,11 @@
 
     worker = await initBalancesWorker();
 
-    const {
-      account: { identifier },
-      ledgerCanisterId,
-    } = data;
+    const { accounts, ledgerCanisterId } = data;
 
     worker?.startBalancesTimer({
       ledgerCanisterId,
-      accountIdentifiers: [identifier],
+      accountIdentifiers: accounts.map(({ identifier }) => identifier),
       callback,
     });
   };

--- a/frontend/src/lib/components/accounts/SnsAccountsBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsBalancesObserver.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { nonNullish } from "@dfinity/utils";
+  import {
+    snsOnlyProjectStore,
+    snsProjectSelectedStore,
+  } from "$lib/derived/sns/sns-selected-project.derived";
+  import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
+  import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
+  import type { CanisterId } from "$lib/types/canister";
+
+  let ledgerCanisterId: CanisterId | undefined;
+  $: ledgerCanisterId = $snsProjectSelectedStore?.summary.ledgerCanisterId;
+</script>
+
+{#if nonNullish($snsOnlyProjectStore) && nonNullish(ledgerCanisterId)}
+  <SnsBalancesObserver
+    rootCanisterId={$snsOnlyProjectStore}
+    {ledgerCanisterId}
+    accounts={$snsProjectAccountsStore ?? []}
+  >
+    <slot />
+  </SnsBalancesObserver>
+{/if}

--- a/frontend/src/lib/components/accounts/SnsBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/SnsBalancesObserver.svelte
@@ -10,7 +10,7 @@
 
   export let rootCanisterId: CanisterId;
   export let ledgerCanisterId: CanisterId;
-  export let account: Account;
+  export let accounts: Account[];
 
   const callback: BalancesCallback = ({ balances }) => {
     const accounts = balances
@@ -37,7 +37,7 @@
 
   let data: BalancesObserverData;
   $: data = {
-    account,
+    accounts,
     ledgerCanisterId: ledgerCanisterId.toText(),
   };
 </script>

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -10,6 +10,7 @@
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { nonNullish } from "@dfinity/utils";
   import { tokensStore } from "$lib/stores/tokens.store";
+  import SnsAccountsBalancesObserver from "$lib/components/accounts/SnsAccountsBalancesObserver.svelte";
 
   export let goToWallet: (account: Account) => Promise<void>;
 
@@ -37,14 +38,16 @@
   {#if loading}
     <SkeletonCard size="medium" />
   {:else}
-    {#each $snsProjectAccountsStore ?? [] as account}
-      <AccountCard
-        role="link"
-        on:click={() => goToWallet(account)}
-        hash
-        {account}
-        {token}>{account.name ?? $i18n.accounts.main}</AccountCard
-      >
-    {/each}
+    <SnsAccountsBalancesObserver>
+      {#each $snsProjectAccountsStore ?? [] as account}
+        <AccountCard
+          role="link"
+          on:click={() => goToWallet(account)}
+          hash
+          {account}
+          {token}>{account.name ?? $i18n.accounts.main}</AccountCard
+        >
+      {/each}
+    </SnsAccountsBalancesObserver>
   {/if}
 </div>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -32,7 +32,7 @@
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import { tokensStore } from "$lib/stores/tokens.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
-  import SnsWalletBalancesObserver from "$lib/components/accounts/SnsWalletBalancesObserver.svelte";
+  import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
 
   let showModal: "send" | undefined = undefined;
 
@@ -130,9 +130,9 @@
   <main class="legacy" data-tid="sns-wallet">
     <section>
       {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore)}
-        <SnsWalletBalancesObserver
+        <SnsBalancesObserver
           rootCanisterId={$snsOnlyProjectStore}
-          account={$selectedAccountStore.account}
+          accounts={[$selectedAccountStore.account]}
           ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
         >
           <Summary />
@@ -146,7 +146,7 @@
             account={$selectedAccountStore.account}
             {token}
           />
-        </SnsWalletBalancesObserver>
+        </SnsBalancesObserver>
       {:else}
         <Spinner />
       {/if}

--- a/frontend/src/lib/types/icrc.observer.ts
+++ b/frontend/src/lib/types/icrc.observer.ts
@@ -6,7 +6,7 @@ export type BalancesObserverData = Pick<
   PostMessageDataRequestBalances,
   "ledgerCanisterId"
 > & {
-  account: Account;
+  accounts: Account[];
 };
 
 export type TransactionsObserverData = Pick<

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
@@ -30,7 +30,7 @@ describe("IcrcBalancesObserver", () => {
 
   const data: BalancesObserverData = {
     ledgerCanisterId: ledgerCanisterIdMock.toText(),
-    account: mockMainAccount,
+    accounts: [mockMainAccount],
   };
 
   it("should init worker with parameters", async () => {
@@ -46,7 +46,7 @@ describe("IcrcBalancesObserver", () => {
         msg: "nnsStartBalancesTimer",
         data: {
           ledgerCanisterId: data.ledgerCanisterId,
-          accountIdentifiers: [data.account.identifier],
+          accountIdentifiers: data.accounts.map(({ identifier }) => identifier),
           host: HOST,
           fetchRootKey: FETCH_ROOT_KEY,
         },

--- a/frontend/src/tests/lib/components/accounts/SnsBalancesObserverTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/SnsBalancesObserverTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import SnsWalletBalancesObserver from "$lib/components/accounts/SnsWalletBalancesObserver.svelte";
+  import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
   import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
   import {
     ledgerCanisterIdMock,
@@ -7,10 +7,10 @@
   } from "$tests/mocks/sns.api.mock";
 </script>
 
-<SnsWalletBalancesObserver
-  account={mockSnsMainAccount}
+<SnsBalancesObserver
+  accounts={[mockSnsMainAccount]}
   rootCanisterId={rootCanisterIdMock}
   ledgerCanisterId={ledgerCanisterIdMock}
 >
   <div data-tid="test-observer" />
-</SnsWalletBalancesObserver>
+</SnsBalancesObserver>

--- a/frontend/src/tests/lib/components/accounts/SnsWalletBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsWalletBalancesObserver.spec.ts
@@ -14,7 +14,7 @@ import type {
 import type { PostMessageDataResponseSync } from "$lib/types/post-message.sync";
 import type { PostMessage } from "$lib/types/post-messages";
 import { page } from "$mocks/$app/stores";
-import SnsWalletBalancesObserverTest from "$tests/lib/components/accounts/SnsWalletBalancesObserverTest.svelte";
+import SnsBalancesObserverTest from "$tests/lib/components/accounts/SnsBalancesObserverTest.svelte";
 import { PostMessageMock } from "$tests/mocks/post-message.mocks";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
@@ -77,13 +77,13 @@ describe("SnsWalletBalancesObserver", () => {
   });
 
   it("should init data and render slotted content", async () => {
-    const { getByTestId } = render(SnsWalletBalancesObserverTest);
+    const { getByTestId } = render(SnsBalancesObserverTest);
 
     await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
   });
 
   it("should update account store on new sync message", async () => {
-    const { getByTestId } = render(SnsWalletBalancesObserverTest);
+    const { getByTestId } = render(SnsBalancesObserverTest);
 
     await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
 
@@ -117,7 +117,7 @@ describe("SnsWalletBalancesObserver", () => {
   });
 
   it("should populate error to sync store on error message from worker", async () => {
-    const { getByTestId } = render(SnsWalletBalancesObserverTest);
+    const { getByTestId } = render(SnsBalancesObserverTest);
 
     await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
 

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -74,6 +74,32 @@ jest.mock("$lib/services/ckbtc-info.services", () => {
   };
 });
 
+jest.mock("$lib/services/worker-transactions.services", () => ({
+  initTransactionsWorker: jest.fn(() =>
+    Promise.resolve({
+      startTransactionsTimer: () => {
+        // Do nothing
+      },
+      stopTransactionsTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
+jest.mock("$lib/services/worker-balances.services", () => ({
+  initBalancesWorker: jest.fn(() =>
+    Promise.resolve({
+      startBalancesTimer: () => {
+        // Do nothing
+      },
+      stopBalancesTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
 describe("Accounts", () => {
   beforeAll(() => {
     jest


### PR DESCRIPTION
# Motivation

As for Sns wallet, we want to periodically refresh the accounts displayed on the Sns Accounts page. However, as no transactions are displayed, we only want to refresh the balances on that particular page.

# PRs

- Follow-up of #2639

# Changes

- rename `SnsWalletBalancesObserver` to `SnsBalancesObserver`
- extend property from a single account to an array of accounts
- use observer in `SnsAccounts` page