### PR TITLE
Steal II code to update didc and rust

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -1,0 +1,55 @@
+# A GitHub Actions workflow that regularly checks for new didc releases
+# and creates a PR on new versions.
+name: didc Update
+on:
+  schedule:
+    # check for new didc releases daily at 7:30
+    - cron: '30 7 * * *'
+jobs:
+  didc-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        # First, check didc releases (on the candid repo) for a new version.
+      - name: Check new didc version
+        id: update
+        run: |
+          current_didc_release=$(sed <.didc-release 's/#.*$//' | sed '/^$/d')
+          echo "current didc release '$current_didc_release'"
+
+          latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
+          echo "latest didc release '$latest_didc_release'"
+
+          if [ "$current_didc_release" != "$latest_didc_release" ]
+          then
+            echo didc needs an update
+            sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
+            DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_RELEASE)' dfx.json  | sponge dfx.json
+            echo "updated=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=0" >> "$GITHUB_OUTPUT"
+          fi
+
+          cat ./.didc-release
+        # If the .didc-release was updated, create a PR.
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.updated == '1' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GIX_BOT_PAT }}
+          base: main
+          add-paths: ./.didc-release
+          commit-message: Update didc release
+          committer: GitHub <noreply@github.com>
+          author: gix-bot <gix-bot@users.noreply.github.com>
+          branch: bot-didc-update
+          delete-branch: true
+          title: 'Update didc release'
+          # Since this is a scheduled job, a failure won't be shown on any
+          # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "didc update failed"

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -1,0 +1,65 @@
+# A GitHub Actions workflow that regularly checks for new Rust toolchain release
+# and creates a PR on new versions.
+name: Rust Update
+on:
+  schedule:
+    # check for new rust versions weekly
+    - cron: '30 3 * * FRI'
+jobs:
+  rust-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        # First, check rust GitHub releases for a new version. We assume that the
+        # latest version's tag name is the version.
+      - name: Check new rust version
+        id: update
+        run: |
+          current_rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
+          echo "current rust version '$current_rust_version'"
+          release_data=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/rust-lang/rust/releases/latest)
+          latest_rust_version=$(echo -n "$release_data" | jq -cMr .tag_name)
+
+          # The GitHub API has some hiccups, so we check the value before going further
+          if [ -z "$latest_rust_version" ] || [ "$latest_rust_version" = "null" ]
+          then
+            echo "expected a rust version, got '$latest_rust_version'"
+            echo "data received from API:"
+            echo "$release_data"
+            exit 1
+          fi
+
+          echo "latest rust version '$latest_rust_version'"
+
+          if [ "$current_rust_version" != "$latest_rust_version" ]
+          then
+            echo rust toolchain needs an update
+            sed -i -e "s/$current_rust_version/$latest_rust_version/g" ./rust-toolchain.toml
+            echo "updated=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=0" >> "$GITHUB_OUTPUT"
+          fi
+
+          cat ./rust-toolchain.toml
+        # If the rust-toolchain was updated, create a PR.
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.updated == '1' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GIX_BOT_PAT }}
+          base: main
+          add-paths: ./rust-toolchain.toml
+          commit-message: Update rust version
+          committer: GitHub <noreply@github.com>
+          author: gix-bot <gix-bot@users.noreply.github.com>
+          branch: bot-rust-update
+          delete-branch: true
+          title: 'Update rust version'
+          # Since the this is a scheduled job, a failure won't be shown on any
+          # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "Rust update failed"

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -40,6 +40,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
+- Added CI workflows to update rust and didc automatically.
 - CreateServiceNervousSystem proposal support.
 - Base64 image support for payload rendering.
 - `scripts/canister_ids` can now remove canisters from `canister_ids.json`.


### PR DESCRIPTION
# Motivation
II has some cute GitHub actions for updating dependencies automatically.

In our case, our code is closely intertwined with other canisters and codebases, in a way that II is not, so these automated PRs will often require manual intervention but they are still nice to have.

# Changes
* Import the didc and rust update workflows from the II repo.
* Adapt the didc versioning code for our repo.
* Format.

# Tests
* Wait and see what PRs it produces.

# Todos

- [x] Add entry to changelog (if necessary).
