### PR TITLE
GIX-1683: SnsPageHeader and PageHeader

### DIFF
--- a/frontend/src/lib/components/common/PageHeader.svelte
+++ b/frontend/src/lib/components/common/PageHeader.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<div class="container" data-tid={testId}>
+  <slot name="start" />
+  <slot name="end" />
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+    justify-content: center;
+    align-items: center;
+
+    @include media.min-width(medium) {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
@@ -4,39 +4,25 @@
   import IdentifierHash from "../ui/IdentifierHash.svelte";
   import { MAX_NEURON_ID_DIGITS } from "$lib/constants/neurons.constants";
   import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
+  import PageHeader from "../common/PageHeader.svelte";
 
   export let neuron: NeuronInfo;
 </script>
 
-<div class="container" data-tid="nns-neuron-page-header-component">
-  <UniversePageSummary universe={NNS_UNIVERSE} />
-  <span class="description header-end">
+<PageHeader testId="nns-neuron-page-header-component">
+  <UniversePageSummary slot="start" universe={NNS_UNIVERSE} />
+  <span slot="end" class="description header-end">
     <IdentifierHash
       identifier={neuron.neuronId.toString()}
       splitLength={MAX_NEURON_ID_DIGITS / 2}
     />
   </span>
-</div>
+</PageHeader>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
-
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding);
-    justify-content: center;
-    align-items: center;
-
-    @include media.min-width(medium) {
-      flex-direction: row;
-      justify-content: space-between;
-    }
-
-    .header-end {
-      // The IdentifierHash has the copy button at the end which has some extra padding.
-      // This is needed to align in the center the UniversePageSummary and the IdentifierHash in mobile view.
-      padding-left: var(--padding-1_5x);
-    }
+  .header-end {
+    // The IdentifierHash has the copy button at the end which has some extra padding.
+    // This is needed to align in the center the UniversePageSummary and the IdentifierHash in mobile view.
+    padding-left: var(--padding-1_5x);
   }
 </style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte
@@ -1,1 +1,37 @@
-<div>GIX-1683</div>
+<script lang="ts">
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "$lib/types/sns-neuron-detail.context";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { getContext } from "svelte";
+  import UniversePageSummary from "../universe/UniversePageSummary.svelte";
+  import IdentifierHash from "../ui/IdentifierHash.svelte";
+  import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+  import { nonNullish } from "@dfinity/utils";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
+  import PageHeader from "../common/PageHeader.svelte";
+
+  const { store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let neuron: SnsNeuron | undefined | null;
+  $: neuron = $store.neuron;
+</script>
+
+<PageHeader testId="sns-neuron-page-header-component">
+  <UniversePageSummary slot="start" universe={$selectedUniverseStore} />
+  <span slot="end" class="description header-end">
+    {#if nonNullish(neuron)}
+      <IdentifierHash identifier={getSnsNeuronIdAsHexString(neuron)} />
+    {/if}
+  </span>
+</PageHeader>
+
+<style lang="scss">
+  .header-end {
+    // The IdentifierHash has the copy button at the end which has some extra padding.
+    // This is needed to align in the center the UniversePageSummary and the IdentifierHash in mobile view.
+    padding-left: var(--padding-1_5x);
+  }
+</style>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronPageHeader from "$lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte";
+import { snsQueryStore } from "$lib/stores/sns.store";
+import { page } from "$mocks/$app/stores";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { SnsNeuronPageHeaderPo } from "$tests/page-objects/SnsNeuronPageHeader.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
+
+describe("SnsNeuronPageHeader", () => {
+  const renderSnsNeuronCmp = (neuron: SnsNeuron) => {
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronPageHeader,
+      neuron,
+      reload: jest.fn(),
+    });
+
+    return SnsNeuronPageHeaderPo.under(new JestPageObjectElement(container));
+  };
+  it("should render the Sns universe name", async () => {
+    const projectName = "Tetris";
+    const rootCanisterId = mockPrincipal;
+    const responses = snsResponseFor({
+      principal: rootCanisterId,
+      lifecycle: SnsSwapLifecycle.Committed,
+      projectName,
+    });
+    snsQueryStore.setData(responses);
+    page.mock({ data: { universe: rootCanisterId.toText() } });
+
+    const po = renderSnsNeuronCmp(mockSnsNeuron);
+
+    expect(await po.getUniverse()).toEqual(projectName);
+  });
+});

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -10,7 +10,8 @@ import { nonNullish, toNullable } from "@dfinity/utils";
 import {
   mockDerived,
   mockInit,
-  mockQueryMetadata,
+  mockQueryMetadataResponse,
+  mockQueryTokenResponse,
   principal,
   summaryForLifecycle,
 } from "./sns-projects.mock";
@@ -41,16 +42,24 @@ export const snsResponseFor = ({
   certified = false,
   restrictedCountries,
   directParticipantCount,
+  projectName,
 }: {
   principal: Principal;
   lifecycle: SnsSwapLifecycle;
   certified?: boolean;
   restrictedCountries?: string[];
   directParticipantCount?: [] | [bigint];
+  projectName?: string;
 }): [QuerySnsMetadata[], QuerySnsSwapState[]] => [
   [
     {
-      ...mockQueryMetadata,
+      metadata: {
+        ...mockQueryMetadataResponse,
+        name: nonNullish(projectName)
+          ? [projectName]
+          : mockQueryMetadataResponse.name,
+      },
+      token: mockQueryTokenResponse,
       rootCanisterId: principal.toText(),
       certified,
     },

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeader.page-object.ts
@@ -1,0 +1,21 @@
+import { UniversePageSummaryPo } from "$tests/page-objects/UniversePageSummary.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsNeuronPageHeaderPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-page-header-component";
+
+  static under(element: PageObjectElement): SnsNeuronPageHeaderPo {
+    return new SnsNeuronPageHeaderPo(
+      element.byTestId(SnsNeuronPageHeaderPo.TID)
+    );
+  }
+
+  getUniversePageSummaryPo(): UniversePageSummaryPo {
+    return UniversePageSummaryPo.under(this.root);
+  }
+
+  getUniverse(): Promise<string> {
+    return this.getUniversePageSummaryPo().getTitle();
+  }
+}


### PR DESCRIPTION
# Motivation

We are reshuffling the data displayed in the neuron details.

In this PR: Add the new header for the SNS neuron detail page. See screenshot attached.

# Changes

* New common component `PageHeader` in `common`.
* `NnsNeuronPageHeader` uses new `PageHeader`.
* Implement `SnsNeuronPageHeader` that uses also `PageHeader`.

# Tests

* Add spec file for `SnsNeuronPageHeader`.
* New page object `SnsNeuronPageHeaderPo`.

# Todos

Not yet worth a changelog entry.
