### PR TITLE
E2E: Merge neurons

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -53,6 +53,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Set a custom URL for `internet_identity` on `ic` rather than using the default.
 - Improve Canister Detail tests by mocking the api layer instead of services.
 - Copied the newest version of clap.bash from snsdemo.
+- Migrated some end-to-end tests from Wdio to Playwright.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,0 +1,65 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+test("Test merge neurons", async ({ page, context }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("NNS Dapp");
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  step("Get some ICP");
+  // We need an account before we can get ICP.
+  await appPo
+    .getAccountsPo()
+    .getNnsAccountsPo()
+    .getMainAccountCardPo()
+    .waitFor();
+  await appPo.getTokens(10);
+
+  step("Go to the neurons tab");
+  await appPo.goToNeurons();
+
+  step("Stake a neuron");
+  const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();
+  const neuronsPo = appPo.getNeuronsPo().getNnsNeuronsPo();
+
+  const stake1 = 1;
+  const dissolveDelayDays1 = 3 * 365;
+  await footerPo.stakeNeuron({
+    amount: stake1,
+    dissolveDelayDays: dissolveDelayDays1,
+  });
+  const neuronId1 = (await neuronsPo.getNeuronIds())[0];
+
+  step("Stake a second neuron");
+  const stake2 = 7;
+  const dissolveDelayDays2 = 7 * 365;
+  await footerPo.stakeNeuron({
+    amount: stake2,
+    dissolveDelayDays: dissolveDelayDays2,
+  });
+  const neuronId2 = (await neuronsPo.getNeuronIds())[0];
+
+  expect(await (await neuronsPo.getNeuronCardPo(neuronId1)).getBalance()).toBe(
+    stake1
+  );
+  expect(await (await neuronsPo.getNeuronCardPo(neuronId2)).getBalance()).toBe(
+    stake2
+  );
+
+  step("Merge neurons");
+  await footerPo.mergeNeurons({
+    sourceNeurondId: neuronId1,
+    targetNeuronId: neuronId2,
+  });
+
+  expect(await (await neuronsPo.getNeuronCardPo(neuronId2)).getBalance()).toBe(
+    stake1 + stake2 - 0.0001
+  );
+
+  expect(await neuronsPo.getNeuronIds()).not.toContain(neuronId1);
+});

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -57,8 +57,9 @@ test("Test merge neurons", async ({ page, context }) => {
     targetNeuronId: neuronId2,
   });
 
+  const transactionFee = 0.0001;
   expect(await (await neuronsPo.getNeuronCardPo(neuronId2)).getBalance()).toBe(
-    stake1 + stake2 - 0.0001
+    stake1 + stake2 - transactionFee
   );
 
   expect(await neuronsPo.getNeuronIds()).not.toContain(neuronId1);

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -21,4 +21,19 @@ export class MergeNeuronsModalPo extends BasePageObject {
   getTitle(): Promise<string> {
     return this.getText("modal-title");
   }
+
+  async mergeNeurons({
+    sourceNeurondId,
+    targetNeuronId,
+  }: {
+    sourceNeurondId: string;
+    targetNeuronId: string;
+  }): Promise<void> {
+    await this.getSelectNeuronsToMergePo().selectNeurons({
+      sourceNeurondId,
+      targetNeuronId,
+    });
+    await this.getConfirmNeuronsMergePo().getConfirmMergeButtonPo().click();
+    await this.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -37,4 +37,8 @@ export class NnsNeuronCardPo extends BasePageObject {
   isDisabled(): Promise<boolean> {
     return this.getNeuronCardContainerPo().isDisabled();
   }
+
+  async getBalance(): Promise<number> {
+    return Number(await this.getText("token-value"));
+  }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
@@ -1,4 +1,5 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -21,8 +22,16 @@ export class NnsNeuronsFooterPo extends BasePageObject {
     return NnsStakeNeuronModalPo.under(this.root);
   }
 
+  getMergeNeuronsModalPo(): MergeNeuronsModalPo {
+    return MergeNeuronsModalPo.under(this.root);
+  }
+
   clickStakeNeuronsButton(): Promise<void> {
     return this.getStakeNeuronsButtonPo().click();
+  }
+
+  clickMergeNeuronsButton(): Promise<void> {
+    return this.click("merge-neurons-button");
   }
 
   async stakeNeuron({
@@ -36,5 +45,19 @@ export class NnsNeuronsFooterPo extends BasePageObject {
     const modal = this.getNnsStakeNeuronModalPo();
     await modal.stake({ amount, dissolveDelayDays });
     await modal.waitForAbsent();
+  }
+
+  async mergeNeurons({
+    sourceNeurondId,
+    targetNeuronId,
+  }: {
+    sourceNeurondId: string;
+    targetNeuronId: string;
+  }): Promise<void> {
+    await this.clickMergeNeuronsButton();
+    await this.getMergeNeuronsModalPo().mergeNeurons({
+      sourceNeurondId,
+      targetNeuronId,
+    });
   }
 }

--- a/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectNeuronsToMerge.page-object.ts
@@ -16,7 +16,40 @@ export class SelectNeuronsToMergePo extends BasePageObject {
     return NnsNeuronCardPo.allUnder(this.root);
   }
 
+  async getNnsNeuronCardPo(neuronId: string): Promise<NnsNeuronCardPo> {
+    const neuronCards = await this.getNnsNeuronCardPos();
+
+    for (const neuronCard of neuronCards) {
+      const id = await neuronCard.getNeuronId();
+      if (id === neuronId) {
+        return neuronCard;
+      }
+    }
+
+    throw new Error(`Neuron card with id ${neuronId} not found`);
+  }
+
   getConfirmSelectionButtonPo(): ButtonPo {
     return this.getButton("merge-neurons-confirm-selection-button");
+  }
+
+  async selectNeuron(neuronId: string): Promise<void> {
+    const card = await this.getNnsNeuronCardPo(neuronId);
+    if (await card.isSelected()) {
+      throw new Error(`Neuron card with id ${neuronId} is already selected.`);
+    }
+    await card.click();
+  }
+
+  async selectNeurons({
+    sourceNeurondId,
+    targetNeuronId,
+  }: {
+    sourceNeurondId: string;
+    targetNeuronId: string;
+  }): Promise<void> {
+    await this.selectNeuron(sourceNeurondId);
+    await this.selectNeuron(targetNeuronId);
+    await this.getConfirmSelectionButtonPo().click();
   }
 }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,4 +1,5 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -7,6 +8,10 @@ export class SetDissolveDelayPo extends BasePageObject {
 
   static under(element: PageObjectElement): SetDissolveDelayPo {
     return new SetDissolveDelayPo(element.byTestId(SetDissolveDelayPo.TID));
+  }
+
+  getTextInputPo(): TextInputPo {
+    return TextInputPo.under({ element: this.root });
   }
 
   getUpdateButtonPo(): ButtonPo {
@@ -35,13 +40,15 @@ export class SetDissolveDelayPo extends BasePageObject {
     return this.click("cancel-neuron-delay");
   }
 
-  async setDissolveDelayDays(days: "max" | 0): Promise<void> {
+  async setDissolveDelayDays(days: "max" | number): Promise<void> {
     if (days === 0) {
       await this.clickSkip();
       return;
     }
     if (days === "max") {
       await this.clickMax();
+    } else {
+      await this.getTextInputPo().typeText(days.toString());
     }
     await this.clickUpdate();
   }

--- a/frontend/src/tests/page-objects/TextInput.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInput.page-object.ts
@@ -12,7 +12,9 @@ export class TextInputPo extends SimpleBasePageObject {
   }): TextInputPo {
     if (isNullish(testId)) {
       return new TextInputPo(
-        element.querySelector("input[type=text], input:not([type])")
+        element.querySelector(
+          "input[type=text], input[type=number], input:not([type])"
+        )
       );
     }
     return new TextInputPo(

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -71,12 +71,13 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
     return this.locator.textContent();
   }
 
-  getAttribute(_attribute: string): Promise<string | null> {
-    throw new Error("Not implement");
+  getAttribute(attribute: string): Promise<string | null> {
+    return this.locator.getAttribute(attribute);
   }
 
-  getClasses(): Promise<string[] | null> {
-    throw new Error("Not implement");
+  async getClasses(): Promise<string[] | null> {
+    const classNames = await this.getAttribute("class");
+    return classNames?.split(" ");
   }
 
   async isPresent(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

I want to replace this old wdio e2e test with a Playwright e2e test so we can delete the old test:
https://github.com/dfinity/nns-dapp/blob/main/e2e-tests/specs/user-N03-neurons-merged.e2e.ts

I tried to follow the same steps as that test.

# Changes

1. Add `merge-neurons.spec.ts` which does the e2e test to merge neurons.
2. Add necessary page objects and test IDs.
3. Allow specifying the dissolve non-zero delay when staking a neuron.
4. Allow `TextInputPo` to be used for `<input type="number"` as well since the interface is the same.
5. Implement `getAttribute` and `getClasses` on `PlaywrightPageObjectElement` because it's needed for `NnsNeuronCardPo.isSelected`.

# Tests

yes

# Todos

Is it worth mentioning? It's not new coverage just the same coverage in a different way.

- [ ] Add entry to changelog (if necessary).