### PR TITLE
build: upgrade next and ic-management

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.8-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.tgz",
-      "integrity": "sha512-iApnrBJb0HoHiLPbbF8eLdvhXQRhpFmdw2RMdP3gSLHDqzFtUtXCfPl98+7/0o9cqblxGBVpO9eL39IE9GeRmg==",
+      "version": "0.0.8-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.1.tgz",
+      "integrity": "sha512-hHRRE3yNUdXUNp5dkDIjENM6B78IDr2y4Zq2rBSsoUYfrGiycZsPVXAEFyituzcNZ7eMsKU10AJdloe4moClqg==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.15-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.tgz",
-      "integrity": "sha512-4RfZ5YLF7rq8UPJEp+CX7fkP0FsY4HVxvY4AL+yZK1HV9meTfQoGBcdE6+lyfflz3JE4NPhWoHn8HckzPvtChA==",
+      "version": "0.0.15-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.1.tgz",
+      "integrity": "sha512-gZfknZLKW8DuurTIrRVF7yu1l/4q8YQ8bkZKBGwElDyw8g9iSmkNLsqPl+ECRu8sVJdnqC82hOsJ7QTBLU9O9w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.5-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.tgz",
-      "integrity": "sha512-TOPpiJsUSmk+R4qV03gmOUr6KOwovQp9VChCq4nxd2t39z4/7LAYFwMtlQQECXc1TavIKYsfSzw5hQSoxmUqDg==",
+      "version": "0.0.5-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.1.tgz",
+      "integrity": "sha512-UTaMq9UP0Tl09Fdd9IFy/zuo6m08oIyGLdFA/vsJGhq/049EIFrqVxkXawdIY8/jQjfTTz5QkxuanG12XJ335Q==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.12-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.tgz",
-      "integrity": "sha512-Lp6FYHxuA3qlhemPomQKu8aK2wOMj4wKvRpyn+vBh2glSXE4waLnSxmwHVcdZyYM7lhhstB+BEGdJDIsoke3Uw==",
+      "version": "0.0.12-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.1.tgz",
+      "integrity": "sha512-4IPiUvsrEggiY2eIpSoQuc/nNJUtvBOGVlT1rLvNN2DGFNxg/ujk3tK1W0qYkJhKBxdIRQNfLge0AWeSIfxI3A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.4-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.tgz",
-      "integrity": "sha512-fwsVs01aY90Wq0dVcHzzPO04sI5ENtp1zAAo/sObMiFvZ+0Y/H9AmshLggmSFH9c7TYONw5GZ1XI2Rs0QdL2xA==",
+      "version": "0.16.4-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.1.tgz",
+      "integrity": "sha512-Y1fta1tT8r8Cmj+0Fou8CW6Xy2w5F8JUI+fJ0iO6Fx1+m8kfld1WefjZhKgos7L7j/HiZZoNG3jYDYCk/yoKiA==",
       "dependencies": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.5-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.tgz",
-      "integrity": "sha512-LaBR5FIQyEfqMn4oYuR06l7k3omQKFwxx54BWjKnkylOVSc0Ha2MGeEMHJYKeSh43p2ktZKnmKSivyxjzxWTpg==",
+      "version": "0.0.5-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.1.tgz",
+      "integrity": "sha512-pZMoPFIhaPFgAFIA4y6aY7yhP3yhCISMKChbBGTLVRdEj6ZLFUGvLOkED6SSNI+lXIguYOWP8k3xQolxCu8STg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.19-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.tgz",
-      "integrity": "sha512-UTjbVqjVJsKIDa+ErQ0wzMta10sD2a3BiRRCjA8iPhpsVvGsrZhUYNpLxDER5xwVMXAh8WjfhGX1fD6xlqQ21Q==",
+      "version": "0.0.19-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.1.tgz",
+      "integrity": "sha512-wl+P2x64bPHj/ZDw5MFHkSZRkGz6W5HbW6hTwRRVh9cj7VfVOiR0f8f625JUOGBLa05Gw75Ql3JOGhW3X1of7Q==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.19-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.tgz",
-      "integrity": "sha512-DcBjqT4sH1GWvfQTgURawuarv9rb9wke2Mbrr+9C5iZNeFU/s+/K1oudjVU6Q8Zi5cmoAfvskgrH1+hyX82s8A==",
+      "version": "0.0.19-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.1.tgz",
+      "integrity": "sha512-s+JKVxQGZXKQT8lybaOJmKhcz87VRdZRPawooLyD0zkVzA7HQWB3Wat8dHQseEZC9MkQTLDeTIikW6sIPccnMw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9994,9 +9994,9 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.8-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.tgz",
-      "integrity": "sha512-iApnrBJb0HoHiLPbbF8eLdvhXQRhpFmdw2RMdP3gSLHDqzFtUtXCfPl98+7/0o9cqblxGBVpO9eL39IE9GeRmg==",
+      "version": "0.0.8-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.1.tgz",
+      "integrity": "sha512-hHRRE3yNUdXUNp5dkDIjENM6B78IDr2y4Zq2rBSsoUYfrGiycZsPVXAEFyituzcNZ7eMsKU10AJdloe4moClqg==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10004,9 +10004,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.15-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.tgz",
-      "integrity": "sha512-4RfZ5YLF7rq8UPJEp+CX7fkP0FsY4HVxvY4AL+yZK1HV9meTfQoGBcdE6+lyfflz3JE4NPhWoHn8HckzPvtChA==",
+      "version": "0.0.15-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.1.tgz",
+      "integrity": "sha512-gZfknZLKW8DuurTIrRVF7yu1l/4q8YQ8bkZKBGwElDyw8g9iSmkNLsqPl+ECRu8sVJdnqC82hOsJ7QTBLU9O9w==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10020,9 +10020,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.5-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.tgz",
-      "integrity": "sha512-TOPpiJsUSmk+R4qV03gmOUr6KOwovQp9VChCq4nxd2t39z4/7LAYFwMtlQQECXc1TavIKYsfSzw5hQSoxmUqDg==",
+      "version": "0.0.5-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.1.tgz",
+      "integrity": "sha512-UTaMq9UP0Tl09Fdd9IFy/zuo6m08oIyGLdFA/vsJGhq/049EIFrqVxkXawdIY8/jQjfTTz5QkxuanG12XJ335Q==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10040,24 +10040,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.12-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.tgz",
-      "integrity": "sha512-Lp6FYHxuA3qlhemPomQKu8aK2wOMj4wKvRpyn+vBh2glSXE4waLnSxmwHVcdZyYM7lhhstB+BEGdJDIsoke3Uw==",
+      "version": "0.0.12-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.1.tgz",
+      "integrity": "sha512-4IPiUvsrEggiY2eIpSoQuc/nNJUtvBOGVlT1rLvNN2DGFNxg/ujk3tK1W0qYkJhKBxdIRQNfLge0AWeSIfxI3A==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.4-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.tgz",
-      "integrity": "sha512-fwsVs01aY90Wq0dVcHzzPO04sI5ENtp1zAAo/sObMiFvZ+0Y/H9AmshLggmSFH9c7TYONw5GZ1XI2Rs0QdL2xA==",
+      "version": "0.16.4-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.1.tgz",
+      "integrity": "sha512-Y1fta1tT8r8Cmj+0Fou8CW6Xy2w5F8JUI+fJ0iO6Fx1+m8kfld1WefjZhKgos7L7j/HiZZoNG3jYDYCk/yoKiA==",
       "requires": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.5-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.tgz",
-      "integrity": "sha512-LaBR5FIQyEfqMn4oYuR06l7k3omQKFwxx54BWjKnkylOVSc0Ha2MGeEMHJYKeSh43p2ktZKnmKSivyxjzxWTpg==",
+      "version": "0.0.5-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.1.tgz",
+      "integrity": "sha512-pZMoPFIhaPFgAFIA4y6aY7yhP3yhCISMKChbBGTLVRdEj6ZLFUGvLOkED6SSNI+lXIguYOWP8k3xQolxCu8STg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10072,17 +10072,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.19-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.tgz",
-      "integrity": "sha512-UTjbVqjVJsKIDa+ErQ0wzMta10sD2a3BiRRCjA8iPhpsVvGsrZhUYNpLxDER5xwVMXAh8WjfhGX1fD6xlqQ21Q==",
+      "version": "0.0.19-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.1.tgz",
+      "integrity": "sha512-wl+P2x64bPHj/ZDw5MFHkSZRkGz6W5HbW6hTwRRVh9cj7VfVOiR0f8f625JUOGBLa05Gw75Ql3JOGhW3X1of7Q==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.19-next-2023-07-03",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.tgz",
-      "integrity": "sha512-DcBjqT4sH1GWvfQTgURawuarv9rb9wke2Mbrr+9C5iZNeFU/s+/K1oudjVU6Q8Zi5cmoAfvskgrH1+hyX82s8A==",
+      "version": "0.0.19-next-2023-07-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.1.tgz",
+      "integrity": "sha512-s+JKVxQGZXKQT8lybaOJmKhcz87VRdZRPawooLyD0zkVzA7HQWB3Wat8dHQseEZC9MkQTLDeTIikW6sIPccnMw==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.7-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-26.2.tgz",
-      "integrity": "sha512-uKFEBLYX0xd/yJv/67CMKz6HYtqRn+GYc/5gUzQocEcCMDTmuTcXEsj7iaUdS9UncTSjXJoKSs1RBq7j7COqpA==",
+      "version": "0.0.8-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.tgz",
+      "integrity": "sha512-iApnrBJb0HoHiLPbbF8eLdvhXQRhpFmdw2RMdP3gSLHDqzFtUtXCfPl98+7/0o9cqblxGBVpO9eL39IE9GeRmg==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.14-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-26.2.tgz",
-      "integrity": "sha512-wbBulXOcZ08kZZHBZLHqFF5ftTa/bU6T1mgS53/rSfe53Q3lZOKlC/od65YUMQHyzQIE4JWP7CCQCgriEica+A==",
+      "version": "0.0.15-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.tgz",
+      "integrity": "sha512-4RfZ5YLF7rq8UPJEp+CX7fkP0FsY4HVxvY4AL+yZK1HV9meTfQoGBcdE6+lyfflz3JE4NPhWoHn8HckzPvtChA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.4-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-26.2.tgz",
-      "integrity": "sha512-RWHMS+jZRRrPJRf9Zvtztn8pUQD8vnwZDFwZPkdomuRJwtLq8PATaPiELMsDPBdfi/5RT9mrbNS5V8oioAWaRA==",
+      "version": "0.0.5-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.tgz",
+      "integrity": "sha512-TOPpiJsUSmk+R4qV03gmOUr6KOwovQp9VChCq4nxd2t39z4/7LAYFwMtlQQECXc1TavIKYsfSzw5hQSoxmUqDg==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.11-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-26.2.tgz",
-      "integrity": "sha512-ws1wQUOcRO83l+kBsmTY3lcDOx2N7YSz+lameu5IpCLR1oivvNn93qjQLn3BnS8V3H6Nfckj78g28ZVVWDYGVw==",
+      "version": "0.0.12-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.tgz",
+      "integrity": "sha512-Lp6FYHxuA3qlhemPomQKu8aK2wOMj4wKvRpyn+vBh2glSXE4waLnSxmwHVcdZyYM7lhhstB+BEGdJDIsoke3Uw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.3-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-26.2.tgz",
-      "integrity": "sha512-rAhP0QMz7V+TNXQPQDPF4R/pC/9tJ4EYd+7p26O3dL3mdpQofmDPK0fZAXB7q4RrAG3GIB+p7Qt8uYs9+pZ6Qw==",
+      "version": "0.16.4-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.tgz",
+      "integrity": "sha512-fwsVs01aY90Wq0dVcHzzPO04sI5ENtp1zAAo/sObMiFvZ+0Y/H9AmshLggmSFH9c7TYONw5GZ1XI2Rs0QdL2xA==",
       "dependencies": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.4-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-26.2.tgz",
-      "integrity": "sha512-kCfaeJdswJWaCtFrnHtGPIaaFQW7/lh+8QF1Z72XzAumCPB3KN2xaewwLJ+hzSbesMgNsIa1Y2msCn+s3ugKDg==",
+      "version": "0.0.5-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.tgz",
+      "integrity": "sha512-LaBR5FIQyEfqMn4oYuR06l7k3omQKFwxx54BWjKnkylOVSc0Ha2MGeEMHJYKeSh43p2ktZKnmKSivyxjzxWTpg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.18-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-26.2.tgz",
-      "integrity": "sha512-hLoXKVAAITc6p4ptWJZ/y6cIqxCjeleFDHIQApoT7CB9CClUKEEa5So9ccUpGdjZS161UeZQtO6XeJ8L+W4gbA==",
+      "version": "0.0.19-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.tgz",
+      "integrity": "sha512-UTjbVqjVJsKIDa+ErQ0wzMta10sD2a3BiRRCjA8iPhpsVvGsrZhUYNpLxDER5xwVMXAh8WjfhGX1fD6xlqQ21Q==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.18-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-26.2.tgz",
-      "integrity": "sha512-skoeF6rS7UuqyonMNVeNpaEoJOpPN0QbReiDw8q1wCNy4KWKjMytspSqhFVSDJYL8ECsfnnAxyqRo55FQ2qsWg==",
+      "version": "0.0.19-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.tgz",
+      "integrity": "sha512-DcBjqT4sH1GWvfQTgURawuarv9rb9wke2Mbrr+9C5iZNeFU/s+/K1oudjVU6Q8Zi5cmoAfvskgrH1+hyX82s8A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -9994,9 +9994,9 @@
       }
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.7-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.7-next-2023-06-26.2.tgz",
-      "integrity": "sha512-uKFEBLYX0xd/yJv/67CMKz6HYtqRn+GYc/5gUzQocEcCMDTmuTcXEsj7iaUdS9UncTSjXJoKSs1RBq7j7COqpA==",
+      "version": "0.0.8-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.8-next-2023-07-03.tgz",
+      "integrity": "sha512-iApnrBJb0HoHiLPbbF8eLdvhXQRhpFmdw2RMdP3gSLHDqzFtUtXCfPl98+7/0o9cqblxGBVpO9eL39IE9GeRmg==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10004,9 +10004,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.14-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.14-next-2023-06-26.2.tgz",
-      "integrity": "sha512-wbBulXOcZ08kZZHBZLHqFF5ftTa/bU6T1mgS53/rSfe53Q3lZOKlC/od65YUMQHyzQIE4JWP7CCQCgriEica+A==",
+      "version": "0.0.15-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.15-next-2023-07-03.tgz",
+      "integrity": "sha512-4RfZ5YLF7rq8UPJEp+CX7fkP0FsY4HVxvY4AL+yZK1HV9meTfQoGBcdE6+lyfflz3JE4NPhWoHn8HckzPvtChA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10020,9 +10020,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.4-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.4-next-2023-06-26.2.tgz",
-      "integrity": "sha512-RWHMS+jZRRrPJRf9Zvtztn8pUQD8vnwZDFwZPkdomuRJwtLq8PATaPiELMsDPBdfi/5RT9mrbNS5V8oioAWaRA==",
+      "version": "0.0.5-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.5-next-2023-07-03.tgz",
+      "integrity": "sha512-TOPpiJsUSmk+R4qV03gmOUr6KOwovQp9VChCq4nxd2t39z4/7LAYFwMtlQQECXc1TavIKYsfSzw5hQSoxmUqDg==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10040,24 +10040,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.11-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.11-next-2023-06-26.2.tgz",
-      "integrity": "sha512-ws1wQUOcRO83l+kBsmTY3lcDOx2N7YSz+lameu5IpCLR1oivvNn93qjQLn3BnS8V3H6Nfckj78g28ZVVWDYGVw==",
+      "version": "0.0.12-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.12-next-2023-07-03.tgz",
+      "integrity": "sha512-Lp6FYHxuA3qlhemPomQKu8aK2wOMj4wKvRpyn+vBh2glSXE4waLnSxmwHVcdZyYM7lhhstB+BEGdJDIsoke3Uw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.3-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.3-next-2023-06-26.2.tgz",
-      "integrity": "sha512-rAhP0QMz7V+TNXQPQDPF4R/pC/9tJ4EYd+7p26O3dL3mdpQofmDPK0fZAXB7q4RrAG3GIB+p7Qt8uYs9+pZ6Qw==",
+      "version": "0.16.4-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.4-next-2023-07-03.tgz",
+      "integrity": "sha512-fwsVs01aY90Wq0dVcHzzPO04sI5ENtp1zAAo/sObMiFvZ+0Y/H9AmshLggmSFH9c7TYONw5GZ1XI2Rs0QdL2xA==",
       "requires": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.4-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.4-next-2023-06-26.2.tgz",
-      "integrity": "sha512-kCfaeJdswJWaCtFrnHtGPIaaFQW7/lh+8QF1Z72XzAumCPB3KN2xaewwLJ+hzSbesMgNsIa1Y2msCn+s3ugKDg==",
+      "version": "0.0.5-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.5-next-2023-07-03.tgz",
+      "integrity": "sha512-LaBR5FIQyEfqMn4oYuR06l7k3omQKFwxx54BWjKnkylOVSc0Ha2MGeEMHJYKeSh43p2ktZKnmKSivyxjzxWTpg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10072,17 +10072,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.18-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.18-next-2023-06-26.2.tgz",
-      "integrity": "sha512-hLoXKVAAITc6p4ptWJZ/y6cIqxCjeleFDHIQApoT7CB9CClUKEEa5So9ccUpGdjZS161UeZQtO6XeJ8L+W4gbA==",
+      "version": "0.0.19-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.19-next-2023-07-03.tgz",
+      "integrity": "sha512-UTjbVqjVJsKIDa+ErQ0wzMta10sD2a3BiRRCjA8iPhpsVvGsrZhUYNpLxDER5xwVMXAh8WjfhGX1fD6xlqQ21Q==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.18-next-2023-06-26.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.18-next-2023-06-26.2.tgz",
-      "integrity": "sha512-skoeF6rS7UuqyonMNVeNpaEoJOpPN0QbReiDw8q1wCNy4KWKjMytspSqhFVSDJYL8ECsfnnAxyqRo55FQ2qsWg==",
+      "version": "0.0.19-next-2023-07-03",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.19-next-2023-07-03.tgz",
+      "integrity": "sha512-DcBjqT4sH1GWvfQTgURawuarv9rb9wke2Mbrr+9C5iZNeFU/s+/K1oudjVU6Q8Zi5cmoAfvskgrH1+hyX82s8A==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/canisters/ic-management/converters.ts
+++ b/frontend/src/lib/canisters/ic-management/converters.ts
@@ -26,7 +26,14 @@ const getCanisterStatus = (
 };
 
 export const toCanisterDetails = ({
-  response: { memory_size, status, cycles, settings, module_hash },
+  response: {
+    memory_size,
+    status,
+    cycles,
+    settings,
+    module_hash,
+    idle_cycles_burned_per_day,
+  },
   canisterId,
 }: {
   response: CanisterStatusResponse;
@@ -46,4 +53,5 @@ export const toCanisterDetails = ({
     module_hash.length > 0 && module_hash[0] !== undefined
       ? new Uint8Array(module_hash[0]).buffer
       : undefined,
+  idleCyclesBurnedPerDay: idle_cycles_burned_per_day,
 });

--- a/frontend/src/lib/canisters/ic-management/ic-management.canister.types.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.canister.types.ts
@@ -20,4 +20,5 @@ export interface CanisterDetails {
   cycles: bigint;
   settings: CanisterSettings;
   moduleHash?: ArrayBuffer;
+  idleCyclesBurnedPerDay: bigint;
 }

--- a/frontend/src/lib/worker-api/canisters.worker-api.ts
+++ b/frontend/src/lib/worker-api/canisters.worker-api.ts
@@ -4,9 +4,9 @@ import { mapError } from "$lib/canisters/ic-management/ic-management.errors";
 import type { CanisterActorParams } from "$lib/types/worker";
 import { mapCanisterId } from "$lib/utils/canisters.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { ManagementCanisterRecord } from "@dfinity/agent";
-import { getManagementCanister, HttpAgent } from "@dfinity/agent";
+import { HttpAgent } from "@dfinity/agent";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
+import { ICManagementCanister } from "@dfinity/ic-management";
 
 export const queryCanisterDetails = async ({
   identity,
@@ -16,15 +16,15 @@ export const queryCanisterDetails = async ({
 }: { canisterId: string } & CanisterActorParams): Promise<CanisterDetails> => {
   logWithTimestamp(`Getting canister ${canisterId} details call...`);
   const {
-    icMgtService: { canister_status },
+    icMgtService: { canisterStatus },
   } = await canisters({ identity, host, fetchRootKey });
 
   try {
     const canister_id = mapCanisterId(canisterId);
 
-    const rawResponse: CanisterStatusResponse = await canister_status({
-      canister_id,
-    });
+    const rawResponse: CanisterStatusResponse = await canisterStatus(
+      canister_id
+    );
 
     const response = toCanisterDetails({
       response: rawResponse,
@@ -44,7 +44,7 @@ const canisters = async ({
   host,
   fetchRootKey,
 }: CanisterActorParams): Promise<{
-  icMgtService: ManagementCanisterRecord;
+  icMgtService: ICManagementCanister;
 }> => {
   const agent = new HttpAgent({
     identity,
@@ -55,7 +55,7 @@ const canisters = async ({
     await agent.fetchRootKey();
   }
 
-  const icMgtService = getManagementCanister({ agent });
+  const icMgtService = ICManagementCanister.create({ agent });
 
   return { icMgtService };
 };

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -8,18 +8,19 @@ import {
   mockCanisterId,
   mockCanisterSettings,
 } from "$tests/mocks/canisters.mock";
-import type { ActorSubclass, ManagementCanisterRecord } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
+import type { _SERVICE as IcManagementService } from "@dfinity/ic-management/dist/candid/ic-management";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 
 describe("ICManagementCanister", () => {
-  const createICManagement = async (service: ManagementCanisterRecord) => {
+  const createICManagement = async (service: IcManagementService) => {
     const defaultAgent = await createAgent({ identity: mockIdentity });
 
     return ICManagementCanister.create({
       agent: defaultAgent,
-      serviceOverride: service as ActorSubclass<ManagementCanisterRecord>,
+      serviceOverride: service as ActorSubclass<IcManagementService>,
     });
   };
 
@@ -41,8 +42,9 @@ describe("ICManagementCanister", () => {
         cycles: BigInt(10_000),
         settings,
         module_hash: [],
+        idle_cycles_burned_per_day: BigInt(30_000),
       };
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.canister_status.mockResolvedValue(response);
 
       const icManagement = await createICManagement(service);
@@ -56,7 +58,7 @@ describe("ICManagementCanister", () => {
 
     it("throws UserNotTheControllerError", async () => {
       const error = new Error("code: 403");
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.canister_status.mockRejectedValue(error);
 
       const icManagement = await createICManagement(service);
@@ -69,7 +71,7 @@ describe("ICManagementCanister", () => {
 
     it("throws Error", async () => {
       const error = new Error("Test");
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.canister_status.mockRejectedValue(error);
 
       const icManagement = await createICManagement(service);
@@ -83,7 +85,7 @@ describe("ICManagementCanister", () => {
 
   describe("updateSettings", () => {
     it("calls update_settings with new settings", async () => {
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.update_settings.mockResolvedValue(undefined);
 
       const icManagement = await createICManagement(service);
@@ -101,7 +103,7 @@ describe("ICManagementCanister", () => {
           "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
         ],
       };
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.update_settings.mockResolvedValue(undefined);
 
       const icManagement = await createICManagement(service);
@@ -115,7 +117,7 @@ describe("ICManagementCanister", () => {
 
     it("throws UserNotTheControllerError", async () => {
       const error = new Error("code: 403");
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.update_settings.mockRejectedValue(error);
 
       const icManagement = await createICManagement(service);
@@ -130,7 +132,7 @@ describe("ICManagementCanister", () => {
 
     it("throws Error", async () => {
       const error = new Error("Test");
-      const service = mock<ManagementCanisterRecord>();
+      const service = mock<IcManagementService>();
       service.update_settings.mockRejectedValue(error);
 
       const icManagement = await createICManagement(service);

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -23,8 +23,6 @@ describe("canisters-worker-api", () => {
     idle_cycles_burned_per_day: 300n,
   };
 
-  const MockHttpAgent = jest.fn();
-
   beforeEach(async () => {
     jest.resetAllMocks();
 

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -3,6 +3,8 @@ import { queryCanisterDetails } from "$lib/worker-api/canisters.worker-api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
+import { ICManagementCanister } from "@dfinity/ic-management";
+import { mock } from "jest-mock-extended";
 
 jest.mock("@dfinity/agent");
 
@@ -18,17 +20,20 @@ describe("canisters-worker-api", () => {
       compute_allocation: 5n,
     },
     module_hash: [],
+    idle_cycles_burned_per_day: 300n,
   };
 
   const MockHttpAgent = jest.fn();
 
   beforeEach(async () => {
     jest.resetAllMocks();
-    const module = await import("@dfinity/agent");
-    module.HttpAgent = MockHttpAgent;
-    module.getManagementCanister = jest.fn().mockReturnValue({
-      canister_status: async () => response,
-    });
+
+    const mockICManagementCanister = mock<ICManagementCanister>();
+    jest
+      .spyOn(ICManagementCanister, "create")
+      .mockImplementation(() => mockICManagementCanister);
+
+    mockICManagementCanister.canisterStatus.mockResolvedValue(response);
   });
 
   describe("queryCanisterDetails", () => {
@@ -53,6 +58,7 @@ describe("canisters-worker-api", () => {
           computeAllocation: 5n,
         },
         moduleHash: undefined,
+        idleCyclesBurnedPerDay: 300n,
       });
     });
   });

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -46,6 +46,7 @@ export const mockCanisterDetails: CanisterDetails = {
     memoryAllocation: BigInt(1000),
     computeAllocation: BigInt(2000),
   },
+  idleCyclesBurnedPerDay: BigInt(3000),
 };
 
 export const mockCanistersStoreSubscribe = (


### PR DESCRIPTION
# Motivation

Bump ic-js to next after release of ic-js v0.0.18.

Implement the usage of the `@dfinity/ic-management` library because the definition in agent-js is not up-to-date anymore and ship a fix to use this library locally.

# PRs

- [x] https://github.com/dfinity/ic-js/pull/377

