### PR TITLE
A flag to update the golden files for release-sop.test

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -49,6 +49,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Test that no new change log entries are added to existing releases.
 - New feature flag "ENABLE_NEURON_SETTINGS".
 - Playwright connects to PLAYWRIGHT_BASE_URL if specified in the environment.
+- release-sop.test now has a flag to update golden files.
 
 #### Changed
 

--- a/scripts/nns-dapp/release-sop.test
+++ b/scripts/nns-dapp/release-sop.test
@@ -38,9 +38,14 @@ test_with_data() {
   fi
 
   if [ "$actualExitCode" != "$expectedExitCode" ]; then
-    echo "Expected exit code $expectedExitCode, got $actualExitCode" >&2
-    echo "FAILED: $1"
-    exit 1
+    if [ "${UPDATE_TESTS:-}" = "true" ]; then
+      jq -r --argjson actualExitCode "$actualExitCode" '.expectedExitCode = $actualExitCode' "$json_file" | sponge "$json_file"
+      echo "UPDATED $test_name"
+    else
+      echo "Expected exit code $expectedExitCode, got $actualExitCode" >&2
+      echo "FAILED: $1"
+      exit 1
+    fi
   fi
 
   echo "PASSED: $1"

--- a/scripts/nns-dapp/release-sop.test
+++ b/scripts/nns-dapp/release-sop.test
@@ -6,16 +6,12 @@ SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
-clap.define long=update desc="A test to update so it passes again" variable=UPDATE_TEST default=""
+clap.define long=update desc="Update golden output to make the tests pass " variable=UPDATE_TESTS nargs=0 default="false"
 # Source the output file ------------------------------------------------------
 source "$(clap.build)"
 
 test_with_data() {
   test_name="$1"
-  if [ "${UPDATE_TEST:-$test_name}" != "$test_name" ]; then
-    echo "SKIPPED $test_name"
-    return
-  fi
   json_file="$SOURCE_DIR/$test_name.json"
   expectedExitCode="$(jq -r '.expectedExitCode' "$json_file")"
   expectedOutput="$(jq -r '.expectedOutput[]' "$json_file")"
@@ -28,13 +24,13 @@ test_with_data() {
   set -e
 
   if ! diff <(echo "$actualOutput") <(echo "$expectedOutput"); then
-    if [ "${UPDATE_TEST:-}" = "$test_name" ]; then
+    if [ "${UPDATE_TESTS:-}" = "true" ]; then
       jq -r --arg actualOutput "$actualOutput" '.expectedOutput = ($actualOutput | split("\n"))' "$json_file" | sponge "$json_file"
       echo "UPDATED $test_name"
     else
       (
         echo "ERROR: actual output differs from expected output. See diff above."
-        echo "Run '"$0" --update $test_name' to update the test."
+        echo "Run '"$0" --update' to update the tests."
         echo "FAILED: $1"
       ) >&2
       exit 1

--- a/scripts/nns-dapp/release-sop.test
+++ b/scripts/nns-dapp/release-sop.test
@@ -3,8 +3,20 @@ set -euo pipefail
 
 SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define long=update desc="A test to update so it passes again" variable=UPDATE_TEST default=""
+# Source the output file ------------------------------------------------------
+source "$(clap.build)"
+
 test_with_data() {
-  json_file="$SOURCE_DIR/$1.json"
+  test_name="$1"
+  if [ "${UPDATE_TEST:-$test_name}" != "$test_name" ]; then
+    echo "SKIPPED $test_name"
+    return
+  fi
+  json_file="$SOURCE_DIR/$test_name.json"
   expectedExitCode="$(jq -r '.expectedExitCode' "$json_file")"
   expectedOutput="$(jq -r '.expectedOutput[]' "$json_file")"
 
@@ -16,11 +28,17 @@ test_with_data() {
   set -e
 
   if ! diff <(echo "$actualOutput") <(echo "$expectedOutput"); then
-    (
-      echo "ERROR: actual output differs from expected output. See diff above."
-      echo "FAILED: $1"
-    ) >&2
-    exit 1
+    if [ "${UPDATE_TEST:-}" = "$test_name" ]; then
+      jq -r --arg actualOutput "$actualOutput" '.expectedOutput = ($actualOutput | split("\n"))' "$json_file" | sponge "$json_file"
+      echo "UPDATED $test_name"
+    else
+      (
+        echo "ERROR: actual output differs from expected output. See diff above."
+        echo "Run '"$0" --update $test_name' to update the test."
+        echo "FAILED: $1"
+      ) >&2
+      exit 1
+    fi
   fi
 
   if [ "$actualExitCode" != "$expectedExitCode" ]; then


### PR DESCRIPTION
# Motivation

When we change `release-sop` we also have to update the test json files.
This might be tedious.

# Changes

Add `--update` flag to `release-sop.test` to automatically update the test golden files.

# Tests

I manually change a test json file and ran the test:
```
$ scripts/nns-dapp/release-sop.test 
PASSED: release-sop-test-no-args
PASSED: release-sop-test-new-and-continue
PASSED: release-sop-test-invalid-name
1c1
< Branch Release-2001-02-29 already exists.
---
> XBranch Release-2001-02-29 already exists.
ERROR: actual output differs from expected output. See diff above.
Run 'scripts/nns-dapp/release-sop.test --update release-sop-test-branch-exists' to update the test.
FAILED: release-sop-test-branch-exists
```

Then I followed the instruction:
```
$ scripts/nns-dapp/release-sop.test --update release-sop-test-branch-exists
SKIPPED release-sop-test-no-args
SKIPPED release-sop-test-new-and-continue
SKIPPED release-sop-test-invalid-name
1c1
< Branch Release-2001-02-29 already exists.
---
> XBranch Release-2001-02-29 already exists.
UPDATED release-sop-test-branch-exists
PASSED: release-sop-test-branch-exists
SKIPPED release-sop-test-uncommitted-changes
SKIPPED release-sop-test-continue-with-name
SKIPPED release-sop-test-continue-invalid-branch
SKIPPED release-sop-test-successful-release
SKIPPED release-sop-test-continue-after-success
```
Then the test json file was back how it was before.


# Todos

- [x] Add entry to changelog (if necessary).
