### PR TITLE
GIX-1684: SnsNeuronVotingPowerSection

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -2,27 +2,17 @@
   import { Section } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import {
-    SELECTED_SNS_NEURON_CONTEXT_KEY,
-    type SelectedSnsNeuronContext,
-  } from "$lib/types/sns-neuron-detail.context";
-  import { getContext } from "svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { snsNeuronVotingPower } from "$lib/utils/sns-neuron.utils";
-  import { nonNullish, type Token } from "@dfinity/utils";
+  import type { Token } from "@dfinity/utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import SnsStakeItemAction from "./SnsStakeItemAction.svelte";
   import type { Universe } from "$lib/types/universe";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
 
   export let parameters: SnsNervousSystemParameters;
+  export let neuron: SnsNeuron;
   export let token: Token;
-
-  const { store }: SelectedSnsNeuronContext =
-    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-
-  let neuron: SnsNeuron | undefined | null;
-  $: neuron = $store.neuron;
 
   let universe: Universe;
   $: universe = $selectedUniverseStore;
@@ -31,11 +21,9 @@
 <Section testId="sns-neuron-voting-power-section-component">
   <h3 slot="title">{$i18n.neurons.voting_power}</h3>
   <p slot="end" class="title-value" data-tid="voting-power">
-    {#if nonNullish(neuron)}
-      {formatVotingPower(
-        snsNeuronVotingPower({ neuron, snsParameters: parameters })
-      )}
-    {/if}
+    {formatVotingPower(
+      snsNeuronVotingPower({ neuron, snsParameters: parameters })
+    )}
   </p>
   <p slot="description">
     {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {
@@ -43,9 +31,7 @@
     })}
   </p>
   <ul class="content">
-    {#if nonNullish(neuron)}
-      <SnsStakeItemAction {neuron} {token} {universe} />
-    {/if}
+    <SnsStakeItemAction {neuron} {token} {universe} />
   </ul>
 </Section>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -1,1 +1,69 @@
-<div>GIX-1684</div>
+<script lang="ts">
+  import { Section } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import {
+    SELECTED_SNS_NEURON_CONTEXT_KEY,
+    type SelectedSnsNeuronContext,
+  } from "$lib/types/sns-neuron-detail.context";
+  import { getContext } from "svelte";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import { snsNeuronVotingPower } from "$lib/utils/sns-neuron.utils";
+  import { nonNullish, type Token } from "@dfinity/utils";
+  import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import SnsStakeItemAction from "./SnsStakeItemAction.svelte";
+  import type { Universe } from "$lib/types/universe";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
+
+  export let parameters: SnsNervousSystemParameters;
+  export let token: Token;
+
+  const { store }: SelectedSnsNeuronContext =
+    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
+
+  let neuron: SnsNeuron | undefined | null;
+  $: neuron = $store.neuron;
+
+  let universe: Universe;
+  $: universe = $selectedUniverseStore;
+</script>
+
+<Section testId="sns-neuron-voting-power-section-component">
+  <h3 slot="title">{$i18n.neurons.voting_power}</h3>
+  <p slot="end" class="title-value" data-tid="voting-power">
+    {#if nonNullish(neuron)}
+      {formatVotingPower(
+        snsNeuronVotingPower({ neuron, snsParameters: parameters })
+      )}
+    {/if}
+  </p>
+  <p slot="description">
+    {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {
+      $token: token.symbol,
+    })}
+  </p>
+  <ul class="content">
+    {#if nonNullish(neuron)}
+      <SnsStakeItemAction {neuron} {token} {universe} />
+    {/if}
+  </ul>
+</Section>
+
+<style lang="scss">
+  h3,
+  p {
+    margin: 0;
+  }
+
+  .title-value {
+    font-size: var(--font-size-h3);
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+
+    padding: 0;
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakeItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakeItemAction.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { ItemAction } from "@dfinity/gix-components";
+  import UniverseLogo from "../universe/UniverseLogo.svelte";
+  import type { Token } from "@dfinity/utils";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatToken } from "$lib/utils/token.utils";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
+  import SnsIncreaseStakeButton from "./actions/SnsIncreaseStakeButton.svelte";
+  import type { Universe } from "$lib/types/universe";
+
+  export let neuron: SnsNeuron;
+  export let token: Token;
+  export let universe: Universe;
+</script>
+
+<ItemAction testId="sns-stake-item-action-component">
+  <UniverseLogo
+    slot="icon"
+    size="big"
+    {universe}
+    framed
+    horizontalPadding={false}
+  />
+  <div class="content">
+    <h4 class="token-value">
+      <span data-tid="stake-value"
+        >{formatToken({ value: getSnsNeuronStake(neuron) })}</span
+      ><span>{token.symbol}</span>
+    </h4>
+    <p class="description">{$i18n.neurons.ic_stake}</p>
+  </div>
+  <SnsIncreaseStakeButton slot="actions" variant="secondary" />
+</ItemAction>
+
+<style lang="scss">
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
+
+    p,
+    h4 {
+      margin: 0;
+    }
+  }
+
+  .token-value {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
+
+  export let variant: "primary" | "secondary" = "primary";
 </script>
 
 <button
-  class="primary"
+  class={variant}
   data-tid="sns-increase-stake"
   on:click={() => openSnsNeuronModal({ type: "increase-stake" })}
   >{$i18n.neuron_detail.increase_stake}</button

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -151,12 +151,12 @@
           <SkeletonCard cardType="info" separator />
           <SkeletonCard cardType="info" separator />
         {:else}
-          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters)}
+          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token)}
             <div class="section-wrapper">
               <SnsNeuronPageHeader />
               <SnsNeuronPageHeading {parameters} />
               <Separator spacing="none" />
-              <SnsNeuronVotingPowerSection />
+              <SnsNeuronVotingPowerSection {parameters} {token} />
               <SnsNeuronMaturitySection />
               <SnsNeuronAdvancedSection />
             </div>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -157,6 +157,7 @@
               <SnsNeuronPageHeading {parameters} />
               <Separator spacing="none" />
               <SnsNeuronVotingPowerSection {parameters} {token} />
+              <Separator spacing="none" />
               <SnsNeuronMaturitySection />
               <SnsNeuronAdvancedSection />
             </div>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -151,12 +151,16 @@
           <SkeletonCard cardType="info" separator />
           <SkeletonCard cardType="info" separator />
         {:else}
-          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token)}
+          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron)}
             <div class="section-wrapper">
               <SnsNeuronPageHeader />
               <SnsNeuronPageHeading {parameters} />
               <Separator spacing="none" />
-              <SnsNeuronVotingPowerSection {parameters} {token} />
+              <SnsNeuronVotingPowerSection
+                neuron={$selectedSnsNeuronStore.neuron}
+                {parameters}
+                {token}
+              />
               <Separator spacing="none" />
               <SnsNeuronMaturitySection />
               <SnsNeuronAdvancedSection />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronVotingPowerSection from "$lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte";
+import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
+import { SnsNeuronVotingPowerSectionPo } from "$tests/page-objects/SnsNeuronVotingPowerSection.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
+import type { SnsNeuron } from "@dfinity/sns";
+
+describe("NnsStakeItemAction", () => {
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronVotingPowerSection,
+      neuron,
+      reload: () => undefined,
+      props: {
+        parameters: snsNervousSystemParametersMock,
+        token: mockToken,
+      },
+    });
+
+    return SnsNeuronVotingPowerSectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render voting power", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      stake: 314000000n,
+      stakedMaturity: 100000000n,
+      state: NeuronState.Locked,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getVotingPower()).toBe("5.28");
+  });
+
+  it("should render item actions", async () => {
+    const po = renderComponent(mockSnsNeuron);
+
+    expect(await po.hasStakeItemAction()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import SnsNeuronVotingPowerSection from "$lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte";
-import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -14,14 +14,14 @@ import { SnsNeuronVotingPowerSectionPo } from "$tests/page-objects/SnsNeuronVoti
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
 
 describe("NnsStakeItemAction", () => {
+  const nowInSeconds = 1689843195;
   const renderComponent = (neuron: SnsNeuron) => {
-    const { container } = renderSelectedSnsNeuronContext({
-      Component: SnsNeuronVotingPowerSection,
-      neuron,
-      reload: () => undefined,
+    const { container } = render(SnsNeuronVotingPowerSection, {
       props: {
+        neuron,
         parameters: snsNervousSystemParametersMock,
         token: mockToken,
       },
@@ -32,16 +32,23 @@ describe("NnsStakeItemAction", () => {
     );
   };
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(nowInSeconds * 1000);
+  });
+
   it("should render voting power", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       stake: 314000000n,
       stakedMaturity: 100000000n,
       state: NeuronState.Locked,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+      ageSinceSeconds: BigInt(nowInSeconds - SECONDS_IN_YEAR),
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getVotingPower()).toBe("5.28");
+    expect(await po.getVotingPower()).toBe("5.23");
   });
 
   it("should render item actions", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsStakeItemAction from "$lib/components/sns-neuron-detail/SnsStakeItemAction.svelte";
+import {
+  createMockSnsNeuron,
+  mockSnsNeuron,
+} from "$tests/mocks/sns-neurons.mock";
+import { mockToken, mockUniverse } from "$tests/mocks/sns-projects.mock";
+import { SnsStakeItemActionPo } from "$tests/page-objects/SnsStakeItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SnsStakeItemAction", () => {
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(SnsStakeItemAction, {
+      props: {
+        neuron,
+        universe: mockUniverse,
+        token: mockToken,
+      },
+    });
+
+    return SnsStakeItemActionPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render Stake of the neuron", async () => {
+    const stake = 314000000n;
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      stake,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getStake()).toBe("3.14");
+  });
+
+  it("should render increase stake button", async () => {
+    const po = renderComponent(mockSnsNeuron);
+
+    expect(await po.hasIncreaseStakeButton()).toBe(true);
+  });
+});

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -7,6 +7,7 @@ import type {
   SnsSwapCommitment,
 } from "$lib/types/sns";
 import type { QuerySnsMetadata } from "$lib/types/sns.query";
+import type { Universe } from "$lib/types/universe";
 import {
   IcrcMetadataResponseEntries,
   type IcrcTokenMetadataResponse,
@@ -339,4 +340,9 @@ export const mockQueryMetadata: QuerySnsMetadata = {
 export const mockTokenStore = (run: Subscriber<Token>) => {
   run(mockSnsToken);
   return () => undefined;
+};
+
+export const mockUniverse: Universe = {
+  canisterId: principal(0).toText(),
+  summary: mockSnsFullProject.summary,
 };

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsStakeItemActionPo } from "./SnsStakeItemAction.page-object";
+
+export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-voting-power-section-component";
+
+  static under(element: PageObjectElement): SnsNeuronVotingPowerSectionPo {
+    return new SnsNeuronVotingPowerSectionPo(
+      element.byTestId(SnsNeuronVotingPowerSectionPo.TID)
+    );
+  }
+
+  getVotingPower(): Promise<string> {
+    return this.getText("voting-power");
+  }
+
+  getStakeItemActionPo(): SnsStakeItemActionPo {
+    return SnsStakeItemActionPo.under(this.root);
+  }
+
+  hasStakeItemAction(): Promise<boolean> {
+    return this.getStakeItemActionPo().isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsStakeItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsStakeItemAction.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsStakeItemActionPo extends BasePageObject {
+  private static readonly TID = "sns-stake-item-action-component";
+
+  static under(element: PageObjectElement): SnsStakeItemActionPo {
+    return new SnsStakeItemActionPo(element.byTestId(SnsStakeItemActionPo.TID));
+  }
+
+  getStake(): Promise<string> {
+    return this.getText("stake-value");
+  }
+
+  hasIncreaseStakeButton(): Promise<boolean> {
+    return this.getButton("sns-increase-stake").isPresent();
+  }
+}


### PR DESCRIPTION
# Motivation

We are reshuffling the data in the neuron detail page.

In this PR: Setup voting power section for sns neuron detail page

# Changes

* Implement SnsNeuronVotingPowerSection.
* New component SnsStakeItemAction.
* Add "variant" prop to SnsIncreaseStakeButton.
* Add Separator between Maturity and Voting Power sections in SnsNeutonDetail.

# Tests

* Test file and PO for SnsNeuronVotingPowerSection.
* Test file and PO for SnsStakeItemAction

# Todos

Not yet worth an entry.
