### PR TITLE
feat: add copy button to the sns proposal proposer id

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -21,6 +21,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Improve reponsiveness in proposal filter modals.
 * Improve responsiveness in proposal filter modals.
 * Only Locked neurons are mergeable.
+* Add copy button to sns proposal proposer id.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposerEntry.svelte
@@ -22,6 +22,8 @@
       tagName="span"
       text={proposerText}
       id="proposer-id"
+      showCopy
+      flowLessCopy
     />
   </svelte:fragment>
 

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -8,6 +8,8 @@
   export let id: string;
   export let text: string;
   export let showCopy = false;
+  // remove copy icon from the css flow
+  export let flowLessCopy = false;
   export let className: string | undefined = undefined;
   export let splitLength: number | undefined = undefined;
 
@@ -15,14 +17,16 @@
   $: shortenText = shortenWithMiddleEllipsis(text, splitLength);
 </script>
 
-<span data-tid="hash-component">
+<span data-tid="hash-component" class:flowLessCopy>
   <Tooltip {id} {text}>
     <svelte:element this={tagName} data-tid={testId} class={className}>
       {shortenText}</svelte:element
     >
   </Tooltip>
   {#if showCopy}
-    <Copy value={text} />
+    <div class="copy">
+      <Copy value={text} />
+    </div>
   {/if}
 </span>
 
@@ -30,5 +34,18 @@
   span {
     display: inline-flex;
     gap: var(--padding-0_5x);
+
+    &.flowLessCopy {
+      // add padding to the right of the text to make space for the copy icon (button + padding)
+      padding-right: calc(var(--padding-4x) + var(--padding-0_5x));
+
+      // center vertically the copy icon
+      .copy {
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translate(0, -50%);
+      }
+    }
   }
 </style>

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -71,12 +71,21 @@
 
   let destroyed = false;
   onDestroy(() => (destroyed = true));
+
+  const onclick = (e: MouseEvent) => {
+    console.log("click", e);
+  };
 </script>
 
 <svelte:window bind:innerWidth />
 
 <div class="tooltip-wrapper" data-tid="tooltip-component">
-  <div class="tooltip-target" aria-describedby={id} bind:this={target}>
+  <div
+    class="tooltip-target"
+    aria-describedby={id}
+    bind:this={target}
+    on:click={onclick}
+  >
     <slot />
   </div>
   <div

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -71,21 +71,12 @@
 
   let destroyed = false;
   onDestroy(() => (destroyed = true));
-
-  const onclick = (e: MouseEvent) => {
-    console.log("click", e);
-  };
 </script>
 
 <svelte:window bind:innerWidth />
 
 <div class="tooltip-wrapper" data-tid="tooltip-component">
-  <div
-    class="tooltip-target"
-    aria-describedby={id}
-    bind:this={target}
-    on:click={onclick}
-  >
+  <div class="tooltip-target" aria-describedby={id} bind:this={target}>
     <slot />
   </div>
   <div


### PR DESCRIPTION
# Motivation

The sns proposal proposer ID text is shortened so it's not possible to copy it from the UI. This pr adds the copy button to solve it.

# Changes

- add `flowLessCopy` param. Otherwise the button is not centered and stretch out the card bottom.
![image](https://github.com/dfinity/nns-dapp/assets/98811342/021d85e6-ba3b-4e48-8303-0c5a05c65f3a)
- add the copy button to proposer id

# Tests

- manually, because only style changes

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

| Before | Now |
|--------|--------|
| ![image](https://github.com/dfinity/nns-dapp/assets/98811342/e2802dc0-0095-47b5-94fc-6ac071cfcc43) | ![image](https://github.com/dfinity/nns-dapp/assets/98811342/afee09b1-5c75-4937-86a3-f0cb12089f2f) | 
