### PR TITLE
Update CI workflow name used by ci-link

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -44,6 +44,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Deleted the now empty `docker-build` and `aggregator` GitHub workflows.
 #### Fixed
 - Script to download WASM from CI no longer relies on broken `gh --status` flag.
+- ci-link script uses correct workflow name.
 #### Security
 
 ## Proposal 123245

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -44,7 +44,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Deleted the now empty `docker-build` and `aggregator` GitHub workflows.
 #### Fixed
 - Script to download WASM from CI no longer relies on broken `gh --status` flag.
-- ci-link script uses correct workflow name.
+* ci-link script uses correct workflow name.
 #### Security
 
 ## Proposal 123245

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -22,6 +22,8 @@ clap.define short=c long=commit desc="The commit, tag or reference to find" vari
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-ci_build_run_id="$("$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT")"
+ci_build_run_ids="$("$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT" --all)"
 
-echo "https://github.com/dfinity/nns-dapp/actions/runs/$ci_build_run_id"
+for id in $ci_build_run_ids; do
+  echo "https://github.com/dfinity/nns-dapp/actions/runs/$id"
+done

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -22,7 +22,7 @@ clap.define short=c long=commit desc="The commit, tag or reference to find" vari
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-ci_build_run_ids="$("$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT" --all)"
+"$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT" --all | sed 's!.*!https://github.com/dfinity/nns-dapp/actions/runs/&!g'
 
 for id in $ci_build_run_ids; do
   echo "https://github.com/dfinity/nns-dapp/actions/runs/$id"

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -23,7 +23,3 @@ clap.define short=c long=commit desc="The commit, tag or reference to find" vari
 source "$(clap.build)"
 
 "$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT" --all | sed 's!.*!https://github.com/dfinity/nns-dapp/actions/runs/&!g'
-
-for id in $ci_build_run_ids; do
-  echo "https://github.com/dfinity/nns-dapp/actions/runs/$id"
-done

--- a/scripts/nns-dapp/ci-link
+++ b/scripts/nns-dapp/ci-link
@@ -22,7 +22,6 @@ clap.define short=c long=commit desc="The commit, tag or reference to find" vari
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-DFX_COMMIT="$(git rev-parse "$DFX_COMMIT")"
-export DFX_COMMIT
+ci_build_run_id="$("$SOURCE_DIR/nns-dapp/get-ci-build-run" --commit "$DFX_COMMIT" --limit "$DFX_LIMIT")"
 
-gh run list --workflow "Docker build" --limit "${DFX_LIMIT}" --json name,conclusion,databaseId,headSha --jq '.[] | select(.headSha==env.DFX_COMMIT) | select(.conclusion=="success") | "https://github.com/dfinity/nns-dapp/actions/runs/\(.databaseId)"'
+echo "https://github.com/dfinity/nns-dapp/actions/runs/$ci_build_run_id"

--- a/scripts/nns-dapp/get-ci-build-run
+++ b/scripts/nns-dapp/get-ci-build-run
@@ -17,14 +17,15 @@ source "$SOURCE_DIR/../clap.bash"
 # Define options
 clap.define short=c long=commit desc="Commit to get build run for" variable=COMMIT default="tags/release-candidate"
 clap.define short=l long=limit desc="--limit passed to gh run list" variable=LIMIT default="200"
+clap.define short=a long=all desc="output all IDs for the commit" variable=ALL nargs=0 default="false"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 COMMIT="$(git rev-parse "$COMMIT")"
 
-ci_build_run_id="$(gh run list --workflow "$WORKFLOW_NAME" --limit "$LIMIT" --json databaseId,headSha,conclusion | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit and .conclusion == "success")' | jq -r '.databaseId' | tail -1)"
+ci_build_run_ids="$(gh run list --workflow "$WORKFLOW_NAME" --limit "$LIMIT" --json databaseId,headSha,conclusion | jq --arg commit "$COMMIT" '.[] | select(.headSha == $commit and .conclusion == "success")' | jq -r '.databaseId')"
 
-if ! [ "$ci_build_run_id" ]; then
+if ! [ "$ci_build_run_ids" ]; then
   (
     echo "No successful $WORKFLOW_NAME run found for commit $COMMIT."
     echo "If the commit is too new, the run may not have finished yet."
@@ -33,4 +34,8 @@ if ! [ "$ci_build_run_id" ]; then
   exit 1
 fi
 
-echo "$ci_build_run_id"
+if [ "$ALL" = "true" ]; then
+  echo "$ci_build_run_ids"
+else
+  echo "$ci_build_run_ids" | tail -1
+fi

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -15,7 +15,7 @@ export DFX_NETWORK
 
 mkdir -p release/ci
 [[ "${CI:-}" != "" ]] || {
-  CI="$("$SOURCE_DIR/nns-dapp/ci-link" --commit tags/release-candidate | grep .)"
+  CI="$("$SOURCE_DIR/nns-dapp/ci-link" --commit tags/release-candidate | tail -n1 | grep .)"
 }
 WASM="release/ci/nns-dapp.wasm.gz"
 if test -f "$WASM"; then

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -15,7 +15,7 @@ export DFX_NETWORK
 
 mkdir -p release/ci
 [[ "${CI:-}" != "" ]] || {
-  CI="$("$SOURCE_DIR/nns-dapp/ci-link" --commit tags/release-candidate | tail -n1 | grep .)"
+  CI="$("$SOURCE_DIR/nns-dapp/ci-link" --commit tags/release-candidate | grep .)"
 }
 WASM="release/ci/nns-dapp.wasm.gz"
 if test -f "$WASM"; then


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/2744 changed workflow names.
`scripts/nns-dapp/ci-link` expects there to be a workflow named "Docker build" but it no longer exists.

# Changes

Change `scripts/nns-dapp/ci-link` to use `scripts/nns-dapp/get-ci-build-run` which is tested.
The only difference is that `ci-link` used to output multiple links and now only 1.
But the only place where it's used, it was followed by `tail -n 1` so this fine.

# Tests

None, but now most of the work is done by `scripts/nns-dapp/get-ci-build-run`, which is used by `scripts/nns-dapp/download-ci-wasm` and thus tested here: https://github.com/dfinity/nns-dapp/blob/75936135f738040a3cdfeec73d626cb4e3b9eb46/.github/workflows/checks.yml#L271


# Todos

- [x] Add entry to changelog (if necessary).
