### PR TITLE
GIX-1683: SnsNeuronPageHeading & PageHeading

### DIFF
--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<div class="container" data-tid={testId}>
+  <slot name="title" />
+  <h3 class="description">
+    <slot name="subtitle" />
+  </h3>
+</div>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-1_5x);
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+
+    h3 {
+      margin: 0;
+      font-weight: normal;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -5,6 +5,7 @@
   import { formatVotingPower, neuronStake } from "$lib/utils/neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
+  import PageHeading from "../common/PageHeading.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -15,28 +16,11 @@
   });
 </script>
 
-<div class="container" data-tid="nns-neuron-page-heading-component">
-  <AmountDisplay {amount} size="huge" singleLine />
-  <h3 class="description" data-tid="voting-power-subtitle">
+<PageHeading testId="nns-neuron-page-heading-component">
+  <AmountDisplay slot="title" {amount} size="huge" singleLine />
+  <svelte:fragment slot="subtitle">
     {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
       $votingPower: formatVotingPower(neuron.votingPower),
     })}
-  </h3>
-</div>
-
-<style lang="scss">
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-1_5x);
-    justify-content: center;
-    align-items: center;
-
-    width: 100%;
-
-    h3 {
-      margin: 0;
-      font-weight: normal;
-    }
-  }
-</style>
+  </svelte:fragment>
+</PageHeading>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "$lib/types/sns-neuron-detail.context";
+  import { getContext } from "svelte";
+  import AmountDisplay from "../ic/AmountDisplay.svelte";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import { TokenAmount, type Token, nonNullish } from "@dfinity/utils";
+  import { tokensStore } from "$lib/stores/tokens.store";
+  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import {
+    getSnsNeuronStake,
+    snsNeuronVotingPower,
+  } from "$lib/utils/sns-neuron.utils";
+  import { formatNumber } from "$lib/utils/format.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import PageHeading from "../common/PageHeading.svelte";
+
+  export let parameters: SnsNervousSystemParameters;
+
+  const { store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let neuron: SnsNeuron | undefined | null;
+  $: neuron = $store.neuron;
+
+  let token: Token | undefined;
+  $: token = $tokensStore[$selectedUniverseIdStore.toText()].token;
+
+  let amount: TokenAmount | undefined;
+  $: amount =
+    nonNullish(token) && nonNullish(neuron)
+      ? TokenAmount.fromE8s({
+          amount: getSnsNeuronStake(neuron),
+          token: token,
+        })
+      : undefined;
+</script>
+
+<PageHeading testId="sns-neuron-page-heading-component">
+  <svelte:fragment slot="title">
+    {#if nonNullish(amount)}
+      <AmountDisplay {amount} size="huge" singleLine />
+    {/if}
+  </svelte:fragment>
+  <svelte:fragment slot="subtitle">
+    {#if nonNullish(neuron)}
+      {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
+        $votingPower: formatNumber(
+          snsNeuronVotingPower({ neuron, snsParameters: parameters })
+        ),
+      })}
+    {/if}
+  </svelte:fragment>
+</PageHeading>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -42,6 +42,8 @@
   import SnsNeuronVotingPowerSection from "$lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte";
   import SnsNeuronMaturitySection from "$lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte";
   import SnsNeuronAdvancedSection from "$lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte";
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
 
   export let neuronId: string | null | undefined;
 
@@ -149,11 +151,15 @@
           <SkeletonCard cardType="info" separator />
           <SkeletonCard cardType="info" separator />
         {:else}
-          {#if $ENABLE_NEURON_SETTINGS}
-            <SnsNeuronPageHeader />
-            <SnsNeuronVotingPowerSection />
-            <SnsNeuronMaturitySection />
-            <SnsNeuronAdvancedSection />
+          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters)}
+            <div class="section-wrapper">
+              <SnsNeuronPageHeader />
+              <SnsNeuronPageHeading {parameters} />
+              <Separator spacing="none" />
+              <SnsNeuronVotingPowerSection />
+              <SnsNeuronMaturitySection />
+              <SnsNeuronAdvancedSection />
+            </div>
           {/if}
           <Summary />
 
@@ -179,3 +185,11 @@
 
   <SnsNeuronModals />
 </TestIdWrapper>
+
+<style lang="scss">
+  .section-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+  }
+</style>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
+import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import {
+  mockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+
+describe("SnsNeuronPageHeading", () => {
+  const renderSnsNeuronCmp = (neuron: SnsNeuron) => {
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronPageHeading,
+      neuron,
+      reload: jest.fn(),
+      props: {
+        parameters: snsNervousSystemParametersMock,
+      },
+    });
+
+    return SnsNeuronPageHeadingPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render the neuron's stake", async () => {
+    const stake = 314_000_000n;
+    const po = renderSnsNeuronCmp({
+      ...mockSnsNeuron,
+      cached_neuron_stake_e8s: stake,
+    });
+
+    expect(await po.getStake()).toEqual("3.14");
+  });
+});

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -1,0 +1,21 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsNeuronPageHeadingPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-page-heading-component";
+
+  static under(element: PageObjectElement): SnsNeuronPageHeadingPo {
+    return new SnsNeuronPageHeadingPo(
+      element.byTestId(SnsNeuronPageHeadingPo.TID)
+    );
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+
+  getStake(): Promise<string> {
+    return this.getAmountDisplayPo().getAmount();
+  }
+}


### PR DESCRIPTION
# Motivation

We are reshuffling how the data is displayed in the neuron detail page.

In this PR: Introduce the new heading component for the SNS neuron detail page.

# Changes

* New component in common `PageHeading`.
* `NnsNeuronPageHeader` uses the new `PageHeading`.
* New component `SnsNeuronPageHeading` that also uses `PageHeading`.
* Add a wrapper that sets spacing for the new components of SnsNeuronDetailPage and render the new `SnsNeuronPageHeading` and a separator.

# Tests

* Spec file for new component `SnsNeuronPageHeading`.

# Todos

Changes not worth still a changelog entry.
