### PR TITLE
ICP transfer with Icrc addresses as destination

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,6 +11,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
+* Support for ICP transactions with Icrc addresses as the destination.
+
 #### Changed
 
 * Improve visibility of proposal summary headers.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -92,6 +92,7 @@
     "not_mergeable": "This neuron can't be merged.",
     "invalid_account_id": "Sorry, the account id is not valid. Please try again with a valid account id.",
     "address_not_valid": "Please enter a valid address.",
+    "address_not_icp_icrc_valid": "The address is invalid. Please try again with a valid address identifier.",
     "invalid_percentage": "Sorry, the percentage amount is not valid.",
     "principal_not_valid": "Please enter a valid principal.",
     "input_length": "Input must be longer than $length characters.",

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -4,6 +4,7 @@ import {
   renameSubAccount as renameSubAccountApi,
 } from "$lib/api/accounts.api";
 import { queryAccountBalance, sendICP } from "$lib/api/icp-ledger.api";
+import { icrcTransfer } from "$lib/api/icrc-ledger.api";
 import { addAccount, queryAccount } from "$lib/api/nns-dapp.api";
 import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import type {
@@ -16,6 +17,7 @@ import {
   SYNC_ACCOUNTS_RETRY_MAX_ATTEMPTS,
   SYNC_ACCOUNTS_RETRY_SECONDS,
 } from "$lib/constants/accounts.constants";
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
@@ -28,6 +30,7 @@ import {
   type SingleMutationIcpAccountsStore,
 } from "$lib/stores/icp-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type {
   Account,
   AccountIdentifierText,
@@ -36,7 +39,13 @@ import type {
   IcpAccountIdentifierText,
 } from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";
-import { findAccount, getAccountByPrincipal } from "$lib/utils/accounts.utils";
+import {
+  findAccount,
+  getAccountByPrincipal,
+  invalidIcpAddress,
+  invalidIcrcAddress,
+} from "$lib/utils/accounts.utils";
+import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import {
   isForceCallStrategy,
   notForceCallStrategy,
@@ -49,7 +58,7 @@ import {
   pollingLimit,
 } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
-import { encodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger";
 import {
   ICPToken,
   TokenAmount,
@@ -292,18 +301,43 @@ export const transferICP = async ({
 
     const tokenAmount = TokenAmount.fromNumber({ amount, token: ICPToken });
 
-    await sendICP({
-      identity,
-      to,
-      fromSubAccount: subAccount,
-      amount: tokenAmount,
-    });
+    const feeE8s = get(mainTransactionFeeE8sStore);
+
+    const validIcrcAddress = !invalidIcrcAddress(to);
+    const validIcpAddress = !invalidIcpAddress(to);
+
+    // UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.
+    if (!validIcrcAddress && !validIcpAddress) {
+      toastsError({
+        labelKey: "error.address_not_icp_icrc_valid",
+      });
+      return { success: false };
+    }
+
+    await (validIcrcAddress
+      ? icrcTransfer({
+          identity,
+          to: decodeIcrcAccount(to),
+          fromSubAccount: subAccount,
+          amount: tokenAmount.toE8s(),
+          canisterId: LEDGER_CANISTER_ID,
+          createdAt: nowInBigIntNanoSeconds(),
+          fee: feeE8s,
+        })
+      : sendICP({
+          identity,
+          to,
+          fromSubAccount: subAccount,
+          amount: tokenAmount,
+        }));
 
     // Transfer can be to one of the user's account.
     const toAccount = findAccount({
       identifier: to,
       accounts: get(nnsAccountsListStore),
     });
+
+    // TODO: GIX-1704 use ICRC
     await Promise.all([
       loadBalance({ accountIdentifier: identifier }),
       nonNullish(toAccount)

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -301,8 +301,6 @@ export const transferICP = async ({
 
     const tokenAmount = TokenAmount.fromNumber({ amount, token: ICPToken });
 
-    const feeE8s = get(mainTransactionFeeE8sStore);
-
     const validIcrcAddress = !invalidIcrcAddress(to);
     const validIcpAddress = !invalidIcpAddress(to);
 
@@ -313,6 +311,8 @@ export const transferICP = async ({
       });
       return { success: false };
     }
+
+    const feeE8s = get(mainTransactionFeeE8sStore);
 
     await (validIcrcAddress
       ? icrcTransfer({

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -96,6 +96,7 @@ interface I18nError {
   not_mergeable: string;
   invalid_account_id: string;
   address_not_valid: string;
+  address_not_icp_icrc_valid: string;
   invalid_percentage: string;
   principal_not_valid: string;
   input_length: string;

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -80,9 +80,9 @@ export const invalidAddress = ({
     });
   }
 
-  // NNS universe doesn't use ICRC yet
+  // NNS universe accepts ICP and ICRC adresses for transactions
   if (isUniverseNns(rootCanisterId)) {
-    return invalidIcpAddress(address);
+    return invalidIcrcAddress(address) && invalidIcpAddress(address);
   }
 
   // Consider it as an ICRC address

--- a/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddressInput.spec.ts
@@ -71,14 +71,14 @@ describe("AddressInput", () => {
       expect(queryByTestId("input-error-message")).toBeInTheDocument();
     });
 
-    it("should show error message on blur when SNS address", async () => {
+    it("should accept ICRC address on blur", async () => {
       const { container, queryByTestId } = render(AddressInput, { props });
 
       const input = container.querySelector("input") as HTMLInputElement;
 
       await fireEvent.input(input, { target: { value: snsAccount } });
       await fireEvent.blur(input);
-      expect(queryByTestId("input-error-message")).toBeInTheDocument();
+      expect(queryByTestId("input-error-message")).not.toBeInTheDocument();
     });
 
     it("should show error message on blur when BTC address", async () => {

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -771,6 +771,22 @@ describe("icp-accounts.services", () => {
       expect(spySendICP).toHaveBeenCalled();
     });
 
+    it("should not transfer ICP for invalid address", async () => {
+      const spy = jest
+        .spyOn(icrcLedgerApi, "icrcTransfer")
+        .mockResolvedValue(BigInt(1));
+
+      const result = await transferICP({
+        ...transferICPParams,
+        destinationAddress: "test",
+      });
+
+      expect(spySendICP).not.toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
+
+      expect(result.success).toBeFalsy();
+    });
+
     it("should transfer ICP using an Icrc destination address", async () => {
       const spy = jest
         .spyOn(icrcLedgerApi, "icrcTransfer")

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -243,6 +243,24 @@ describe("accounts-utils", () => {
           })
         ).toBeTruthy();
       });
+
+      it("should be a valid Icrc address for ICP universe", () => {
+        expect(
+          invalidAddress({
+            address: subaccountString,
+            network: undefined,
+            rootCanisterId: OWN_CANISTER_ID,
+          })
+        ).toBeFalsy();
+
+        expect(
+          invalidAddress({
+            address: subaccountString,
+            network: TransactionNetwork.ICP,
+            rootCanisterId: OWN_CANISTER_ID,
+          })
+        ).toBeFalsy();
+      });
     });
 
     describe("invalidIcpAddress", () => {


### PR DESCRIPTION
# Motivation

Support for ICP transactions with Icrc addresses as the destination.

# Changes

- extend `transferICP` to either use existing `sendICP` or if destination address is an Icrc address `icrcTransfer`
- extend `invalidAddress` to accept Icrc for Nns, that way user can enter an Icrc address in the input field of the transaction modal
