### PR TITLE
Rm unused field

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -53,6 +53,9 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Deprecated
 #### Removed
+
+* Duplicate `ic-cdk-optimizer` version field.
+
 #### Fixed
 
 #### Security

--- a/dfx.json
+++ b/dfx.json
@@ -645,7 +645,6 @@
         "NODE_VERSION": "18.14.2",
         "WASM_NM_VERSION": "0.2.0",
         "IC_WASM_VERSION": "0.3.6",
-        "IC_CDK_OPTIMIZER_VERSION": "0.3.1",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2023-06-30",


### PR DESCRIPTION
# Motivation
There are two version fields for the `ic-cdk-optimizer` in `dfx.json`.  Only one is used.  Confusing.

# Changes
* Delete the unused version field.

# Tests
See CI.

# Todos

- [x] Add entry to changelog (if necessary).
