### PR TITLE
Fast CI runners for e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           retention-days: 3
   test-playwright-e2e-shard-1-of-2:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest-m
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
@@ -67,7 +67,7 @@ jobs:
           shard_count: 2
   test-playwright-e2e-shard-2-of-2:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest-m
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -30,6 +30,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+Use faster GitHub runners for e2e tests.
+
 #### Deprecated
 #### Removed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -31,7 +31,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
-Use faster GitHub runners for e2e tests.
+* Use faster GitHub runners for e2e tests.
 * Replace `ic-cdk-optimizer` with `ic-wasm shrink`.
 
 #### Deprecated


### PR DESCRIPTION
# Motivation

End-to-end tests take a lot of time and we are adding more of them.
They are sharded in 2 shards, which can easily be increased but that also duplicates the setup overhead.

# Changes

Set `runs-on: ubuntu-latest-m` for Playwright e2e jobs on CI.

# Tests

When I tested with a fast runner on 1 of the 2 shards it ran in 4 minutes while the other took 6 minutes.

# Todos

- [x] Add entry to changelog (if necessary).
