### PR TITLE
Ignore sign-in "error" UserInterrupt

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -20,6 +20,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 * Disable functionality buttons while SNS neuron is vesting.
+* Ignore sign-in "error" `UserInterrupt`.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/common/SignIn.svelte
+++ b/frontend/src/lib/components/common/SignIn.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-  import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
-  import { toastsError } from "$lib/stores/toasts.store";
   import { Spinner } from "@dfinity/gix-components";
   import { layoutAuthReady } from "$lib/stores/layout.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
-
-  // Asks the user to authenticate themselves with a TPM or similar.
-  const signIn = async () => {
-    const onError = (err: unknown) =>
-      toastsError({
-        labelKey: "error.sign_in",
-        err,
-      });
-
-    await authStore.signIn(onError);
-  };
+  import { login } from "$lib/services/auth.services";
 
   let disabled = true;
   $: disabled = $authSignedInStore || !$layoutAuthReady;
 </script>
 
-<button on:click={signIn} data-tid="login-button" class="primary" {disabled}>
+<button on:click={login} data-tid="login-button" class="primary" {disabled}>
   <slot>{$i18n.auth.login}</slot>
   {#if disabled}
     <div class="spinner">

--- a/frontend/src/lib/components/header/LoginIconOnly.svelte
+++ b/frontend/src/lib/components/header/LoginIconOnly.svelte
@@ -1,26 +1,14 @@
 <script lang="ts">
   import { IconLogin } from "@dfinity/gix-components";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import { layoutAuthReady } from "$lib/stores/layout.store";
-
-  // TODO: Same code as in SignIn.svelte maybe we can refactore
-  const signIn = async () => {
-    const onError = (err: unknown) =>
-      toastsError({
-        labelKey: "error.sign_in",
-        err,
-      });
-
-    await authStore.signIn(onError);
-  };
+  import { login } from "$lib/services/auth.services";
 </script>
 
 <button
   data-tid="toolbar-login"
   class="icon-only toggle"
-  on:click={signIn}
+  on:click={login}
   aria-label={$i18n.auth.login}
   disabled={!$layoutAuthReady}
 >

--- a/frontend/src/lib/services/auth.services.ts
+++ b/frontend/src/lib/services/auth.services.ts
@@ -1,6 +1,6 @@
 import { authStore } from "$lib/stores/auth.store";
 import { startBusy } from "$lib/stores/busy.store";
-import { toastsShow } from "$lib/stores/toasts.store";
+import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { ToastMsg } from "$lib/types/toast";
 import { replaceHistory } from "$lib/utils/route.utils";
 import type { Identity } from "@dfinity/agent";
@@ -10,6 +10,22 @@ import { get } from "svelte/store";
 
 const msgParam = "msg";
 const levelParam = "level";
+
+export const login = async () => {
+  const onError = (err: unknown) => {
+    if (err === "UserInterrupt") {
+      // We do not display an error if user explicitly cancelled the process of sign-in. User is most certainly aware of it.
+      return;
+    }
+
+    toastsError({
+      labelKey: "error.sign_in",
+      err,
+    });
+  };
+
+  await authStore.signIn(onError);
+};
 
 export const logout = async ({
   msg = undefined,


### PR DESCRIPTION
# Motivation

Agent-js bubbles the error `UserInterrupt` when user interrupts the sign-in flow which per extension is displayed in a toast error in NNS dapp. Because this has not much value for most of the users, we are going to ignore these particular "error".

# Changes

- if `UserInterrupt` then no toast
- refactor duplicated code and solve TODO
