### PR TITLE
feat: utils to try to convert an Icrc account identifier to Icp

### DIFF
--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -234,6 +234,13 @@ export const sumAccounts = (
 export const hasAccounts = (accounts: Account[]): boolean =>
   accounts.length > 0;
 
+/**
+ * The NNS Dapp backend accepts ICP account identifiers. The dapp now also supports Icrc textual representation, which is why we may not always know if an identifier is in ICP format or Icrc format.
+ * This utility optimistically tries to interpret the identifier passed as a parameter as an Icrc textual representation and convert it to an ICP identifier.
+ * If the conversion fails, the utility returns the identifier passed as the parameter, which could be a valid or invalid ICP identifier.
+ *
+ * @param accountIdentifier A valid or invalid ICP identifier.
+ */
 export const toIcpAccountIdentifier = (
   accountIdentifier: AccountIdentifierText
 ): IcpAccountIdentifierText => {

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -1,15 +1,19 @@
 import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
 import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
-import type { Account } from "$lib/types/account";
+import type {
+  Account,
+  AccountIdentifierText,
+  IcpAccountIdentifierText,
+} from "$lib/types/account";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { TransactionNetwork } from "$lib/types/transaction";
 import { sumAmountE8s } from "$lib/utils/token.utils";
 import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
 import { BtcNetwork, parseBtcAddress, type BtcAddress } from "@dfinity/ckbtc";
 import { decodeIcrcAccount } from "@dfinity/ledger";
-import { checkAccountId } from "@dfinity/nns";
+import { AccountIdentifier, SubAccount, checkAccountId } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { isNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { isUniverseNns } from "./universe.utils";
 
 /*
@@ -229,3 +233,37 @@ export const sumAccounts = (
 
 export const hasAccounts = (accounts: Account[]): boolean =>
   accounts.length > 0;
+
+export const toIcpAccountIdentifier = (
+  accountIdentifier: AccountIdentifierText
+): IcpAccountIdentifierText => {
+  try {
+    return maybeIcrcToIcpAccountIdentifier(accountIdentifier);
+  } catch (err: unknown) {
+    // We ignore the error. The provided account identifier was not a valid Icrc account identifier.
+    // We continue with the provided account identifier which might either be a valid Icp account identifier or just incorrect.
+  }
+
+  return accountIdentifier;
+};
+
+const maybeIcrcToIcpAccountIdentifier = (
+  accountIdentifier: AccountIdentifierText
+): IcpAccountIdentifierText => {
+  const { owner: principal, subaccount } = decodeIcrcAccount(accountIdentifier);
+
+  const sub = nonNullish(subaccount)
+    ? SubAccount.fromBytes(subaccount)
+    : undefined;
+
+  if (sub instanceof Error) {
+    throw sub;
+  }
+
+  return AccountIdentifier.fromPrincipal({
+    principal,
+    ...(nonNullish(sub) && {
+      subAccount: sub,
+    }),
+  }).toHex();
+};

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -17,6 +17,7 @@ import {
   mainAccount,
   sumAccounts,
   sumNnsAccounts,
+  toIcpAccountIdentifier,
 } from "$lib/utils/accounts.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
@@ -625,5 +626,21 @@ describe("accounts-utils", () => {
       expect(hasAccounts([mockMainAccount])).toBeTruthy());
 
     it("should not have accounts", () => expect(hasAccounts([])).toBe(false));
+  });
+
+  describe("toIcpAccountIdentifier", () => {
+    it("should returns an icp account identifier for an icrc account identifier", () => {
+      expect(toIcpAccountIdentifier(mockSnsMainAccount.identifier)).toEqual(
+        "97783b7f0f34634c06ced774bd1bd27d2c76e80b0dd88f56ad55b3ecab292f68"
+      );
+    });
+
+    it("should returns the account identifier parameter if not an icrc account identifier", () => {
+      expect(toIcpAccountIdentifier(mockMainAccount.identifier)).toEqual(
+        mockMainAccount.identifier
+      );
+
+      expect(toIcpAccountIdentifier("123456")).toEqual("123456");
+    });
   });
 });


### PR DESCRIPTION
# Motivation

When ICP will use Icrc, we will need to get the ICP identifier from an Icrc textual representation to query NNS dapp backend. This PR introduces a utils that tries such conversion and fallback to ICP.

# Changes

- new utils function `toIcpAccountIdentifier` that tries to either map an ICRC textual account identifier or fallback to value provided

