### PR TITLE
GIX-1725: Merge Only Locked Neurons

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -20,6 +20,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Setting Dissolve Delay supports 888 years.
 * Improve reponsiveness in proposal filter modals.
 * Improve responsiveness in proposal filter modals.
+* Only Locked neurons are mergeable.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -309,6 +309,7 @@
     "cannot_merge_neuron_community": "Neurons that joined the Neurons' Fund can't be merged.",
     "cannot_merge_neuron_spawning": "Neurons that are spawning can't be merged.",
     "cannot_merge_neuron_hotkey": "You cannot merge neurons controlled by a hotkey.",
+    "cannot_merge_neuron_state": "Only locked neurons can be merged.",
     "only_merge_two": "You can only merge two neurons at a time.",
     "need_two_to_merge": "You need at least two neurons to merge",
     "irreversible_action": "This action is irreversible.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -319,6 +319,7 @@ interface I18nNeurons {
   cannot_merge_neuron_community: string;
   cannot_merge_neuron_spawning: string;
   cannot_merge_neuron_hotkey: string;
+  cannot_merge_neuron_state: string;
   only_merge_two: string;
   need_two_to_merge: string;
   irreversible_action: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -447,6 +447,9 @@ export const isEnoughMaturityToSpawn = ({
 export const isSpawning = (neuron: NeuronInfo): boolean =>
   neuron.state === NeuronState.Spawning;
 
+const isLocked = (neuron: NeuronInfo): boolean =>
+  neuron.state === NeuronState.Locked;
+
 // Tested with `mapMergeableNeurons`
 const isMergeableNeuron = ({
   neuron,
@@ -457,7 +460,7 @@ const isMergeableNeuron = ({
 }): boolean =>
   !hasJoinedCommunityFund(neuron) &&
   !isSpawning(neuron) &&
-  neuron.state === NeuronState.Locked &&
+  isLocked(neuron) &&
   isNeuronControllable({ neuron, accounts });
 
 const getMergeableNeuronMessageKey = ({
@@ -476,7 +479,7 @@ const getMergeableNeuronMessageKey = ({
   if (!isNeuronControllable({ neuron, accounts })) {
     return "neurons.cannot_merge_neuron_hotkey";
   }
-  if (neuron.state !== NeuronState.Locked) {
+  if (!isLocked(neuron)) {
     return "neurons.cannot_merge_neuron_state";
   }
 };
@@ -592,7 +595,7 @@ const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
 };
 
 /**
- * This function checks whether two neurons can be merged
+ * This function checks whether two or more neurons can be merged
  * but it doesn't check if each neuron is mergeable.
  *
  * The mergeability of each neuron should be checked before calling this function.

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -457,6 +457,7 @@ const isMergeableNeuron = ({
 }): boolean =>
   !hasJoinedCommunityFund(neuron) &&
   !isSpawning(neuron) &&
+  neuron.state === NeuronState.Locked &&
   isNeuronControllable({ neuron, accounts });
 
 const getMergeableNeuronMessageKey = ({
@@ -474,6 +475,9 @@ const getMergeableNeuronMessageKey = ({
   }
   if (!isNeuronControllable({ neuron, accounts })) {
     return "neurons.cannot_merge_neuron_hotkey";
+  }
+  if (neuron.state !== NeuronState.Locked) {
+    return "neurons.cannot_merge_neuron_state";
   }
 };
 
@@ -587,6 +591,12 @@ const sameManageNeuronFollowees = (neurons: NeuronInfo[]): boolean => {
   return allHaveSameFollowees(sortedFollowees);
 };
 
+/**
+ * This function checks whether two neurons can be merged
+ * but it doesn't check if each neuron is mergeable.
+ *
+ * The mergeability of each neuron should be checked before calling this function.
+ */
 export const canBeMerged = (
   neurons: NeuronInfo[]
 ): { isValid: boolean; messageKey?: string } => {

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -23,7 +23,7 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { NeuronInfo } from "@dfinity/nns";
+import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 
 jest.mock("$lib/api/governance.api");
 
@@ -87,11 +87,13 @@ describe("MergeNeuronsModal", () => {
     const controller = testIdentity.getPrincipal().toText();
     const mergeableNeuron1 = {
       neuronId: BigInt(10),
+      state: NeuronState.Locked,
       controller,
       stake: BigInt(12 * E8S_PER_ICP),
     };
     const mergeableNeuron2 = {
       neuronId: BigInt(11),
+      state: NeuronState.Locked,
       controller,
       stake: BigInt(34 * E8S_PER_ICP),
     };
@@ -349,10 +351,12 @@ describe("MergeNeuronsModal", () => {
     const controller = mockHardwareWalletAccount.principal?.toText() as string;
     const mergeableNeuron1 = {
       neuronId: BigInt(10),
+      state: NeuronState.Locked,
       controller,
     };
     const mergeableNeuron2 = {
       neuronId: BigInt(11),
+      state: NeuronState.Locked,
       controller,
     };
     const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
@@ -381,10 +385,12 @@ describe("MergeNeuronsModal", () => {
   describe("when neurons from main user and hardware wallet", () => {
     const neuronHW = {
       neuronId: BigInt(10),
+      state: NeuronState.Locked,
       controller: mockHardwareWalletAccount.principal?.toText() as string,
     };
     const neuronMain = {
       neuronId: BigInt(11),
+      state: NeuronState.Locked,
       controller: testIdentity.getPrincipal().toText(),
     };
     const neurons = [neuronMain, neuronHW];

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1163,6 +1163,7 @@ describe("neuron-utils", () => {
     it("wraps mergeable neurons with true if mergeable", () => {
       const neuron = {
         ...mockNeuron,
+        state: NeuronState.Locked,
         fullNeuron: {
           ...mockFullNeuron,
           hasJoinedCommunityFund: undefined,
@@ -1193,6 +1194,7 @@ describe("neuron-utils", () => {
     it("wraps mergeable neurons with false if user is not controller or joined community fund", () => {
       const neuron = {
         ...mockNeuron,
+        state: NeuronState.Locked,
         fullNeuron: {
           ...mockFullNeuron,
           hasJoinedCommunityFund: undefined,
@@ -1225,6 +1227,46 @@ describe("neuron-utils", () => {
       const neuron = {
         ...mockNeuron,
         state: NeuronState.Spawning,
+        fullNeuron: {
+          ...mockFullNeuron,
+          hasJoinedCommunityFund: undefined,
+          controller: mockIdentity.getPrincipal().toText(),
+        },
+      };
+      const wrappedNeurons = mapMergeableNeurons({
+        neurons: [neuron],
+        accounts: {
+          main: mockMainAccount,
+        },
+        selectedNeurons: [],
+      });
+      expect(wrappedNeurons[0].mergeable).toBe(false);
+    });
+
+    it("wraps mergeable neurons with false if neuron is Dissolving", () => {
+      const neuron = {
+        ...mockNeuron,
+        state: NeuronState.Dissolving,
+        fullNeuron: {
+          ...mockFullNeuron,
+          hasJoinedCommunityFund: undefined,
+          controller: mockIdentity.getPrincipal().toText(),
+        },
+      };
+      const wrappedNeurons = mapMergeableNeurons({
+        neurons: [neuron],
+        accounts: {
+          main: mockMainAccount,
+        },
+        selectedNeurons: [],
+      });
+      expect(wrappedNeurons[0].mergeable).toBe(false);
+    });
+
+    it("wraps mergeable neurons with false if neuron is Dissolved", () => {
+      const neuron = {
+        ...mockNeuron,
+        state: NeuronState.Dissolved,
         fullNeuron: {
           ...mockFullNeuron,
           hasJoinedCommunityFund: undefined,
@@ -1313,6 +1355,7 @@ describe("neuron-utils", () => {
     it("wraps selected neurons with selected property true", () => {
       const neuron = {
         ...mockNeuron,
+        state: NeuronState.Locked,
         fullNeuron: {
           ...mockFullNeuron,
           hasJoinedCommunityFund: undefined,
@@ -1347,6 +1390,7 @@ describe("neuron-utils", () => {
     it(`does not allow to have more mergeable once ${MAX_NEURONS_MERGED} is reached`, () => {
       const neuron = {
         ...mockNeuron,
+        state: NeuronState.Locked,
         fullNeuron: {
           ...mockFullNeuron,
           hasJoinedCommunityFund: undefined,


### PR DESCRIPTION
# Motivation

As explained [here](https://forum.dfinity.org/t/52-year-neuron-fixes/21301),  only neurons in the Locked state are mergeable until further notice.

To avoid confusion with the users, we should apply this condition on top of the rest of conditions we use to disable neurons when merging them.

# Changes

* Add a new case in neuron util helper `isMergeableNeuron`.
* Add the same case in neuron util helper `getMergeableNeuronMessageKey`.

# Tests

* Add a new teste case in `mapMergeableNeurons` which uses the helpers.
* Add the Locked state explicitly in the merging neurons tests. This was not strictly necessary because the mock neuron is already in the locked state. But I preferred to be explicit that the locked state is required for a mergeable neuron.

# Todos

- [x] Add entry to changelog (if necessary).
