### PR TITLE
More details in merge neurons simulation

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -37,6 +37,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Security
 #### Not Published
 
+* Progress on merge neurons preview, behind a flag.
+
 ### Operations
 
 #### Added

--- a/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -78,11 +78,19 @@
 <div class="wrapper" data-tid="confirm-neurons-merge-component">
   <h3>{$i18n.neurons.merge_neurons_modal_title_2}</h3>
 
-  <NnsNeuronDetailCard neuron={sourceNeuron} testId="source-neuron-card" />
+  {#if $ENABLE_SIMULATE_MERGE_NEURONS}
+    <NnsNeuronDetailCard neuron={sourceNeuron} testId="source-neuron-card" />
+  {:else}
+    <NnsNeuronInfo neuron={sourceNeuron} testId="source-neuron-info" />
+  {/if}
 
   <h3>{$i18n.neurons.merge_neurons_modal_into}</h3>
 
-  <NnsNeuronDetailCard neuron={targetNeuron} testId="target-neuron-card" />
+  {#if $ENABLE_SIMULATE_MERGE_NEURONS}
+    <NnsNeuronDetailCard neuron={targetNeuron} testId="target-neuron-card" />
+  {:else}
+    <NnsNeuronInfo neuron={targetNeuron} testId="target-neuron-info" />
+  {/if}
 
   {#if showMergeResult}
     <div data-tid="merge-result-section">

--- a/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmNeuronsMerge.svelte
@@ -16,6 +16,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { Html, busy } from "@dfinity/gix-components";
   import NnsNeuronInfo from "./NnsNeuronInfo.svelte";
+  import NnsNeuronDetailCard from "./NnsNeuronDetailCard.svelte";
 
   export let neurons: NeuronInfo[];
 
@@ -77,11 +78,11 @@
 <div class="wrapper" data-tid="confirm-neurons-merge-component">
   <h3>{$i18n.neurons.merge_neurons_modal_title_2}</h3>
 
-  <NnsNeuronInfo neuron={sourceNeuron} testId="source-neuron-info" />
+  <NnsNeuronDetailCard neuron={sourceNeuron} testId="source-neuron-card" />
 
   <h3>{$i18n.neurons.merge_neurons_modal_into}</h3>
 
-  <NnsNeuronInfo neuron={targetNeuron} testId="target-neuron-info" />
+  <NnsNeuronDetailCard neuron={targetNeuron} testId="target-neuron-card" />
 
   {#if showMergeResult}
     <div data-tid="merge-result-section">
@@ -90,10 +91,9 @@
       {#if isNullish(simulatedMergedNeuron)}
         <SkeletonCard cardType="info" />
       {:else}
-        <!-- TODO: Show more information about the neuron. -->
-        <NnsNeuronInfo
+        <NnsNeuronDetailCard
           neuron={simulatedMergedNeuron}
-          testId="merged-neuron-info"
+          testId="merged-neuron-card"
         />
       {/if}
     </div>

--- a/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { secondsToDuration } from "$lib/utils/date.utils";
+  import {
+    formatVotingPower,
+    formattedStakedMaturity,
+    formattedTotalMaturity,
+    neuronAge,
+    neuronStake,
+  } from "$lib/utils/neuron.utils";
+  import { Card, KeyValuePair } from "@dfinity/gix-components";
+  import { ICPToken, TokenAmount, type NeuronInfo } from "@dfinity/nns";
+
+  export let neuron: NeuronInfo;
+  export let testId: string = "nns-neuron-detail-card-component";
+
+  let stake: TokenAmount;
+  $: stake = TokenAmount.fromE8s({
+    amount: neuronStake(neuron),
+    token: ICPToken,
+  });
+</script>
+
+<Card {testId}>
+  <KeyValuePair testId="neuron-id">
+    <span class="label" slot="key">{$i18n.neurons.neuron_id}</span>
+    <span class="value" slot="value">{neuron.neuronId}</span>
+  </KeyValuePair>
+  <KeyValuePair testId="stake">
+    <span class="label" slot="key">{$i18n.neurons.ic_stake}</span>
+    <span class="value" slot="value"
+      ><AmountDisplay inline singleLine amount={stake} /></span
+    >
+  </KeyValuePair>
+  <KeyValuePair testId="dissolve-delay">
+    <span slot="key" class="label">{$i18n.neurons.dissolve_delay_title}</span>
+    <span slot="value" class="value"
+      >{secondsToDuration(neuron.dissolveDelaySeconds)}</span
+    >
+  </KeyValuePair>
+  <KeyValuePair testId="age">
+    <span class="label" slot="key">{$i18n.neurons.age}</span>
+    <span class="value" slot="value" data-tid="nns-neuron-age">
+      {secondsToDuration(neuronAge(neuron))}
+    </span>
+  </KeyValuePair>
+  <KeyValuePair testId="voting-power">
+    <span class="label" slot="key">{$i18n.neurons.voting_power}</span>
+    <span class="value" slot="value"
+      >{formatVotingPower(neuron.votingPower)}</span
+    >
+  </KeyValuePair>
+  <KeyValuePair testId="maturity">
+    <span class="label" slot="key">{$i18n.neuron_detail.maturity_title}</span>
+    <span class="value" slot="value">{formattedTotalMaturity(neuron)}</span>
+  </KeyValuePair>
+  <KeyValuePair testId="staked-maturity">
+    <span class="label" slot="key">{$i18n.neurons.staked}</span>
+    <span slot="value">{formattedStakedMaturity(neuron)}</span>
+  </KeyValuePair>
+</Card>

--- a/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
@@ -10,10 +10,11 @@
     neuronStake,
   } from "$lib/utils/neuron.utils";
   import { Card, KeyValuePair } from "@dfinity/gix-components";
-  import { ICPToken, TokenAmount, type NeuronInfo } from "@dfinity/nns";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { ICPToken, TokenAmount } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
-  export let testId: string = "nns-neuron-detail-card-component";
+  export let testId = "nns-neuron-detail-card-component";
 
   let stake: TokenAmount;
   $: stake = TokenAmount.fromE8s({

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
@@ -11,7 +11,6 @@ import { render } from "@testing-library/svelte";
 describe("NnsNeuronDetailCard", () => {
   const renderComponent = (neuron) => {
     const { container } = render(NnsNeuronDetailCard, { neuron });
-    //console.log('dskloetx container', container.innerHTML);
     return NnsNeuronDetailCardPo.under({
       element: new JestPageObjectElement(container),
     });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsNeuronDetailCard from "$lib/components/neurons/NnsNeuronDetailCard.svelte";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsNeuronDetailCardPo } from "$tests/page-objects/NnsNeuronDetailCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("NnsNeuronDetailCard", () => {
+  const renderComponent = (neuron) => {
+    const { container } = render(NnsNeuronDetailCard, { neuron });
+    //console.log('dskloetx container', container.innerHTML);
+    return NnsNeuronDetailCardPo.under({
+      element: new JestPageObjectElement(container),
+    });
+  };
+
+  it("should render neuron id", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      neuronId: BigInt(123789),
+    });
+
+    expect(await po.getNeuronId()).toBe("123789");
+  });
+
+  it("should render neuron stake", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        cachedNeuronStake: BigInt(3_000_000_000),
+        neuronFees: BigInt(1_000_000_000),
+      },
+    });
+
+    expect(await po.getStake()).toBe("20.00 ICP");
+  });
+
+  it("should render neuron dissolve delay", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      dissolveDelaySeconds: BigInt(180 * 24 * 3600),
+    });
+
+    expect(await po.getDissolveDelay()).toBe("180 days");
+  });
+
+  it("should render neuron age", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      ageSeconds: BigInt(90.5 * 24 * 3600),
+    });
+
+    expect(await po.getAge()).toBe("90 days, 12 hours");
+  });
+
+  it("should render neuron voting power", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      votingPower: BigInt(3_000_000_000),
+    });
+
+    expect(await po.getVotingPower()).toBe("30.00");
+  });
+
+  it("should render neuron maturiry", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        maturityE8sEquivalent: BigInt(300_000_000),
+        stakedMaturityE8sEquivalent: BigInt(500_000_000),
+      },
+    });
+
+    expect(await po.getMaturity()).toBe("8.00");
+  });
+
+  it("should render neuron staked maturiry", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockFullNeuron,
+        maturityE8sEquivalent: BigInt(300_000_000),
+        stakedMaturityE8sEquivalent: BigInt(500_000_000),
+      },
+    });
+
+    expect(await po.getStakedMaturity()).toBe("5.00");
+  });
+});

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -221,7 +221,10 @@ describe("MergeNeuronsModal", () => {
         false
       );
       expect(
-        await po.getConfirmNeuronsMergePo().getMergedNeuronInfoPo().isPresent()
+        await po
+          .getConfirmNeuronsMergePo()
+          .getMergedNeuronDetailCardPo()
+          .isPresent()
       ).toBe(false);
       expect(simulateMergeNeurons).not.toBeCalled();
 
@@ -248,11 +251,11 @@ describe("MergeNeuronsModal", () => {
       expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
         true
       );
-      const mergeNeuronInfo = po
+      const mergedNeuronCard = po
         .getConfirmNeuronsMergePo()
-        .getMergedNeuronInfoPo();
-      expect(await mergeNeuronInfo.isPresent()).toBe(true);
-      expect(await mergeNeuronInfo.getBalance()).toBe("46.00 ICP Stake");
+        .getMergedNeuronDetailCardPo();
+      expect(await mergedNeuronCard.isPresent()).toBe(true);
+      expect(await mergedNeuronCard.getStake()).toBe("46.00 ICP");
       // Just to show where the 46 is coming from:
       expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(
         BigInt(46 * E8S_PER_ICP)
@@ -285,10 +288,10 @@ describe("MergeNeuronsModal", () => {
       expect(
         await po.getConfirmNeuronsMergePo().getSkeletonCardPo().isPresent()
       ).toBe(true);
-      const mergeNeuronInfo = po
+      const mergedNeuronCard = po
         .getConfirmNeuronsMergePo()
-        .getMergedNeuronInfoPo();
-      expect(await mergeNeuronInfo.isPresent()).toBe(false);
+        .getMergedNeuronDetailCardPo();
+      expect(await mergedNeuronCard.isPresent()).toBe(false);
 
       fakeGovernanceApi.resume();
       await runResolvedPromises();
@@ -298,7 +301,7 @@ describe("MergeNeuronsModal", () => {
       expect(
         await po.getConfirmNeuronsMergePo().getSkeletonCardPo().isPresent()
       ).toBe(false);
-      expect(await mergeNeuronInfo.isPresent()).toBe(true);
+      expect(await mergedNeuronCard.isPresent()).toBe(true);
     });
   });
 

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -216,6 +216,26 @@ describe("MergeNeuronsModal", () => {
         .getConfirmSelectionButtonPo()
         .click();
 
+      expect(await po.getConfirmNeuronsMergePo().isPresent()).toBe(true);
+      expect(
+        await po.getConfirmNeuronsMergePo().getSourceNeuronInfoPo().isPresent()
+      ).toBe(true);
+      expect(
+        await po
+          .getConfirmNeuronsMergePo()
+          .getSourceNeuronDetailCardPo()
+          .isPresent()
+      ).toBe(false);
+      expect(
+        await po.getConfirmNeuronsMergePo().getTargetNeuronInfoPo().isPresent()
+      ).toBe(true);
+      expect(
+        await po
+          .getConfirmNeuronsMergePo()
+          .getTargetNeuronDetailCardPo()
+          .isPresent()
+      ).toBe(false);
+
       await runResolvedPromises();
       expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(
         false
@@ -246,6 +266,26 @@ describe("MergeNeuronsModal", () => {
         .getSelectNeuronsToMergePo()
         .getConfirmSelectionButtonPo()
         .click();
+
+      expect(await po.getConfirmNeuronsMergePo().isPresent()).toBe(true);
+      expect(
+        await po.getConfirmNeuronsMergePo().getSourceNeuronInfoPo().isPresent()
+      ).toBe(false);
+      expect(
+        await po
+          .getConfirmNeuronsMergePo()
+          .getSourceNeuronDetailCardPo()
+          .isPresent()
+      ).toBe(true);
+      expect(
+        await po.getConfirmNeuronsMergePo().getTargetNeuronInfoPo().isPresent()
+      ).toBe(false);
+      expect(
+        await po
+          .getConfirmNeuronsMergePo()
+          .getTargetNeuronDetailCardPo()
+          .isPresent()
+      ).toBe(true);
 
       await runResolvedPromises();
       expect(await po.getConfirmNeuronsMergePo().hasMergeResultSection()).toBe(

--- a/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
@@ -1,5 +1,6 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { NnsNeuronDetailCardPo } from "$tests/page-objects/NnsNeuronDetailCard.page-object";
+import { NnsNeuronInfoPo } from "$tests/page-objects/NnsNeuronInfo.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -13,10 +14,24 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
     );
   }
 
+  getSourceNeuronInfoPo(): NnsNeuronInfoPo {
+    return NnsNeuronInfoPo.under({
+      element: this.root,
+      testId: "source-neuron-info",
+    });
+  }
+
   getSourceNeuronDetailCardPo(): NnsNeuronDetailCardPo {
     return NnsNeuronDetailCardPo.under({
       element: this.root,
       testId: "source-neuron-card",
+    });
+  }
+
+  getTargetNeuronInfoPo(): NnsNeuronInfoPo {
+    return NnsNeuronInfoPo.under({
+      element: this.root,
+      testId: "target-neuron-info",
     });
   }
 

--- a/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmNeuronsMerge.page-object.ts
@@ -1,5 +1,5 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { NnsNeuronInfoPo } from "$tests/page-objects/NnsNeuronInfo.page-object";
+import { NnsNeuronDetailCardPo } from "$tests/page-objects/NnsNeuronDetailCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -13,17 +13,17 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
     );
   }
 
-  getSourceNeuronInfoPo(): NnsNeuronInfoPo {
-    return NnsNeuronInfoPo.under({
+  getSourceNeuronDetailCardPo(): NnsNeuronDetailCardPo {
+    return NnsNeuronDetailCardPo.under({
       element: this.root,
-      testId: "source-neuron-info",
+      testId: "source-neuron-card",
     });
   }
 
-  getTargetNeuronInfoPo(): NnsNeuronInfoPo {
-    return NnsNeuronInfoPo.under({
+  getTargetNeuronDetailCardPo(): NnsNeuronDetailCardPo {
+    return NnsNeuronDetailCardPo.under({
       element: this.root,
-      testId: "target-neuron-info",
+      testId: "target-neuron-card",
     });
   }
 
@@ -31,10 +31,10 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
     return SkeletonCardPo.under(this.root);
   }
 
-  getMergedNeuronInfoPo(): NnsNeuronInfoPo {
-    return NnsNeuronInfoPo.under({
+  getMergedNeuronDetailCardPo(): NnsNeuronDetailCardPo {
+    return NnsNeuronDetailCardPo.under({
       element: this.root,
-      testId: "merged-neuron-info",
+      testId: "merged-neuron-card",
     });
   }
 
@@ -43,11 +43,11 @@ export class ConfirmNeuronsMergePo extends BasePageObject {
   }
 
   getSourceNeuronId(): Promise<string> {
-    return this.getSourceNeuronInfoPo().getNeuronId();
+    return this.getSourceNeuronDetailCardPo().getNeuronId();
   }
 
   getTargetNeuronId(): Promise<string> {
-    return this.getTargetNeuronInfoPo().getNeuronId();
+    return this.getTargetNeuronDetailCardPo().getNeuronId();
   }
 
   hasMergeResultSection(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NnsNeuronDetailCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetailCard.page-object.ts
@@ -1,0 +1,47 @@
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsNeuronDetailCardPo extends BasePageObject {
+  static under({
+    element,
+    testId = "nns-neuron-detail-card-component",
+  }: {
+    element: PageObjectElement;
+    testId?: string;
+  }): NnsNeuronDetailCardPo {
+    return new NnsNeuronDetailCardPo(element.byTestId(testId));
+  }
+
+  getValue(testId: string): Promise<string> {
+    return KeyValuePairPo.under({ element: this.root, testId }).getValueText();
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getValue("neuron-id");
+  }
+
+  async getStake(): Promise<string> {
+    return (await this.getValue("stake")).trim();
+  }
+
+  getDissolveDelay(): Promise<string> {
+    return this.getValue("dissolve-delay");
+  }
+
+  getAge(): Promise<string> {
+    return this.getValue("age");
+  }
+
+  getVotingPower(): Promise<string> {
+    return this.getValue("voting-power");
+  }
+
+  getMaturity(): Promise<string> {
+    return this.getValue("maturity");
+  }
+
+  getStakedMaturity(): Promise<string> {
+    return this.getValue("staked-maturity");
+  }
+}


### PR DESCRIPTION
# Motivation

We want to show the results or merging neurons before the user commits.
This PR adds more details in the `ConfirmNeuronsMerge` steps.
Here you can see what it looks like but the details are not important because this is behind a feature flag just to try it out and iterate on:

<img width="611" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/84eb3d97-09fe-4590-ae27-f318ca373108">


# Changes

1. Add new component `NnsNeuronDetailCard`
2. Use it instead of `NnsNeuronInfo` in `ConfirmNeuronsMerge`

# Tests

1. `frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts` is modified to work with the new card.
2. A new test is added for the new component.
3. A page object is added for the new component.

# Todos

- [x] Add entry to changelog (if necessary).
