### PR TITLE
GIX-1715: Use SetDissolveDelay for SNS neurons

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -16,6 +16,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 * Removed `OWN_CANISTER_URL`.
+* Setting Dissolve Delay supports 888 years.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -247,25 +247,28 @@ export const stopDissolving = async ({
   logWithTimestamp(`Stop dissolving sns neuron complete.`);
 };
 
-export const increaseDissolveDelay = async ({
+export const setDissolveDelay = async ({
   identity,
   rootCanisterId,
   neuronId,
-  additionalDissolveDelaySeconds,
+  dissolveTimestampSeconds,
 }: {
   identity: Identity;
   rootCanisterId: Principal;
   neuronId: SnsNeuronId;
-  additionalDissolveDelaySeconds: number;
+  dissolveTimestampSeconds: number;
 }): Promise<void> => {
   logWithTimestamp(`Increase sns dissolve delay call...`);
 
-  const { increaseDissolveDelay } = await wrapper({
+  const { setDissolveTimestamp } = await wrapper({
     identity,
     rootCanisterId: rootCanisterId.toText(),
     certified: true,
   });
-  await increaseDissolveDelay({ neuronId, additionalDissolveDelaySeconds });
+  await setDissolveTimestamp({
+    neuronId,
+    dissolveTimestampSeconds: BigInt(dissolveTimestampSeconds),
+  });
 
   logWithTimestamp(`Increase sns dissolve delay complete.`);
 };

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -4,11 +4,11 @@ import {
   autoStakeMaturity as autoStakeMaturityApi,
   disburse as disburseApi,
   getSnsNeuron as getSnsNeuronApi,
-  increaseDissolveDelay as increaseDissolveDelayApi,
   querySnsNeuron,
   querySnsNeurons,
   refreshNeuron,
   removeNeuronPermissions,
+  setDissolveDelay,
   setFollowees,
   splitNeuron as splitNeuronApi,
   stakeMaturity as stakeMaturityApi,
@@ -31,12 +31,12 @@ import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
 import {
   followeesByFunction,
-  getSnsDissolveDelaySeconds,
   getSnsNeuronByHexId,
   hasAutoStakeMaturityOn,
   isEnoughAmountToSplit,
@@ -488,16 +488,12 @@ export const updateDelay = async ({
 }): Promise<{ success: boolean }> => {
   try {
     const identity = await getSnsNeuronIdentity();
-    const currentDissolveDelay =
-      getSnsDissolveDelaySeconds(neuron) ?? BigInt(0);
-    const additionalDissolveDelaySeconds =
-      dissolveDelaySeconds - Number(currentDissolveDelay);
 
-    await increaseDissolveDelayApi({
+    await setDissolveDelay({
       rootCanisterId,
       identity,
       neuronId: fromDefinedNullable(neuron.id),
-      additionalDissolveDelaySeconds,
+      dissolveTimestampSeconds: nowInSeconds() + dissolveDelaySeconds,
     });
 
     return { success: true };

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -10,7 +10,6 @@ import {
   getNervousSystemFunctions,
   getNeuronBalance,
   getSnsNeuron,
-  increaseDissolveDelay,
   nervousSystemParameters,
   queryProposal,
   queryProposals,
@@ -19,6 +18,7 @@ import {
   refreshNeuron,
   registerVote,
   removeNeuronPermissions,
+  setDissolveDelay,
   setFollowees,
   splitNeuron,
   stakeMaturity,
@@ -79,7 +79,7 @@ describe("sns-api", () => {
   const splitNeuronSpy = jest.fn().mockResolvedValue(undefined);
   const startDissolvingSpy = jest.fn().mockResolvedValue(undefined);
   const stopDissolvingSpy = jest.fn().mockResolvedValue(undefined);
-  const increaseDissolveDelaySpy = jest.fn().mockResolvedValue(undefined);
+  const setDissolveDelaySpy = jest.fn().mockResolvedValue(undefined);
   const getNeuronBalanceSpy = jest.fn().mockResolvedValue(undefined);
   const refreshNeuronSpy = jest.fn().mockResolvedValue(undefined);
   const claimNeuronSpy = jest.fn().mockResolvedValue(undefined);
@@ -131,7 +131,7 @@ describe("sns-api", () => {
         splitNeuron: splitNeuronSpy,
         startDissolving: startDissolvingSpy,
         stopDissolving: stopDissolvingSpy,
-        increaseDissolveDelay: increaseDissolveDelaySpy,
+        setDissolveTimestamp: setDissolveDelaySpy,
         getNeuronBalance: getNeuronBalanceSpy,
         refreshNeuron: refreshNeuronSpy,
         claimNeuron: claimNeuronSpy,
@@ -254,15 +254,20 @@ describe("sns-api", () => {
     expect(stopDissolvingSpy).toBeCalled();
   });
 
-  it("should increaseDissolveDelay", async () => {
-    await increaseDissolveDelay({
+  it("should setDissolveDelay", async () => {
+    const dissolveTimestampSeconds = 123;
+    const neuronId = { id: arrayOfNumberToUint8Array([1, 2, 3]) };
+    await setDissolveDelay({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
-      neuronId: { id: arrayOfNumberToUint8Array([1, 2, 3]) },
-      additionalDissolveDelaySeconds: 123,
+      neuronId,
+      dissolveTimestampSeconds,
     });
 
-    expect(increaseDissolveDelaySpy).toBeCalled();
+    expect(setDissolveDelaySpy).toBeCalledWith({
+      dissolveTimestampSeconds: BigInt(dissolveTimestampSeconds),
+      neuronId,
+    });
   });
 
   it("should stakeMaturity", async () => {

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -37,6 +37,8 @@ const roundUpSecondsToWholeDays = (seconds: number): number =>
   daysToSeconds(secondsToDays(seconds));
 
 describe("IncreaseSnsDissolveDelayModal", () => {
+  const nowInSeconds = 1689063315;
+  const now = nowInSeconds * 1000;
   const neuron: SnsNeuron = {
     ...mockSnsNeuron,
     dissolve_state: [
@@ -65,6 +67,9 @@ describe("IncreaseSnsDissolveDelayModal", () => {
     jest
       .spyOn(authServices, "getAuthenticatedIdentity")
       .mockResolvedValue(testIdentity);
+
+    jest.clearAllTimers();
+    jest.useFakeTimers().setSystemTime(now);
 
     snsParametersStore.reset();
     snsParametersStore.setParameters({
@@ -139,7 +144,7 @@ describe("IncreaseSnsDissolveDelayModal", () => {
 
     confirmButton && (await fireEvent.click(confirmButton));
 
-    expect(snsGovernanceApi.increaseDissolveDelay).toBeCalledTimes(1);
+    expect(snsGovernanceApi.setDissolveDelay).toBeCalledTimes(1);
   });
 
   it("should be able to change dissolve delay in the confirmation screen using input", async () => {
@@ -183,10 +188,10 @@ describe("IncreaseSnsDissolveDelayModal", () => {
 
     confirmButton && (await fireEvent.click(confirmButton));
 
-    expect(snsGovernanceApi.increaseDissolveDelay).toBeCalledTimes(1);
-    expect(snsGovernanceApi.increaseDissolveDelay).toBeCalledWith(
+    expect(snsGovernanceApi.setDissolveDelay).toBeCalledTimes(1);
+    expect(snsGovernanceApi.setDissolveDelay).toBeCalledWith(
       expect.objectContaining({
-        additionalDissolveDelaySeconds: dissolveDelaySeconds,
+        dissolveTimestampSeconds: dissolveDelaySeconds + nowInSeconds,
       })
     );
   });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -612,51 +612,37 @@ describe("sns-neurons-services", () => {
   });
 
   describe("updateDelay ", () => {
-    const spyOnIncreaseDissolveDelay = jest
-      .spyOn(governanceApi, "increaseDissolveDelay")
+    const spyOnSetDissolveDelay = jest
+      .spyOn(governanceApi, "setDissolveDelay")
       .mockImplementation(() => Promise.resolve());
+    const nowInSeconds = 1689063315;
+    const now = nowInSeconds * 1000;
 
-    beforeEach(spyOnIncreaseDissolveDelay.mockClear);
+    beforeEach(() => {
+      jest.clearAllTimers();
+      jest.useFakeTimers().setSystemTime(now);
+      spyOnSetDissolveDelay.mockClear();
+    });
 
-    it("should call sns api increaseDissolveDelay", async () => {
+    it("should call sns api setDissolveDelay with dissolve timestamp", async () => {
       const neuronId = fromDefinedNullable(mockSnsNeuron.id);
       const identity = mockIdentity;
       const rootCanisterId = mockPrincipal;
+      const dissolveDelaySeconds = 123;
       const { success } = await updateDelay({
         rootCanisterId,
-        dissolveDelaySeconds: 123,
+        dissolveDelaySeconds,
         neuron: mockSnsNeuron,
       });
 
       expect(success).toBeTruthy();
 
-      expect(spyOnIncreaseDissolveDelay).toBeCalledWith({
+      expect(spyOnSetDissolveDelay).toBeCalledWith({
         neuronId,
         identity,
         rootCanisterId,
-        additionalDissolveDelaySeconds: 123,
+        dissolveTimestampSeconds: nowInSeconds + dissolveDelaySeconds,
       });
-    });
-
-    it("should calculate additionalDissolveDelaySeconds", async () => {
-      const rootCanisterId = mockPrincipal;
-      const { success } = await updateDelay({
-        rootCanisterId,
-        dissolveDelaySeconds: 333,
-        neuron: {
-          ...mockSnsNeuron,
-          dissolve_state: [{ DissolveDelaySeconds: BigInt(111) }],
-        },
-      });
-
-      expect(success).toBeTruthy();
-
-      expect(spyOnIncreaseDissolveDelay).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          additionalDissolveDelaySeconds: 222,
-        })
-      );
     });
   });
 


### PR DESCRIPTION
# Motivation

Dragginz SNS project has a max dissolve delay of 888 years.

The manageNeuron endpoint with IncreaseDissolveDelay doesn't support such a large number because it uses nat32.

In this PR: The NNS Dapp uses SetDissolveTimestamp which uses a nat64.

# Changes

* Change sns governance api `increaseDissolveDelay` for `setDissolveDelay` that uses the `SetDissolveTimestamp` manage neuron endpoint.
* Sns neuron service `updateDelay` uses the `setDissolveDelay`.

# Tests

* Substitute sns governance api test in `increaseDissolveDelay` for `setDissolveDelay`.
* Fix broken spec files after refactor.

# Todos

- [x] Add entry to changelog (if necessary).
