### PR TITLE
Auto close sync indicator

### DIFF
--- a/frontend/src/lib/components/header/AccountSyncIndicator.svelte
+++ b/frontend/src/lib/components/header/AccountSyncIndicator.svelte
@@ -53,6 +53,16 @@
   $: description = syncDescription($syncOverallStatusStore);
 
   const toggle = () => (visible = !visible);
+
+  const close = (state: SyncState) => {
+    if (!visible || state !== "idle") {
+      return;
+    }
+
+    toggle();
+  };
+
+  $: close($syncOverallStatusStore);
 </script>
 
 {#if $authSignedInStore && nonNullish(icon)}


### PR DESCRIPTION
# Motivation

If user click on the indicator while in progress, a popover is displayed.
The popover and indicator goes hidden as soon as the worker is idle.
When the worker starts again, the indicator is displayed and because the state might not have been resetted, the popover is currently displayed again automatically, which is a bit surprising.

To avoid this behavior, let's close the popover state as soon as the indicator turns idle.