### PR TITLE
Upgrade Playwright

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@mixer/parallel-prettier": "^2.0.3",
-        "@playwright/test": "^1.32.2",
+        "@playwright/test": "^1.36",
         "@rollup/plugin-inject": "^5.0.3",
         "@sveltejs/adapter-static": "^2.0.2",
         "@sveltejs/kit": "^1.18.0",
@@ -2048,19 +2048,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
+      "integrity": "sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.2"
+        "playwright-core": "1.36.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -7464,15 +7464,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
+      "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/postcss": {
@@ -10877,14 +10877,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
+      "integrity": "sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.32.2"
+        "playwright-core": "1.36.1"
       }
     },
     "@polka/url": {
@@ -14925,9 +14925,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
+      "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
       "dev": true
     },
     "postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@mixer/parallel-prettier": "^2.0.3",
-    "@playwright/test": "^1.32.2",
+    "@playwright/test": "^1.36",
     "@rollup/plugin-inject": "^5.0.3",
     "@sveltejs/adapter-static": "^2.0.2",
     "@sveltejs/kit": "^1.18.0",


### PR DESCRIPTION
# Motivation

Playwright 1.32 which we currently use, uses Firefox 111.
Dynamic imports from workers (which we use) are only supported from Firefox 114.

# Changes

Upgrade Playwright to version 1.36, which uses Firefox 115.

# Tests

still pass

# Todos

- [ ] Add entry to changelog (if necessary).

not worth mentioning