### PR TITLE
GIX-1683: Add "huge" to AmountDisplay

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -9,10 +9,9 @@
   export let inline = false;
   export let singleLine = false;
   export let title = false;
-  export let huge = false;
   export let copy = false;
   export let text = false;
-  export let inheritSize = false;
+  export let size: "inherit" | "huge" | undefined = undefined;
   export let sign: "+" | "-" | "" = "";
   export let detailed: boolean | "height_decimals" = false;
 </script>
@@ -20,11 +19,11 @@
 <div
   class:inline
   class:singleLine
-  class:inheritSize
+  class:inheritSize={size === "inherit"}
   class:title
   class:copy
   class:text
-  class:huge
+  class:huge={size === "huge"}
   class:plus-sign={sign === "+"}
   data-tid="token-value-label"
 >

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -9,6 +9,7 @@
   export let inline = false;
   export let singleLine = false;
   export let title = false;
+  export let huge = false;
   export let copy = false;
   export let text = false;
   export let inheritSize = false;
@@ -23,6 +24,7 @@
   class:title
   class:copy
   class:text
+  class:huge
   class:plus-sign={sign === "+"}
   data-tid="token-value-label"
 >
@@ -124,6 +126,10 @@
         // Custom line-height in case the value is spread on multiple lines - we have to amend the particular size of the copy button
         line-height: 1.8;
       }
+    }
+
+    &.huge span.value {
+      font-size: var(--font-size-huge);
     }
   }
 

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -72,7 +72,7 @@
   {#if myCommitment !== undefined}
     <dt><ProjectUserCommitmentLabel {summary} {swapCommitment} /></dt>
     <dd data-tid="commitment-token-value">
-      <AmountDisplay amount={myCommitment} singleLine inheritSize />
+      <AmountDisplay amount={myCommitment} singleLine size="inherit" />
     </dd>
   {/if}
 </dl>


### PR DESCRIPTION
# Motivation

New neuron settings has as title the stake of the neuron in a similar display but huge font.

In this PR: Add one prop "huge" to `AmountDisplay`.

# Changes

* New prop "huge" to `AmountDisplay` that uses the `font-size-huge`

# Tests

Only UI changes.

# Todos

Not worth mentioning changes yet.
