### PR TITLE
GIX-1685: SnsNeuronMaturitySection and related

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconExpandCircleDown } from "@dfinity/gix-components";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { formattedMaturity } from "$lib/utils/sns-neuron.utils";
+  import SnsStakeMaturityButton from "./actions/SnsStakeMaturityButton.svelte";
+
+  export let neuron: SnsNeuron;
+</script>
+
+<CommonItemAction testId="sns-available-maturity-item-action-component">
+  <IconExpandCircleDown slot="icon" />
+  <span slot="title" data-tid="available-maturity"
+    >{formattedMaturity(neuron)}</span
+  >
+  <svelte:fragment slot="subtitle"
+    >{$i18n.neuron_detail.available_description}</svelte:fragment
+  >
+  <SnsStakeMaturityButton variant="secondary" />
+</CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { IconExpandCircleDown } from "@dfinity/gix-components";
-  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { formattedMaturity } from "$lib/utils/sns-neuron.utils";
   import SnsStakeMaturityButton from "./actions/SnsStakeMaturityButton.svelte";

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
@@ -5,8 +5,18 @@
   import SnsAvailableMaturityActionItem from "./SnsAvailableMaturityActionItem.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { formattedTotalMaturity } from "$lib/utils/sns-neuron.utils";
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "$lib/types/sns-neuron-detail.context";
+  import { getContext } from "svelte";
+  import { nonNullish } from "@dfinity/utils";
 
-  export let neuron: SnsNeuron;
+  const { store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let neuron: SnsNeuron | undefined | null;
+  $: neuron = $store.neuron;
 </script>
 
 <Section testId="sns-neuron-maturity-section-component">
@@ -17,10 +27,12 @@
   <p slot="description">
     {$i18n.neuron_detail.maturity_section_description}
   </p>
-  <ul class="content">
-    <SnsStakedMaturityActionItem {neuron} />
-    <SnsAvailableMaturityActionItem {neuron} />
-  </ul>
+  {#if nonNullish(neuron)}
+    <ul class="content">
+      <SnsStakedMaturityActionItem {neuron} />
+      <SnsAvailableMaturityActionItem {neuron} />
+    </ul>
+  {/if}
 </Section>
 
 <style lang="scss">

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
@@ -1,1 +1,43 @@
-<div>GIX-1685</div>
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { Section } from "@dfinity/gix-components";
+  import SnsStakedMaturityActionItem from "./SnsStakedMaturityActionItem.svelte";
+  import SnsAvailableMaturityActionItem from "./SnsAvailableMaturityActionItem.svelte";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { formattedTotalMaturity } from "$lib/utils/sns-neuron.utils";
+
+  export let neuron: SnsNeuron;
+</script>
+
+<Section testId="sns-neuron-maturity-section-component">
+  <h3 slot="title">{$i18n.neuron_detail.maturity_title}</h3>
+  <p slot="end" class="title-value" data-tid="total-maturity">
+    {formattedTotalMaturity(neuron)}
+  </p>
+  <p slot="description">
+    {$i18n.neuron_detail.maturity_section_description}
+  </p>
+  <ul class="content">
+    <SnsStakedMaturityActionItem {neuron} />
+    <SnsAvailableMaturityActionItem {neuron} />
+  </ul>
+</Section>
+
+<style lang="scss">
+  h3,
+  p {
+    margin: 0;
+  }
+
+  .title-value {
+    font-size: var(--font-size-h3);
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+
+    padding: 0;
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconStakedMaturity } from "@dfinity/gix-components";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { formattedStakedMaturity } from "$lib/utils/sns-neuron.utils";
+
+  export let neuron: SnsNeuron;
+</script>
+
+<CommonItemAction testId="sns-staked-maturity-item-action-component">
+  <IconStakedMaturity slot="icon" />
+  <span slot="title" data-tid="staked-maturity"
+    >{formattedStakedMaturity(neuron)}</span
+  >
+  <svelte:fragment slot="subtitle"
+    >{$i18n.neuron_detail.staked_description}</svelte:fragment
+  >
+</CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { IconStakedMaturity } from "@dfinity/gix-components";
-  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { formattedStakedMaturity } from "$lib/utils/sns-neuron.utils";
 

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
@@ -9,6 +9,8 @@
   import { getContext } from "svelte";
   import StakeMaturityButton from "$lib/components/neuron-detail/actions/StakeMaturityButton.svelte";
 
+  export let variant: "primary" | "secondary" = "primary";
+
   const context: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
   const { store }: SelectedSnsNeuronContext = context;
@@ -22,4 +24,4 @@
   const showModal = () => openSnsNeuronModal({ type: "stake-maturity" });
 </script>
 
-<StakeMaturityButton {enoughMaturity} on:click={showModal} />
+<StakeMaturityButton {enoughMaturity} {variant} on:click={showModal} />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsAvailableMaturityActionItem from "$lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { SnsAvailableMaturityActionItemPo } from "$tests/page-objects/SnsAvailableMaturityActionItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
+
+describe("SnsAvailableMaturityActionItem", () => {
+  const mockNeuron = createMockSnsNeuron({
+    id: [1],
+    maturity: 314000000n,
+  });
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        passPropNeuron: true,
+        rootCanisterId: mockCanisterId,
+        testComponent: SnsAvailableMaturityActionItem,
+      },
+    });
+
+    return SnsAvailableMaturityActionItemPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render available maturity", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.getMaturity()).toBe("3.14");
+  });
+
+  it("should render stake maturity button", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasStakeButton()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronMaturitySection from "$lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronMaturitySectionPo } from "$tests/page-objects/SnsNeuronMaturitySection.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
+
+describe("SnsNeuronMaturitySection", () => {
+  const mockNeuron = createMockSnsNeuron({
+    id: [1],
+    stakedMaturity: 100_000_000n,
+    maturity: 214_000_000n,
+  });
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        rootCanisterId: mockCanisterId,
+        passPropNeuron: true,
+        testComponent: SnsNeuronMaturitySection,
+      },
+    });
+
+    return SnsNeuronMaturitySectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render total maturity", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.getTotalMaturity()).toBe("3.14");
+  });
+
+  it("should render item actions", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.hasStakedMaturityItemAction()).toBe(true);
+    expect(await po.hasAvailableMaturityItemAction()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
@@ -22,7 +22,6 @@ describe("SnsNeuronMaturitySection", () => {
       props: {
         neuron,
         rootCanisterId: mockCanisterId,
-        passPropNeuron: true,
         testComponent: SnsNeuronMaturitySection,
       },
     });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsStakedMaturityActionItem from "$lib/components/sns-neuron-detail/SnsStakedMaturityActionItem.svelte";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { SnsStakedMaturityActionItemPo } from "$tests/page-objects/SnsStakedMaturityActionItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
+
+describe("SnsStakedMaturityActionItem", () => {
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        rootCanisterId: mockCanisterId,
+        passPropNeuron: true,
+        testComponent: SnsStakedMaturityActionItem,
+      },
+    });
+
+    return SnsStakedMaturityActionItemPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render staked maturity", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      stakedMaturity: 314000000n,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getStakedMaturity()).toBe("3.14");
+  });
+});

--- a/frontend/src/tests/page-objects/SnsAvailableMaturityActionItem.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsAvailableMaturityActionItem.page-object.ts
@@ -1,0 +1,20 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsAvailableMaturityActionItemPo extends BasePageObject {
+  private static readonly TID = "sns-available-maturity-item-action-component";
+
+  static under(element: PageObjectElement): SnsAvailableMaturityActionItemPo {
+    return new SnsAvailableMaturityActionItemPo(
+      element.byTestId(SnsAvailableMaturityActionItemPo.TID)
+    );
+  }
+
+  getMaturity(): Promise<string> {
+    return this.getText("available-maturity");
+  }
+
+  hasStakeButton(): Promise<boolean> {
+    return this.getButton("stake-maturity-button").isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
@@ -1,0 +1,34 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsAvailableMaturityActionItemPo } from "./SnsAvailableMaturityActionItem.page-object";
+import { SnsStakedMaturityActionItemPo } from "./SnsStakedMaturityActionItem.page-object";
+
+export class SnsNeuronMaturitySectionPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-maturity-section-component";
+
+  static under(element: PageObjectElement): SnsNeuronMaturitySectionPo {
+    return new SnsNeuronMaturitySectionPo(
+      element.byTestId(SnsNeuronMaturitySectionPo.TID)
+    );
+  }
+
+  getTotalMaturity(): Promise<string> {
+    return this.getText("total-maturity");
+  }
+
+  getStakedMaturityItemActionPo(): SnsStakedMaturityActionItemPo {
+    return SnsStakedMaturityActionItemPo.under(this.root);
+  }
+
+  hasStakedMaturityItemAction(): Promise<boolean> {
+    return this.getStakedMaturityItemActionPo().isPresent();
+  }
+
+  getAvailableMaturityItemActionPo(): SnsAvailableMaturityActionItemPo {
+    return SnsAvailableMaturityActionItemPo.under(this.root);
+  }
+
+  hasAvailableMaturityItemAction(): Promise<boolean> {
+    return this.getAvailableMaturityItemActionPo().isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsStakedMaturityActionItem.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsStakedMaturityActionItem.page-object.ts
@@ -1,0 +1,16 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsStakedMaturityActionItemPo extends BasePageObject {
+  private static readonly TID = "sns-staked-maturity-item-action-component";
+
+  static under(element: PageObjectElement): SnsStakedMaturityActionItemPo {
+    return new SnsStakedMaturityActionItemPo(
+      element.byTestId(SnsStakedMaturityActionItemPo.TID)
+    );
+  }
+
+  getStakedMaturity(): Promise<string> {
+    return this.getText("staked-maturity");
+  }
+}


### PR DESCRIPTION
# Motivation

We are shuffling some data in the neuron details to make it more user friendly.

In this PR: Create the component that will show the maturity section for SNS neurons.

# Changes

* New component SnsAvailableMaturityActionItem.
* New component SnsStakedMaturityActionItem.
* Implement SnsNeuronMaturitySection using both previous components.
* Add variant prop to SnsStakeMaturityButton.

# Tests

* New test SnsAvailableMaturityActionItem with PO.
* New test SnsStakedMaturityActionItem with PO.
* New test SnsNeuronMaturitySection with PO.

# Todos

Not worth entry in the changelog yet.
