### PR TITLE
Address TODO: Use pop_first

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -19,6 +19,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Simplify rust cache expiry with `pop_first()`.
 * Disable functionality buttons while SNS neuron is vesting.
 * Ignore sign-in "error" `UserInterrupt`.
 

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -43,7 +43,7 @@ pub async fn get_proposal_payload(proposal_id: u64) -> Result<Json, String> {
 
 fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_json: String) {
     if cache.len() >= CACHE_SIZE_LIMIT {
-        cache.pop_first()
+        cache.pop_first();
     }
 
     cache.insert(proposal_id, payload_json);

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -43,10 +43,7 @@ pub async fn get_proposal_payload(proposal_id: u64) -> Result<Json, String> {
 
 fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_json: String) {
     if cache.len() >= CACHE_SIZE_LIMIT {
-        // TODO replace this with `pop_first` once it is stablized
-        if let Some(key) = cache.iter().next().map(|(key, _)| *key) {
-            cache.remove(&key);
-        }
+        cache.pop_first()
     }
 
     cache.insert(proposal_id, payload_json);


### PR DESCRIPTION
# Motivation
When the proposal payload cache was written, `pop_first()` existed but only in unstable rust.  Now it is available in stable, so we can close the TODO.

# Changes
* Simplify code with `pop_first()`

# Tests
* Existing tests should suffice.

# Todos

- [x] Add entry to changelog (if necessary).
