### PR TITLE
Set custom URL for II on the ic

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -48,6 +48,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Made per-network configuration in dfx.json optional.
 - Consolidated the `docker-build` and `aggregator` GitHub workflows into the `build` workflow, to reuse the build artefacts and so reduce network load on the runners.
 - Increased timeout on end-to-end tests running on CI.
+- Set a custom URL for `internet_identity` on `ic` rather than using the default.
+
 #### Deprecated
 #### Removed
 - Deleted the now empty `docker-build` and `aggregator` GitHub workflows.

--- a/dfx.json
+++ b/dfx.json
@@ -54,6 +54,10 @@
       "wasm": "internet_identity_dev.wasm",
       "candid": "internet_identity.did",
       "build": "curl --fail -sSL \"https://github.com/dfinity/internet-identity/releases/download/release-2023-01-31/internet_identity_dev.wasm\" -o internet_identity_dev.wasm",
+      "url": {
+        "mainnet": "https://identity.internetcomputer.org/",
+        "ic": "https://identity.internetcomputer.org/"
+      },
       "remote": {
         "id": {
           "local": "qhbym-qaaaa-aaaaa-aaafq-cai"
@@ -195,7 +199,6 @@
         "API_HOST": "https://icp-api.io",
         "STATIC_HOST": "https://icp0.io",
         "OWN_CANISTER_URL": "https://nns.internetcomputer.org",
-        "IDENTITY_SERVICE_URL": "https://identity.internetcomputer.org/",
         "FEATURE_FLAGS": {
           "ENABLE_SNS_VOTING": true,
           "ENABLE_SNS_AGGREGATOR": true,


### PR DESCRIPTION
# Motivation
There is a currently a custom URL for II for mainnet deployments, but not for deployments to the app subnet.

When the app subnet deployment was using the mainnet config, this was not a problem.  Now that the app deployment uses its own config, we need correct values.

# Changes
- Move the custom URL to the canister config, as the network entries are deprecated.
- Add a custom URL for deployments to the ic.

# Tests
- Tested manually for the `ic` network.
- CI has a test to confirm that the mainnet config is unchanged.
- Making a full config test similar to that used to test the mainnet config requires more changes, so I would rather do this in a separate PR.

# Todos

- [x] Add entry to changelog (if necessary).
