### PR TITLE
Fix: Tooltip Split Sns Neuron Button

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -29,6 +29,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Enable voting for proposals that are decided but still accepting votes.
+* Misplaced tooltip for disabled SNS neuron split button.
 
 #### Security
 #### Not Published

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -106,4 +106,12 @@
   .content-cell-details {
     gap: var(--padding-1_5x);
   }
+
+  .buttons {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--padding-1_5x);
+  }
 </style>


### PR DESCRIPTION
# Motivation

Tooltip is misplaced for the Split SNS neuron button.

# Changes

* Add style to wrapper of the button to set the tooltip.

# Tests

Only style issues.
