### PR TITLE
GIX-1658: Fix task runner substitutes canister

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -34,6 +34,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Enable voting for proposals that are decided but still accepting votes.
 * Misplaced tooltip for disabled SNS neuron split button.
+* Fix bug with newly created canisters where the name was ovewritten to empty string.
 
 #### Security
 #### Not Published

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -822,7 +822,7 @@ impl AccountsStore {
                 let account = self.accounts.get_mut(&account_identifier.to_vec()).unwrap();
 
                 let mut index_to_remove: Option<usize> = None;
-                for (index,c) in account.canisters.iter().enumerate() {
+                for (index, c) in account.canisters.iter().enumerate() {
                     if !request.name.is_empty() && c.name == request.name {
                         return AttachCanisterResponse::NameAlreadyTaken;
                     }
@@ -832,7 +832,8 @@ impl AccountsStore {
                         if c.name.is_empty() && !request.name.is_empty() {
                             index_to_remove = Some(index);
                         } else {
-                            return AttachCanisterResponse::CanisterAlreadyAttached;  // Note: It might be nice to tell the user the name of the existing canister.
+                            return AttachCanisterResponse::CanisterAlreadyAttached;
+                            // Note: It might be nice to tell the user the name of the existing canister.
                         }
                     }
                 }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -915,7 +915,7 @@ impl AccountsStore {
             let account = self.accounts.get_mut(&account_identifier.to_vec()).unwrap();
 
             // We only attach if it doesn't already exist
-            if let None = Self::find_canister_index(account, canister_id) {
+            if Self::find_canister_index(account, canister_id).is_none() {
                 account.canisters.push(NamedCanister {
                     name: "".to_string(),
                     canister_id,


### PR DESCRIPTION
# Motivation

User wants to add a name when creating a canister.

There was a bug in the create canister flow.

When creating a canister, the nns-dapp backend has a runner task that attached a newly created canister. This method was overriding the previous attched canister by the method `attach_canister` with an empty name.

# Changes

* Attach the canister in the runner flow only if canister_id is not alreay attached.
* Manage race condition in `attach_canister` method. The runner could be faster than the call to this request.

# Tests

* Add tests for `attach_newly_created_canister`.
* Add test for new condition in `attach_canister`.

# Todos

- [x] Add entry to changelog (if necessary).
