### PR TITLE
Refactor ckBTCTransfer moved and renamed to icrcTransfer

### DIFF
--- a/frontend/src/lib/api/ckbtc-ledger.api.ts
+++ b/frontend/src/lib/api/ckbtc-ledger.api.ts
@@ -1,20 +1,13 @@
-import { createAgent } from "$lib/api/agent.api";
 import {
   getIcrcAccount,
   getIcrcToken,
-  icrcTransfer as transferIcrcApi,
-  type IcrcTransferParams,
+  icrcLedgerCanister,
 } from "$lib/api/icrc-ledger.api";
-import { HOST } from "$lib/constants/environment.constants";
 import type { Account, AccountType } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
-import {
-  IcrcLedgerCanister,
-  type IcrcAccount,
-  type IcrcBlockIndex,
-} from "@dfinity/ledger";
+import type { Identity } from "@dfinity/agent";
+import type { IcrcAccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 
 export const getCkBTCAccount = async ({
@@ -32,7 +25,7 @@ export const getCkBTCAccount = async ({
 
   const {
     canister: { balance },
-  } = await ckBTCLedgerCanister({ identity, canisterId });
+  } = await icrcLedgerCanister({ identity, canisterId });
 
   const callParams = {
     certified,
@@ -62,7 +55,7 @@ export const getCkBTCToken = async ({
 
   const {
     canister: { metadata: getMetadata },
-  } = await ckBTCLedgerCanister({ identity, canisterId });
+  } = await icrcLedgerCanister({ identity, canisterId });
 
   const token = await getIcrcToken({
     certified,
@@ -72,54 +65,4 @@ export const getCkBTCToken = async ({
   logWithTimestamp("Getting ckBTC token: done");
 
   return token;
-};
-
-export const ckBTCTransfer = async ({
-  identity,
-  canisterId,
-  ...rest
-}: {
-  identity: Identity;
-  canisterId: Principal;
-} & Omit<IcrcTransferParams, "transfer">): Promise<IcrcBlockIndex> => {
-  logWithTimestamp("Getting ckBTC transfer: call...");
-
-  const {
-    canister: { transfer: transferApi },
-  } = await ckBTCLedgerCanister({ identity, canisterId });
-
-  const blockIndex = await transferIcrcApi({
-    ...rest,
-    transfer: transferApi,
-  });
-
-  logWithTimestamp("Getting ckBTC transfer: done");
-
-  return blockIndex;
-};
-
-const ckBTCLedgerCanister = async ({
-  identity,
-  canisterId,
-}: {
-  identity: Identity;
-  canisterId: Principal;
-}): Promise<{
-  canister: IcrcLedgerCanister;
-  agent: HttpAgent;
-}> => {
-  const agent = await createAgent({
-    identity,
-    host: HOST,
-  });
-
-  const canister = IcrcLedgerCanister.create({
-    agent,
-    canisterId,
-  });
-
-  return {
-    canister,
-    agent,
-  };
 };

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,7 +1,7 @@
 import {
   getIcrcAccount,
   getIcrcToken,
-  icrcTransfer as transferIcrcApi,
+  executeIcrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
 } from "$lib/api/icrc-ledger.api";
 import type { Account } from "$lib/types/account";

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -1,5 +1,5 @@
-import { ckBTCTransfer } from "$lib/api/ckbtc-ledger.api";
 import type { IcrcTransferParams } from "$lib/api/icrc-ledger.api";
+import { icrcTransfer } from "$lib/api/icrc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
@@ -92,7 +92,7 @@ export const ckBTCTransferTokens = async ({
         identity: Identity;
       } & Omit<IcrcTransferParams, "transfer">
     ) =>
-      await ckBTCTransfer({
+      await icrcTransfer({
         ...params,
         canisterId: universeId,
       }),

--- a/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
@@ -1,8 +1,4 @@
-import {
-  ckBTCTransfer,
-  getCkBTCAccount,
-  getCkBTCToken,
-} from "$lib/api/ckbtc-ledger.api";
+import { getCkBTCAccount, getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -90,24 +86,6 @@ describe("ckbtc-ledger api", () => {
         });
 
       expect(call).rejects.toThrowError();
-    });
-  });
-
-  describe("transfer", () => {
-    it("successfully calls transfer api", async () => {
-      const transferSpy =
-        ledgerCanisterMock.transfer.mockResolvedValue(undefined);
-
-      await ckBTCTransfer({
-        identity: mockIdentity,
-        to: { owner: mockIdentity.getPrincipal() },
-        amount: BigInt(10_000_000),
-        createdAt: BigInt(123456),
-        fee: BigInt(10_000),
-        canisterId: CKBTC_LEDGER_CANISTER_ID,
-      });
-
-      expect(transferSpy).toBeCalled();
     });
   });
 });

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -1,4 +1,5 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ckbtcLedgerApi from "$lib/api/ckbtc-ledger.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import {
   CKBTC_INDEX_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
@@ -37,7 +38,7 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call api.getCkBTCAccount and load neurons in store", async () => {
       const spyQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -56,7 +57,7 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call error callback", async () => {
       const spyQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
         .mockRejectedValue(new Error());
 
       const spy = jest.fn();
@@ -89,7 +90,7 @@ describe("ckbtc-accounts-services", () => {
       });
 
       jest
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
         .mockImplementation(() => Promise.reject(undefined));
 
       await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -112,11 +113,11 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call ckBTC accounts and token and load them in store", async () => {
       const spyAccountsQuery = jest
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       const spyTokenQuery = jest
-        .spyOn(ledgerApi, "getCkBTCToken")
+        .spyOn(ckbtcLedgerApi, "getCkBTCToken")
         .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
       await services.syncCkBTCAccounts({
@@ -146,7 +147,7 @@ describe("ckbtc-accounts-services", () => {
 
   describe("ckBTCTransferTokens", () => {
     const spyAccounts = jest
-      .spyOn(ledgerApi, "getCkBTCAccount")
+      .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
       .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
     beforeEach(() => {
@@ -162,7 +163,7 @@ describe("ckbtc-accounts-services", () => {
       tokensStore.setTokens(mockTokens);
 
       const spyTransfer = jest
-        .spyOn(ledgerApi, "ckBTCTransfer")
+        .spyOn(icrcLedgerApi, "icrcTransfer")
         .mockResolvedValue(456n);
 
       const { blockIndex } = await services.ckBTCTransferTokens({
@@ -183,7 +184,7 @@ describe("ckbtc-accounts-services", () => {
       tokensStore.setTokens(mockTokens);
 
       const spyTransfer = jest
-        .spyOn(ledgerApi, "ckBTCTransfer")
+        .spyOn(icrcLedgerApi, "icrcTransfer")
         .mockResolvedValue(456n);
 
       const { blockIndex } = await services.ckBTCTransferTokens({
@@ -206,7 +207,7 @@ describe("ckbtc-accounts-services", () => {
       tokensStore.setTokens(mockTokens);
 
       const spyTransfer = jest
-        .spyOn(ledgerApi, "ckBTCTransfer")
+        .spyOn(icrcLedgerApi, "icrcTransfer")
         .mockRejectedValue(new Error("test error"));
 
       const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
@@ -230,7 +231,7 @@ describe("ckbtc-accounts-services", () => {
       tokensStore.reset();
 
       const spyTransfer = jest
-        .spyOn(ledgerApi, "ckBTCTransfer")
+        .spyOn(icrcLedgerApi, "icrcTransfer")
         .mockRejectedValue(new Error("test error"));
 
       const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");


### PR DESCRIPTION
# Motivation

`ckBTCTransfer` is actually already generic and can be used as it to perform any ICRC transfer, which we aim to do for ICP. Therefore this PR moves and rename the function to `icrc-ledger.api.icrcTransfer()`.
