### PR TITLE
E2E: Compile tests (with --noEmit) to catch type errors

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -30,6 +30,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Install `ic-wasm` as part of the setup command.
 * Better visibility of upgrade cycle consumption, wasm size and memory usage.
 * Check that release-sop is the newest version when it's run.
+* Compile end-to-end tests to catch type errors.
 
 #### Changed
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "format": "pprettier --write './**/*.{ts,js,mjs,json,scss,svelte,html}'",
     "format:modified": "prettier --write $(git diff --diff-filter=ACM --name-only | egrep \"\\.(ts|js|mjs|json|scss|svelte|html)$\" | cut -d'/' -f2-)",
     "test": "TZ=UTC jest",
-    "test-e2e": "playwright test",
+    "test-e2e": "tsc --noEmit -p src/tests/e2e/tsconfig.json && playwright test",
     "update:next": "npm update @dfinity/utils @dfinity/nns-proto @dfinity/ledger @dfinity/nns @dfinity/sns @dfinity/cmc @dfinity/ckbtc @dfinity/ic-management",
     "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger@next @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",

--- a/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
@@ -39,7 +39,7 @@ export class NnsNeuronsFooterPo extends BasePageObject {
     dissolveDelayDays,
   }: {
     amount: number;
-    dissolveDelayDays: "max" | 0;
+    dissolveDelayDays: "max" | number;
   }): Promise<void> {
     await this.clickStakeNeuronsButton();
     const modal = this.getNnsStakeNeuronModalPo();

--- a/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
@@ -39,7 +39,7 @@ export class NnsStakeNeuronModalPo extends BasePageObject {
     dissolveDelayDays = "max",
   }: {
     amount: number;
-    dissolveDelayDays?: "max" | 0;
+    dissolveDelayDays?: "max" | number;
   }): Promise<void> {
     await this.getNnsStakeNeuronPo().stake(amount);
     await this.getSetDissolveDelayPo().setDissolveDelayDays(dissolveDelayDays);

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -4,7 +4,7 @@ import { expect, type Locator, type Page } from "@playwright/test";
 export class PlaywrightPageObjectElement implements PageObjectElement {
   readonly locator: Locator;
 
-  constructor(locator: Locator | Page) {
+  constructor(locator: Locator) {
     this.locator = locator;
   }
 
@@ -100,7 +100,7 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
     return this.locator.type(text);
   }
 
-  selectOption(text: string): Promise<void> {
-    return this.locator.selectOption(text);
+  async selectOption(text: string): Promise<void> {
+    await this.locator.selectOption(text);
   }
 }


### PR DESCRIPTION
# Motivation

Currently, type errors in e2e tests are not caught.

# Changes

1. Compile e2e test before running them when using `npm test-e2e`.
2. Fix existing type errors.

# Tests

test only

# Todos

- [x] Add entry to changelog (if necessary).
