### PR TITLE
Make CI more robust

### DIFF
--- a/scripts/dfx-canister-url
+++ b/scripts/dfx-canister-url
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeuo pipefail
+set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
@@ -136,7 +136,7 @@ network_url() {
   test -n "${network_url:-}" || network_url="$(network_config | h="${DFX_URL_TYPE^^}_HOST" jq -re '.[env.DFX_NETWORK].config | .[env.h] // .HOST // empty' || true)"
   test -n "${network_url}" || [[ "${DFX_NETWORK:-}" != "local" ]] || network_url="http://localhost:8080"
   test -n "${network_url}" || network_url="https://${DFX_NETWORK}.testnet.dfinity.network"
-  echo "${network_url:-}" | head -n1
+  echo "${network_url%%$'\n'*}"
 }
 
 canister_url() {

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -43,6 +43,12 @@ DID_PATH="${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did"
 
 cd "$GIT_ROOT"
 
+: "Ensure that tools are installed and working.  Rustfmt in particular can self-upgrade when called and the self-upgrade can fail."
+{
+  didc --version
+  rustfmt --version
+} >/dev/null
+
 ##########################
 # Translate candid to Rust
 ##########################


### PR DESCRIPTION
# Motivation
CI has failed several times over the last day or so.  Let's address some of the issues.

- A pipefail when getting the first entry from `dfx canister url`.
- A failure when rustfmt self-updates in a pipe.

# Changes
- Remove the failing pipe by getting the first line using bash.  This is also nicer as it doesn't have to spin up another process.
- Call rustfmt on its own before use.  This costs a process call but makes rustfmt self-update in isolation before use.

# Tests
See CI.

# Todos

- [ ] Add entry to changelog (if necessary).
