### PR TITLE
Observe ckBTC transactions

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -16,6 +16,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { onMount } from "svelte";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import CkBTCWalletTransactionsObserver from "$lib/components/accounts/CkBTCWalletTransactionsObserver.svelte";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
@@ -84,12 +85,19 @@
   >;
 </script>
 
-<IcrcTransactionsList
-  on:nnsIntersect={loadNextTransactions}
+<CkBTCWalletTransactionsObserver
+  {indexCanisterId}
   {account}
-  {transactions}
-  {loading}
   {completed}
-  {descriptions}
-  {token}
-/>
+  {universeId}
+>
+  <IcrcTransactionsList
+    on:nnsIntersect={loadNextTransactions}
+    {account}
+    {transactions}
+    {loading}
+    {completed}
+    {descriptions}
+    {token}
+  />
+</CkBTCWalletTransactionsObserver>

--- a/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
@@ -1,27 +1,23 @@
 <script lang="ts">
-  import type { TransactionsObserverData } from "$lib/types/icrc.observer";
-  import { isNullish, nonNullish } from "@dfinity/utils";
-  import {
-    snsOnlyProjectStore,
-    snsProjectSelectedStore,
-  } from "$lib/derived/sns/sns-selected-project.derived";
-  import IcrcTransactionsObserver from "$lib/components/accounts/IcrcTransactionsObserver.svelte";
+  import type { CanisterId } from "$lib/types/canister";
   import type { UniverseCanisterId } from "$lib/types/universe";
-  import type { TransactionsCallback } from "$lib/services/worker-transactions.services";
   import type { Account } from "$lib/types/account";
+  import type { TransactionsObserverData } from "$lib/types/icrc.observer";
+  import IcrcTransactionsObserver from "$lib/components/accounts/IcrcTransactionsObserver.svelte";
+  import type { TransactionsCallback } from "$lib/services/worker-transactions.services";
+  import { isNullish } from "@dfinity/utils";
   import { addObservedTransactionsToStore } from "$lib/services/observer.services";
 
+  export let indexCanisterId: CanisterId;
+  export let universeId: UniverseCanisterId;
   export let account: Account;
   export let completed: boolean;
 
   let data: TransactionsObserverData | undefined;
-  $: data = nonNullish($snsProjectSelectedStore)
-    ? {
-        account,
-        indexCanisterId:
-          $snsProjectSelectedStore.summary.indexCanisterId.toText(),
-      }
-    : undefined;
+  $: data = {
+    account,
+    indexCanisterId: indexCanisterId.toText(),
+  };
 
   const callback: TransactionsCallback = ({ transactions }) => {
     if (isNullish(universeId)) {
@@ -35,13 +31,8 @@
       transactions,
     });
   };
-
-  let universeId: UniverseCanisterId | undefined;
-  $: universeId = $snsOnlyProjectStore;
 </script>
 
-{#if nonNullish(data) && nonNullish(universeId)}
-  <IcrcTransactionsObserver {data} {callback}>
-    <slot />
-  </IcrcTransactionsObserver>
-{/if}
+<IcrcTransactionsObserver {data} {callback}>
+  <slot />
+</IcrcTransactionsObserver>

--- a/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
@@ -13,7 +13,7 @@
   export let account: Account;
   export let completed: boolean;
 
-  let data: TransactionsObserverData | undefined;
+  let data: TransactionsObserverData;
   $: data = {
     account,
     indexCanisterId: indexCanisterId.toText(),

--- a/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletTransactionsObserver.svelte
@@ -6,7 +6,7 @@
   import IcrcTransactionsObserver from "$lib/components/accounts/IcrcTransactionsObserver.svelte";
   import type { TransactionsCallback } from "$lib/services/worker-transactions.services";
   import { isNullish } from "@dfinity/utils";
-  import { addObservedTransactionsToStore } from "$lib/services/observer.services";
+  import { addObservedIcrcTransactionsToStore } from "$lib/services/observer.services";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
@@ -25,7 +25,7 @@
       return;
     }
 
-    addObservedTransactionsToStore({
+    addObservedIcrcTransactionsToStore({
       universeId,
       completed,
       transactions,

--- a/frontend/src/lib/components/accounts/SnsWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/SnsWalletTransactionsObserver.svelte
@@ -9,7 +9,7 @@
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { TransactionsCallback } from "$lib/services/worker-transactions.services";
   import type { Account } from "$lib/types/account";
-  import { addObservedTransactionsToStore } from "$lib/services/observer.services";
+  import { addObservedIcrcTransactionsToStore } from "$lib/services/observer.services";
 
   export let account: Account;
   export let completed: boolean;
@@ -29,7 +29,7 @@
       return;
     }
 
-    addObservedTransactionsToStore({
+    addObservedIcrcTransactionsToStore({
       universeId,
       completed,
       transactions,

--- a/frontend/src/lib/services/observer.services.ts
+++ b/frontend/src/lib/services/observer.services.ts
@@ -1,0 +1,31 @@
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import type { PostMessageDataResponseTransaction } from "$lib/types/post-message.transactions";
+import type { UniverseCanisterId } from "$lib/types/universe";
+import { jsonReviver } from "$lib/utils/json.utils";
+
+export const addObservedTransactionsToStore = ({
+  universeId,
+  completed,
+  transactions,
+}: {
+  universeId: UniverseCanisterId;
+  completed: boolean;
+  transactions: PostMessageDataResponseTransaction[];
+}) => {
+  for (const transaction of transactions) {
+    const {
+      transactions: jsonTransactions,
+      mostRecentTxId: _,
+      accountIdentifier,
+      ...rest
+    } = transaction;
+
+    icrcTransactionsStore.addTransactions({
+      ...rest,
+      accountIdentifier,
+      transactions: JSON.parse(jsonTransactions, jsonReviver),
+      canisterId: universeId,
+      completed,
+    });
+  }
+};

--- a/frontend/src/lib/services/observer.services.ts
+++ b/frontend/src/lib/services/observer.services.ts
@@ -3,7 +3,7 @@ import type { PostMessageDataResponseTransaction } from "$lib/types/post-message
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { jsonReviver } from "$lib/utils/json.utils";
 
-export const addObservedTransactionsToStore = ({
+export const addObservedIcrcTransactionsToStore = ({
   universeId,
   completed,
   transactions,

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -27,6 +27,19 @@ jest.mock("$lib/services/ckbtc-transactions.services", () => {
   };
 });
 
+jest.mock("$lib/services/worker-transactions.services", () => ({
+  initTransactionsWorker: jest.fn(() =>
+    Promise.resolve({
+      startTransactionsTimer: () => {
+        // Do nothing
+      },
+      stopTransactionsTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
 describe("CkBTCTransactionList", () => {
   const renderCkBTCTransactionList = () =>
     render(CkBTCTransactionsList, {

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletTransactionsObserver.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import { syncStore } from "$lib/stores/sync.store";
+import type { PostMessageDataResponseSync } from "$lib/types/post-message.sync";
+import type {
+  PostMessageDataRequestTransactions,
+  PostMessageDataResponseTransactions,
+} from "$lib/types/post-message.transactions";
+import type { PostMessage } from "$lib/types/post-messages";
+import { jsonReplacer } from "$lib/utils/json.utils";
+import { page } from "$mocks/$app/stores";
+import CkBTCWalletTransactionsObserverTest from "$tests/lib/components/accounts/CkBTCWalletTransactionsObserverTest.svelte";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockIcrcTransactionMint,
+  mockIcrcTransactionWithId,
+} from "$tests/mocks/icrc-transactions.mock";
+import { PostMessageMock } from "$tests/mocks/post-message.mocks";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("CkBTCWalletTransactionsObserver", () => {
+  type TransactionsMessageEvent = MessageEvent<
+    PostMessage<
+      PostMessageDataResponseTransactions | PostMessageDataResponseSync
+    >
+  >;
+
+  let postMessageMock: PostMessageMock<TransactionsMessageEvent>;
+
+  const transaction = {
+    canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+    transactions: [mockIcrcTransactionWithId],
+    accountIdentifier: mockCkBTCMainAccount.identifier,
+    oldestTxId: BigInt(10),
+    completed: false,
+  };
+
+  beforeEach(() => {
+    icrcTransactionsStore.addTransactions(transaction);
+
+    page.mock({
+      routeId: AppPath.Wallet,
+      data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
+    });
+
+    postMessageMock = new PostMessageMock();
+
+    jest.mock("$lib/workers/transactions.worker?worker", () => {
+      return class TransactionsWorker {
+        constructor() {
+          postMessageMock.subscribe(async (msg) => await this.onmessage(msg));
+        }
+
+        postMessage(_data: {
+          msg: "nnsStartTransactionsTimer" | "nnsStopTransactionsTimer";
+          data?: PostMessageDataRequestTransactions;
+        }) {
+          // Nothing here
+        }
+
+        onmessage = async (_params: TransactionsMessageEvent) => {
+          // Nothing here
+        };
+      };
+    });
+  });
+
+  it("should init data and render slotted content", async () => {
+    const { getByTestId } = render(CkBTCWalletTransactionsObserverTest);
+
+    await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
+  });
+
+  it("should update account store on new sync message", async () => {
+    const { getByTestId } = render(CkBTCWalletTransactionsObserverTest);
+
+    await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
+
+    const transactionsStore = get(icrcTransactionsStore);
+
+    expect(transactionsStore[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]).toEqual({
+      [mockCkBTCMainAccount.identifier]: {
+        transactions: transaction.transactions,
+        completed: transaction.completed,
+        oldestTxId: transaction.oldestTxId,
+      },
+    });
+
+    await waitFor(() => expect(postMessageMock.ready).toBeTruthy());
+
+    const oldestTxId = transaction.oldestTxId - 1n;
+
+    postMessageMock.emit({
+      data: {
+        msg: "nnsSyncTransactions",
+        data: {
+          transactions: [
+            {
+              accountIdentifier: mockCkBTCMainAccount.identifier,
+              transactions: JSON.stringify(
+                [mockIcrcTransactionMint],
+                jsonReplacer
+              ),
+              oldestTxId,
+            },
+          ],
+        },
+      },
+    } as TransactionsMessageEvent);
+
+    await waitFor(() => {
+      const updatedStore = get(icrcTransactionsStore);
+      expect(updatedStore[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]).toEqual({
+        [mockCkBTCMainAccount.identifier]: {
+          transactions: [...transaction.transactions, mockIcrcTransactionMint],
+          completed: true,
+          oldestTxId,
+        },
+      });
+    });
+  });
+
+  it("should populate error to sync store on error message from worker", async () => {
+    const { getByTestId } = render(CkBTCWalletTransactionsObserverTest);
+
+    await waitFor(() => expect(getByTestId("test-observer")).not.toBeNull());
+
+    const store = get(syncStore);
+    expect(store).toEqual({
+      balances: "idle",
+      transactions: "idle",
+    });
+
+    await waitFor(() => expect(postMessageMock.ready).toBeTruthy());
+
+    postMessageMock.emit({
+      data: {
+        msg: "nnsSyncErrorTransactions",
+      },
+    } as TransactionsMessageEvent);
+
+    await waitFor(() => {
+      const updatedStore = get(syncStore);
+      expect(updatedStore).toEqual({
+        balances: "idle",
+        transactions: "error",
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletTransactionsObserverTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletTransactionsObserverTest.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import CkBTCWalletTransactionsObserver from "$lib/components/accounts/CkBTCWalletTransactionsObserver.svelte";
+  import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+  import {
+    CKTESTBTC_INDEX_CANISTER_ID,
+    CKTESTBTC_UNIVERSE_CANISTER_ID,
+  } from "$lib/constants/ckbtc-canister-ids.constants";
+</script>
+
+<CkBTCWalletTransactionsObserver
+  account={mockCkBTCMainAccount}
+  completed={true}
+  universeId={CKTESTBTC_UNIVERSE_CANISTER_ID}
+  indexCanisterId={CKTESTBTC_INDEX_CANISTER_ID}
+>
+  <div data-tid="test-observer" />
+</CkBTCWalletTransactionsObserver>

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -81,6 +81,19 @@ jest.mock("$lib/services/ckbtc-info.services", () => {
   };
 });
 
+jest.mock("$lib/services/worker-transactions.services", () => ({
+  initTransactionsWorker: jest.fn(() =>
+    Promise.resolve({
+      startTransactionsTimer: () => {
+        // Do nothing
+      },
+      stopTransactionsTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
 describe("CkBTCWallet", () => {
   const props = {
     accountIdentifier: mockCkBTCMainAccount.identifier,

--- a/frontend/src/tests/lib/services/oberserver.services.spec.ts
+++ b/frontend/src/tests/lib/services/oberserver.services.spec.ts
@@ -1,0 +1,59 @@
+import { addObservedTransactionsToStore } from "$lib/services/observer.services";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import { jsonReplacer } from "$lib/utils/json.utils";
+import {
+  mockIcrcTransactionMint,
+  mockIcrcTransactionWithId,
+} from "$tests/mocks/icrc-transactions.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { get } from "svelte/store";
+
+describe("observer.services", () => {
+  const transaction = {
+    canisterId: rootCanisterIdMock,
+    transactions: [mockIcrcTransactionWithId],
+    accountIdentifier: mockSnsMainAccount.identifier,
+    oldestTxId: BigInt(10),
+    completed: false,
+  };
+
+  beforeEach(() => {
+    icrcTransactionsStore.addTransactions(transaction);
+  });
+
+  it("should update account store on new sync message", () => {
+    const transactionsStore = get(icrcTransactionsStore);
+
+    expect(transactionsStore[rootCanisterIdMock.toText()]).toEqual({
+      [mockSnsMainAccount.identifier]: {
+        transactions: transaction.transactions,
+        completed: transaction.completed,
+        oldestTxId: transaction.oldestTxId,
+      },
+    });
+
+    const oldestTxId = transaction.oldestTxId - 1n;
+
+    addObservedTransactionsToStore({
+      universeId: rootCanisterIdMock,
+      completed: true,
+      transactions: [
+        {
+          accountIdentifier: mockSnsMainAccount.identifier,
+          transactions: JSON.stringify([mockIcrcTransactionMint], jsonReplacer),
+          oldestTxId,
+        },
+      ],
+    });
+
+    const updatedStore = get(icrcTransactionsStore);
+    expect(updatedStore[rootCanisterIdMock.toText()]).toEqual({
+      [mockSnsMainAccount.identifier]: {
+        transactions: [...transaction.transactions, mockIcrcTransactionMint],
+        completed: true,
+        oldestTxId,
+      },
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/oberserver.services.spec.ts
+++ b/frontend/src/tests/lib/services/oberserver.services.spec.ts
@@ -1,4 +1,4 @@
-import { addObservedTransactionsToStore } from "$lib/services/observer.services";
+import { addObservedIcrcTransactionsToStore } from "$lib/services/observer.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { jsonReplacer } from "$lib/utils/json.utils";
 import {
@@ -35,7 +35,7 @@ describe("observer.services", () => {
 
     const oldestTxId = transaction.oldestTxId - 1n;
 
-    addObservedTransactionsToStore({
+    addObservedIcrcTransactionsToStore({
       universeId: rootCanisterIdMock,
       completed: true,
       transactions: [


### PR DESCRIPTION
# Motivation

Use the new web workers to observe the ckBTC transactions in the dedicated wallet page.

# Changes

- extract `SnsWalletTransactionsObserver` web worker transactions callback to a service to reuse it for ckBTC
- create `CkBTCWalletTransactionsObserver`

# Screenshots

![demo](https://github.com/dfinity/nns-dapp/assets/16886711/959108d7-2be9-4b10-a9fd-335f3f40c036)

