### PR TITLE
E2E: Always use 6 workers

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Let's not enable retries until we actually need them */
   retries: 0,
   /* Number of tests that can be run in parallel. */
-  workers: process.env.CI ? 3 : 6,
+  workers: 6,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
# Motivation

We are now using faster machines to run e2e tests on CI.
These should also be capable of running more tests in parallel.

# Changes

Always use 6 workers for e2e tests.

# Tests

Looking at the CI run, the tests are noticeably slower but not twice as slow so in total it's a win. 

# Todos

- [ ] Add entry to changelog (if necessary).

Not note-worthy.
