### PR TITLE
Remove timeout from waitForAbsent and fix ProjectDetail test

### DIFF
--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -502,10 +502,15 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           );
 
           expect(await projectDetail.hasCommitmentAmount()).toBe(false);
-          await projectDetail.participate({
+
+          await projectDetail.clickParticipate();
+          const modal = projectDetail.getParticipateSwapModalPo();
+          await modal.participate({
             amount: amountICP,
             acceptConditions: false,
           });
+          await advanceTime();
+          await modal.waitForAbsent();
           expect(await projectDetail.getCommitmentAmount()).toBe(
             formattedAmountICP
           );

--- a/frontend/src/tests/page-objects/ParticipateButton.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateButton.page-object.ts
@@ -13,11 +13,15 @@ export class ParticipateButtonPo extends BasePageObject {
     return ParticipateSwapModalPo.under(this.root);
   }
 
+  click(): Promise<void> {
+    return this.getButton().click();
+  }
+
   async participate(params: {
     amount: number;
     acceptConditions: boolean;
   }): Promise<void> {
-    await this.getButton().click();
+    await this.click();
     const modal = this.getParticipateSwapModalPo();
     await modal.participate(params);
     await modal.waitForAbsent();

--- a/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectDetail.page-object.ts
@@ -1,7 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
 import { ProjectInfoSectionPo } from "$tests/page-objects/ProjectInfoSection.page-object";
 import { ProjectMetadataSectionPo } from "$tests/page-objects/ProjectMetadataSection.page-object";
 import { ProjectStatusSectionPo } from "$tests/page-objects/ProjectStatusSection.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import type { ButtonPo } from "./Button.page-object";
 
@@ -30,6 +31,12 @@ export class ProjectDetailPo extends BasePageObject {
       .getButton();
   }
 
+  getParticipateSwapModalPo(): ParticipateSwapModalPo {
+    return this.getProjectStatusSectionPo()
+      .getParticipateButtonPo()
+      .getParticipateSwapModalPo();
+  }
+
   getProjectName(): Promise<string> {
     return this.getProjectMetadataSectionPo().getProjectName();
   }
@@ -48,6 +55,10 @@ export class ProjectDetailPo extends BasePageObject {
 
   hasCommitmentAmount(): Promise<boolean> {
     return this.getProjectStatusSectionPo().hasCommitmentAmount();
+  }
+
+  clickParticipate(): Promise<void> {
+    return this.getProjectStatusSectionPo().clickParticipate();
   }
 
   participate(params: {

--- a/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectStatusSection.page-object.ts
@@ -29,6 +29,10 @@ export class ProjectStatusSectionPo extends BasePageObject {
     return this.getProjectStatusPo().getStatus();
   }
 
+  clickParticipate(): Promise<void> {
+    return this.getParticipateButtonPo().click();
+  }
+
   participate(params: {
     amount: number;
     acceptConditions: boolean;

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -111,15 +111,9 @@ export class JestPageObjectElement implements PageObjectElement {
   }
 
   waitForAbsent(): Promise<void> {
-    return waitFor(
-      async () => {
-        return expect(await this.isPresent()).toBe(false);
-      },
-      // TODO: Needed for the swap participation flow. Remove.
-      // To remove we need to use different describes in ProjectDetail.spec.ts
-      // Describes that mock timers and describes that don't.
-      { timeout: 5_000 }
-    );
+    return waitFor(async () => {
+      return expect(await this.isPresent()).toBe(false);
+    });
   }
 
   // Resolves to null if the element is not present.


### PR DESCRIPTION
# Motivation

During the ProjectDetail test the participation modal only closed after a timeout.
We put a timeout in waitForAbsent as a work around, but the proper fix is to advance the fake timers at the right time.
This means we can't call the same `participate` function that's used by the e2e test because it does all the steps together and we need to advance time between some of the steps.
We could just always advance time in `waitForAbsent` but advancing time is only allowed when fake timers are used and there is no way to query Jest/Vitest whether fake timers are being used.

# Changes

1. In `ProjectDetail.spec.ts`, instead of calling `projectDetail.participate()`, perform the individual steps and `await advanceTime()` before expecting the modal to be closed.
2. Add convenience methods to page objects to make doing the individual steps a bit easier.
3. Remove the timeout from `waitForAbsent` in `frontend/src/tests/page-objects/jest.page-object.ts`.

# Tests

Only tests.

# Todos

- [ ] Add entry to changelog (if necessary).

I don't think it's warranted.