### PR TITLE
GIX-1686: SnsNeuronAdvancedSection Part 1

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -1,1 +1,87 @@
-<div>GIX-1686</div>
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { KeyValuePair, Section } from "@dfinity/gix-components";
+  import { secondsToDateTime } from "$lib/utils/date.utils";
+  import Hash from "../ui/Hash.svelte";
+  import type { SnsNeuron } from "@dfinity/sns";
+  import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+  import SnsNeuronAge from "../sns-neurons/SnsNeuronAge.svelte";
+  import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger";
+  import type { Principal } from "@dfinity/principal";
+  import { nonNullish } from "@dfinity/utils";
+  import SnsNeuronVestingPeriodRemaining from "./SnsNeuronVestingPeriodRemaining.svelte";
+
+  export let governanceCanisterId: Principal | undefined;
+  export let neuron: SnsNeuron;
+
+  let neuronAccount: IcrcAccount | undefined;
+  $: neuronAccount = nonNullish(governanceCanisterId)
+    ? {
+        owner: governanceCanisterId,
+        subaccount: neuron?.id[0]?.id,
+      }
+    : undefined;
+</script>
+
+<Section testId="sns-neuron-advanced-section-component">
+  <h3 slot="title">{$i18n.neuron_detail.advanced_settings_title}</h3>
+  <p slot="description">
+    {$i18n.neuron_detail.advanced_settings_description}
+  </p>
+  <div class="content">
+    {#if nonNullish(neuron)}
+      <KeyValuePair>
+        <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
+        <Hash
+          slot="value"
+          className="value"
+          tagName="span"
+          testId="neuron-id"
+          text={getSnsNeuronIdAsHexString(neuron)}
+          showCopy
+          flowLessCopy
+          id="neuron-id"
+        />
+      </KeyValuePair>
+      <KeyValuePair>
+        <span slot="key" class="label">{$i18n.neuron_detail.created}</span>
+        <span slot="value" class="value" data-tid="neuron-created"
+          >{secondsToDateTime(neuron.created_timestamp_seconds)}</span
+        >
+      </KeyValuePair>
+      <SnsNeuronAge {neuron} />
+      {#if nonNullish(neuronAccount)}
+        <KeyValuePair>
+          <span slot="key" class="label"
+            >{$i18n.neuron_detail.neuron_account}</span
+          >
+          <Hash
+            slot="value"
+            className="value"
+            tagName="span"
+            testId="neuron-account"
+            text={encodeIcrcAccount(neuronAccount)}
+            id="neuron-account"
+            showCopy
+            flowLessCopy
+          />
+        </KeyValuePair>
+      {/if}
+      <SnsNeuronVestingPeriodRemaining {neuron} />
+    {/if}
+  </div>
+</Section>
+
+<style lang="scss">
+  h3,
+  p {
+    margin: 0;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -44,6 +44,7 @@
   import SnsNeuronAdvancedSection from "$lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
 
   export let neuronId: string | null | undefined;
 
@@ -76,6 +77,10 @@
 
   let token: Token;
   $: token = $snsTokenSymbolSelectedStore as Token;
+
+  let governanceCanisterId: Principal | undefined;
+  $: governanceCanisterId =
+    $selectedUniverseStore.summary?.governanceCanisterId;
 
   const loadNeuron = async (
     { forceFetch }: { forceFetch: boolean } = { forceFetch: false }
@@ -163,7 +168,11 @@
               />
               <Separator spacing="none" />
               <SnsNeuronMaturitySection />
-              <SnsNeuronAdvancedSection />
+              <Separator spacing="none" />
+              <SnsNeuronAdvancedSection
+                neuron={$selectedSnsNeuronStore.neuron}
+                {governanceCanisterId}
+              />
             </div>
           {/if}
           <Summary />

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronAdvancedSection from "$lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte";
+import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronAdvancedSectionPo } from "$tests/page-objects/SnsNeuronAdvancedSection.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SnsNeuronAdvancedSection", () => {
+  const nowInSeconds = 1689843195;
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(SnsNeuronAdvancedSection, {
+      props: {
+        neuron,
+        governanceCanisterId: mockPrincipal,
+      },
+    });
+
+    return SnsNeuronAdvancedSectionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(nowInSeconds * 1000);
+  });
+
+  it("should render neuron data", async () => {
+    const id = [
+      154, 174, 251, 49, 236, 17, 214, 189, 195, 140, 58, 89, 61, 29, 138, 113,
+      79, 48, 136, 37, 96, 61, 215, 50, 182, 65, 198, 97, 8, 19, 238, 36,
+    ];
+    const created = BigInt(nowInSeconds - SECONDS_IN_MONTH);
+    const neuron = createMockSnsNeuron({
+      id,
+      createdTimestampSeconds: created,
+      ageSinceSeconds: created + BigInt(SECONDS_IN_DAY * 10),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.neuronId()).toBe("9aaefb3...813ee24");
+    expect(normalizeWhitespace(await po.neuronCreated())).toBe(
+      "Jun 19, 2023 10:23 PM"
+    );
+    expect(await po.neuronAge()).toBe("20 days, 10 hours");
+    expect(await po.neuronAccount()).toBe("xlmdg-v...813ee24");
+  });
+});

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -36,6 +36,7 @@ export const createMockSnsNeuron = ({
   ageSinceSeconds = BigInt(1000),
   stakedMaturity = BigInt(100_000_000),
   maturity = BigInt(100_000_000),
+  createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
 }: {
   stake?: bigint;
   id: number[];
@@ -51,6 +52,7 @@ export const createMockSnsNeuron = ({
   ageSinceSeconds?: bigint;
   stakedMaturity?: bigint;
   maturity?: bigint;
+  createdTimestampSeconds?: bigint;
 }): SnsNeuron => {
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
@@ -58,7 +60,7 @@ export const createMockSnsNeuron = ({
     source_nns_neuron_id: [],
     maturity_e8s_equivalent: maturity,
     cached_neuron_stake_e8s: stake,
-    created_timestamp_seconds: BigInt(nowInSeconds() - SECONDS_IN_DAY),
+    created_timestamp_seconds: createdTimestampSeconds,
     staked_maturity_e8s_equivalent: [stakedMaturity],
     auto_stake_maturity: [],
     aging_since_timestamp_seconds: ageSinceSeconds,

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -1,0 +1,42 @@
+import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsNeuronAgePo } from "./SnsNeuronAge.page-object";
+
+export class SnsNeuronAdvancedSectionPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-advanced-section-component";
+
+  static under(element: PageObjectElement): SnsNeuronAdvancedSectionPo {
+    return new SnsNeuronAdvancedSectionPo(
+      element.byTestId(SnsNeuronAdvancedSectionPo.TID)
+    );
+  }
+
+  neuronId(): Promise<string> {
+    return this.getText("neuron-id");
+  }
+
+  neuronCreated(): Promise<string> {
+    return this.getText("neuron-created");
+  }
+
+  getNnsNeuronAgePo(): SnsNeuronAgePo {
+    return SnsNeuronAgePo.under(this.root);
+  }
+
+  neuronAge(): Promise<string> {
+    return this.getNnsNeuronAgePo().getNeuronAge();
+  }
+
+  neuronAccount(): Promise<string> {
+    return this.getText("neuron-account");
+  }
+
+  getVestingPeriodPo(): SnsNeuronVestingPeriodRemainingPo {
+    return SnsNeuronVestingPeriodRemainingPo.under(this.root);
+  }
+
+  vestingPeriodIsPresent(): Promise<boolean> {
+    return this.getVestingPeriodPo().vestingPeriodIsPresent();
+  }
+}


### PR DESCRIPTION
# Motivation

We are reshuffling data around in the neuron details page.

In this PR: First part of the advanced section for SNS neuron details page.

# Changes

* Implement SnsNeuronAdvancedSection.
* Pass necessary props from SnsNeuronDetail.
* Add Separator between Maturity and Advanced sections.

# Tests

* Test file and PO for SnsNeuronAdvancedSection.

# Todos

Not yet worth an entry in the changelog.
