### PR TITLE
Set -x scripts/dfx-canister-url

### DIFF
--- a/scripts/dfx-canister-url
+++ b/scripts/dfx-canister-url
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 


### PR DESCRIPTION
# Motivation

We are getting this mysterious error very often:
```
/home/runner/work/nns-dapp/nns-dapp/scripts/dfx-canister-url: line 139: echo: write error: Broken pipe
```
Example: https://github.com/dfinity/nns-dapp/actions/runs/5484564664/jobs/9992356558

Setting `set -x` to make the script output what it does, might help debugging.

# Changes

`set -x` in `scripts/dfx-canister-url`


# Tests

none

# Todos

- [ ] Add entry to changelog (if necessary).

None