### PR TITLE
Fix: Dissolve Delay Modal current Delay in Dissolving SNS neuron

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte
@@ -7,7 +7,10 @@
   } from "@dfinity/gix-components";
   import { createEventDispatcher } from "svelte";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { getSnsLockedTimeInSeconds } from "$lib/utils/sns-neuron.utils";
+  import {
+    getSnsDissolvingTimeInSeconds,
+    getSnsLockedTimeInSeconds,
+  } from "$lib/utils/sns-neuron.utils";
   import ConfirmSnsDissolveDelay from "$lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte";
   import type { Token } from "@dfinity/utils";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -37,7 +40,11 @@
   let currentStep: WizardStep | undefined;
   let modal: WizardModal;
 
-  let delayInSeconds = Number(getSnsLockedTimeInSeconds(neuron) ?? 0n);
+  let delayInSeconds = Number(
+    getSnsLockedTimeInSeconds(neuron) ??
+      getSnsDissolvingTimeInSeconds(neuron) ??
+      0n
+  );
 
   $: if ($snsOnlyProjectStore !== undefined) {
     loadSnsParameters($snsOnlyProjectStore);

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -17,10 +17,12 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import {
+  createMockSnsNeuron,
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken, fromDefinedNullable } from "@dfinity/utils";
@@ -93,6 +95,36 @@ describe("IncreaseSnsDissolveDelayModal", () => {
     const { container } = await renderIncreaseDelayModal(neuron);
 
     expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should use current dissolve delay value when locked", async () => {
+    const dissolveDelaySeconds = 12345555n;
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      dissolveDelaySeconds,
+    });
+    const { queryByTestId } = await renderIncreaseDelayModal(neuron);
+
+    expect((queryByTestId("input-range") as HTMLInputElement).value).toBe(
+      dissolveDelaySeconds.toString()
+    );
+  });
+
+  it("should use current dissolve delay value when dissolving", async () => {
+    const whenDissolvedTimestampSeconds = BigInt(
+      nowInSeconds + SECONDS_IN_YEAR
+    );
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      whenDissolvedTimestampSeconds,
+    });
+    const { queryByTestId } = await renderIncreaseDelayModal(neuron);
+
+    expect((queryByTestId("input-range") as HTMLInputElement).value).toBe(
+      SECONDS_IN_YEAR.toString()
+    );
   });
 
   it("should have the update delay button disabled by default", async () => {

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -30,6 +30,9 @@ export const createMockSnsNeuron = ({
   vesting,
   votingPowerMultiplier = BigInt(100),
   dissolveDelaySeconds = BigInt(Math.floor(3600 * 24 * 365 * 2)),
+  whenDissolvedTimestampSeconds = BigInt(
+    Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
+  ),
   ageSinceSeconds = BigInt(1000),
   stakedMaturity = BigInt(100_000_000),
   maturity = BigInt(100_000_000),
@@ -44,6 +47,7 @@ export const createMockSnsNeuron = ({
   vesting?: boolean;
   votingPowerMultiplier?: bigint;
   dissolveDelaySeconds?: bigint;
+  whenDissolvedTimestampSeconds?: bigint;
   ageSinceSeconds?: bigint;
   stakedMaturity?: bigint;
   maturity?: bigint;
@@ -65,9 +69,7 @@ export const createMockSnsNeuron = ({
         : [
             state === NeuronState.Dissolving
               ? {
-                  WhenDissolvedTimestampSeconds: BigInt(
-                    Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
-                  ),
+                  WhenDissolvedTimestampSeconds: whenDissolvedTimestampSeconds,
                 }
               : {
                   DissolveDelaySeconds: dissolveDelaySeconds,


### PR DESCRIPTION
# Motivation

Bug: When a user tried to increase the dissolve delay of a dissolving SNS neuron, the modal didn't show the current dissolve delay. Instead, it showed 0, as if there was no dissolve delay.

# Changes

* Use also the dissolving time in the IncreaseSnsDissolveDelayModal.

# Tests

* Add a test that the delay is as expected both when neuron is locked and dissolving.

# Todos

- [ ] Add entry to changelog (if necessary).
