### PR TITLE
GIX-1656: Apply same rules and show errors when creating and renaming canisters

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,11 +13,13 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Render SNS neuron voting power in neuron detail page.
 * Users can add a name when creating a new canister.
+* Improve error management when renaming and creating canisters.
 
 #### Changed
 
 * Simplify rust cache expiry with `pop_first()`.
 * Updated `bitcoin-canister` revision for proposal payload support.
+* Allow renaming canister with empty string.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/common/TextInputForm.svelte
+++ b/frontend/src/lib/components/common/TextInputForm.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import Input from "../ui/Input.svelte";
+  import InputWithError from "../ui/InputWithError.svelte";
 
   export let text: string | undefined = undefined;
   export let placeholderLabelKey: string;
   export let busy = false;
   export let disabledConfirm = false;
+  export let errorMessage: string | undefined = undefined;
   export let testId: string | undefined = undefined;
   export let required = true;
 
@@ -18,14 +19,14 @@
 >
   <div>
     <p class="label"><slot name="label" /></p>
-    <!-- TODO: Show (optional) error message when button is disabled -->
-    <Input
+    <InputWithError
       inputType="text"
       {placeholderLabelKey}
       name="add-text-input"
       bind:value={text}
       disabled={busy}
       {required}
+      {errorMessage}
     />
   </div>
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -441,6 +441,7 @@
     "confirm_remove_last_controller_description": "This is the last remaining controller. If you remove it, nobody will be able to control the canister.",
     "unlink_success": "Canister successfully unlinked",
     "rename_success": "Canister successfully renamed to \"$name\"",
+    "canister_name_error_too_long": "Canister name too long. Maximum of $max characters allowed.",
     "confirm_new_controller": "Confirm New Controller",
     "enter_controller": "Enter Controller",
     "edit_controller": "Edit Controller",

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -27,6 +27,7 @@
   } from "@dfinity/gix-components";
   import TextInputForm from "$lib/components/common/TextInputForm.svelte";
   import { nonNullish } from "@dfinity/utils";
+  import { errorCanisterNameMessage } from "$lib/utils/canisters.utils";
 
   let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
@@ -133,6 +134,7 @@
         bind:text={name}
         disabledConfirm={nonNullish(name) &&
           name.length >= MAX_CANISTER_NAME_LENGTH}
+        errorMessage={errorCanisterNameMessage(name)}
         required={false}
       >
         <svelte:fragment slot="label"

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -133,7 +133,7 @@
         on:nnsClose={modal.back}
         bind:text={name}
         disabledConfirm={nonNullish(name) &&
-          name.length >= MAX_CANISTER_NAME_LENGTH}
+          name.length > MAX_CANISTER_NAME_LENGTH}
         errorMessage={errorCanisterNameMessage(name)}
         required={false}
       >

--- a/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
@@ -61,7 +61,7 @@
     busy={$busy}
     disabledConfirm={$busy ||
       (nonNullish(currentName) &&
-        currentName?.length >= MAX_CANISTER_NAME_LENGTH)}
+        currentName.length > MAX_CANISTER_NAME_LENGTH)}
     errorMessage={errorCanisterNameMessage(currentName)}
     required={false}
   >

--- a/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/RenameCanisterModal.svelte
@@ -7,10 +7,12 @@
     type CanisterDetailsContext,
   } from "$lib/types/canister-detail.context";
   import { createEventDispatcher, getContext } from "svelte";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
   import { renameCanister } from "$lib/services/canisters.services";
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
+  import { errorCanisterNameMessage } from "$lib/utils/canisters.utils";
 
   const { store }: CanisterDetailsContext = getContext<CanisterDetailsContext>(
     CANISTER_DETAILS_CONTEXT_KEY
@@ -57,9 +59,11 @@
     bind:text={currentName}
     placeholderLabelKey="canister_detail.rename_canister_placeholder"
     busy={$busy}
-    disabledConfirm={isNullish(currentName) ||
-      currentName?.length === 0 ||
-      $busy}
+    disabledConfirm={$busy ||
+      (nonNullish(currentName) &&
+        currentName?.length >= MAX_CANISTER_NAME_LENGTH)}
+    errorMessage={errorCanisterNameMessage(currentName)}
+    required={false}
   >
     <svelte:fragment slot="label"
       >{$i18n.canister_detail.rename_canister_title}</svelte:fragment

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -456,6 +456,7 @@ interface I18nCanister_detail {
   confirm_remove_last_controller_description: string;
   unlink_success: string;
   rename_success: string;
+  canister_name_error_too_long: string;
   confirm_new_controller: string;
   enter_controller: string;
   edit_controller: string;

--- a/frontend/src/lib/utils/canisters.utils.ts
+++ b/frontend/src/lib/utils/canisters.utils.ts
@@ -1,14 +1,17 @@
 import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
 import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { ONE_TRILLION } from "$lib/constants/icp.constants";
 import type { AuthStoreData } from "$lib/stores/auth.store";
 import type { CanistersStore } from "$lib/stores/canisters.store";
 import { i18n } from "$lib/stores/i18n";
 import type { CanisterId } from "$lib/types/canister";
 import { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { formatNumber } from "./format.utils";
+import { replacePlaceholders } from "./i18n.utils";
 
 export const getCanisterFromStore = ({
   canisterId,
@@ -75,3 +78,14 @@ export const canisterStatusToText = (status: CanisterStatus): string => {
 
 export const mapCanisterId = (canisterId: CanisterId | string): CanisterId =>
   typeof canisterId === "string" ? Principal.fromText(canisterId) : canisterId;
+
+export const errorCanisterNameMessage = (name: string | undefined) => {
+  if (nonNullish(name) && name?.length >= MAX_CANISTER_NAME_LENGTH) {
+    const i18nObj = get(i18n);
+    return replacePlaceholders(
+      i18nObj.canister_detail.canister_name_error_too_long,
+      { $max: String(MAX_CANISTER_NAME_LENGTH) }
+    );
+  }
+  return undefined;
+};

--- a/frontend/src/lib/utils/canisters.utils.ts
+++ b/frontend/src/lib/utils/canisters.utils.ts
@@ -80,7 +80,7 @@ export const mapCanisterId = (canisterId: CanisterId | string): CanisterId =>
   typeof canisterId === "string" ? Principal.fromText(canisterId) : canisterId;
 
 export const errorCanisterNameMessage = (name: string | undefined) => {
-  if (nonNullish(name) && name?.length >= MAX_CANISTER_NAME_LENGTH) {
+  if (nonNullish(name) && name.length > MAX_CANISTER_NAME_LENGTH) {
     const i18nObj = get(i18n);
     return replacePlaceholders(
       i18nObj.canister_detail.canister_name_error_too_long,

--- a/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
+++ b/frontend/src/tests/lib/components/common/TextInputForm.spec.ts
@@ -69,6 +69,15 @@ describe("TextInputForm", () => {
     );
   });
 
+  it("should not render the error message", async () => {
+    const errorMessage = "This is a test error";
+    const { getByText } = render(TextInputForm, {
+      props: { ...mandatoryProps, errorMessage },
+    });
+
+    expect(getByText(errorMessage)).toBeInTheDocument();
+  });
+
   it("should trigger nnsClose when cancel is clicked", () => {
     const { getByTestId, component } = render(TextInputForm, {
       props: mandatoryProps,

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -59,6 +59,26 @@ describe("CreateCanisterModal", () => {
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
+  const selectAccountGoToNameForm = async ({
+    queryAllByTestId,
+    queryByTestId,
+  }) => {
+    // Wait for the onMount to load the conversion rate
+    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
+    // wait to update local variable with conversion rate
+    await tick();
+
+    const accountCards = queryAllByTestId("account-card");
+    expect(accountCards.length).toBe(2);
+
+    fireEvent.click(accountCards[0]);
+
+    // Enter Name Screen
+    await waitFor(() =>
+      expect(queryByTestId("create-canister-name-form")).toBeInTheDocument()
+    );
+  };
+
   const testCreateCanister = async (canisterName: string) => {
     const {
       queryByTestId,
@@ -69,15 +89,7 @@ describe("CreateCanisterModal", () => {
     } = await renderModal({
       component: CreateCanisterModal,
     });
-    // Wait for the onMount to load the conversion rate
-    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
-    // wait to update local variable with conversion rate
-    await tick();
-
-    const accountCards = queryAllByTestId("account-card");
-    expect(accountCards.length).toBe(2);
-
-    fireEvent.click(accountCards[0]);
+    await selectAccountGoToNameForm({ queryAllByTestId, queryByTestId });
 
     // Enter Name Screen
     await waitFor(() =>
@@ -168,20 +180,8 @@ describe("CreateCanisterModal", () => {
     const { queryByTestId, queryAllByTestId } = await renderModal({
       component: CreateCanisterModal,
     });
-    // Wait for the onMount to load the conversion rate
-    await waitFor(() => expect(getIcpToCyclesExchangeRate).toBeCalled());
-    // wait to update local variable with conversion rate
-    await tick();
 
-    const accountCards = queryAllByTestId("account-card");
-    expect(accountCards.length).toBe(2);
-
-    fireEvent.click(accountCards[0]);
-
-    // Enter Name Screen
-    await waitFor(() =>
-      expect(queryByTestId("create-canister-name-form")).toBeInTheDocument()
-    );
+    await selectAccountGoToNameForm({ queryAllByTestId, queryByTestId });
 
     const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH + 1);
     const nameInputElement = queryByTestId("input-ui-element");
@@ -193,6 +193,25 @@ describe("CreateCanisterModal", () => {
     expect(
       queryByTestId("confirm-text-input-screen-button").getAttribute("disabled")
     ).not.toBeNull();
+  });
+
+  it("should have enabled button when creating a canister with name maximum allowed", async () => {
+    const { queryByTestId, queryAllByTestId } = await renderModal({
+      component: CreateCanisterModal,
+    });
+
+    await selectAccountGoToNameForm({ queryAllByTestId, queryByTestId });
+
+    const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH);
+    const nameInputElement = queryByTestId("input-ui-element");
+    nameInputElement &&
+      (await fireEvent.input(nameInputElement, {
+        target: { value: longName },
+      }));
+
+    expect(
+      queryByTestId("confirm-text-input-screen-button").getAttribute("disabled")
+    ).toBeNull();
   });
 
   it("should have disabled button when creating canister with less T Cycles than minimum", async () => {

--- a/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import * as canisterApi from "$lib/api/canisters.api";
+import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { authStore } from "$lib/stores/auth.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId, mockCanisters } from "$tests/mocks/canisters.mock";
@@ -50,10 +51,21 @@ describe("RenameCanisterModal", () => {
     expect(canisterApi.renameCanister).toBeCalledTimes(1);
   });
 
-  it("shows disabled button when input is empty", async () => {
+  it("shows enabled button when input is empty", async () => {
     const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
 
     po.enterName("");
+
+    await runResolvedPromises();
+
+    expect(await po.getRenameButton().isDisabled()).toBe(false);
+  });
+
+  it("shows disabled button when input is longer than 24 characters", async () => {
+    const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH + 1);
+    const po = renderComponent({ canisterId: mockCanisterId, name: "name" });
+
+    po.enterName(longName);
 
     await runResolvedPromises();
 

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -1,6 +1,7 @@
 import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canister.types";
 import {
   canisterStatusToText,
+  errorCanisterNameMessage,
   formatCyclesToTCycles,
   getCanisterFromStore,
   isController,
@@ -173,5 +174,24 @@ describe("canister-utils", () => {
       expect(canisterStatusToText(CanisterStatus.Running)).toEqual(
         en.canister_detail.status_running
       ));
+  });
+
+  describe("errorCanisterNameMessage", () => {
+    it("returns undefined if no canister name", () => {
+      expect(errorCanisterNameMessage(undefined)).toBeUndefined();
+      expect(errorCanisterNameMessage("")).toBeUndefined();
+    });
+
+    it("returns undefined if valid canister name", () => {
+      expect(errorCanisterNameMessage("My favorite dapp")).toBeUndefined();
+    });
+
+    it("returns an error message if canister name longer than max", () => {
+      expect(
+        errorCanisterNameMessage(
+          "My favorite dapp with a super duper long name"
+        )
+      ).toBe("Canister name too long. Maximum of 24 characters allowed.");
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -1,4 +1,5 @@
 import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canister.types";
+import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import {
   canisterStatusToText,
   errorCanisterNameMessage,
@@ -184,6 +185,9 @@ describe("canister-utils", () => {
 
     it("returns undefined if valid canister name", () => {
       expect(errorCanisterNameMessage("My favorite dapp")).toBeUndefined();
+      expect(
+        errorCanisterNameMessage("a".repeat(MAX_CANISTER_NAME_LENGTH))
+      ).toBeUndefined();
     });
 
     it("returns an error message if canister name longer than max", () => {
@@ -191,6 +195,9 @@ describe("canister-utils", () => {
         errorCanisterNameMessage(
           "My favorite dapp with a super duper long name"
         )
+      ).toBe("Canister name too long. Maximum of 24 characters allowed.");
+      expect(
+        errorCanisterNameMessage("a".repeat(MAX_CANISTER_NAME_LENGTH + 1))
       ).toBe("Canister name too long. Maximum of 24 characters allowed.");
     });
   });


### PR DESCRIPTION
# Motivation

The rules when naming canisters on creating or afterwards was not consistent and there was no feedback to the user about them

In this PR: I apply the same rules in both flows and show an error message to the user when needed.

# Changes

* Add `errorMessage` parameter to `TextInputForm`.
* New canister util `errorCanisterNameMessage` that returns error or `undefined`.
* Use new parameter with new util in `RenameCanisterModal`.
* Use new parameter with new util in `CreateCanisterModal`.
* Change the rules to disable the button in `RenameCanisterModal`.

# Tests

* Test new parameter in `TextInputForm`.
* Test new cansiter util `errorCanisterNameMessage`.
* Add a test case in `CreateCanisterModal`.
* Add a test case in `RenameCanisterModal` and change the expectation when input is empty.

# Todos

- [x] Add entry to changelog (if necessary).
