### PR TITLE
Feat: Improve Increase Dissolve Delay buttons

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -16,6 +16,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 * Improve visibility of proposal summary headers.
+* Improve copy in button to set or increase dissolve delay of a neuron.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
@@ -6,10 +6,14 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { getContext } from "svelte";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import { NeuronState } from "@dfinity/nns";
 
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
   );
+
+  let isUnlocked: boolean;
+  $: isUnlocked = $store.neuron?.state === NeuronState.Dissolved;
 </script>
 
 <button
@@ -18,5 +22,8 @@
     openNnsNeuronModal({
       type: "increase-dissolve-delay",
       data: { neuron: $store.neuron },
-    })}>{$i18n.neuron_detail.increase_dissolve_delay}</button
+    })}
+  >{isUnlocked
+    ? $i18n.neurons.set_dissolve_delay
+    : $i18n.neuron_detail.increase_dissolve_delay}</button
 >

--- a/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
-  import { isVesting } from "$lib/utils/sns-neuron.utils";
+  import { getSnsNeuronState, isVesting } from "$lib/utils/sns-neuron.utils";
   import type { SnsNeuron } from "@dfinity/sns";
   import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
+  import { NeuronState } from "@dfinity/nns";
 
   export let neuron: SnsNeuron;
+
+  let isUnlocked: boolean;
+  $: isUnlocked = getSnsNeuronState(neuron) === NeuronState.Dissolved;
 </script>
 
 <VestingTooltipWrapper {neuron}>
@@ -14,6 +18,8 @@
     disabled={isVesting(neuron)}
     data-tid="sns-increase-dissolve-delay"
     on:click={() => openSnsNeuronModal({ type: "increase-dissolve-delay" })}
-    >{$i18n.neuron_detail.increase_dissolve_delay}</button
+    >{isUnlocked
+      ? $i18n.neurons.set_dissolve_delay
+      : $i18n.neuron_detail.increase_dissolve_delay}</button
   >
 </VestingTooltipWrapper>

--- a/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -37,7 +37,13 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<WizardModal
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+  testId="increase-dissolve-delay-modal-component"
+>
   <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
   {#if currentStep?.name === "SetDissolveDelay"}
     <SetNnsDissolveDelay

--- a/frontend/src/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte
@@ -78,7 +78,13 @@
   };
 </script>
 
-<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose>
+<WizardModal
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+  testId="increase-sns-dissolve-delay-modal-component"
+>
   <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
   {#if currentStep?.name === "SetSnsDissolveDelay"}
     <SetSnsDissolveDelay

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import IncreaseDissolveDelayButton from "$lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState, type NeuronInfo } from "@dfinity/nns";
+import { render } from "@testing-library/svelte";
+import NeuronContextTest from "../NeuronContextTest.svelte";
+
+describe("IncreaseDissolveDelayButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = (neuron: NeuronInfo) => {
+    const { container } = render(NeuronContextTest, {
+      props: {
+        neuron,
+        testComponent: IncreaseDissolveDelayButton,
+      },
+    });
+
+    return ButtonPo.under({
+      element: new JestPageObjectElement(container),
+    });
+  };
+
+  it("should render 'Increase Delay' text for non unlocked neurons", async () => {
+    const lockedNeuron = {
+      ...mockNeuron,
+      state: NeuronState.Locked,
+    };
+    const po = renderComponent(lockedNeuron);
+    expect(await po.getText()).toEqual("Increase Delay");
+  });
+
+  it("should render 'Set Dissolve Delay' text for unlocked neurons", async () => {
+    const unlockedNeuron = {
+      ...mockNeuron,
+      state: NeuronState.Dissolved,
+    };
+    const po = renderComponent(unlockedNeuron);
+    expect(await po.getText()).toEqual("Set Dissolve Delay");
+  });
+
+  it("opens Increase Dissolve Delay Modal", async () => {
+    const { container, getByTestId } = render(NeuronContextTest, {
+      props: {
+        neuron: mockNeuron,
+        testComponent: IncreaseDissolveDelayButton,
+      },
+    });
+
+    const po = ButtonPo.under({
+      element: new JestPageObjectElement(container),
+    });
+
+    await po.click();
+
+    expect(
+      getByTestId("increase-dissolve-delay-modal-component")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.spec.ts
@@ -47,7 +47,7 @@ describe("IncreaseDissolveDelayButton", () => {
   });
 
   it("opens Increase Dissolve Delay Modal", async () => {
-    const { container, getByTestId } = render(NeuronContextTest, {
+    const { container, queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,
         testComponent: IncreaseDissolveDelayButton,
@@ -58,10 +58,14 @@ describe("IncreaseDissolveDelayButton", () => {
       element: new JestPageObjectElement(container),
     });
 
+    expect(
+      queryByTestId("increase-dissolve-delay-modal-component")
+    ).not.toBeInTheDocument();
+
     await po.click();
 
     expect(
-      getByTestId("increase-dissolve-delay-modal-component")
+      queryByTestId("increase-dissolve-delay-modal-component")
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
+import { snsQueryStore } from "$lib/stores/sns.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+} from "$tests/mocks/sns-neurons.mock";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
+import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
+import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
+import { render, waitFor } from "@testing-library/svelte";
+import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
+
+// Avoid triggering the api call to not have to mock the api layer. Not needed for this test.
+jest.mock("$lib/services/sns-parameters.services");
+
+describe("IncreaseSnsDissolveDelayButton", () => {
+  const rootCanisterId = mockPrincipal;
+  const response = snsResponseFor({
+    principal: rootCanisterId,
+    lifecycle: SnsSwapLifecycle.Committed,
+    certified: true,
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    snsQueryStore.reset();
+    snsQueryStore.setData(response);
+    tokensStore.reset();
+    tokensStore.setToken({
+      canisterId: rootCanisterId,
+      certified: true,
+      token: mockToken,
+    });
+    page.mock({ data: { universe: rootCanisterId.toText() } });
+  });
+
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(SnsNeuronContextTest, {
+      props: {
+        neuron,
+        passPropNeuron: true,
+        rootCanisterId,
+        testComponent: IncreaseSnsDissolveDelayButton,
+      },
+    });
+
+    return ButtonPo.under({
+      element: new JestPageObjectElement(container),
+    });
+  };
+
+  it("should render 'Increase Delay' text for non unlocked neurons", async () => {
+    const lockedNeuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+    });
+    const po = renderComponent(lockedNeuron);
+    expect(await po.getText()).toEqual("Increase Delay");
+  });
+
+  it("should render 'Set Dissolve Delay' text for unlocked neurons", async () => {
+    const unlockedNeuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const po = renderComponent(unlockedNeuron);
+    expect(await po.getText()).toEqual("Set Dissolve Delay");
+  });
+
+  it("should open increase increase dissolve delay modal", async () => {
+    const { container, getByTestId } = render(SnsNeuronContextTest, {
+      props: {
+        neuron: mockSnsNeuron,
+        passPropNeuron: true,
+        rootCanisterId,
+        testComponent: IncreaseSnsDissolveDelayButton,
+      },
+    });
+
+    const po = ButtonPo.under({
+      element: new JestPageObjectElement(container),
+    });
+    await po.click();
+
+    await waitFor(() =>
+      expect(
+        getByTestId("increase-sns-dissolve-delay-modal-component")
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -77,7 +77,7 @@ describe("IncreaseSnsDissolveDelayButton", () => {
   });
 
   it("should open increase increase dissolve delay modal", async () => {
-    const { container, getByTestId } = render(SnsNeuronContextTest, {
+    const { container, queryByTestId } = render(SnsNeuronContextTest, {
       props: {
         neuron: mockSnsNeuron,
         passPropNeuron: true,
@@ -89,11 +89,15 @@ describe("IncreaseSnsDissolveDelayButton", () => {
     const po = ButtonPo.under({
       element: new JestPageObjectElement(container),
     });
+    expect(
+      queryByTestId("increase-sns-dissolve-delay-modal-component")
+    ).not.toBeInTheDocument();
+
     await po.click();
 
     await waitFor(() =>
       expect(
-        getByTestId("increase-sns-dissolve-delay-modal-component")
+        queryByTestId("increase-sns-dissolve-delay-modal-component")
       ).toBeInTheDocument()
     );
   });


### PR DESCRIPTION
# Motivation

Improve the text in the "Increase Dissolve Delay" button. If neuron is unlocked, there is no dissolve delay to increase. Instead, the user sets the dissolve delay.

# Changes

* Check the state and render a different text in `IncreaseDissolveDelayButton`.
* Check the state and render a different text in `IncreaseSnsDissolveDelayButton`.

# Tests

* Add missing test file for component `IncreaseDissolveDelayButton`.
* Add missing test file for component `IncreaseSnsDissolveDelayButton`.

# Todos

- [x] Add entry to changelog (if necessary).
