### PR TITLE
Copy newest clap.bash from snsdemo

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -55,6 +55,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Increased timeout on end-to-end tests running on CI.
 - Set a custom URL for `internet_identity` on `ic` rather than using the default.
 - Improve Canister Detail tests by mocking the api layer instead of services.
+- Copied the newest version of clap.bash from snsdemo.
 
 #### Deprecated
 #### Removed

--- a/scripts/clap.bash
+++ b/scripts/clap.bash
@@ -54,7 +54,7 @@ function clap.define() {
 	done
 
 	if [ "$variable" = "" ]; then
-		clap.throw_error "You must give a variable for option: ($short/$long)"
+		clap.throw_error "You must give a variable for option: (${short:-}/${long:-})"
 	fi
 
 	if [ "${val:-}" = "" ]; then
@@ -62,7 +62,7 @@ function clap.define() {
 	fi
 
 	# build OPTIONS and help
-	clap_usage="${clap_usage}#NL#TB${short} $(printf "%-25s %s" "${long}:" "${desc}")"
+	clap_usage="${clap_usage}#NL#TB${short:-} $(printf "%-25s %s" "${long}:" "${desc}")"
 	if [ "${default:-}" != "" ] && [ "${nargs:-}" != "0" ]; then
 		clap_usage="${clap_usage} [default:$default]"
 	fi
@@ -75,9 +75,9 @@ function clap.define() {
 		clap_flag_match="${clap_flag_match}#NL#TB#TB${long}${short:+|${short}})#NL#TB#TB#TB${variable}=(); for ((i=0; i<nargs; i++)); do ${variable}+=( \"\$1\" ); shift 1; done;;"
 	fi
 	if [ "${default:-}" != "" ]; then
-		clap_defaults="${clap_defaults}#NL${variable}=${default}"
+		clap_defaults="${clap_defaults}#NL${variable}=${default@Q}"
 	fi
-	clap_arguments_string="${clap_arguments_string}${shortname}"
+	clap_arguments_string="${clap_arguments_string}${shortname:-}"
 	if [ "${val:-}" = "\$OPTARG" ]; then
 		clap_arguments_string="${clap_arguments_string}:"
 	fi


### PR DESCRIPTION
# Motivation

Short arguments should be optional.
They were made optional in snsdemo in https://github.com/dfinity/snsdemo/pull/104 but not yet in nns-dapp.

# Changes

Copy `snsdemo/bin/clap.bash` to `nns-dapp/scripts`.

# Tests

`clap` itself is tested in `snsdemo`.
For `nns-dapp`, CI should still pass.

# Todos

- [x] Add entry to changelog (if necessary).
