### PR TITLE
Prefix accounts.store with icp

### DIFF
--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
   import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
@@ -21,7 +21,7 @@
     <IcpTransactionModal on:nnsClose={closeModal} />
   {/if}
 
-  {#if nonNullish($accountsStore)}
+  {#if nonNullish($icpAccountsStore)}
     <Footer>
       <button
         class="primary full-width"

--- a/frontend/src/lib/components/accounts/NnsAddAccount.svelte
+++ b/frontend/src/lib/components/accounts/NnsAddAccount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import AddAccountModal from "$lib/modals/accounts/AddAccountModal.svelte";
@@ -16,7 +16,7 @@
     <AddAccountModal on:nnsClose={closeModal} />
   {/if}
 
-  {#if nonNullish($accountsStore)}
+  {#if nonNullish($icpAccountsStore)}
     <button
       class="card"
       on:click={openAddAccountModal}

--- a/frontend/src/lib/components/accounts/NnsSelectAccount.svelte
+++ b/frontend/src/lib/components/accounts/NnsSelectAccount.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import AccountCard from "./AccountCard.svelte";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
@@ -18,15 +18,15 @@
   };
 
   let mainAccount: Account | undefined;
-  $: mainAccount = $accountsStore?.main;
+  $: mainAccount = $icpAccountsStore?.main;
 
   let subAccounts: Account[];
-  $: subAccounts = ($accountsStore?.subAccounts ?? []).filter(
+  $: subAccounts = ($icpAccountsStore?.subAccounts ?? []).filter(
     ({ identifier }: Account) => identifier !== filterIdentifier
   );
 
   let hardwareWalletAccounts: Account[];
-  $: hardwareWalletAccounts = ($accountsStore?.hardwareWallets ?? []).filter(
+  $: hardwareWalletAccounts = ($icpAccountsStore?.hardwareWallets ?? []).filter(
     ({ identifier }: Account) => identifier !== filterIdentifier
   );
 

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
@@ -2,7 +2,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { onMount } from "svelte";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {
@@ -23,7 +23,7 @@
     isNeuronControllable({
       neuron,
       identity: $authStore.identity,
-      accounts: $accountsStore,
+      accounts: $icpAccountsStore,
     }) ||
     isHotKeyControllable({
       neuron,

--- a/frontend/src/lib/components/neuron-detail/NeuronJoinFundCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronJoinFundCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import { isNeuronControllableByUser } from "$lib/utils/neuron.utils";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
@@ -13,7 +13,7 @@
   let isControlledByUser: boolean;
   $: isControlledByUser = isNeuronControllableByUser({
     neuron,
-    mainAccount: $accountsStore.main,
+    mainAccount: $icpAccountsStore.main,
   });
 </script>
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -4,7 +4,7 @@
   import { IconClose, Value } from "@dfinity/gix-components";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { removeHotkey } from "$lib/services/neurons.services";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { authStore } from "$lib/stores/auth.store";
   import { stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
@@ -38,7 +38,7 @@
   $: isControllable = isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
   let hotkeys: string[];
   $: hotkeys = neuron.fullNeuron?.hotKeys ?? [];

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronInfoStake.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronInfoStake.svelte
@@ -13,7 +13,7 @@
     isHotKeyControllable,
     isNeuronControllable,
   } from "$lib/utils/neuron.utils";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { authStore } from "$lib/stores/auth.store";
   import Separator from "$lib/components/ui/Separator.svelte";
 
@@ -23,7 +23,7 @@
   $: isControllable = isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
 
   let hotkeyControlled: boolean;

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMaturityCard.svelte
@@ -17,7 +17,7 @@
     formattedTotalMaturity,
     maturityLastDistribution,
   } from "$lib/utils/neuron.utils";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
   import { nonNullish } from "@dfinity/utils";
@@ -29,7 +29,7 @@
   $: isControllable = isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
 
   let showDetails: boolean;

--- a/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
@@ -12,7 +12,7 @@
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import AutoStakeMaturity from "$lib/components/neuron-detail/actions/AutoStakeMaturity.svelte";
   import { authStore } from "$lib/stores/auth.store";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
 
@@ -23,7 +23,7 @@
   $: disabled = !isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
 
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(

--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -2,7 +2,7 @@
   import type { NeuronId } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "$lib/constants/neurons.constants";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import { translate } from "$lib/utils/i18n.utils";
@@ -19,7 +19,7 @@
   let neurons: MergeableNeuron[];
   $: neurons = mapMergeableNeurons({
     neurons: $definedNeuronsStore,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
     selectedNeurons: mapNeuronIds({
       neuronIds: selectedNeuronIds,
       neurons: $definedNeuronsStore,

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -2,13 +2,13 @@
  * A derived store that returns the accounts as an array of accounts.
  */
 
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { derived, type Readable } from "svelte/store";
 
 export const nnsAccountsListStore: Readable<Account[]> = derived(
-  accountsStore,
+  icpAccountsStore,
   ({ main, subAccounts, hardwareWallets }) =>
     main === undefined
       ? []

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { canistersStore } from "$lib/stores/canisters.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
@@ -99,7 +99,7 @@ export const initDebugStore = () =>
     [
       // TODO (L2-611): anonymize wallet id and neuron ids
       busyStore,
-      accountsStore,
+      icpAccountsStore,
       neuronsStore,
       knownNeuronsStore,
       canistersStore,

--- a/frontend/src/lib/derived/universes-accounts-balance.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts-balance.derived.ts
@@ -1,5 +1,8 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { accountsStore, type AccountsStore } from "$lib/stores/accounts.store";
+import {
+  icpAccountsStore,
+  type IcpAccountsStore,
+} from "$lib/stores/icp-accounts.store";
 import type { IcrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import {
@@ -21,10 +24,10 @@ export type UniversesAccountsBalanceReadableStore = Record<
 >;
 
 export const universesAccountsBalance = derived<
-  [AccountsStore, SnsAccountsStore, IcrcAccountsStore],
+  [IcpAccountsStore, SnsAccountsStore, IcrcAccountsStore],
   UniversesAccountsBalanceReadableStore
 >(
-  [accountsStore, snsAccountsStore, icrcAccountsStore],
+  [icpAccountsStore, snsAccountsStore, icrcAccountsStore],
   ([$accountsStore, $snsAccountsStore, $icrcAccountsStore]) => ({
     [OWN_CANISTER_ID_TEXT]: {
       balanceE8s: sumNnsAccounts($accountsStore),

--- a/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -6,7 +6,7 @@
   import { Spinner } from "@dfinity/gix-components";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
   import { addFollowee } from "$lib/services/neurons.services";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
@@ -25,7 +25,7 @@
   $: isControllableByUser = isNeuronControllable({
     neuron,
     identity: $authStore.identity,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
   let isControllableByHotkey: boolean;
   $: isControllableByHotkey = isHotKeyControllable({

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -21,14 +21,14 @@
   import ConfirmSpawnHW from "$lib/components/neuron-detail/ConfirmSpawnHW.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { goto } from "$app/navigation";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
 
   let controlledByHardwareWallet: boolean;
   $: controlledByHardwareWallet = isNeuronControlledByHardwareWallet({
     neuron,
-    accounts: $accountsStore,
+    accounts: $icpAccountsStore,
   });
 
   const hardwareWalletSteps: WizardSteps = [

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -3,7 +3,7 @@
   import NnsAddAccount from "$lib/components/accounts/NnsAddAccount.svelte";
   import { i18n } from "$lib/stores/i18n";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { nonNullish } from "@dfinity/utils";
   import type { Account } from "$lib/types/account";
   import { onDestroy, onMount } from "svelte";
@@ -25,18 +25,18 @@
 </script>
 
 <div class="card-grid" data-tid="accounts-body">
-  {#if nonNullish($accountsStore?.main)}
+  {#if nonNullish($icpAccountsStore?.main)}
     <!-- Workaround: Type checker does not get $accountsStore.main is defined here -->
-    {@const mainAccount = $accountsStore.main}
+    {@const mainAccount = $icpAccountsStore.main}
 
     <AccountCard
       role="link"
       on:click={() => goToWallet(mainAccount)}
       hash
-      account={$accountsStore.main}
+      account={$icpAccountsStore.main}
       token={ICPToken}>{$i18n.accounts.main}</AccountCard
     >
-    {#each $accountsStore.subAccounts ?? [] as subAccount}
+    {#each $icpAccountsStore.subAccounts ?? [] as subAccount}
       <AccountCard
         role="link"
         on:click={() => goToWallet(subAccount)}
@@ -45,7 +45,7 @@
         token={ICPToken}>{subAccount.name}</AccountCard
       >
     {/each}
-    {#each $accountsStore.hardwareWallets ?? [] as walletAccount}
+    {#each $icpAccountsStore.hardwareWallets ?? [] as walletAccount}
       <AccountCard
         role="link"
         on:click={() => goToWallet(walletAccount)}

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -9,7 +9,7 @@
     loadBalance,
     pollAccounts,
   } from "$lib/services/accounts.services";
-  import { accountsStore } from "$lib/stores/accounts.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -92,7 +92,7 @@
     // handle unknown accountIdentifier from URL
     if (
       account === undefined &&
-      $accountsStore.main !== undefined &&
+      $icpAccountsStore.main !== undefined &&
       $pageStore.path === AppPath.Wallet
     ) {
       toastsError({

--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -21,11 +21,11 @@ import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import {
-  accountsStore,
-  type SingleMutationAccountsStore,
-} from "$lib/stores/accounts.store";
+  icpAccountsStore,
+  type SingleMutationIcpAccountsStore,
+} from "$lib/stores/icp-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type {
   Account,
@@ -80,7 +80,7 @@ export const loadAccounts = async ({
 }: {
   identity: Identity;
   certified: boolean;
-}): Promise<AccountsStoreData> => {
+}): Promise<IcpAccountsStoreData> => {
   // Helper
   const getAccountBalance = (identifierString: string): Promise<bigint> =>
     queryAccountBalance({
@@ -124,7 +124,7 @@ export const loadAccounts = async ({
 };
 
 type SyncAccontsErrorHandler = (params: {
-  mutableStore: SingleMutationAccountsStore;
+  mutableStore: SingleMutationIcpAccountsStore;
   err: unknown;
   certified: boolean;
 }) => void;
@@ -140,7 +140,7 @@ const defaultErrorHandlerAccounts: SyncAccontsErrorHandler = ({
   err,
   certified,
 }: {
-  mutableStore: SingleMutationAccountsStore;
+  mutableStore: SingleMutationIcpAccountsStore;
   err: unknown;
   certified: boolean;
 }) => {
@@ -165,8 +165,8 @@ const syncAccountsWithErrorHandler = (
   errorHandler: SyncAccontsErrorHandler
 ): Promise<void> => {
   const mutableStore =
-    accountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
-  return queryAndUpdate<AccountsStoreData, unknown>({
+    icpAccountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
+  return queryAndUpdate<IcpAccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),
     onLoad: ({ response: accounts }) => mutableStore.set(accounts),
     onError: ({ error: err, certified }) => {
@@ -202,7 +202,8 @@ export const loadBalance = async ({
   accountIdentifier: IcpAccountIdentifierText;
 }): Promise<void> => {
   const strategy = FORCE_CALL_STRATEGY;
-  const mutableStore = accountsStore.getSingleMutationAccountsStore(strategy);
+  const mutableStore =
+    icpAccountsStore.getSingleMutationAccountsStore(strategy);
   return queryAndUpdate<bigint, unknown>({
     request: ({ identity, certified }) =>
       queryAccountBalance({ identity, certified, accountIdentifier }),
@@ -363,7 +364,7 @@ export const getAccountIdentity = async (
 export const getAccountIdentityByPrincipal = async (
   principalString: string
 ): Promise<Identity | LedgerIdentity | undefined> => {
-  const accounts = get(accountsStore);
+  const accounts = get(icpAccountsStore);
   const account = getAccountByPrincipal({
     principal: principalString,
     accounts,
@@ -430,7 +431,7 @@ const pollAccountsId = Symbol("poll-accounts");
 const pollLoadAccounts = async (params: {
   identity: Identity;
   certified: boolean;
-}): Promise<AccountsStoreData> =>
+}): Promise<IcpAccountsStoreData> =>
   poll({
     fn: () => loadAccounts(params),
     // Any error is an unknown error and worth a retry
@@ -452,7 +453,7 @@ const pollLoadAccounts = async (params: {
  */
 export const pollAccounts = async (certified = true) => {
   const overrideCertified = isForceCallStrategy() ? false : certified;
-  const accounts = get(accountsStore);
+  const accounts = get(icpAccountsStore);
 
   // Skip if accounts are already loaded and certified
   // `certified` might be `undefined` if not yet loaded.
@@ -465,7 +466,7 @@ export const pollAccounts = async (certified = true) => {
   }
 
   const mutableStore =
-    accountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
+    icpAccountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
   try {
     const identity = await getAuthenticatedIdentity();
     const certifiedAccounts = await pollLoadAccounts({

--- a/frontend/src/lib/services/busy.services.ts
+++ b/frontend/src/lib/services/busy.services.ts
@@ -1,5 +1,5 @@
-import { accountsStore } from "$lib/stores/accounts.store";
 import { startBusy, type BusyStateInitiatorType } from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { isNeuronControlledByHardwareWallet } from "$lib/utils/neuron.utils";
 import type { NeuronId } from "@dfinity/nns";
 import { get } from "svelte/store";
@@ -19,7 +19,7 @@ export const startBusyNeuron = ({
   }
   const hardwareWalletNeuron = isNeuronControlledByHardwareWallet({
     neuron,
-    accounts: get(accountsStore),
+    accounts: get(icpAccountsStore),
   });
   startBusy({
     initiator,

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -4,8 +4,8 @@ import {
   getTestAccountBalance,
 } from "$lib/api/dev.api";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
-import { accountsStore } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   snsAccountsStore,
   type SnsAccountsStoreData,
@@ -18,7 +18,7 @@ import { loadSnsAccounts } from "./sns-accounts.services";
 export const getTestBalance = getTestAccountBalance;
 
 export const getICPs = async (icps: number) => {
-  const { main }: AccountsStoreData = get(accountsStore);
+  const { main }: IcpAccountsStoreData = get(icpAccountsStore);
 
   if (!main) {
     throw new Error("No account found to get ICPs");

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -10,8 +10,8 @@ import {
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import {
   toastsError,
@@ -419,7 +419,7 @@ export const mergeNeurons = async ({
     const identity: Identity = await getIdentityOfControllerByNeuronId(
       targetNeuronId
     );
-    const accounts = get(accountsStore);
+    const accounts = get(icpAccountsStore);
     if (
       isNeuronControlledByHardwareWallet({ neuron: targetNeuron, accounts })
     ) {
@@ -607,7 +607,7 @@ export const splitNeuron = async ({
     const identity: Identity = await getIdentityOfControllerByNeuronId(
       neuron.neuronId
     );
-    const accounts = get(accountsStore);
+    const accounts = get(icpAccountsStore);
     if (isNeuronControlledByHardwareWallet({ neuron, accounts })) {
       await assertLedgerVersion({
         identity,

--- a/frontend/src/lib/services/seed-neurons.services.ts
+++ b/frontend/src/lib/services/seed-neurons.services.ts
@@ -2,8 +2,8 @@ import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import type { Secp256k1PublicKey } from "$lib/keys/secp256k1";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { mapNeuronErrorToToastMessage } from "$lib/utils/error.utils";
 import { translate } from "$lib/utils/i18n.utils";
@@ -18,7 +18,7 @@ const buf2hex = (buffer: ArrayBuffer): string =>
 // Method to be used only from the Dev Tools console.
 // This code is temporary and should be removed.
 export const claimSeedNeurons = async () => {
-  const accounts = get(accountsStore);
+  const accounts = get(icpAccountsStore);
   const hardwareWallet = accounts.hardwareWallets?.[0];
   if (accounts?.main === undefined) {
     alert("Account not yet loaded. Wait a little longer and try again.");

--- a/frontend/src/lib/stores/icp-accounts.store.ts
+++ b/frontend/src/lib/stores/icp-accounts.store.ts
@@ -4,15 +4,15 @@ import { isNullish } from "@dfinity/utils";
 import type { Readable } from "svelte/store";
 import { queuedStore } from "./queued-store";
 
-export interface AccountsStoreData {
+export interface IcpAccountsStoreData {
   main?: Account;
   subAccounts?: Account[];
   hardwareWallets?: Account[];
   certified?: boolean;
 }
 
-export interface SingleMutationAccountsStore {
-  set: (data: AccountsStoreData) => void;
+export interface SingleMutationIcpAccountsStore {
+  set: (data: IcpAccountsStoreData) => void;
   setBalance: ({
     certified,
     accountIdentifier,
@@ -26,7 +26,7 @@ export interface SingleMutationAccountsStore {
   cancel: () => void;
 }
 
-export interface AccountsStore extends Readable<AccountsStoreData> {
+export interface IcpAccountsStore extends Readable<IcpAccountsStoreData> {
   // Returns a store on which operations can be performed for a single
   // mutation. Note that the changes applied for both the query and update
   // response count as a single mutation and should be applied using the same
@@ -34,18 +34,18 @@ export interface AccountsStore extends Readable<AccountsStoreData> {
   // update response of the same mutation.
   getSingleMutationAccountsStore: (
     strategy?: QueryAndUpdateStrategy | undefined
-  ) => SingleMutationAccountsStore;
+  ) => SingleMutationIcpAccountsStore;
   resetForTesting: () => void;
   // Set the store contents if you don't care about the queryAndUpdate race
   // condition.
-  setForTesting: (data: AccountsStoreData) => void;
+  setForTesting: (data: IcpAccountsStoreData) => void;
 }
 
 /**
  * A store that contains the account information.
  */
-const initAccountsStore = (): AccountsStore => {
-  const initialAccounts: AccountsStoreData = {
+const initIcpAccountsStore = (): IcpAccountsStore => {
+  const initialAccounts: IcpAccountsStoreData = {
     main: undefined,
     subAccounts: undefined,
     hardwareWallets: undefined,
@@ -53,15 +53,15 @@ const initAccountsStore = (): AccountsStore => {
   };
 
   const { subscribe, getSingleMutationStore, resetForTesting } =
-    queuedStore<AccountsStoreData>(initialAccounts);
+    queuedStore<IcpAccountsStoreData>(initialAccounts);
 
   const getSingleMutationAccountsStore = (
     strategy?: QueryAndUpdateStrategy | undefined
-  ): SingleMutationAccountsStore => {
+  ): SingleMutationIcpAccountsStore => {
     const { set, update, cancel } = getSingleMutationStore(strategy);
 
     return {
-      set(accounts: AccountsStoreData) {
+      set(accounts: IcpAccountsStoreData) {
         set({ data: accounts, certified: accounts.certified || false });
       },
 
@@ -107,11 +107,11 @@ const initAccountsStore = (): AccountsStore => {
     getSingleMutationAccountsStore,
     resetForTesting,
 
-    setForTesting(accounts: AccountsStoreData) {
+    setForTesting(accounts: IcpAccountsStoreData) {
       const mutableStore = getSingleMutationAccountsStore();
       mutableStore.set(accounts);
     },
   };
 };
 
-export const accountsStore = initAccountsStore();
+export const icpAccountsStore = initIcpAccountsStore();

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -1,5 +1,5 @@
 import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import type { Account } from "$lib/types/account";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { TransactionNetwork } from "$lib/types/transaction";
@@ -22,7 +22,7 @@ export const getAccountByPrincipal = ({
   accounts: { main, hardwareWallets },
 }: {
   principal: string;
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
 }): Account | undefined => {
   if (main?.principal?.toText() === principal) {
     return main;
@@ -210,7 +210,7 @@ export const accountName = ({
   account?.name ?? (account?.type === "main" ? mainName : account?.name ?? "");
 
 export const sumNnsAccounts = (
-  accounts: AccountsStoreData | undefined
+  accounts: IcpAccountsStoreData | undefined
 ): bigint | undefined =>
   accounts?.main?.balanceE8s !== undefined
     ? sumAmountE8s(

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -18,7 +18,7 @@ import {
   TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";
@@ -326,7 +326,7 @@ export const isNeuronControllable = ({
 }: {
   neuron: NeuronInfo;
   identity?: Identity | null;
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
 }): boolean =>
   fullNeuron?.controller !== undefined &&
   (fullNeuron.controller === identity?.getPrincipal().toText() ||
@@ -338,7 +338,7 @@ export const isNeuronControlledByHardwareWallet = ({
   accounts,
 }: {
   neuron: NeuronInfo;
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
 }): boolean => {
   if (neuron.fullNeuron?.controller !== undefined) {
     const account = getAccountByPrincipal({
@@ -457,7 +457,7 @@ const isMergeableNeuron = ({
   accounts,
 }: {
   neuron: NeuronInfo;
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
 }): boolean =>
   !hasJoinedCommunityFund(neuron) &&
   !isSpawning(neuron) &&
@@ -469,7 +469,7 @@ const getMergeableNeuronMessageKey = ({
   accounts,
 }: {
   neuron: NeuronInfo;
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
 }): string | undefined => {
   if (hasJoinedCommunityFund(neuron)) {
     return "neurons.cannot_merge_neuron_community";
@@ -505,7 +505,7 @@ export const mapMergeableNeurons = ({
   selectedNeurons,
 }: {
   neurons: NeuronInfo[];
-  accounts: AccountsStoreData;
+  accounts: IcpAccountsStoreData;
   selectedNeurons: NeuronInfo[];
 }): MergeableNeuron[] =>
   neurons

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -3,12 +3,12 @@ import {
   resetNeuronsApiService,
 } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import {
   createMockIdentity,
   mockIdentity,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import {
   createMockKnownNeuron,
   createMockNeuron,

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -5,8 +5,8 @@ import {
 } from "$lib/api/accounts.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import type { GetTransactionsResponse } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { mockSubAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSentToSubAccountTransaction } from "$tests/mocks/transaction.mock";
 import { mock } from "jest-mock-extended";
 

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -19,12 +19,12 @@ import {
 import { CYCLES_MINTING_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
-import { mockSubAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCanisterDetails,
   mockCanisterSettings,
 } from "$tests/mocks/canisters.mock";
+import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { CMCCanister, ProcessingError } from "@dfinity/cmc";
 import { AccountIdentifier, LedgerCanister, SubAccount } from "@dfinity/nns";
 import { ICPToken, TokenAmount, principalToSubAccount } from "@dfinity/utils";

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -22,8 +22,8 @@ import {
   startDissolving,
   stopDissolving,
 } from "$lib/api/governance.api";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister, LedgerCanister, Topic, Vote } from "@dfinity/nns";

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -3,8 +3,8 @@ import {
   sendICP,
   transactionFee,
 } from "$lib/api/icp-ledger.api";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";

--- a/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
+++ b/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
@@ -1,7 +1,7 @@
 import { addAccount, queryAccount } from "$lib/api/nns-dapp.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
-import { mockAccountDetails } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { mock } from "jest-mock-extended";
 
 describe("nns-dapp api", () => {

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -20,12 +20,12 @@ import type {
   CreateSubAccountResponse,
   GetAccountResponse,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockCanister, mockCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockAccountDetails,
   mockSubAccountDetails,
-} from "$tests/mocks/accounts.store.mock";
-import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockCanister, mockCanisters } from "$tests/mocks/canisters.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";

--- a/frontend/src/tests/lib/components/accounts/AccountBadge.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountBadge.spec.ts
@@ -3,12 +3,12 @@
  */
 
 import AccountBadge from "$lib/components/accounts/AccountBadge.svelte";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { render } from "@testing-library/svelte";
 
 describe("AccountBadge", () => {

--- a/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -6,7 +6,7 @@ import AccountCard from "$lib/components/accounts/AccountCard.svelte";
 import type { Account } from "$lib/types/account";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import type { Token } from "@dfinity/utils";
 import { ICPToken } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";

--- a/frontend/src/tests/lib/components/accounts/Address.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/Address.spec.ts
@@ -3,8 +3,8 @@
  */
 
 import NnsAddress from "$lib/components/accounts/NnsAddress.svelte";
-import { mockAddressInputValid } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockAddressInputValid } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("NnsAddress", () => {

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -5,9 +5,9 @@
 import AddressInput from "$lib/components/accounts/AddressInput.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { TransactionNetwork } from "$lib/types/transaction";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import { mockBTCAddressMainnet } from "../../../mocks/ckbtc-accounts.mock";
 

--- a/frontend/src/tests/lib/components/accounts/BitcoinAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinAddress.spec.ts
@@ -12,13 +12,13 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { render, waitFor } from "@testing-library/svelte";
 import { page } from "../../../../../__mocks__/$app/stores";
 

--- a/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -4,8 +4,8 @@
 
 import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletListNeuronsButton.spec.ts
@@ -4,8 +4,8 @@
 
 import HardwareWalletListNeurons from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
 import { listNeuronsHardwareWalletProxy } from "$lib/proxy/icp-ledger.services.proxy";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
@@ -6,7 +6,7 @@ import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.
 import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
 import type { BalancesObserverData } from "$lib/types/icrc.observer";
 import type { PostMessageDataRequestBalances } from "$lib/types/post-message.balances";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ledgerCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { render, waitFor } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -7,9 +7,9 @@ import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import type { Account } from "$lib/types/account";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import {
   mockSnsMainAccount,

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsObserver.spec.ts
@@ -6,7 +6,7 @@ import IcrcTransactionsObserver from "$lib/components/accounts/IcrcTransactionsO
 import { FETCH_ROOT_KEY, HOST } from "$lib/constants/environment.constants";
 import type { TransactionsObserverData } from "$lib/types/icrc.observer";
 import type { PostMessageDataRequestTransactions } from "$lib/types/post-message.transactions";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { indexCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { render, waitFor } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -3,12 +3,12 @@
  */
 
 import NnsDestinationAddress from "$lib/components/accounts/NnsDestinationAddress.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { render } from "@testing-library/svelte";
 
 describe("NnsDestinationAddress", () => {
@@ -18,7 +18,7 @@ describe("NnsDestinationAddress", () => {
   };
 
   jest
-    .spyOn(accountsStore, "subscribe")
+    .spyOn(icpAccountsStore, "subscribe")
     .mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount, mockSubAccount2])
     );

--- a/frontend/src/tests/lib/components/accounts/NnsSelectAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsSelectAccount.spec.ts
@@ -3,19 +3,19 @@
  */
 
 import NnsSelectAccount from "$lib/components/accounts/NnsSelectAccount.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("NnsSelectAccount", () => {
   beforeEach(() => {
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
   });
 
   it("should render a skeleton-card until accounts loaded", () => {
@@ -28,7 +28,7 @@ describe("NnsSelectAccount", () => {
 
   it("should render list of accounts once loaded", () => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe());
 
     const { getByText } = render(NnsSelectAccount);
@@ -43,7 +43,7 @@ describe("NnsSelectAccount", () => {
 
   it("should not render hardware wallets when prop hideHardwareWalletAccounts is true", () => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
       );
@@ -67,7 +67,7 @@ describe("NnsSelectAccount", () => {
   });
 
   it("should render a title with subaccount", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,
@@ -85,7 +85,7 @@ describe("NnsSelectAccount", () => {
   });
 
   it("should render a title with hardware wallet", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: [mockSubAccount],
@@ -103,7 +103,7 @@ describe("NnsSelectAccount", () => {
   });
 
   it("should not render a title with hardware wallet if these kind of accounts should be hidden", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: [mockSubAccount],
@@ -120,7 +120,7 @@ describe("NnsSelectAccount", () => {
   });
 
   it("should render no title if no accounts listed", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: undefined,
@@ -137,7 +137,7 @@ describe("NnsSelectAccount", () => {
 
   it("should filter an account for a given identifier", () => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe());
 
     const { getByText } = render(NnsSelectAccount, {

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -6,11 +6,11 @@ import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svel
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
@@ -5,9 +5,9 @@
 import RenameSubAccountAction from "$lib/components/accounts/RenameSubAccountAction.svelte";
 import { renameSubAccount } from "$lib/services/accounts.services";
 import type { Account } from "$lib/types/account";
-import { mockSubAccount } from "$tests/mocks/accounts.store.mock";
 import { renderSelectedAccountContext } from "$tests/mocks/context-wrapper.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent } from "@testing-library/dom";
 
 jest.mock("$lib/services/accounts.services");

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountButton.spec.ts
@@ -3,8 +3,8 @@
  */
 
 import RenameSubAccount from "$lib/components/accounts/RenameSubAccountButton.svelte";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import WalletContextTest from "./WalletContextTest.svelte";

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -4,15 +4,15 @@
 
 import SelectAccountDropdown from "$lib/components/accounts/SelectAccountDropdown.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
@@ -20,7 +20,7 @@ describe("SelectAccountDropdown", () => {
   describe("no accounts", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
     });
 
     const props = { rootCanisterId: OWN_CANISTER_ID };
@@ -40,7 +40,7 @@ describe("SelectAccountDropdown", () => {
     const hardwareWallets = [mockHardwareWalletAccount];
 
     beforeEach(() => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts,
         hardwareWallets,

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -4,14 +4,14 @@
 
 import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsAccountsStoreSubscribe } from "$tests/mocks/sns-accounts.mock";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -26,7 +26,7 @@ describe("SelectDestinationAddress", () => {
     const hardwareWallets = [mockHardwareWalletAccount];
 
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe(subaccounts, hardwareWallets)
       );

--- a/frontend/src/tests/lib/components/accounts/TransactionList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionList.spec.ts
@@ -8,8 +8,8 @@ import {
   type WalletContext,
   type WalletStore,
 } from "$lib/types/wallet.context";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockReceivedFromMainAccountTransaction } from "$tests/mocks/transaction.mock";
 import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";

--- a/frontend/src/tests/lib/components/accounts/WalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletActions.spec.ts
@@ -6,7 +6,7 @@ import WalletActions from "$lib/components/accounts/WalletActions.svelte";
 import {
   mockHardwareWalletAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { render } from "@testing-library/svelte";
 import WalletContextTest from "./WalletContextTest.svelte";
 

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -12,8 +12,8 @@ import {
 } from "$lib/types/wallet.context";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, type Token } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get, writable } from "svelte/store";

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -4,7 +4,7 @@
 
 import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronJoinFundCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronJoinFundCard.spec.ts
@@ -3,14 +3,14 @@
  */
 
 import NeuronJoinFundCard from "$lib/components/neuron-detail/NeuronJoinFundCard.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -30,7 +30,7 @@ describe("NeuronJoinFundCard", () => {
       .mockImplementation(mockAuthStoreSubscribe);
 
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
       );

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronInfoStake.spec.ts
@@ -3,15 +3,15 @@
  */
 
 import NnsNeuronInfoStake from "$lib/components/neuron-detail/NnsNeuronInfoStake.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -31,7 +31,7 @@ describe("NnsNeuronInfoStake", () => {
       .mockImplementation(mockAuthStoreSubscribe);
 
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
       );

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMaturityCard.spec.ts
@@ -4,22 +4,22 @@
 
 import NnsNeuronMaturityCard from "$lib/components/neuron-detail/NnsNeuronMaturityCard.svelte";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import {
   formattedStakedMaturity,
   formattedTotalMaturity,
 } from "$lib/utils/neuron.utils";
 import {
-  mockAccountsStoreSubscribe,
-  mockHardwareWalletAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import {
+  mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
@@ -205,7 +205,7 @@ describe("NnsNeuronMaturityCard", () => {
   describe("hw", () => {
     beforeAll(() =>
       jest
-        .spyOn(accountsStore, "subscribe")
+        .spyOn(icpAccountsStore, "subscribe")
         .mockImplementation(
           mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
         )

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronMetaInfoCard.spec.ts
@@ -3,17 +3,17 @@
  */
 
 import NnsNeuronMetaInfoCard from "$lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { secondsToDuration } from "$lib/utils/date.utils";
 import { formatVotingPower, neuronAge } from "$lib/utils/neuron.utils";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -33,7 +33,7 @@ describe("NnsNeuronMetaInfoCard", () => {
       .mockImplementation(mockAuthStoreSubscribe);
 
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
       );

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -3,9 +3,9 @@
  */
 
 import DisburseButton from "$lib/components/neuron-detail/actions/DisburseButton.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import en from "$tests/mocks/i18n.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
@@ -28,7 +28,7 @@ describe("DisburseButton", () => {
 
   it("opens disburse nns neuron modal", async () => {
     // To avoid that the modal requests the accounts
-    accountsStore.setForTesting(mockAccountsStoreData);
+    icpAccountsStore.setForTesting(mockAccountsStoreData);
     const { container, queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -3,9 +3,9 @@
  */
 
 import NnsIncreaseStakeButton from "$lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import en from "$tests/mocks/i18n.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
@@ -48,7 +48,7 @@ describe("NnsIncreaseStakeButton", () => {
 
   it("opens Increase Neuron Stake Modal", async () => {
     // To avoid that the modal requests the accounts
-    accountsStore.setForTesting(mockAccountsStoreData);
+    icpAccountsStore.setForTesting(mockAccountsStoreData);
     const { container } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
@@ -4,11 +4,11 @@
 
 import NnsNeuronsFooter from "$lib/components/neurons/NnsNeuronsFooter.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import {
   buildMockNeuronsStoreSubscribe,
   mockFullNeuron,
@@ -53,7 +53,7 @@ describe("NnsNeurons", () => {
 
     it("should open stake neuron modal", async () => {
       // To avoid that the modal requests the accounts
-      accountsStore.setForTesting(mockAccountsStoreData);
+      icpAccountsStore.setForTesting(mockAccountsStoreData);
       const { queryByTestId, queryByText, getByTestId } =
         render(NnsNeuronsFooter);
 

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -4,18 +4,18 @@
 
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
 import {
   authStoreMock,
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import {
   createSummary,
   createTransferableAmount,
@@ -109,7 +109,7 @@ describe("ParticipateButton", () => {
 
       // When the modal appears, it will trigger `pollAccounts`
       // which trigger api calls if accounts are not loaded.
-      accountsStore.setForTesting(mockAccountsStoreData);
+      icpAccountsStore.setForTesting(mockAccountsStoreData);
 
       const { getByTestId } = renderContextCmp({
         summary: mockSnsFullProject.summary,

--- a/frontend/src/tests/lib/components/transaction/TransactionDescription.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionDescription.spec.ts
@@ -4,8 +4,8 @@
 
 import TransactionDescription from "$lib/components/transaction/TransactionDescription.svelte";
 import { TransactionNetwork } from "$lib/types/transaction";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { render } from "@testing-library/svelte";
 
 describe("TransactionDescription", () => {

--- a/frontend/src/tests/lib/components/transaction/TransactionReview.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReview.spec.ts
@@ -4,12 +4,12 @@
 
 import TransactionReview from "$lib/components/transaction/TransactionReview.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import {
   authStoreMock,
   mockIdentity,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
@@ -4,8 +4,8 @@
 
 import TransactionSource from "$lib/components/transaction/TransactionSource.svelte";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -5,14 +5,14 @@ import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svel
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockSnsFullProject,
   mockSummary,
@@ -127,7 +127,7 @@ describe("SelectUniverseCard", () => {
 
   describe("project-balance", () => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe(
           [mockSubAccount],

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -7,7 +7,7 @@ import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.co
 import { CKBTC_UNIVERSE } from "$lib/derived/ckbtc-universes.derived";
 import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -15,16 +15,16 @@ import type { Universe } from "$lib/types/universe";
 import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import {
-  mockAccountsStoreSubscribe,
-  mockHardwareWalletAccount,
-  mockMainAccount,
-  mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
 import en from "$tests/mocks/i18n.mock";
+import {
+  mockAccountsStoreSubscribe,
+  mockHardwareWalletAccount,
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   mockProjectSubscribe,
@@ -81,7 +81,7 @@ describe("UniverseAccountsBalance", () => {
 
   describe("balance", () => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(
         mockAccountsStoreSubscribe(
           [mockSubAccount],

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { get } from "svelte/store";
 
 describe("accounts", () => {
   describe("nnsAccountsListStore", () => {
     it("returns nns accounts in an array", () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSnsMainAccount],
         hardwareWallets: [],

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -1,18 +1,18 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import {
   mockAccountsStoreSubscribe,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("universes-accounts-balance.derived", () => {
   jest
-    .spyOn(accountsStore, "subscribe")
+    .spyOn(icpAccountsStore, "subscribe")
     .mockImplementation(mockAccountsStoreSubscribe([], []));
 
   const rootCanisterId = mockSnsFullProject.rootCanisterId;

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -1,15 +1,15 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import {
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
@@ -18,7 +18,7 @@ import { get } from "svelte/store";
 
 describe("universes-accounts", () => {
   it("should derive Nns accounts", () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],
@@ -61,7 +61,7 @@ describe("universes-accounts", () => {
   });
 
   it("should derive all accounts", () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -4,13 +4,13 @@
 
 import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
 import { transferICP } from "$lib/services/accounts.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreSubscribe,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { fireEvent, waitFor } from "@testing-library/svelte";
@@ -36,7 +36,7 @@ describe("IcpTransactionModal", () => {
 
   beforeEach(() => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
   });
 

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -3,14 +3,14 @@
  */
 
 import ReceiveModal from "$lib/modals/accounts/ReceiveModal.svelte";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 import { OWN_CANISTER_ID } from "../../../../lib/constants/canister-ids.constants";
-import { accountsStore } from "../../../../lib/stores/accounts.store";
 import type { Account } from "../../../../lib/types/account";
 import {
   mockMainAccount,
   mockSubAccount,
-} from "../../../mocks/accounts.store.mock";
+} from "../../../mocks/icp-accounts.store.mock";
 import { renderModal } from "../../../mocks/modal.mock";
 
 describe("ReceiveModal", () => {
@@ -73,7 +73,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should render a dropdown to select account", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: undefined,
@@ -89,7 +89,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should select account", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,

--- a/frontend/src/tests/lib/modals/accounts/RenameSubAccountModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/RenameSubAccountModal.spec.ts
@@ -4,9 +4,9 @@
 
 import RenameSubAccountModal from "$lib/modals/accounts/RenameSubAccountModal.svelte";
 import type { Account } from "$lib/types/account";
-import { mockSubAccount } from "$tests/mocks/accounts.store.mock";
 import { renderSelectedAccountContext } from "$tests/mocks/context-wrapper.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModalSelectedAccountContextWrapper } from "$tests/mocks/modal.mock";
 
 describe("RenameSubAccountModal", () => {

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -5,13 +5,13 @@ import {
   getIcpToCyclesExchangeRate,
   topUpCanister,
 } from "$lib/services/canisters.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsSuccess } from "$lib/stores/toasts.store";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
@@ -34,7 +34,7 @@ jest.mock("$lib/stores/toasts.store", () => {
 
 describe("AddCyclesModal", () => {
   jest
-    .spyOn(accountsStore, "subscribe")
+    .spyOn(icpAccountsStore, "subscribe")
     .mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
     );

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -10,16 +10,16 @@ import {
   createCanister,
   getIcpToCyclesExchangeRate,
 } from "$lib/services/canisters.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsShow } from "$lib/stores/toasts.store";
+import { mockCanister } from "$tests/mocks/canisters.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockCanister } from "$tests/mocks/canisters.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent } from "@testing-library/dom";
@@ -44,7 +44,7 @@ jest.mock("$lib/stores/toasts.store", () => {
 
 describe("CreateCanisterModal", () => {
   jest
-    .spyOn(accountsStore, "subscribe")
+    .spyOn(icpAccountsStore, "subscribe")
     .mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount], [mockHardwareWalletAccount])
     );

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -10,13 +10,13 @@ import { pageStore } from "$lib/derived/page.derived";
 import DisburseNnsNeuronModal from "$lib/modals/neurons/DisburseNnsNeuronModal.svelte";
 import { cancelPollAccounts } from "$lib/services/accounts.services";
 import { disburse } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import {
@@ -53,7 +53,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -143,7 +143,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts store is empty", () => {
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
     });
     it("should fetch accounts and render account selector", async () => {
       const mainBalanceE8s = BigInt(10_000_000);
@@ -167,7 +167,7 @@ describe("DisburseNnsNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -6,13 +6,13 @@ import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import IncreaseNeuronStakeModal from "$lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
 import { topUpNeuron } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/dom";
@@ -63,7 +63,7 @@ describe("IncreaseNeuronStakeModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      accountsStore.setForTesting(mockAccountsStoreData);
+      icpAccountsStore.setForTesting(mockAccountsStoreData);
     });
 
     it("should call top up neuron", async () => {

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -8,17 +8,17 @@ import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import type { Account } from "$lib/types/account";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
+import { createMockIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { createMockIdentity } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -40,7 +40,7 @@ describe("MergeNeuronsModal", () => {
       .spyOn(authServices, "getAuthenticatedIdentity")
       .mockResolvedValue(testIdentity);
     jest.clearAllMocks();
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
     neuronsStore.reset();
     resetNeuronsApiService();
   });
@@ -71,7 +71,7 @@ describe("MergeNeuronsModal", () => {
     neurons: fakeGovernanceApi.FakeNeuronParams[],
     hardwareWalletAccounts: Account[] = []
   ): Promise<MergeNeuronsModalPo> => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: { ...mockMainAccount, principal: testIdentity.getPrincipal() },
       hardwareWallets: hardwareWalletAccounts,
     });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -4,12 +4,12 @@
 
 import NnsStakeMaturityModal from "$lib/modals/neurons/NnsStakeMaturityModal.svelte";
 import { stakeMaturity } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import {
   mockAccountsStoreSubscribe,
   mockHardwareWalletAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { selectPercentage } from "$tests/utils/neurons-modal.test-utils";
@@ -103,7 +103,7 @@ describe("NnsStakeMaturityModal", () => {
   describe("HW", () => {
     beforeAll(() =>
       jest
-        .spyOn(accountsStore, "subscribe")
+        .spyOn(icpAccountsStore, "subscribe")
         .mockImplementation(
           mockAccountsStoreSubscribe([], [mockHardwareWalletAccount])
         )

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -13,22 +13,22 @@ import {
   stakeNeuron,
   updateDelay,
 } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import {
@@ -95,7 +95,7 @@ describe("NnsStakeNeuronModal", () => {
     const newBalanceE8s = BigInt(10_000_000);
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -313,7 +313,7 @@ describe("NnsStakeNeuronModal", () => {
         accountIdentifier: selectedAccountIdentifier,
       });
       // New balance is set in the store.
-      expect(get(accountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
     });
 
     it("should be able to change dissolve delay in the confirmation screen", async () => {
@@ -414,7 +414,7 @@ describe("NnsStakeNeuronModal", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       neuronsStore.setNeurons({ neurons: [], certified: true });
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -532,7 +532,7 @@ describe("NnsStakeNeuronModal", () => {
   describe("when accounts are not loaded", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       const mainBalanceE8s = BigInt(10_000_000);
       jest
         .spyOn(ledgerApi, "queryAccountBalance")
@@ -557,7 +557,7 @@ describe("NnsStakeNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -4,12 +4,12 @@
 
 import SpawnNeuronModal from "$lib/modals/neurons/SpawnNeuronModal.svelte";
 import { spawnNeuron } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent } from "@testing-library/svelte";
@@ -31,7 +31,7 @@ describe("SpawnNeuronModal", () => {
   };
 
   beforeAll(() =>
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     })

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -8,8 +8,8 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import ParticipateSwapModal from "$lib/modals/sns/sale/ParticipateSwapModal.svelte";
 import { cancelPollAccounts } from "$lib/services/accounts.services";
 import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import {
   PROJECT_DETAIL_CONTEXT_KEY,
@@ -18,14 +18,14 @@ import {
 } from "$lib/types/project-detail.context";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import {
-  mockAccountDetails,
-  mockAccountsStoreData,
-  mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
+import {
+  mockAccountDetails,
+  mockAccountsStoreData,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModalContextWrapper } from "$tests/mocks/modal.mock";
 import {
   createBuyersState,
@@ -75,7 +75,7 @@ describe("ParticipateSwapModal", () => {
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
     jest.mocked(initiateSnsSaleParticipation).mockClear();
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
     snsTicketsStore.setNoTicket(rootCanisterIdMock);
   });
 
@@ -134,7 +134,7 @@ describe("ParticipateSwapModal", () => {
 
   describe("when accounts are available", () => {
     beforeEach(() => {
-      accountsStore.setForTesting(mockAccountsStoreData);
+      icpAccountsStore.setForTesting(mockAccountsStoreData);
     });
 
     const participate = async (po: ParticipateSwapModalPo) => {
@@ -220,7 +220,7 @@ describe("ParticipateSwapModal", () => {
     let resolveQueryAccounts;
 
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -286,7 +286,7 @@ describe("ParticipateSwapModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       const now = Date.now();
       jest.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -5,21 +5,21 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
 import { formatToken } from "$lib/utils/token.utils";
 import {
-  mockAccountsStoreSubscribe,
-  mockMainAccount,
-  mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import {
+  mockAccountsStoreSubscribe,
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsAccountsStoreSubscribe } from "$tests/mocks/sns-accounts.mock";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
@@ -79,7 +79,7 @@ describe("TransactionModal", () => {
 
   beforeEach(() => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe([mockSubAccount]));
 
     jest

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -7,14 +7,14 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
 import { cancelPollAccounts } from "$lib/services/accounts.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formatToken } from "$lib/utils/token.utils";
 import {
   mockAccountDetails,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   advanceTime,
   runResolvedPromises,
@@ -33,7 +33,7 @@ describe("NnsAccounts", () => {
 
   describe("when there are accounts", () => {
     beforeEach(() => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [],
         hardwareWallets: [],
@@ -66,7 +66,7 @@ describe("NnsAccounts", () => {
     });
 
     it("should render subaccount cards", () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [],
@@ -83,7 +83,7 @@ describe("NnsAccounts", () => {
     });
 
     it("should render hardware wallet account cards", () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -103,7 +103,7 @@ describe("NnsAccounts", () => {
   describe("summary", () => {
     beforeAll(() => {
       jest.clearAllMocks();
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -120,7 +120,7 @@ describe("NnsAccounts", () => {
 
   describe("when no accounts", () => {
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       const mainBalanceE8s = BigInt(10_000_000);
       jest
         .spyOn(ledgerApi, "queryAccountBalance")
@@ -150,7 +150,7 @@ describe("NnsAccounts", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -8,18 +8,18 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { cancelPollAccounts } from "$lib/services/accounts.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   modalToolbarSelector,
   waitModalIntroEnd,
@@ -82,7 +82,7 @@ describe("NnsWallet", () => {
   describe("no accounts", () => {
     beforeEach(() => {
       cancelPollAccounts();
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest
         .spyOn(nnsDappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
@@ -126,7 +126,7 @@ describe("NnsWallet", () => {
   describe("accounts loaded", () => {
     beforeAll(() => {
       jest.clearAllMocks();
-      accountsStore.setForTesting(mockAccountsStoreData);
+      icpAccountsStore.setForTesting(mockAccountsStoreData);
     });
 
     it("should render nns project name", async () => {
@@ -241,7 +241,7 @@ describe("NnsWallet", () => {
 
   describe("accounts loaded (Hardware Wallet)", () => {
     beforeEach(() => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -269,7 +269,7 @@ describe("NnsWallet", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -13,8 +13,8 @@ import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
@@ -23,15 +23,15 @@ import { formatToken, numberToE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeLocationApi from "$tests/fakes/location-api.fake";
 import {
-  mockAccountDetails,
-  mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockAuthStoreNoIdentitySubscribe,
   mockAuthStoreSubscribe,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import {
+  mockAccountDetails,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   snsResponseFor,
   snsResponsesForLifecycle,
@@ -458,7 +458,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
         beforeEach(() => {
           // Do not rely on the `loadAccounts` from the modal.
-          accountsStore.setForTesting({
+          icpAccountsStore.setForTesting({
             main: mockMainAccount,
             subAccounts: [],
             hardwareWallets: [],

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -13,14 +13,14 @@ import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-tr
 import Accounts from "$lib/routes/Accounts.svelte";
 import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
 import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { page } from "$mocks/$app/stores";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   mockProjectSubscribe,
@@ -132,7 +132,7 @@ describe("Accounts", () => {
       accounts: [mockSnsMainAccount],
     });
 
-    accountsStore.setForTesting(mockAccountsStoreData);
+    icpAccountsStore.setForTesting(mockAccountsStoreData);
   });
 
   it("should render NnsAccounts by default", () => {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -5,12 +5,12 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Wallet from "$lib/routes/Wallet.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
-import { mockAccountsStoreData } from "$tests/mocks/accounts.store.mock";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
 import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -50,7 +50,7 @@ describe("Wallet", () => {
         lifecycle: SnsSwapLifecycle.Committed,
       })
     );
-    accountsStore.setForTesting(mockAccountsStoreData);
+    icpAccountsStore.setForTesting(mockAccountsStoreData);
   });
 
   beforeAll(() =>

--- a/frontend/src/tests/lib/services/accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/accounts.services.spec.ts
@@ -25,17 +25,9 @@ import {
   syncAccounts,
   transferICP,
 } from "$lib/services/accounts.services";
-import { accountsStore } from "$lib/stores/accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import * as toastsFunctions from "$lib/stores/toasts.store";
 import type { NewTransaction } from "$lib/types/transaction";
-import {
-  mockAccountDetails,
-  mockHardwareWalletAccount,
-  mockHardwareWalletAccountDetails,
-  mockMainAccount,
-  mockSubAccount,
-  mockSubAccountDetails,
-} from "$tests/mocks/accounts.store.mock";
 import {
   mockIdentity,
   mockIdentityErrorMsg,
@@ -43,6 +35,14 @@ import {
   setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import {
+  mockAccountDetails,
+  mockHardwareWalletAccount,
+  mockHardwareWalletAccountDetails,
+  mockMainAccount,
+  mockSubAccount,
+  mockSubAccountDetails,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockSentToSubAccountTransaction } from "$tests/mocks/transaction.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import {
@@ -71,7 +71,7 @@ describe("accounts-services", () => {
     jest.spyOn(console, "error").mockImplementation(jest.fn);
     jest.clearAllMocks();
     toastsStore.reset();
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
   });
 
   describe("getOrCreateAccount", () => {
@@ -220,7 +220,7 @@ describe("accounts-services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
 
-      const accounts = get(accountsStore);
+      const accounts = get(icpAccountsStore);
       expect(accounts).toEqual(mockAccounts);
     });
 
@@ -270,7 +270,7 @@ describe("accounts-services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
 
-      const accounts = get(accountsStore);
+      const accounts = get(icpAccountsStore);
       expect(accounts).toEqual(mockAccounts);
     });
 
@@ -325,14 +325,14 @@ describe("accounts-services", () => {
       });
       await syncAccounts();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
       );
 
       resolveUpdateResponse();
       await runResolvedPromises();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: updateMainBalanceE8s, certified: true })
       );
     });
@@ -371,7 +371,7 @@ describe("accounts-services", () => {
       });
       await syncAccounts();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
       );
 
@@ -382,14 +382,14 @@ describe("accounts-services", () => {
       await syncAccounts();
       await runResolvedPromises();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: newerMainBalanceE8s, certified: true })
       );
 
       resolveUpdateResponse();
       await runResolvedPromises();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: newerMainBalanceE8s, certified: true })
       );
     });
@@ -401,10 +401,10 @@ describe("accounts-services", () => {
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
-      expect(get(accountsStore).main.balanceE8s).toEqual(
+      expect(get(icpAccountsStore).main.balanceE8s).toEqual(
         mockMainAccount.balanceE8s
       );
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -421,7 +421,7 @@ describe("accounts-services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
 
-      expect(get(accountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
     });
 
     it("should not show error if only query fails", async () => {
@@ -434,7 +434,7 @@ describe("accounts-services", () => {
           }
           throw new Error("test");
         });
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -448,7 +448,7 @@ describe("accounts-services", () => {
       const queryAccountBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockRejectedValue(error);
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -494,7 +494,7 @@ describe("accounts-services", () => {
       });
       await syncAccounts();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
       );
 
@@ -505,14 +505,14 @@ describe("accounts-services", () => {
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
       await runResolvedPromises();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: newerMainBalanceE8s })
       );
 
       resolveUpdateResponse();
       await runResolvedPromises();
 
-      expect(get(accountsStore)).toEqual(
+      expect(get(icpAccountsStore)).toEqual(
         accountsWith({ mainBalanceE8s: newerMainBalanceE8s })
       );
     });
@@ -561,7 +561,7 @@ describe("accounts-services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
 
-      const accounts = get(accountsStore);
+      const accounts = get(icpAccountsStore);
       expect(accounts).toEqual(mockAccounts);
     });
 
@@ -640,7 +640,7 @@ describe("accounts-services", () => {
     });
 
     it("should sync destination balances after transfer ICP to own account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -834,7 +834,7 @@ describe("accounts-services", () => {
 
   describe("getAccountIdentity", () => {
     it("returns user identity if main account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentity(
@@ -844,7 +844,7 @@ describe("accounts-services", () => {
     });
 
     it("returns user identity if main account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -855,7 +855,7 @@ describe("accounts-services", () => {
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -870,7 +870,7 @@ describe("accounts-services", () => {
 
   describe("getAccountIdentityByPrincipal", () => {
     it("returns user identity if main account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentityByPrincipal(
@@ -880,7 +880,7 @@ describe("accounts-services", () => {
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -893,7 +893,7 @@ describe("accounts-services", () => {
     });
 
     it("returns null if no main account nor hardware wallet account", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -917,7 +917,7 @@ describe("accounts-services", () => {
     };
 
     beforeEach(() => {
-      accountsStore.resetForTesting();
+      icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
       jest.clearAllMocks();
       cancelPollAccounts();
@@ -943,7 +943,7 @@ describe("accounts-services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(1);
 
-      const accounts = get(accountsStore);
+      const accounts = get(icpAccountsStore);
       expect(accounts).toEqual(mockAccounts);
     });
 
@@ -1000,7 +1000,7 @@ describe("accounts-services", () => {
       await advanceTime(99 * retryDelay);
       expect(queryAccountSpy).toBeCalledTimes(expectedCalls);
 
-      const accounts = get(accountsStore);
+      const accounts = get(icpAccountsStore);
       return expect(accounts).toEqual(mockAccounts);
     });
 

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -4,7 +4,7 @@
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
-import { mockAccountDetails } from "$tests/mocks/accounts.store.mock";
+import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/nns";

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 import { startBusyNeuron } from "$lib/services/busy.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import * as busyStore from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 
 describe("busy-services", () => {
@@ -21,7 +21,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
     });
     const neuron = {
@@ -41,7 +41,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy with message if neuron controlled by hardware wallet", async () => {
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     });

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -16,7 +16,6 @@ import {
 } from "$lib/services/canisters.services";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import {
   mockIdentity,
   mockIdentityErrorMsg,
@@ -29,6 +28,7 @@ import {
   mockCanisters,
 } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { get } from "svelte/store";

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -16,7 +16,6 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
-import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
@@ -25,6 +24,7 @@ import {
   mockCkBTCToken,
   mockCkBTCWithdrawalAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { mockTokens } from "$tests/mocks/tokens.mock";
 import { CkBTCMinterCanister, type RetrieveBtcOk } from "@dfinity/ckbtc";
 import {

--- a/frontend/src/tests/lib/services/dev.services.spec.ts
+++ b/frontend/src/tests/lib/services/dev.services.spec.ts
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 import { getICPs } from "$lib/services/dev.services";
-import { accountsStore } from "$lib/stores/accounts.store";
-import { mockAccountsStoreSubscribe } from "$tests/mocks/accounts.store.mock";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { mockAccountsStoreSubscribe } from "$tests/mocks/icp-accounts.store.mock";
 
 describe("dev-services", () => {
   beforeEach(() => {
     jest
-      .spyOn(accountsStore, "subscribe")
+      .spyOn(icpAccountsStore, "subscribe")
       .mockImplementation(mockAccountsStoreSubscribe());
   });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -12,17 +12,12 @@ import {
 } from "$lib/services/accounts.services";
 import * as services from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import * as busyStore from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
-import {
-  mockHardwareWalletAccount,
-  mockMainAccount,
-  mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
 import {
   mockIdentity,
   mockIdentityErrorMsg,
@@ -30,6 +25,11 @@ import {
   setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { MockLedgerIdentity } from "$tests/mocks/ledger.identity.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import type { Identity } from "@dfinity/agent";
@@ -159,7 +159,7 @@ describe("neurons-services", () => {
     spyGetNeuron.mockClear();
     jest.clearAllMocks();
     neuronsStore.reset();
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
     resetIdentity();
     resetAccountIdentity();
     toastsStore.reset();
@@ -894,7 +894,7 @@ describe("neurons-services", () => {
         ...mockHardwareWalletAccount,
         principal: smallerVersionIdentity.getPrincipal(),
       };
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [hwAccount],
       });
@@ -991,7 +991,7 @@ describe("neurons-services", () => {
     });
 
     it("should simulate merging neurons if HW controlled", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -1327,7 +1327,7 @@ describe("neurons-services", () => {
         ...mockHardwareWalletAccount,
         principal: smallerVersionIdentity.getPrincipal(),
       };
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         hardwareWallets: [hwAccount],
       });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -17,9 +17,9 @@ import {
   participateInSnsSale,
   restoreSnsSaleParticipation,
 } from "$lib/services/sns-sale.services";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
 import * as toastsStore from "$lib/stores/toasts.store";
@@ -27,14 +27,14 @@ import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import {
-  mockMainAccount,
-  mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import {
   mockAuthStoreSubscribe,
   mockIdentity,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   createSummary,
   mockProjectSubscribe,
@@ -166,7 +166,7 @@ describe("sns-api", () => {
     jest.clearAllMocks();
 
     snsTicketsStore.reset();
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
 
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNotifyPaymentFailureApi.mockResolvedValue(undefined);
@@ -998,7 +998,7 @@ describe("sns-api", () => {
       jest.useFakeTimers().setSystemTime(now);
     });
     it("should call postprocess and APIs", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
@@ -1025,13 +1025,13 @@ describe("sns-api", () => {
     });
 
     it("should update account's balance in the store", async () => {
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      expect(get(accountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1042,7 +1042,7 @@ describe("sns-api", () => {
         ticket: testTicket,
       });
 
-      expect(get(accountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
     });
 
     it("should update subaccounts's balance in the store", async () => {
@@ -1051,14 +1051,14 @@ describe("sns-api", () => {
         owner: mockIdentity.getPrincipal(),
         subaccount: arrayOfNumberToUint8Array(mockSubAccount.subAccount),
       });
-      accountsStore.setForTesting({
+      icpAccountsStore.setForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
       const postprocessSpy = jest.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
 
-      expect(get(accountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1069,7 +1069,7 @@ describe("sns-api", () => {
         ticket: snsTicket.ticket,
       });
 
-      expect(get(accountsStore).subAccounts[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore).subAccounts[0].balanceE8s).toEqual(
         newBalanceE8s
       );
     });

--- a/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
@@ -1,15 +1,15 @@
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
-import { accountsStore } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { get } from "svelte/store";
 
-describe("accountsStore", () => {
+describe("icpAccountsStore", () => {
   const expectStoreInitialValues = () => {
-    const initState: AccountsStoreData = get(accountsStore);
+    const initState: IcpAccountsStoreData = get(icpAccountsStore);
 
     expect(initState.main).toBeUndefined();
     expect(initState.subAccounts).toBeUndefined();
@@ -18,8 +18,8 @@ describe("accountsStore", () => {
 
   // Convenience functions for tests that don't care about the functionality of
   // the queued store to handle out of order responses.
-  const accountsStoreSet = (accounts: AccountsStoreData) => {
-    const mutableStore = accountsStore.getSingleMutationAccountsStore();
+  const accountsStoreSet = (accounts: IcpAccountsStoreData) => {
+    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
     mutableStore.set(accounts);
   };
 
@@ -30,17 +30,17 @@ describe("accountsStore", () => {
     accountIdentifier: string;
     balanceE8s: bigint;
   }) => {
-    const mutableStore = accountsStore.getSingleMutationAccountsStore();
+    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
     mutableStore.setBalance({ accountIdentifier, balanceE8s, certified: true });
   };
 
   const accountsStoreReset = () => {
-    const mutableStore = accountsStore.getSingleMutationAccountsStore();
+    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
     mutableStore.reset({ certified: true });
   };
 
   beforeEach(() => {
-    accountsStore.resetForTesting();
+    icpAccountsStore.resetForTesting();
   });
 
   it("initializes to undefined", () => {
@@ -50,12 +50,12 @@ describe("accountsStore", () => {
   it("should set main account", () => {
     accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
 
-    const { main } = get(accountsStore);
+    const { main } = get(icpAccountsStore);
     expect(main).toEqual(mockMainAccount);
   });
 
   it("should set certified data", () => {
-    const { certified: initialCertified } = get(accountsStore);
+    const { certified: initialCertified } = get(icpAccountsStore);
     expect(initialCertified).toBe(undefined);
 
     accountsStoreSet({
@@ -64,7 +64,7 @@ describe("accountsStore", () => {
       certified: true,
     });
 
-    const { certified } = get(accountsStore);
+    const { certified } = get(icpAccountsStore);
     expect(certified).toBeTruthy();
   });
 
@@ -75,23 +75,23 @@ describe("accountsStore", () => {
   });
 
   it("should not override new data with stale data", () => {
-    const mutableStore1 = accountsStore.getSingleMutationAccountsStore();
+    const mutableStore1 = icpAccountsStore.getSingleMutationAccountsStore();
     mutableStore1.set({
       main: mockMainAccount,
       subAccounts: [],
       certified: false,
     });
 
-    expect(get(accountsStore).subAccounts).toHaveLength(0);
+    expect(get(icpAccountsStore).subAccounts).toHaveLength(0);
 
-    const mutableStore2 = accountsStore.getSingleMutationAccountsStore();
+    const mutableStore2 = icpAccountsStore.getSingleMutationAccountsStore();
     mutableStore2.set({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       certified: false,
     });
 
-    expect(get(accountsStore).subAccounts).toHaveLength(1);
+    expect(get(icpAccountsStore).subAccounts).toHaveLength(1);
 
     // Slow update response for out-dated state without subaccount
     mutableStore1.set({
@@ -101,14 +101,14 @@ describe("accountsStore", () => {
     });
 
     // Should not have overridden the newer data with subaccount
-    expect(get(accountsStore).subAccounts).toHaveLength(1);
+    expect(get(icpAccountsStore).subAccounts).toHaveLength(1);
   });
 
   describe("setBalance", () => {
     it("should set balance for main account", () => {
       accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
 
-      expect(get(accountsStore)?.main.balanceE8s).toEqual(
+      expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(
         mockMainAccount.balanceE8s
       );
       const newBalanceE8s = BigInt(100);
@@ -117,7 +117,7 @@ describe("accountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      expect(get(accountsStore)?.main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(newBalanceE8s);
     });
 
     it("should set balance for subaccount", () => {
@@ -126,7 +126,7 @@ describe("accountsStore", () => {
         subAccounts: [mockSubAccount],
       });
 
-      expect(get(accountsStore)?.subAccounts[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore)?.subAccounts[0].balanceE8s).toEqual(
         mockSubAccount.balanceE8s
       );
       const newBalanceE8s = BigInt(100);
@@ -135,7 +135,7 @@ describe("accountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      const store = get(accountsStore);
+      const store = get(icpAccountsStore);
       expect(store?.subAccounts[0].balanceE8s).toEqual(newBalanceE8s);
       expect(store.main.balanceE8s).toEqual(mockMainAccount.balanceE8s);
     });
@@ -147,7 +147,7 @@ describe("accountsStore", () => {
         hardwareWallets: [mockHardwareWalletAccount],
       });
 
-      expect(get(accountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
         mockHardwareWalletAccount.balanceE8s
       );
       const newBalanceE8s = BigInt(100);
@@ -156,7 +156,7 @@ describe("accountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      expect(get(accountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
         newBalanceE8s
       );
     });
@@ -174,7 +174,7 @@ describe("accountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      const store = get(accountsStore);
+      const store = get(icpAccountsStore);
       expect(store?.hardwareWallets[0].balanceE8s).toEqual(
         mockHardwareWalletAccount.balanceE8s
       );
@@ -211,13 +211,13 @@ describe("accountsStore", () => {
         mainBalance: bigint;
         subBalance: bigint;
       }) => {
-        expect(get(accountsStore)?.main.balanceE8s).toEqual(mainBalance);
-        expect(get(accountsStore)?.subAccounts[0].balanceE8s).toEqual(
+        expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(mainBalance);
+        expect(get(icpAccountsStore)?.subAccounts[0].balanceE8s).toEqual(
           subBalance
         );
       };
 
-      const mutableStore1 = accountsStore.getSingleMutationAccountsStore();
+      const mutableStore1 = icpAccountsStore.getSingleMutationAccountsStore();
       mutableStore1.set(
         dataWithBalances({
           mainBalance: mainBalance1,
@@ -227,7 +227,7 @@ describe("accountsStore", () => {
       );
       expectBalances({ mainBalance: mainBalance1, subBalance: subBalance1 });
 
-      const mutableStore2 = accountsStore.getSingleMutationAccountsStore();
+      const mutableStore2 = icpAccountsStore.getSingleMutationAccountsStore();
       mutableStore2.setBalance({
         accountIdentifier: mockSubAccount.identifier,
         balanceE8s: subBalance2,

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -18,15 +18,15 @@ import {
   sumAccounts,
   sumNnsAccounts,
 } from "$lib/utils/accounts.utils";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   mockAddressInputInvalid,
   mockAddressInputValid,
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockCanisterId } from "$tests/mocks/canisters.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -4,9 +4,9 @@ import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
-import { mockMainAccount } from "$tests/mocks/accounts.store.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 
 describe("ckbtc.utils", () => {

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -11,7 +11,7 @@ import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "$tests//mocks/sns-accounts.mock";
-import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -64,11 +64,11 @@ import {
   type IneligibleNeuronData,
   type InvalidState,
 } from "$lib/utils/neuron.utils";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockFullNeuron,
   mockNeuron,

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -14,12 +14,12 @@ import {
   transactionName,
   transactionType,
 } from "$lib/utils/transactions.utils";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockMainAccount,
   mockSubAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,

--- a/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
+++ b/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
@@ -1,6 +1,6 @@
 import type { WalletStore } from "$lib/types/wallet.context";
 import { writable } from "svelte/store";
-import { mockMainAccount } from "./accounts.store.mock";
+import { mockMainAccount } from "./icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "./neurons.mock";
 
 export const mockNeuronStake = {

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -3,7 +3,7 @@ import type {
   HardwareWalletAccountDetails,
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import type { AccountsStoreData } from "$lib/stores/accounts.store";
+import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import type { Account } from "$lib/types/account";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
@@ -72,7 +72,7 @@ export const mockAccountsStoreData = {
 
 export const mockAccountsStoreSubscribe =
   (subAccounts: Account[] = [], hardwareWalletAccounts: Account[] = []) =>
-  (run: Subscriber<AccountsStoreData>): (() => void) => {
+  (run: Subscriber<IcpAccountsStoreData>): (() => void) => {
     run({
       main: mockMainAccount,
       subAccounts,

--- a/frontend/src/tests/mocks/nns-dapp.canister.mock.ts
+++ b/frontend/src/tests/mocks/nns-dapp.canister.mock.ts
@@ -9,7 +9,7 @@ import {
   mockAccountDetails,
   mockMainAccount,
   mockSubAccountDetails,
-} from "./accounts.store.mock";
+} from "./icp-accounts.store.mock";
 
 // eslint-disable-next-line
 // @ts-ignore: test file

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -1,7 +1,7 @@
 import type { SnsAccountsStoreData } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import { mockSubAccountArray } from "$tests/mocks/accounts.store.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,7 +1,7 @@
 import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Transaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
-import { mockMainAccount, mockSubAccount } from "./accounts.store.mock";
+import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
 
 export const mockSentToSubAccountTransaction = {
   transaction_type: [{ Transfer: null }],

--- a/frontend/src/tests/mocks/wallet.store.mock.ts
+++ b/frontend/src/tests/mocks/wallet.store.mock.ts
@@ -1,6 +1,6 @@
 import type { WalletStore } from "$lib/types/wallet.context";
 import { writable } from "svelte/store";
-import { mockMainAccount } from "./accounts.store.mock";
+import { mockMainAccount } from "./icp-accounts.store.mock";
 
 export const mockWalletStore = writable<WalletStore>({
   account: mockMainAccount,

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -7,14 +7,14 @@ import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import Accounts from "$lib/routes/Accounts.svelte";
-import { accountsStore } from "$lib/stores/accounts.store";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockMainAccount,
-} from "$tests/mocks/accounts.store.mock";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+} from "$tests/mocks/icp-accounts.store.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
@@ -47,7 +47,7 @@ describe("Accounts", () => {
 
   it("should create a subaccount in NNS", async () => {
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-    accountsStore.setForTesting({
+    icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],


### PR DESCRIPTION
# Motivation

Now that we have various tokens and dedicated stores (`icrc-accounts.store`), I was thinking that prefixing `accounts.store` with `icp` - i.e. `icp-accounts.store` - makes it more explicit and easier to read.

WDYT @lmuntaner ?

# Changes

- refactoring only, no functional changes

# Notes

There is another store and service that can be prefixed later as well in separate PRs.