### PR TITLE
Test SNS hotkey management

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -36,6 +36,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Better visibility of upgrade cycle consumption, wasm size and memory usage.
 * Check that release-sop is the newest version when it's run.
 * Compile end-to-end tests to catch type errors.
+* Support SNS neuron permission in fake SNS governance API.
 
 #### Changed
 

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -10,7 +10,6 @@ import {
   installImplAndBlockRest,
   makePausable,
 } from "$tests/utils/module.test-utils";
-import { assertNonNullish } from "$tests/utils/utils.test-utils";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 import type {
@@ -18,6 +17,7 @@ import type {
   SnsNervousSystemFunction,
   SnsNervousSystemParameters,
   SnsNeuronId,
+  SnsNeuronPermissionType,
   SnsProposalData,
   SnsProposalId,
 } from "@dfinity/sns";
@@ -26,7 +26,7 @@ import {
   neuronSubaccount,
   type SnsNeuron,
 } from "@dfinity/sns";
-import { fromNullable, isNullish } from "@dfinity/utils";
+import { fromNullable, isNullish, toNullable } from "@dfinity/utils";
 
 const modulePath = "$lib/api/sns-governance.api";
 
@@ -40,6 +40,8 @@ const fakeFunctions = {
   claimNeuron,
   queryProposals,
   queryProposal,
+  addNeuronPermissions,
+  removeNeuronPermissions,
 };
 
 //////////////////////////////////////////////
@@ -85,6 +87,18 @@ const getNeuron = ({
   );
 };
 
+const getNeuronOrThrow = (params: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  neuronId: SnsNeuronId;
+}): SnsNeuron => {
+  const neuron = getNeuron(params);
+  if (isNullish(neuron)) {
+    throw new SnsGovernanceError("No neuron for given NeuronId.");
+  }
+  return neuron;
+};
+
 const getProposals = (keyParams: KeyParams) => {
   const key = mapKey(keyParams);
   let proposalsList = proposals.get(key);
@@ -103,6 +117,54 @@ const getNervousFunctions = (rootCanisterId: Principal) => {
     nervousFunctions.set(key, nervousFunctionsList);
   }
   return nervousFunctionsList;
+};
+
+const getNeuronPrincipalPermissionEntry = ({
+  principal,
+  neuronId,
+  ...keyParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}): { permission_type: Int32Array } => {
+  const neuron = getNeuronOrThrow({ ...keyParams, neuronId });
+  let permissionEntry = neuron.permissions.find(
+    (entry) => fromNullable(entry.principal).toText() === principal.toText()
+  );
+  if (isNullish(permissionEntry)) {
+    permissionEntry = {
+      principal: toNullable(principal),
+      permission_type: new Int32Array(),
+    };
+    neuron.permissions.push(permissionEntry);
+  }
+  return permissionEntry;
+};
+
+const getNeuronPrincipalPermissions = (entryParams: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}): SnsNeuronPermissionType[] => {
+  const entry = getNeuronPrincipalPermissionEntry(entryParams);
+  return Array.from(entry.permission_type);
+};
+
+const setNeuronPrincipalPermissions = ({
+  permissions,
+  ...entryParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  permissions: SnsNeuronPermissionType[];
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}) => {
+  const entry = getNeuronPrincipalPermissionEntry(entryParams);
+  entry.permission_type = Int32Array.from(permissions);
 };
 
 ////////////////////////
@@ -165,7 +227,7 @@ async function refreshNeuron(params: {
   identity: Identity;
   neuronId: SnsNeuronId;
 }): Promise<void> {
-  assertNonNullish(getNeuron(params));
+  getNeuronOrThrow(params);
 }
 
 async function claimNeuron({
@@ -219,11 +281,7 @@ async function getSnsNeuron({
   certified: boolean;
   neuronId: SnsNeuronId;
 }): Promise<SnsNeuron> {
-  const neuron = getNeuron({ ...keyParams, neuronId });
-  if (isNullish(neuron)) {
-    throw new SnsGovernanceError("No neuron for given NeuronId.");
-  }
-  return neuron;
+  return getNeuronOrThrow({ ...keyParams, neuronId });
 }
 
 async function queryProposals({
@@ -263,6 +321,49 @@ async function queryProposal({
     );
   }
   return proposal;
+}
+
+async function addNeuronPermissions({
+  permissions,
+  ...permissionEntryParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  permissions: SnsNeuronPermissionType[];
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}): Promise<void> {
+  const currentPermissions = getNeuronPrincipalPermissions(
+    permissionEntryParams
+  );
+  const newPermissions = Array.from(
+    new Set([...currentPermissions, ...permissions])
+  );
+  setNeuronPrincipalPermissions({
+    ...permissionEntryParams,
+    permissions: newPermissions,
+  });
+}
+
+async function removeNeuronPermissions({
+  permissions,
+  ...permissionEntryParams
+}: {
+  identity: Identity;
+  rootCanisterId: Principal;
+  permissions: SnsNeuronPermissionType[];
+  principal: Principal;
+  neuronId: SnsNeuronId;
+}): Promise<void> {
+  const currentPermissions = getNeuronPrincipalPermissions(
+    permissionEntryParams
+  );
+  const toRemove = new Set(permissions);
+  const newPermissions = currentPermissions.filter((p) => !toRemove.has(p));
+  setNeuronPrincipalPermissions({
+    ...permissionEntryParams,
+    permissions: newPermissions,
+  });
 }
 
 /////////////////////////////////

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -119,7 +119,7 @@ const getNervousFunctions = (rootCanisterId: Principal) => {
   return nervousFunctionsList;
 };
 
-const getNeuronPrincipalPermissionEntry = ({
+const getOrCreateNeuronPrincipalPermissionEntry = ({
   principal,
   neuronId,
   ...keyParams
@@ -149,7 +149,7 @@ const getNeuronPrincipalPermissions = (entryParams: {
   principal: Principal;
   neuronId: SnsNeuronId;
 }): SnsNeuronPermissionType[] => {
-  const entry = getNeuronPrincipalPermissionEntry(entryParams);
+  const entry = getOrCreateNeuronPrincipalPermissionEntry(entryParams);
   return Array.from(entry.permission_type);
 };
 
@@ -163,7 +163,7 @@ const setNeuronPrincipalPermissions = ({
   principal: Principal;
   neuronId: SnsNeuronId;
 }) => {
-  const entry = getNeuronPrincipalPermissionEntry(entryParams);
+  const entry = getOrCreateNeuronPrincipalPermissionEntry(entryParams);
   entry.permission_type = Int32Array.from(permissions);
 };
 

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -203,8 +203,6 @@ describe("SnsNeuronDetail", () => {
     const hotkeyPrincipal =
       "dskxv-lqp33-5g7ev-qesdj-fwwkb-3eze4-6tlur-42rxy-n4gag-6t4a3-tae";
 
-    beforeEach(() => {});
-
     it("can not be added without permission", async () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,

--- a/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronHotkeysCard.page-object.ts
@@ -1,3 +1,4 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -45,8 +46,12 @@ export class SnsNeuronHotkeysCardPo extends BasePageObject {
     throw new Error(`Hotkey not found: ${principal}`);
   }
 
+  getAddHotkeyButtonPo(): ButtonPo {
+    return ButtonPo.under({ element: this.root, testId: "add-hotkey-button" });
+  }
+
   clickAddHotkey(): Promise<void> {
-    return this.click("add-hotkey-button");
+    return this.getAddHotkeyButtonPo().click();
   }
 
   async removeHotkey(principal: string): Promise<void> {


### PR DESCRIPTION
# Motivation

There is a race condition with query and update calls when adding/removing SNS neuron hotkeys.
I want to use `queuedStore` to fix the race condition for which I will want to add unit test coverage.
Currently there is no unit test coverage in `SnsNeuronDetail.spec.ts` for adding/removing hotkeys.
So before fixing the race condition I want to improve the existing test coverage so it's easier to test the fix later.

# Changes

1. Support adding/removing SNS neuron permissions in `frontend/src/tests/fakes/sns-governance-api.fake.ts`.
2. In `frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts` test adding and removing hotkeys and also not having permission to add hotkeys.

# Tests

yes

# Todos

- [x] Add entry to changelog (if necessary).
