### PR TITLE
GIX-1684: New Nns Neuron State Item Action

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -2,45 +2,61 @@
   import { ItemAction } from "@dfinity/gix-components";
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
   import {
-    getAgeBonusText,
+    ageMultiplier,
     getStateInfo,
+    neuronAgeBonus,
     type StateInfo,
   } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { keyOf } from "$lib/utils/utils";
   import DisburseButton from "./actions/DisburseButton.svelte";
   import DissolveActionButton from "./actions/DissolveActionButton.svelte";
+  import Tooltip from "../ui/Tooltip.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let neuron: NeuronInfo;
 
   let stateInfo: StateInfo | undefined;
   $: stateInfo = getStateInfo(neuron.state);
 
-  let ageBonusText: string;
-  $: ageBonusText = getAgeBonusText({ neuron, i18n: $i18n });
+  let ageBonus: number;
+  $: ageBonus = ageMultiplier(neuron.ageSeconds);
 </script>
 
-{#if stateInfo !== undefined}
-  <ItemAction testId="nns-stake-item-action-component">
-    <div slot="icon" class="icon">
-      <!-- TODO: Use new icons -->
-      <svelte:component this={stateInfo.Icon} />
-    </div>
-    <div class="content">
-      <p class="icp-value">
-        {keyOf({ obj: $i18n.neuron_state, key: NeuronState[neuron.state] })}
+<ItemAction testId="nns-neuron-state-item-action-component">
+  <svelte:fragment slot="icon">
+    {#if stateInfo !== undefined}
+      <div class="icon">
+        <svelte:component this={stateInfo.Icon} />
+      </div>
+    {/if}
+  </svelte:fragment>
+  <div class="content">
+    <h4 class="icp-value" data-tid="state-text">
+      {keyOf({ obj: $i18n.neuron_state, key: NeuronState[neuron.state] })}
+    </h4>
+    {#if neuron.state === NeuronState.Locked}
+      <Tooltip id="neuron-age-bonus" text={ageBonus.toFixed(8)}>
+        <p class="description" data-tid="age-bonus-text">
+          {replacePlaceholders($i18n.neuron_detail.age_bonus_label, {
+            $ageBonus: ageBonus.toFixed(2),
+          })}
+        </p>
+      </Tooltip>
+    {:else}
+      <p class="description" data-tid="age-bonus-text">
+        {$i18n.neuron_detail.no_age_bonus}
       </p>
-      <p class="description">{ageBonusText}</p>
-    </div>
-    <svelte:fragment slot="actions">
-      {#if neuron.state === NeuronState.Dissolved}
-        <DisburseButton />
-      {:else}
-        <DissolveActionButton neuronState={neuron.state} />
-      {/if}
-    </svelte:fragment>
-  </ItemAction>
-{/if}
+    {/if}
+  </div>
+  <svelte:fragment slot="actions">
+    {#if neuron.state === NeuronState.Dissolved}
+      <DisburseButton />
+    {:else}
+      <DissolveActionButton neuronState={neuron.state} />
+    {/if}
+  </svelte:fragment>
+</ItemAction>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
@@ -62,7 +78,8 @@
     flex-direction: column;
     gap: var(--padding);
 
-    p {
+    p,
+    h4 {
       margin: 0;
     }
   }

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -4,7 +4,6 @@
   import {
     ageMultiplier,
     getStateInfo,
-    neuronAgeBonus,
     type StateInfo,
   } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -31,7 +31,7 @@
     {/if}
   </svelte:fragment>
   <div class="content">
-    <h4 class="icp-value" data-tid="state-text">
+    <h4 data-tid="state-text">
       {keyOf({ obj: $i18n.neuron_state, key: NeuronState[neuron.state] })}
     </h4>
     {#if neuron.state === NeuronState.Locked}
@@ -81,11 +81,5 @@
     h4 {
       margin: 0;
     }
-  }
-
-  .icp-value {
-    display: flex;
-    align-items: center;
-    gap: var(--padding-0_5x);
   }
 </style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { ItemAction } from "@dfinity/gix-components";
+  import { NeuronState, type NeuronInfo } from "@dfinity/nns";
+  import {
+    getAgeBonusText,
+    getStateInfo,
+    type StateInfo,
+  } from "$lib/utils/neuron.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import { keyOf } from "$lib/utils/utils";
+  import DisburseButton from "./actions/DisburseButton.svelte";
+  import DissolveActionButton from "./actions/DissolveActionButton.svelte";
+
+  export let neuron: NeuronInfo;
+
+  let stateInfo: StateInfo | undefined;
+  $: stateInfo = getStateInfo(neuron.state);
+
+  let ageBonusText: string;
+  $: ageBonusText = getAgeBonusText({ neuron, i18n: $i18n });
+</script>
+
+{#if stateInfo !== undefined}
+  <ItemAction testId="nns-stake-item-action-component">
+    <div slot="icon" class="icon">
+      <!-- TODO: Use new icons -->
+      <svelte:component this={stateInfo.Icon} />
+    </div>
+    <div class="content">
+      <p class="icp-value">
+        {keyOf({ obj: $i18n.neuron_state, key: NeuronState[neuron.state] })}
+      </p>
+      <p class="description">{ageBonusText}</p>
+    </div>
+    <svelte:fragment slot="actions">
+      {#if neuron.state === NeuronState.Dissolved}
+        <DisburseButton />
+      {:else}
+        <DissolveActionButton neuronState={neuron.state} />
+      {/if}
+    </svelte:fragment>
+  </ItemAction>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .icon {
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: var(--border-radius);
+    background: var(--content-background);
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .icp-value {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -6,6 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import NnsStakeItemAction from "./NnsStakeItemAction.svelte";
+  import NnsNeuronStateItemAction from "./NnsNeuronStateItemAction.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -28,6 +29,7 @@
   </p>
   <ul class="content">
     <NnsStakeItemAction {neuron} />
+    <NnsNeuronStateItemAction {neuron} />
   </ul>
 </Section>
 
@@ -44,7 +46,7 @@
   .content {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-3x);
 
     padding: 0;
   }

--- a/frontend/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/DissolveActionButton.svelte
@@ -25,6 +25,7 @@
 
 <button
   class="secondary"
+  data-tid="nns-dissolve-action-button"
   on:click={() =>
     openNnsNeuronModal({ type: "dissolve", data: { neuron: $store.neuron } })}
   >{keyOf({ obj: $i18n.neuron_detail, key: buttonKey })}</button

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -563,6 +563,8 @@
     "voting_power_section_description": "Voting Power = ($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus",
     "maturity_section_description": "Earn rewards by voting on proposals and/or following active neurons.",
     "staked_description": "Staked",
+    "age_bonus_label": "Age bonus: $ageBonus",
+    "no_age_bonus": "No age bonus",
     "join_community_fund_description": "Are you sure you want this neuron to <strong>join</strong> the neurons' fund?",
     "leave_community_fund_description": "Are you sure you want this neuron to <strong>leave</strong> the neurons' fund?",
     "participate_community_fund": "Participate in neurons' fund.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -586,6 +586,8 @@ interface I18nNeuron_detail {
   voting_power_section_description: string;
   maturity_section_description: string;
   staked_description: string;
+  age_bonus_label: string;
+  no_age_bonus: string;
   join_community_fund_description: string;
   leave_community_fund_description: string;
   participate_community_fund: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -54,6 +54,7 @@ import {
 } from "./accounts.utils";
 import { nowInSeconds } from "./date.utils";
 import { formatNumber } from "./format.utils";
+import { replacePlaceholders } from "./i18n.utils";
 import { getVotingBallot, getVotingPower } from "./proposals.utils";
 import { toNnsVote } from "./sns-proposals.utils";
 import { formatToken } from "./token.utils";
@@ -893,4 +894,23 @@ export const maturityLastDistribution = ({
     (fromNullable(rounds_since_last_distribution) ?? 1n) *
       BigInt(SECONDS_IN_DAY)
   );
+};
+
+export const getAgeBonusText = ({
+  neuron,
+  i18n,
+}: {
+  neuron: NeuronInfo;
+  i18n: I18n;
+}): string => {
+  const ageMultiplier = bonusMultiplier({
+    amount: neuron.ageSeconds,
+    multiplier: AGE_MULTIPLIER,
+    max: SECONDS_IN_FOUR_YEARS,
+  });
+  return neuron.state === NeuronState.Locked
+    ? replacePlaceholders(i18n.neuron_detail.age_bonus_label, {
+        $ageBonus: ageMultiplier.toFixed(2),
+      })
+    : i18n.neuron_detail.no_age_bonus;
 };

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -54,7 +54,6 @@ import {
 } from "./accounts.utils";
 import { nowInSeconds } from "./date.utils";
 import { formatNumber } from "./format.utils";
-import { replacePlaceholders } from "./i18n.utils";
 import { getVotingBallot, getVotingPower } from "./proposals.utils";
 import { toNnsVote } from "./sns-proposals.utils";
 import { formatToken } from "./token.utils";
@@ -894,23 +893,4 @@ export const maturityLastDistribution = ({
     (fromNullable(rounds_since_last_distribution) ?? 1n) *
       BigInt(SECONDS_IN_DAY)
   );
-};
-
-export const getAgeBonusText = ({
-  neuron,
-  i18n,
-}: {
-  neuron: NeuronInfo;
-  i18n: I18n;
-}): string => {
-  const ageMultiplier = bonusMultiplier({
-    amount: neuron.ageSeconds,
-    multiplier: AGE_MULTIPLIER,
-    max: SECONDS_IN_FOUR_YEARS,
-  });
-  return neuron.state === NeuronState.Locked
-    ? replacePlaceholders(i18n.neuron_detail.age_bonus_label, {
-        $ageBonus: ageMultiplier.toFixed(2),
-      })
-    : i18n.neuron_detail.no_age_bonus;
 };

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
+import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState, type NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+
+describe("NnsNeuronStateItemAction", () => {
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: NnsNeuronStateItemAction,
+      },
+    });
+
+    return NnsNeuronStateItemActionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render locked text and Start dissolving button if neuron is locked", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Locked,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Locked");
+    expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
+  });
+
+  it("should render dissolving text and Stop dissolving button if neuron is dissolving", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolving,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Dissolving");
+    expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
+  });
+
+  it("should render unlocked text and disburse button if neuron is unlocked", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolved,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Unlocked");
+    expect(await po.hasDisburseButton()).toBe(true);
+  });
+
+  it("should render age bonus for Locked neurons", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Locked,
+      ageSeconds: BigInt(SECONDS_IN_FOUR_YEARS),
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("Age bonus: 1.25");
+  });
+
+  it("should render no age bonus for dissolving neurons", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolving,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("No age bonus");
+  });
+
+  it("should render no age bonus for unlocked neurons", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolving,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("No age bonus");
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -39,4 +39,10 @@ describe("NnsStakeItemAction", () => {
 
     expect(await po.hasStakeItemAction()).toBe(true);
   });
+
+  it("should render NnsNeuronStateItemAction", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasNeuronStateItemAction()).toBe(true);
+  });
 });

--- a/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
@@ -1,0 +1,28 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsNeuronStateItemActionPo extends BasePageObject {
+  private static readonly TID = "nns-neuron-state-item-action-component";
+
+  static under(element: PageObjectElement): NnsNeuronStateItemActionPo {
+    return new NnsNeuronStateItemActionPo(
+      element.byTestId(NnsNeuronStateItemActionPo.TID)
+    );
+  }
+
+  getState(): Promise<string> {
+    return this.getText("state-text");
+  }
+
+  getAgeBonus(): Promise<string> {
+    return this.getText("age-bonus-text");
+  }
+
+  hasDisburseButton(): Promise<boolean> {
+    return this.getButton("disburse-button").isPresent();
+  }
+
+  getDissolveButtonText(): Promise<string> {
+    return this.getButton("nns-dissolve-action-button").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -24,7 +24,7 @@ export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
     return this.getStakeItemActionPo().isPresent();
   }
 
-  getNeuronStateItemActionPo(): NnsStakeItemActionPo {
+  getNeuronStateItemActionPo(): NnsNeuronStateItemActionPo {
     return NnsNeuronStateItemActionPo.under(this.root);
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsNeuronStateItemActionPo } from "./NnsNeuronStateItemAction.page-object";
 import { NnsStakeItemActionPo } from "./NnsStakeItemAction.page-object";
 
 export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
@@ -20,6 +21,14 @@ export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
   }
 
   hasStakeItemAction(): Promise<boolean> {
+    return this.getStakeItemActionPo().isPresent();
+  }
+
+  getNeuronStateItemActionPo(): NnsStakeItemActionPo {
+    return NnsNeuronStateItemActionPo.under(this.root);
+  }
+
+  hasNeuronStateItemAction(): Promise<boolean> {
     return this.getStakeItemActionPo().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

We are shuffling how data is displayed in the neuron detail page.

In this PR: Adds the item that will show the neuron state along with the related actions.

# Changes

* New component `NnsNeuronStateItemAction`.
* Render new component `NnsNeuronStateItemAction` in `NnsNeuronVotingPowerSection`.

# Tests

* Add test case in `NnsNeuronVotingPowerSection` that new component is rendered.
* Add spec file for new compoment `NnsNeuronStateItemAction` and related PO.

# Todos

Not yet worth an entry in the changelog.
