### PR TITLE
GIX-1656: Add renaming canister api and service

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -96,6 +96,26 @@ export const attachCanister = async ({
   logWithTimestamp("Attaching canister call complete.");
 };
 
+export const renameCanister = async ({
+  identity,
+  name,
+  canisterId,
+}: {
+  identity: Identity;
+  name: string;
+  canisterId: Principal;
+}): Promise<void> => {
+  logWithTimestamp("Renaming canister call...");
+  const { nnsDapp } = await canisters(identity);
+
+  await nnsDapp.renameCanister({
+    name,
+    canisterId,
+  });
+
+  logWithTimestamp("Renaming canister call complete.");
+};
+
 export const updateSettings = async ({
   identity,
   settings,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -271,6 +271,39 @@ export class NNSDappCanister {
     throw new Error(`Error attaching canister ${JSON.stringify(response)}`);
   };
 
+  public renameCanister = async ({
+    name,
+    canisterId,
+  }: {
+    name: string;
+    canisterId: Principal;
+  }): Promise<void> => {
+    const response = await this.certifiedService.rename_canister({
+      name,
+      canister_id: canisterId,
+    });
+    if ("Ok" in response) {
+      return;
+    }
+    if ("NameAlreadyTaken" in response && response.NameAlreadyTaken === null) {
+      throw new CanisterNameAlreadyTakenError("error__canister.name_taken", {
+        $name: name,
+      });
+    }
+    if ("NameTooLong" in response && response.NameTooLong === null) {
+      throw new CanisterNameTooLongError("error__canister.name_too_long", {
+        $name: name,
+      });
+    }
+    if ("CanisterNotFound" in response && response.CanisterNotFound === null) {
+      throw new CanisterNotFoundError("error__canister.unlink_not_found", {
+        $canisterId: canisterId.toText(),
+      });
+    }
+    // Edge case
+    throw new Error(`Error renaming canister ${JSON.stringify(response)}`);
+  };
+
   public detachCanister = async (canisterId: Principal): Promise<void> => {
     const response = await this.certifiedService.detach_canister({
       canister_id: canisterId,

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -145,13 +145,13 @@ export class NNSDappCanister {
     const response: RegisterHardwareWalletResponse =
       await this.certifiedService.register_hardware_wallet(request);
 
-    if ("AccountNotFound" in response && response.AccountNotFound === null) {
+    if ("AccountNotFound" in response) {
       throw new AccountNotFoundError(
         "error__attach_wallet.register_hardware_wallet"
       );
     }
 
-    if ("NameTooLong" in response && response.NameTooLong === null) {
+    if ("NameTooLong" in response) {
       throw new NameTooLongError(
         "error__attach_wallet.create_hardware_wallet_too_long",
         {
@@ -160,19 +160,13 @@ export class NNSDappCanister {
       );
     }
 
-    if (
-      "HardwareWalletAlreadyRegistered" in response &&
-      response.HardwareWalletAlreadyRegistered === null
-    ) {
+    if ("HardwareWalletAlreadyRegistered" in response) {
       throw new HardwareWalletAttachError(
         "error__attach_wallet.already_registered"
       );
     }
 
-    if (
-      "HardwareWalletLimitExceeded" in response &&
-      response.HardwareWalletLimitExceeded === null
-    ) {
+    if ("HardwareWalletLimitExceeded" in response) {
       throw new HardwareWalletAttachError(
         "error__attach_wallet.limit_exceeded"
       );
@@ -185,7 +179,7 @@ export class NNSDappCanister {
     const response: RenameSubAccountResponse =
       await this.certifiedService.rename_sub_account(request);
 
-    if ("AccountNotFound" in response && response.AccountNotFound === null) {
+    if ("AccountNotFound" in response) {
       throw new AccountNotFoundError(
         "error__account.rename_account_not_found",
         {
@@ -194,16 +188,13 @@ export class NNSDappCanister {
       );
     }
 
-    if (
-      "SubAccountNotFound" in response &&
-      response.SubAccountNotFound === null
-    ) {
+    if ("SubAccountNotFound" in response) {
       throw new AccountNotFoundError("error__account.subaccount_not_found", {
         $account_identifier: request.account_identifier,
       });
     }
 
-    if ("NameTooLong" in response && response.NameTooLong === null) {
+    if ("NameTooLong" in response) {
       throw new NameTooLongError("error__account.subaccount_too_long", {
         $subAccountName: request.new_name,
       });
@@ -240,10 +231,7 @@ export class NNSDappCanister {
     if ("Ok" in response) {
       return;
     }
-    if (
-      "CanisterAlreadyAttached" in response &&
-      response.CanisterAlreadyAttached === null
-    ) {
+    if ("CanisterAlreadyAttached" in response) {
       throw new CanisterAlreadyAttachedError(
         "error__canister.already_attached",
         {
@@ -251,20 +239,17 @@ export class NNSDappCanister {
         }
       );
     }
-    if ("NameAlreadyTaken" in response && response.NameAlreadyTaken === null) {
+    if ("NameAlreadyTaken" in response) {
       throw new CanisterNameAlreadyTakenError("error__canister.name_taken", {
         $name: name,
       });
     }
-    if ("NameTooLong" in response && response.NameTooLong === null) {
+    if ("NameTooLong" in response) {
       throw new CanisterNameTooLongError("error__canister.name_too_long", {
         $name: name,
       });
     }
-    if (
-      "CanisterLimitExceeded" in response &&
-      response.CanisterLimitExceeded === null
-    ) {
+    if ("CanisterLimitExceeded" in response) {
       throw new CanisterLimitExceededError("error__canister.limit_exceeded");
     }
     // Edge case
@@ -285,17 +270,17 @@ export class NNSDappCanister {
     if ("Ok" in response) {
       return;
     }
-    if ("NameAlreadyTaken" in response && response.NameAlreadyTaken === null) {
+    if ("NameAlreadyTaken" in response) {
       throw new CanisterNameAlreadyTakenError("error__canister.name_taken", {
         $name: name,
       });
     }
-    if ("NameTooLong" in response && response.NameTooLong === null) {
+    if ("NameTooLong" in response) {
       throw new CanisterNameTooLongError("error__canister.name_too_long", {
         $name: name,
       });
     }
-    if ("CanisterNotFound" in response && response.CanisterNotFound === null) {
+    if ("CanisterNotFound" in response) {
       throw new CanisterNotFoundError("error__canister.unlink_not_found", {
         $canisterId: canisterId.toText(),
       });
@@ -311,7 +296,7 @@ export class NNSDappCanister {
     if ("Ok" in response) {
       return;
     }
-    if ("CanisterNotFound" in response && response.CanisterNotFound === null) {
+    if ("CanisterNotFound" in response) {
       throw new CanisterNotFoundError("error__canister.unlink_not_found", {
         $canisterId: canisterId.toText(),
       });

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -147,6 +147,17 @@ export const idlFactory = ({ IDL }) => {
     HardwareWalletLimitExceeded: IDL.Null,
     NameTooLong: IDL.Null,
   });
+  const RenameCanisterRequest = IDL.Record({
+    name: IDL.Text,
+    canister_id: IDL.Principal,
+  });
+  const RenameCanisterResponse = IDL.Variant({
+    Ok: IDL.Null,
+    CanisterNotFound: IDL.Null,
+    AccountNotFound: IDL.Null,
+    NameAlreadyTaken: IDL.Null,
+    NameTooLong: IDL.Null,
+  });
   const RenameSubAccountRequest = IDL.Record({
     new_name: IDL.Text,
     account_identifier: AccountIdentifier,
@@ -168,6 +179,11 @@ export const idlFactory = ({ IDL }) => {
     attach_canister: IDL.Func(
       [AttachCanisterRequest],
       [AttachCanisterResponse],
+      []
+    ),
+    rename_canister: IDL.Func(
+      [RenameCanisterRequest],
+      [RenameCanisterResponse],
       []
     ),
     create_sub_account: IDL.Func([IDL.Text], [CreateSubAccountResponse], []),

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -155,6 +155,21 @@ type AttachCanisterResponse =
         NameTooLong;
     };
 
+type RenameCanisterRequest =
+    record {
+        name: text;
+        canister_id: principal;
+    };
+
+type RenameCanisterResponse =
+    variant {
+        Ok;
+        NameAlreadyTaken;
+        NameTooLong;
+        CanisterNotFound;
+        AccountNotFound;
+    };
+
 type AddPendingNotifySwapRequest =
     record {
         buyer: principal;
@@ -231,6 +246,7 @@ service : {
     register_hardware_wallet: (RegisterHardwareWalletRequest) -> (RegisterHardwareWalletResponse);
     get_canisters: () -> (vec CanisterDetails) query;
     attach_canister: (AttachCanisterRequest) -> (AttachCanisterResponse);
+    rename_canister: (RenameCanisterRequest) -> (RenameCanisterResponse);
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
     get_stats: () -> (Stats) query;

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -147,6 +147,17 @@ export const idlFactory = ({ IDL }) => {
     HardwareWalletLimitExceeded: IDL.Null,
     NameTooLong: IDL.Null,
   });
+  const RenameCanisterRequest = IDL.Record({
+    name: IDL.Text,
+    canister_id: IDL.Principal,
+  });
+  const RenameCanisterResponse = IDL.Variant({
+    Ok: IDL.Null,
+    CanisterNotFound: IDL.Null,
+    AccountNotFound: IDL.Null,
+    NameAlreadyTaken: IDL.Null,
+    NameTooLong: IDL.Null,
+  });
   const RenameSubAccountRequest = IDL.Record({
     new_name: IDL.Text,
     account_identifier: AccountIdentifier,
@@ -168,6 +179,11 @@ export const idlFactory = ({ IDL }) => {
     attach_canister: IDL.Func(
       [AttachCanisterRequest],
       [AttachCanisterResponse],
+      []
+    ),
+    rename_canister: IDL.Func(
+      [RenameCanisterRequest],
+      [RenameCanisterResponse],
       []
     ),
     create_sub_account: IDL.Func([IDL.Text], [CreateSubAccountResponse], []),

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -89,6 +89,16 @@ export type RegisterHardwareWalletResponse =
   | { HardwareWalletAlreadyRegistered: null }
   | { HardwareWalletLimitExceeded: null }
   | { NameTooLong: null };
+export interface RenameCanisterRequest {
+  name: string;
+  canister_id: Principal;
+}
+export type RenameCanisterResponse =
+  | { Ok: null }
+  | { CanisterNotFound: null }
+  | { AccountNotFound: null }
+  | { NameAlreadyTaken: null }
+  | { NameTooLong: null };
 export interface RenameSubAccountRequest {
   new_name: string;
   account_identifier: AccountIdentifierString;
@@ -160,6 +170,9 @@ export default interface _SERVICE {
   attach_canister: (
     arg_0: AttachCanisterRequest
   ) => Promise<AttachCanisterResponse>;
+  rename_canister: (
+    arg_0: RenameCanisterRequest
+  ) => Promise<RenameCanisterResponse>;
   create_sub_account: (arg_0: string) => Promise<CreateSubAccountResponse>;
   detach_canister: (
     arg_0: DetachCanisterRequest

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -426,6 +426,7 @@
     "top_up_canister": "Top Up Canister",
     "top_up_successful": "Cycles added successfully",
     "unlink": "Unlink",
+    "rename": "Rename",
     "confirm_unlink_title": "Confirm Unlinking",
     "confirm_unlink_description_1": "This will unlink the canister from your account, it does not change the controller.",
     "confirm_unlink_description_2": "If you control the canister, ensure you have its identifier stored securely.",

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -5,6 +5,7 @@ import {
   getIcpToCyclesExchangeRate as getIcpToCyclesExchangeRateApi,
   queryCanisterDetails as queryCanisterDetailsApi,
   queryCanisters,
+  renameCanister as renameCanisterApi,
   topUpCanister as topUpCanisterApi,
   updateSettings as updateSettingsApi,
 } from "$lib/api/canisters.api";
@@ -94,6 +95,30 @@ export const createCanister = async ({
       mapCanisterErrorToToastMessage(error, "error.canister_creation_unknown")
     );
     return;
+  }
+};
+
+export const renameCanister = async ({
+  name,
+  canisterId,
+}: {
+  name: string;
+  canisterId: Principal;
+}): Promise<{ success: boolean }> => {
+  try {
+    const identity = await getAuthenticatedIdentity();
+    await renameCanisterApi({
+      identity,
+      name,
+      canisterId,
+    });
+    await listCanisters({ clearBeforeQuery: false });
+    return { success: true };
+  } catch (error: unknown) {
+    toastsShow(
+      mapCanisterErrorToToastMessage(error, "error.canister_creation_unknown")
+    );
+    return { success: false };
   }
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -441,6 +441,7 @@ interface I18nCanister_detail {
   top_up_canister: string;
   top_up_successful: string;
   unlink: string;
+  rename: string;
   confirm_unlink_title: string;
   confirm_unlink_description_1: string;
   confirm_unlink_description_2: string;

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -5,6 +5,7 @@ import {
   getIcpToCyclesExchangeRate,
   queryCanisterDetails,
   queryCanisters,
+  renameCanister,
   topUpCanister,
   updateSettings,
 } from "$lib/api/canisters.api";
@@ -91,6 +92,20 @@ describe("canisters-api", () => {
         canisterId: mockCanisterDetails.id,
         name: "",
       });
+    });
+  });
+
+  describe("renameCanister", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("should call the nns dapp canister to rename the canister", async () => {
+      await renameCanister({
+        identity: mockIdentity,
+        canisterId: mockCanisterDetails.id,
+        name: "test name",
+      });
+
+      expect(mockNNSDappCanister.renameCanister).toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -366,6 +366,72 @@ describe("NNSDapp", () => {
     });
   });
 
+  describe("NNSDapp.renameCanister", () => {
+    it("should call rename_canister", async () => {
+      const service = mock<NNSDappService>();
+      service.rename_canister.mockResolvedValue({ Ok: null });
+      const nnsDapp = await createNnsDapp(service);
+
+      await nnsDapp.renameCanister({
+        name: "test",
+        canisterId: mockCanister.canister_id,
+      });
+
+      expect(service.rename_canister).toBeCalledWith({
+        name: "test",
+        canister_id: mockCanister.canister_id,
+      });
+    });
+
+    it("should throw CanisterNotFound", async () => {
+      const service = mock<NNSDappService>();
+      service.rename_canister.mockResolvedValue({
+        CanisterNotFound: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.renameCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterNotFoundError);
+    });
+
+    it("should throw CanisterNameAlreadyTakenError", async () => {
+      const service = mock<NNSDappService>();
+      service.rename_canister.mockResolvedValue({
+        NameAlreadyTaken: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.renameCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterNameAlreadyTakenError);
+    });
+
+    it("should throw CanisterNameTooLongError", async () => {
+      const service = mock<NNSDappService>();
+      service.rename_canister.mockResolvedValue({
+        NameTooLong: null,
+      });
+      const nnsDapp = await createNnsDapp(service);
+
+      const call = () =>
+        nnsDapp.renameCanister({
+          name: "test",
+          canisterId: mockCanister.canister_id,
+        });
+
+      expect(call).rejects.toThrowError(CanisterNameTooLongError);
+    });
+  });
+
   describe("NNSDapp.detachCanister", () => {
     it("should call attach_canister", async () => {
       const service = mock<NNSDappService>();


### PR DESCRIPTION
# Motivation

Users want to be able to add names to their canisters.

In this PR: I extend the nns-dapp canister to support the endpoint for renaming and create the api and service functions.

# Changes

* Extend nns dapp canister candid files and related.
* New method in nns-dapp canister class `renameCanister`.
* New canister api function `renameCanister`.
* New canister service `renameCanister`.

# Tests

* Test new nns-dapp canister method `renameCanister`.
* Test new api function `renameCanister`
* Test new service `renameCanister`

# Todos

Not yet any entry in the changelog because nothing is exposed to the user yet.
