### PR TITLE
Fmt autogenerated rust

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,6 +152,7 @@ jobs:
         run: |
           if git diff | grep . ; then
                   echo "ERROR: The code is not consistent with the IC_COMMIT in dfx.json"
+                  echo "Note:  didc version: $(didc --version)"
                   exit 1
           fi
   release-templating-works:

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,8 +1,13 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 69f5c1ff8..3c3a440de 100644
+index 582c902e6..e71ccd0a4 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -8,8 +8,9 @@ use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+@@ -3,12 +3,12 @@
+ #![allow(non_camel_case_types)]
+ #![allow(dead_code)]
+ 
+-use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
++use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
@@ -10,88 +15,112 @@ index 69f5c1ff8..3c3a440de 100644
 -// use ic_cdk::api::call::CallResult as Result;
 +// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 +// use ic_cdk::api::call::CallResult;
-+
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GenericNervousSystemFunction {
-@@ -21,7 +22,7 @@ pub struct GenericNervousSystemFunction {
+@@ -20,7 +20,7 @@ pub struct GenericNervousSystemFunction {
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum FunctionType {
--  NativeNervousSystemFunction{},
-+  NativeNervousSystemFunction(EmptyRecord),
-   GenericNervousSystemFunction(GenericNervousSystemFunction),
+-    NativeNervousSystemFunction {},
++    NativeNervousSystemFunction(EmptyRecord),
+     GenericNervousSystemFunction(GenericNervousSystemFunction),
  }
  
-@@ -245,7 +246,10 @@ pub struct Split { memo: u64, amount_e8s: u64 }
- pub struct Follow { function_id: u64, followees: Vec<NeuronId> }
- 
+@@ -220,12 +220,12 @@ pub enum Action {
+     ManageNervousSystemParameters(NervousSystemParameters),
+     AddGenericNervousSystemFunction(NervousSystemFunction),
+     RemoveGenericNervousSystemFunction(u64),
+-    UpgradeSnsToNextVersion {},
++    UpgradeSnsToNextVersion(EmptyRecord),
+     RegisterDappCanisters(RegisterDappCanisters),
+     TransferSnsTreasuryFunds(TransferSnsTreasuryFunds),
+     UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
+     DeregisterDappCanisters(DeregisterDappCanisters),
+-    Unspecified {},
++    Unspecified(EmptyRecord),
+     ManageSnsMetadata(ManageSnsMetadata),
+     ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
+     Motion(Motion),
+@@ -309,8 +309,8 @@ pub struct SetDissolveTimestamp {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct Account { owner: Option<candid::Principal>, subaccount: Option<Subaccount> }
-+pub struct Account {
-+  pub  owner: Option<candid::Principal>,
-+  pub  subaccount: Option<Subaccount>,
-+}
- 
+ pub enum Operation {
+     ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
+-    StopDissolving {},
+-    StartDissolving {},
++    StopDissolving(EmptyRecord),
++    StartDissolving(EmptyRecord),
+     IncreaseDissolveDelay(IncreaseDissolveDelay),
+     SetDissolveTimestamp(SetDissolveTimestamp),
+ }
+@@ -341,7 +341,7 @@ pub struct MemoAndController {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct DisburseMaturity {
-@@ -286,10 +290,13 @@ pub struct FinalizeDisburseMaturity {
+ pub enum By {
+     MemoAndController(MemoAndController),
+-    NeuronId {},
++    NeuronId(EmptyRecord),
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct MemoAndController { controller: Option<candid::Principal>, memo: u64 }
-+pub struct MemoAndController {
-+  pub  controller: Option<candid::Principal>,
-+  pub  memo: u64,
-+}
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub enum By { MemoAndController(MemoAndController), NeuronId{} }
-+pub enum By { MemoAndController(MemoAndController), NeuronId(EmptyRecord) }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct ClaimOrRefresh { by: Option<By> }
-@@ -440,7 +447,7 @@ pub struct GetMaturityModulationResponse {
+@@ -384,7 +384,7 @@ pub enum Command_2 {
+     DisburseMaturity(DisburseMaturity),
+     Configure(Configure),
+     RegisterVote(RegisterVote),
+-    SyncCommand {},
++    SyncCommand(EmptyRecord),
+     MakeProposal(Proposal),
+     FinalizeDisburseMaturity(FinalizeDisburseMaturity),
+     ClaimOrRefreshNeuron(ClaimOrRefresh),
+@@ -515,7 +515,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct GetMetadataResponse {
-   pub  url: Option<String>,
-   pub  logo: Option<String>,
-@@ -514,7 +521,7 @@ pub struct GetSnsInitializationParametersResponse {
-   pub  sns_initialization_parameters: String,
+     pub url: Option<String>,
+     pub logo: Option<String>,
+@@ -609,7 +609,7 @@ pub struct GetSnsInitializationParametersResponse {
+     pub sns_initialization_parameters: String,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct ListNervousSystemFunctionsResponse {
-   pub  reserved_ids: Vec<u64>,
-   pub  functions: Vec<NervousSystemFunction>,
-@@ -562,10 +569,7 @@ pub enum Command {
+     pub reserved_ids: Vec<u64>,
+     pub functions: Vec<NervousSystemFunction>,
+@@ -704,27 +704,27 @@ pub struct DisburseResponse {
+ pub enum Command_1 {
+     Error(GovernanceError),
+     Split(SplitResponse),
+-    Follow {},
++    Follow(EmptyRecord),
+     DisburseMaturity(DisburseMaturityResponse),
+     ClaimOrRefresh(ClaimOrRefreshResponse),
+-    Configure {},
+-    RegisterVote {},
++    Configure(EmptyRecord),
++    RegisterVote(EmptyRecord),
+     MakeProposal(GetProposal),
+-    RemoveNeuronPermission {},
++    RemoveNeuronPermission(EmptyRecord),
+     StakeMaturity(StakeMaturityResponse),
+     MergeMaturity(MergeMaturityResponse),
+     Disburse(DisburseResponse),
+-    AddNeuronPermission {},
++    AddNeuronPermission(EmptyRecord),
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct ManageNeuron {
--  pub  subaccount: serde_bytes::ByteBuf,
--  pub  command: Option<Command>,
--}
-+pub struct ManageNeuron { subaccount: serde_bytes::ByteBuf, command: Option<Command> }
+ pub struct ManageNeuronResponse {
+-    pub command: Option<Command_1>,
++    command: Option<Command_1>,
+ }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SplitResponse { created_neuron_id: Option<NeuronId> }
-@@ -615,7 +619,7 @@ pub struct SetMode { mode: i32 }
- pub struct set_mode_ret0 {}
- 
- pub struct SERVICE(pub candid::Principal);
--impl SERVICE {
-+impl SERVICE{
-   pub async fn claim_swap_neurons(
-     &self,
-     arg0: ClaimSwapNeuronsRequest,
-@@ -686,4 +690,3 @@ impl SERVICE {
-     ic_cdk::call(self.0, "set_mode", (arg0,)).await
-   }
+ pub struct SetMode {
+-    pub mode: i32,
++    mode: i32,
  }
--
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -3,430 +3,499 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
 // use ic_cdk::api::call::CallResult;
 
-
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GenericNervousSystemFunction {
-  pub  validator_canister_id: Option<candid::Principal>,
-  pub  target_canister_id: Option<candid::Principal>,
-  pub  validator_method_name: Option<String>,
-  pub  target_method_name: Option<String>,
+    pub validator_canister_id: Option<candid::Principal>,
+    pub target_canister_id: Option<candid::Principal>,
+    pub validator_method_name: Option<String>,
+    pub target_method_name: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum FunctionType {
-  NativeNervousSystemFunction(EmptyRecord),
-  GenericNervousSystemFunction(GenericNervousSystemFunction),
+    NativeNervousSystemFunction(EmptyRecord),
+    GenericNervousSystemFunction(GenericNervousSystemFunction),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NervousSystemFunction {
-  pub  id: u64,
-  pub  name: String,
-  pub  description: Option<String>,
-  pub  function_type: Option<FunctionType>,
+    pub id: u64,
+    pub name: String,
+    pub description: Option<String>,
+    pub function_type: Option<FunctionType>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GovernanceCachedMetrics {
-  pub  not_dissolving_neurons_e8s_buckets: Vec<(u64,f64,)>,
-  pub  garbage_collectable_neurons_count: u64,
-  pub  neurons_with_invalid_stake_count: u64,
-  pub  not_dissolving_neurons_count_buckets: Vec<(u64,u64,)>,
-  pub  neurons_with_less_than_6_months_dissolve_delay_count: u64,
-  pub  dissolved_neurons_count: u64,
-  pub  total_staked_e8s: u64,
-  pub  total_supply_governance_tokens: u64,
-  pub  not_dissolving_neurons_count: u64,
-  pub  dissolved_neurons_e8s: u64,
-  pub  neurons_with_less_than_6_months_dissolve_delay_e8s: u64,
-  pub  dissolving_neurons_count_buckets: Vec<(u64,u64,)>,
-  pub  dissolving_neurons_count: u64,
-  pub  dissolving_neurons_e8s_buckets: Vec<(u64,f64,)>,
-  pub  timestamp_seconds: u64,
+    pub not_dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
+    pub garbage_collectable_neurons_count: u64,
+    pub neurons_with_invalid_stake_count: u64,
+    pub not_dissolving_neurons_count_buckets: Vec<(u64, u64)>,
+    pub neurons_with_less_than_6_months_dissolve_delay_count: u64,
+    pub dissolved_neurons_count: u64,
+    pub total_staked_e8s: u64,
+    pub total_supply_governance_tokens: u64,
+    pub not_dissolving_neurons_count: u64,
+    pub dissolved_neurons_e8s: u64,
+    pub neurons_with_less_than_6_months_dissolve_delay_e8s: u64,
+    pub dissolving_neurons_count_buckets: Vec<(u64, u64)>,
+    pub dissolving_neurons_count: u64,
+    pub dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
+    pub timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct MaturityModulation {
-  pub  current_basis_points: Option<i32>,
-  pub  updated_at_timestamp_seconds: Option<u64>,
+    pub current_basis_points: Option<i32>,
+    pub updated_at_timestamp_seconds: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronId { id: serde_bytes::ByteBuf }
+pub struct NeuronId {
+    id: serde_bytes::ByteBuf,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Followees { followees: Vec<NeuronId> }
+pub struct Followees {
+    followees: Vec<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DefaultFollowees { followees: Vec<(u64,Followees,)> }
+pub struct DefaultFollowees {
+    followees: Vec<(u64, Followees)>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronPermissionList { permissions: Vec<i32> }
+pub struct NeuronPermissionList {
+    permissions: Vec<i32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct VotingRewardsParameters {
-  pub  final_reward_rate_basis_points: Option<u64>,
-  pub  initial_reward_rate_basis_points: Option<u64>,
-  pub  reward_rate_transition_duration_seconds: Option<u64>,
-  pub  round_duration_seconds: Option<u64>,
+    pub final_reward_rate_basis_points: Option<u64>,
+    pub initial_reward_rate_basis_points: Option<u64>,
+    pub reward_rate_transition_duration_seconds: Option<u64>,
+    pub round_duration_seconds: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NervousSystemParameters {
-  pub  default_followees: Option<DefaultFollowees>,
-  pub  max_dissolve_delay_seconds: Option<u64>,
-  pub  max_dissolve_delay_bonus_percentage: Option<u64>,
-  pub  max_followees_per_function: Option<u64>,
-  pub  neuron_claimer_permissions: Option<NeuronPermissionList>,
-  pub  neuron_minimum_stake_e8s: Option<u64>,
-  pub  max_neuron_age_for_age_bonus: Option<u64>,
-  pub  initial_voting_period_seconds: Option<u64>,
-  pub  neuron_minimum_dissolve_delay_to_vote_seconds: Option<u64>,
-  pub  reject_cost_e8s: Option<u64>,
-  pub  max_proposals_to_keep_per_action: Option<u32>,
-  pub  wait_for_quiet_deadline_increase_seconds: Option<u64>,
-  pub  max_number_of_neurons: Option<u64>,
-  pub  transaction_fee_e8s: Option<u64>,
-  pub  max_number_of_proposals_with_ballots: Option<u64>,
-  pub  max_age_bonus_percentage: Option<u64>,
-  pub  neuron_grantable_permissions: Option<NeuronPermissionList>,
-  pub  voting_rewards_parameters: Option<VotingRewardsParameters>,
-  pub  maturity_modulation_disabled: Option<bool>,
-  pub  max_number_of_principals_per_neuron: Option<u64>,
+    pub default_followees: Option<DefaultFollowees>,
+    pub max_dissolve_delay_seconds: Option<u64>,
+    pub max_dissolve_delay_bonus_percentage: Option<u64>,
+    pub max_followees_per_function: Option<u64>,
+    pub neuron_claimer_permissions: Option<NeuronPermissionList>,
+    pub neuron_minimum_stake_e8s: Option<u64>,
+    pub max_neuron_age_for_age_bonus: Option<u64>,
+    pub initial_voting_period_seconds: Option<u64>,
+    pub neuron_minimum_dissolve_delay_to_vote_seconds: Option<u64>,
+    pub reject_cost_e8s: Option<u64>,
+    pub max_proposals_to_keep_per_action: Option<u32>,
+    pub wait_for_quiet_deadline_increase_seconds: Option<u64>,
+    pub max_number_of_neurons: Option<u64>,
+    pub transaction_fee_e8s: Option<u64>,
+    pub max_number_of_proposals_with_ballots: Option<u64>,
+    pub max_age_bonus_percentage: Option<u64>,
+    pub neuron_grantable_permissions: Option<NeuronPermissionList>,
+    pub voting_rewards_parameters: Option<VotingRewardsParameters>,
+    pub maturity_modulation_disabled: Option<bool>,
+    pub max_number_of_principals_per_neuron: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Version {
-  pub  archive_wasm_hash: serde_bytes::ByteBuf,
-  pub  root_wasm_hash: serde_bytes::ByteBuf,
-  pub  swap_wasm_hash: serde_bytes::ByteBuf,
-  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
-  pub  governance_wasm_hash: serde_bytes::ByteBuf,
-  pub  index_wasm_hash: serde_bytes::ByteBuf,
+    pub archive_wasm_hash: serde_bytes::ByteBuf,
+    pub root_wasm_hash: serde_bytes::ByteBuf,
+    pub swap_wasm_hash: serde_bytes::ByteBuf,
+    pub ledger_wasm_hash: serde_bytes::ByteBuf,
+    pub governance_wasm_hash: serde_bytes::ByteBuf,
+    pub index_wasm_hash: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ProposalId { id: u64 }
+pub struct ProposalId {
+    id: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RewardEvent {
-  pub  rounds_since_last_distribution: Option<u64>,
-  pub  actual_timestamp_seconds: u64,
-  pub  end_timestamp_seconds: Option<u64>,
-  pub  distributed_e8s_equivalent: u64,
-  pub  round: u64,
-  pub  settled_proposals: Vec<ProposalId>,
+    pub rounds_since_last_distribution: Option<u64>,
+    pub actual_timestamp_seconds: u64,
+    pub end_timestamp_seconds: Option<u64>,
+    pub distributed_e8s_equivalent: u64,
+    pub round: u64,
+    pub settled_proposals: Vec<ProposalId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpgradeInProgress {
-  pub  mark_failed_at_seconds: u64,
-  pub  checking_upgrade_lock: u64,
-  pub  proposal_id: u64,
-  pub  target_version: Option<Version>,
+    pub mark_failed_at_seconds: u64,
+    pub checking_upgrade_lock: u64,
+    pub proposal_id: u64,
+    pub target_version: Option<Version>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GovernanceError { error_message: String, error_type: i32 }
+pub struct GovernanceError {
+    error_message: String,
+    error_type: i32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Ballot { vote: i32, cast_timestamp_seconds: u64, voting_power: u64 }
+pub struct Ballot {
+    vote: i32,
+    cast_timestamp_seconds: u64,
+    voting_power: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Tally { no: u64, yes: u64, total: u64, timestamp_seconds: u64 }
+pub struct Tally {
+    no: u64,
+    yes: u64,
+    total: u64,
+    timestamp_seconds: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct RegisterDappCanisters { canister_ids: Vec<candid::Principal> }
+pub struct RegisterDappCanisters {
+    canister_ids: Vec<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Subaccount { subaccount: serde_bytes::ByteBuf }
+pub struct Subaccount {
+    subaccount: serde_bytes::ByteBuf,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransferSnsTreasuryFunds {
-  pub  from_treasury: i32,
-  pub  to_principal: Option<candid::Principal>,
-  pub  to_subaccount: Option<Subaccount>,
-  pub  memo: Option<u64>,
-  pub  amount_e8s: u64,
+    pub from_treasury: i32,
+    pub to_principal: Option<candid::Principal>,
+    pub to_subaccount: Option<Subaccount>,
+    pub memo: Option<u64>,
+    pub amount_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpgradeSnsControlledCanister {
-  pub  new_canister_wasm: serde_bytes::ByteBuf,
-  pub  mode: Option<i32>,
-  pub  canister_id: Option<candid::Principal>,
-  pub  canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
+    pub new_canister_wasm: serde_bytes::ByteBuf,
+    pub mode: Option<i32>,
+    pub canister_id: Option<candid::Principal>,
+    pub canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DeregisterDappCanisters {
-  pub  canister_ids: Vec<candid::Principal>,
-  pub  new_controllers: Vec<candid::Principal>,
+    pub canister_ids: Vec<candid::Principal>,
+    pub new_controllers: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ManageSnsMetadata {
-  pub  url: Option<String>,
-  pub  logo: Option<String>,
-  pub  name: Option<String>,
-  pub  description: Option<String>,
+    pub url: Option<String>,
+    pub logo: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ExecuteGenericNervousSystemFunction {
-  pub  function_id: u64,
-  pub  payload: serde_bytes::ByteBuf,
+    pub function_id: u64,
+    pub payload: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Motion { motion_text: String }
+pub struct Motion {
+    motion_text: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Action {
-  ManageNervousSystemParameters(NervousSystemParameters),
-  AddGenericNervousSystemFunction(NervousSystemFunction),
-  RemoveGenericNervousSystemFunction(u64),
-  UpgradeSnsToNextVersion(EmptyRecord),
-  RegisterDappCanisters(RegisterDappCanisters),
-  TransferSnsTreasuryFunds(TransferSnsTreasuryFunds),
-  UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
-  DeregisterDappCanisters(DeregisterDappCanisters),
-  Unspecified(EmptyRecord),
-  ManageSnsMetadata(ManageSnsMetadata),
-  ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
-  Motion(Motion),
+    ManageNervousSystemParameters(NervousSystemParameters),
+    AddGenericNervousSystemFunction(NervousSystemFunction),
+    RemoveGenericNervousSystemFunction(u64),
+    UpgradeSnsToNextVersion(EmptyRecord),
+    RegisterDappCanisters(RegisterDappCanisters),
+    TransferSnsTreasuryFunds(TransferSnsTreasuryFunds),
+    UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
+    DeregisterDappCanisters(DeregisterDappCanisters),
+    Unspecified(EmptyRecord),
+    ManageSnsMetadata(ManageSnsMetadata),
+    ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
+    Motion(Motion),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Proposal {
-  pub  url: String,
-  pub  title: String,
-  pub  action: Option<Action>,
-  pub  summary: String,
+    pub url: String,
+    pub title: String,
+    pub action: Option<Action>,
+    pub summary: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct WaitForQuietState { current_deadline_timestamp_seconds: u64 }
+pub struct WaitForQuietState {
+    current_deadline_timestamp_seconds: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ProposalData {
-  pub  id: Option<ProposalId>,
-  pub  payload_text_rendering: Option<String>,
-  pub  action: u64,
-  pub  failure_reason: Option<GovernanceError>,
-  pub  ballots: Vec<(String,Ballot,)>,
-  pub  reward_event_round: u64,
-  pub  failed_timestamp_seconds: u64,
-  pub  reward_event_end_timestamp_seconds: Option<u64>,
-  pub  proposal_creation_timestamp_seconds: u64,
-  pub  initial_voting_period_seconds: u64,
-  pub  reject_cost_e8s: u64,
-  pub  latest_tally: Option<Tally>,
-  pub  wait_for_quiet_deadline_increase_seconds: u64,
-  pub  decided_timestamp_seconds: u64,
-  pub  proposal: Option<Proposal>,
-  pub  proposer: Option<NeuronId>,
-  pub  wait_for_quiet_state: Option<WaitForQuietState>,
-  pub  is_eligible_for_rewards: bool,
-  pub  executed_timestamp_seconds: u64,
+    pub id: Option<ProposalId>,
+    pub payload_text_rendering: Option<String>,
+    pub action: u64,
+    pub failure_reason: Option<GovernanceError>,
+    pub ballots: Vec<(String, Ballot)>,
+    pub reward_event_round: u64,
+    pub failed_timestamp_seconds: u64,
+    pub reward_event_end_timestamp_seconds: Option<u64>,
+    pub proposal_creation_timestamp_seconds: u64,
+    pub initial_voting_period_seconds: u64,
+    pub reject_cost_e8s: u64,
+    pub latest_tally: Option<Tally>,
+    pub wait_for_quiet_deadline_increase_seconds: u64,
+    pub decided_timestamp_seconds: u64,
+    pub proposal: Option<Proposal>,
+    pub proposer: Option<NeuronId>,
+    pub wait_for_quiet_state: Option<WaitForQuietState>,
+    pub is_eligible_for_rewards: bool,
+    pub executed_timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Split { memo: u64, amount_e8s: u64 }
+pub struct Split {
+    memo: u64,
+    amount_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Follow { function_id: u64, followees: Vec<NeuronId> }
+pub struct Follow {
+    function_id: u64,
+    followees: Vec<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Account {
-  pub  owner: Option<candid::Principal>,
-  pub  subaccount: Option<Subaccount>,
+    pub owner: Option<candid::Principal>,
+    pub subaccount: Option<Subaccount>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DisburseMaturity {
-  pub  to_account: Option<Account>,
-  pub  percentage_to_disburse: u32,
+    pub to_account: Option<Account>,
+    pub percentage_to_disburse: u32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ChangeAutoStakeMaturity {
-  pub  requested_setting_for_auto_stake_maturity: bool,
+    pub requested_setting_for_auto_stake_maturity: bool,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct IncreaseDissolveDelay { additional_dissolve_delay_seconds: u32 }
+pub struct IncreaseDissolveDelay {
+    additional_dissolve_delay_seconds: u32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetDissolveTimestamp { dissolve_timestamp_seconds: u64 }
+pub struct SetDissolveTimestamp {
+    dissolve_timestamp_seconds: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Operation {
-  ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
-  StopDissolving(EmptyRecord),
-  StartDissolving(EmptyRecord),
-  IncreaseDissolveDelay(IncreaseDissolveDelay),
-  SetDissolveTimestamp(SetDissolveTimestamp),
+    ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
+    StopDissolving(EmptyRecord),
+    StartDissolving(EmptyRecord),
+    IncreaseDissolveDelay(IncreaseDissolveDelay),
+    SetDissolveTimestamp(SetDissolveTimestamp),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Configure { operation: Option<Operation> }
+pub struct Configure {
+    operation: Option<Operation>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct RegisterVote { vote: i32, proposal: Option<ProposalId> }
+pub struct RegisterVote {
+    vote: i32,
+    proposal: Option<ProposalId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct FinalizeDisburseMaturity {
-  pub  amount_to_be_disbursed_e8s: u64,
-  pub  to_account: Option<Account>,
+    pub amount_to_be_disbursed_e8s: u64,
+    pub to_account: Option<Account>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct MemoAndController {
-  pub  controller: Option<candid::Principal>,
-  pub  memo: u64,
+    pub controller: Option<candid::Principal>,
+    pub memo: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum By { MemoAndController(MemoAndController), NeuronId(EmptyRecord) }
+pub enum By {
+    MemoAndController(MemoAndController),
+    NeuronId(EmptyRecord),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ClaimOrRefresh { by: Option<By> }
+pub struct ClaimOrRefresh {
+    by: Option<By>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RemoveNeuronPermissions {
-  pub  permissions_to_remove: Option<NeuronPermissionList>,
-  pub  principal_id: Option<candid::Principal>,
+    pub permissions_to_remove: Option<NeuronPermissionList>,
+    pub principal_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct AddNeuronPermissions {
-  pub  permissions_to_add: Option<NeuronPermissionList>,
-  pub  principal_id: Option<candid::Principal>,
+    pub permissions_to_add: Option<NeuronPermissionList>,
+    pub principal_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct MergeMaturity { percentage_to_merge: u32 }
+pub struct MergeMaturity {
+    percentage_to_merge: u32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Amount { e8s: u64 }
+pub struct Amount {
+    e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Disburse { to_account: Option<Account>, amount: Option<Amount> }
+pub struct Disburse {
+    to_account: Option<Account>,
+    amount: Option<Amount>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Command_2 {
-  Split(Split),
-  Follow(Follow),
-  DisburseMaturity(DisburseMaturity),
-  Configure(Configure),
-  RegisterVote(RegisterVote),
-  SyncCommand(EmptyRecord),
-  MakeProposal(Proposal),
-  FinalizeDisburseMaturity(FinalizeDisburseMaturity),
-  ClaimOrRefreshNeuron(ClaimOrRefresh),
-  RemoveNeuronPermissions(RemoveNeuronPermissions),
-  AddNeuronPermissions(AddNeuronPermissions),
-  MergeMaturity(MergeMaturity),
-  Disburse(Disburse),
+    Split(Split),
+    Follow(Follow),
+    DisburseMaturity(DisburseMaturity),
+    Configure(Configure),
+    RegisterVote(RegisterVote),
+    SyncCommand(EmptyRecord),
+    MakeProposal(Proposal),
+    FinalizeDisburseMaturity(FinalizeDisburseMaturity),
+    ClaimOrRefreshNeuron(ClaimOrRefresh),
+    RemoveNeuronPermissions(RemoveNeuronPermissions),
+    AddNeuronPermissions(AddNeuronPermissions),
+    MergeMaturity(MergeMaturity),
+    Disburse(Disburse),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronInFlightCommand { command: Option<Command_2>, timestamp: u64 }
+pub struct NeuronInFlightCommand {
+    command: Option<Command_2>,
+    timestamp: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronPermission {
-  pub  principal: Option<candid::Principal>,
-  pub  permission_type: Vec<i32>,
+    pub principal: Option<candid::Principal>,
+    pub permission_type: Vec<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum DissolveState {
-  DissolveDelaySeconds(u64),
-  WhenDissolvedTimestampSeconds(u64),
+    DissolveDelaySeconds(u64),
+    WhenDissolvedTimestampSeconds(u64),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DisburseMaturityInProgress {
-  pub  timestamp_of_disbursement_seconds: u64,
-  pub  amount_e8s: u64,
-  pub  account_to_disburse_to: Option<Account>,
+    pub timestamp_of_disbursement_seconds: u64,
+    pub amount_e8s: u64,
+    pub account_to_disburse_to: Option<Account>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Neuron {
-  pub  id: Option<NeuronId>,
-  pub  staked_maturity_e8s_equivalent: Option<u64>,
-  pub  permissions: Vec<NeuronPermission>,
-  pub  maturity_e8s_equivalent: u64,
-  pub  cached_neuron_stake_e8s: u64,
-  pub  created_timestamp_seconds: u64,
-  pub  source_nns_neuron_id: Option<u64>,
-  pub  auto_stake_maturity: Option<bool>,
-  pub  aging_since_timestamp_seconds: u64,
-  pub  dissolve_state: Option<DissolveState>,
-  pub  voting_power_percentage_multiplier: u64,
-  pub  vesting_period_seconds: Option<u64>,
-  pub  disburse_maturity_in_progress: Vec<DisburseMaturityInProgress>,
-  pub  followees: Vec<(u64,Followees,)>,
-  pub  neuron_fees_e8s: u64,
+    pub id: Option<NeuronId>,
+    pub staked_maturity_e8s_equivalent: Option<u64>,
+    pub permissions: Vec<NeuronPermission>,
+    pub maturity_e8s_equivalent: u64,
+    pub cached_neuron_stake_e8s: u64,
+    pub created_timestamp_seconds: u64,
+    pub source_nns_neuron_id: Option<u64>,
+    pub auto_stake_maturity: Option<bool>,
+    pub aging_since_timestamp_seconds: u64,
+    pub dissolve_state: Option<DissolveState>,
+    pub voting_power_percentage_multiplier: u64,
+    pub vesting_period_seconds: Option<u64>,
+    pub disburse_maturity_in_progress: Vec<DisburseMaturityInProgress>,
+    pub followees: Vec<(u64, Followees)>,
+    pub neuron_fees_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Governance {
-  pub  root_canister_id: Option<candid::Principal>,
-  pub  id_to_nervous_system_functions: Vec<(u64,NervousSystemFunction,)>,
-  pub  metrics: Option<GovernanceCachedMetrics>,
-  pub  maturity_modulation: Option<MaturityModulation>,
-  pub  mode: i32,
-  pub  parameters: Option<NervousSystemParameters>,
-  pub  is_finalizing_disburse_maturity: Option<bool>,
-  pub  deployed_version: Option<Version>,
-  pub  sns_initialization_parameters: String,
-  pub  latest_reward_event: Option<RewardEvent>,
-  pub  pending_version: Option<UpgradeInProgress>,
-  pub  swap_canister_id: Option<candid::Principal>,
-  pub  ledger_canister_id: Option<candid::Principal>,
-  pub  proposals: Vec<(u64,ProposalData,)>,
-  pub  in_flight_commands: Vec<(String,NeuronInFlightCommand,)>,
-  pub  sns_metadata: Option<ManageSnsMetadata>,
-  pub  neurons: Vec<(String,Neuron,)>,
-  pub  genesis_timestamp_seconds: u64,
+    pub root_canister_id: Option<candid::Principal>,
+    pub id_to_nervous_system_functions: Vec<(u64, NervousSystemFunction)>,
+    pub metrics: Option<GovernanceCachedMetrics>,
+    pub maturity_modulation: Option<MaturityModulation>,
+    pub mode: i32,
+    pub parameters: Option<NervousSystemParameters>,
+    pub is_finalizing_disburse_maturity: Option<bool>,
+    pub deployed_version: Option<Version>,
+    pub sns_initialization_parameters: String,
+    pub latest_reward_event: Option<RewardEvent>,
+    pub pending_version: Option<UpgradeInProgress>,
+    pub swap_canister_id: Option<candid::Principal>,
+    pub ledger_canister_id: Option<candid::Principal>,
+    pub proposals: Vec<(u64, ProposalData)>,
+    pub in_flight_commands: Vec<(String, NeuronInFlightCommand)>,
+    pub sns_metadata: Option<ManageSnsMetadata>,
+    pub neurons: Vec<(String, Neuron)>,
+    pub genesis_timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronParameters {
-  pub  controller: Option<candid::Principal>,
-  pub  dissolve_delay_seconds: Option<u64>,
-  pub  source_nns_neuron_id: Option<u64>,
-  pub  stake_e8s: Option<u64>,
-  pub  followees: Vec<NeuronId>,
-  pub  hotkey: Option<candid::Principal>,
-  pub  neuron_id: Option<NeuronId>,
+    pub controller: Option<candid::Principal>,
+    pub dissolve_delay_seconds: Option<u64>,
+    pub source_nns_neuron_id: Option<u64>,
+    pub stake_e8s: Option<u64>,
+    pub followees: Vec<NeuronId>,
+    pub hotkey: Option<candid::Principal>,
+    pub neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ClaimSwapNeuronsRequest { neuron_parameters: Vec<NeuronParameters> }
+pub struct ClaimSwapNeuronsRequest {
+    neuron_parameters: Vec<NeuronParameters>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SwapNeuron { id: Option<NeuronId>, status: i32 }
+pub struct SwapNeuron {
+    id: Option<NeuronId>,
+    status: i32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ClaimedSwapNeurons { swap_neurons: Vec<SwapNeuron> }
+pub struct ClaimedSwapNeurons {
+    swap_neurons: Vec<SwapNeuron>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum ClaimSwapNeuronsResult { Ok(ClaimedSwapNeurons), Err(i32) }
+pub enum ClaimSwapNeuronsResult {
+    Ok(ClaimedSwapNeurons),
+    Err(i32),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ClaimSwapNeuronsResponse {
-  pub  claim_swap_neurons_result: Option<ClaimSwapNeuronsResult>,
+    pub claim_swap_neurons_result: Option<ClaimSwapNeuronsResult>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -440,7 +509,7 @@ pub struct get_maturity_modulation_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetMaturityModulationResponse {
-  pub  maturity_modulation: Option<MaturityModulation>,
+    pub maturity_modulation: Option<MaturityModulation>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -448,59 +517,79 @@ pub struct get_metadata_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct GetMetadataResponse {
-  pub  url: Option<String>,
-  pub  logo: Option<String>,
-  pub  name: Option<String>,
-  pub  description: Option<String>,
+    pub url: Option<String>,
+    pub logo: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_mode_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetModeResponse { mode: Option<i32> }
+pub struct GetModeResponse {
+    mode: Option<i32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetNeuron { neuron_id: Option<NeuronId> }
+pub struct GetNeuron {
+    neuron_id: Option<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result { Error(GovernanceError), Neuron(Neuron) }
+pub enum Result {
+    Error(GovernanceError),
+    Neuron(Neuron),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetNeuronResponse { result: Option<Result> }
+pub struct GetNeuronResponse {
+    result: Option<Result>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetProposal { proposal_id: Option<ProposalId> }
+pub struct GetProposal {
+    proposal_id: Option<ProposalId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result_1 { Error(GovernanceError), Proposal(ProposalData) }
+pub enum Result_1 {
+    Error(GovernanceError),
+    Proposal(ProposalData),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetProposalResponse { result: Option<Result_1> }
+pub struct GetProposalResponse {
+    result: Option<Result_1>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum CanisterStatusType { stopped, stopping, running }
+pub enum CanisterStatusType {
+    stopped,
+    stopping,
+    running,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettingsArgs {
-  pub  controller: candid::Principal,
-  pub  freezing_threshold: candid::Nat,
-  pub  controllers: Vec<candid::Principal>,
-  pub  memory_allocation: candid::Nat,
-  pub  compute_allocation: candid::Nat,
+    pub controller: candid::Principal,
+    pub freezing_threshold: candid::Nat,
+    pub controllers: Vec<candid::Principal>,
+    pub memory_allocation: candid::Nat,
+    pub compute_allocation: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResultV2 {
-  pub  controller: candid::Principal,
-  pub  status: CanisterStatusType,
-  pub  freezing_threshold: candid::Nat,
-  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
-  pub  memory_size: candid::Nat,
-  pub  cycles: candid::Nat,
-  pub  settings: DefiniteCanisterSettingsArgs,
-  pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<serde_bytes::ByteBuf>,
+    pub controller: candid::Principal,
+    pub status: CanisterStatusType,
+    pub freezing_threshold: candid::Nat,
+    pub balance: Vec<(serde_bytes::ByteBuf, candid::Nat)>,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
+    pub settings: DefiniteCanisterSettingsArgs,
+    pub idle_cycles_burned_per_day: candid::Nat,
+    pub module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -508,8 +597,8 @@ pub struct get_running_sns_version_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetRunningSnsVersionResponse {
-  pub  deployed_version: Option<Version>,
-  pub  pending_version: Option<UpgradeInProgress>,
+    pub deployed_version: Option<Version>,
+    pub pending_version: Option<UpgradeInProgress>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -517,175 +606,196 @@ pub struct get_sns_initialization_parameters_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetSnsInitializationParametersResponse {
-  pub  sns_initialization_parameters: String,
+    pub sns_initialization_parameters: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct ListNervousSystemFunctionsResponse {
-  pub  reserved_ids: Vec<u64>,
-  pub  functions: Vec<NervousSystemFunction>,
+    pub reserved_ids: Vec<u64>,
+    pub functions: Vec<NervousSystemFunction>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListNeurons {
-  pub  of_principal: Option<candid::Principal>,
-  pub  limit: u32,
-  pub  start_page_at: Option<NeuronId>,
+    pub of_principal: Option<candid::Principal>,
+    pub limit: u32,
+    pub start_page_at: Option<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListNeuronsResponse { neurons: Vec<Neuron> }
+pub struct ListNeuronsResponse {
+    neurons: Vec<Neuron>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListProposals {
-  pub  include_reward_status: Vec<i32>,
-  pub  before_proposal: Option<ProposalId>,
-  pub  limit: u32,
-  pub  exclude_type: Vec<u64>,
-  pub  include_status: Vec<i32>,
+    pub include_reward_status: Vec<i32>,
+    pub before_proposal: Option<ProposalId>,
+    pub limit: u32,
+    pub exclude_type: Vec<u64>,
+    pub include_status: Vec<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListProposalsResponse { proposals: Vec<ProposalData> }
+pub struct ListProposalsResponse {
+    proposals: Vec<ProposalData>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct StakeMaturity { percentage_to_stake: Option<u32> }
+pub struct StakeMaturity {
+    percentage_to_stake: Option<u32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Command {
-  Split(Split),
-  Follow(Follow),
-  DisburseMaturity(DisburseMaturity),
-  ClaimOrRefresh(ClaimOrRefresh),
-  Configure(Configure),
-  RegisterVote(RegisterVote),
-  MakeProposal(Proposal),
-  StakeMaturity(StakeMaturity),
-  RemoveNeuronPermissions(RemoveNeuronPermissions),
-  AddNeuronPermissions(AddNeuronPermissions),
-  MergeMaturity(MergeMaturity),
-  Disburse(Disburse),
+    Split(Split),
+    Follow(Follow),
+    DisburseMaturity(DisburseMaturity),
+    ClaimOrRefresh(ClaimOrRefresh),
+    Configure(Configure),
+    RegisterVote(RegisterVote),
+    MakeProposal(Proposal),
+    StakeMaturity(StakeMaturity),
+    RemoveNeuronPermissions(RemoveNeuronPermissions),
+    AddNeuronPermissions(AddNeuronPermissions),
+    MergeMaturity(MergeMaturity),
+    Disburse(Disburse),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ManageNeuron { subaccount: serde_bytes::ByteBuf, command: Option<Command> }
+pub struct ManageNeuron {
+    subaccount: serde_bytes::ByteBuf,
+    command: Option<Command>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SplitResponse { created_neuron_id: Option<NeuronId> }
+pub struct SplitResponse {
+    created_neuron_id: Option<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DisburseMaturityResponse { amount_disbursed_e8s: u64 }
+pub struct DisburseMaturityResponse {
+    amount_disbursed_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ClaimOrRefreshResponse { refreshed_neuron_id: Option<NeuronId> }
+pub struct ClaimOrRefreshResponse {
+    refreshed_neuron_id: Option<NeuronId>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct StakeMaturityResponse { maturity_e8s: u64, staked_maturity_e8s: u64 }
+pub struct StakeMaturityResponse {
+    maturity_e8s: u64,
+    staked_maturity_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct MergeMaturityResponse {
-  pub  merged_maturity_e8s: u64,
-  pub  new_stake_e8s: u64,
+    pub merged_maturity_e8s: u64,
+    pub new_stake_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DisburseResponse { transfer_block_height: u64 }
+pub struct DisburseResponse {
+    transfer_block_height: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Command_1 {
-  Error(GovernanceError),
-  Split(SplitResponse),
-  Follow(EmptyRecord),
-  DisburseMaturity(DisburseMaturityResponse),
-  ClaimOrRefresh(ClaimOrRefreshResponse),
-  Configure(EmptyRecord),
-  RegisterVote(EmptyRecord),
-  MakeProposal(GetProposal),
-  RemoveNeuronPermission(EmptyRecord),
-  StakeMaturity(StakeMaturityResponse),
-  MergeMaturity(MergeMaturityResponse),
-  Disburse(DisburseResponse),
-  AddNeuronPermission(EmptyRecord),
+    Error(GovernanceError),
+    Split(SplitResponse),
+    Follow(EmptyRecord),
+    DisburseMaturity(DisburseMaturityResponse),
+    ClaimOrRefresh(ClaimOrRefreshResponse),
+    Configure(EmptyRecord),
+    RegisterVote(EmptyRecord),
+    MakeProposal(GetProposal),
+    RemoveNeuronPermission(EmptyRecord),
+    StakeMaturity(StakeMaturityResponse),
+    MergeMaturity(MergeMaturityResponse),
+    Disburse(DisburseResponse),
+    AddNeuronPermission(EmptyRecord),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ManageNeuronResponse { command: Option<Command_1> }
+pub struct ManageNeuronResponse {
+    command: Option<Command_1>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetMode { mode: i32 }
+pub struct SetMode {
+    mode: i32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct set_mode_ret0 {}
 
 pub struct SERVICE(pub candid::Principal);
-impl SERVICE{
-  pub async fn claim_swap_neurons(
-    &self,
-    arg0: ClaimSwapNeuronsRequest,
-  ) -> CallResult<(ClaimSwapNeuronsResponse,)> {
-    ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
-  }
-  pub async fn fail_stuck_upgrade_in_progress(
-    &self,
-    arg0: fail_stuck_upgrade_in_progress_arg0,
-  ) -> CallResult<(fail_stuck_upgrade_in_progress_ret0,)> {
-    ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
-  }
-  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-    ic_cdk::call(self.0, "get_build_metadata", ()).await
-  }
-  pub async fn get_latest_reward_event(&self) -> CallResult<(RewardEvent,)> {
-    ic_cdk::call(self.0, "get_latest_reward_event", ()).await
-  }
-  pub async fn get_maturity_modulation(
-    &self,
-    arg0: get_maturity_modulation_arg0,
-  ) -> CallResult<(GetMaturityModulationResponse,)> {
-    ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
-  }
-  pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> CallResult<
-    (GetMetadataResponse,)
-  > { ic_cdk::call(self.0, "get_metadata", (arg0,)).await }
-  pub async fn get_mode(&self, arg0: get_mode_arg0) -> CallResult<
-    (GetModeResponse,)
-  > { ic_cdk::call(self.0, "get_mode", (arg0,)).await }
-  pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<
-    (NervousSystemParameters,)
-  > { ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await }
-  pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<
-    (GetNeuronResponse,)
-  > { ic_cdk::call(self.0, "get_neuron", (arg0,)).await }
-  pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<
-    (GetProposalResponse,)
-  > { ic_cdk::call(self.0, "get_proposal", (arg0,)).await }
-  pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<
-    (CanisterStatusResultV2,)
-  > { ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await }
-  pub async fn get_running_sns_version(
-    &self,
-    arg0: get_running_sns_version_arg0,
-  ) -> CallResult<(GetRunningSnsVersionResponse,)> {
-    ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
-  }
-  pub async fn get_sns_initialization_parameters(
-    &self,
-    arg0: get_sns_initialization_parameters_arg0,
-  ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
-    ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
-  }
-  pub async fn list_nervous_system_functions(&self) -> CallResult<
-    (ListNervousSystemFunctionsResponse,)
-  > { ic_cdk::call(self.0, "list_nervous_system_functions", ()).await }
-  pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<
-    (ListNeuronsResponse,)
-  > { ic_cdk::call(self.0, "list_neurons", (arg0,)).await }
-  pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<
-    (ListProposalsResponse,)
-  > { ic_cdk::call(self.0, "list_proposals", (arg0,)).await }
-  pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<
-    (ManageNeuronResponse,)
-  > { ic_cdk::call(self.0, "manage_neuron", (arg0,)).await }
-  pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(set_mode_ret0,)> {
-    ic_cdk::call(self.0, "set_mode", (arg0,)).await
-  }
+impl SERVICE {
+    pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
+        ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await
+    }
+    pub async fn fail_stuck_upgrade_in_progress(
+        &self,
+        arg0: fail_stuck_upgrade_in_progress_arg0,
+    ) -> CallResult<(fail_stuck_upgrade_in_progress_ret0,)> {
+        ic_cdk::call(self.0, "fail_stuck_upgrade_in_progress", (arg0,)).await
+    }
+    pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
+        ic_cdk::call(self.0, "get_build_metadata", ()).await
+    }
+    pub async fn get_latest_reward_event(&self) -> CallResult<(RewardEvent,)> {
+        ic_cdk::call(self.0, "get_latest_reward_event", ()).await
+    }
+    pub async fn get_maturity_modulation(
+        &self,
+        arg0: get_maturity_modulation_arg0,
+    ) -> CallResult<(GetMaturityModulationResponse,)> {
+        ic_cdk::call(self.0, "get_maturity_modulation", (arg0,)).await
+    }
+    pub async fn get_metadata(&self, arg0: get_metadata_arg0) -> CallResult<(GetMetadataResponse,)> {
+        ic_cdk::call(self.0, "get_metadata", (arg0,)).await
+    }
+    pub async fn get_mode(&self, arg0: get_mode_arg0) -> CallResult<(GetModeResponse,)> {
+        ic_cdk::call(self.0, "get_mode", (arg0,)).await
+    }
+    pub async fn get_nervous_system_parameters(&self, arg0: ()) -> CallResult<(NervousSystemParameters,)> {
+        ic_cdk::call(self.0, "get_nervous_system_parameters", (arg0,)).await
+    }
+    pub async fn get_neuron(&self, arg0: GetNeuron) -> CallResult<(GetNeuronResponse,)> {
+        ic_cdk::call(self.0, "get_neuron", (arg0,)).await
+    }
+    pub async fn get_proposal(&self, arg0: GetProposal) -> CallResult<(GetProposalResponse,)> {
+        ic_cdk::call(self.0, "get_proposal", (arg0,)).await
+    }
+    pub async fn get_root_canister_status(&self, arg0: ()) -> CallResult<(CanisterStatusResultV2,)> {
+        ic_cdk::call(self.0, "get_root_canister_status", (arg0,)).await
+    }
+    pub async fn get_running_sns_version(
+        &self,
+        arg0: get_running_sns_version_arg0,
+    ) -> CallResult<(GetRunningSnsVersionResponse,)> {
+        ic_cdk::call(self.0, "get_running_sns_version", (arg0,)).await
+    }
+    pub async fn get_sns_initialization_parameters(
+        &self,
+        arg0: get_sns_initialization_parameters_arg0,
+    ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
+        ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
+    }
+    pub async fn list_nervous_system_functions(&self) -> CallResult<(ListNervousSystemFunctionsResponse,)> {
+        ic_cdk::call(self.0, "list_nervous_system_functions", ()).await
+    }
+    pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
+        ic_cdk::call(self.0, "list_neurons", (arg0,)).await
+    }
+    pub async fn list_proposals(&self, arg0: ListProposals) -> CallResult<(ListProposalsResponse,)> {
+        ic_cdk::call(self.0, "list_proposals", (arg0,)).await
+    }
+    pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
+        ic_cdk::call(self.0, "manage_neuron", (arg0,)).await
+    }
+    pub async fn set_mode(&self, arg0: SetMode) -> CallResult<(set_mode_ret0,)> {
+        ic_cdk::call(self.0, "set_mode", (arg0,)).await
+    }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -59,22 +59,22 @@ pub struct MaturityModulation {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronId {
-    id: serde_bytes::ByteBuf,
+    pub id: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Followees {
-    followees: Vec<NeuronId>,
+    pub followees: Vec<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefaultFollowees {
-    followees: Vec<(u64, Followees)>,
+    pub followees: Vec<(u64, Followees)>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronPermissionList {
-    permissions: Vec<i32>,
+    pub permissions: Vec<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -121,7 +121,7 @@ pub struct Version {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ProposalId {
-    id: u64,
+    pub id: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -144,33 +144,33 @@ pub struct UpgradeInProgress {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GovernanceError {
-    error_message: String,
-    error_type: i32,
+    pub error_message: String,
+    pub error_type: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Ballot {
-    vote: i32,
-    cast_timestamp_seconds: u64,
-    voting_power: u64,
+    pub vote: i32,
+    pub cast_timestamp_seconds: u64,
+    pub voting_power: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Tally {
-    no: u64,
-    yes: u64,
-    total: u64,
-    timestamp_seconds: u64,
+    pub no: u64,
+    pub yes: u64,
+    pub total: u64,
+    pub timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RegisterDappCanisters {
-    canister_ids: Vec<candid::Principal>,
+    pub canister_ids: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Subaccount {
-    subaccount: serde_bytes::ByteBuf,
+    pub subaccount: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -212,7 +212,7 @@ pub struct ExecuteGenericNervousSystemFunction {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Motion {
-    motion_text: String,
+    pub motion_text: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -241,7 +241,7 @@ pub struct Proposal {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct WaitForQuietState {
-    current_deadline_timestamp_seconds: u64,
+    pub current_deadline_timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -269,14 +269,14 @@ pub struct ProposalData {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Split {
-    memo: u64,
-    amount_e8s: u64,
+    pub memo: u64,
+    pub amount_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Follow {
-    function_id: u64,
-    followees: Vec<NeuronId>,
+    pub function_id: u64,
+    pub followees: Vec<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -298,12 +298,12 @@ pub struct ChangeAutoStakeMaturity {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct IncreaseDissolveDelay {
-    additional_dissolve_delay_seconds: u32,
+    pub additional_dissolve_delay_seconds: u32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDissolveTimestamp {
-    dissolve_timestamp_seconds: u64,
+    pub dissolve_timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -317,13 +317,13 @@ pub enum Operation {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Configure {
-    operation: Option<Operation>,
+    pub operation: Option<Operation>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RegisterVote {
-    vote: i32,
-    proposal: Option<ProposalId>,
+    pub vote: i32,
+    pub proposal: Option<ProposalId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -346,7 +346,7 @@ pub enum By {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ClaimOrRefresh {
-    by: Option<By>,
+    pub by: Option<By>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -363,18 +363,18 @@ pub struct AddNeuronPermissions {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct MergeMaturity {
-    percentage_to_merge: u32,
+    pub percentage_to_merge: u32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Amount {
-    e8s: u64,
+    pub e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Disburse {
-    to_account: Option<Account>,
-    amount: Option<Amount>,
+    pub to_account: Option<Account>,
+    pub amount: Option<Amount>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -396,8 +396,8 @@ pub enum Command_2 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronInFlightCommand {
-    command: Option<Command_2>,
-    timestamp: u64,
+    pub command: Option<Command_2>,
+    pub timestamp: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -473,18 +473,18 @@ pub struct NeuronParameters {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ClaimSwapNeuronsRequest {
-    neuron_parameters: Vec<NeuronParameters>,
+    pub neuron_parameters: Vec<NeuronParameters>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SwapNeuron {
-    id: Option<NeuronId>,
-    status: i32,
+    pub id: Option<NeuronId>,
+    pub status: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ClaimedSwapNeurons {
-    swap_neurons: Vec<SwapNeuron>,
+    pub swap_neurons: Vec<SwapNeuron>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -528,12 +528,12 @@ pub struct get_mode_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetModeResponse {
-    mode: Option<i32>,
+    pub mode: Option<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetNeuron {
-    neuron_id: Option<NeuronId>,
+    pub neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -544,12 +544,12 @@ pub enum Result {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetNeuronResponse {
-    result: Option<Result>,
+    pub result: Option<Result>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetProposal {
-    proposal_id: Option<ProposalId>,
+    pub proposal_id: Option<ProposalId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -560,7 +560,7 @@ pub enum Result_1 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetProposalResponse {
-    result: Option<Result_1>,
+    pub result: Option<Result_1>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -624,7 +624,7 @@ pub struct ListNeurons {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListNeuronsResponse {
-    neurons: Vec<Neuron>,
+    pub neurons: Vec<Neuron>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -638,12 +638,12 @@ pub struct ListProposals {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListProposalsResponse {
-    proposals: Vec<ProposalData>,
+    pub proposals: Vec<ProposalData>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct StakeMaturity {
-    percentage_to_stake: Option<u32>,
+    pub percentage_to_stake: Option<u32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -664,29 +664,29 @@ pub enum Command {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ManageNeuron {
-    subaccount: serde_bytes::ByteBuf,
-    command: Option<Command>,
+    pub subaccount: serde_bytes::ByteBuf,
+    pub command: Option<Command>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SplitResponse {
-    created_neuron_id: Option<NeuronId>,
+    pub created_neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DisburseMaturityResponse {
-    amount_disbursed_e8s: u64,
+    pub amount_disbursed_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ClaimOrRefreshResponse {
-    refreshed_neuron_id: Option<NeuronId>,
+    pub refreshed_neuron_id: Option<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct StakeMaturityResponse {
-    maturity_e8s: u64,
-    staked_maturity_e8s: u64,
+    pub maturity_e8s: u64,
+    pub staked_maturity_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -697,7 +697,7 @@ pub struct MergeMaturityResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DisburseResponse {
-    transfer_block_height: u64,
+    pub transfer_block_height: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 4878b0b12..4ee8d9890 100644
+index 7cbb51d8e..efb2fe93b 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -4,12 +4,12 @@
+@@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -18,9 +18,9 @@ index 4878b0b12..4ee8d9890 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum MetadataValue {
-@@ -80,30 +80,25 @@ pub type Block = Box<Value>;
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct BlockRange { blocks: Vec<Block> }
+@@ -93,23 +93,21 @@ pub struct BlockRange {
+     pub blocks: Vec<Block>,
+ }
  
 -candid::define_function!(pub QueryBlockArchiveFn : (GetBlocksArgs) -> (
 -    BlockRange,
@@ -30,34 +30,26 @@ index 4878b0b12..4ee8d9890 100644
 +pub type QueryBlockArchiveFn = candid::Func;
 +#[derive(CandidType, Deserialize)]
 +pub struct GetBlocksResponse_archived_blocks_inner {
-   pub  callback: QueryBlockArchiveFn,
-   pub  start: BlockIndex,
-   pub  length: candid::Nat,
+     pub callback: QueryBlockArchiveFn,
+     pub start: BlockIndex,
+     pub length: candid::Nat,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResponse {
-   pub  certificate: Option<serde_bytes::ByteBuf>,
-   pub  first_index: BlockIndex,
-   pub  blocks: Vec<Block>,
-   pub  chain_length: u64,
--  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_item>,
-+  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
+     pub certificate: Option<serde_bytes::ByteBuf>,
+     pub first_index: BlockIndex,
+     pub blocks: Vec<Block>,
+     pub chain_length: u64,
+-    pub archived_blocks: Vec<GetBlocksResponse_archived_blocks_item>,
++    pub archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
  }
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct DataCertificate {
--  pub  certificate: Option<serde_bytes::ByteBuf>,
--  pub  hash_tree: serde_bytes::ByteBuf,
--}
-+pub struct DataCertificate { certificate: Option<serde_bytes::ByteBuf>, hash_tree: serde_bytes::ByteBuf }
- 
- pub type TxIndex = candid::Nat;
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -147,29 +142,27 @@ pub struct Transaction {
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct TransactionRange { transactions: Vec<Transaction> }
+@@ -165,27 +163,25 @@ pub struct TransactionRange {
+     pub transactions: Vec<Transaction>,
+ }
  
 -candid::define_function!(pub QueryArchiveFn : (GetTransactionsRequest) -> (
 -    TransactionRange,
@@ -67,65 +59,34 @@ index 4878b0b12..4ee8d9890 100644
 +pub type QueryArchiveFn = candid::Func;
 +#[derive(CandidType, Deserialize)]
 +pub struct GetTransactionsResponse_archived_transactions_inner {
-   pub  callback: QueryArchiveFn,
-   pub  start: TxIndex,
-   pub  length: candid::Nat,
+     pub callback: QueryArchiveFn,
+     pub start: TxIndex,
+     pub length: candid::Nat,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetTransactionsResponse {
-   pub  first_index: TxIndex,
-   pub  log_length: candid::Nat,
-   pub  transactions: Vec<Transaction>,
-   pub  archived_transactions: Vec<
--    GetTransactionsResponse_archived_transactions_item
-+    GetTransactionsResponse_archived_transactions_inner
-   >,
+     pub first_index: TxIndex,
+     pub log_length: candid::Nat,
+     pub transactions: Vec<Transaction>,
+-    pub archived_transactions: Vec<GetTransactionsResponse_archived_transactions_item>,
++    pub archived_transactions: Vec<GetTransactionsResponse_archived_transactions_inner>,
  }
  
  pub type Tokens = candid::Nat;
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct icrc1_supported_standards_ret0_item { url: String, name: String }
-+pub struct icrc1_supported_standards_ret0_inner { url: String, name: String }
- 
- pub type Timestamp = u64;
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -198,16 +191,19 @@ pub enum TransferError {
- pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
- 
- pub struct SERVICE(pub candid::Principal);
--impl SERVICE {
-+impl SERVICE{
-   pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
-     (GetBlocksResponse,)
-   > { ic_cdk::call(self.0, "get_blocks", (arg0,)).await }
-   pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
-     ic_cdk::call(self.0, "get_data_certificate", ()).await
-   }
--  pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<
--    (GetTransactionsResponse,)
--  > { ic_cdk::call(self.0, "get_transactions", (arg0,)).await }
-+  pub async fn get_transactions(
-+    &self,
-+    arg0: GetTransactionsRequest,
-+  ) -> CallResult<(GetTransactionsResponse,)> {
-+    ic_cdk::call(self.0, "get_transactions", (arg0,)).await
-+  }
-   pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
-     ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
-   }
-@@ -227,7 +223,7 @@ impl SERVICE {
-     ic_cdk::call(self.0, "icrc1_name", ()).await
-   }
-   pub async fn icrc1_supported_standards(&self) -> CallResult<
--    (Vec<icrc1_supported_standards_ret0_item>,)
-+    (Vec<icrc1_supported_standards_ret0_inner>,)
-   > { ic_cdk::call(self.0, "icrc1_supported_standards", ()).await }
-   pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
-     ic_cdk::call(self.0, "icrc1_symbol", ()).await
-@@ -239,4 +235,3 @@ impl SERVICE {
-     (TransferResult,)
-   > { ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await }
+-pub struct icrc1_supported_standards_ret0_item {
++pub struct icrc1_supported_standards_ret0_inner {
+     pub url: String,
+     pub name: String,
  }
--
+@@ -248,7 +244,7 @@ impl SERVICE {
+     pub async fn icrc1_name(&self) -> CallResult<(String,)> {
+         ic_cdk::call(self.0, "icrc1_name", ()).await
+     }
+-    pub async fn icrc1_supported_standards(&self) -> CallResult<(Vec<icrc1_supported_standards_ret0_item>,)> {
++    pub async fn icrc1_supported_standards(&self) -> CallResult<(Vec<icrc1_supported_standards_ret0_inner>,)> {
+         ic_cdk::call(self.0, "icrc1_supported_standards", ()).await
+     }
+     pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -12,225 +12,248 @@ use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum MetadataValue {
-  Int(candid::Int),
-  Nat(candid::Nat),
-  Blob(serde_bytes::ByteBuf),
-  Text(String),
+    Int(candid::Int),
+    Nat(candid::Nat),
+    Blob(serde_bytes::ByteBuf),
+    Text(String),
 }
 
 pub type Subaccount = serde_bytes::ByteBuf;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Account { owner: candid::Principal, subaccount: Option<Subaccount> }
+pub struct Account {
+    owner: candid::Principal,
+    subaccount: Option<Subaccount>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum ChangeFeeCollector { SetTo(Account), Unset }
+pub enum ChangeFeeCollector {
+    SetTo(Account),
+    Unset,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpgradeArgs {
-  pub  token_symbol: Option<String>,
-  pub  transfer_fee: Option<u64>,
-  pub  metadata: Option<Vec<(String,MetadataValue,)>>,
-  pub  change_fee_collector: Option<ChangeFeeCollector>,
-  pub  token_name: Option<String>,
+    pub token_symbol: Option<String>,
+    pub transfer_fee: Option<u64>,
+    pub metadata: Option<Vec<(String, MetadataValue)>>,
+    pub change_fee_collector: Option<ChangeFeeCollector>,
+    pub token_name: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InitArgs_archive_options {
-  pub  num_blocks_to_archive: u64,
-  pub  trigger_threshold: u64,
-  pub  max_message_size_bytes: Option<u64>,
-  pub  cycles_for_archive_creation: Option<u64>,
-  pub  node_max_memory_size_bytes: Option<u64>,
-  pub  controller_id: candid::Principal,
+    pub num_blocks_to_archive: u64,
+    pub trigger_threshold: u64,
+    pub max_message_size_bytes: Option<u64>,
+    pub cycles_for_archive_creation: Option<u64>,
+    pub node_max_memory_size_bytes: Option<u64>,
+    pub controller_id: candid::Principal,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InitArgs {
-  pub  token_symbol: String,
-  pub  transfer_fee: u64,
-  pub  metadata: Vec<(String,MetadataValue,)>,
-  pub  minting_account: Account,
-  pub  initial_balances: Vec<(Account,u64,)>,
-  pub  fee_collector_account: Option<Account>,
-  pub  archive_options: InitArgs_archive_options,
-  pub  token_name: String,
+    pub token_symbol: String,
+    pub transfer_fee: u64,
+    pub metadata: Vec<(String, MetadataValue)>,
+    pub minting_account: Account,
+    pub initial_balances: Vec<(Account, u64)>,
+    pub fee_collector_account: Option<Account>,
+    pub archive_options: InitArgs_archive_options,
+    pub token_name: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum LedgerArg { Upgrade(Option<UpgradeArgs>), Init(InitArgs) }
+pub enum LedgerArg {
+    Upgrade(Option<UpgradeArgs>),
+    Init(InitArgs),
+}
 
 pub type BlockIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetBlocksArgs { start: BlockIndex, length: candid::Nat }
+pub struct GetBlocksArgs {
+    start: BlockIndex,
+    length: candid::Nat,
+}
 
-pub type Map = Vec<(String,Box<Value>,)>;
+pub type Map = Vec<(String, Box<Value>)>;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum Value {
-  Int(candid::Int),
-  Map(Map),
-  Nat(candid::Nat),
-  Nat64(u64),
-  Blob(serde_bytes::ByteBuf),
-  Text(String),
-  Array(Vec<Box<Value>>),
+    Int(candid::Int),
+    Map(Map),
+    Nat(candid::Nat),
+    Nat64(u64),
+    Blob(serde_bytes::ByteBuf),
+    Text(String),
+    Array(Vec<Box<Value>>),
 }
 
 pub type Block = Box<Value>;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct BlockRange { blocks: Vec<Block> }
+pub struct BlockRange {
+    blocks: Vec<Block>,
+}
 
 pub type QueryBlockArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse_archived_blocks_inner {
-  pub  callback: QueryBlockArchiveFn,
-  pub  start: BlockIndex,
-  pub  length: candid::Nat,
+    pub callback: QueryBlockArchiveFn,
+    pub start: BlockIndex,
+    pub length: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
-  pub  certificate: Option<serde_bytes::ByteBuf>,
-  pub  first_index: BlockIndex,
-  pub  blocks: Vec<Block>,
-  pub  chain_length: u64,
-  pub  archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
+    pub certificate: Option<serde_bytes::ByteBuf>,
+    pub first_index: BlockIndex,
+    pub blocks: Vec<Block>,
+    pub chain_length: u64,
+    pub archived_blocks: Vec<GetBlocksResponse_archived_blocks_inner>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DataCertificate { certificate: Option<serde_bytes::ByteBuf>, hash_tree: serde_bytes::ByteBuf }
+pub struct DataCertificate {
+    certificate: Option<serde_bytes::ByteBuf>,
+    hash_tree: serde_bytes::ByteBuf,
+}
 
 pub type TxIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetTransactionsRequest { start: TxIndex, length: candid::Nat }
+pub struct GetTransactionsRequest {
+    start: TxIndex,
+    length: candid::Nat,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction_burn_inner {
-  pub  from: Account,
-  pub  memo: Option<serde_bytes::ByteBuf>,
-  pub  created_at_time: Option<u64>,
-  pub  amount: candid::Nat,
+    pub from: Account,
+    pub memo: Option<serde_bytes::ByteBuf>,
+    pub created_at_time: Option<u64>,
+    pub amount: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction_mint_inner {
-  pub  to: Account,
-  pub  memo: Option<serde_bytes::ByteBuf>,
-  pub  created_at_time: Option<u64>,
-  pub  amount: candid::Nat,
+    pub to: Account,
+    pub memo: Option<serde_bytes::ByteBuf>,
+    pub created_at_time: Option<u64>,
+    pub amount: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction_transfer_inner {
-  pub  to: Account,
-  pub  fee: Option<candid::Nat>,
-  pub  from: Account,
-  pub  memo: Option<serde_bytes::ByteBuf>,
-  pub  created_at_time: Option<u64>,
-  pub  amount: candid::Nat,
+    pub to: Account,
+    pub fee: Option<candid::Nat>,
+    pub from: Account,
+    pub memo: Option<serde_bytes::ByteBuf>,
+    pub created_at_time: Option<u64>,
+    pub amount: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Transaction {
-  pub  burn: Option<Transaction_burn_inner>,
-  pub  kind: String,
-  pub  mint: Option<Transaction_mint_inner>,
-  pub  timestamp: u64,
-  pub  transfer: Option<Transaction_transfer_inner>,
+    pub burn: Option<Transaction_burn_inner>,
+    pub kind: String,
+    pub mint: Option<Transaction_mint_inner>,
+    pub timestamp: u64,
+    pub transfer: Option<Transaction_transfer_inner>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct TransactionRange { transactions: Vec<Transaction> }
+pub struct TransactionRange {
+    transactions: Vec<Transaction>,
+}
 
 pub type QueryArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse_archived_transactions_inner {
-  pub  callback: QueryArchiveFn,
-  pub  start: TxIndex,
-  pub  length: candid::Nat,
+    pub callback: QueryArchiveFn,
+    pub start: TxIndex,
+    pub length: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
-  pub  first_index: TxIndex,
-  pub  log_length: candid::Nat,
-  pub  transactions: Vec<Transaction>,
-  pub  archived_transactions: Vec<
-    GetTransactionsResponse_archived_transactions_inner
-  >,
+    pub first_index: TxIndex,
+    pub log_length: candid::Nat,
+    pub transactions: Vec<Transaction>,
+    pub archived_transactions: Vec<GetTransactionsResponse_archived_transactions_inner>,
 }
 
 pub type Tokens = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct icrc1_supported_standards_ret0_inner { url: String, name: String }
+pub struct icrc1_supported_standards_ret0_inner {
+    url: String,
+    name: String,
+}
 
 pub type Timestamp = u64;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransferArg {
-  pub  to: Account,
-  pub  fee: Option<Tokens>,
-  pub  memo: Option<serde_bytes::ByteBuf>,
-  pub  from_subaccount: Option<Subaccount>,
-  pub  created_at_time: Option<Timestamp>,
-  pub  amount: Tokens,
+    pub to: Account,
+    pub fee: Option<Tokens>,
+    pub memo: Option<serde_bytes::ByteBuf>,
+    pub from_subaccount: Option<Subaccount>,
+    pub created_at_time: Option<Timestamp>,
+    pub amount: Tokens,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum TransferError {
-  GenericError{ message: String, error_code: candid::Nat },
-  TemporarilyUnavailable,
-  BadBurn{ min_burn_amount: Tokens },
-  Duplicate{ duplicate_of: BlockIndex },
-  BadFee{ expected_fee: Tokens },
-  CreatedInFuture{ ledger_time: u64 },
-  TooOld,
-  InsufficientFunds{ balance: Tokens },
+    GenericError { message: String, error_code: candid::Nat },
+    TemporarilyUnavailable,
+    BadBurn { min_burn_amount: Tokens },
+    Duplicate { duplicate_of: BlockIndex },
+    BadFee { expected_fee: Tokens },
+    CreatedInFuture { ledger_time: u64 },
+    TooOld,
+    InsufficientFunds { balance: Tokens },
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum TransferResult { Ok(BlockIndex), Err(TransferError) }
+pub enum TransferResult {
+    Ok(BlockIndex),
+    Err(TransferError),
+}
 
 pub struct SERVICE(pub candid::Principal);
-impl SERVICE{
-  pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<
-    (GetBlocksResponse,)
-  > { ic_cdk::call(self.0, "get_blocks", (arg0,)).await }
-  pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
-    ic_cdk::call(self.0, "get_data_certificate", ()).await
-  }
-  pub async fn get_transactions(
-    &self,
-    arg0: GetTransactionsRequest,
-  ) -> CallResult<(GetTransactionsResponse,)> {
-    ic_cdk::call(self.0, "get_transactions", (arg0,)).await
-  }
-  pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
-    ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
-  }
-  pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
-    ic_cdk::call(self.0, "icrc1_decimals", ()).await
-  }
-  pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
-    ic_cdk::call(self.0, "icrc1_fee", ()).await
-  }
-  pub async fn icrc1_metadata(&self) -> CallResult<
-    (Vec<(String,MetadataValue,)>,)
-  > { ic_cdk::call(self.0, "icrc1_metadata", ()).await }
-  pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
-    ic_cdk::call(self.0, "icrc1_minting_account", ()).await
-  }
-  pub async fn icrc1_name(&self) -> CallResult<(String,)> {
-    ic_cdk::call(self.0, "icrc1_name", ()).await
-  }
-  pub async fn icrc1_supported_standards(&self) -> CallResult<
-    (Vec<icrc1_supported_standards_ret0_inner>,)
-  > { ic_cdk::call(self.0, "icrc1_supported_standards", ()).await }
-  pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
-    ic_cdk::call(self.0, "icrc1_symbol", ()).await
-  }
-  pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
-    ic_cdk::call(self.0, "icrc1_total_supply", ()).await
-  }
-  pub async fn icrc1_transfer(&self, arg0: TransferArg) -> CallResult<
-    (TransferResult,)
-  > { ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await }
+impl SERVICE {
+    pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
+        ic_cdk::call(self.0, "get_blocks", (arg0,)).await
+    }
+    pub async fn get_data_certificate(&self) -> CallResult<(DataCertificate,)> {
+        ic_cdk::call(self.0, "get_data_certificate", ()).await
+    }
+    pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
+        ic_cdk::call(self.0, "get_transactions", (arg0,)).await
+    }
+    pub async fn icrc1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
+        ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
+    }
+    pub async fn icrc1_decimals(&self) -> CallResult<(u8,)> {
+        ic_cdk::call(self.0, "icrc1_decimals", ()).await
+    }
+    pub async fn icrc1_fee(&self) -> CallResult<(Tokens,)> {
+        ic_cdk::call(self.0, "icrc1_fee", ()).await
+    }
+    pub async fn icrc1_metadata(&self) -> CallResult<(Vec<(String, MetadataValue)>,)> {
+        ic_cdk::call(self.0, "icrc1_metadata", ()).await
+    }
+    pub async fn icrc1_minting_account(&self) -> CallResult<(Option<Account>,)> {
+        ic_cdk::call(self.0, "icrc1_minting_account", ()).await
+    }
+    pub async fn icrc1_name(&self) -> CallResult<(String,)> {
+        ic_cdk::call(self.0, "icrc1_name", ()).await
+    }
+    pub async fn icrc1_supported_standards(&self) -> CallResult<(Vec<icrc1_supported_standards_ret0_inner>,)> {
+        ic_cdk::call(self.0, "icrc1_supported_standards", ()).await
+    }
+    pub async fn icrc1_symbol(&self) -> CallResult<(String,)> {
+        ic_cdk::call(self.0, "icrc1_symbol", ()).await
+    }
+    pub async fn icrc1_total_supply(&self) -> CallResult<(Tokens,)> {
+        ic_cdk::call(self.0, "icrc1_total_supply", ()).await
+    }
+    pub async fn icrc1_transfer(&self, arg0: TransferArg) -> CallResult<(TransferResult,)> {
+        ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await
+    }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -21,8 +21,8 @@ pub enum MetadataValue {
 pub type Subaccount = serde_bytes::ByteBuf;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Account {
-    owner: candid::Principal,
-    subaccount: Option<Subaccount>,
+    pub owner: candid::Principal,
+    pub subaccount: Option<Subaccount>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -71,8 +71,8 @@ pub enum LedgerArg {
 pub type BlockIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetBlocksArgs {
-    start: BlockIndex,
-    length: candid::Nat,
+    pub start: BlockIndex,
+    pub length: candid::Nat,
 }
 
 pub type Map = Vec<(String, Box<Value>)>;
@@ -90,7 +90,7 @@ pub enum Value {
 pub type Block = Box<Value>;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct BlockRange {
-    blocks: Vec<Block>,
+    pub blocks: Vec<Block>,
 }
 
 pub type QueryBlockArchiveFn = candid::Func;
@@ -112,15 +112,15 @@ pub struct GetBlocksResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DataCertificate {
-    certificate: Option<serde_bytes::ByteBuf>,
-    hash_tree: serde_bytes::ByteBuf,
+    pub certificate: Option<serde_bytes::ByteBuf>,
+    pub hash_tree: serde_bytes::ByteBuf,
 }
 
 pub type TxIndex = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetTransactionsRequest {
-    start: TxIndex,
-    length: candid::Nat,
+    pub start: TxIndex,
+    pub length: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -160,7 +160,7 @@ pub struct Transaction {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransactionRange {
-    transactions: Vec<Transaction>,
+    pub transactions: Vec<Transaction>,
 }
 
 pub type QueryArchiveFn = candid::Func;
@@ -182,8 +182,8 @@ pub struct GetTransactionsResponse {
 pub type Tokens = candid::Nat;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct icrc1_supported_standards_ret0_inner {
-    url: String,
-    name: String,
+    pub url: String,
+    pub name: String,
 }
 
 pub type Timestamp = u64;

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 17d19329e..eb29aeae2 100644
+index 3d08525e4..d85254a2e 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -4,12 +4,12 @@
+@@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -18,26 +18,12 @@ index 17d19329e..eb29aeae2 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SnsRootCanister {
-@@ -82,7 +82,7 @@ pub struct GetSnsCanistersSummaryResponse {
+@@ -91,7 +91,7 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_sns_canisters_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct ListSnsCanistersResponse {
-   pub  root: Option<candid::Principal>,
-   pub  swap: Option<candid::Principal>,
-@@ -124,7 +124,7 @@ pub struct FailedUpdate {
- pub struct SetDappControllersResponse { failed_updates: Vec<FailedUpdate> }
- 
- pub struct SERVICE(pub candid::Principal);
--impl SERVICE {
-+impl SERVICE{
-   pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
-     (CanisterStatusResult,)
-   > { ic_cdk::call(self.0, "canister_status", (arg0,)).await }
-@@ -162,4 +162,3 @@ impl SERVICE {
-     ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
-   }
- }
--
+     pub root: Option<candid::Principal>,
+     pub swap: Option<candid::Principal>,

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -24,7 +24,7 @@ pub struct SnsRootCanister {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterIdRecord {
-    canister_id: candid::Principal,
+    pub canister_id: candid::Principal,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -36,7 +36,7 @@ pub enum CanisterStatusType {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettings {
-    controllers: Vec<candid::Principal>,
+    pub controllers: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -50,7 +50,7 @@ pub struct CanisterStatusResult {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetSnsCanistersSummaryRequest {
-    update_canister_list: Option<bool>,
+    pub update_canister_list: Option<bool>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -104,7 +104,7 @@ pub struct ListSnsCanistersResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RegisterDappCanisterRequest {
-    canister_id: Option<candid::Principal>,
+    pub canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -112,7 +112,7 @@ pub struct register_dapp_canister_ret0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RegisterDappCanistersRequest {
-    canister_ids: Vec<candid::Principal>,
+    pub canister_ids: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -126,8 +126,8 @@ pub struct SetDappControllersRequest {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterCallError {
-    code: Option<i32>,
-    description: String,
+    pub code: Option<i32>,
+    pub description: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -138,7 +138,7 @@ pub struct FailedUpdate {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDappControllersResponse {
-    failed_updates: Vec<FailedUpdate>,
+    pub failed_updates: Vec<FailedUpdate>,
 }
 
 pub struct SERVICE(pub candid::Principal);

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -12,70 +12,80 @@ use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsRootCanister {
-  pub  dapp_canister_ids: Vec<candid::Principal>,
-  pub  testflight: bool,
-  pub  latest_ledger_archive_poll_timestamp_seconds: Option<u64>,
-  pub  archive_canister_ids: Vec<candid::Principal>,
-  pub  governance_canister_id: Option<candid::Principal>,
-  pub  index_canister_id: Option<candid::Principal>,
-  pub  swap_canister_id: Option<candid::Principal>,
-  pub  ledger_canister_id: Option<candid::Principal>,
+    pub dapp_canister_ids: Vec<candid::Principal>,
+    pub testflight: bool,
+    pub latest_ledger_archive_poll_timestamp_seconds: Option<u64>,
+    pub archive_canister_ids: Vec<candid::Principal>,
+    pub governance_canister_id: Option<candid::Principal>,
+    pub index_canister_id: Option<candid::Principal>,
+    pub swap_canister_id: Option<candid::Principal>,
+    pub ledger_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CanisterIdRecord { canister_id: candid::Principal }
+pub struct CanisterIdRecord {
+    canister_id: candid::Principal,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum CanisterStatusType { stopped, stopping, running }
+pub enum CanisterStatusType {
+    stopped,
+    stopping,
+    running,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DefiniteCanisterSettings { controllers: Vec<candid::Principal> }
+pub struct DefiniteCanisterSettings {
+    controllers: Vec<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResult {
-  pub  controller: candid::Principal,
-  pub  status: CanisterStatusType,
-  pub  memory_size: candid::Nat,
-  pub  settings: DefiniteCanisterSettings,
-  pub  module_hash: Option<serde_bytes::ByteBuf>,
+    pub controller: candid::Principal,
+    pub status: CanisterStatusType,
+    pub memory_size: candid::Nat,
+    pub settings: DefiniteCanisterSettings,
+    pub module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetSnsCanistersSummaryRequest { update_canister_list: Option<bool> }
+pub struct GetSnsCanistersSummaryRequest {
+    update_canister_list: Option<bool>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettingsArgs {
-  pub  freezing_threshold: candid::Nat,
-  pub  controllers: Vec<candid::Principal>,
-  pub  memory_allocation: candid::Nat,
-  pub  compute_allocation: candid::Nat,
+    pub freezing_threshold: candid::Nat,
+    pub controllers: Vec<candid::Principal>,
+    pub memory_allocation: candid::Nat,
+    pub compute_allocation: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResultV2 {
-  pub  status: CanisterStatusType,
-  pub  memory_size: candid::Nat,
-  pub  cycles: candid::Nat,
-  pub  settings: DefiniteCanisterSettingsArgs,
-  pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<serde_bytes::ByteBuf>,
+    pub status: CanisterStatusType,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
+    pub settings: DefiniteCanisterSettingsArgs,
+    pub idle_cycles_burned_per_day: candid::Nat,
+    pub module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterSummary {
-  pub  status: Option<CanisterStatusResultV2>,
-  pub  canister_id: Option<candid::Principal>,
+    pub status: Option<CanisterStatusResultV2>,
+    pub canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetSnsCanistersSummaryResponse {
-  pub  root: Option<CanisterSummary>,
-  pub  swap: Option<CanisterSummary>,
-  pub  ledger: Option<CanisterSummary>,
-  pub  index: Option<CanisterSummary>,
-  pub  governance: Option<CanisterSummary>,
-  pub  dapps: Vec<CanisterSummary>,
-  pub  archives: Vec<CanisterSummary>,
+    pub root: Option<CanisterSummary>,
+    pub swap: Option<CanisterSummary>,
+    pub ledger: Option<CanisterSummary>,
+    pub index: Option<CanisterSummary>,
+    pub governance: Option<CanisterSummary>,
+    pub dapps: Vec<CanisterSummary>,
+    pub archives: Vec<CanisterSummary>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -83,81 +93,87 @@ pub struct list_sns_canisters_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct ListSnsCanistersResponse {
-  pub  root: Option<candid::Principal>,
-  pub  swap: Option<candid::Principal>,
-  pub  ledger: Option<candid::Principal>,
-  pub  index: Option<candid::Principal>,
-  pub  governance: Option<candid::Principal>,
-  pub  dapps: Vec<candid::Principal>,
-  pub  archives: Vec<candid::Principal>,
+    pub root: Option<candid::Principal>,
+    pub swap: Option<candid::Principal>,
+    pub ledger: Option<candid::Principal>,
+    pub index: Option<candid::Principal>,
+    pub governance: Option<candid::Principal>,
+    pub dapps: Vec<candid::Principal>,
+    pub archives: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct RegisterDappCanisterRequest { canister_id: Option<candid::Principal> }
+pub struct RegisterDappCanisterRequest {
+    canister_id: Option<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct register_dapp_canister_ret0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct RegisterDappCanistersRequest { canister_ids: Vec<candid::Principal> }
+pub struct RegisterDappCanistersRequest {
+    canister_ids: Vec<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct register_dapp_canisters_ret0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDappControllersRequest {
-  pub  canister_ids: Option<RegisterDappCanistersRequest>,
-  pub  controller_principal_ids: Vec<candid::Principal>,
+    pub canister_ids: Option<RegisterDappCanistersRequest>,
+    pub controller_principal_ids: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CanisterCallError { code: Option<i32>, description: String }
+pub struct CanisterCallError {
+    code: Option<i32>,
+    description: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct FailedUpdate {
-  pub  err: Option<CanisterCallError>,
-  pub  dapp_canister_id: Option<candid::Principal>,
+    pub err: Option<CanisterCallError>,
+    pub dapp_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetDappControllersResponse { failed_updates: Vec<FailedUpdate> }
+pub struct SetDappControllersResponse {
+    failed_updates: Vec<FailedUpdate>,
+}
 
 pub struct SERVICE(pub candid::Principal);
-impl SERVICE{
-  pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<
-    (CanisterStatusResult,)
-  > { ic_cdk::call(self.0, "canister_status", (arg0,)).await }
-  pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
-    ic_cdk::call(self.0, "get_build_metadata", ()).await
-  }
-  pub async fn get_sns_canisters_summary(
-    &self,
-    arg0: GetSnsCanistersSummaryRequest,
-  ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
-    ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
-  }
-  pub async fn list_sns_canisters(
-    &self,
-    arg0: list_sns_canisters_arg0,
-  ) -> CallResult<(ListSnsCanistersResponse,)> {
-    ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
-  }
-  pub async fn register_dapp_canister(
-    &self,
-    arg0: RegisterDappCanisterRequest,
-  ) -> CallResult<(register_dapp_canister_ret0,)> {
-    ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
-  }
-  pub async fn register_dapp_canisters(
-    &self,
-    arg0: RegisterDappCanistersRequest,
-  ) -> CallResult<(register_dapp_canisters_ret0,)> {
-    ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
-  }
-  pub async fn set_dapp_controllers(
-    &self,
-    arg0: SetDappControllersRequest,
-  ) -> CallResult<(SetDappControllersResponse,)> {
-    ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
-  }
+impl SERVICE {
+    pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
+        ic_cdk::call(self.0, "canister_status", (arg0,)).await
+    }
+    pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
+        ic_cdk::call(self.0, "get_build_metadata", ()).await
+    }
+    pub async fn get_sns_canisters_summary(
+        &self,
+        arg0: GetSnsCanistersSummaryRequest,
+    ) -> CallResult<(GetSnsCanistersSummaryResponse,)> {
+        ic_cdk::call(self.0, "get_sns_canisters_summary", (arg0,)).await
+    }
+    pub async fn list_sns_canisters(&self, arg0: list_sns_canisters_arg0) -> CallResult<(ListSnsCanistersResponse,)> {
+        ic_cdk::call(self.0, "list_sns_canisters", (arg0,)).await
+    }
+    pub async fn register_dapp_canister(
+        &self,
+        arg0: RegisterDappCanisterRequest,
+    ) -> CallResult<(register_dapp_canister_ret0,)> {
+        ic_cdk::call(self.0, "register_dapp_canister", (arg0,)).await
+    }
+    pub async fn register_dapp_canisters(
+        &self,
+        arg0: RegisterDappCanistersRequest,
+    ) -> CallResult<(register_dapp_canisters_ret0,)> {
+        ic_cdk::call(self.0, "register_dapp_canisters", (arg0,)).await
+    }
+    pub async fn set_dapp_controllers(
+        &self,
+        arg0: SetDappControllersRequest,
+    ) -> CallResult<(SetDappControllersResponse,)> {
+        ic_cdk::call(self.0, "set_dapp_controllers", (arg0,)).await
+    }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index f71811d32..b373161c8 100644
+index a21002e86..e0827feb2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-@@ -4,17 +4,17 @@
+@@ -3,19 +3,19 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -18,139 +18,46 @@ index f71811d32..b373161c8 100644
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
- pub struct Countries { iso_codes: Vec<String> }
+ pub struct Countries {
+     pub iso_codes: Vec<String>,
+ }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
  pub struct Init {
-   pub  sns_root_canister_id: String,
-   pub  fallback_controller_principal_ids: Vec<String>,
-@@ -79,7 +79,7 @@ pub struct SettleCommunityFundParticipationResult {
+     pub sns_root_canister_id: String,
+     pub fallback_controller_principal_ids: Vec<String>,
+@@ -111,7 +111,7 @@ pub struct SettleCommunityFundParticipationResult {
+ 
+ #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+ pub enum Possibility_2 {
+-    Ok {},
++    Ok,
+     Err(CanisterCallError),
  }
  
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub enum Possibility_2 { Ok{}, Err(CanisterCallError) }
-+pub enum Possibility_2 { Ok, Err(CanisterCallError) }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SetModeCallResult { possibility: Option<Possibility_2> }
-@@ -217,13 +217,13 @@ pub struct GetOpenTicketResponse { result: Option<Result_1> }
+@@ -274,13 +274,13 @@ pub struct GetOpenTicketResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_sale_parameters_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
  pub struct NeuronBasketConstructionParameters {
-   pub  dissolve_delay_interval_seconds: u64,
-   pub  count: u64,
+     pub dissolve_delay_interval_seconds: u64,
+     pub count: u64,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
  pub struct Params {
-   pub  min_participant_icp_e8s: u64,
-   pub  neuron_basket_construction_parameters: Option<
-@@ -302,11 +302,8 @@ pub struct DerivedState {
-   pub  cf_neuron_count: Option<u64>,
+     pub min_participant_icp_e8s: u64,
+     pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
+@@ -375,7 +375,7 @@ pub struct DerivedState {
+     pub cf_neuron_count: Option<u64>,
  }
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct GetStateResponse {
--  pub  swap: Option<Swap>,
--  pub  derived: Option<DerivedState>,
--}
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
-+pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct ListCommunityFundParticipantsRequest {
-@@ -320,10 +317,7 @@ pub struct ListCommunityFundParticipantsResponse {
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct ListDirectParticipantsRequest {
--  pub  offset: Option<u32>,
--  pub  limit: Option<u32>,
--}
-+pub struct ListDirectParticipantsRequest { offset: Option<u32>, limit: Option<u32> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct Participant {
-@@ -335,21 +329,13 @@ pub struct Participant {
- pub struct ListDirectParticipantsResponse { participants: Vec<Participant> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct ListSnsNeuronRecipesRequest {
--  pub  offset: Option<u64>,
--  pub  limit: Option<u32>,
--}
-+pub struct ListSnsNeuronRecipesRequest { offset: Option<u64>, limit: Option<u32> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct ListSnsNeuronRecipesResponse {
--  pub  sns_neuron_recipes: Vec<SnsNeuronRecipe>,
--}
-+pub struct ListSnsNeuronRecipesResponse { sns_neuron_recipes: Vec<SnsNeuronRecipe> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct NewSaleTicketRequest {
--  pub  subaccount: Option<serde_bytes::ByteBuf>,
--  pub  amount_icp_e8s: u64,
--}
-+pub struct NewSaleTicketRequest { subaccount: Option<serde_bytes::ByteBuf>, amount_icp_e8s: u64 }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct InvalidUserAmount {
-@@ -399,28 +385,37 @@ pub struct RefreshBuyerTokensResponse {
- pub struct restore_dapp_controllers_arg0 {}
- 
- pub struct SERVICE(pub candid::Principal);
--impl SERVICE {
--  pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<
--    (ErrorRefundIcpResponse,)
--  > { ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await }
-+impl SERVICE{
-+  pub async fn error_refund_icp(
-+    &self,
-+    arg0: ErrorRefundIcpRequest,
-+  ) -> CallResult<(ErrorRefundIcpResponse,)> {
-+    ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
-+  }
-   pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<
-     (FinalizeSwapResponse,)
-   > { ic_cdk::call(self.0, "finalize_swap", (arg0,)).await }
-   pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<
-     (GetBuyerStateResponse,)
-   > { ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await }
--  pub async fn get_buyers_total(&self, arg0: get_buyers_total_arg0) -> CallResult<
--    (GetBuyersTotalResponse,)
--  > { ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await }
-+  pub async fn get_buyers_total(
-+    &self,
-+    arg0: get_buyers_total_arg0,
-+  ) -> CallResult<(GetBuyersTotalResponse,)> {
-+    ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
-+  }
-   pub async fn get_canister_status(
-     &self,
-     arg0: get_canister_status_arg0,
-   ) -> CallResult<(CanisterStatusResultV2,)> {
-     ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
-   }
--  pub async fn get_derived_state(&self, arg0: get_derived_state_arg0) -> CallResult<
--    (GetDerivedStateResponse,)
--  > { ic_cdk::call(self.0, "get_derived_state", (arg0,)).await }
-+  pub async fn get_derived_state(
-+    &self,
-+    arg0: get_derived_state_arg0,
-+  ) -> CallResult<(GetDerivedStateResponse,)> {
-+    ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
-+  }
-   pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<
-     (GetInitResponse,)
-   > { ic_cdk::call(self.0, "get_init", (arg0,)).await }
-@@ -482,4 +477,3 @@ impl SERVICE {
-     ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
-   }
- }
--
+ pub struct GetStateResponse {
+     pub swap: Option<Swap>,
+     pub derived: Option<DerivedState>,

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -11,150 +11,197 @@ use ic_cdk::api::call::CallResult;
 // use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
-pub struct Countries { iso_codes: Vec<String> }
+pub struct Countries {
+    iso_codes: Vec<String>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Init {
-  pub  sns_root_canister_id: String,
-  pub  fallback_controller_principal_ids: Vec<String>,
-  pub  neuron_minimum_stake_e8s: Option<u64>,
-  pub  confirmation_text: Option<String>,
-  pub  nns_governance_canister_id: String,
-  pub  transaction_fee_e8s: Option<u64>,
-  pub  icp_ledger_canister_id: String,
-  pub  sns_ledger_canister_id: String,
-  pub  sns_governance_canister_id: String,
-  pub  restricted_countries: Option<Countries>,
+    pub sns_root_canister_id: String,
+    pub fallback_controller_principal_ids: Vec<String>,
+    pub neuron_minimum_stake_e8s: Option<u64>,
+    pub confirmation_text: Option<String>,
+    pub nns_governance_canister_id: String,
+    pub transaction_fee_e8s: Option<u64>,
+    pub icp_ledger_canister_id: String,
+    pub sns_ledger_canister_id: String,
+    pub sns_governance_canister_id: String,
+    pub restricted_countries: Option<Countries>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ErrorRefundIcpRequest { source_principal_id: Option<candid::Principal> }
+pub struct ErrorRefundIcpRequest {
+    source_principal_id: Option<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Ok { block_height: Option<u64> }
+pub struct Ok {
+    block_height: Option<u64>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Err { description: Option<String>, error_type: Option<i32> }
+pub struct Err {
+    description: Option<String>,
+    error_type: Option<i32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result { Ok(Ok), Err(Err) }
+pub enum Result {
+    Ok(Ok),
+    Err(Err),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ErrorRefundIcpResponse { result: Option<Result> }
+pub struct ErrorRefundIcpResponse {
+    result: Option<Result>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct finalize_swap_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CanisterCallError { code: Option<i32>, description: String }
+pub struct CanisterCallError {
+    code: Option<i32>,
+    description: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct FailedUpdate {
-  pub  err: Option<CanisterCallError>,
-  pub  dapp_canister_id: Option<candid::Principal>,
+    pub err: Option<CanisterCallError>,
+    pub dapp_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetDappControllersResponse { failed_updates: Vec<FailedUpdate> }
+pub struct SetDappControllersResponse {
+    failed_updates: Vec<FailedUpdate>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Possibility { Ok(SetDappControllersResponse), Err(CanisterCallError) }
+pub enum Possibility {
+    Ok(SetDappControllersResponse),
+    Err(CanisterCallError),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetDappControllersCallResult { possibility: Option<Possibility> }
+pub struct SetDappControllersCallResult {
+    possibility: Option<Possibility>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GovernanceError { error_message: String, error_type: i32 }
+pub struct GovernanceError {
+    error_message: String,
+    error_type: i32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Response { governance_error: Option<GovernanceError> }
+pub struct Response {
+    governance_error: Option<GovernanceError>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Possibility_1 { Ok(Response), Err(CanisterCallError) }
+pub enum Possibility_1 {
+    Ok(Response),
+    Err(CanisterCallError),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SettleCommunityFundParticipationResult {
-  pub  possibility: Option<Possibility_1>,
+    pub possibility: Option<Possibility_1>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Possibility_2 { Ok, Err(CanisterCallError) }
+pub enum Possibility_2 {
+    Ok,
+    Err(CanisterCallError),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SetModeCallResult { possibility: Option<Possibility_2> }
+pub struct SetModeCallResult {
+    possibility: Option<Possibility_2>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SweepResult {
-  pub  failure: u32,
-  pub  skipped: u32,
-  pub  invalid: u32,
-  pub  success: u32,
-  pub  global_failures: u32,
+    pub failure: u32,
+    pub skipped: u32,
+    pub invalid: u32,
+    pub success: u32,
+    pub global_failures: u32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct FinalizeSwapResponse {
-  pub  set_dapp_controllers_call_result: Option<SetDappControllersCallResult>,
-  pub  settle_community_fund_participation_result: Option<
-    SettleCommunityFundParticipationResult
-  >,
-  pub  error_message: Option<String>,
-  pub  set_mode_call_result: Option<SetModeCallResult>,
-  pub  sweep_icp_result: Option<SweepResult>,
-  pub  claim_neuron_result: Option<SweepResult>,
-  pub  sweep_sns_result: Option<SweepResult>,
+    pub set_dapp_controllers_call_result: Option<SetDappControllersCallResult>,
+    pub settle_community_fund_participation_result: Option<SettleCommunityFundParticipationResult>,
+    pub error_message: Option<String>,
+    pub set_mode_call_result: Option<SetModeCallResult>,
+    pub sweep_icp_result: Option<SweepResult>,
+    pub claim_neuron_result: Option<SweepResult>,
+    pub sweep_sns_result: Option<SweepResult>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetBuyerStateRequest { principal_id: Option<candid::Principal> }
+pub struct GetBuyerStateRequest {
+    principal_id: Option<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TransferableAmount {
-  pub  transfer_fee_paid_e8s: Option<u64>,
-  pub  transfer_start_timestamp_seconds: u64,
-  pub  amount_e8s: u64,
-  pub  amount_transferred_e8s: Option<u64>,
-  pub  transfer_success_timestamp_seconds: u64,
+    pub transfer_fee_paid_e8s: Option<u64>,
+    pub transfer_start_timestamp_seconds: u64,
+    pub amount_e8s: u64,
+    pub amount_transferred_e8s: Option<u64>,
+    pub transfer_success_timestamp_seconds: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct BuyerState { icp: Option<TransferableAmount> }
+pub struct BuyerState {
+    icp: Option<TransferableAmount>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetBuyerStateResponse { buyer_state: Option<BuyerState> }
+pub struct GetBuyerStateResponse {
+    buyer_state: Option<BuyerState>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_buyers_total_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetBuyersTotalResponse { buyers_total: u64 }
+pub struct GetBuyersTotalResponse {
+    buyers_total: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_canister_status_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum CanisterStatusType { stopped, stopping, running }
+pub enum CanisterStatusType {
+    stopped,
+    stopping,
+    running,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DefiniteCanisterSettingsArgs {
-  pub  controller: candid::Principal,
-  pub  freezing_threshold: candid::Nat,
-  pub  controllers: Vec<candid::Principal>,
-  pub  memory_allocation: candid::Nat,
-  pub  compute_allocation: candid::Nat,
+    pub controller: candid::Principal,
+    pub freezing_threshold: candid::Nat,
+    pub controllers: Vec<candid::Principal>,
+    pub memory_allocation: candid::Nat,
+    pub compute_allocation: candid::Nat,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterStatusResultV2 {
-  pub  controller: candid::Principal,
-  pub  status: CanisterStatusType,
-  pub  freezing_threshold: candid::Nat,
-  pub  balance: Vec<(serde_bytes::ByteBuf,candid::Nat,)>,
-  pub  memory_size: candid::Nat,
-  pub  cycles: candid::Nat,
-  pub  settings: DefiniteCanisterSettingsArgs,
-  pub  idle_cycles_burned_per_day: candid::Nat,
-  pub  module_hash: Option<serde_bytes::ByteBuf>,
+    pub controller: candid::Principal,
+    pub status: CanisterStatusType,
+    pub freezing_threshold: candid::Nat,
+    pub balance: Vec<(serde_bytes::ByteBuf, candid::Nat)>,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
+    pub settings: DefiniteCanisterSettingsArgs,
+    pub idle_cycles_burned_per_day: candid::Nat,
+    pub module_hash: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -162,26 +209,28 @@ pub struct get_derived_state_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetDerivedStateResponse {
-  pub  sns_tokens_per_icp: Option<f64>,
-  pub  buyer_total_icp_e8s: Option<u64>,
-  pub  cf_participant_count: Option<u64>,
-  pub  direct_participant_count: Option<u64>,
-  pub  cf_neuron_count: Option<u64>,
+    pub sns_tokens_per_icp: Option<f64>,
+    pub buyer_total_icp_e8s: Option<u64>,
+    pub cf_participant_count: Option<u64>,
+    pub direct_participant_count: Option<u64>,
+    pub cf_neuron_count: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_init_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetInitResponse { init: Option<Init> }
+pub struct GetInitResponse {
+    init: Option<Init>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_lifecycle_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetLifecycleResponse {
-  pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
-  pub  lifecycle: Option<i32>,
+    pub decentralization_sale_open_timestamp_seconds: Option<u64>,
+    pub lifecycle: Option<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -189,180 +238,226 @@ pub struct get_open_ticket_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Icrc1Account {
-  pub  owner: Option<candid::Principal>,
-  pub  subaccount: Option<serde_bytes::ByteBuf>,
+    pub owner: Option<candid::Principal>,
+    pub subaccount: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Ticket {
-  pub  creation_time: u64,
-  pub  ticket_id: u64,
-  pub  account: Option<Icrc1Account>,
-  pub  amount_icp_e8s: u64,
+    pub creation_time: u64,
+    pub ticket_id: u64,
+    pub account: Option<Icrc1Account>,
+    pub amount_icp_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Ok_1 { ticket: Option<Ticket> }
+pub struct Ok_1 {
+    ticket: Option<Ticket>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Err_1 { error_type: Option<i32> }
+pub struct Err_1 {
+    error_type: Option<i32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result_1 { Ok(Ok_1), Err(Err_1) }
+pub enum Result_1 {
+    Ok(Ok_1),
+    Err(Err_1),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetOpenTicketResponse { result: Option<Result_1> }
+pub struct GetOpenTicketResponse {
+    result: Option<Result_1>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_sale_parameters_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct NeuronBasketConstructionParameters {
-  pub  dissolve_delay_interval_seconds: u64,
-  pub  count: u64,
+    pub dissolve_delay_interval_seconds: u64,
+    pub count: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Params {
-  pub  min_participant_icp_e8s: u64,
-  pub  neuron_basket_construction_parameters: Option<
-    NeuronBasketConstructionParameters
-  >,
-  pub  max_icp_e8s: u64,
-  pub  swap_due_timestamp_seconds: u64,
-  pub  min_participants: u32,
-  pub  sns_token_e8s: u64,
-  pub  sale_delay_seconds: Option<u64>,
-  pub  max_participant_icp_e8s: u64,
-  pub  min_icp_e8s: u64,
+    pub min_participant_icp_e8s: u64,
+    pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
+    pub max_icp_e8s: u64,
+    pub swap_due_timestamp_seconds: u64,
+    pub min_participants: u32,
+    pub sns_token_e8s: u64,
+    pub sale_delay_seconds: Option<u64>,
+    pub max_participant_icp_e8s: u64,
+    pub min_icp_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetSaleParametersResponse { params: Option<Params> }
+pub struct GetSaleParametersResponse {
+    params: Option<Params>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_state_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NeuronId { id: serde_bytes::ByteBuf }
+pub struct NeuronId {
+    id: serde_bytes::ByteBuf,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronAttributes {
-  pub  dissolve_delay_seconds: u64,
-  pub  memo: u64,
-  pub  followees: Vec<NeuronId>,
+    pub dissolve_delay_seconds: u64,
+    pub memo: u64,
+    pub followees: Vec<NeuronId>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CfInvestment { hotkey_principal: String, nns_neuron_id: u64 }
+pub struct CfInvestment {
+    hotkey_principal: String,
+    nns_neuron_id: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DirectInvestment { buyer_principal: String }
+pub struct DirectInvestment {
+    buyer_principal: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Investor { CommunityFund(CfInvestment), Direct(DirectInvestment) }
+pub enum Investor {
+    CommunityFund(CfInvestment),
+    Direct(DirectInvestment),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsNeuronRecipe {
-  pub  sns: Option<TransferableAmount>,
-  pub  claimed_status: Option<i32>,
-  pub  neuron_attributes: Option<NeuronAttributes>,
-  pub  investor: Option<Investor>,
+    pub sns: Option<TransferableAmount>,
+    pub claimed_status: Option<i32>,
+    pub neuron_attributes: Option<NeuronAttributes>,
+    pub investor: Option<Investor>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CfNeuron { nns_neuron_id: u64, amount_icp_e8s: u64 }
+pub struct CfNeuron {
+    nns_neuron_id: u64,
+    amount_icp_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct CfParticipant { hotkey_principal: String, cf_neurons: Vec<CfNeuron> }
+pub struct CfParticipant {
+    hotkey_principal: String,
+    cf_neurons: Vec<CfNeuron>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Swap {
-  pub  neuron_recipes: Vec<SnsNeuronRecipe>,
-  pub  next_ticket_id: Option<u64>,
-  pub  decentralization_sale_open_timestamp_seconds: Option<u64>,
-  pub  finalize_swap_in_progress: Option<bool>,
-  pub  cf_participants: Vec<CfParticipant>,
-  pub  init: Option<Init>,
-  pub  purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
-  pub  lifecycle: i32,
-  pub  purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
-  pub  buyers: Vec<(String,BuyerState,)>,
-  pub  params: Option<Params>,
-  pub  open_sns_token_swap_proposal_id: Option<u64>,
+    pub neuron_recipes: Vec<SnsNeuronRecipe>,
+    pub next_ticket_id: Option<u64>,
+    pub decentralization_sale_open_timestamp_seconds: Option<u64>,
+    pub finalize_swap_in_progress: Option<bool>,
+    pub cf_participants: Vec<CfParticipant>,
+    pub init: Option<Init>,
+    pub purge_old_tickets_last_completion_timestamp_nanoseconds: Option<u64>,
+    pub lifecycle: i32,
+    pub purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
+    pub buyers: Vec<(String, BuyerState)>,
+    pub params: Option<Params>,
+    pub open_sns_token_swap_proposal_id: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DerivedState {
-  pub  sns_tokens_per_icp: f32,
-  pub  buyer_total_icp_e8s: u64,
-  pub  cf_participant_count: Option<u64>,
-  pub  direct_participant_count: Option<u64>,
-  pub  cf_neuron_count: Option<u64>,
+    pub sns_tokens_per_icp: f32,
+    pub buyer_total_icp_e8s: u64,
+    pub cf_participant_count: Option<u64>,
+    pub direct_participant_count: Option<u64>,
+    pub cf_neuron_count: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
-pub struct GetStateResponse { pub swap: Option<Swap>, pub derived: Option<DerivedState> }
+pub struct GetStateResponse {
+    pub swap: Option<Swap>,
+    pub derived: Option<DerivedState>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListCommunityFundParticipantsRequest {
-  pub  offset: Option<u64>,
-  pub  limit: Option<u32>,
+    pub offset: Option<u64>,
+    pub limit: Option<u32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListCommunityFundParticipantsResponse {
-  pub  cf_participants: Vec<CfParticipant>,
+    pub cf_participants: Vec<CfParticipant>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListDirectParticipantsRequest { offset: Option<u32>, limit: Option<u32> }
+pub struct ListDirectParticipantsRequest {
+    offset: Option<u32>,
+    limit: Option<u32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Participant {
-  pub  participation: Option<BuyerState>,
-  pub  participant_id: Option<candid::Principal>,
+    pub participation: Option<BuyerState>,
+    pub participant_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListDirectParticipantsResponse { participants: Vec<Participant> }
+pub struct ListDirectParticipantsResponse {
+    participants: Vec<Participant>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListSnsNeuronRecipesRequest { offset: Option<u64>, limit: Option<u32> }
+pub struct ListSnsNeuronRecipesRequest {
+    offset: Option<u64>,
+    limit: Option<u32>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListSnsNeuronRecipesResponse { sns_neuron_recipes: Vec<SnsNeuronRecipe> }
+pub struct ListSnsNeuronRecipesResponse {
+    sns_neuron_recipes: Vec<SnsNeuronRecipe>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NewSaleTicketRequest { subaccount: Option<serde_bytes::ByteBuf>, amount_icp_e8s: u64 }
+pub struct NewSaleTicketRequest {
+    subaccount: Option<serde_bytes::ByteBuf>,
+    amount_icp_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InvalidUserAmount {
-  pub  min_amount_icp_e8s_included: u64,
-  pub  max_amount_icp_e8s_included: u64,
+    pub min_amount_icp_e8s_included: u64,
+    pub max_amount_icp_e8s_included: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Err_2 {
-  pub  invalid_user_amount: Option<InvalidUserAmount>,
-  pub  existing_ticket: Option<Ticket>,
-  pub  error_type: i32,
+    pub invalid_user_amount: Option<InvalidUserAmount>,
+    pub existing_ticket: Option<Ticket>,
+    pub error_type: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result_2 { Ok(Ok_1), Err(Err_2) }
+pub enum Result_2 {
+    Ok(Ok_1),
+    Err(Err_2),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct NewSaleTicketResponse { result: Option<Result_2> }
+pub struct NewSaleTicketResponse {
+    result: Option<Result_2>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct notify_payment_failure_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct OpenRequest {
-  pub  cf_participants: Vec<CfParticipant>,
-  pub  params: Option<Params>,
-  pub  open_sns_token_swap_proposal_id: Option<u64>,
+    pub cf_participants: Vec<CfParticipant>,
+    pub params: Option<Params>,
+    pub open_sns_token_swap_proposal_id: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -370,109 +465,94 @@ pub struct open_ret0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RefreshBuyerTokensRequest {
-  pub  confirmation_text: Option<String>,
-  pub  buyer: String,
+    pub confirmation_text: Option<String>,
+    pub buyer: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct RefreshBuyerTokensResponse {
-  pub  icp_accepted_participation_e8s: u64,
-  pub  icp_ledger_account_balance_e8s: u64,
+    pub icp_accepted_participation_e8s: u64,
+    pub icp_ledger_account_balance_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct restore_dapp_controllers_arg0 {}
 
 pub struct SERVICE(pub candid::Principal);
-impl SERVICE{
-  pub async fn error_refund_icp(
-    &self,
-    arg0: ErrorRefundIcpRequest,
-  ) -> CallResult<(ErrorRefundIcpResponse,)> {
-    ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
-  }
-  pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<
-    (FinalizeSwapResponse,)
-  > { ic_cdk::call(self.0, "finalize_swap", (arg0,)).await }
-  pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<
-    (GetBuyerStateResponse,)
-  > { ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await }
-  pub async fn get_buyers_total(
-    &self,
-    arg0: get_buyers_total_arg0,
-  ) -> CallResult<(GetBuyersTotalResponse,)> {
-    ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
-  }
-  pub async fn get_canister_status(
-    &self,
-    arg0: get_canister_status_arg0,
-  ) -> CallResult<(CanisterStatusResultV2,)> {
-    ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
-  }
-  pub async fn get_derived_state(
-    &self,
-    arg0: get_derived_state_arg0,
-  ) -> CallResult<(GetDerivedStateResponse,)> {
-    ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
-  }
-  pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<
-    (GetInitResponse,)
-  > { ic_cdk::call(self.0, "get_init", (arg0,)).await }
-  pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> CallResult<
-    (GetLifecycleResponse,)
-  > { ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await }
-  pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> CallResult<
-    (GetOpenTicketResponse,)
-  > { ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await }
-  pub async fn get_sale_parameters(
-    &self,
-    arg0: get_sale_parameters_arg0,
-  ) -> CallResult<(GetSaleParametersResponse,)> {
-    ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
-  }
-  pub async fn get_state(&self, arg0: get_state_arg0) -> CallResult<
-    (GetStateResponse,)
-  > { ic_cdk::call(self.0, "get_state", (arg0,)).await }
-  pub async fn list_community_fund_participants(
-    &self,
-    arg0: ListCommunityFundParticipantsRequest,
-  ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
-    ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
-  }
-  pub async fn list_direct_participants(
-    &self,
-    arg0: ListDirectParticipantsRequest,
-  ) -> CallResult<(ListDirectParticipantsResponse,)> {
-    ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
-  }
-  pub async fn list_sns_neuron_recipes(
-    &self,
-    arg0: ListSnsNeuronRecipesRequest,
-  ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
-    ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
-  }
-  pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<
-    (NewSaleTicketResponse,)
-  > { ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await }
-  pub async fn notify_payment_failure(
-    &self,
-    arg0: notify_payment_failure_arg0,
-  ) -> CallResult<(Ok_1,)> {
-    ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
-  }
-  pub async fn open(&self, arg0: OpenRequest) -> CallResult<(open_ret0,)> {
-    ic_cdk::call(self.0, "open", (arg0,)).await
-  }
-  pub async fn refresh_buyer_tokens(
-    &self,
-    arg0: RefreshBuyerTokensRequest,
-  ) -> CallResult<(RefreshBuyerTokensResponse,)> {
-    ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
-  }
-  pub async fn restore_dapp_controllers(
-    &self,
-    arg0: restore_dapp_controllers_arg0,
-  ) -> CallResult<(SetDappControllersCallResult,)> {
-    ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
-  }
+impl SERVICE {
+    pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
+        ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await
+    }
+    pub async fn finalize_swap(&self, arg0: finalize_swap_arg0) -> CallResult<(FinalizeSwapResponse,)> {
+        ic_cdk::call(self.0, "finalize_swap", (arg0,)).await
+    }
+    pub async fn get_buyer_state(&self, arg0: GetBuyerStateRequest) -> CallResult<(GetBuyerStateResponse,)> {
+        ic_cdk::call(self.0, "get_buyer_state", (arg0,)).await
+    }
+    pub async fn get_buyers_total(&self, arg0: get_buyers_total_arg0) -> CallResult<(GetBuyersTotalResponse,)> {
+        ic_cdk::call(self.0, "get_buyers_total", (arg0,)).await
+    }
+    pub async fn get_canister_status(&self, arg0: get_canister_status_arg0) -> CallResult<(CanisterStatusResultV2,)> {
+        ic_cdk::call(self.0, "get_canister_status", (arg0,)).await
+    }
+    pub async fn get_derived_state(&self, arg0: get_derived_state_arg0) -> CallResult<(GetDerivedStateResponse,)> {
+        ic_cdk::call(self.0, "get_derived_state", (arg0,)).await
+    }
+    pub async fn get_init(&self, arg0: get_init_arg0) -> CallResult<(GetInitResponse,)> {
+        ic_cdk::call(self.0, "get_init", (arg0,)).await
+    }
+    pub async fn get_lifecycle(&self, arg0: get_lifecycle_arg0) -> CallResult<(GetLifecycleResponse,)> {
+        ic_cdk::call(self.0, "get_lifecycle", (arg0,)).await
+    }
+    pub async fn get_open_ticket(&self, arg0: get_open_ticket_arg0) -> CallResult<(GetOpenTicketResponse,)> {
+        ic_cdk::call(self.0, "get_open_ticket", (arg0,)).await
+    }
+    pub async fn get_sale_parameters(
+        &self,
+        arg0: get_sale_parameters_arg0,
+    ) -> CallResult<(GetSaleParametersResponse,)> {
+        ic_cdk::call(self.0, "get_sale_parameters", (arg0,)).await
+    }
+    pub async fn get_state(&self, arg0: get_state_arg0) -> CallResult<(GetStateResponse,)> {
+        ic_cdk::call(self.0, "get_state", (arg0,)).await
+    }
+    pub async fn list_community_fund_participants(
+        &self,
+        arg0: ListCommunityFundParticipantsRequest,
+    ) -> CallResult<(ListCommunityFundParticipantsResponse,)> {
+        ic_cdk::call(self.0, "list_community_fund_participants", (arg0,)).await
+    }
+    pub async fn list_direct_participants(
+        &self,
+        arg0: ListDirectParticipantsRequest,
+    ) -> CallResult<(ListDirectParticipantsResponse,)> {
+        ic_cdk::call(self.0, "list_direct_participants", (arg0,)).await
+    }
+    pub async fn list_sns_neuron_recipes(
+        &self,
+        arg0: ListSnsNeuronRecipesRequest,
+    ) -> CallResult<(ListSnsNeuronRecipesResponse,)> {
+        ic_cdk::call(self.0, "list_sns_neuron_recipes", (arg0,)).await
+    }
+    pub async fn new_sale_ticket(&self, arg0: NewSaleTicketRequest) -> CallResult<(NewSaleTicketResponse,)> {
+        ic_cdk::call(self.0, "new_sale_ticket", (arg0,)).await
+    }
+    pub async fn notify_payment_failure(&self, arg0: notify_payment_failure_arg0) -> CallResult<(Ok_1,)> {
+        ic_cdk::call(self.0, "notify_payment_failure", (arg0,)).await
+    }
+    pub async fn open(&self, arg0: OpenRequest) -> CallResult<(open_ret0,)> {
+        ic_cdk::call(self.0, "open", (arg0,)).await
+    }
+    pub async fn refresh_buyer_tokens(
+        &self,
+        arg0: RefreshBuyerTokensRequest,
+    ) -> CallResult<(RefreshBuyerTokensResponse,)> {
+        ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
+    }
+    pub async fn restore_dapp_controllers(
+        &self,
+        arg0: restore_dapp_controllers_arg0,
+    ) -> CallResult<(SetDappControllersCallResult,)> {
+        ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
+    }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -12,7 +12,7 @@ use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Countries {
-    iso_codes: Vec<String>,
+    pub iso_codes: Vec<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -31,18 +31,18 @@ pub struct Init {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ErrorRefundIcpRequest {
-    source_principal_id: Option<candid::Principal>,
+    pub source_principal_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Ok {
-    block_height: Option<u64>,
+    pub block_height: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Err {
-    description: Option<String>,
-    error_type: Option<i32>,
+    pub description: Option<String>,
+    pub error_type: Option<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -53,7 +53,7 @@ pub enum Result {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ErrorRefundIcpResponse {
-    result: Option<Result>,
+    pub result: Option<Result>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -61,8 +61,8 @@ pub struct finalize_swap_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CanisterCallError {
-    code: Option<i32>,
-    description: String,
+    pub code: Option<i32>,
+    pub description: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -73,7 +73,7 @@ pub struct FailedUpdate {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDappControllersResponse {
-    failed_updates: Vec<FailedUpdate>,
+    pub failed_updates: Vec<FailedUpdate>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -84,18 +84,18 @@ pub enum Possibility {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetDappControllersCallResult {
-    possibility: Option<Possibility>,
+    pub possibility: Option<Possibility>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GovernanceError {
-    error_message: String,
-    error_type: i32,
+    pub error_message: String,
+    pub error_type: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Response {
-    governance_error: Option<GovernanceError>,
+    pub governance_error: Option<GovernanceError>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -117,7 +117,7 @@ pub enum Possibility_2 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetModeCallResult {
-    possibility: Option<Possibility_2>,
+    pub possibility: Option<Possibility_2>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -142,7 +142,7 @@ pub struct FinalizeSwapResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetBuyerStateRequest {
-    principal_id: Option<candid::Principal>,
+    pub principal_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -156,12 +156,12 @@ pub struct TransferableAmount {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct BuyerState {
-    icp: Option<TransferableAmount>,
+    pub icp: Option<TransferableAmount>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetBuyerStateResponse {
-    buyer_state: Option<BuyerState>,
+    pub buyer_state: Option<BuyerState>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -169,7 +169,7 @@ pub struct get_buyers_total_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetBuyersTotalResponse {
-    buyers_total: u64,
+    pub buyers_total: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -221,7 +221,7 @@ pub struct get_init_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetInitResponse {
-    init: Option<Init>,
+    pub init: Option<Init>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -252,12 +252,12 @@ pub struct Ticket {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Ok_1 {
-    ticket: Option<Ticket>,
+    pub ticket: Option<Ticket>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Err_1 {
-    error_type: Option<i32>,
+    pub error_type: Option<i32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -268,7 +268,7 @@ pub enum Result_1 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetOpenTicketResponse {
-    result: Option<Result_1>,
+    pub result: Option<Result_1>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -295,7 +295,7 @@ pub struct Params {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetSaleParametersResponse {
-    params: Option<Params>,
+    pub params: Option<Params>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -303,7 +303,7 @@ pub struct get_state_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronId {
-    id: serde_bytes::ByteBuf,
+    pub id: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -315,13 +315,13 @@ pub struct NeuronAttributes {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CfInvestment {
-    hotkey_principal: String,
-    nns_neuron_id: u64,
+    pub hotkey_principal: String,
+    pub nns_neuron_id: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DirectInvestment {
-    buyer_principal: String,
+    pub buyer_principal: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -340,14 +340,14 @@ pub struct SnsNeuronRecipe {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CfNeuron {
-    nns_neuron_id: u64,
-    amount_icp_e8s: u64,
+    pub nns_neuron_id: u64,
+    pub amount_icp_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct CfParticipant {
-    hotkey_principal: String,
-    cf_neurons: Vec<CfNeuron>,
+    pub hotkey_principal: String,
+    pub cf_neurons: Vec<CfNeuron>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -394,8 +394,8 @@ pub struct ListCommunityFundParticipantsResponse {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListDirectParticipantsRequest {
-    offset: Option<u32>,
-    limit: Option<u32>,
+    pub offset: Option<u32>,
+    pub limit: Option<u32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -406,24 +406,24 @@ pub struct Participant {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListDirectParticipantsResponse {
-    participants: Vec<Participant>,
+    pub participants: Vec<Participant>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListSnsNeuronRecipesRequest {
-    offset: Option<u64>,
-    limit: Option<u32>,
+    pub offset: Option<u64>,
+    pub limit: Option<u32>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListSnsNeuronRecipesResponse {
-    sns_neuron_recipes: Vec<SnsNeuronRecipe>,
+    pub sns_neuron_recipes: Vec<SnsNeuronRecipe>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NewSaleTicketRequest {
-    subaccount: Option<serde_bytes::ByteBuf>,
-    amount_icp_e8s: u64,
+    pub subaccount: Option<serde_bytes::ByteBuf>,
+    pub amount_icp_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -447,7 +447,7 @@ pub enum Result_2 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NewSaleTicketResponse {
-    result: Option<Result_2>,
+    pub result: Option<Result_2>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index a3c5425ed..a8fc475ec 100644
+index 9d36cbf1c..36ae2f307 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -4,12 +4,12 @@
+@@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
@@ -18,46 +18,12 @@ index a3c5425ed..a8fc475ec 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct SnsWasmCanisterInitPayload {
-@@ -120,7 +120,9 @@ pub struct DeployNewSnsResponse {
- pub struct get_allowed_principals_arg0 {}
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct GetAllowedPrincipalsResponse { allowed_principals: Vec<candid::Principal> }
-+pub struct GetAllowedPrincipalsResponse {
-+  pub  allowed_principals: Vec<candid::Principal>,
-+}
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SnsVersion {
-@@ -171,7 +173,7 @@ pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+@@ -208,7 +208,7 @@ pub struct InsertUpgradePathEntriesResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
  pub struct DeployedSns {
-   pub  root_canister_id: Option<candid::Principal>,
-   pub  governance_canister_id: Option<candid::Principal>,
-@@ -181,7 +183,7 @@ pub struct DeployedSns {
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
--pub struct ListDeployedSnsesResponse { instances: Vec<DeployedSns> }
-+pub struct ListDeployedSnsesResponse { pub instances: Vec<DeployedSns> }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct ListUpgradeStepsRequest {
-@@ -236,7 +238,7 @@ pub struct UpdateSnsSubnetListRequest {
- pub struct UpdateSnsSubnetListResponse { error: Option<SnsWasmError> }
- 
- pub struct SERVICE(pub candid::Principal);
--impl SERVICE {
-+impl SERVICE{
-   pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
-     (AddWasmResponse,)
-   > { ic_cdk::call(self.0, "add_wasm", (arg0,)).await }
-@@ -298,4 +300,3 @@ impl SERVICE {
-     ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
-   }
- }
--
+     pub root_canister_id: Option<candid::Principal>,
+     pub governance_canister_id: Option<candid::Principal>,

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -12,107 +12,133 @@ use ic_cdk::api::call::CallResult;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsWasmCanisterInitPayload {
-  pub  allowed_principals: Vec<candid::Principal>,
-  pub  access_controls_enabled: bool,
-  pub  sns_subnet_ids: Vec<candid::Principal>,
+    pub allowed_principals: Vec<candid::Principal>,
+    pub access_controls_enabled: bool,
+    pub sns_subnet_ids: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SnsWasm { wasm: serde_bytes::ByteBuf, canister_type: i32 }
+pub struct SnsWasm {
+    wasm: serde_bytes::ByteBuf,
+    canister_type: i32,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct AddWasmRequest { hash: serde_bytes::ByteBuf, wasm: Option<SnsWasm> }
+pub struct AddWasmRequest {
+    hash: serde_bytes::ByteBuf,
+    wasm: Option<SnsWasm>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SnsWasmError { message: String }
+pub struct SnsWasmError {
+    message: String,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub enum Result { Error(SnsWasmError), Hash(serde_bytes::ByteBuf) }
+pub enum Result {
+    Error(SnsWasmError),
+    Hash(serde_bytes::ByteBuf),
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct AddWasmResponse { result: Option<Result> }
+pub struct AddWasmResponse {
+    result: Option<Result>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct TreasuryDistribution { total_e8s: u64 }
+pub struct TreasuryDistribution {
+    total_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct NeuronDistribution {
-  pub  controller: Option<candid::Principal>,
-  pub  dissolve_delay_seconds: u64,
-  pub  memo: u64,
-  pub  stake_e8s: u64,
-  pub  vesting_period_seconds: Option<u64>,
+    pub controller: Option<candid::Principal>,
+    pub dissolve_delay_seconds: u64,
+    pub memo: u64,
+    pub stake_e8s: u64,
+    pub vesting_period_seconds: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DeveloperDistribution { developer_neurons: Vec<NeuronDistribution> }
+pub struct DeveloperDistribution {
+    developer_neurons: Vec<NeuronDistribution>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct AirdropDistribution { airdrop_neurons: Vec<NeuronDistribution> }
+pub struct AirdropDistribution {
+    airdrop_neurons: Vec<NeuronDistribution>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct SwapDistribution { total_e8s: u64, initial_swap_amount_e8s: u64 }
+pub struct SwapDistribution {
+    total_e8s: u64,
+    initial_swap_amount_e8s: u64,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct FractionalDeveloperVotingPower {
-  pub  treasury_distribution: Option<TreasuryDistribution>,
-  pub  developer_distribution: Option<DeveloperDistribution>,
-  pub  airdrop_distribution: Option<AirdropDistribution>,
-  pub  swap_distribution: Option<SwapDistribution>,
+    pub treasury_distribution: Option<TreasuryDistribution>,
+    pub developer_distribution: Option<DeveloperDistribution>,
+    pub airdrop_distribution: Option<AirdropDistribution>,
+    pub swap_distribution: Option<SwapDistribution>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum InitialTokenDistribution {
-  FractionalDeveloperVotingPower(FractionalDeveloperVotingPower),
+    FractionalDeveloperVotingPower(FractionalDeveloperVotingPower),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct Countries { iso_codes: Vec<String> }
+pub struct Countries {
+    iso_codes: Vec<String>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsInitPayload {
-  pub  url: Option<String>,
-  pub  max_dissolve_delay_seconds: Option<u64>,
-  pub  max_dissolve_delay_bonus_percentage: Option<u64>,
-  pub  fallback_controller_principal_ids: Vec<String>,
-  pub  token_symbol: Option<String>,
-  pub  final_reward_rate_basis_points: Option<u64>,
-  pub  neuron_minimum_stake_e8s: Option<u64>,
-  pub  confirmation_text: Option<String>,
-  pub  logo: Option<String>,
-  pub  name: Option<String>,
-  pub  initial_voting_period_seconds: Option<u64>,
-  pub  neuron_minimum_dissolve_delay_to_vote_seconds: Option<u64>,
-  pub  description: Option<String>,
-  pub  max_neuron_age_seconds_for_age_bonus: Option<u64>,
-  pub  initial_reward_rate_basis_points: Option<u64>,
-  pub  wait_for_quiet_deadline_increase_seconds: Option<u64>,
-  pub  transaction_fee_e8s: Option<u64>,
-  pub  max_age_bonus_percentage: Option<u64>,
-  pub  initial_token_distribution: Option<InitialTokenDistribution>,
-  pub  reward_rate_transition_duration_seconds: Option<u64>,
-  pub  token_name: Option<String>,
-  pub  proposal_reject_cost_e8s: Option<u64>,
-  pub  restricted_countries: Option<Countries>,
+    pub url: Option<String>,
+    pub max_dissolve_delay_seconds: Option<u64>,
+    pub max_dissolve_delay_bonus_percentage: Option<u64>,
+    pub fallback_controller_principal_ids: Vec<String>,
+    pub token_symbol: Option<String>,
+    pub final_reward_rate_basis_points: Option<u64>,
+    pub neuron_minimum_stake_e8s: Option<u64>,
+    pub confirmation_text: Option<String>,
+    pub logo: Option<String>,
+    pub name: Option<String>,
+    pub initial_voting_period_seconds: Option<u64>,
+    pub neuron_minimum_dissolve_delay_to_vote_seconds: Option<u64>,
+    pub description: Option<String>,
+    pub max_neuron_age_seconds_for_age_bonus: Option<u64>,
+    pub initial_reward_rate_basis_points: Option<u64>,
+    pub wait_for_quiet_deadline_increase_seconds: Option<u64>,
+    pub transaction_fee_e8s: Option<u64>,
+    pub max_age_bonus_percentage: Option<u64>,
+    pub initial_token_distribution: Option<InitialTokenDistribution>,
+    pub reward_rate_transition_duration_seconds: Option<u64>,
+    pub token_name: Option<String>,
+    pub proposal_reject_cost_e8s: Option<u64>,
+    pub restricted_countries: Option<Countries>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct DeployNewSnsRequest { sns_init_payload: Option<SnsInitPayload> }
+pub struct DeployNewSnsRequest {
+    sns_init_payload: Option<SnsInitPayload>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsCanisterIds {
-  pub  root: Option<candid::Principal>,
-  pub  swap: Option<candid::Principal>,
-  pub  ledger: Option<candid::Principal>,
-  pub  index: Option<candid::Principal>,
-  pub  governance: Option<candid::Principal>,
+    pub root: Option<candid::Principal>,
+    pub swap: Option<candid::Principal>,
+    pub ledger: Option<candid::Principal>,
+    pub index: Option<candid::Principal>,
+    pub governance: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DeployNewSnsResponse {
-  pub  subnet_id: Option<candid::Principal>,
-  pub  error: Option<SnsWasmError>,
-  pub  canisters: Option<SnsCanisterIds>,
+    pub subnet_id: Option<candid::Principal>,
+    pub error: Option<SnsWasmError>,
+    pub canisters: Option<SnsCanisterIds>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -120,182 +146,192 @@ pub struct get_allowed_principals_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetAllowedPrincipalsResponse {
-  pub  allowed_principals: Vec<candid::Principal>,
+    pub allowed_principals: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsVersion {
-  pub  archive_wasm_hash: serde_bytes::ByteBuf,
-  pub  root_wasm_hash: serde_bytes::ByteBuf,
-  pub  swap_wasm_hash: serde_bytes::ByteBuf,
-  pub  ledger_wasm_hash: serde_bytes::ByteBuf,
-  pub  governance_wasm_hash: serde_bytes::ByteBuf,
-  pub  index_wasm_hash: serde_bytes::ByteBuf,
+    pub archive_wasm_hash: serde_bytes::ByteBuf,
+    pub root_wasm_hash: serde_bytes::ByteBuf,
+    pub swap_wasm_hash: serde_bytes::ByteBuf,
+    pub ledger_wasm_hash: serde_bytes::ByteBuf,
+    pub governance_wasm_hash: serde_bytes::ByteBuf,
+    pub index_wasm_hash: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetNextSnsVersionRequest {
-  pub  governance_canister_id: Option<candid::Principal>,
-  pub  current_version: Option<SnsVersion>,
+    pub governance_canister_id: Option<candid::Principal>,
+    pub current_version: Option<SnsVersion>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetNextSnsVersionResponse { next_version: Option<SnsVersion> }
+pub struct GetNextSnsVersionResponse {
+    next_version: Option<SnsVersion>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct get_sns_subnet_ids_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetSnsSubnetIdsResponse { sns_subnet_ids: Vec<candid::Principal> }
+pub struct GetSnsSubnetIdsResponse {
+    sns_subnet_ids: Vec<candid::Principal>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetWasmRequest { hash: serde_bytes::ByteBuf }
+pub struct GetWasmRequest {
+    hash: serde_bytes::ByteBuf,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct GetWasmResponse { wasm: Option<SnsWasm> }
+pub struct GetWasmResponse {
+    wasm: Option<SnsWasm>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsUpgrade {
-  pub  next_version: Option<SnsVersion>,
-  pub  current_version: Option<SnsVersion>,
+    pub next_version: Option<SnsVersion>,
+    pub current_version: Option<SnsVersion>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InsertUpgradePathEntriesRequest {
-  pub  upgrade_path: Vec<SnsUpgrade>,
-  pub  sns_governance_canister_id: Option<candid::Principal>,
+    pub upgrade_path: Vec<SnsUpgrade>,
+    pub sns_governance_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct InsertUpgradePathEntriesResponse { error: Option<SnsWasmError> }
+pub struct InsertUpgradePathEntriesResponse {
+    error: Option<SnsWasmError>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct list_deployed_snses_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct DeployedSns {
-  pub  root_canister_id: Option<candid::Principal>,
-  pub  governance_canister_id: Option<candid::Principal>,
-  pub  index_canister_id: Option<candid::Principal>,
-  pub  swap_canister_id: Option<candid::Principal>,
-  pub  ledger_canister_id: Option<candid::Principal>,
+    pub root_canister_id: Option<candid::Principal>,
+    pub governance_canister_id: Option<candid::Principal>,
+    pub index_canister_id: Option<candid::Principal>,
+    pub swap_canister_id: Option<candid::Principal>,
+    pub ledger_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListDeployedSnsesResponse { pub instances: Vec<DeployedSns> }
+pub struct ListDeployedSnsesResponse {
+    pub instances: Vec<DeployedSns>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListUpgradeStepsRequest {
-  pub  limit: u32,
-  pub  starting_at: Option<SnsVersion>,
-  pub  sns_governance_canister_id: Option<candid::Principal>,
+    pub limit: u32,
+    pub starting_at: Option<SnsVersion>,
+    pub sns_governance_canister_id: Option<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct PrettySnsVersion {
-  pub  archive_wasm_hash: String,
-  pub  root_wasm_hash: String,
-  pub  swap_wasm_hash: String,
-  pub  ledger_wasm_hash: String,
-  pub  governance_wasm_hash: String,
-  pub  index_wasm_hash: String,
+    pub archive_wasm_hash: String,
+    pub root_wasm_hash: String,
+    pub swap_wasm_hash: String,
+    pub ledger_wasm_hash: String,
+    pub governance_wasm_hash: String,
+    pub index_wasm_hash: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListUpgradeStep {
-  pub  pretty_version: Option<PrettySnsVersion>,
-  pub  version: Option<SnsVersion>,
+    pub pretty_version: Option<PrettySnsVersion>,
+    pub version: Option<SnsVersion>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct ListUpgradeStepsResponse { steps: Vec<ListUpgradeStep> }
+pub struct ListUpgradeStepsResponse {
+    steps: Vec<ListUpgradeStep>,
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateAllowedPrincipalsRequest {
-  pub  added_principals: Vec<candid::Principal>,
-  pub  removed_principals: Vec<candid::Principal>,
+    pub added_principals: Vec<candid::Principal>,
+    pub removed_principals: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum UpdateAllowedPrincipalsResult {
-  Error(SnsWasmError),
-  AllowedPrincipals(GetAllowedPrincipalsResponse),
+    Error(SnsWasmError),
+    AllowedPrincipals(GetAllowedPrincipalsResponse),
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateAllowedPrincipalsResponse {
-  pub  update_allowed_principals_result: Option<UpdateAllowedPrincipalsResult>,
+    pub update_allowed_principals_result: Option<UpdateAllowedPrincipalsResult>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateSnsSubnetListRequest {
-  pub  sns_subnet_ids_to_add: Vec<candid::Principal>,
-  pub  sns_subnet_ids_to_remove: Vec<candid::Principal>,
+    pub sns_subnet_ids_to_add: Vec<candid::Principal>,
+    pub sns_subnet_ids_to_remove: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-pub struct UpdateSnsSubnetListResponse { error: Option<SnsWasmError> }
+pub struct UpdateSnsSubnetListResponse {
+    error: Option<SnsWasmError>,
+}
 
 pub struct SERVICE(pub candid::Principal);
-impl SERVICE{
-  pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<
-    (AddWasmResponse,)
-  > { ic_cdk::call(self.0, "add_wasm", (arg0,)).await }
-  pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<
-    (DeployNewSnsResponse,)
-  > { ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await }
-  pub async fn get_allowed_principals(
-    &self,
-    arg0: get_allowed_principals_arg0,
-  ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
-    ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
-  }
-  pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<
-    (Vec<(String,String,)>,)
-  > { ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await }
-  pub async fn get_next_sns_version(
-    &self,
-    arg0: GetNextSnsVersionRequest,
-  ) -> CallResult<(GetNextSnsVersionResponse,)> {
-    ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
-  }
-  pub async fn get_sns_subnet_ids(
-    &self,
-    arg0: get_sns_subnet_ids_arg0,
-  ) -> CallResult<(GetSnsSubnetIdsResponse,)> {
-    ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
-  }
-  pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<
-    (GetWasmResponse,)
-  > { ic_cdk::call(self.0, "get_wasm", (arg0,)).await }
-  pub async fn insert_upgrade_path_entries(
-    &self,
-    arg0: InsertUpgradePathEntriesRequest,
-  ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
-    ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
-  }
-  pub async fn list_deployed_snses(
-    &self,
-    arg0: list_deployed_snses_arg0,
-  ) -> CallResult<(ListDeployedSnsesResponse,)> {
-    ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
-  }
-  pub async fn list_upgrade_steps(
-    &self,
-    arg0: ListUpgradeStepsRequest,
-  ) -> CallResult<(ListUpgradeStepsResponse,)> {
-    ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
-  }
-  pub async fn update_allowed_principals(
-    &self,
-    arg0: UpdateAllowedPrincipalsRequest,
-  ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
-    ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
-  }
-  pub async fn update_sns_subnet_list(
-    &self,
-    arg0: UpdateSnsSubnetListRequest,
-  ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
-    ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
-  }
+impl SERVICE {
+    pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
+        ic_cdk::call(self.0, "add_wasm", (arg0,)).await
+    }
+    pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
+        ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await
+    }
+    pub async fn get_allowed_principals(
+        &self,
+        arg0: get_allowed_principals_arg0,
+    ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
+        ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+    }
+    pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
+        ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await
+    }
+    pub async fn get_next_sns_version(
+        &self,
+        arg0: GetNextSnsVersionRequest,
+    ) -> CallResult<(GetNextSnsVersionResponse,)> {
+        ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
+    }
+    pub async fn get_sns_subnet_ids(&self, arg0: get_sns_subnet_ids_arg0) -> CallResult<(GetSnsSubnetIdsResponse,)> {
+        ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
+    }
+    pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
+        ic_cdk::call(self.0, "get_wasm", (arg0,)).await
+    }
+    pub async fn insert_upgrade_path_entries(
+        &self,
+        arg0: InsertUpgradePathEntriesRequest,
+    ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
+        ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
+    }
+    pub async fn list_deployed_snses(
+        &self,
+        arg0: list_deployed_snses_arg0,
+    ) -> CallResult<(ListDeployedSnsesResponse,)> {
+        ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
+    }
+    pub async fn list_upgrade_steps(&self, arg0: ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
+        ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
+    }
+    pub async fn update_allowed_principals(
+        &self,
+        arg0: UpdateAllowedPrincipalsRequest,
+    ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
+        ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
+    }
+    pub async fn update_sns_subnet_list(
+        &self,
+        arg0: UpdateSnsSubnetListRequest,
+    ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
+        ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
+    }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -19,19 +19,19 @@ pub struct SnsWasmCanisterInitPayload {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsWasm {
-    wasm: serde_bytes::ByteBuf,
-    canister_type: i32,
+    pub wasm: serde_bytes::ByteBuf,
+    pub canister_type: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct AddWasmRequest {
-    hash: serde_bytes::ByteBuf,
-    wasm: Option<SnsWasm>,
+    pub hash: serde_bytes::ByteBuf,
+    pub wasm: Option<SnsWasm>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsWasmError {
-    message: String,
+    pub message: String,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -42,12 +42,12 @@ pub enum Result {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct AddWasmResponse {
-    result: Option<Result>,
+    pub result: Option<Result>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct TreasuryDistribution {
-    total_e8s: u64,
+    pub total_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -61,18 +61,18 @@ pub struct NeuronDistribution {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DeveloperDistribution {
-    developer_neurons: Vec<NeuronDistribution>,
+    pub developer_neurons: Vec<NeuronDistribution>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct AirdropDistribution {
-    airdrop_neurons: Vec<NeuronDistribution>,
+    pub airdrop_neurons: Vec<NeuronDistribution>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SwapDistribution {
-    total_e8s: u64,
-    initial_swap_amount_e8s: u64,
+    pub total_e8s: u64,
+    pub initial_swap_amount_e8s: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -90,7 +90,7 @@ pub enum InitialTokenDistribution {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct Countries {
-    iso_codes: Vec<String>,
+    pub iso_codes: Vec<String>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -122,7 +122,7 @@ pub struct SnsInitPayload {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct DeployNewSnsRequest {
-    sns_init_payload: Option<SnsInitPayload>,
+    pub sns_init_payload: Option<SnsInitPayload>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -167,7 +167,7 @@ pub struct GetNextSnsVersionRequest {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetNextSnsVersionResponse {
-    next_version: Option<SnsVersion>,
+    pub next_version: Option<SnsVersion>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -175,17 +175,17 @@ pub struct get_sns_subnet_ids_arg0 {}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetSnsSubnetIdsResponse {
-    sns_subnet_ids: Vec<candid::Principal>,
+    pub sns_subnet_ids: Vec<candid::Principal>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetWasmRequest {
-    hash: serde_bytes::ByteBuf,
+    pub hash: serde_bytes::ByteBuf,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GetWasmResponse {
-    wasm: Option<SnsWasm>,
+    pub wasm: Option<SnsWasm>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -202,7 +202,7 @@ pub struct InsertUpgradePathEntriesRequest {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct InsertUpgradePathEntriesResponse {
-    error: Option<SnsWasmError>,
+    pub error: Option<SnsWasmError>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -247,7 +247,7 @@ pub struct ListUpgradeStep {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ListUpgradeStepsResponse {
-    steps: Vec<ListUpgradeStep>,
+    pub steps: Vec<ListUpgradeStep>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
@@ -275,7 +275,7 @@ pub struct UpdateSnsSubnetListRequest {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct UpdateSnsSubnetListResponse {
-    error: Option<SnsWasmError>,
+    pub error: Option<SnsWasmError>,
 }
 
 pub struct SERVICE(pub candid::Principal);

--- a/scripts/dfx-canister-url
+++ b/scripts/dfx-canister-url
@@ -136,7 +136,7 @@ network_url() {
   test -n "${network_url:-}" || network_url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' || true)"
   test -n "${network_url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || network_url="http://localhost:8080"
   test -n "${network_url}" || network_url="https://${DFX_NETWORK}.testnet.dfinity.network"
-  echo "${network_url:-}" | head -n1
+  echo "${network_url%%$'\n'*}"
 }
 
 canister_url() {

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -43,6 +43,9 @@ DID_PATH="${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did"
 
 cd "$GIT_ROOT"
 
+which didc
+didc --version
+
 ##########################
 # Translate candid to Rust
 ##########################

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -43,9 +43,11 @@ DID_PATH="${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did"
 
 cd "$GIT_ROOT"
 
-which didc
-didc --version
-rustfmt --version
+: "Ensure that tools are installed and working.  Rustfmt in particular can self-upgrade when called and the self-upgrade can fail."
+{
+  didc --version
+  rustfmt --version
+} >/dev/null
 
 ##########################
 # Translate candid to Rust

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -45,6 +45,7 @@ cd "$GIT_ROOT"
 
 which didc
 didc --version
+rustfmt --version
 
 ##########################
 # Translate candid to Rust

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -56,7 +56,6 @@ cd "$GIT_ROOT"
   #
   # We import traits that we apply to the Rust types.
   cat <<-EOF
-	#![cfg_attr(rustfmt, rustfmt_skip)]
 	#![allow(clippy::all)]
 	#![allow(clippy::missing_docs_in_private_items)]
 	#![allow(non_camel_case_types)]

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -87,14 +87,16 @@ cd "$GIT_ROOT"
   #     is not guaranteed to be correct.
   # shellcheck disable=SC2016
   didc bind "${DID_PATH}" --target rs |
+    rustfmt --edition 2021 |
     sed -E 's/^(struct|enum|type) /pub &/;
             s@^use .*@// &@;
             s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
-            s/^  [a-z].*:/  pub&/;s/^( *pub ) *pub /\1/;
+            s/^    [a-z].*:/    pub&/;s/^( *pub ) *pub /\1/;
 	    /impl SERVICE/,${s/-> Result/-> CallResult/g};
 	    /^pub struct /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
 	    s/\<Principal\>/candid::&/g;
-	    '
+	    ' |
+    rustfmt --edition 2021
 } >"${RUST_PATH}"
 if test -f "${PATCH_PATH}"; then
   (


### PR DESCRIPTION
# Motivation
The patch files applied when generating Rust from SNS .did files have grown quite large and break easily.  There are a few changes in the automatic generation that can make the patch files significantly smaller.  Here is the fourth, or forth for the FORTH programmers of Fife:

The patch files contain ~150 lines of diff due to formatting.  If we format the auto-generated code, the patch files change but in total the patch files become significantly smaller and more consistent.

# Changes
Normally it is advisable to change only one of the code or the patch files, but when formatting it is impossible to avoid changing both.

The Rust files are changed in these ways:
* Remove the header in the autogenerated rust that prevents rustfmt from formatting the files.  (See commit d732dba44eb983684ca2bceaa41840c19cf9b063)
* Format the autogenerated rust files by calling `cargo fmt` (See commit 0235deb3ee48e039a9a81a016420ff76216f16e6)
* Make all struct fields public.  (See commit 76aac4810e0e36d780c315f7bddf8122658ce664) Previously most were public, but the autogenerator missed fields in structs that were short enough to be one-liners.  This is no longer the case, so I manually checked every difference between the autogenerated files and the existing rust and added pub where appropriate.

The autogeneration is changed by:
- Formatting the autogenerated code.
  - Note: This is done after didc and again after sed, so that the sed input and output are both formatted consistently.

The patch files are updated to match.

# Tests
- See CI.
- The proof of correctness is:
  - The rust files have no semantic changes apart from making some fields pub. The remaining changes are in formatting.

# Todos

- [ ] Add entry to changelog (if necessary).
