### PR TITLE
fix: broken onDestroy on navigation

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -55,7 +55,7 @@
   $: seconds = date.getTime() / 1000;
 </script>
 
-<article data-tid="transaction-card" transition:fade|local>
+<article data-tid="transaction-card" transition:fade|global>
   <div class="icon" class:send={!isReceive}>
     <IconNorthEast size="24px" />
   </div>

--- a/frontend/src/routes/(app)/(u)/(detail)/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/+layout.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { isNullish } from "@dfinity/utils";
+  import { navigating } from "$app/stores";
+</script>
+
+<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
+{#if isNullish($navigating)}
+  <slot />
+{/if}

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -14,6 +14,7 @@
   onMount(async () => await initAppAuth());
 </script>
 
+<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
 {#if isNullish($navigating)}
   <Layout layout="stretch">
     <Banner />


### PR DESCRIPTION
# Motivation

Reverting layout based fix for missing onDestroy after disbursing sns neuron ([more info](https://github.com/dfinity/nns-dapp/pull/2861))

# PRs

Revert PR #2865

# Changes

- apply the workaround from the wallet page to all detail pages.
- set local to global animation flag

# Tests

Tested manually

