### PR TITLE
GIX-1657: Add name when linking canister

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,10 +12,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 * Render SNS neuron voting power in neuron detail page.
-* Users can add a name when creating a new canister.
-* Improve error management when renaming and creating canisters.
-* Add canister name validation in the canister api functions.
-* Users can link canisters with a name.
+* Users can now add names to canisters to easily identify them.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -15,6 +15,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Users can add a name when creating a new canister.
 * Improve error management when renaming and creating canisters.
 * Add canister name validation in the canister api functions.
+* Users can link canisters with a name.
 
 #### Changed
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -404,7 +404,7 @@
     "link_canister_title": "Link Canister To Account",
     "link_canister_subtitle": "Enter the id of a canister, to top up its cycles",
     "link_canister_success": "The canister ($canisterId) was linked successfully",
-    "enter_canister_id": "Enter Canister ID:",
+    "enter_canister_id": "Enter Canister ID",
     "canister_id": "Canister ID",
     "enter_name": "Enter Canister Name",
     "enter_name_label": "Enter Canister Name (optional)",

--- a/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
@@ -8,6 +8,7 @@
   import { createEventDispatcher } from "svelte";
   import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
   import InputWithError from "$lib/components/ui/InputWithError.svelte";
+  import { errorCanisterNameMessage } from "$lib/utils/canisters.utils";
 
   let principal: Principal | undefined;
   let name = "";
@@ -64,6 +65,7 @@
         placeholderLabelKey="canisters.name"
         name="canister-name"
         required={false}
+        errorMessage={errorCanisterNameMessage(name)}
       >
         <svelte:fragment slot="label"
           >{$i18n.canisters.enter_name_label}</svelte:fragment
@@ -81,7 +83,7 @@
         {$i18n.core.cancel}
       </button>
       <button
-        data-tid="add-principal-button"
+        data-tid="link-canister-button"
         class="primary"
         type="submit"
         disabled={principal === undefined || $busy}

--- a/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
@@ -1,28 +1,16 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import {
-    WizardModal,
-    type WizardStep,
-    type WizardSteps,
-  } from "@dfinity/gix-components";
+  import { busy, Modal } from "@dfinity/gix-components";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { attachCanister } from "$lib/services/canisters.services";
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import type { Principal } from "@dfinity/principal";
   import { createEventDispatcher } from "svelte";
-  import AddPrincipal from "$lib/components/common/AddPrincipal.svelte";
-
-  const steps: WizardSteps = [
-    {
-      name: "EnterCanisterId",
-      title: $i18n.canisters.link_canister,
-    },
-  ];
-
-  let currentStep: WizardStep | undefined;
-  let modal: WizardModal;
+  import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
+  import InputWithError from "$lib/components/ui/InputWithError.svelte";
 
   let principal: Principal | undefined;
+  let name = "";
 
   const dispatcher = createEventDispatcher();
   const attach = async () => {
@@ -34,7 +22,10 @@
       return;
     }
     startBusy({ initiator: "link-canister" });
-    const { success } = await attachCanister(principal);
+    const { success } = await attachCanister({
+      canisterId: principal,
+      name,
+    });
     stopBusy("link-canister");
     if (success) {
       toastsSuccess({
@@ -49,17 +40,62 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<Modal on:nnsClose>
   <svelte:fragment slot="title"
     ><span data-tid="link-canister-modal-title"
-      >{currentStep?.title ?? $i18n.canisters.link_canister}</span
+      >{$i18n.canisters.link_canister}</span
     ></svelte:fragment
   >
 
-  {#if currentStep?.name === "EnterCanisterId"}
-    <AddPrincipal bind:principal on:nnsSelectPrincipal={attach} on:nnsClose>
-      <span slot="title">{$i18n.canisters.enter_canister_id}</span>
-      <span slot="button">{$i18n.core.confirm}</span>
-    </AddPrincipal>
-  {/if}
-</WizardModal>
+  <form on:submit|preventDefault={attach}>
+    <div class="fields">
+      <PrincipalInput
+        bind:principal
+        placeholderLabelKey="core.principal_id"
+        name="principal"
+      >
+        <svelte:fragment slot="label"
+          >{$i18n.canisters.enter_canister_id}</svelte:fragment
+        >
+      </PrincipalInput>
+      <InputWithError
+        bind:value={name}
+        inputType="text"
+        placeholderLabelKey="canisters.name"
+        name="canister-name"
+        required={false}
+      >
+        <svelte:fragment slot="label"
+          >{$i18n.canisters.enter_name_label}</svelte:fragment
+        >
+      </InputWithError>
+    </div>
+
+    <div class="toolbar">
+      <button
+        class="secondary"
+        type="button"
+        data-tid="cancel-button"
+        on:click={() => dispatcher("nnsClose")}
+      >
+        {$i18n.core.cancel}
+      </button>
+      <button
+        data-tid="add-principal-button"
+        class="primary"
+        type="submit"
+        disabled={principal === undefined || $busy}
+      >
+        {$i18n.core.confirm}
+      </button>
+    </div>
+  </form>
+</Modal>
+
+<style lang="scss">
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/LinkCanisterModal.svelte
@@ -9,9 +9,12 @@
   import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
   import InputWithError from "$lib/components/ui/InputWithError.svelte";
   import { errorCanisterNameMessage } from "$lib/utils/canisters.utils";
+  import { nonNullish } from "@dfinity/utils";
 
   let principal: Principal | undefined;
   let name = "";
+  let errorMessage: string | undefined = undefined;
+  $: errorMessage = errorCanisterNameMessage(name);
 
   const dispatcher = createEventDispatcher();
   const attach = async () => {
@@ -65,7 +68,7 @@
         placeholderLabelKey="canisters.name"
         name="canister-name"
         required={false}
-        errorMessage={errorCanisterNameMessage(name)}
+        {errorMessage}
       >
         <svelte:fragment slot="label"
           >{$i18n.canisters.enter_name_label}</svelte:fragment
@@ -86,7 +89,7 @@
         data-tid="link-canister-button"
         class="primary"
         type="submit"
-        disabled={principal === undefined || $busy}
+        disabled={principal === undefined || $busy || nonNullish(errorMessage)}
       >
         {$i18n.core.confirm}
       </button>

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -237,14 +237,19 @@ export const updateSettings = async ({
   }
 };
 
-export const attachCanister = async (
-  canisterId: Principal
-): Promise<{ success: boolean }> => {
+export const attachCanister = async ({
+  name,
+  canisterId,
+}: {
+  name?: string;
+  canisterId: Principal;
+}): Promise<{ success: boolean }> => {
   try {
     const identity = await getAuthenticatedIdentity();
     await attachCanisterApi({
       identity,
       canisterId,
+      name,
     });
     await listCanisters({ clearBeforeQuery: false });
     return { success: true };

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -98,6 +98,14 @@ describe("LinkCanisterModal", () => {
       component: LinkCanisterModal,
     });
 
+    const inputElement = container.querySelector("input[name='principal']");
+    expect(inputElement).not.toBeNull();
+
+    inputElement &&
+      (await fireEvent.input(inputElement, {
+        target: { value: "aaaaa-aa" },
+      }));
+
     const nameInputElement = container.querySelector(
       "input[name='canister-name']"
     );

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -1,14 +1,9 @@
 /**
  * @jest-environment jsdom
  */
+import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import LinkCanisterModal from "$lib/modals/canisters/LinkCanisterModal.svelte";
 import { attachCanister } from "$lib/services/canisters.services";
-import { accountsStore } from "$lib/stores/accounts.store";
-import {
-  mockAccountsStoreSubscribe,
-  mockHardwareWalletAccount,
-  mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
@@ -29,23 +24,18 @@ jest.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("LinkCanisterModal", () => {
-  jest
-    .spyOn(accountsStore, "subscribe")
-    .mockImplementation(
-      mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
-    );
   it("should display modal", () => {
     const { container } = render(LinkCanisterModal);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
   });
 
-  it("should attach an existing canister and close modal", async () => {
+  it("should attach a canister by id and close modal", async () => {
     const { queryByTestId, container, component } = await renderModal({
       component: LinkCanisterModal,
     });
 
-    const inputElement = container.querySelector("input[type='text']");
+    const inputElement = container.querySelector("input[name='principal']");
     expect(inputElement).not.toBeNull();
 
     inputElement &&
@@ -53,10 +43,18 @@ describe("LinkCanisterModal", () => {
         target: { value: "aaaaa-aa" },
       }));
 
+    const nameInputElement = container.querySelector(
+      "input[name='canister-name']"
+    );
+    nameInputElement &&
+      (await fireEvent.input(nameInputElement, {
+        target: { value: "My fancy canister" },
+      }));
+
     const onClose = jest.fn();
     component.$on("nnsClose", onClose);
 
-    await clickByTestId(queryByTestId, "add-principal-button");
+    await clickByTestId(queryByTestId, "link-canister-button");
     expect(attachCanister).toBeCalled();
 
     await waitFor(() => expect(onClose).toBeCalled());
@@ -79,7 +77,7 @@ describe("LinkCanisterModal", () => {
       component: LinkCanisterModal,
     });
 
-    const inputElement = container.querySelector("input[type='text']");
+    const inputElement = container.querySelector("input[name='principal']");
     expect(inputElement).not.toBeNull();
 
     inputElement &&
@@ -90,8 +88,30 @@ describe("LinkCanisterModal", () => {
 
     expect(queryByText(en.error.principal_not_valid)).toBeInTheDocument();
 
-    const buttonElement = queryByTestId("add-principal-button");
+    const buttonElement = queryByTestId("link-canister-button");
     expect(buttonElement).not.toBeNull();
     expect(buttonElement?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("should show an error and have disabled button if name is longer than max", async () => {
+    const { queryByTestId, queryByText, container } = await renderModal({
+      component: LinkCanisterModal,
+    });
+
+    const nameInputElement = container.querySelector(
+      "input[name='canister-name']"
+    );
+    nameInputElement &&
+      (await fireEvent.input(nameInputElement, {
+        target: { value: "a".repeat(MAX_CANISTER_NAME_LENGTH + 1) },
+      }));
+    nameInputElement && (await fireEvent.blur(nameInputElement));
+
+    expect(
+      queryByText("Canister name too long. Maximum of 24 characters allowed.")
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId("link-canister-button")?.hasAttribute("disabled")
+    ).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -18,6 +18,7 @@ import { canistersStore } from "$lib/stores/canisters.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import {
+  mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
@@ -121,9 +122,16 @@ describe("canisters-services", () => {
 
   describe("attachCanister", () => {
     it("should call api to attach canister and list canisters again", async () => {
-      const response = await attachCanister(mockCanisterDetails.id);
+      const response = await attachCanister({
+        canisterId: mockCanisters[0].canister_id,
+        name: mockCanisters[0].name,
+      });
       expect(response.success).toBe(true);
-      expect(spyAttachCanister).toBeCalled();
+      expect(spyAttachCanister).toBeCalledWith({
+        canisterId: mockCanisters[0].canister_id,
+        name: mockCanisters[0].name,
+        identity: mockIdentity,
+      });
       expect(spyQueryCanisters).toBeCalled();
 
       const store = get(canistersStore);
@@ -133,7 +141,9 @@ describe("canisters-services", () => {
     it("should not attach canister if no identity", async () => {
       setNoIdentity();
 
-      const response = await attachCanister(mockCanisterDetails.id);
+      const response = await attachCanister({
+        canisterId: mockCanisterDetails.id,
+      });
       expect(response.success).toBe(false);
       expect(spyAttachCanister).not.toBeCalled();
       expect(spyQueryCanisters).not.toBeCalled();


### PR DESCRIPTION
# Motivation

Users want to have name in their canisters. Also when they link a canister.

In this PR: Add an input field for the name in the flow to link a canister.

# Changes

* Remove the WizardModal and instead add a new field for the name in the LinkCanisterModal.
* Add `name` parameter in the `attachCanister` service.

# Tests

* Fix tests for `attachCanister` service.
* Add name in the `LinkCanisterModal` main test case and add a couple of more cases.

# Todos

- [ ] Add entry to changelog (if necessary).
