### PR TITLE
Improve changelog about canister name

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,7 +12,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 * Render SNS neuron voting power in neuron detail page.
-* Users can now add names to canisters to easily identify them.
+* Users can now add names to canisters to easily identify them within NNS dapp only.
 
 #### Changed
 


### PR DESCRIPTION
# Motivation

Improve to changelog to make it clear that the "canister name" is not implemented on the protocol level.
