### PR TITLE
Wait for the main account when getting test tokens

### DIFF
--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -1,3 +1,4 @@
+import type { Account } from "$lib/types/account";
 import {
   acquireICPTs,
   acquireSnsTokens,
@@ -11,14 +12,32 @@ import {
   type SnsAccountsStoreData,
 } from "$lib/stores/sns-accounts.store";
 import type { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { syncAccounts } from "./accounts.services";
 import { loadSnsAccounts } from "./sns-accounts.services";
 
 export const getTestBalance = getTestAccountBalance;
 
-export const getICPs = async (icps: number) => {
+const getMainAccount = async (): Promise<Account> => {
   const { main }: IcpAccountsStoreData = get(icpAccountsStore);
+  if (nonNullish(main)) {
+    return main;
+  }
+  return new Promise((resolve) => {
+    const unsubscribe = icpAccountsStore.subscribe(
+      ({ main }: IcpAccountsStoreData) => {
+        if (nonNullish(main)) {
+          unsubscribe();
+          resolve(main);
+        }
+      }
+    );
+  });
+};
+
+export const getICPs = async (icps: number) => {
+  const main = await getMainAccount();
 
   if (!main) {
     throw new Error("No account found to get ICPs");

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -1,4 +1,3 @@
-import type { Account } from "$lib/types/account";
 import {
   acquireICPTs,
   acquireSnsTokens,
@@ -11,6 +10,7 @@ import {
   snsAccountsStore,
   type SnsAccountsStoreData,
 } from "$lib/stores/sns-accounts.store";
+import type { Account } from "$lib/types/account";
 import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -12,12 +12,6 @@ test("Test disburse neuron", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  // We need an account before we can get ICP.
-  await appPo
-    .getAccountsPo()
-    .getNnsAccountsPo()
-    .getMainAccountCardPo()
-    .waitFor();
   await appPo.getTokens(10);
 
   step("Go to the neurons tab");

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -12,12 +12,6 @@ test("Test merge neurons", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  // We need an account before we can get ICP.
-  await appPo
-    .getAccountsPo()
-    .getNnsAccountsPo()
-    .getMainAccountCardPo()
-    .waitFor();
   await appPo.getTokens(10);
 
   step("Go to the neurons tab");

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -14,12 +14,6 @@ test("Test neuron voting", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  // We need an account before we can get ICP.
-  await appPo
-    .getAccountsPo()
-    .getNnsAccountsPo()
-    .getMainAccountCardPo()
-    .waitFor();
   await appPo.getTokens(41);
 
   // should be created before dummy proposals

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -13,11 +13,6 @@ test("Test SNS participation", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP to participate in the sale");
-  await appPo
-    .getAccountsPo()
-    .getNnsAccountsPo()
-    .getMainAccountCardPo()
-    .waitFor();
   await appPo.getTokens(20);
 
   step("D001: User can see the list of open sales");


### PR DESCRIPTION
# Motivation

When getting tokens for testing, a main account needs to be already loaded or you get an error.
End-to-end tests are fast enough to be burned by this so many of them need to explicitly wait for the main account to appear before trying to get tokens.

# Changes

In the `getICPs` function, wait for the main account to be loaded if it isn't already.

# Tests

Tests still pass even though they no longer wait for the main account to be present.

# Todos

- [ ] Add entry to changelog (if necessary).

Not note worthy (?)
