### PR TITLE
feat: aggregator html page js review

### DIFF
--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -32,7 +32,7 @@
           const aggregatorUrl = "";
 
           const renderSns = ({canister_ids: {root_canister_id}, meta: {name}}) => {
-              const div = document.createElement("article");
+              const article = document.createElement("article");
 
               const img = document.createElement("img");
               img.loading = "lazy";
@@ -42,10 +42,10 @@
               a.href = `${aggregatorUrl}/root/${root_canister_id}/slow.json`;
               a.text = name;
 
-              div.appendChild(img);
-              div.appendChild(a);
+              article.appendChild(img);
+              article.appendChild(a);
 
-              return div;
+              return article;
           }
 
           const renderSnses = (latest) => {

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -26,7 +26,7 @@
       </ul>
       <h2>Recent SNSs</h2>
 
-      <script async>
+      <script>
           // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io/v1/sns
           // Use the above for local development of this HTML page
           const aggregatorUrl = "";

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -26,7 +26,7 @@
       </ul>
       <h2>Recent SNSs</h2>
 
-      <script async="true">
+      <script async>
           // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io/v1/sns
           // Use the above for local development of this HTML page
           const aggregatorUrl = "";

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="utf-8">
     <title>SNS aggregator</title>
-    <style>
-	.sns {
+    <style lang="css">
+	article {
 	  display: flex;
 	  align-items: center;
 	}
+
+    img {
+        width: 100px;
+        aspect-ratio: 1/1;
+    }
     </style>
-    <script>
-	    fetch('/v1/sns/list/latest/slow.json').then(response => response.json()).then(latest => {
-		    document.body.innerHTML +=latest.map(sns => `<div class="sns"><img src="/v1/sns/root/${sns.canister_ids.root_canister_id}/logo.png" width="100px" height="100px"></img><a href="/v1/sns/root/${sns.canister_ids.root_canister_id}/slow.json">${sns.meta.name}</a></div>`).join('')
-	    });
-    </script>
   </head>
   <body>
 	  <h1>SNS aggregator</h1>
@@ -25,5 +25,39 @@
           <li>The SNS logo is at: /v1/sns/root/$CANISTER_ID/logo.png</li>
       </ul>
       <h2>Recent SNSs</h2>
+
+      <script async="true">
+          // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io/v1/sns
+          // Use the above for local development of this HTML page
+          const aggregatorUrl = "";
+
+          const renderSns = ({canister_ids: {root_canister_id}, meta: {name}}) => {
+              const div = document.createElement("article");
+
+              const img = document.createElement("img");
+              img.loading = "lazy";
+              img.src = `${aggregatorUrl}/root/${root_canister_id}/logo.png`;
+
+              const a = document.createElement("a");
+              a.href = `${aggregatorUrl}/root/${root_canister_id}/slow.json`;
+              a.text = name;
+
+              div.appendChild(img);
+              div.appendChild(a);
+
+              return div;
+          }
+
+          const renderSnses = (latest) => {
+              const fragment = document.createDocumentFragment();
+              fragment.append(...latest.map(renderSns));
+
+              document.querySelector("script")?.after(fragment);
+          }
+
+          const loadSnses = () => fetch(`${aggregatorUrl}/list/latest/slow.json`).then(response => response.json()).then(latest => renderSnses(latest));
+
+          document.addEventListener("DOMContentLoaded", loadSnses, {once: true});
+      </script>
   </body>
 </html>

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>SNS aggregator</title>
-    <style lang="css">
+    <style>
 	article {
 	  display: flex;
 	  align-items: center;


### PR DESCRIPTION
# Motivation

More verbose and therefore a bit more heavier but, this review of the JS code of the `index.html` of the aggregator makes it a bit easier to manipulate if we want to add in the future additional information within the list of Snses.

# Changes

- create element and append those to the DOM instead of parsing HTML (`innerHTML = ...`)
- move the script to the end of the body
- wait for HTML elements to be loaded before starting the script
- add a comment and variable for the root url (useful for local development)
- size of the image through css
- image load set as `lazy`
- `article` instead of `div` to improve semantic