### PR TITLE
fix: Pass the target

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -81,7 +81,7 @@ set -x
 docker build --target check-environment .
 
 if DOCKER_BUILDKIT=1 docker build \
-  --target scratch \
+  --target "$DFX_TARGET" \
   "$PROGRESS" \
   --build-arg DFX_NETWORK="$DFX_NETWORK" \
   --build-arg COMMIT="$COMMIT" \


### PR DESCRIPTION
# Motivation
In docker builds, changing the target is a way of building a subset of resources and is useful when iterating fast in development.  A flag was added in bc8d3cf8d0278132d0360f62acbee64e8836543d to allow setting the target without editing `docker-build.sh` but unfortunately the flag was not passed through.

# Changes
- Pass the `--target` flag value through to docker.

# Tests
- Running docker build with `--target configurator` now tests the build configuration.

Note that as this target is not a scratch image, it outputs an entire OS image.  To do this well, the build also needs to set output to none, caching only, or to define more scratch targets.  Once that is done it might make sense to test this in CI.  As it is, it is useful to tell, quickly, whether a step succeeds or fails but not more than that.

# Todos

- [ ] Add entry to changelog (if necessary).
  - I don't believe this is significant enough to be necessary.  It would make sense once there are more scratch targets.