### PR TITLE
Remove load Sns transactions onMount in wallet

### DIFF
--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -3,7 +3,6 @@
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
-  import { onMount } from "svelte";
   import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
   import type { IcrcTransactionData } from "$lib/types/transaction";
   import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -13,21 +13,13 @@
   } from "$lib/utils/icrc-transactions.utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsWalletTransactionsObserver from "$lib/components/accounts/SnsWalletTransactionsObserver.svelte";
+  import { syncStore } from "$lib/stores/sync.store";
 
   export let account: Account;
   export let rootCanisterId: Principal;
   export let token: IcrcTokenMetadata | undefined;
 
-  let loading = true;
-
-  onMount(async () => {
-    loading = true;
-    await loadSnsAccountNextTransactions({
-      account,
-      canisterId: rootCanisterId,
-    });
-    loading = false;
-  });
+  let loading = false;
 
   // `loadMore` depends on props account and rootCanisterId
   let loadMore: () => Promise<void>;
@@ -66,7 +58,7 @@
     on:nnsIntersect={loadMore}
     {account}
     {transactions}
-    {loading}
+    loading={loading || $syncStore.transactions === "in_progress"}
     {governanceCanisterId}
     {completed}
     {token}

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
@@ -4,10 +4,8 @@
 
 import SnsTransactionList from "$lib/components/accounts/SnsTransactionsList.svelte";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
-import * as services from "$lib/services/sns-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { page } from "$mocks/$app/stores";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   mockIcrcTransactionsStoreSubscribe,
   mockIcrcTransactionWithId,
@@ -58,14 +56,6 @@ describe("SnsTransactionList", () => {
     jest
       .spyOn(snsProjectsStore, "subscribe")
       .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
-  });
-
-  it("should call service to load transactions", () => {
-    const spy = jest.spyOn(services, "loadSnsAccountNextTransactions");
-
-    renderSnsTransactionList(mockSnsMainAccount, mockPrincipal);
-
-    expect(spy).toBeCalled();
   });
 
   it("should render transactions from store", () => {


### PR DESCRIPTION
# Motivation

We can spare loading the transactions in the Sns Wallet on the UI side because this operation is now executed in a Web Worker.

# Notes

Because of the [Web Worker](https://caniuse.com/?search=worker%20module) support, users using old version of Firefox on desktop would have to upgrade to upgrade their browser to access their transactions. On Firefox Android they would have to use another browser.

# Changes

- remove `loadTransactions` on mount