### PR TITLE
style: proposal summary header styles

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,6 +13,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Improve visibility of proposal summary headers.
+
 #### Deprecated
 #### Removed
 #### Fixed

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -57,10 +57,7 @@
     }
 
     :global(h2) {
-      font-size: min(
-        var(--summary-header-font-size),
-        calc(var(--summary-header-font-size) * 0.8)
-      );
+      font-size: calc(var(--summary-header-font-size) * 0.8);
     }
 
     // H3-H6 looks the same

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -41,32 +41,38 @@
       }
     }
 
-    :global(h1) {
+    // custom h1-h2 styles
+    :global(h1),
+    :global(h2) {
       @include fonts.h4;
+      font-weight: var(--font-weight-normal);
       margin-bottom: var(--padding-2x);
+      color: var(--value-color);
+    }
+
+    // Content header font size should not be larger than the summary header font size
+    --summary-header-font-size: var(--font-size-h2);
+    :global(h1) {
+      font-size: calc(var(--summary-header-font-size) * 0.9);
     }
 
     :global(h2) {
+      font-size: min(
+        var(--summary-header-font-size),
+        calc(var(--summary-header-font-size) * 0.8)
+      );
+    }
+
+    // H3-H6 looks the same
+    :global(h3),
+    :global(h4),
+    :global(h5),
+    :global(h6) {
       @include fonts.h5;
-      margin-bottom: var(--padding-2x);
-    }
-
-    :global(h3),
-    :global(h4),
-    :global(h5),
-    :global(h6) {
-      @include fonts.standard(true);
+      font-size: var(--font-size-standard);
+      font-weight: var(--font-weight-bold);
       margin-bottom: var(--padding);
-    }
-
-    :global(h1),
-    :global(h2),
-    :global(h3),
-    :global(h4),
-    :global(h5),
-    :global(h6) {
       color: var(--value-color);
-      font-weight: 400;
     }
 
     :global(table),


### PR DESCRIPTION
# Motivation

Restyle proposal summary headers to be more distinguishable.

# Changes

- custom h1-h2, size to be between normal and component header
- h3-h6 to be bold

# Tests

| Before | After |
|--------|--------|
| <img width="708" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/5dd2c492-f0d9-4206-a4db-142da980056d"> | <img width="708" alt="Screenshot 2023-07-18 at 10 25 20" src="https://github.com/dfinity/nns-dapp/assets/98811342/11c9abe0-b76d-4f77-bef1-0a1e98eb87a1"> | 

# Todos

- [x] Add entry to changelog (if necessary).
