### PR TITLE
GIX-1684: Nns neuron voting power section

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -5,7 +5,7 @@
   import { formatVotingPower, neuronStake } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import StakeItemAction from "./StakeItemAction.svelte";
+  import NnsStakeItemAction from "./NnsStakeItemAction.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -16,16 +16,18 @@
   });
 </script>
 
-<Section>
+<Section testId="nns-neuron-voting-power-section-component">
   <h3 slot="title">{$i18n.neurons.voting_power}</h3>
-  <h3 slot="end">{formatVotingPower(neuron.votingPower)}</h3>
+  <h3 slot="end" data-tid="voting-power">
+    {formatVotingPower(neuron.votingPower)}
+  </h3>
   <p slot="description">
     {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {
       $token: ICPToken.symbol,
     })}
   </p>
   <ul class="content">
-    <StakeItemAction {neuron} />
+    <NnsStakeItemAction {neuron} />
   </ul>
 </Section>
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -1,1 +1,44 @@
-<div>GIX-1684</div>
+<script lang="ts">
+  import { Section } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { ICPToken, TokenAmount } from "@dfinity/utils";
+  import { formatVotingPower, neuronStake } from "$lib/utils/neuron.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import StakeItemAction from "./StakeItemAction.svelte";
+
+  export let neuron: NeuronInfo;
+
+  let amount: TokenAmount;
+  $: amount = TokenAmount.fromE8s({
+    amount: neuronStake(neuron),
+    token: ICPToken,
+  });
+</script>
+
+<Section>
+  <h3 slot="title">{$i18n.neurons.voting_power}</h3>
+  <h3 slot="end">{formatVotingPower(neuron.votingPower)}</h3>
+  <p slot="description">
+    {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {
+      $token: ICPToken.symbol,
+    })}
+  </p>
+  <ul class="content">
+    <StakeItemAction {neuron} />
+  </ul>
+</Section>
+
+<style lang="scss">
+  h3,
+  p {
+    margin: 0;
+  }
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    padding: 0;
+  }
+</style>

--- a/frontend/src/lib/components/neuron-detail/NnsStakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsStakeItemAction.svelte
@@ -12,7 +12,7 @@
   export let neuron: NeuronInfo;
 </script>
 
-<ItemAction>
+<ItemAction testId="nns-stake-item-action-component">
   <UniverseLogo
     slot="icon"
     size="big"
@@ -22,9 +22,9 @@
   />
   <div class="content">
     <p class="icp-value">
-      <span>{formatToken({ value: neuronStake(neuron) })}</span><span
-        >{ICPToken.symbol}</span
-      >
+      <span data-tid="stake-value"
+        >{formatToken({ value: neuronStake(neuron) })}</span
+      ><span>{ICPToken.symbol}</span>
     </p>
     <p class="description">{$i18n.neurons.ic_stake}</p>
   </div>

--- a/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { ItemAction } from "@dfinity/gix-components";
+  import UniverseLogo from "../universe/UniverseLogo.svelte";
+  import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
+  import NnsIncreaseStakeButton from "./actions/NnsIncreaseStakeButton.svelte";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import { ICPToken } from "@dfinity/utils";
+  import { neuronStake } from "$lib/utils/neuron.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatToken } from "$lib/utils/token.utils";
+
+  export let neuron: NeuronInfo;
+</script>
+
+<ItemAction>
+  <UniverseLogo
+    slot="icon"
+    size="big"
+    universe={NNS_UNIVERSE}
+    framed
+    horizontalPadding={false}
+  />
+  <div class="content">
+    <p class="icp-value">
+      <span>{formatToken({ value: neuronStake(neuron) })}</span><span
+        >{ICPToken.symbol}</span
+      >
+    </p>
+    <p class="description">{$i18n.neurons.ic_stake}</p>
+  </div>
+  <NnsIncreaseStakeButton slot="actions" variant="secondary" />
+</ItemAction>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .icp-value {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
@@ -16,6 +16,7 @@
 
 <button
   class={variant}
+  data-tid="nns-increase-stake-button-component"
   on:click={() =>
     openNnsNeuronModal({
       type: "increase-stake",

--- a/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
@@ -7,13 +7,15 @@
   import { getContext } from "svelte";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
 
+  export let variant: "primary" | "secondary" = "primary";
+
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
   );
 </script>
 
 <button
-  class="primary"
+  class={variant}
   on:click={() =>
     openNnsNeuronModal({
       type: "increase-stake",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -560,6 +560,7 @@
     "split_neuron": "Split Neuron",
     "voting_power_subtitle": "Voting Power: $votingPower",
     "voting_power_tooltip_with_stake": "Calculated as: <br/>($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus<br/>($stake + $st4kedMaturity) x $delayMultiplier x $ageMultiplier",
+    "voting_power_section_description": "Voting Power = ($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus",
     "join_community_fund_description": "Are you sure you want this neuron to <strong>join</strong> the neurons' fund?",
     "leave_community_fund_description": "Are you sure you want this neuron to <strong>leave</strong> the neurons' fund?",
     "participate_community_fund": "Participate in neurons' fund.",

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -154,7 +154,7 @@
               <NnsNeuronPageHeader {neuron} />
               <NnsNeuronPageHeading {neuron} />
               <Separator spacing="none" />
-              <NnsNeuronVotingPowerSection />
+              <NnsNeuronVotingPowerSection {neuron} />
               <NnsNeuronMaturitySection />
               <NnsNeuronAdvancedSection />
             </div>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -583,6 +583,7 @@ interface I18nNeuron_detail {
   split_neuron: string;
   voting_power_subtitle: string;
   voting_power_tooltip_with_stake: string;
+  voting_power_section_description: string;
   join_community_fund_description: string;
   leave_community_fund_description: string;
   participate_community_fund: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronContextTest.svelte
@@ -11,6 +11,7 @@
 
   export let testComponent: typeof SvelteComponent;
   export let neuron: NeuronInfo | undefined;
+  export let componentProps: Record<string, unknown> = {};
 
   export const neuronStore = writable<NnsNeuronStore>({
     neuron,
@@ -21,6 +22,6 @@
   });
 </script>
 
-<svelte:component this={testComponent} />
+<svelte:component this={testComponent} {...componentProps} />
 
 <NnsNeuronModals />

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsNeuronVotingPowerSection from "$lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+
+describe("NnsStakeItemAction", () => {
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: NnsNeuronVotingPowerSection,
+      },
+    });
+
+    return NnsNeuronVotingPowerSectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render voting power", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      votingPower: 614000000n,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getVotingPower()).toBe("6.14");
+  });
+
+  it("should render NnsStakeItemAction", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasStakeItemAction()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsStakeItemAction from "$lib/components/neuron-detail/NnsStakeItemAction.svelte";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsStakeItemActionPo } from "$tests/page-objects/NnsStakeItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+
+describe("NnsStakeItemAction", () => {
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: NnsStakeItemAction,
+      },
+    });
+
+    return NnsStakeItemActionPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render ICP Stake of the neuron", async () => {
+    const stake = 314000000n;
+    const neuronFees = 0n;
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: stake,
+        neuronFees,
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getStake()).toBe("3.14");
+  });
+
+  it("should render increase stake button", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasIncreaseStakeButton()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -27,6 +27,20 @@ describe("NnsIncreaseStakeButton", () => {
     expect(getByText(en.neuron_detail.increase_stake)).toBeInTheDocument();
   });
 
+  it("uses variant", () => {
+    const variant = "secondary";
+    const { container } = render(NeuronContextTest, {
+      props: {
+        neuron: mockNeuron,
+        testComponent: NnsIncreaseStakeButton,
+      },
+    });
+
+    expect(container.querySelector("button").classList.contains(variant)).toBe(
+      true
+    );
+  });
+
   it("opens Increase Neuron Stake Modal", async () => {
     // To avoid that the modal requests the accounts
     accountsStore.setForTesting(mockAccountsStoreData);

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -29,16 +29,21 @@ describe("NnsIncreaseStakeButton", () => {
 
   it("uses variant", () => {
     const variant = "secondary";
-    const { container } = render(NeuronContextTest, {
+    const { queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,
         testComponent: NnsIncreaseStakeButton,
+        componentProps: {
+          variant,
+        },
       },
     });
 
-    expect(container.querySelector("button").classList.contains(variant)).toBe(
-      true
-    );
+    expect(
+      queryByTestId("nns-increase-stake-button-component").classList.contains(
+        variant
+      )
+    ).toBe(true);
   });
 
   it("opens Increase Neuron Stake Modal", async () => {

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsStakeItemActionPo } from "./NnsStakeItemAction.page-object";
+
+export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
+  private static readonly TID = "nns-neuron-voting-power-section-component";
+
+  static under(element: PageObjectElement): NnsNeuronVotingPowerSectionPo {
+    return new NnsNeuronVotingPowerSectionPo(
+      element.byTestId(NnsNeuronVotingPowerSectionPo.TID)
+    );
+  }
+
+  getVotingPower(): Promise<string> {
+    return this.getText("voting-power");
+  }
+
+  getStakeItemActionPo(): NnsStakeItemActionPo {
+    return NnsStakeItemActionPo.under(this.root);
+  }
+
+  hasStakeItemAction(): Promise<boolean> {
+    return this.getStakeItemActionPo().isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsStakeItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeItemAction.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsStakeItemActionPo extends BasePageObject {
+  private static readonly TID = "nns-stake-item-action-component";
+
+  static under(element: PageObjectElement): NnsStakeItemActionPo {
+    return new NnsStakeItemActionPo(element.byTestId(NnsStakeItemActionPo.TID));
+  }
+
+  getStake(): Promise<string> {
+    return this.getText("stake-value");
+  }
+
+  hasIncreaseStakeButton(): Promise<boolean> {
+    return this.getButton("nns-increase-stake-button-component").isPresent();
+  }
+}


### PR DESCRIPTION
# Motivation

We want to shuffle the information displayed in the neuron detail page.

In this PR: Setup the voting power section rendering the stake only. See screenshot.

# Changes

* Implement `NnsNeuronVotingPowerSection`.
* New component `NnsStakeItemAction`.

# Tests

* Test the implementation of `NnsNeuronVotingPowerSection`.
* Test the new component `NnsStakeItemAction`.

# Todos

This is not yet worth an entry in the changelog.
