### PR TITLE
Chore: Use new neuron state icons

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Improve responsiveness in proposal filter modals.
 * Only Locked neurons are mergeable.
 * Add copy button to sns proposal proposer id.
+* New neuron state icons.
 
 #### Deprecated
 #### Removed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-07-17.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.1.tgz",
-      "integrity": "sha512-f8VGEG9HuTaGaAR5Gbjl/VQOfgUk4M6jL0KpqRgsEyLZCV7R3Zy01oSbhau1VSwEsbPJMREs0jw+L3+puH6RDg==",
+      "version": "2.6.0-next-2023-07-17.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.2.tgz",
+      "integrity": "sha512-abA69v9Kfrb8oHF4+bFaP1TMbF7I58D17Hzbc+fE12HadOMaoNCBES0KP7Afz1s+Mno+dOsL/Mh+/H/0JMxktA==",
       "dependencies": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
@@ -10010,9 +10010,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-07-17.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.1.tgz",
-      "integrity": "sha512-f8VGEG9HuTaGaAR5Gbjl/VQOfgUk4M6jL0KpqRgsEyLZCV7R3Zy01oSbhau1VSwEsbPJMREs0jw+L3+puH6RDg==",
+      "version": "2.6.0-next-2023-07-17.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.2.tgz",
+      "integrity": "sha512-abA69v9Kfrb8oHF4+bFaP1TMbF7I58D17Hzbc+fE12HadOMaoNCBES0KP7Afz1s+Mno+dOsL/Mh+/H/0JMxktA==",
       "requires": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-07-13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-13.1.tgz",
-      "integrity": "sha512-Dp/oLnx2OQNDVw7sHWmqxX0JtznY0DEBTq6xCxcMAIoJ8RosVrhl82FjXXSSXU27/5NaiAyleP04cAlir1hBfg==",
+      "version": "2.6.0-next-2023-07-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.1.tgz",
+      "integrity": "sha512-f8VGEG9HuTaGaAR5Gbjl/VQOfgUk4M6jL0KpqRgsEyLZCV7R3Zy01oSbhau1VSwEsbPJMREs0jw+L3+puH6RDg==",
       "dependencies": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
@@ -10010,9 +10010,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.6.0-next-2023-07-13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-13.1.tgz",
-      "integrity": "sha512-Dp/oLnx2OQNDVw7sHWmqxX0JtznY0DEBTq6xCxcMAIoJ8RosVrhl82FjXXSSXU27/5NaiAyleP04cAlir1hBfg==",
+      "version": "2.6.0-next-2023-07-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.6.0-next-2023-07-17.1.tgz",
+      "integrity": "sha512-f8VGEG9HuTaGaAR5Gbjl/VQOfgUk4M6jL0KpqRgsEyLZCV7R3Zy01oSbhau1VSwEsbPJMREs0jw+L3+puH6RDg==",
       "requires": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
+++ b/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
@@ -5,6 +5,7 @@
   import { NeuronState } from "@dfinity/nns";
   import { getStateInfo } from "$lib/utils/neuron.utils";
   import { keyOf } from "$lib/utils/utils";
+  import { ICON_SIZE_SMALL_PIXELS } from "$lib/constants/layout.constants";
 
   export let state: NeuronState;
 
@@ -14,7 +15,7 @@
 
 {#if stateInfo !== undefined}
   <div class="status" data-tid="neuron-state-info">
-    <svelte:component this={stateInfo.Icon} />
+    <svelte:component this={stateInfo.Icon} size={ICON_SIZE_SMALL_PIXELS} />
     {keyOf({ obj: $i18n.neuron_state, key: NeuronState[state] })}
   </div>
 {/if}

--- a/frontend/src/lib/constants/layout.constants.ts
+++ b/frontend/src/lib/constants/layout.constants.ts
@@ -1,3 +1,4 @@
 export const ICON_SIZE_LARGE = "44px";
+export const ICON_SIZE_SMALL_PIXELS = 18;
 
 export const INTERSECTION_THRESHOLD = 0.5;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -26,8 +26,9 @@ import type { Identity } from "@dfinity/agent";
 import type { WizardStep } from "@dfinity/gix-components";
 import {
   IconHistoryToggleOff,
-  IconLockClock,
+  IconLockClosed,
   IconLockOpen,
+  IconPace,
 } from "@dfinity/gix-components";
 import {
   NeuronState,
@@ -70,7 +71,7 @@ type StateMapper = {
 export const stateTextMapper: StateMapper = {
   [NeuronState.Locked]: {
     textKey: "locked",
-    Icon: IconLockClock,
+    Icon: IconLockClosed,
     status: "ok",
   },
   [NeuronState.Unspecified]: {
@@ -84,7 +85,7 @@ export const stateTextMapper: StateMapper = {
   },
   [NeuronState.Dissolving]: {
     textKey: "dissolving",
-    Icon: IconHistoryToggleOff,
+    Icon: IconPace,
     status: "warn",
   },
   [NeuronState.Spawning]: {


### PR DESCRIPTION
# Motivation

Use the new icons for the change to the new neuron detail page.

# Changes

* Upgrade gix-components.
* Change two icons for the NeuronState mapper.
* Set the size of the neuron state icon instead of relying on the default.

# Tests

Only UI changes. No test needed.

# Todos

- [x] Add entry to changelog (if necessary).
