### PR TITLE
GIX-1683: UniversePageSummary Component

### DIFF
--- a/frontend/src/lib/components/universe/UniverseLogo.svelte
+++ b/frontend/src/lib/components/universe/UniverseLogo.svelte
@@ -14,6 +14,7 @@
   export let universe: Universe;
   export let size: "big" | "small" = "small";
   export let framed = false;
+  export let horizontalPadding = true;
 
   let summary: SnsSummary | undefined;
   $: summary = universe.summary;
@@ -36,7 +37,7 @@
   $: title = universeLogoAlt(universe);
 </script>
 
-<div class={`${size}`} data-tid="project-logo">
+<div class={`${size}`} class:horizontalPadding data-tid="project-logo">
   <Logo src={logo} alt={title} {size} {framed} testId="logo" />
 </div>
 
@@ -48,7 +49,7 @@
     width: fit-content;
   }
 
-  .small {
+  .small.horizontalPadding {
     padding: 0 var(--padding);
   }
 </style>

--- a/frontend/src/lib/components/universe/UniversePageSummary.svelte
+++ b/frontend/src/lib/components/universe/UniversePageSummary.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Universe } from "$lib/types/universe";
+  import UniverseLogo from "./UniverseLogo.svelte";
+  import UniverseName from "./UniverseName.svelte";
+
+  export let universe: Universe;
+</script>
+
+<div class="summary" data-tid="universe-page-summary-component">
+  <UniverseLogo {universe} framed horizontalPadding={false} />
+  <span><UniverseName {universe} /></span>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .summary {
+    display: flex;
+    gap: var(--padding);
+  }
+
+  span {
+    @include fonts.h3;
+    @include text.truncate;
+  }
+</style>

--- a/frontend/src/tests/lib/components/universe/UniversePageSummary.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniversePageSummary.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { CKTESTBTC_UNIVERSE } from "$lib//derived/ckbtc-universes.derived";
+import UniversePageSummary from "$lib/components/universe/UniversePageSummary.svelte";
+import { CKBTC_UNIVERSE } from "$lib/derived/ckbtc-universes.derived";
+import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
+import {
+  mockSnsFullProject,
+  mockSummary,
+} from "$tests/mocks/sns-projects.mock";
+import { UniversePageSummaryPo } from "$tests/page-objects/UniversePageSummary.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("UniversePageSummary", () => {
+  const renderComponent = (universe) => {
+    const { container } = render(UniversePageSummary, {
+      props: { universe },
+    });
+
+    return UniversePageSummaryPo.under(new JestPageObjectElement(container));
+  };
+
+  it("shout render IC", async () => {
+    const po = renderComponent(NNS_UNIVERSE);
+    expect(await po.getTitle()).toEqual("Internet Computer");
+  });
+
+  it("shout render sns", async () => {
+    const mockSnsUniverse = {
+      summary: mockSummary,
+      canisterId: mockSnsFullProject.rootCanisterId.toText(),
+    };
+    const po = renderComponent(mockSnsUniverse);
+    expect(await po.getTitle()).toEqual("Tetris");
+  });
+
+  it("shout render ckBTC", async () => {
+    const po = renderComponent(CKBTC_UNIVERSE);
+    expect(await po.getTitle()).toEqual("ckBTC");
+  });
+
+  it("shout render ckTESTBTC", async () => {
+    const po = renderComponent(CKTESTBTC_UNIVERSE);
+    expect(await po.getTitle()).toEqual("ckTESTBTC");
+  });
+});

--- a/frontend/src/tests/page-objects/UniversePageSummary.page-object.ts
+++ b/frontend/src/tests/page-objects/UniversePageSummary.page-object.ts
@@ -1,0 +1,16 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UniversePageSummaryPo extends BasePageObject {
+  private static readonly TID = "universe-page-summary-component";
+
+  static under(element: PageObjectElement): UniversePageSummaryPo {
+    return new UniversePageSummaryPo(
+      element.byTestId(UniversePageSummaryPo.TID)
+    );
+  }
+
+  async getTitle(): Promise<string> {
+    return (await this.getText()).trim();
+  }
+}


### PR DESCRIPTION
# Motivation

The new neuron settings page shows the summary different from now.

In this PR: New component reusing UniverseLogo and UniverseName components.

# Changes

* New component `UniversePageSummary`.
* New prop `horizontalPadding` in `UniverseLogo`.

I didn't want to reuse `Summary` because it has many different configurations and I didn't want to extend it even more.

# Tests

* Test new component `UniversePageSummary`.
* New page component `UniversePageSummaryPo`.

# Todos

Not worth a changelog entry yet.
