### PR TITLE
Rename getSingleMutationAccountsStore to getSingleMutationIcpAccountsStore

### DIFF
--- a/frontend/src/lib/services/accounts.services.ts
+++ b/frontend/src/lib/services/accounts.services.ts
@@ -165,7 +165,7 @@ const syncAccountsWithErrorHandler = (
   errorHandler: SyncAccontsErrorHandler
 ): Promise<void> => {
   const mutableStore =
-    icpAccountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
+    icpAccountsStore.getSingleMutationIcpAccountsStore(FORCE_CALL_STRATEGY);
   return queryAndUpdate<IcpAccountsStoreData, unknown>({
     request: (options) => loadAccounts(options),
     onLoad: ({ response: accounts }) => mutableStore.set(accounts),
@@ -203,7 +203,7 @@ export const loadBalance = async ({
 }): Promise<void> => {
   const strategy = FORCE_CALL_STRATEGY;
   const mutableStore =
-    icpAccountsStore.getSingleMutationAccountsStore(strategy);
+    icpAccountsStore.getSingleMutationIcpAccountsStore(strategy);
   return queryAndUpdate<bigint, unknown>({
     request: ({ identity, certified }) =>
       queryAccountBalance({ identity, certified, accountIdentifier }),
@@ -466,7 +466,7 @@ export const pollAccounts = async (certified = true) => {
   }
 
   const mutableStore =
-    icpAccountsStore.getSingleMutationAccountsStore(FORCE_CALL_STRATEGY);
+    icpAccountsStore.getSingleMutationIcpAccountsStore(FORCE_CALL_STRATEGY);
   try {
     const identity = await getAuthenticatedIdentity();
     const certifiedAccounts = await pollLoadAccounts({

--- a/frontend/src/lib/stores/icp-accounts.store.ts
+++ b/frontend/src/lib/stores/icp-accounts.store.ts
@@ -32,7 +32,7 @@ export interface IcpAccountsStore extends Readable<IcpAccountsStoreData> {
   // response count as a single mutation and should be applied using the same
   // store. The purpose of this store is to be able to associate the query and
   // update response of the same mutation.
-  getSingleMutationAccountsStore: (
+  getSingleMutationIcpAccountsStore: (
     strategy?: QueryAndUpdateStrategy | undefined
   ) => SingleMutationIcpAccountsStore;
   resetForTesting: () => void;
@@ -55,7 +55,7 @@ const initIcpAccountsStore = (): IcpAccountsStore => {
   const { subscribe, getSingleMutationStore, resetForTesting } =
     queuedStore<IcpAccountsStoreData>(initialAccounts);
 
-  const getSingleMutationAccountsStore = (
+  const getSingleMutationIcpAccountsStore = (
     strategy?: QueryAndUpdateStrategy | undefined
   ): SingleMutationIcpAccountsStore => {
     const { set, update, cancel } = getSingleMutationStore(strategy);
@@ -104,11 +104,11 @@ const initIcpAccountsStore = (): IcpAccountsStore => {
 
   return {
     subscribe,
-    getSingleMutationAccountsStore,
+    getSingleMutationIcpAccountsStore,
     resetForTesting,
 
     setForTesting(accounts: IcpAccountsStoreData) {
-      const mutableStore = getSingleMutationAccountsStore();
+      const mutableStore = getSingleMutationIcpAccountsStore();
       mutableStore.set(accounts);
     },
   };

--- a/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
@@ -19,7 +19,7 @@ describe("icpAccountsStore", () => {
   // Convenience functions for tests that don't care about the functionality of
   // the queued store to handle out of order responses.
   const accountsStoreSet = (accounts: IcpAccountsStoreData) => {
-    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
+    const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore.set(accounts);
   };
 
@@ -30,12 +30,12 @@ describe("icpAccountsStore", () => {
     accountIdentifier: string;
     balanceE8s: bigint;
   }) => {
-    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
+    const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore.setBalance({ accountIdentifier, balanceE8s, certified: true });
   };
 
   const accountsStoreReset = () => {
-    const mutableStore = icpAccountsStore.getSingleMutationAccountsStore();
+    const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore.reset({ certified: true });
   };
 
@@ -75,7 +75,7 @@ describe("icpAccountsStore", () => {
   });
 
   it("should not override new data with stale data", () => {
-    const mutableStore1 = icpAccountsStore.getSingleMutationAccountsStore();
+    const mutableStore1 = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore1.set({
       main: mockMainAccount,
       subAccounts: [],
@@ -84,7 +84,7 @@ describe("icpAccountsStore", () => {
 
     expect(get(icpAccountsStore).subAccounts).toHaveLength(0);
 
-    const mutableStore2 = icpAccountsStore.getSingleMutationAccountsStore();
+    const mutableStore2 = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore2.set({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
@@ -217,7 +217,8 @@ describe("icpAccountsStore", () => {
         );
       };
 
-      const mutableStore1 = icpAccountsStore.getSingleMutationAccountsStore();
+      const mutableStore1 =
+        icpAccountsStore.getSingleMutationIcpAccountsStore();
       mutableStore1.set(
         dataWithBalances({
           mainBalance: mainBalance1,
@@ -227,7 +228,8 @@ describe("icpAccountsStore", () => {
       );
       expectBalances({ mainBalance: mainBalance1, subBalance: subBalance1 });
 
-      const mutableStore2 = icpAccountsStore.getSingleMutationAccountsStore();
+      const mutableStore2 =
+        icpAccountsStore.getSingleMutationIcpAccountsStore();
       mutableStore2.setBalance({
         accountIdentifier: mockSubAccount.identifier,
         balanceE8s: subBalance2,


### PR DESCRIPTION
# Motivation

Renaming function was missing in #2897

# Changes

- rename `getSingleMutationAccountsStore` to `getSingleMutationIcpAccountsStore`
