### PR TITLE
Fix an re-enabled change log entries test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -276,17 +276,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: scripts/nns-dapp/split-changelog.test
-        #  TODO: Fix and enable the test again
-        #  past-changelog:
-        #    name: Test that no new change log entries are added to past releases.
-        #    runs-on: ubuntu-20.04
-        #    steps:
-        #      - uses: actions/checkout@v3
-        #        with:
-        #          fetch-depth: 0
-        #      - run: scripts/past-changelog-test
+  past-changelog:
+    name: Test that no new change log entries are added to past releases.
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: scripts/past-changelog-test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -6,7 +6,11 @@ set -xeuo pipefail
 CHANGELOG="CHANGELOG-Nns-Dapp.md"
 MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 
-LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"
+if ! LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"; then
+  echo "PASSED: No new entries were added to $CHANGELOG"
+  exit 0
+fi
+
 LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG" | cut -d: -f1)"
 LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
 LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "$LAST_RELEASE_HEADING" "$CHANGELOG" | cut -d: -f1)"


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/2825 I added a test to make sure new changelog entries aren't incorrectly merged into an existing release.
The test prevented merging PRs without new entries in `CHANGELOG_Nns-Dapp.md` so I disabled it.

# Changes

1. Make the test pass if there are no new entries in `CHANGELOG_Nns-Dapp.md`.
2. Enable the test again.

# Tests

It's a test.

# Todos

- [ ] Add entry to changelog (if necessary).

Entry already exists.
And not adding an entry verifies that it's allowed now.
