### PR TITLE
GIX-1683: IdentifierHash new prop splitLength

### DIFF
--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -9,9 +9,10 @@
   export let text: string;
   export let showCopy = false;
   export let className: string | undefined = undefined;
+  export let splitLength: number | undefined = undefined;
 
   let shortenText: string;
-  $: shortenText = shortenWithMiddleEllipsis(text);
+  $: shortenText = shortenWithMiddleEllipsis(text, splitLength);
 </script>
 
 <span data-tid="hash-component">

--- a/frontend/src/lib/components/ui/IdentifierHash.svelte
+++ b/frontend/src/lib/components/ui/IdentifierHash.svelte
@@ -2,6 +2,7 @@
   import Hash from "$lib/components/ui/Hash.svelte";
 
   export let identifier: string;
+  export let splitLength: number | undefined = undefined;
 </script>
 
 <Hash
@@ -10,4 +11,5 @@
   testId="identifier"
   text={identifier}
   showCopy
+  {splitLength}
 />

--- a/frontend/src/tests/lib/components/ui/Hash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Hash.spec.ts
@@ -19,6 +19,18 @@ describe("Hash", () => {
     expect(small?.textContent).toEqual(shortenWithMiddleEllipsis(identifier));
   });
 
+  it("should use the splitLength prop", () => {
+    const splitLength = 3;
+    const { getByTestId } = render(Hash, {
+      props: { text: identifier, testId, id: identifier, splitLength },
+    });
+
+    const small = getByTestId(testId);
+    expect(small?.textContent).toEqual(
+      shortenWithMiddleEllipsis(identifier, splitLength)
+    );
+  });
+
   it("should render a tooltip with all identifier", () => {
     const { container } = render(Hash, {
       props: { text: identifier, testId, id: identifier },


### PR DESCRIPTION
# Motivation

We don't need to cut NNS neuron ids in the new neuron settings.

Current IdentifierHash can't be configured to when start splitting and uses the default of the `shortenWithMiddleEllipsis` util.

# Changes

* Expose the `splitLength` parameter of `shortenWithMiddleEllipsis` within `Hash` component.
* Expose the `splitLength` parameter of `Hash` within `IdentifierHash` component.

# Tests

* Test that the new prop in `Hash` is being used.

# Todos

Not worth mentioning in the changelog.
