### PR TITLE
GIX-1684: SnsNeuronStateItemAction

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { NeuronState } from "@dfinity/nns";
+  import { getStateInfo, type StateInfo } from "$lib/utils/neuron.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import { keyOf } from "$lib/utils/utils";
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import {
+    ageMultiplier,
+    getSnsNeuronState,
+  } from "$lib/utils/sns-neuron.utils";
+  import DisburseSnsButton from "./actions/DisburseSnsButton.svelte";
+  import DissolveSnsNeuronButton from "./actions/DissolveSnsNeuronButton.svelte";
+
+  export let neuron: SnsNeuron;
+  export let snsParameters: SnsNervousSystemParameters;
+
+  let state: NeuronState;
+  $: state = getSnsNeuronState(neuron);
+
+  let stateInfo: StateInfo | undefined;
+  $: stateInfo = getStateInfo(state);
+
+  let ageBonus: number;
+  $: ageBonus = ageMultiplier({ neuron, snsParameters });
+</script>
+
+<CommonItemAction testId="sns-neuron-state-item-action-component">
+  <svelte:fragment slot="icon">
+    {#if stateInfo?.Icon !== undefined}
+      <svelte:component this={stateInfo.Icon} />
+    {/if}
+  </svelte:fragment>
+  <span slot="title" data-tid="state-text">
+    {keyOf({ obj: $i18n.neuron_state, key: NeuronState[state] })}
+  </span>
+  <svelte:fragment slot="subtitle">
+    {#if state === NeuronState.Locked}
+      <Tooltip id="neuron-age-bonus" text={ageBonus.toFixed(8)}>
+        <span data-tid="age-bonus-text">
+          {replacePlaceholders($i18n.neuron_detail.age_bonus_label, {
+            $ageBonus: ageBonus.toFixed(2),
+          })}
+        </span>
+      </Tooltip>
+    {:else}
+      <span data-tid="age-bonus-text">
+        {$i18n.neuron_detail.no_age_bonus}
+      </span>
+    {/if}
+  </svelte:fragment>
+  {#if state === NeuronState.Dissolved}
+    <DisburseSnsButton {neuron} />
+  {:else}
+    <DissolveSnsNeuronButton {neuron} />
+  {/if}
+</CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -9,6 +9,7 @@
   import SnsStakeItemAction from "./SnsStakeItemAction.svelte";
   import type { Universe } from "$lib/types/universe";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
+  import SnsNeuronStateItemAction from "./SnsNeuronStateItemAction.svelte";
 
   export let parameters: SnsNervousSystemParameters;
   export let neuron: SnsNeuron;
@@ -32,6 +33,7 @@
   </p>
   <ul class="content">
     <SnsStakeItemAction {neuron} {token} {universe} />
+    <SnsNeuronStateItemAction {neuron} snsParameters={parameters} />
   </ul>
 </Section>
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronStateItemAction from "$lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte";
+import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
+import {
+  createMockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
+import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SnsNeuronStateItemAction", () => {
+  const nowInSeconds = 1689843195;
+  const renderComponent = (neuron: SnsNeuron) => {
+    const { container } = render(SnsNeuronStateItemAction, {
+      props: {
+        neuron,
+        snsParameters: snsNervousSystemParametersMock,
+      },
+    });
+
+    return SnsNeuronStateItemActionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(nowInSeconds * 1000);
+  });
+
+  it("should render locked text and Start dissolving button if neuron is locked", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Locked");
+    expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
+  });
+
+  it("should render dissolving text and Stop dissolving button if neuron is dissolving", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Dissolving");
+    expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
+  });
+
+  it("should render unlocked text and disburse button if neuron is unlocked", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getState()).toBe("Unlocked");
+    expect(await po.hasDisburseButton()).toBe(true);
+  });
+
+  it("should render age bonus for Locked neurons", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      ageSinceSeconds: BigInt(nowInSeconds - SECONDS_IN_FOUR_YEARS),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("Age bonus: 1.25");
+  });
+
+  it("should render no age bonus for dissolving neurons", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("No age bonus");
+  });
+
+  it("should render no age bonus for unlocked neurons", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getAgeBonus()).toBe("No age bonus");
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -55,5 +55,6 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(mockSnsNeuron);
 
     expect(await po.hasStakeItemAction()).toBe(true);
+    expect(await po.hasStateItemAction()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,0 +1,28 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsNeuronStateItemActionPo extends BasePageObject {
+  private static readonly TID = "sns-neuron-state-item-action-component";
+
+  static under(element: PageObjectElement): SnsNeuronStateItemActionPo {
+    return new SnsNeuronStateItemActionPo(
+      element.byTestId(SnsNeuronStateItemActionPo.TID)
+    );
+  }
+
+  getState(): Promise<string> {
+    return this.getText("state-text");
+  }
+
+  getAgeBonus(): Promise<string> {
+    return this.getText("age-bonus-text");
+  }
+
+  hasDisburseButton(): Promise<boolean> {
+    return this.getButton("disburse-button").isPresent();
+  }
+
+  getDissolveButtonText(): Promise<string> {
+    return this.getButton("sns-dissolve-button").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SnsNeuronStateItemActionPo } from "./SnsNeuronStateItemAction.page-object";
 import { SnsStakeItemActionPo } from "./SnsStakeItemAction.page-object";
 
 export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
@@ -21,5 +22,13 @@ export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
 
   hasStakeItemAction(): Promise<boolean> {
     return this.getStakeItemActionPo().isPresent();
+  }
+
+  getStateItemActionPo(): SnsNeuronStateItemActionPo {
+    return SnsNeuronStateItemActionPo.under(this.root);
+  }
+
+  hasStateItemAction(): Promise<boolean> {
+    return this.getStateItemActionPo().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

We are reshuffling the data in the neuron details page.

In this PR: the item that has the information and actions about the SNS neuron state.

# Changes

* New component SnsNeuronStateItemAction.
* Use new component in SnsNeuronVotingPowerSection.

# Tests

* Test that new component is present in SnsNeuronVotingPowerSection.
* New test file and PO for SnsNeuronStateItemAction.

# Todos

Not worth an entry yet.