### PR TITLE
GIX-1658: Add canister name check api

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -14,6 +14,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Render SNS neuron voting power in neuron detail page.
 * Users can add a name when creating a new canister.
 * Improve error management when renaming and creating canisters.
+* Add canister name validation in the canister api functions.
 
 #### Changed
 

--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -35,7 +35,7 @@ import { nnsDappCanister } from "./nns-dapp.api";
 
 // This way, TS understands that if it's invalid, then the name is a string
 type LongName = string;
-const invalidName = (name: string | undefined): name is LongName =>
+const isNameTooLong = (name: string | undefined): name is LongName =>
   nonNullish(name) && name?.length > MAX_CANISTER_NAME_LENGTH;
 
 export const queryCanisters = async ({
@@ -96,7 +96,7 @@ export const attachCanister = async ({
 }): Promise<void> => {
   logWithTimestamp("Attaching canister call...");
 
-  if (invalidName(name)) {
+  if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
     });
@@ -123,7 +123,7 @@ export const renameCanister = async ({
 }): Promise<void> => {
   logWithTimestamp("Renaming canister call...");
 
-  if (invalidName(name)) {
+  if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
     });
@@ -220,7 +220,8 @@ export const createCanister = async ({
 
   // Failing fast here is specially important.
   // Otherwise the transaction will take place and attaching the canister will fail.
-  if (invalidName(name)) {
+  // Worst case, the NNS Dapp canister periodic runner will catch the transaction and attach the canister without a name.
+  if (isNameTooLong(name)) {
     throw new CanisterNameTooLongError("error__canister.name_too_long", {
       $name: name,
     });

--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -122,6 +122,13 @@ export const renameCanister = async ({
   canisterId: Principal;
 }): Promise<void> => {
   logWithTimestamp("Renaming canister call...");
+
+  if (invalidName(name)) {
+    throw new CanisterNameTooLongError("error__canister.name_too_long", {
+      $name: name,
+    });
+  }
+
   const { nnsDapp } = await canisters(identity);
 
   await nnsDapp.renameCanister({

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -126,6 +126,23 @@ describe("canisters-api", () => {
 
       expect(mockNNSDappCanister.renameCanister).toBeCalled();
     });
+
+    it("should fail to rename if name is longer than max", async () => {
+      const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH + 1);
+      const call = () =>
+        renameCanister({
+          identity: mockIdentity,
+          canisterId: mockCanisterDetails.id,
+          name: longName,
+        });
+
+      expect(call).rejects.toThrowError(
+        new NameTooLongError("error__canister.name_too_long", {
+          $name: longName,
+        })
+      );
+      expect(mockNNSDappCanister.renameCanister).not.toBeCalled();
+    });
   });
 
   describe("updateSettings", () => {

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -249,6 +249,28 @@ describe("canisters-api", () => {
       expect(response).toEqual(mockCanisterDetails.id);
     });
 
+    it("should attach the canister if name max length", async () => {
+      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockCMCCanister.notifyCreateCanister.mockResolvedValue(
+        mockCanisterDetails.id
+      );
+
+      const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH);
+      const response = await createCanister({
+        identity: mockIdentity,
+        amount: TokenAmount.fromString({
+          amount: "3",
+          token: ICPToken,
+        }) as TokenAmount,
+        name: longName,
+      });
+      expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
+        name: longName,
+        canisterId: mockCanisterDetails.id,
+      });
+      expect(response).toEqual(mockCanisterDetails.id);
+    });
+
     it("should notify twice if the first call returns Processing", async () => {
       mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
       mockCMCCanister.notifyCreateCanister


### PR DESCRIPTION
# Motivation

Fail in the client if we know that the backend will fail when attaching, creating, or renaming a canister.

# Changes

* Add a check for the canister name length in canister api layer.

# Tests

* New test case for `attachCanister`, `createCanister` and `renameCanister`.

# Todos

- [x] Add entry to changelog (if necessary).
