### PR TITLE
Call result patches

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -10,6 +10,7 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 ### Added
 ### Changed
+- Shortened the patch files used when importing NNS types.
 ### Fixed
 ### Security
 ### Not Published

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 28bc6ec98..3c3a440de 100644
+index 58f8b0a38..3c3a440de 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -8,20 +8,21 @@ use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
@@ -270,7 +270,7 @@ index 28bc6ec98..3c3a440de 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -614,76 +618,75 @@ pub struct SetMode { mode: i32 }
+@@ -614,8 +618,8 @@ pub struct SetMode { mode: i32 }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct set_mode_ret0 {}
  
@@ -281,88 +281,7 @@ index 28bc6ec98..3c3a440de 100644
    pub async fn claim_swap_neurons(
      &self,
      arg0: ClaimSwapNeuronsRequest,
--  ) -> Result<(ClaimSwapNeuronsResponse,)> {
-+  ) -> CallResult<(ClaimSwapNeuronsResponse,)> {
-     ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
-   }
-   pub async fn fail_stuck_upgrade_in_progress(
-     &self,
-     arg0: fail_stuck_upgrade_in_progress_arg0,
--  ) -> Result<(fail_stuck_upgrade_in_progress_ret0,)> {
-+  ) -> CallResult<(fail_stuck_upgrade_in_progress_ret0,)> {
-     ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
-   }
--  pub async fn get_build_metadata(&self) -> Result<(String,)> {
-+  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-     ic_cdk::call(self.0, "get_build_metadata", ()).await
-   }
--  pub async fn get_latest_reward_event(&self) -> Result<(RewardEvent,)> {
-+  pub async fn get_latest_reward_event(&self) -> CallResult<(RewardEvent,)> {
-     ic_cdk::call(self.0, "get_latest_reward_event", ()).await
-   }
-   pub async fn get_maturity_modulation(
-     &self,
-     arg0: get_maturity_modulation_arg0,
--  ) -> Result<(GetMaturityModulationResponse,)> {
-+  ) -> CallResult<(GetMaturityModulationResponse,)> {
-     ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
-   }
--  pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> Result<
-+  pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> CallResult<
-     (GetMetadataResponse,)
-   > { ic_cdk::call(self.0, "get_metadata", (arg0,)).await }
--  pub async fn get_mode(&self, arg0: get_mode_arg0) -> Result<
-+  pub async fn get_mode(&self, arg0: get_mode_arg0) -> CallResult<
-     (GetModeResponse,)
-   > { ic_cdk::call(self.0, "get_mode", (arg0,)).await }
--  pub async fn get_nervous_system_parameters(&self, arg0: ()) -> Result<
-+  pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<
-     (NervousSystemParameters,)
-   > { ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await }
--  pub async fn get_neuron(&self, arg0: GetNeuron) -> Result<
-+  pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<
-     (GetNeuronResponse,)
-   > { ic_cdk::call(self.0, "get_neuron", (arg0,)).await }
--  pub async fn get_proposal(&self, arg0: GetProposal) -> Result<
-+  pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<
-     (GetProposalResponse,)
-   > { ic_cdk::call(self.0, "get_proposal", (arg0,)).await }
--  pub async fn get_root_canister_status(&self, arg0: ()) -> Result<
-+  pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<
-     (CanisterStatusResultV2,)
-   > { ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await }
-   pub async fn get_running_sns_version(
-     &self,
-     arg0: get_running_sns_version_arg0,
--  ) -> Result<(GetRunningSnsVersionResponse,)> {
-+  ) -> CallResult<(GetRunningSnsVersionResponse,)> {
-     ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
-   }
-   pub async fn get_sns_initialization_parameters(
-     &self,
-     arg0: get_sns_initialization_parameters_arg0,
--  ) -> Result<(GetSnsInitializationParametersResponse,)> {
-+  ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
-     ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
-   }
--  pub async fn list_nervous_system_functions(&self) -> Result<
-+  pub async fn list_nervous_system_functions(&self) -> CallResult<
-     (ListNervousSystemFunctionsResponse,)
-   > { ic_cdk::call(self.0, "list_nervous_system_functions", ()).await }
--  pub async fn list_neurons(&self, arg0: ListNeurons) -> Result<
-+  pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<
-     (ListNeuronsResponse,)
-   > { ic_cdk::call(self.0, "list_neurons", (arg0,)).await }
--  pub async fn list_proposals(&self, arg0: ListProposals) -> Result<
-+  pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<
-     (ListProposalsResponse,)
-   > { ic_cdk::call(self.0, "list_proposals", (arg0,)).await }
--  pub async fn manage_neuron(&self, arg0: ManageNeuron) -> Result<
-+  pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<
-     (ManageNeuronResponse,)
-   > { ic_cdk::call(self.0, "manage_neuron", (arg0,)).await }
--  pub async fn set_mode(&self, arg0: SetMode) -> Result<(set_mode_ret0,)> {
-+  pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(set_mode_ret0,)> {
+@@ -686,4 +690,3 @@ impl SERVICE {
      ic_cdk::call(self.0, "set_mode", (arg0,)).await
    }
  }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 8c26d1bf1..4ee8d9890 100644
+index 0f919e668..4ee8d9890 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -4,12 +4,12 @@
@@ -109,70 +109,42 @@ index 8c26d1bf1..4ee8d9890 100644
  
  pub type Timestamp = u64;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -197,46 +190,48 @@ pub enum TransferError {
+@@ -197,17 +190,20 @@ pub enum TransferError {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
  
 -pub struct SERVICE(pub Principal);
 -impl SERVICE {
--  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> Result<
 +pub struct SERVICE(pub candid::Principal);
 +impl SERVICE{
-+  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
+   pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
      (GetBlocksResponse,)
    > { ic_cdk::call(self.0, "get_blocks", (arg0,)).await }
--  pub async fn get_data_certificate(&self) -> Result<(DataCertificate,)> {
-+  pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
+   pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
      ic_cdk::call(self.0, "get_data_certificate", ()).await
    }
--  pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> Result<
+-  pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<
 -    (GetTransactionsResponse,)
 -  > { ic_cdk::call(self.0, "get_transactions", (arg0,)).await }
--  pub async fn icrc1_balance_of(&self, arg0: Account) -> Result<(Tokens,)> {
 +  pub async fn get_transactions(
 +    &self,
 +    arg0: GetTransactionsRequest,
 +  ) -> CallResult<(GetTransactionsResponse,)> {
 +    ic_cdk::call(self.0, "get_transactions", (arg0,)).await
 +  }
-+  pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
+   pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
      ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
    }
--  pub async fn icrc1_decimals(&self) -> Result<(u8,)> {
-+  pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
-     ic_cdk::call(self.0, "icrc1_decimals", ()).await
-   }
--  pub async fn icrc1_fee(&self) -> Result<(Tokens,)> {
-+  pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
-     ic_cdk::call(self.0, "icrc1_fee", ()).await
-   }
--  pub async fn icrc1_metadata(&self) -> Result<
-+  pub async fn icrc1_metadata(&self) -> CallResult<
-     (Vec<(String,MetadataValue,)>,)
-   > { ic_cdk::call(self.0, "icrc1_metadata", ()).await }
--  pub async fn icrc1_minting_account(&self) -> Result<(Option<Account>,)> {
-+  pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
-     ic_cdk::call(self.0, "icrc1_minting_account", ()).await
-   }
--  pub async fn icrc1_name(&self) -> Result<(String,)> {
-+  pub async fn icrc1_name(&self) -> CallResult<(String,)> {
+@@ -227,7 +223,7 @@ impl SERVICE {
      ic_cdk::call(self.0, "icrc1_name", ()).await
    }
--  pub async fn icrc1_supported_standards(&self) -> Result<
+   pub async fn icrc1_supported_standards(&self) -> CallResult<
 -    (Vec<icrc1_supported_standards_ret0_item>,)
-+  pub async fn icrc1_supported_standards(&self) -> CallResult<
 +    (Vec<icrc1_supported_standards_ret0_inner>,)
    > { ic_cdk::call(self.0, "icrc1_supported_standards", ()).await }
--  pub async fn icrc1_symbol(&self) -> Result<(String,)> {
-+  pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
+   pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
      ic_cdk::call(self.0, "icrc1_symbol", ()).await
-   }
--  pub async fn icrc1_total_supply(&self) -> Result<(Tokens,)> {
-+  pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
-     ic_cdk::call(self.0, "icrc1_total_supply", ()).await
-   }
--  pub async fn icrc1_transfer(&self, arg0: TransferArg) -> Result<
-+  pub async fn icrc1_transfer(&self, arg0: TransferArg) -> CallResult<
+@@ -239,4 +235,3 @@ impl SERVICE {
      (TransferResult,)
    > { ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await }
  }

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 66c2d6742..eb29aeae2 100644
+index 19535668a..eb29aeae2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
 @@ -4,37 +4,37 @@
@@ -115,7 +115,7 @@ index 66c2d6742..eb29aeae2 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -117,49 +117,48 @@ pub struct CanisterCallError { code: Option<i32>, description: String }
+@@ -117,14 +117,14 @@ pub struct CanisterCallError { code: Option<i32>, description: String }
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct FailedUpdate {
    pub  err: Option<CanisterCallError>,
@@ -128,49 +128,12 @@ index 66c2d6742..eb29aeae2 100644
  
 -pub struct SERVICE(pub Principal);
 -impl SERVICE {
--  pub async fn canister_status(&self, arg0: CanisterIdRecord) -> Result<
 +pub struct SERVICE(pub candid::Principal);
 +impl SERVICE{
-+  pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
+   pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
      (CanisterStatusResult,)
    > { ic_cdk::call(self.0, "canister_status", (arg0,)).await }
--  pub async fn get_build_metadata(&self) -> Result<(String,)> {
-+  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-     ic_cdk::call(self.0, "get_build_metadata", ()).await
-   }
-   pub async fn get_sns_canisters_summary(
-     &self,
-     arg0: GetSnsCanistersSummaryRequest,
--  ) -> Result<(GetSnsCanistersSummaryResponse,)> {
-+  ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
-     ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
-   }
-   pub async fn list_sns_canisters(
-     &self,
-     arg0: list_sns_canisters_arg0,
--  ) -> Result<(ListSnsCanistersResponse,)> {
-+  ) -> CallResult<(ListSnsCanistersResponse,)> {
-     ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
-   }
-   pub async fn register_dapp_canister(
-     &self,
-     arg0: RegisterDappCanisterRequest,
--  ) -> Result<(register_dapp_canister_ret0,)> {
-+  ) -> CallResult<(register_dapp_canister_ret0,)> {
-     ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
-   }
-   pub async fn register_dapp_canisters(
-     &self,
-     arg0: RegisterDappCanistersRequest,
--  ) -> Result<(register_dapp_canisters_ret0,)> {
-+  ) -> CallResult<(register_dapp_canisters_ret0,)> {
-     ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
-   }
-   pub async fn set_dapp_controllers(
-     &self,
-     arg0: SetDappControllersRequest,
--  ) -> Result<(SetDappControllersResponse,)> {
-+  ) -> CallResult<(SetDappControllersResponse,)> {
+@@ -162,4 +162,3 @@ impl SERVICE {
      ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
    }
  }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 79a9b463e..b373161c8 100644
+index b1cfb799f..b373161c8 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -4,17 +4,17 @@
@@ -162,16 +162,15 @@ index 79a9b463e..b373161c8 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct InvalidUserAmount {
-@@ -398,88 +384,96 @@ pub struct RefreshBuyerTokensResponse {
+@@ -398,29 +384,38 @@ pub struct RefreshBuyerTokensResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct restore_dapp_controllers_arg0 {}
  
 -pub struct SERVICE(pub Principal);
 -impl SERVICE {
--  pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> Result<
+-  pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<
 -    (ErrorRefundIcpResponse,)
 -  > { ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await }
--  pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> Result<
 +pub struct SERVICE(pub candid::Principal);
 +impl SERVICE{
 +  pub async fn error_refund_icp(
@@ -180,14 +179,13 @@ index 79a9b463e..b373161c8 100644
 +  ) -> CallResult<(ErrorRefundIcpResponse,)> {
 +    ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
 +  }
-+  pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<
+   pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<
      (FinalizeSwapResponse,)
    > { ic_cdk::call(self.0, "finalize_swap", (arg0,)).await }
--  pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> Result<
-+  pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<
+   pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<
      (GetBuyerStateResponse,)
    > { ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await }
--  pub async fn get_buyers_total(&self, arg0: get_buyers_total_arg0) -> Result<
+-  pub async fn get_buyers_total(&self, arg0: get_buyers_total_arg0) -> CallResult<
 -    (GetBuyersTotalResponse,)
 -  > { ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await }
 +  pub async fn get_buyers_total(
@@ -199,90 +197,22 @@ index 79a9b463e..b373161c8 100644
    pub async fn get_canister_status(
      &self,
      arg0: get_canister_status_arg0,
--  ) -> Result<(CanisterStatusResultV2,)> {
-+  ) -> CallResult<(CanisterStatusResultV2,)> {
+   ) -> CallResult<(CanisterStatusResultV2,)> {
      ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
    }
--  pub async fn get_derived_state(&self, arg0: get_derived_state_arg0) -> Result<
+-  pub async fn get_derived_state(&self, arg0: get_derived_state_arg0) -> CallResult<
 -    (GetDerivedStateResponse,)
 -  > { ic_cdk::call(self.0, "get_derived_state", (arg0,)).await }
--  pub async fn get_init(&self, arg0: get_init_arg0) -> Result<
 +  pub async fn get_derived_state(
 +    &self,
 +    arg0: get_derived_state_arg0,
 +  ) -> CallResult<(GetDerivedStateResponse,)> {
 +    ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
 +  }
-+  pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<
+   pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<
      (GetInitResponse,)
    > { ic_cdk::call(self.0, "get_init", (arg0,)).await }
--  pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> Result<
-+  pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> CallResult<
-     (GetLifecycleResponse,)
-   > { ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await }
--  pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> Result<
-+  pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> CallResult<
-     (GetOpenTicketResponse,)
-   > { ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await }
-   pub async fn get_sale_parameters(
-     &self,
-     arg0: get_sale_parameters_arg0,
--  ) -> Result<(GetSaleParametersResponse,)> {
-+  ) -> CallResult<(GetSaleParametersResponse,)> {
-     ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
-   }
--  pub async fn get_state(&self, arg0: get_state_arg0) -> Result<
-+  pub async fn get_state(&self, arg0: get_state_arg0) -> CallResult<
-     (GetStateResponse,)
-   > { ic_cdk::call(self.0, "get_state", (arg0,)).await }
-   pub async fn list_community_fund_participants(
-     &self,
-     arg0: ListCommunityFundParticipantsRequest,
--  ) -> Result<(ListCommunityFundParticipantsResponse,)> {
-+  ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
-     ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
-   }
-   pub async fn list_direct_participants(
-     &self,
-     arg0: ListDirectParticipantsRequest,
--  ) -> Result<(ListDirectParticipantsResponse,)> {
-+  ) -> CallResult<(ListDirectParticipantsResponse,)> {
-     ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
-   }
-   pub async fn list_sns_neuron_recipes(
-     &self,
-     arg0: ListSnsNeuronRecipesRequest,
--  ) -> Result<(ListSnsNeuronRecipesResponse,)> {
-+  ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
-     ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
-   }
--  pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> Result<
-+  pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<
-     (NewSaleTicketResponse,)
-   > { ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await }
-   pub async fn notify_payment_failure(
-     &self,
-     arg0: notify_payment_failure_arg0,
--  ) -> Result<(Ok_1,)> {
-+  ) -> CallResult<(Ok_1,)> {
-     ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
-   }
--  pub async fn open(&self, arg0: OpenRequest) -> Result<(open_ret0,)> {
-+  pub async fn open(&self, arg0: OpenRequest) -> CallResult<(open_ret0,)> {
-     ic_cdk::call(self.0, "open", (arg0,)).await
-   }
-   pub async fn refresh_buyer_tokens(
-     &self,
-     arg0: RefreshBuyerTokensRequest,
--  ) -> Result<(RefreshBuyerTokensResponse,)> {
-+  ) -> CallResult<(RefreshBuyerTokensResponse,)> {
-     ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
-   }
-   pub async fn restore_dapp_controllers(
-     &self,
-     arg0: restore_dapp_controllers_arg0,
--  ) -> Result<(SetDappControllersCallResult,)> {
-+  ) -> CallResult<(SetDappControllersCallResult,)> {
+@@ -482,4 +477,3 @@ impl SERVICE {
      ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
    }
  }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 4d2c3f61e..a8fc475ec 100644
+index 5337584b6..a8fc475ec 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 @@ -4,18 +4,18 @@
@@ -139,7 +139,7 @@ index 4d2c3f61e..a8fc475ec 100644
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -228,74 +230,73 @@ pub struct UpdateAllowedPrincipalsResponse {
+@@ -228,15 +230,15 @@ pub struct UpdateAllowedPrincipalsResponse {
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct UpdateSnsSubnetListRequest {
@@ -154,78 +154,12 @@ index 4d2c3f61e..a8fc475ec 100644
  
 -pub struct SERVICE(pub Principal);
 -impl SERVICE {
--  pub async fn add_wasm(&self, arg0: AddWasmRequest) -> Result<
 +pub struct SERVICE(pub candid::Principal);
 +impl SERVICE{
-+  pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
+   pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
      (AddWasmResponse,)
    > { ic_cdk::call(self.0, "add_wasm", (arg0,)).await }
--  pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> Result<
-+  pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<
-     (DeployNewSnsResponse,)
-   > { ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await }
-   pub async fn get_allowed_principals(
-     &self,
-     arg0: get_allowed_principals_arg0,
--  ) -> Result<(GetAllowedPrincipalsResponse,)> {
-+  ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
-     ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
-   }
--  pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> Result<
-+  pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<
-     (Vec<(String,String,)>,)
-   > { ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await }
-   pub async fn get_next_sns_version(
-     &self,
-     arg0: GetNextSnsVersionRequest,
--  ) -> Result<(GetNextSnsVersionResponse,)> {
-+  ) -> CallResult<(GetNextSnsVersionResponse,)> {
-     ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
-   }
-   pub async fn get_sns_subnet_ids(
-     &self,
-     arg0: get_sns_subnet_ids_arg0,
--  ) -> Result<(GetSnsSubnetIdsResponse,)> {
-+  ) -> CallResult<(GetSnsSubnetIdsResponse,)> {
-     ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
-   }
--  pub async fn get_wasm(&self, arg0: GetWasmRequest) -> Result<
-+  pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<
-     (GetWasmResponse,)
-   > { ic_cdk::call(self.0, "get_wasm", (arg0,)).await }
-   pub async fn insert_upgrade_path_entries(
-     &self,
-     arg0: InsertUpgradePathEntriesRequest,
--  ) -> Result<(InsertUpgradePathEntriesResponse,)> {
-+  ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
-     ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
-   }
-   pub async fn list_deployed_snses(
-     &self,
-     arg0: list_deployed_snses_arg0,
--  ) -> Result<(ListDeployedSnsesResponse,)> {
-+  ) -> CallResult<(ListDeployedSnsesResponse,)> {
-     ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
-   }
-   pub async fn list_upgrade_steps(
-     &self,
-     arg0: ListUpgradeStepsRequest,
--  ) -> Result<(ListUpgradeStepsResponse,)> {
-+  ) -> CallResult<(ListUpgradeStepsResponse,)> {
-     ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
-   }
-   pub async fn update_allowed_principals(
-     &self,
-     arg0: UpdateAllowedPrincipalsRequest,
--  ) -> Result<(UpdateAllowedPrincipalsResponse,)> {
-+  ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
-     ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
-   }
-   pub async fn update_sns_subnet_list(
-     &self,
-     arg0: UpdateSnsSubnetListRequest,
--  ) -> Result<(UpdateSnsSubnetListResponse,)> {
-+  ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
+@@ -298,4 +300,3 @@ impl SERVICE {
      ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
    }
  }

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -72,6 +72,10 @@ cd "$GIT_ROOT"
   # sed:
   #   - adds additional traits after Deserialize
   #   - Makes structures and their fields "pub"
+  #   - Makes API call response types "CallResult".  The alternative convention is to have:
+  #       use ic_cdk::api::call::CallResult as Result;
+  #     at the top of the rust file but that is both confusing for Rust developers and conflicts
+  #     with custom definitions of Result found in some did files.
   #
   # Final tweaks are defined manually and encoded as patch files.  The changes typically include:
   #   - Replacing the anonymous result{} type in enums with EmptyRecord.  didc produces valid rust code, but
@@ -79,6 +83,7 @@ cd "$GIT_ROOT"
   #   - We need a few but not all of the types to have the Default macro
   #   - Any corrections to the output of the sed script.  sed is not a Rust parser; the sed output
   #     is not guaranteed to be correct.
+  # shellcheck disable=SC2016
   didc bind "${DID_PATH}" --target rs |
     sed -E 's/^(struct|enum|type) /pub &/;
             s@^use .*@// &@;

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -83,7 +83,8 @@ cd "$GIT_ROOT"
     sed -E 's/^(struct|enum|type) /pub &/;
             s@^use .*@// &@;
             s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
-            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;'
+            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;
+	    /impl SERVICE/,${s/-> Result/-> CallResult/g}'
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (


### PR DESCRIPTION
# Motivation
The patch files applied when generating Rust from SNS .did files are quite large and break easily.  There are a few changes in the automatic generation that can make the patch files significantly smaller.  Here is the first:

Service definitions have return type `CallResult` but `didc` generates `Result` in the rust code, with the expectation that the `CallResult` will be imported as `Result`.  Unfortunately that expectation can often not be met as `Result` is used for other purposes.  So the patch files have many lines dedicated to changeing the `Result` in the API signatures to `CallResult`.  This can be automated.

# Changes
- Use `CallResult` instead of `Result` when auto-generating code.
- Delete patch file lines that used to do the same.

# Tests
Observe that the test "IC Commit" generates the rust files and gets the same result as before.

# Todos

- [x] Add entry to changelog (if necessary).
