### PR TITLE
GIX-1685: NNS neuron available maturity item action

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { formattedMaturity } from "$lib/utils/neuron.utils";
+  import { IconExpandCircleDown } from "@dfinity/gix-components";
+  import type { NeuronInfo } from "@dfinity/nns";
+  import NnsStakeMaturityButton from "./actions/NnsStakeMaturityButton.svelte";
+  import SpawnNeuronButton from "./actions/SpawnNeuronButton.svelte";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
+
+  export let neuron: NeuronInfo;
+</script>
+
+<CommonItemAction testId="nns-available-maturity-item-action-component">
+  <IconExpandCircleDown slot="icon" />
+  <span slot="title" data-tid="available-maturity"
+    >{formattedMaturity(neuron)}</span
+  >
+  <svelte:fragment slot="subtitle"
+    >{$i18n.neuron_detail.available_description}</svelte:fragment
+  >
+  <NnsStakeMaturityButton {neuron} variant="secondary" />
+  <SpawnNeuronButton {neuron} />
+</CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturitySection.svelte
@@ -4,6 +4,7 @@
   import { Section } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import NnsStakedMaturityActionItem from "./NnsStakedMaturityActionItem.svelte";
+  import NnsAvailableMaturityActionItem from "./NnsAvailableMaturityActionItem.svelte";
 
   export let neuron: NeuronInfo;
 </script>
@@ -18,6 +19,7 @@
   </p>
   <ul class="content">
     <NnsStakedMaturityActionItem {neuron} />
+    <NnsAvailableMaturityActionItem {neuron} />
   </ul>
 </Section>
 
@@ -34,7 +36,7 @@
   .content {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-3x);
 
     padding: 0;
   }

--- a/frontend/src/lib/components/neuron-detail/NnsStakedMaturityActionItem.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsStakedMaturityActionItem.svelte
@@ -1,44 +1,19 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { formattedStakedMaturity } from "$lib/utils/neuron.utils";
-  import { IconStakedMaturity, ItemAction } from "@dfinity/gix-components";
+  import { IconStakedMaturity } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import NnsStakeMaturityButton from "./actions/NnsStakeMaturityButton.svelte";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
 
   export let neuron: NeuronInfo;
 </script>
 
-<ItemAction testId="nns-staked-maturity-item-action-component">
-  <div slot="icon" class="icon">
-    <IconStakedMaturity />
-  </div>
-  <div class="content">
-    <h4 data-tid="staked-maturity">{formattedStakedMaturity(neuron)}</h4>
-    <p class="description">{$i18n.neuron_detail.staked_description}</p>
-  </div>
-  <NnsStakeMaturityButton slot="actions" {neuron} variant="secondary" />
-</ItemAction>
-
-<style lang="scss">
-  .content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding);
-    p,
-    h4 {
-      margin: 0;
-    }
-  }
-
-  .icon {
-    width: 100%;
-    height: 100%;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    border-radius: var(--border-radius);
-    background: var(--content-background);
-  }
-</style>
+<CommonItemAction testId="nns-staked-maturity-item-action-component">
+  <IconStakedMaturity slot="icon" />
+  <span slot="title" data-tid="staked-maturity"
+    >{formattedStakedMaturity(neuron)}</span
+  >
+  <svelte:fragment slot="subtitle"
+    >{$i18n.neuron_detail.staked_description}</svelte:fragment
+  >
+</CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -63,7 +63,7 @@
         }
       )}
     >
-      <button disabled class="secondary" on:click={showModal}>
+      <button disabled class="secondary">
         {$i18n.neuron_detail.spawn_neuron}
       </button>
     </Tooltip>

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -16,6 +16,7 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { getContext } from "svelte";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -36,33 +37,35 @@
     openNnsNeuronModal({ type: "spawn", data: { neuron: $store.neuron } });
 </script>
 
-{#if enoughMaturity}
-  <button class="secondary" on:click={showModal}>
-    {$i18n.neuron_detail.spawn_neuron}
-  </button>
-{:else}
-  <Tooltip
-    id="spawn-maturity-button"
-    text={replacePlaceholders(
-      $i18n.neuron_detail.spawn_neuron_disabled_tooltip,
-      {
-        $amount: formatNumber(
-          MIN_NEURON_STAKE / E8S_PER_ICP / SPAWN_VARIANCE_PERCENTAGE,
-          { minFraction: 4, maxFraction: 4 }
-        ),
-        $min: formatNumber(MIN_NEURON_STAKE / E8S_PER_ICP, {
-          minFraction: 0,
-          maxFraction: 0,
-        }),
-        $varibility: formatPercentage(SPAWN_VARIANCE_PERCENTAGE, {
-          minFraction: 0,
-          maxFraction: 0,
-        }),
-      }
-    )}
-  >
-    <button disabled class="secondary" on:click={showModal}>
+<TestIdWrapper testId="spawn-neuron-button-component">
+  {#if enoughMaturity}
+    <button class="secondary" on:click={showModal}>
       {$i18n.neuron_detail.spawn_neuron}
     </button>
-  </Tooltip>
-{/if}
+  {:else}
+    <Tooltip
+      id="spawn-maturity-button"
+      text={replacePlaceholders(
+        $i18n.neuron_detail.spawn_neuron_disabled_tooltip,
+        {
+          $amount: formatNumber(
+            MIN_NEURON_STAKE / E8S_PER_ICP / SPAWN_VARIANCE_PERCENTAGE,
+            { minFraction: 4, maxFraction: 4 }
+          ),
+          $min: formatNumber(MIN_NEURON_STAKE / E8S_PER_ICP, {
+            minFraction: 0,
+            maxFraction: 0,
+          }),
+          $varibility: formatPercentage(SPAWN_VARIANCE_PERCENTAGE, {
+            minFraction: 0,
+            maxFraction: 0,
+          }),
+        }
+      )}
+    >
+      <button disabled class="secondary" on:click={showModal}>
+        {$i18n.neuron_detail.spawn_neuron}
+      </button>
+    </Tooltip>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/ui/CommonItemAction.svelte
+++ b/frontend/src/lib/components/ui/CommonItemAction.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { ItemAction } from "@dfinity/gix-components";
+
+  export let testId: string;
+</script>
+
+<ItemAction {testId}>
+  <div class="icon" slot="icon">
+    <slot name="icon" />
+  </div>
+  <div class="content">
+    <h4 data-tid="staked-maturity"><slot name="title" /></h4>
+    <p class="description"><slot name="subtitle" /></p>
+  </div>
+  <div slot="actions" class="actions">
+    <slot />
+  </div>
+</ItemAction>
+
+<style lang="scss">
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+    p,
+    h4 {
+      margin: 0;
+    }
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--padding);
+  }
+
+  .icon {
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: var(--border-radius);
+    background: var(--content-background);
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -565,6 +565,7 @@
     "staked_description": "Staked",
     "age_bonus_label": "Age bonus: $ageBonus",
     "no_age_bonus": "No age bonus",
+    "available_description": "Available",
     "join_community_fund_description": "Are you sure you want this neuron to <strong>join</strong> the neurons' fund?",
     "leave_community_fund_description": "Are you sure you want this neuron to <strong>leave</strong> the neurons' fund?",
     "participate_community_fund": "Participate in neurons' fund.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -588,6 +588,7 @@ interface I18nNeuron_detail {
   staked_description: string;
   age_bonus_label: string;
   no_age_bonus: string;
+  available_description: string;
   join_community_fund_description: string;
   leave_community_fund_description: string;
   participate_community_fund: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import NnsAvailableMaturityActionItem from "$lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { NnsAvailableMaturityActionItemPo } from "$tests/page-objects/NnsAvailableMaturityActionItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
+
+describe("NnsAvailableMaturityActionItem", () => {
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: NnsAvailableMaturityActionItem,
+      },
+    });
+
+    return NnsAvailableMaturityActionItemPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render available maturity", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        maturityE8sEquivalent: 314000000n,
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getMaturity()).toBe("3.14");
+  });
+
+  it("should render buttons", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasSpawnButton()).toBe(true);
+    expect(await po.hasStakeButton()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturitySection.spec.ts
@@ -38,9 +38,10 @@ describe("NnsNeuronMaturitySection", () => {
     expect(await po.getTotalMaturity()).toBe("3.14");
   });
 
-  it("should render NnsStakedMaturityItemAction", async () => {
+  it("should render item actions", async () => {
     const po = renderComponent(mockNeuron);
 
     expect(await po.hasStakedMaturityItemAction()).toBe(true);
+    expect(await po.hasAvailableMaturityItemAction()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityActionItem.spec.ts
@@ -36,10 +36,4 @@ describe("NnsStakedMaturityActionItem", () => {
 
     expect(await po.getStakedMaturity()).toBe("3.14");
   });
-
-  it("should render stake maturity button", async () => {
-    const po = renderComponent(mockNeuron);
-
-    expect(await po.hasStakeButton()).toBe(true);
-  });
 });

--- a/frontend/src/tests/page-objects/NnsAvailableMaturityActionItem.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAvailableMaturityActionItem.page-object.ts
@@ -1,0 +1,26 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NnsAvailableMaturityActionItemPo extends BasePageObject {
+  private static readonly TID = "nns-available-maturity-item-action-component";
+
+  static under(element: PageObjectElement): NnsAvailableMaturityActionItemPo {
+    return new NnsAvailableMaturityActionItemPo(
+      element.byTestId(NnsAvailableMaturityActionItemPo.TID)
+    );
+  }
+
+  getMaturity(): Promise<string> {
+    return this.getText("available-maturity");
+  }
+
+  hasStakeButton(): Promise<boolean> {
+    return this.getButton("stake-maturity-button").isPresent();
+  }
+
+  hasSpawnButton(): Promise<boolean> {
+    // The spawn button is wrapped by `TestIdWrapper` because
+    // it might render a simple button or a Tooltip and a button inside it.
+    return this.root.byTestId("spawn-neuron-button-component").isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsAvailableMaturityActionItemPo } from "./NnsAvailableMaturityActionItem.page-object";
 import { NnsStakedMaturityActionItemPo } from "./NnsStakedMaturityActionItem.page-object";
 
 export class NnsNeuronMaturitySectionPo extends BasePageObject {
@@ -21,5 +22,13 @@ export class NnsNeuronMaturitySectionPo extends BasePageObject {
 
   hasStakedMaturityItemAction(): Promise<boolean> {
     return this.getStakedMaturityItemActionPo().isPresent();
+  }
+
+  getAvailableMaturityItemActionPo(): NnsAvailableMaturityActionItemPo {
+    return NnsAvailableMaturityActionItemPo.under(this.root);
+  }
+
+  hasAvailableMaturityItemAction(): Promise<boolean> {
+    return this.getAvailableMaturityItemActionPo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/NnsStakedMaturityActionItem.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakedMaturityActionItem.page-object.ts
@@ -13,8 +13,4 @@ export class NnsStakedMaturityActionItemPo extends BasePageObject {
   getStakedMaturity(): Promise<string> {
     return this.getText("staked-maturity");
   }
-
-  hasStakeButton(): Promise<boolean> {
-    return this.getButton("stake-maturity-button").isPresent();
-  }
 }


### PR DESCRIPTION
# Motivation

We're shuffling data in the neuron detail page.

In this PR: The item to display the available maturity of a NNS Neuron.

# Changes

* New component `NnsAvailableMaturityItemAction`.
* Use new component `NnsAvailableMaturityItemAction` in `NnsNeuronMaturitySection`.
* New UI component `CommonItemAction` to share the most common styles used for `ItemActions`.
* Use `CommonItemAction` in `NnsStakedMaturityActionItem` and remove the "Stake Maturity" button. This was an error implemented until now.

# Tests

* Test new component `NnsAvailableMaturityItemAction` using a PO.
* Add new test case in `NnsNeuronMaturitySection` to check new action item is rendered.
* Remove testing for Stake Maturity button in `NnsStakedMaturityActionItem`

# Todos

Not worth an entry yet.
