### PR TITLE
Fix: Sns Voting Power in PageHeading

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -13,10 +13,10 @@
     getSnsNeuronStake,
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
-  import { formatNumber } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import PageHeading from "../common/PageHeading.svelte";
+  import { formatVotingPower } from "$lib/utils/neuron.utils";
 
   export let parameters: SnsNervousSystemParameters;
 
@@ -45,13 +45,13 @@
       <AmountDisplay {amount} size="huge" singleLine />
     {/if}
   </svelte:fragment>
-  <svelte:fragment slot="subtitle">
+  <span slot="subtitle" data-tid="voting-power">
     {#if nonNullish(neuron)}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-        $votingPower: formatNumber(
+        $votingPower: formatVotingPower(
           snsNeuronVotingPower({ neuron, snsParameters: parameters })
         ),
       })}
     {/if}
-  </svelte:fragment>
+  </span>
 </PageHeading>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -3,13 +3,16 @@
  */
 
 import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
+import { SECONDS_IN_EIGHT_YEARS } from "$lib/constants/constants";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import {
+  createMockSnsNeuron,
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 
 describe("SnsNeuronPageHeading", () => {
@@ -34,5 +37,19 @@ describe("SnsNeuronPageHeading", () => {
     });
 
     expect(await po.getStake()).toEqual("3.14");
+  });
+
+  it("should render the neuron's voting power", async () => {
+    const stake = 314_000_000n;
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_EIGHT_YEARS),
+      stakedMaturity: 100_000_000n,
+      stake,
+    });
+    const po = renderSnsNeuronCmp(neuron);
+
+    expect(await po.getVotingPower()).toEqual("Voting Power: 5.59");
   });
 });

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -18,4 +18,8 @@ export class SnsNeuronPageHeadingPo extends BasePageObject {
   getStake(): Promise<string> {
     return this.getAmountDisplayPo().getAmount();
   }
+
+  getVotingPower(): Promise<string> {
+    return this.getText("voting-power");
+  }
 }


### PR DESCRIPTION
# Motivation

The voting power was incorrect in the new SNS neuron page heading.

# Changes

* Use util to formatVotingPower in the SnsPageHeading

# Tests

* Add a test to check the value of the voting power in the SnsPageHeading.

# Todos

Not worth an entry yet.
