### PR TITLE
GIX-1677: Remove VITE_OWN_CANISTER_URL from e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           done
       - name: Run Playwright end-to-end tests
         working-directory: frontend
-        run: PLAYWRIGHT_BASE_URL="$(scripts/dfx-canister-url nns-dapp)" npm run test-e2e
+        run: PLAYWRIGHT_BASE_URL="$(../scripts/dfx-canister-url nns-dapp)" npm run test-e2e
       - name: Upload Playwright results
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           done
       - name: Run Playwright end-to-end tests
         working-directory: frontend
-        run: npm run test-e2e
+        run: PLAYWRIGHT_BASE_URL="$(scripts/dfx-canister-url nns-dapp)" npm run test-e2e
       - name: Upload Playwright results
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -47,6 +47,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Script to reorganize CHANGELOG-Nns-Dapp.md after a release.
 - Test that no new change log entries are added to existing releases.
 - New feature flag "ENABLE_NEURON_SETTINGS".
+- Playwright connects to PLAYWRIGHT_BASE_URL if specified in the environment.
 
 #### Changed
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
 import * as dotenv from "dotenv";
-dotenv.config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -32,9 +31,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.CI
-      ? process.env.VITE_OWN_CANISTER_URL
-      : "http://localhost:5173",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:5173",
     screenshot: "only-on-failure",
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "retain-on-failure",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-import * as dotenv from "dotenv";
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
# Motivation

VITE_OWN_CANISTER_URL should not be used by the frontend code so we want to remove it.
But it's also used in the Playwright config to determine where to connect to.
We can use `scripts/dfx-canister-url` to determine where to connect instead.

# Changes

1. In `frontend/playwright.config.ts` use environment variable `PLAYWRIGHT_BASE_URL` instead of `VITE_OWN_CANISTER_URL`.
2. Remove `dotenv` from `frontend/playwright.config.ts` because it's no longer used.
3. In `.github/workflows/build.yml` use `scripts/dfx-canister-url` to set `PLAYWRIGHT_BASE_URL`.

# Tests

Yes

# Todos

- [x] Add entry to changelog (if necessary).
