### PR TITLE
GIX-1656: Rename canister modal

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -64,6 +64,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Decode the payment (amount) from the QR code reader.
 * Add "Select All" and "Clear" selection in proposal filters.
 * Add vesting information in SNS neuron detail.
+* Render SNS neuron voting power in neuron detail page.
+* Users can now add a name to their canisters after linking or creating them.
 
 #### Changed
 

--- a/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { busy } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { emit } from "$lib/utils/events.utils";
+  import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
+
+  const openModal = () =>
+    emit<CanisterDetailModal>({
+      message: "nnsCanisterDetailModal",
+      detail: { type: "rename" },
+    });
+</script>
+
+<button
+  class="secondary"
+  type="button"
+  on:click={openModal}
+  disabled={$busy}
+  data-tid="rename-canister-button"
+>
+  {$i18n.canister_detail.rename}
+</button>

--- a/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
@@ -4,11 +4,12 @@
   import { emit } from "$lib/utils/events.utils";
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
 
-  const openModal = () =>
+  const openModal = () => {
     emit<CanisterDetailModal>({
       message: "nnsCanisterDetailModal",
       detail: { type: "rename" },
     });
+  };
 </script>
 
 <button

--- a/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
+++ b/frontend/src/lib/components/canister-detail/RenameCanisterButton.svelte
@@ -16,7 +16,7 @@
   type="button"
   on:click={openModal}
   disabled={$busy}
-  data-tid="rename-canister-button"
+  data-tid="rename-canister-button-component"
 >
   {$i18n.canister_detail.rename}
 </button>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -440,6 +440,7 @@
     "confirm_remove_controller_user_description_2": "You will lose access to the canister.",
     "confirm_remove_last_controller_description": "This is the last remaining controller. If you remove it, nobody will be able to control the canister.",
     "unlink_success": "Canister successfully unlinked",
+    "rename_success": "Canister successfully renamed to \"$name\"",
     "confirm_new_controller": "Confirm New Controller",
     "enter_controller": "Enter Controller",
     "edit_controller": "Edit Controller",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -445,6 +445,9 @@
     "edit_controller": "Edit Controller",
     "new_controller": "New Controller",
     "add_controller": "Add Controller",
+    "rename_canister": "Rename Canister",
+    "rename_canister_title": "Enter New Canister Name",
+    "rename_canister_placeholder": "Canister Name",
     "status_stopped": "Stopped",
     "status_stopping": "Stopping",
     "status_running": "Running"

--- a/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
+++ b/frontend/src/lib/modals/canisters/CanisterDetailModals.svelte
@@ -10,6 +10,7 @@
     CanisterDetailModalType,
   } from "$lib/types/canister-detail.modal";
   import type { Principal } from "@dfinity/principal";
+  import RenameCanisterModal from "./RenameCanisterModal.svelte";
 
   let modal: CanisterDetailModal | undefined = undefined;
   const close = () => (modal = undefined);
@@ -42,4 +43,8 @@
 
 {#if type === "remove-controller" && controller !== undefined}
   <RemoveCanisterControllerModal {controller} on:nnsClose={close} />
+{/if}
+
+{#if type === "rename"}
+  <RenameCanisterModal on:nnsClose={close} />
 {/if}

--- a/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { Modal, busy } from "@dfinity/gix-components";
+  import TextInputForm from "$lib/components/common/TextInputForm.svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "$lib/types/canister-detail.context";
+  import { getContext } from "svelte";
+  import { isNullish } from "@dfinity/utils";
+
+  const { store }: CanisterDetailsContext = getContext<CanisterDetailsContext>(
+    CANISTER_DETAILS_CONTEXT_KEY
+  );
+
+  let currentName = $store.info?.name;
+
+  const rename = () => {
+    console.log("renaming", currentName);
+  };
+</script>
+
+<Modal on:nnsClose>
+  <svelte:fragment slot="title"
+    ><span>{$i18n.canister_detail.rename_canister}</span></svelte:fragment
+  >
+
+  <TextInputForm
+    on:nnsConfirmText={rename}
+    on:nnsClose
+    bind:text={currentName}
+    placeholderLabelKey="canister_detail.rename_canister_placeholder"
+    busy={$busy}
+    disabledConfirm={isNullish(currentName) ||
+      currentName?.length === 0 ||
+      $busy}
+  >
+    <svelte:fragment slot="label"
+      >{$i18n.canister_detail.rename_canister_title}</svelte:fragment
+    >
+    <svelte:fragment slot="cancel-text">{$i18n.core.cancel}</svelte:fragment>
+    <svelte:fragment slot="confirm-text"
+      >{$i18n.canister_detail.rename}</svelte:fragment
+    >
+  </TextInputForm>
+</Modal>

--- a/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
@@ -6,8 +6,11 @@
     CANISTER_DETAILS_CONTEXT_KEY,
     type CanisterDetailsContext,
   } from "$lib/types/canister-detail.context";
-  import { getContext } from "svelte";
-  import { isNullish } from "@dfinity/utils";
+  import { createEventDispatcher, getContext } from "svelte";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { renameCanister } from "$lib/services/canisters.services";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
 
   const { store }: CanisterDetailsContext = getContext<CanisterDetailsContext>(
     CANISTER_DETAILS_CONTEXT_KEY
@@ -15,17 +18,40 @@
 
   let currentName = $store.info?.name;
 
-  const rename = () => {
-    console.log("renaming", currentName);
+  const dispatch = createEventDispatcher();
+  const rename = async () => {
+    const canisterId = $store.info?.canister_id;
+    // For type safety reasons. If the modal is open, the canister id is set in the store of the context.
+    if (nonNullish(canisterId)) {
+      startBusy({
+        initiator: "rename-canister",
+      });
+      const { success } = await renameCanister({
+        canisterId,
+        // For type safety reasons. Button is disabled if `currentName` is nullish or ""
+        name: currentName ?? "",
+      });
+
+      stopBusy("rename-canister");
+
+      if (success) {
+        dispatch("nnsClose");
+        toastsSuccess({
+          labelKey: "canister_detail.rename_success",
+          substitutions: { $name: currentName ?? "" },
+        });
+      }
+    }
   };
 </script>
 
-<Modal on:nnsClose>
+<Modal on:nnsClose testId="rename-canister-modal-component">
   <svelte:fragment slot="title"
     ><span>{$i18n.canister_detail.rename_canister}</span></svelte:fragment
   >
 
   <TextInputForm
+    testId="rename-canister-form"
     on:nnsConfirmText={rename}
     on:nnsClose
     bind:text={currentName}

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -35,6 +35,7 @@
   import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
   import { emit } from "$lib/utils/events.utils";
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
+  import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
 
   // BEGIN: loading and navigation
 
@@ -191,6 +192,7 @@
         <CanisterCardSubTitle canister={canisterInfo} />
         <div class="actions">
           <UnlinkCanisterButton canisterId={canisterInfo.canister_id} />
+          <RenameCanisterButton />
         </div>
       {:else}
         <div class="loader-title">
@@ -233,6 +235,7 @@
     margin-bottom: var(--padding-3x);
     display: flex;
     justify-content: end;
+    gap: var(--padding-2x);
   }
 
   .error-message {

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -36,6 +36,7 @@
   import { emit } from "$lib/utils/events.utils";
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
   import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   // BEGIN: loading and navigation
 
@@ -184,49 +185,51 @@
     });
 </script>
 
-<Island>
-  <main class="legacy">
-    <section>
-      {#if canisterInfo !== undefined}
-        <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
-        <CanisterCardSubTitle canister={canisterInfo} />
-        <div class="actions">
-          <UnlinkCanisterButton canisterId={canisterInfo.canister_id} />
-          <RenameCanisterButton />
-        </div>
-      {:else}
-        <div class="loader-title">
-          <SkeletonText tagName="h1" />
-        </div>
-        <div class="loader-subtitle">
-          <SkeletonText />
-        </div>
-      {/if}
-      {#if canisterDetails !== undefined}
-        <CyclesCard cycles={canisterDetails.cycles} />
-        <ControllersCard />
-      {:else if errorKey !== undefined}
-        <CardInfo testId="canister-details-error-card">
-          <p class="error-message">{translate({ labelKey: errorKey })}</p>
-        </CardInfo>
-      {:else}
-        <SkeletonCard cardType="info" />
-        <SkeletonCard cardType="info" />
-      {/if}
-    </section>
-  </main>
-</Island>
+<TestIdWrapper testId="canister-detail-component">
+  <Island>
+    <main class="legacy">
+      <section>
+        {#if canisterInfo !== undefined}
+          <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
+          <CanisterCardSubTitle canister={canisterInfo} />
+          <div class="actions">
+            <UnlinkCanisterButton canisterId={canisterInfo.canister_id} />
+            <RenameCanisterButton />
+          </div>
+        {:else}
+          <div class="loader-title">
+            <SkeletonText tagName="h1" />
+          </div>
+          <div class="loader-subtitle">
+            <SkeletonText />
+          </div>
+        {/if}
+        {#if canisterDetails !== undefined}
+          <CyclesCard cycles={canisterDetails.cycles} />
+          <ControllersCard />
+        {:else if errorKey !== undefined}
+          <CardInfo testId="canister-details-error-card">
+            <p class="error-message">{translate({ labelKey: errorKey })}</p>
+          </CardInfo>
+        {:else}
+          <SkeletonCard cardType="info" />
+          <SkeletonCard cardType="info" />
+        {/if}
+      </section>
+    </main>
+  </Island>
 
-<Footer columns={1}>
-  <button
-    class="primary"
-    on:click={openModal}
-    disabled={canisterInfo === undefined || $busy}
-    >{$i18n.canister_detail.add_cycles}</button
-  >
-</Footer>
+  <Footer columns={1}>
+    <button
+      class="primary"
+      on:click={openModal}
+      disabled={canisterInfo === undefined || $busy}
+      >{$i18n.canister_detail.add_cycles}</button
+    >
+  </Footer>
 
-<CanisterDetailModals />
+  <CanisterDetailModals />
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -10,6 +10,7 @@ export type BusyStateInitiatorType =
   | "update-delay"
   | "link-canister"
   | "unlink-canister"
+  | "rename-canister"
   | "create-canister"
   | "top-up-canister"
   | "add-controller-canister"

--- a/frontend/src/lib/types/canister-detail.modal.ts
+++ b/frontend/src/lib/types/canister-detail.modal.ts
@@ -4,6 +4,7 @@ export type CanisterDetailModalType =
   | "add-cycles"
   | "unlink"
   | "add-controller"
+  | "rename"
   | "remove-controller";
 
 export interface CanisterDetailModal {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -460,6 +460,9 @@ interface I18nCanister_detail {
   edit_controller: string;
   new_controller: string;
   add_controller: string;
+  rename_canister: string;
+  rename_canister_title: string;
+  rename_canister_placeholder: string;
   status_stopped: string;
   status_stopping: string;
   status_running: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -455,6 +455,7 @@ interface I18nCanister_detail {
   confirm_remove_controller_user_description_2: string;
   confirm_remove_last_controller_description: string;
   unlink_success: string;
+  rename_success: string;
   confirm_new_controller: string;
   enter_controller: string;
   edit_controller: string;

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import RenameCanisterButtonTest from "./RenameCanisterButtonTest.svelte";
+
+describe("RenameCanisterButton", () => {
+  it("opens rename canister modal", async () => {
+    const { queryByTestId } = render(RenameCanisterButtonTest);
+
+    const buttonElement = queryByTestId("rename-canister-button-component");
+    expect(buttonElement).not.toBeNull();
+
+    buttonElement && (await fireEvent.click(buttonElement));
+
+    const modal = queryByTestId("rename-canister-modal-component");
+    expect(modal).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
@@ -2,19 +2,24 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from "@testing-library/svelte";
+import { RenameCanisterButtonPo } from "$tests/page-objects/RenameCanisterButton.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
 import RenameCanisterButtonTest from "./RenameCanisterButtonTest.svelte";
 
 describe("RenameCanisterButton", () => {
-  it("opens rename canister modal", async () => {
-    const { queryByTestId } = render(RenameCanisterButtonTest);
+  it("emits rename canister modal event", (done) => {
+    const { container, component } = render(RenameCanisterButtonTest);
 
-    const buttonElement = queryByTestId("rename-canister-button-component");
-    expect(buttonElement).not.toBeNull();
+    const po = RenameCanisterButtonPo.under({
+      element: new JestPageObjectElement(container),
+    });
 
-    buttonElement && (await fireEvent.click(buttonElement));
+    component.$on("nnsCanisterDetailModal", (data: CustomEvent) => {
+      expect(data.detail).toEqual({ type: "rename" });
+      done();
+    });
 
-    const modal = queryByTestId("rename-canister-modal-component");
-    expect(modal).toBeInTheDocument();
+    po.click();
   });
 });

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButton.spec.ts
@@ -2,21 +2,21 @@
  * @jest-environment jsdom
  */
 
+import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
 import { RenameCanisterButtonPo } from "$tests/page-objects/RenameCanisterButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import RenameCanisterButtonTest from "./RenameCanisterButtonTest.svelte";
 
 describe("RenameCanisterButton", () => {
   it("emits rename canister modal event", (done) => {
-    const { container, component } = render(RenameCanisterButtonTest);
+    const { container } = render(RenameCanisterButton);
 
     const po = RenameCanisterButtonPo.under({
       element: new JestPageObjectElement(container),
     });
 
-    component.$on("nnsCanisterDetailModal", (data: CustomEvent) => {
-      expect(data.detail).toEqual({ type: "rename" });
+    window.addEventListener("nnsCanisterDetailModal", (event: CustomEvent) => {
+      expect(event.detail).toEqual({ type: "rename" });
       done();
     });
 

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
@@ -1,19 +1,7 @@
 <script lang="ts">
-  import { setContext } from "svelte";
-  import {
-    CANISTER_DETAILS_CONTEXT_KEY,
-    type CanisterDetailsContext,
-  } from "$lib/types/canister-detail.context";
-  import { mockCanisterDetailsStore } from "$tests/mocks/canisters.mock";
-  import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
   import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
-
-  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
-    store: mockCanisterDetailsStore,
-    reloadDetails: () => Promise.resolve(undefined),
-  });
 </script>
 
-<RenameCanisterButton />
+<svelte:window on:nnsCanisterDetailModal />
 
-<CanisterDetailModals />
+<RenameCanisterButton />

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+  } from "$lib/types/canister-detail.context";
+  import { mockCanisterDetailsStore } from "$tests/mocks/canisters.mock";
+  import CanisterDetailModals from "$lib/modals/canisters/CanisterDetailModals.svelte";
+  import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
+
+  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
+    store: mockCanisterDetailsStore,
+    reloadDetails: () => Promise.resolve(undefined),
+  });
+</script>
+
+<RenameCanisterButton />
+
+<CanisterDetailModals />

--- a/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
+++ b/frontend/src/tests/lib/components/canister-detail/RenameCanisterButtonTest.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-  import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
-</script>
-
-<svelte:window on:nnsCanisterDetailModal />
-
-<RenameCanisterButton />

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as canisterApi from "$lib/api/canisters.api";
+import { authStore } from "$lib/stores/auth.store";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId, mockCanisters } from "$tests/mocks/canisters.mock";
+import { RenameCanisterModalPo } from "$tests/page-objects/RenameCanisterModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { render } from "@testing-library/svelte";
+import RenameCanisterModalTest from "./RenameCanisterModalTest.svelte";
+
+jest.mock("$lib/api/canisters.api");
+
+describe("RenameCanisterModal", () => {
+  blockAllCallsTo(["$lib/api/canisters.api"]);
+
+  beforeEach(() => {
+    jest.spyOn(canisterApi, "renameCanister").mockResolvedValue(undefined);
+    jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue(mockCanisters);
+    authStore.setForTesting(mockIdentity);
+  });
+
+  const renderComponent = ({ canisterId, name }) => {
+    const { container } = render(RenameCanisterModalTest, {
+      props: { canisterId, name },
+    });
+
+    return RenameCanisterModalPo.under(new JestPageObjectElement(container));
+  };
+
+  it("calls the canister api to rename canister", async () => {
+    const newName = "new name";
+    const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
+
+    po.enterNewName(newName);
+
+    po.clickRenameButton();
+
+    await runResolvedPromises();
+
+    expect(canisterApi.renameCanister).toBeCalledWith({
+      canisterId: mockCanisterId,
+      name: newName,
+      identity: mockIdentity,
+    });
+  });
+
+  it("shows disabled button when input is empty", async () => {
+    const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
+
+    po.enterNewName("");
+
+    await runResolvedPromises();
+
+    expect(await po.getRenameButton().isDisabled()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -36,7 +36,7 @@ describe("RenameCanisterModal", () => {
     const newName = "new name";
     const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
 
-    po.enterNewName(newName);
+    po.enterName(newName);
 
     po.clickRenameButton();
 
@@ -47,12 +47,13 @@ describe("RenameCanisterModal", () => {
       name: newName,
       identity: mockIdentity,
     });
+    expect(canisterApi.renameCanister).toBeCalledTimes(1);
   });
 
   it("shows disabled button when input is empty", async () => {
     const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
 
-    po.enterNewName("");
+    po.enterName("");
 
     await runResolvedPromises();
 

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModalTest.svelte
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModalTest.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import {
+    CANISTER_DETAILS_CONTEXT_KEY,
+    type CanisterDetailsContext,
+    type SelectCanisterDetailsStore,
+  } from "$lib/types/canister-detail.context";
+  import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
+  import RenameCanisterModal from "$lib/modals/canisters/RenameCanisterModal.svelte";
+  import type { Principal } from "@dfinity/principal";
+  import { writable } from "svelte/store";
+
+  export let canisterId: Principal;
+  export let name: string;
+
+  const mockCanisterDetailsStore = writable<SelectCanisterDetailsStore>({
+    info: {
+      name,
+      canister_id: canisterId,
+    },
+    details: {
+      ...mockCanisterDetails,
+      id: canisterId,
+    },
+    controller: true,
+  });
+
+  setContext<CanisterDetailsContext>(CANISTER_DETAILS_CONTEXT_KEY, {
+    store: mockCanisterDetailsStore,
+    reloadDetails: () => Promise.resolve(),
+  });
+</script>
+
+<RenameCanisterModal on:nnsClose />

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -5,16 +5,20 @@
 import * as canisterApi from "$lib/api/canisters.api";
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
 import CanisterDetail from "$lib/pages/CanisterDetail.svelte";
+import { authStore } from "$lib/stores/auth.store";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCanister,
   mockCanisterDetails,
   mockCanisterId,
 } from "$tests/mocks/canisters.mock";
+import { CanisterDetailPo } from "$tests/page-objects/CanisterDetail.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 
 jest.mock("$lib/api/canisters.api");
 
@@ -23,6 +27,7 @@ describe("CanisterDetail", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    authStore.setForTesting(mockIdentity);
     canistersStore.setCanisters({ canisters: undefined, certified: true });
   });
 
@@ -57,20 +62,19 @@ describe("CanisterDetail", () => {
 
     it("should render rename button", async () => {
       const { queryByTestId } = render(CanisterDetail, props);
-      await waitFor(() =>
-        expect(
-          queryByTestId("rename-canister-button-component")
-        ).toBeInTheDocument()
-      );
+
+      await runResolvedPromises();
+
+      expect(
+        queryByTestId("rename-canister-button-component")
+      ).toBeInTheDocument();
     });
 
     it("should render cards", async () => {
       const { queryByTestId } = render(CanisterDetail, props);
 
-      await waitFor(() =>
-        expect(queryByTestId("canister-cycles-card")).toBeInTheDocument()
-      );
-      // Waiting for the one above is enough
+      await runResolvedPromises();
+
       expect(queryByTestId("canister-controllers-card")).toBeInTheDocument();
     });
   });
@@ -127,9 +131,8 @@ describe("CanisterDetail", () => {
     it("should not render cards if user is not the controller", async () => {
       const { queryByTestId } = render(CanisterDetail, props);
 
-      await waitFor(() =>
-        expect(queryByTestId("canister-details-error-card")).toBeInTheDocument()
-      );
+      await runResolvedPromises();
+
       // Waiting for the one above is enough
       expect(queryByTestId("canister-cycles-card")).not.toBeInTheDocument();
       expect(
@@ -138,32 +141,52 @@ describe("CanisterDetail", () => {
     });
   });
 
-  describe("if user is not the controller", () => {
+  describe("rename button", () => {
+    const newName = "new name";
+    const oldName = "old name";
+    const canisterOldName = {
+      canister_id: canisterId,
+      name: oldName,
+    };
+    const canisterNewName = {
+      ...canisterOldName,
+      name: newName,
+    };
     beforeEach(() => {
       jest
         .spyOn(canisterApi, "queryCanisterDetails")
-        .mockRejectedValue(new UserNotTheControllerError());
-      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
-        {
-          canister_id: canisterId,
-          name: "",
-        },
-      ]);
+        .mockResolvedValue(mockCanisterDetails);
+      jest
+        .spyOn(canisterApi, "queryCanisters")
+        .mockResolvedValueOnce([canisterOldName])
+        .mockResolvedValueOnce([canisterOldName])
+        .mockResolvedValueOnce([canisterNewName])
+        .mockResolvedValueOnce([canisterNewName]);
+      jest.spyOn(canisterApi, "renameCanister").mockResolvedValue(undefined);
     });
 
-    it("should not render cards if user is not the controller", async () => {
-      const { queryByTestId } = render(CanisterDetail, props);
+    it("should rename the canister successfully", async () => {
+      const { container } = render(CanisterDetail, props);
 
-      await waitFor(() =>
-        expect(queryByTestId("canister-details-error-card")).toBeInTheDocument()
-      );
-      // Waiting for the one above is enough
-      expect(queryByTestId("canister-cycles-card")).not.toBeInTheDocument();
-      expect(
-        queryByTestId("canister-controllers-card")
-      ).not.toBeInTheDocument();
+      const po = CanisterDetailPo.under(new JestPageObjectElement(container));
+
+      await runResolvedPromises();
+
+      expect(await po.getCanisterTitle()).toBe(oldName);
+
+      await po.clickRename();
+      await po.getRenameCanisterModalPo().isPresent();
+      await po.renameCanister(newName);
+
+      await runResolvedPromises();
+
+      expect(await po.getCanisterTitle()).toBe(newName);
+      expect(canisterApi.renameCanister).toHaveBeenCalledTimes(1);
+      expect(canisterApi.renameCanister).toHaveBeenCalledWith({
+        canisterId,
+        name: newName,
+        identity: mockIdentity,
+      });
     });
   });
-
-  // TODO: Add tests that renames the canister
 });

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -55,6 +55,15 @@ describe("CanisterDetail", () => {
       ).toEqual(mockCanister.canister_id.toText());
     });
 
+    it("should render rename button", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+      await waitFor(() =>
+        expect(
+          queryByTestId("rename-canister-button-component")
+        ).toBeInTheDocument()
+      );
+    });
+
     it("should render cards", async () => {
       const { queryByTestId } = render(CanisterDetail, props);
 
@@ -128,4 +137,33 @@ describe("CanisterDetail", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("if user is not the controller", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(canisterApi, "queryCanisterDetails")
+        .mockRejectedValue(new UserNotTheControllerError());
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: "",
+        },
+      ]);
+    });
+
+    it("should not render cards if user is not the controller", async () => {
+      const { queryByTestId } = render(CanisterDetail, props);
+
+      await waitFor(() =>
+        expect(queryByTestId("canister-details-error-card")).toBeInTheDocument()
+      );
+      // Waiting for the one above is enough
+      expect(queryByTestId("canister-cycles-card")).not.toBeInTheDocument();
+      expect(
+        queryByTestId("canister-controllers-card")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // TODO: Add tests that renames the canister
 });

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -26,8 +26,9 @@ export class CanisterDetailPo extends BasePageObject {
   }
 
   async renameCanister(newName: string): Promise<void> {
-    await this.getRenameCanisterModalPo().enterNewName(newName);
+    await this.getRenameCanisterModalPo().enterName(newName);
     await this.getRenameCanisterModalPo().clickRenameButton();
+    await this.getRenameCanisterModalPo().waitForAbsent();
   }
 
   async getCanisterTitle(): Promise<string> {

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -1,0 +1,36 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ButtonPo } from "./Button.page-object";
+import { RenameCanisterModalPo } from "./RenameCanisterModal.page-object";
+
+export class CanisterDetailPo extends BasePageObject {
+  private static readonly TID = "canister-detail-component";
+
+  static under(element: PageObjectElement): CanisterDetailPo {
+    return new CanisterDetailPo(element.byTestId(CanisterDetailPo.TID));
+  }
+
+  getRenameButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "rename-canister-button-component",
+    });
+  }
+
+  clickRename(): Promise<void> {
+    return this.getRenameButtonPo().click();
+  }
+
+  getRenameCanisterModalPo(): RenameCanisterModalPo {
+    return RenameCanisterModalPo.under(this.root);
+  }
+
+  async renameCanister(newName: string): Promise<void> {
+    await this.getRenameCanisterModalPo().enterNewName(newName);
+    await this.getRenameCanisterModalPo().clickRenameButton();
+  }
+
+  getCanisterTitle(): Promise<string> {
+    return this.root.byTestId("canister-card-title-compomnet").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -26,9 +26,7 @@ export class CanisterDetailPo extends BasePageObject {
   }
 
   async renameCanister(newName: string): Promise<void> {
-    await this.getRenameCanisterModalPo().enterName(newName);
-    await this.getRenameCanisterModalPo().clickRenameButton();
-    await this.getRenameCanisterModalPo().waitForAbsent();
+    await this.getRenameCanisterModalPo().rename(newName);
   }
 
   async getCanisterTitle(): Promise<string> {

--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -30,7 +30,9 @@ export class CanisterDetailPo extends BasePageObject {
     await this.getRenameCanisterModalPo().clickRenameButton();
   }
 
-  getCanisterTitle(): Promise<string> {
-    return this.root.byTestId("canister-card-title-compomnet").getText();
+  async getCanisterTitle(): Promise<string> {
+    return (
+      await this.root.byTestId("canister-card-title-compoment").getText()
+    ).trim();
   }
 }

--- a/frontend/src/tests/page-objects/RenameCanisterButton.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterButton.page-object.ts
@@ -1,0 +1,17 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class RenameCanisterButtonPo extends ButtonPo {
+  static readonly TID = "rename-canister-button-component";
+
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): RenameCanisterButtonPo {
+    return ButtonPo.under({
+      element,
+      testId: RenameCanisterButtonPo.TID,
+    });
+  }
+}

--- a/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
@@ -1,0 +1,33 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TextInputFormPo } from "$tests/page-objects/TextInputForm.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class RenameCanisterModalPo extends BasePageObject {
+  private static readonly TID = "rename-canister-modal-component";
+
+  static under(element: PageObjectElement): RenameCanisterModalPo {
+    return new RenameCanisterModalPo(
+      element.byTestId(RenameCanisterModalPo.TID)
+    );
+  }
+
+  getTextInputFormPo(): TextInputFormPo {
+    return TextInputFormPo.under({
+      element: this.root,
+      testId: "rename-canister-form",
+    });
+  }
+
+  enterNewName(name: string): Promise<void> {
+    return this.getTextInputFormPo().enterText(name);
+  }
+
+  getRenameButton(): ButtonPo {
+    return this.getTextInputFormPo().getConfirmButtonPo();
+  }
+
+  clickRenameButton(): Promise<void> {
+    return this.getTextInputFormPo().clickSubmitButton();
+  }
+}

--- a/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
@@ -19,7 +19,7 @@ export class RenameCanisterModalPo extends BasePageObject {
     });
   }
 
-  enterNewName(name: string): Promise<void> {
+  enterName(name: string): Promise<void> {
     return this.getTextInputFormPo().enterText(name);
   }
 

--- a/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
@@ -30,4 +30,10 @@ export class RenameCanisterModalPo extends BasePageObject {
   clickRenameButton(): Promise<void> {
     return this.getTextInputFormPo().clickSubmitButton();
   }
+
+  async rename(newName: string): Promise<void> {
+    await this.enterName(newName);
+    await this.clickRenameButton();
+    await this.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/TextInputForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInputForm.page-object.ts
@@ -1,0 +1,37 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TextInputFormPo extends BasePageObject {
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
+  }): TextInputFormPo {
+    return new TextInputFormPo(element.byTestId(testId));
+  }
+
+  getTextInputPo(): TextInputPo {
+    return TextInputPo.under({
+      element: this.root,
+    });
+  }
+
+  enterText(text: string): Promise<void> {
+    return this.getTextInputPo().typeText(text);
+  }
+
+  getConfirmButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "confirm-text-input-screen-button",
+    });
+  }
+
+  clickSubmitButton(): Promise<void> {
+    return this.getConfirmButtonPo().click();
+  }
+}


### PR DESCRIPTION
# Motivation

Users want to be able to add a name to their canisters.

In this PR: Users can add a name after the canister has been attached to the user.

# Changes

* New button RenameCanisterButton.
* New modal RenameCanisterModal.
* Render new button in CanisterDetail page.

# Tests

* Test that RenameCanisterButton opens modal.
* Test that modal calls api RenameCanisterModal.
* Test that user can rename from CanisterDetail.
* Add related page objects.

# Todos

- [x] Add entry to changelog (if necessary).
