### PR TITLE
Add a manual update trigger for didc and rust updates

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # check for new didc releases daily at 7:30
     - cron: '30 7 * * *'
+  workflow_dispatch:
 jobs:
   didc-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # check for new rust versions weekly
     - cron: '30 3 * * FRI'
+  workflow_dispatch:
 jobs:
   rust-update:
     runs-on: ubuntu-latest

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -40,7 +40,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
-- Added CI workflows to update rust and didc automatically.
+- Added CI workflows to update rust and didc automatically, by cron job or button click.
 - CreateServiceNervousSystem proposal support.
 - Base64 image support for payload rendering.
 - `scripts/canister_ids` can now remove canisters from `canister_ids.json`.


### PR DESCRIPTION
# Motivation
It would be useful to be able to trigger the didc and rust update workflows manually rather than either by waiting for the next cron time or by adding a temporary trigger in a toy PR.

# Changes
* Add a manual trigger, in the form of `workflow_dispatch`, for the rust and didc update workflows.

# Tests
Workflow dispatch cannot be tested until it is merged in main, as the button is the button in the UI is defined in main.

# Todos

- [x] Add entry to changelog (if necessary).
