### PR TITLE
Fix SnsNeuronDetail.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import { increaseStakeNeuron } from "$lib/api/sns.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -52,6 +53,7 @@ describe("SnsNeuronDetail", () => {
     lifecycle: SnsSwapLifecycle.Committed,
   });
   const projectName = "Test SNS";
+  const nonExistingNeuronId = "111111";
   // Clone the summary to avoid mutating the mock
   const summary = { ...responses[0][0] };
   summary.metadata.name = [projectName];
@@ -193,14 +195,13 @@ describe("SnsNeuronDetail", () => {
         const { path } = get(pageStore);
         expect(path).toEqual(AppPath.Neurons);
       });
+      expect(snsGovernanceApi.getSnsNeuron).not.toBeCalled();
     });
   });
 
   describe("when neuron is not found", () => {
-    beforeEach(() => page.mock({ data: { universe: "invalid-project-id" } }));
-
     const props = {
-      neuronId: getSnsNeuronIdAsHexString(mockSnsNeuron),
+      neuronId: nonExistingNeuronId,
     };
 
     it("should redirect", async () => {
@@ -210,6 +211,7 @@ describe("SnsNeuronDetail", () => {
         const { path } = get(pageStore);
         expect(path).toEqual(AppPath.Neurons);
       });
+      expect(snsGovernanceApi.getSnsNeuron).toBeCalledTimes(2);
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -200,6 +200,13 @@ describe("SnsNeuronDetail", () => {
   });
 
   describe("when neuron is not found", () => {
+    beforeEach(() => {
+      page.mock({
+        data: { universe: rootCanisterId.toText() },
+        routeId: AppPath.Neuron,
+      });
+    });
+
     const props = {
       neuronId: nonExistingNeuronId,
     };


### PR DESCRIPTION
# Motivation

`SnsNeuronDetail.spec.ts` has 2 identical test:
* "when project is an invalid canister id"
* "when neuron is not found"
Both use an invalid universe ID but the second one was supposed to use a valid universe ID but a neuron ID for a neuron that can't be found.

# Changes

In "when neuron is not found":
1. Use a correct `universe`.
2. Use an unknown neuron ID.
3. Expect `snsGovernanceApi.getSnsNeuron` to have been called twice (query + update).

In "when project is an invalid canister id", expect `snsGovernanceApi.getSnsNeuron` not to have been called to distinguish it from the other test as both tests expect a redirect to the neurons overview page.

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).

no