### PR TITLE
Set transitions as |local to solve populating destroy

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -770,11 +770,11 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-29.1.tgz",
-      "integrity": "sha512-X2dxx6Avf1vyeFY6RX6N0hJC3HL2Z31N+nnZW6Jg2/tk4ZL0luNmOgowJUQnfvQTvbjxFiJFwApLtAvvZnyIfQ==",
+      "version": "2.6.0-next-2023-07-12.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-12.1.tgz",
+      "integrity": "sha512-9CN4YrupjHk/99HDkL4RlnUXJojMDKwQNPD1+ZxxZr4e+5tICN7tdHY2KE9bXUt/kE2eJVOPDiwid8TmDYIdCw==",
       "dependencies": {
-        "dompurify": "^3.0.3",
+        "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       },
@@ -3944,9 +3944,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.3.tgz",
-      "integrity": "sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "node_modules/dotenv": {
       "version": "16.0.3",
@@ -10010,11 +10010,11 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-06-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-06-29.1.tgz",
-      "integrity": "sha512-X2dxx6Avf1vyeFY6RX6N0hJC3HL2Z31N+nnZW6Jg2/tk4ZL0luNmOgowJUQnfvQTvbjxFiJFwApLtAvvZnyIfQ==",
+      "version": "2.6.0-next-2023-07-12.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-12.1.tgz",
+      "integrity": "sha512-9CN4YrupjHk/99HDkL4RlnUXJojMDKwQNPD1+ZxxZr4e+5tICN7tdHY2KE9bXUt/kE2eJVOPDiwid8TmDYIdCw==",
       "requires": {
-        "dompurify": "^3.0.3",
+        "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       }
@@ -12276,9 +12276,9 @@
       }
     },
     "dompurify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.3.tgz",
-      "integrity": "sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "dotenv": {
       "version": "16.0.3",

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -55,7 +55,7 @@
   $: seconds = date.getTime() / 1000;
 </script>
 
-<article data-tid="transaction-card" transition:fade>
+<article data-tid="transaction-card" transition:fade|local>
   <div class="icon" class:send={!isReceive}>
     <IconNorthEast size="24px" />
   </div>

--- a/frontend/src/routes/(app)/(u)/(detail)/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/+layout.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  import { isNullish } from "@dfinity/utils";
-  import { navigating } from "$app/stores";
-</script>
-
-<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
-{#if isNullish($navigating)}
-  <slot />
-{/if}

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -14,7 +14,6 @@
   onMount(async () => await initAppAuth());
 </script>
 
-<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
 {#if isNullish($navigating)}
   <Layout layout="stretch">
     <Banner />


### PR DESCRIPTION
# Motivation

Svelte transitions are executed by default in components regardless if their parent components destroy those or not. This behavior is known as the `|global` transitions.

This leads NNS dapp to various issues in which components are not destroyed and therefore, there context remains active.

Until today we solved this by applying a workaround in which we destroyed the all layout in case of navigation. While it solved the issue, this had for side effect to be a bit unpleasant for the eyes as the all page layout disappeared on navigation.

By setting all the animation to `|local` we can solve the issue and make the navigation more fluid.

# References

- documentation: https://svelte.dev/docs/v4-migration-guide#transitions-are-local-by-default
- svelte issue: https://github.com/sveltejs/svelte/issues/6686

# PRs

- [x] https://github.com/dfinity/gix-components/pull/246

# Previous issues

- #1741
- #2861

# Changes

- update gix-cmp to set `|local` to any Svelte transitions
- set `|local` to the Svelte animations implemented in NNS dapp
- remove detail page layout navigating guard

# Notes

In the login page we will continue to observe `$navigating`  because this condition was not only used to solve the issue but, also to present a spinner while the application is loading.
