### PR TITLE
Chore: Move changelog entry

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -15,6 +15,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Users can now add names to canisters to easily identify them within NNS dapp only.
 * Users can now add names to canisters to easily identify them.
 * Periodically check for new transactions and updated balances of the ckBTC tokens/accounts.
+* Users can now add a name to their canisters after linking or creating them.
 
 #### Changed
 
@@ -69,7 +70,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Add "Select All" and "Clear" selection in proposal filters.
 * Add vesting information in SNS neuron detail.
 * Render SNS neuron voting power in neuron detail page.
-* Users can now add a name to their canisters after linking or creating them.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,9 +13,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Render SNS neuron voting power in neuron detail page.
 * Users can now add names to canisters to easily identify them within NNS dapp only.
-* Users can now add names to canisters to easily identify them.
 * Periodically check for new transactions and updated balances of the ckBTC tokens/accounts.
-* Users can now add a name to their canisters after linking or creating them.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -20,7 +20,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Simplify rust cache expiry with `pop_first()`.
 * Updated `bitcoin-canister` revision for proposal payload support.
 * Improve proposal action rendering.
-* Allow renaming canister with empty string.
 
 #### Deprecated
 #### Removed


### PR DESCRIPTION
# Motivation

An entry in the changelog for the previous proposal is wrong because the functionality is not yet released.
It was previously added in https://github.com/dfinity/nns-dapp/pull/2804.

# Changes

* Move entry in the changelog.

# Tests

Only doc changes

# Todos

- [x] Add entry to changelog (if necessary).
