### PR TITLE
Provide default values for dfx snapshot action

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -5,10 +5,13 @@ description: |
 inputs:
   snsdemo_ref:
     description: "The commit at which to use the snsdemo scripts"
-    required: true
+    required: false
+    # Version from 2023-06-06 with dfx v 0.14.1
+    default: "0e61f618018db099a01b1686535fff8eff980d1c"
   snapshot_url:
     description: "The URL of the snapshot to download and install"
-    required: true
+    required: false
+    default: "https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz"
   nns_dapp_wasm:
     description: "The name of the nns-dapp wasm to install"
     required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,6 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
-          # Version from 2023-06-06 with dfx v 0.14.1
-          snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
-          snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
           nns_dapp_wasm: 'nns-dapp.wasm.gz'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
       - name: Generate .env configuration for Playwright end-to-end tests
@@ -129,9 +126,6 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
-          # Version from 2023-06-06 with dfx v0.14.1
-          snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
-          snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
           nns_dapp_wasm: 'nns-dapp.wasm.gz'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
       - name: Add go and SNS scripts to the path
@@ -349,9 +343,6 @@ jobs:
       - name: Start snapshot environment
         uses: ./.github/actions/start_dfx_snapshot
         with:
-          # Version from 2023-06-06 with dfx v 0.14.1
-          snsdemo_ref: '0e61f618018db099a01b1686535fff8eff980d1c'
-          snapshot_url: https://github.com/dfinity/snsdemo/releases/download/release-2023-06-06/snsdemo_snapshot_ubuntu-22.04.tar.xz
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
       - name: Verify that configuration is as provided
         run: scripts/sns/aggregator/test-config


### PR DESCRIPTION
# Motivation

We probably always want to be consistent in which snsdemo commit and snapshot release the `start_dfx_snapshot` action uses and right now we have to update those every time in multiple places.

# Changes

1. Provide default values for `snsdemo_ref` and `snapshot_url` in the `start_dfx_snapshot` action.
2. Stop passing the values for which defaults are provided.

# Tests

CI

# Todos

This is in preparation to use the new snapshot which has the aggregator preloaded.
I'll add an entry when for that PR.
- [ ] Add entry to changelog (if necessary).
