### PR TITLE
Patch remnants

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,13 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 4dd5e7018..e71ccd0a4 100644
+index 1c4dd45ec..e71ccd0a4 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -3,12 +3,12 @@
- #![allow(non_camel_case_types)]
- #![allow(dead_code)]
- 
--use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
-+use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
+@@ -7,8 +7,8 @@ use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,15 +1,13 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 1c4dd45ec..9f4abee6a 100644
+index 1c4dd45ec..6cf95680e 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -7,8 +7,8 @@ use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
- use ic_cdk::api::call::CallResult;
+@@ -8,7 +8,7 @@ use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
--// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+ // use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
 -// use ic_cdk::api::call::CallResult as Result;
-+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-+// use ic_cdk::api::call::CallResult;
++// use ic_cdk::api::call::CallResult as Result
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GenericNervousSystemFunction {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 1c4dd45ec..e71ccd0a4 100644
+index 1c4dd45ec..9f4abee6a 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -7,8 +7,8 @@ use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
@@ -31,18 +31,3 @@ index 1c4dd45ec..e71ccd0a4 100644
  pub struct ListNervousSystemFunctionsResponse {
      pub reserved_ids: Vec<u64>,
      pub functions: Vec<NervousSystemFunction>,
-@@ -719,12 +719,12 @@ pub enum Command_1 {
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct ManageNeuronResponse {
--    pub command: Option<Command_1>,
-+    command: Option<Command_1>,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SetMode {
--    pub mode: i32,
-+    mode: i32,
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 582c902e6..e71ccd0a4 100644
+index 4dd5e7018..e71ccd0a4 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -3,12 +3,12 @@
@@ -18,59 +18,6 @@ index 582c902e6..e71ccd0a4 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct GenericNervousSystemFunction {
-@@ -20,7 +20,7 @@ pub struct GenericNervousSystemFunction {
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub enum FunctionType {
--    NativeNervousSystemFunction {},
-+    NativeNervousSystemFunction(EmptyRecord),
-     GenericNervousSystemFunction(GenericNervousSystemFunction),
- }
- 
-@@ -220,12 +220,12 @@ pub enum Action {
-     ManageNervousSystemParameters(NervousSystemParameters),
-     AddGenericNervousSystemFunction(NervousSystemFunction),
-     RemoveGenericNervousSystemFunction(u64),
--    UpgradeSnsToNextVersion {},
-+    UpgradeSnsToNextVersion(EmptyRecord),
-     RegisterDappCanisters(RegisterDappCanisters),
-     TransferSnsTreasuryFunds(TransferSnsTreasuryFunds),
-     UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
-     DeregisterDappCanisters(DeregisterDappCanisters),
--    Unspecified {},
-+    Unspecified(EmptyRecord),
-     ManageSnsMetadata(ManageSnsMetadata),
-     ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),
-     Motion(Motion),
-@@ -309,8 +309,8 @@ pub struct SetDissolveTimestamp {
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub enum Operation {
-     ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
--    StopDissolving {},
--    StartDissolving {},
-+    StopDissolving(EmptyRecord),
-+    StartDissolving(EmptyRecord),
-     IncreaseDissolveDelay(IncreaseDissolveDelay),
-     SetDissolveTimestamp(SetDissolveTimestamp),
- }
-@@ -341,7 +341,7 @@ pub struct MemoAndController {
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub enum By {
-     MemoAndController(MemoAndController),
--    NeuronId {},
-+    NeuronId(EmptyRecord),
- }
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
-@@ -384,7 +384,7 @@ pub enum Command_2 {
-     DisburseMaturity(DisburseMaturity),
-     Configure(Configure),
-     RegisterVote(RegisterVote),
--    SyncCommand {},
-+    SyncCommand(EmptyRecord),
-     MakeProposal(Proposal),
-     FinalizeDisburseMaturity(FinalizeDisburseMaturity),
-     ClaimOrRefreshNeuron(ClaimOrRefresh),
 @@ -515,7 +515,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}
@@ -89,27 +36,7 @@ index 582c902e6..e71ccd0a4 100644
  pub struct ListNervousSystemFunctionsResponse {
      pub reserved_ids: Vec<u64>,
      pub functions: Vec<NervousSystemFunction>,
-@@ -704,27 +704,27 @@ pub struct DisburseResponse {
- pub enum Command_1 {
-     Error(GovernanceError),
-     Split(SplitResponse),
--    Follow {},
-+    Follow(EmptyRecord),
-     DisburseMaturity(DisburseMaturityResponse),
-     ClaimOrRefresh(ClaimOrRefreshResponse),
--    Configure {},
--    RegisterVote {},
-+    Configure(EmptyRecord),
-+    RegisterVote(EmptyRecord),
-     MakeProposal(GetProposal),
--    RemoveNeuronPermission {},
-+    RemoveNeuronPermission(EmptyRecord),
-     StakeMaturity(StakeMaturityResponse),
-     MergeMaturity(MergeMaturityResponse),
-     Disburse(DisburseResponse),
--    AddNeuronPermission {},
-+    AddNeuronPermission(EmptyRecord),
- }
+@@ -719,12 +719,12 @@ pub enum Command_1 {
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct ManageNeuronResponse {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,16 +1,7 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 1c4dd45ec..6cf95680e 100644
+index 1c4dd45ec..e504fb85b 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -8,7 +8,7 @@ use ic_cdk::api::call::CallResult;
- // This is an experimental feature to generate Rust binding from Candid.
- // You may want to manually adjust some of the types.
- // use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
--// use ic_cdk::api::call::CallResult as Result;
-+// use ic_cdk::api::call::CallResult as Result
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct GenericNervousSystemFunction {
 @@ -515,7 +515,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct get_metadata_arg0 {}

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -7,8 +7,8 @@ use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-// use ic_cdk::api::call::CallResult;
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+// use ic_cdk::api::call::CallResult as Result
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GenericNervousSystemFunction {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -8,7 +8,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
-// use ic_cdk::api::call::CallResult as Result
+// use ic_cdk::api::call::CallResult as Result;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct GenericNervousSystemFunction {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -719,12 +719,12 @@ pub enum Command_1 {
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ManageNeuronResponse {
-    command: Option<Command_1>,
+    pub command: Option<Command_1>,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SetMode {
-    mode: i32,
+    pub mode: i32,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,12 +1,12 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 7cbb51d8e..efb2fe93b 100644
+index 974242e4c..efb2fe93b 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
--use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+-use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,23 +1,7 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 974242e4c..efb2fe93b 100644
+index 974242e4c..e4eda4d8a 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -3,12 +3,12 @@
- #![allow(non_camel_case_types)]
- #![allow(dead_code)]
- 
--use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-+use crate::types::{CandidType, Deserialize, Serialize};
- use ic_cdk::api::call::CallResult;
- // This is an experimental feature to generate Rust binding from Candid.
- // You may want to manually adjust some of the types.
--// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
--// use ic_cdk::api::call::CallResult as Result;
-+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-+// use ic_cdk::api::call::CallResult;
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub enum MetadataValue {
 @@ -93,23 +93,21 @@ pub struct BlockRange {
      pub blocks: Vec<Block>,
  }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -3,12 +3,12 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize};
+use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-// use ic_cdk::api::call::CallResult;
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+// use ic_cdk::api::call::CallResult as Result;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub enum MetadataValue {

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,23 +1,7 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 55ad093fa..d85254a2e 100644
+index 55ad093fa..bf7f5ec8f 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -3,12 +3,12 @@
- #![allow(non_camel_case_types)]
- #![allow(dead_code)]
- 
--use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-+use crate::types::{CandidType, Deserialize, Serialize};
- use ic_cdk::api::call::CallResult;
- // This is an experimental feature to generate Rust binding from Candid.
- // You may want to manually adjust some of the types.
--// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
--// use ic_cdk::api::call::CallResult as Result;
-+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-+// use ic_cdk::api::call::CallResult;
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SnsRootCanister {
 @@ -91,7 +91,7 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_sns_canisters_arg0 {}

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,12 +1,12 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 3d08525e4..d85254a2e 100644
+index 55ad093fa..d85254a2e 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
 @@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
--use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+-use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -3,12 +3,12 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize};
+use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-// use ic_cdk::api::call::CallResult;
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+// use ic_cdk::api::call::CallResult as Result;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsRootCanister {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index a21002e86..e0827feb2 100644
+index 4b6fc9324..e0827feb2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -3,19 +3,19 @@
@@ -31,7 +31,7 @@ index a21002e86..e0827feb2 100644
  
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub enum Possibility_2 {
--    Ok {},
+-    Ok(EmptyRecord),
 +    Ok,
      Err(CanisterCallError),
  }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index b207c99f6..e0827feb2 100644
+index b207c99f6..81477acb6 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -3,19 +3,19 @@
@@ -7,14 +7,12 @@ index b207c99f6..e0827feb2 100644
  #![allow(dead_code)]
  
 -use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-+use crate::types::{CandidType, Deserialize, Serialize};
++use crate::types::{CandidType, Deserialize, EmptyREcord, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.
  // You may want to manually adjust some of the types.
--// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
--// use ic_cdk::api::call::CallResult as Result;
-+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-+// use ic_cdk::api::call::CallResult;
+ // use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+ // use ic_cdk::api::call::CallResult as Result;
  
 -#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 +#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,12 +1,12 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 4b6fc9324..e0827feb2 100644
+index b207c99f6..e0827feb2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -3,19 +3,19 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
--use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+-use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -3,12 +3,12 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize};
+use crate::types::{CandidType, Deserialize, EmptyREcord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-// use ic_cdk::api::call::CallResult;
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+// use ic_cdk::api::call::CallResult as Result;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Countries {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,12 +1,12 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 9d36cbf1c..36ae2f307 100644
+index 67020291f..36ae2f307 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 @@ -3,12 +3,12 @@
  #![allow(non_camel_case_types)]
  #![allow(dead_code)]
  
--use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+-use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 +use crate::types::{CandidType, Deserialize, Serialize};
  use ic_cdk::api::call::CallResult;
  // This is an experimental feature to generate Rust binding from Candid.

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,23 +1,7 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 67020291f..36ae2f307 100644
+index 67020291f..7d2ba7415 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -3,12 +3,12 @@
- #![allow(non_camel_case_types)]
- #![allow(dead_code)]
- 
--use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-+use crate::types::{CandidType, Deserialize, Serialize};
- use ic_cdk::api::call::CallResult;
- // This is an experimental feature to generate Rust binding from Candid.
- // You may want to manually adjust some of the types.
--// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
--// use ic_cdk::api::call::CallResult as Result;
-+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-+// use ic_cdk::api::call::CallResult;
- 
- #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
- pub struct SnsWasmCanisterInitPayload {
 @@ -208,7 +208,7 @@ pub struct InsertUpgradePathEntriesResponse {
  #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
  pub struct list_deployed_snses_arg0 {}

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -3,12 +3,12 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use crate::types::{CandidType, Deserialize, Serialize};
+use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
-// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug};
-// use ic_cdk::api::call::CallResult;
+// use candid::{self, CandidType, Deserialize, Serialize, Clone, Debug, candid::Principal};
+// use ic_cdk::api::call::CallResult as Result;
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct SnsWasmCanisterInitPayload {

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -67,7 +67,7 @@ cd "$GIT_ROOT"
 	#![allow(non_camel_case_types)]
 	#![allow(dead_code)]
 
-	use crate::types::{CandidType, Deserialize, Serialize, EmptyRecord};
+	use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 	use ic_cdk::api::call::CallResult;
 	EOF
   # didc converts the .did to Rust, with the following limitations:

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -99,7 +99,7 @@ cd "$GIT_ROOT"
             s/([{( ]Deserialize)([,})])/\1, Serialize, Clone, Debug\2/;
             s/^    [a-z].*:/    pub&/;s/^( *pub ) *pub /\1/;
 	    /impl SERVICE/,${s/-> Result/-> CallResult/g};
-	    /^pub struct /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
+	    /^pub (struct|enum) /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
 	    s/\<Principal\>/candid::&/g;
 	    ' |
     rustfmt --edition 2021


### PR DESCRIPTION
# Motivation
The patch files applied when generating Rust from SNS .did files have grown quite large and break easily.  There are a few changes that can make the patch files significantly smaller.  Here is the sixth, and possibly even the last:

* The comment added by didc has changed; we can update it in our rust code.
* Some of the remaining patch changes are not needed.

# Changes
* Update the comment at the top of the generated files to match that created by didc.
* Remove changes that don't matter, e.g. the order of entries in module imports.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
