### PR TITLE
Fix types declared in .did

### DIFF
--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -215,8 +215,8 @@ type Stats =
         neurons_topped_up_count: nat64;
         transactions_to_process_queue_length: nat32;
         performance_counts: vec PerformanceCount;
-        nns_dapp_stable_memory_size_gib: opt float64;
-        nns_dapp_wasm_memory_size_gib: opt float64;
+        stable_memory_size_bytes: opt nat64;
+        wasm_memory_size_bytes: opt nat64;
     };
 
 type PerformanceCount =


### PR DESCRIPTION
# Motivation
The nns-dapp .did file does not match the rust code.

# Changes
* Update the names and types of the memory sizes returned by `get_stats`.

# Tests
Running `get_stats()` on the app subnet deployment now returns values, for the memory size, not null.

Note: The sns aggregator has tests that the .did file matches the rust code, obtained by getting the dynamically generated .did file.  However if I recall correctly, the nns-dapp libraries need to be updated before we can do the same here.  It is planned, and that would provide blanket coverage of issues like this.

# Todos

- [x] Add entry to changelog (if necessary).
  - Covered by the existing changelog entry to add these stats.
