### PR TITLE
fix: calls to onDestroy after disburse

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -96,6 +96,8 @@
 
     stopBusy("disburse-sns-neuron");
 
+    dispatcher("nnsClose");
+
     if (success) {
       toastsSuccess({
         labelKey: "neuron_detail.disburse_success",
@@ -103,8 +105,6 @@
 
       await goto($neuronsPathStore, { replaceState: true });
     }
-
-    dispatcher("nnsClose");
   };
 </script>
 


### PR DESCRIPTION
# Motivation

When a Sns neuron is successfully disbursed, the modal in which the action is triggered is closed and the user is automatically redirected to the list of neurons. As a result, we noticed that the page and components `onDestroy` were not called. We fixed the issue by adding a guard at the top of the layout.

Today I debugged the issue again and figured out that the root cause of the particular issue was the fact that the navigation was executed before the dispatcher that closes the modal was triggered.

I couldn't replicate the issue with a sample repo but, by inverting both order, can solve the issue.

# Notes

This PR does not remove the guard. Only fix the particular issue in case we would remove it in the future.

# PRs

Follow-up various PR but, last is #2880

# Changes

- invert `goto` and `dispatch("nnsClose")`
