### PR TITLE
GIX-1656: Rename Canister Endpoint

### DIFF
--- a/rs/backend/nns-dapp-exports.txt
+++ b/rs/backend/nns-dapp-exports.txt
@@ -18,5 +18,6 @@ canister_update create_sub_account
 canister_update detach_canister
 canister_update get_proposal_payload
 canister_update register_hardware_wallet
+canister_update rename_canister
 canister_update rename_sub_account
 main

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -154,6 +154,21 @@ type AttachCanisterResponse =
         NameTooLong;
     };
 
+type RenameCanisterRequest =
+    record {
+        name: text;
+        canister_id: principal;
+    };
+
+type RenameCanisterResponse =
+    variant {
+        Ok;
+        NameAlreadyTaken;
+        NameTooLong;
+        CanisterNotFound;
+        AccountNotFound;
+    };
+
 type AddPendingNotifySwapRequest =
     record {
         buyer: principal;
@@ -244,6 +259,7 @@ service: (opt Config) -> {
     register_hardware_wallet: (RegisterHardwareWalletRequest) -> (RegisterHardwareWalletResponse);
     get_canisters: () -> (vec CanisterDetails) query;
     attach_canister: (AttachCanisterRequest) -> (AttachCanisterResponse);
+    rename_canister: (RenameCanisterRequest) -> (RenameCanisterResponse);
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
     get_stats: () -> (Stats) query;

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -805,7 +805,8 @@ impl AccountsStore {
     }
 
     fn find_canister_index(account: &Account, canister_id: CanisterId) -> Option<usize> {
-        account.canisters
+        account
+            .canisters
             .iter()
             .enumerate()
             .find(|(_, canister)| canister.canister_id == canister_id)
@@ -828,8 +829,7 @@ impl AccountsStore {
 
                 let mut response = RenameCanisterResponse::Ok;
 
-                if let Some(index) = Self::find_canister_index(&account, request.canister_id)
-                {
+                if let Some(index) = Self::find_canister_index(account, request.canister_id) {
                     account.canisters.remove(index);
                     account.canisters.push(NamedCanister {
                         name: request.name,
@@ -852,8 +852,7 @@ impl AccountsStore {
         if self.accounts.get(&account_identifier.to_vec()).is_some() {
             let mut response = DetachCanisterResponse::Ok;
             let account = self.accounts.get_mut(&account_identifier.to_vec()).unwrap();
-            if let Some(index) = Self::find_canister_index(&account, request.canister_id)
-            {
+            if let Some(index) = Self::find_canister_index(account, request.canister_id) {
                 account.canisters.remove(index);
             } else {
                 response = DetachCanisterResponse::CanisterNotFound

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -827,19 +827,17 @@ impl AccountsStore {
                     }
                 }
 
-                let mut response = RenameCanisterResponse::Ok;
-
                 if let Some(index) = Self::find_canister_index(account, request.canister_id) {
                     account.canisters.remove(index);
                     account.canisters.push(NamedCanister {
                         name: request.name,
                         canister_id: request.canister_id,
                     });
+                    sort_canisters(&mut account.canisters);
+                    RenameCanisterResponse::Ok
                 } else {
-                    response = RenameCanisterResponse::CanisterNotFound;
+                    RenameCanisterResponse::CanisterNotFound
                 }
-                sort_canisters(&mut account.canisters);
-                response
             } else {
                 RenameCanisterResponse::AccountNotFound
             }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -821,10 +821,8 @@ impl AccountsStore {
 
             if self.accounts.get(&account_identifier.to_vec()).is_some() {
                 let account = self.accounts.get_mut(&account_identifier.to_vec()).unwrap();
-                for c in account.canisters.iter() {
-                    if !request.name.is_empty() && c.name == request.name {
-                        return RenameCanisterResponse::NameAlreadyTaken;
-                    }
+                if !request.name.is_empty() && account.canisters.iter().any(|c| c.name == request.name) {
+                  return RenameCanisterResponse::NameAlreadyTaken;
                 }
 
                 if let Some(index) = Self::find_canister_index(account, request.canister_id) {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -822,7 +822,7 @@ impl AccountsStore {
             if self.accounts.get(&account_identifier.to_vec()).is_some() {
                 let account = self.accounts.get_mut(&account_identifier.to_vec()).unwrap();
                 if !request.name.is_empty() && account.canisters.iter().any(|c| c.name == request.name) {
-                  return RenameCanisterResponse::NameAlreadyTaken;
+                    return RenameCanisterResponse::NameAlreadyTaken;
                 }
 
                 if let Some(index) = Self::find_canister_index(account, request.canister_id) {

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -939,6 +939,159 @@ fn attach_canister_canister_already_attached() {
 }
 
 #[test]
+fn attach_canister_and_rename() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let initial_name = "ABC".to_string();
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: initial_name.clone(),
+            canister_id,
+        },
+    );
+
+    let canisters = store.get_canisters(principal);
+    assert_eq!(initial_name, canisters[0].name);
+
+    let final_name = "DEF".to_string();
+    store.rename_canister(
+        principal,
+        RenameCanisterRequest {
+            name: final_name.clone(),
+            canister_id,
+        },
+    );
+
+    let canisters = store.get_canisters(principal);
+    assert_eq!(final_name, canisters[0].name);
+}
+
+#[test]
+fn rename_to_taken_name_fails() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+    let canister_id2 = CanisterId::from_str(TEST_ACCOUNT_3).unwrap();
+
+    let name1 = "ABC".to_string();
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: name1.clone(),
+            canister_id,
+        },
+    );
+    let name2 = "DEF".to_string();
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: name2.clone(),
+            canister_id: canister_id2,
+        },
+    );
+    let canisters = store.get_canisters(principal);
+    assert_eq!(name1, canisters[0].name);
+    assert_eq!(name2, canisters[1].name);
+
+    let response = store.rename_canister(
+        principal,
+        RenameCanisterRequest {
+            name: name1.clone(),
+            canister_id: canister_id2,
+        },
+    );
+
+    assert!(matches!(response, RenameCanisterResponse::NameAlreadyTaken));
+
+    let canisters = store.get_canisters(principal);
+    assert_eq!(name1, canisters[0].name);
+    assert_eq!(name2, canisters[1].name);
+}
+
+#[test]
+fn rename_to_long_name_fails() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    let long_name = "ABCDEFGHIJKLMNOPQRSTUVWXY".to_string();
+    let name = "DEF".to_string();
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: name.clone(),
+            canister_id,
+        },
+    );
+    let response = store.rename_canister(
+        principal,
+        RenameCanisterRequest {
+            name: long_name.clone(),
+            canister_id,
+        },
+    );
+    let canisters = store.get_canisters(principal);
+    assert_eq!(name, canisters[0].name);
+    assert!(matches!(response, RenameCanisterResponse::NameTooLong));
+}
+
+#[test]
+fn rename_not_found_canister() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+    let canister_id2 = CanisterId::from_str(TEST_ACCOUNT_3).unwrap();
+
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "DEF".to_string(),
+            canister_id,
+        },
+    );
+    let response = store.rename_canister(
+        principal,
+        RenameCanisterRequest {
+            name: "ABC".to_string(),
+            canister_id: canister_id2,
+        },
+    );
+    assert!(matches!(response, RenameCanisterResponse::CanisterNotFound));
+}
+
+#[test]
+fn rename_not_found_account() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let principal2 = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+
+    let canister_id = CanisterId::from_str(TEST_ACCOUNT_2).unwrap();
+
+    store.attach_canister(
+        principal,
+        AttachCanisterRequest {
+            name: "DEF".to_string(),
+            canister_id,
+        },
+    );
+    let response = store.rename_canister(
+        principal2,
+        RenameCanisterRequest {
+            name: "ABC".to_string(),
+            canister_id,
+        },
+    );
+    assert!(matches!(response, RenameCanisterResponse::AccountNotFound));
+}
+
+#[test]
 fn canisters_ordered_by_name_if_exists_then_by_id() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1032,7 +1032,7 @@ fn rename_to_long_name_fails() {
     let response = store.rename_canister(
         principal,
         RenameCanisterRequest {
-            name: long_name.clone(),
+            name: long_name,
             canister_id,
         },
     );

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -1,9 +1,4 @@
-use crate::accounts_store::{
-    AccountDetails, AddPendingNotifySwapRequest, AddPendingTransactionResponse, AttachCanisterRequest,
-    AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest, DetachCanisterResponse,
-    GetTransactionsRequest, GetTransactionsResponse, NamedCanister, RegisterHardwareWalletRequest,
-    RegisterHardwareWalletResponse, RenameSubAccountRequest, RenameSubAccountResponse, TransactionType,
-};
+use crate::accounts_store::{AccountDetails, AddPendingNotifySwapRequest, AddPendingTransactionResponse, AttachCanisterRequest, AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest, DetachCanisterResponse, GetTransactionsRequest, GetTransactionsResponse, NamedCanister, RegisterHardwareWalletRequest, RegisterHardwareWalletResponse, RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest, RenameSubAccountResponse, TransactionType};
 use crate::arguments::{set_canister_arguments, CanisterArguments};
 use crate::assets::{hash_bytes, insert_asset, insert_tar_xz, Asset};
 use crate::perf::PerformanceCount;
@@ -207,6 +202,17 @@ pub fn attach_canister() {
 fn attach_canister_impl(request: AttachCanisterRequest) -> AttachCanisterResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().attach_canister(principal, request))
+}
+
+/// Renames a canister of the user.
+#[export_name = "canister_update rename_canister"]
+pub fn rename_canister() {
+    over(candid_one, rename_canister_impl);
+}
+
+fn rename_canister_impl(request: RenameCanisterRequest) -> RenameCanisterResponse {
+    let principal = dfn_core::api::caller();
+    STATE.with(|s| s.accounts_store.borrow_mut().rename_canister(principal, request))
 }
 
 /// Detaches a canister from the user's account.

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -1,4 +1,10 @@
-use crate::accounts_store::{AccountDetails, AddPendingNotifySwapRequest, AddPendingTransactionResponse, AttachCanisterRequest, AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest, DetachCanisterResponse, GetTransactionsRequest, GetTransactionsResponse, NamedCanister, RegisterHardwareWalletRequest, RegisterHardwareWalletResponse, RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest, RenameSubAccountResponse, TransactionType};
+use crate::accounts_store::{
+    AccountDetails, AddPendingNotifySwapRequest, AddPendingTransactionResponse, AttachCanisterRequest,
+    AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest, DetachCanisterResponse,
+    GetTransactionsRequest, GetTransactionsResponse, NamedCanister, RegisterHardwareWalletRequest,
+    RegisterHardwareWalletResponse, RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest,
+    RenameSubAccountResponse, TransactionType,
+};
 use crate::arguments::{set_canister_arguments, CanisterArguments};
 use crate::assets::{hash_bytes, insert_asset, insert_tar_xz, Asset};
 use crate::perf::PerformanceCount;


### PR DESCRIPTION
# Motivation

Users want to be able to add names to their canisters.

We already enabled canisters to be created with a name, but we were missing an endpoint to rename canisters.

This PR introduces the nns-dapp canister endpoint to rename canisters.

In another PR: Use this endpoint from the NNS Dapp frontend.

# Changes

* New endpoint `rename_canister` in NNS Dapp canister.
* New method `rename_canister` in AccountsStore to rename a canister.
* Related types.

# Tests

* Test the new method in the AccountsStore.

# Todos

Not yet entry in the changelog until I add all the renaming functionality.

