### PR TITLE
Test that no new change log entries are added to past releases.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          -fetch-depth: 0
+          - fetch-depth: 0
       - run: scripts/past-changelog-test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "past-changelog"]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: scripts/past-changelog-text
+      - run: scripts/past-changelog-test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags"]
     if: ${{ always() }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          - fetch-depth: 0
+          fetch-depth: 0
       - run: scripts/past-changelog-test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "past-changelog"]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          -fetch-depth: 100
+          -fetch-depth: 0
       - run: scripts/past-changelog-test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "past-changelog"]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -270,6 +270,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: scripts/nns-dapp/release-sop.test
+  past-changelog:
+    name: Test that no new change log entries are added to past releases.
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: scripts/past-changelog-text
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags"]
     if: ${{ always() }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: scripts/past-changelog-test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "past-changelog"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -275,6 +275,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          -fetch-depth: 100
       - run: scripts/past-changelog-test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "past-changelog"]

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -40,6 +40,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Base64 image support for payload rendering.
 - `scripts/canister_ids` can now remove canisters from `canister_ids.json`.
 - Added a script to perform part of the release SOP.
+- Test that no new change log entries are added to existing releases.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -63,6 +63,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
+- foo
 * Periodically check for new transactions and updated balances of the SNS tokens/accounts.
 * Decode the payment (amount) from the QR code reader.
 * Add "Select All" and "Clear" selection in proposal filters.

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -63,7 +63,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
-- foo
 * Periodically check for new transactions and updated balances of the SNS tokens/accounts.
 * Decode the payment (amount) from the QR code reader.
 * Add "Select All" and "Clear" selection in proposal filters.

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -8,7 +8,8 @@ MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 
 LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"
 LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG" | cut -d: -f1)"
-LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "^## Proposal [0-9]\+$" "$CHANGELOG" | cut -d: -f1)"
+LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
+LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "$LAST_RELEASE_HEADING" "$CHANGELOG" | cut -d: -f1)"
 
 if [[ "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" ]]; then
   echo "ERROR: $CHANGELOG entries should not be added to existing releases." >&2

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 
 # Test that no new entries are added to already released CHANGELOG sections.
 
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-git diff HEAD~1 "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
+git diff "$(git merge-base HEAD main)" "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
 
 exit 1

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -5,6 +5,6 @@ set -xeuo pipefail
 
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-git diff "$(git merge-base HEAD main)" "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
+git diff "$(git merge-base HEAD origin/main)" "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
 
 exit 1

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -5,6 +5,16 @@ set -xeuo pipefail
 
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-git diff "$(git merge-base HEAD origin/main)" "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
+CHANGELOG="CHANGELOG-Nns-Dapp.md"
+MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 
-exit 1
+LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"
+LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG")"
+LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "^## Proposal \d\+$" "$CHANGELOG")"
+
+if [[ "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" ]]; then
+  echo "ERROR: $CHANGELOG entries should not be added to existing releases." >&2
+  exit 1
+fi
+
+echo "PASSED"

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -3,8 +3,6 @@ set -xeuo pipefail
 
 # Test that no new entries are added to already released CHANGELOG sections.
 
-SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-
 CHANGELOG="CHANGELOG-Nns-Dapp.md"
 MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test that no new entries are added to already released CHANGELOG sections.
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+git diff HEAD~1 "$SOURCE_DIR/../CHANGELOG-Nns-Dapp.md"
+
+exit 1

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -9,8 +9,8 @@ CHANGELOG="CHANGELOG-Nns-Dapp.md"
 MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 
 LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"
-LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG")"
-LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "^## Proposal \d\+$" "$CHANGELOG")"
+LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG" | cut -d: -f1)"
+LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "^## Proposal [0-9]\+$" "$CHANGELOG" | cut -d: -f1)"
 
 if [[ "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" ]]; then
   echo "ERROR: $CHANGELOG entries should not be added to existing releases." >&2


### PR DESCRIPTION
# Motivation

I've seen twice that people added or tried to add an entry in the change log to an already existing release.
I suspect this is because they started the PR before the change log was updated and weren't careful enough when reviewing the results of the merge.

# Changes

Test that no changes are made to `CHANGELOG-Nns-Dapp.md` below the first `## Proposal [0-9]+` line.

We can look at doing the same for `CHANGELOG-Sns_Aggregator.md` but so far there aren't any changes there.

Also added missing entries to `checks-pass.needs` in `checks.yml`.

# Tests

This is a test.

# Todos

- [x] Add entry to changelog (if necessary).
