### PR TITLE
Cleanup account identifier text types

### DIFF
--- a/frontend/src/lib/api/accounts.api.ts
+++ b/frontend/src/lib/api/accounts.api.ts
@@ -64,7 +64,7 @@ export const renameSubAccount = async ({
 }: {
   newName: string;
   identity: Identity;
-  subAccountIdentifier: string;
+  subAccountIdentifier: AccountIdentifierString;
 }): Promise<void> => {
   logWithTimestamp(
     `Renaming SubAccount ${hashCode(subAccountIdentifier)} call...`

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -3,6 +3,7 @@ import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
 import { isLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
+import type { IcpAccountIdentifierText } from "$lib/types/account";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { HttpAgent, Identity } from "@dfinity/agent";
@@ -76,7 +77,7 @@ export const queryAccountBalance = async ({
 }: {
   certified: boolean;
   identity: Identity;
-  accountIdentifier: string;
+  accountIdentifier: IcpAccountIdentifierText;
 }) => {
   logWithTimestamp(`Get account balance call...`);
   const { canister } = await ledgerCanister({ identity });

--- a/frontend/src/lib/components/accounts/BitcoinAddress.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinAddress.svelte
@@ -2,7 +2,7 @@
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CanisterId } from "$lib/types/canister";
-  import type { Account, AccountIdentifierText } from "$lib/types/account";
+  import type { Account } from "$lib/types/account";
   import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
   import { nonNullish } from "@dfinity/utils";
   import type { BtcAddressText } from "$lib/types/bitcoin";
@@ -17,13 +17,14 @@
   import CkBTCWalletActions from "$lib/components/accounts/CkBTCWalletActions.svelte";
   import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 
   export let account: Account;
   export let minterCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
   export let reload: () => Promise<void>;
 
-  let identifier: AccountIdentifierText;
+  let identifier: IcrcAccountIdentifierText;
   $: ({ identifier } = account);
 
   let btcAddress: undefined | BtcAddressText;

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -6,7 +6,7 @@
     Spinner,
   } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import type { Account, AccountIdentifierText } from "$lib/types/account";
+  import type { Account } from "$lib/types/account";
   import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
   import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
   import BITCOIN_LOGO from "$lib/assets/bitcoin.svg";
@@ -23,6 +23,7 @@
   import ReceiveSelectAccountDropdown from "$lib/components/accounts/ReceiveSelectAccountDropdown.svelte";
   import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
   import BitcoinKYTFee from "$lib/components/accounts/BitcoinKYTFee.svelte";
+  import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 
   export let data: CkBTCReceiveModalData;
 
@@ -103,7 +104,7 @@
 
   // When used in ckBTC receive modal, the identifier is originally undefined that's why we reload when it changes
   const loadBitcoinAddress = async (
-    identifier: AccountIdentifierText | undefined
+    identifier: IcrcAccountIdentifierText | undefined
   ) => {
     if (isNullish(identifier)) {
       return;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -43,6 +43,7 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import { ICPToken } from "@dfinity/utils";
+  import type { AccountIdentifierText } from "$lib/types/account";
 
   onMount(() => {
     pollAccounts();
@@ -57,7 +58,7 @@
   let transactions: Transaction[] | undefined;
 
   const reloadTransactions = (
-    accountIdentifier: AccountIdentifierString
+    accountIdentifier: AccountIdentifierText
   ): Promise<void> =>
     getAccountTransactions({
       accountIdentifier,

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -28,10 +28,7 @@
     debugTransactions,
   } from "$lib/derived/debug.derived";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
-  import type {
-    AccountIdentifierString,
-    Transaction,
-  } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
   import { goto } from "$app/navigation";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -43,7 +40,7 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import { ICPToken } from "@dfinity/utils";
-  import type { AccountIdentifierText } from "$lib/types/account";
+  import type { IcpAccountIdentifierText } from "$lib/types/account";
 
   onMount(() => {
     pollAccounts();
@@ -58,7 +55,7 @@
   let transactions: Transaction[] | undefined;
 
   const reloadTransactions = (
-    accountIdentifier: AccountIdentifierText
+    accountIdentifier: IcpAccountIdentifierText
   ): Promise<void> =>
     getAccountTransactions({
       accountIdentifier,

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -8,7 +8,6 @@ import { addAccount, queryAccount } from "$lib/api/nns-dapp.api";
 import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import type {
   AccountDetails,
-  AccountIdentifierString,
   HardwareWalletAccountDetails,
   SubAccountDetails,
   Transaction,
@@ -28,7 +27,11 @@ import {
   type SingleMutationAccountsStore,
 } from "$lib/stores/accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import type { Account, AccountType } from "$lib/types/account";
+import type {
+  Account,
+  AccountIdentifierText,
+  AccountType,
+} from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";
 import { findAccount, getAccountByPrincipal } from "$lib/utils/accounts.utils";
 import {
@@ -195,7 +198,7 @@ export const initAccounts = () => syncAccountsWithErrorHandler(ignoreErrors);
 export const loadBalance = async ({
   accountIdentifier,
 }: {
-  accountIdentifier: string;
+  accountIdentifier: AccountIdentifierText;
 }): Promise<void> => {
   const strategy = FORCE_CALL_STRATEGY;
   const mutableStore = accountsStore.getSingleMutationAccountsStore(strategy);
@@ -308,12 +311,9 @@ export const getAccountTransactions = async ({
   accountIdentifier,
   onLoad,
 }: {
-  accountIdentifier: AccountIdentifierString;
-  onLoad: ({
-    accountIdentifier,
-    transactions,
-  }: {
-    accountIdentifier: AccountIdentifierString;
+  accountIdentifier: AccountIdentifierText;
+  onLoad: (params: {
+    accountIdentifier: AccountIdentifierText;
     transactions: Transaction[];
   }) => void;
 }): Promise<void> =>

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -31,6 +31,7 @@ import type {
   Account,
   AccountIdentifierText,
   AccountType,
+  IcpAccountIdentifierText,
 } from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";
 import { findAccount, getAccountByPrincipal } from "$lib/utils/accounts.utils";
@@ -198,7 +199,7 @@ export const initAccounts = () => syncAccountsWithErrorHandler(ignoreErrors);
 export const loadBalance = async ({
   accountIdentifier,
 }: {
-  accountIdentifier: AccountIdentifierText;
+  accountIdentifier: IcpAccountIdentifierText;
 }): Promise<void> => {
   const strategy = FORCE_CALL_STRATEGY;
   const mutableStore = accountsStore.getSingleMutationAccountsStore(strategy);

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -10,9 +10,9 @@ import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
 import { i18n } from "$lib/stores/i18n";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
-import type { AccountIdentifierText } from "$lib/types/account";
 import type { CanisterId } from "$lib/types/canister";
 import { CkBTCErrorKey, CkBTCSuccessKey } from "$lib/types/ckbtc.errors";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import { toToastError } from "$lib/utils/error.utils";
 import { waitForMilliseconds } from "$lib/utils/utils";
 import {
@@ -38,7 +38,7 @@ export const loadBtcAddress = async ({
   identifier,
 }: {
   minterCanisterId: CanisterId;
-  identifier: AccountIdentifierText;
+  identifier: IcrcAccountIdentifierText;
 }) => {
   const store = get(bitcoinAddressStore);
   const btcAddressLoaded = nonNullish(store[identifier]);

--- a/frontend/src/lib/stores/bitcoin.store.ts
+++ b/frontend/src/lib/stores/bitcoin.store.ts
@@ -1,16 +1,16 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { writableStored } from "$lib/stores/writable-stored";
-import type { AccountIdentifierText } from "$lib/types/account";
 import type { BtcAddressText } from "$lib/types/bitcoin";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type { IcrcBlockIndex } from "@dfinity/ledger";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
-type BitcoinAddressData = Record<AccountIdentifierText, BtcAddressText>;
+type BitcoinAddressData = Record<IcrcAccountIdentifierText, BtcAddressText>;
 
 export interface BitcoinAddressStore extends Readable<BitcoinAddressData> {
   set: (params: {
-    identifier: AccountIdentifierText;
+    identifier: IcrcAccountIdentifierText;
     btcAddress: BtcAddressText;
   }) => void;
   reset: () => void;
@@ -32,7 +32,7 @@ export const initBitcoinAddressStore = (): BitcoinAddressStore => {
       identifier,
       btcAddress,
     }: {
-      identifier: AccountIdentifierText;
+      identifier: IcrcAccountIdentifierText;
       btcAddress: BtcAddressText;
     }) => {
       update((currentState: BitcoinAddressData) => ({

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -1,4 +1,5 @@
 import type { GetTransactionsResponse } from "$lib/api/icrc-index.api";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type {
   UniverseCanisterId,
   UniverseCanisterIdText,
@@ -9,12 +10,10 @@ import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { writable, type Readable } from "svelte/store";
 
-export type IcrcAccountIdentifier = string;
-
 // Each Icrc Account - Sns or ckBTC - is an entry in this store.
 // We use the account string representation as the key to identify the transactions.
 export type IcrcTransactions = Record<
-  IcrcAccountIdentifier,
+  IcrcAccountIdentifierText,
   {
     transactions: IcrcTransactionWithId[];
     oldestTxId?: bigint;

--- a/frontend/src/lib/types/account.ts
+++ b/frontend/src/lib/types/account.ts
@@ -1,4 +1,8 @@
-import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type {
+  AccountIdentifierString,
+  SubAccountArray,
+} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type { Principal } from "@dfinity/principal";
 
 export type AccountType =
@@ -7,7 +11,11 @@ export type AccountType =
   | "hardwareWallet"
   | "withdrawalAccount";
 
-export type AccountIdentifierText = string;
+export type IcpAccountIdentifierText = AccountIdentifierString;
+
+export type AccountIdentifierText =
+  | IcpAccountIdentifierText
+  | IcrcAccountIdentifierText;
 
 export interface Account {
   identifier: AccountIdentifierText;

--- a/frontend/src/lib/types/icrc.ts
+++ b/frontend/src/lib/types/icrc.ts
@@ -1,4 +1,3 @@
-import type { AccountIdentifierText } from "$lib/types/account";
 import type { Token } from "@dfinity/utils";
 
 /**
@@ -10,4 +9,4 @@ export interface IcrcTokenMetadata extends Token {
   // TODO: integrate "decimals" to replace ICP_DISPLAYED_DECIMALS_DETAILED
 }
 
-export type IcrcAccountIdentifierText = AccountIdentifierText;
+export type IcrcAccountIdentifierText = string;

--- a/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
+++ b/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
@@ -1,7 +1,7 @@
 import type { GetTransactionsResponse } from "$lib/api/icrc-index.api";
 import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 
-import type { AccountIdentifierText } from "$lib/types/account";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type {
   PostMessageDataRequestTransactions,
   PostMessageDataResponseTransaction,
@@ -81,7 +81,7 @@ export const getIcrcAccountsTransactions = ({
 
 type GetAccountTransactionsParams = TimerWorkerUtilsSyncParams &
   Omit<PostMessageDataRequestTransactions, "accountIdentifiers"> & {
-    accountIdentifier: AccountIdentifierText;
+    accountIdentifier: IcrcAccountIdentifierText;
     start?: bigint;
     state: TransactionsData | undefined;
   };


### PR DESCRIPTION
# Motivation

This cleanup of the `AccountIdentifierText` type allow us to make a visual difference between `IcpAccountIdentifierText` (current "old" account identifier text representation) and `IcrcAccountIdentifierText` (new Icrc textual representation).

Will be useful for the conversion of ICP to Icrc, it improves readability.

# Changes

- no functional changes, only types were modified
