### PR TITLE
Test: Improve Canister Details Tests

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -50,6 +50,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Consolidated the `docker-build` and `aggregator` GitHub workflows into the `build` workflow, to reuse the build artefacts and so reduce network load on the runners.
 - Increased timeout on end-to-end tests running on CI.
 - Set a custom URL for `internet_identity` on `ic` rather than using the default.
+- Improve Canister Detail tests by mocking the api layer instead of services.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/canisters/CanisterCardTitle.svelte
+++ b/frontend/src/lib/components/canisters/CanisterCardTitle.svelte
@@ -11,7 +11,7 @@
   $: ({ canisterId, validName } = mapCanisterDetails(canister));
 </script>
 
-<div class={`title-block ${titleTag}`}>
+<div class={`title-block ${titleTag}`} data-tid="canister-card-title-compoment">
   <svelte:element this={titleTag} class="title value"
     ><span>{validName ? canister.name : canisterId}</span>
     {#if !validName}

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -128,6 +128,4 @@ describe("CanisterDetail", () => {
       ).not.toBeInTheDocument();
     });
   });
-
-  // TODO: Add tests that renames the canister
 });

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -2,117 +2,132 @@
  * @jest-environment jsdom
  */
 
-import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+import * as canisterApi from "$lib/api/canisters.api";
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
 import CanisterDetail from "$lib/pages/CanisterDetail.svelte";
-import {
-  getCanisterDetails,
-  listCanisters,
-} from "$lib/services/canisters.services";
 import { canistersStore } from "$lib/stores/canisters.store";
-import { mockCanister, mockCanisterDetails } from "$tests/mocks/canisters.mock";
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import {
+  mockCanister,
+  mockCanisterDetails,
+  mockCanisterId,
+} from "$tests/mocks/canisters.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render, waitFor } from "@testing-library/svelte";
 
-const defaultReturn = Promise.resolve(mockCanisterDetails);
-let getCanisterDetailsReturn = defaultReturn;
-const setGetCanisterDetailReturn = (value: Promise<CanisterDetails>) =>
-  (getCanisterDetailsReturn = value);
-const resetGetCanisterDetailReturn = () =>
-  (getCanisterDetailsReturn = defaultReturn);
-jest.mock("$lib/services/canisters.services", () => {
-  return {
-    listCanisters: jest.fn(),
-    routePathCanisterId: () => mockCanister.canister_id.toText(),
-    getCanisterDetails: jest
-      .fn()
-      .mockImplementation(() => getCanisterDetailsReturn),
-    getCanisterFromStore: () => mockCanister,
-  };
-});
+jest.mock("$lib/api/canisters.api");
 
 describe("CanisterDetail", () => {
-  afterEach(() => {
+  blockAllCallsTo(["$lib/api/canisters.api"]);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
     canistersStore.setCanisters({ canisters: undefined, certified: true });
   });
 
+  const canisterId = mockCanisterId;
+
   const props = {
-    canisterId: mockCanister.canister_id.toText(),
+    canisterId: canisterId.toText(),
   };
 
-  it("should render title once loaded", async () => {
-    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
-    const { container } = render(CanisterDetail, props);
-
-    const title = container.querySelector("h1");
-
-    await waitFor(() => expect(title).not.toBeNull());
-    expect((title as HTMLElement).textContent.trim()).toEqual(
-      mockCanister.canister_id.toText()
-    );
-  });
-
-  it("should fetch canisters from nns-dapp if store is not loaded yet", async () => {
-    render(CanisterDetail, props);
-    await waitFor(() => expect(listCanisters).toBeCalled());
-  });
-
-  it("should get canister details", async () => {
-    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
-    render(CanisterDetail, props);
-    await waitFor(() => expect(getCanisterDetails).toBeCalled());
-  });
-
-  it("should render canister id", async () => {
-    // Need to be the same that routePathCanisterId returns.
-    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
-    const { queryAllByText } = render(CanisterDetail, props);
-
-    await waitFor(() =>
-      expect(
-        queryAllByText(mockCanister.canister_id.toText()).length
-      ).toBeGreaterThan(0)
-    );
-  });
-
-  it("should render cards", async () => {
-    // Need to be the same that routePathCanisterId returns.
-    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
-    const { queryByTestId } = render(CanisterDetail, props);
-
-    await waitFor(() =>
-      expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
-    );
-    // Waiting for the one above is enough
-    expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
-  });
-
-  it("should render cards when not certified", async () => {
-    // Need to be the same that routePathCanisterId returns.
-    canistersStore.setCanisters({
-      canisters: [mockCanister],
-      certified: false,
+  describe("canister without name", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(canisterApi, "queryCanisterDetails")
+        .mockResolvedValue(mockCanisterDetails);
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: "",
+        },
+      ]);
     });
-    const { queryByTestId } = render(CanisterDetail, props);
 
-    await waitFor(() =>
-      expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
-    );
-    // Waiting for the one above is enough
-    expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
+    it("should render canister id as title once loaded", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await runResolvedPromises();
+
+      expect(
+        queryByTestId("canister-card-title-compoment").textContent.trim()
+      ).toEqual(mockCanister.canister_id.toText());
+    });
+
+    it("should render cards", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await waitFor(() =>
+        expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
+      );
+      // Waiting for the one above is enough
+      expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
+    });
   });
 
-  it("should not render cards if user is not the controller", async () => {
-    setGetCanisterDetailReturn(Promise.reject(new UserNotTheControllerError()));
-    // Need to be the same that routePathCanisterId returns.
-    canistersStore.setCanisters({ canisters: [mockCanister], certified: true });
-    const { queryByTestId } = render(CanisterDetail, props);
+  describe("canister with name", () => {
+    const canisterName = "canister name";
 
-    await waitFor(() =>
-      expect(queryByTestId("canister-details-error-card")).toBeInTheDocument()
-    );
-    // Waiting for the one above is enough
-    expect(queryByTestId("canister-cycles-card")).not.toBeInTheDocument();
-    expect(queryByTestId("canister-controllers-card")).not.toBeInTheDocument();
-    resetGetCanisterDetailReturn();
+    beforeEach(() => {
+      jest
+        .spyOn(canisterApi, "queryCanisterDetails")
+        .mockResolvedValue(mockCanisterDetails);
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: canisterName,
+        },
+      ]);
+    });
+
+    it("should render canister name as title", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await runResolvedPromises();
+
+      expect(
+        queryByTestId("canister-card-title-compoment").textContent.trim()
+      ).toEqual(canisterName);
+    });
+
+    it("should render canister id", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await runResolvedPromises();
+
+      expect(queryByTestId("identifier").textContent.trim()).toEqual(
+        shortenWithMiddleEllipsis(canisterId.toText())
+      );
+    });
   });
+
+  describe("if user is not the controller", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(canisterApi, "queryCanisterDetails")
+        .mockRejectedValue(new UserNotTheControllerError());
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: "",
+        },
+      ]);
+    });
+
+    it("should not render cards if user is not the controller", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await waitFor(() =>
+        expect(queryByTestId("canister-details-error-card")).toBeInTheDocument()
+      );
+      // Waiting for the one above is enough
+      expect(queryByTestId("canister-cycles-card")).not.toBeInTheDocument();
+      expect(
+        queryByTestId("canister-controllers-card")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // TODO: Add tests that renames the canister
 });


### PR DESCRIPTION
# Motivation

Improve the tests of the CanisterDetail page.

This will allow me to add a test for the rename canister flow later.

# Changes

* Mock api level instead of services layer in CanisterDetail.spec.ts.

# Tests

Only test changes.
