### PR TITLE
E2E: Disburse NNS neuron

### DIFF
--- a/frontend/src/lib/components/accounts/NnsDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/NnsDestinationAddress.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { emptyAddress } from "$lib/utils/accounts.utils";
   import type { Account } from "$lib/types/account";
   import NnsAddress from "./NnsAddress.svelte";
@@ -24,15 +25,17 @@
     dispatcher("nnsAddress", { address: destinationAddress });
 </script>
 
-<NnsAddress bind:address on:submit={onEnterAddress} />
+<TestIdWrapper testId="nns-destination-address-component">
+  <NnsAddress bind:address on:submit={onEnterAddress} />
 
-<!-- Prevent the component to be presented with a scroll offset when navigating between wizard steps -->
-<!-- note about disableSelection: if user is entering an address with the input field, the address is not empty and therefore no account shall be selected -->
-{#if mounted}
-  <NnsSelectAccount
-    on:nnsSelectAccount={onSelectAccount}
-    disableSelection={!emptyAddress(address)}
-    displayTitle={true}
-    {filterIdentifier}
-  />
-{/if}
+  <!-- Prevent the component to be presented with a scroll offset when navigating between wizard steps -->
+  <!-- note about disableSelection: if user is entering an address with the input field, the address is not empty and therefore no account shall be selected -->
+  {#if mounted}
+    <NnsSelectAccount
+      on:nnsSelectAccount={onSelectAccount}
+      disableSelection={!emptyAddress(address)}
+      displayTitle={true}
+      {filterIdentifier}
+    />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronInfoStake.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NnsNeuronAmount from "$lib/components/neurons/NnsNeuronAmount.svelte";
   import type { NeuronInfo } from "@dfinity/nns";
   import { KeyValuePair } from "@dfinity/gix-components";
@@ -32,30 +33,32 @@
   });
 </script>
 
-<KeyValuePair>
-  <h3 slot="key">{$i18n.neurons.ic_stake}</h3>
-  <NnsNeuronAmount {neuron} slot="value" />
-</KeyValuePair>
+<TestIdWrapper testId="nns-neuron-info-stake-component">
+  <KeyValuePair>
+    <h3 slot="key">{$i18n.neurons.ic_stake}</h3>
+    <NnsNeuronAmount {neuron} slot="value" />
+  </KeyValuePair>
 
-<div class="buttons">
-  {#if isControllable}
-    <IncreaseDissolveDelayButton />
-  {/if}
-
-  {#if isControllable || hotkeyControlled}
-    <NnsIncreaseStakeButton />
-  {/if}
-
-  {#if isControllable}
-    {#if neuron.state === NeuronState.Dissolved}
-      <DisburseButton />
-    {:else if neuron.state === NeuronState.Dissolving || neuron.state === NeuronState.Locked}
-      <DissolveActionButton neuronState={neuron.state} />
+  <div class="buttons">
+    {#if isControllable}
+      <IncreaseDissolveDelayButton />
     {/if}
-  {/if}
-</div>
 
-<Separator />
+    {#if isControllable || hotkeyControlled}
+      <NnsIncreaseStakeButton />
+    {/if}
+
+    {#if isControllable}
+      {#if neuron.state === NeuronState.Dissolved}
+        <DisburseButton />
+      {:else if neuron.state === NeuronState.Dissolving || neuron.state === NeuronState.Locked}
+        <DissolveActionButton neuronState={neuron.state} />
+      {/if}
+    {/if}
+  </div>
+
+  <Separator />
+</TestIdWrapper>
 
 <style lang="scss">
   @use "../../themes/mixins/section";

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -96,7 +96,13 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<WizardModal
+  testId="disburse-nns-neuron-modal-component"
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+>
   <svelte:fragment slot="title"
     ><span data-tid="disburse-neuron-modal">{currentStep?.title}</span
     ></svelte:fragment

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import IncreaseDissolveDelayModal from "$lib/modals/neurons/IncreaseDissolveDelayModal.svelte";
   import SplitNeuronModal from "$lib/modals/neurons/SplitNnsNeuronModal.svelte";
   import type { NeuronInfo } from "@dfinity/nns";
@@ -37,52 +38,54 @@
 
 <svelte:window on:nnsNeuronDetailModal={({ detail }) => (modal = detail)} />
 
-{#if nonNullish(neuron)}
-  {#if type === "increase-dissolve-delay"}
-    <IncreaseDissolveDelayModal {neuron} on:nnsClose={close} />
+<TestIdWrapper testId="nns-neuron-modals-component">
+  {#if nonNullish(neuron)}
+    {#if type === "increase-dissolve-delay"}
+      <IncreaseDissolveDelayModal {neuron} on:nnsClose={close} />
+    {/if}
+
+    {#if type === "split-neuron"}
+      <SplitNeuronModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "increase-stake"}
+      <IncreaseNeuronStakeModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "disburse"}
+      <DisburseNnsNeuronModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "dissolve"}
+      <DissolveActionButtonModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "stake-maturity"}
+      <NnsStakeMaturityModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "spawn"}
+      <SpawnNeuronModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "auto-stake-maturity"}
+      <NnsAutoStakeMaturityModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "join-community-fund"}
+      <JoinCommunityFundModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "follow"}
+      <FollowNeuronsModal on:nnsClose={close} neuronId={neuron.neuronId} />
+    {/if}
+
+    {#if type === "add-hotkey"}
+      <AddHotkeyModal on:nnsClose={close} {neuron} />
+    {/if}
   {/if}
 
-  {#if type === "split-neuron"}
-    <SplitNeuronModal on:nnsClose={close} {neuron} />
+  {#if type === "voting-history" && nonNullish(followee)}
+    <VotingHistoryModal neuronId={followee.neuronId} on:nnsClose={close} />
   {/if}
-
-  {#if type === "increase-stake"}
-    <IncreaseNeuronStakeModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "disburse"}
-    <DisburseNnsNeuronModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "dissolve"}
-    <DissolveActionButtonModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "stake-maturity"}
-    <NnsStakeMaturityModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "spawn"}
-    <SpawnNeuronModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "auto-stake-maturity"}
-    <NnsAutoStakeMaturityModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "join-community-fund"}
-    <JoinCommunityFundModal on:nnsClose={close} {neuron} />
-  {/if}
-
-  {#if type === "follow"}
-    <FollowNeuronsModal on:nnsClose={close} neuronId={neuron.neuronId} />
-  {/if}
-
-  {#if type === "add-hotkey"}
-    <AddHotkeyModal on:nnsClose={close} {neuron} />
-  {/if}
-{/if}
-
-{#if type === "voting-history" && nonNullish(followee)}
-  <VotingHistoryModal neuronId={followee.neuronId} on:nnsClose={close} />
-{/if}
+</TestIdWrapper>

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,0 +1,70 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+test("Test disburse neuron", async ({ page, context }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("NNS Dapp");
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  step("Get some ICP");
+  // We need an account before we can get ICP.
+  await appPo
+    .getAccountsPo()
+    .getNnsAccountsPo()
+    .getMainAccountCardPo()
+    .waitFor();
+  await appPo.getTokens(10);
+
+  step("Go to the neurons tab");
+  await appPo.goToNeurons();
+
+  step("Stake a neuron");
+  const stake = 3;
+  await appPo
+    .getNeuronsPo()
+    .getNnsNeuronsFooterPo()
+    .stakeNeuron({ amount: stake, dissolveDelayDays: 0 });
+
+  step("Check account balance before disburse");
+  await appPo.goToAccounts();
+  const mainAccountBalanceBeforeDisburse = Number(
+    await appPo
+      .getAccountsPo()
+      .getNnsAccountsPo()
+      .getMainAccountCardPo()
+      .getBalance()
+  );
+
+  step("Open the neuron details");
+  await appPo.goToNeurons();
+  const neuronCards = await appPo
+    .getNeuronsPo()
+    .getNnsNeuronsPo()
+    .getNeuronCardPos();
+  expect(neuronCards.length).toBe(1);
+  neuronCards[0].click();
+
+  step("Disburse the neuron");
+  await appPo.getNeuronDetailPo().getNnsNeuronDetailPo().disburseNeuron();
+
+  step("Check account balance after disburse");
+  await appPo.goToAccounts();
+  const mainAccountBalanceAfterDisburse = Number(
+    await appPo
+      .getAccountsPo()
+      .getNnsAccountsPo()
+      .getMainAccountCardPo()
+      .getBalance()
+  );
+
+  // Actually there is a difference equal to the transaction fee, but it's
+  // rounded away in the UI.
+  expect(mainAccountBalanceAfterDisburse).toBe(
+    mainAccountBalanceBeforeDisburse + stake
+  );
+});

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -73,6 +73,13 @@ export class AppPo extends BasePageObject {
     await this.getBackdropPo().waitForAbsent();
   }
 
+  async goToAccounts(): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().clickAccounts();
+    // Menu closes automatically.
+    await this.getBackdropPo().waitForAbsent();
+  }
+
   async goToNeurons(): Promise<void> {
     await this.openMenu();
     await this.getMenuItemsPo().clickNeuronStaking();

--- a/frontend/src/tests/page-objects/ConfirmDisburseNeuron.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmDisburseNeuron.page-object.ts
@@ -1,0 +1,16 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ConfirmDisburseNeuronPo extends BasePageObject {
+  private static readonly TID = "confirm-disburse-screen";
+
+  static under(element: PageObjectElement): ConfirmDisburseNeuronPo {
+    return new ConfirmDisburseNeuronPo(
+      element.byTestId(ConfirmDisburseNeuronPo.TID)
+    );
+  }
+
+  clickConfirm(): Promise<void> {
+    return this.click("disburse-neuron-button");
+  }
+}

--- a/frontend/src/tests/page-objects/DisburseNnsNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseNnsNeuronModal.page-object.ts
@@ -1,0 +1,27 @@
+import { ConfirmDisburseNeuronPo } from "$tests/page-objects/ConfirmDisburseNeuron.page-object";
+import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class DisburseNnsNeuronModalPo extends BasePageObject {
+  private static readonly TID = "disburse-nns-neuron-modal-component";
+
+  static under(element: PageObjectElement): DisburseNnsNeuronModalPo {
+    return new DisburseNnsNeuronModalPo(
+      element.byTestId(DisburseNnsNeuronModalPo.TID)
+    );
+  }
+
+  getNnsDestinationAddressPo(): NnsDestinationAddressPo {
+    return NnsDestinationAddressPo.under(this.root);
+  }
+
+  getConfirmDisburseNeuronPo(): ConfirmDisburseNeuronPo {
+    return ConfirmDisburseNeuronPo.under(this.root);
+  }
+
+  async disburseNeuron(): Promise<void> {
+    await this.getNnsDestinationAddressPo().selectMainAccount();
+    await this.getConfirmDisburseNeuronPo().clickConfirm();
+  }
+}

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -9,6 +9,10 @@ export class MenuItemsPo extends BasePageObject {
     return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
   }
 
+  clickAccounts(): Promise<void> {
+    return this.click("menuitem-accounts");
+  }
+
   clickNeuronStaking(): Promise<void> {
     return this.click("menuitem-neurons");
   }

--- a/frontend/src/tests/page-objects/NnsDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsDestinationAddress.page-object.ts
@@ -1,0 +1,21 @@
+import { NnsSelectAccountPo } from "$tests/page-objects/NnsSelectAccount.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsDestinationAddressPo extends BasePageObject {
+  private static readonly TID = "nns-destination-address-component";
+
+  static under(element: PageObjectElement): NnsDestinationAddressPo {
+    return new NnsDestinationAddressPo(
+      element.byTestId(NnsDestinationAddressPo.TID)
+    );
+  }
+
+  getNnsSelectAccountPo(): NnsSelectAccountPo {
+    return NnsSelectAccountPo.under(this.root);
+  }
+
+  selectMainAccount(): Promise<void> {
+    return this.getNnsSelectAccountPo().selectMainAccount();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,4 +1,6 @@
+import { NnsNeuronInfoStakePo } from "$tests/page-objects/NnsNeuronInfoStake.page-object";
 import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
+import { NnsNeuronModalsPo } from "$tests/page-objects/NnsNeuronModals.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -14,6 +16,14 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return SkeletonCardPo.allUnder(this.root);
   }
 
+  getNnsNeuronInfoStakePo(): NnsNeuronInfoStakePo {
+    return NnsNeuronInfoStakePo.under(this.root);
+  }
+
+  getNnsNeuronModalsPo(): NnsNeuronModalsPo {
+    return NnsNeuronModalsPo.under(this.root);
+  }
+
   async isContentLoaded(): Promise<boolean> {
     return (
       (await this.isPresent()) && (await this.getSkeletonCardPos()).length === 0
@@ -22,5 +32,12 @@ export class NnsNeuronDetailPo extends BasePageObject {
 
   getMaturityCardPo(): NnsNeuronMaturityCardPo {
     return NnsNeuronMaturityCardPo.under(this.root);
+  }
+
+  async disburseNeuron(): Promise<void> {
+    await this.getNnsNeuronInfoStakePo().clickDisburse();
+    await this.getNnsNeuronModalsPo()
+      .getDisburseNnsNeuronModalPo()
+      .disburseNeuron();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronInfoStake.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronInfoStake.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsNeuronInfoStakePo extends BasePageObject {
+  private static readonly TID = "nns-neuron-info-stake-component";
+
+  static under(element: PageObjectElement): NnsNeuronInfoStakePo {
+    return new NnsNeuronInfoStakePo(element.byTestId(NnsNeuronInfoStakePo.TID));
+  }
+
+  clickDisburse(): Promise<void> {
+    return this.click("disburse-button");
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -1,0 +1,15 @@
+import { DisburseNnsNeuronModalPo } from "$tests/page-objects/DisburseNnsNeuronModal.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsNeuronModalsPo extends BasePageObject {
+  private static readonly TID = "nns-neuron-modals-component";
+
+  static under(element: PageObjectElement): NnsNeuronModalsPo {
+    return new NnsNeuronModalsPo(element.byTestId(NnsNeuronModalsPo.TID));
+  }
+
+  getDisburseNnsNeuronModalPo(): DisburseNnsNeuronModalPo {
+    return DisburseNnsNeuronModalPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
@@ -25,10 +25,16 @@ export class NnsNeuronsFooterPo extends BasePageObject {
     return this.getStakeNeuronsButtonPo().click();
   }
 
-  async stakeNeuron({ amount }: { amount: number }): Promise<void> {
+  async stakeNeuron({
+    amount,
+    dissolveDelayDays,
+  }: {
+    amount: number;
+    dissolveDelayDays: "max" | 0;
+  }): Promise<void> {
     await this.clickStakeNeuronsButton();
     const modal = this.getNnsStakeNeuronModalPo();
-    await modal.stake({ amount });
+    await modal.stake({ amount, dissolveDelayDays });
     await modal.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
@@ -1,0 +1,21 @@
+import { AccountCardPo } from "$tests/page-objects/AccountCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsSelectAccountPo extends BasePageObject {
+  private static readonly TID = "select-account-screen";
+
+  static under(element: PageObjectElement): NnsSelectAccountPo {
+    return new NnsSelectAccountPo(element.byTestId(NnsSelectAccountPo.TID));
+  }
+
+  getMainAccountCardPo(): AccountCardPo {
+    // There might be multiple cards but the first one should be the main account.
+    return AccountCardPo.under(this.root);
+  }
+
+  async selectMainAccount(): Promise<void> {
+    await this.getMainAccountCardPo().waitFor();
+    await this.getMainAccountCardPo().click();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
@@ -34,10 +34,18 @@ export class NnsStakeNeuronModalPo extends BasePageObject {
     return this.click("close-modal");
   }
 
-  async stake({ amount }: { amount: number }): Promise<void> {
+  async stake({
+    amount,
+    dissolveDelayDays = "max",
+  }: {
+    amount: number;
+    dissolveDelayDays?: "max" | 0;
+  }): Promise<void> {
     await this.getNnsStakeNeuronPo().stake(amount);
-    await this.getSetDissolveDelayPo().setMax();
-    await this.getConfirmDissolveDelayPo().clickConfirm();
+    await this.getSetDissolveDelayPo().setDissolveDelayDays(dissolveDelayDays);
+    if (dissolveDelayDays !== 0) {
+      await this.getConfirmDissolveDelayPo().clickConfirm();
+    }
     await this.getEditFollowNeuronsPo().waitFor();
     await this.closeModal();
   }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,3 +1,4 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -8,12 +8,26 @@ export class SetDissolveDelayPo extends BasePageObject {
     return new SetDissolveDelayPo(element.byTestId(SetDissolveDelayPo.TID));
   }
 
+  getUpdateButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "go-confirm-delay-button",
+    });
+  }
+
+  getMaxButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "max-button",
+    });
+  }
+
   clickUpdate(): Promise<void> {
-    return this.click("go-confirm-delay-button");
+    return this.getUpdateButtonPo().click();
   }
 
   clickMax(): Promise<void> {
-    return this.click("max-button");
+    return this.getMaxButtonPo().click();
   }
 
   clickSkip() {

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,4 +1,3 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -9,30 +8,26 @@ export class SetDissolveDelayPo extends BasePageObject {
     return new SetDissolveDelayPo(element.byTestId(SetDissolveDelayPo.TID));
   }
 
-  getUpdateButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "go-confirm-delay-button",
-    });
-  }
-
-  getMaxButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "max-button",
-    });
-  }
-
   clickUpdate(): Promise<void> {
-    return this.getUpdateButtonPo().click();
+    return this.click("go-confirm-delay-button");
   }
 
   clickMax(): Promise<void> {
-    return this.getMaxButtonPo().click();
+    return this.click("max-button");
   }
 
-  async setMax(): Promise<void> {
-    await this.clickMax();
+  clickSkip() {
+    return this.click("cancel-neuron-delay");
+  }
+
+  async setDissolveDelayDays(days: "max" | 0): Promise<void> {
+    if (days === 0) {
+      await this.clickSkip();
+      return;
+    }
+    if (days === "max") {
+      await this.clickMax();
+    }
     await this.clickUpdate();
   }
 }


### PR DESCRIPTION
# Motivation

I want to replace this old wdio e2e test with a Playwright e2e test so we can delete the old test:
https://github.com/dfinity/nns-dapp/blob/main/e2e-tests/specs/user-N02-neurons-disbursed.e2e.ts

I tried to follow the same steps as that test.

# Changes

1. Add `disburse.spec.ts` which does the e2e test to disburse a neuron.
2. Add necessary page objects and test IDs.
3. Allow specifying the dissolve delay when staking a neuron. Right now it only supports `"max"` and `0`. It's easy to support other numbers but the code path wouldn't be used so let's do that when we use it.

# Tests

yes

# Todos

Is it worth mentioning? It's not new coverage just the same coverage in a different way.

- [ ] Add entry to changelog (if necessary).
