### PR TITLE
Cleanup: Use this.getButton() in page objects

### DIFF
--- a/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterDetail.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { ButtonPo } from "./Button.page-object";
+import type { ButtonPo } from "./Button.page-object";
 import { RenameCanisterModalPo } from "./RenameCanisterModal.page-object";
 
 export class CanisterDetailPo extends BasePageObject {
@@ -11,10 +11,7 @@ export class CanisterDetailPo extends BasePageObject {
   }
 
   getRenameButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "rename-canister-button-component",
-    });
+    return this.getButton("rename-canister-button-component");
   }
 
   clickRename(): Promise<void> {

--- a/frontend/src/tests/page-objects/ConfirmDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmDissolveDelay.page-object.ts
@@ -1,4 +1,4 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -12,10 +12,7 @@ export class ConfirmDissolveDelayPo extends BasePageObject {
   }
 
   getConfirmButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "confirm-delay-button",
-    });
+    return this.getButton("confirm-delay-button");
   }
 
   clickConfirm(): Promise<void> {

--- a/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccountsFooter.page-object.ts
@@ -1,5 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsAccountsFooterPo extends BasePageObject {
@@ -10,10 +10,7 @@ export class NnsAccountsFooterPo extends BasePageObject {
   }
 
   getSendButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "open-new-transaction",
-    });
+    return this.getButton("open-new-transaction");
   }
 
   async clickSend() {

--- a/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronsFooter.page-object.ts
@@ -1,4 +1,4 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -12,10 +12,7 @@ export class NnsNeuronsFooterPo extends BasePageObject {
   }
 
   getStakeNeuronsButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "stake-neuron-button",
-    });
+    return this.getButton("stake-neuron-button");
   }
 
   getNnsStakeNeuronModalPo(): NnsStakeNeuronModalPo {

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -15,10 +15,7 @@ export class SetDissolveDelayPo extends BasePageObject {
   }
 
   getUpdateButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "go-confirm-delay-button",
-    });
+    return this.getButton("go-confirm-delay-button");
   }
 
   getMaxButtonPo(): ButtonPo {

--- a/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMetaInfoCard.page-object.ts
@@ -1,4 +1,4 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { SnsNeuronAgePo } from "$tests/page-objects/SnsNeuronAge.page-object";
 import { SnsNeuronVestingPeriodRemainingPo } from "$tests/page-objects/SnsNeuronVestingPeriodRemaining.page-object";
 import { SnsNeuronVotingPowerPo } from "$tests/page-objects/SnsNeuronVotingPower.page-object";
@@ -19,10 +19,7 @@ export class SnsNeuronMetaInfoCardPo extends BasePageObject {
   }
 
   getSplitButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "split-neuron-button",
-    });
+    return this.getButton("split-neuron-button");
   }
 
   hasSplitButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/SnsNeuronsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronsFooter.page-object.ts
@@ -1,5 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { SnsStakeNeuronModalPo } from "$tests/page-objects/SnsStakeNeuronModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -11,10 +11,7 @@ export class SnsNeuronsFooterPo extends BasePageObject {
   }
 
   getStakeNeuronsButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "stake-sns-neuron-button",
-    });
+    return this.getButton("stake-sns-neuron-button");
   }
 
   getSnsStakeNeuronModalPo(): SnsStakeNeuronModalPo {

--- a/frontend/src/tests/page-objects/TextInputForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInputForm.page-object.ts
@@ -1,4 +1,4 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -25,10 +25,7 @@ export class TextInputFormPo extends BasePageObject {
   }
 
   getConfirmButtonPo(): ButtonPo {
-    return ButtonPo.under({
-      element: this.root,
-      testId: "confirm-text-input-screen-button",
-    });
+    return this.getButton("confirm-text-input-screen-button");
   }
 
   clickSubmitButton(): Promise<void> {

--- a/frontend/src/tests/page-objects/VotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingCard.page-object.ts
@@ -1,4 +1,4 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -14,19 +14,19 @@ export class VotingCardPo extends BasePageObject {
   }
 
   getVoteYesButtonPo(): ButtonPo {
-    return ButtonPo.under({ element: this.root, testId: "vote-yes" });
+    return this.getButton("vote-yes");
   }
 
   getVoteNoButtonPo(): ButtonPo {
-    return ButtonPo.under({ element: this.root, testId: "vote-no" });
+    return this.getButton("vote-no");
   }
 
   getConfirmYesButtonPo(): ButtonPo {
-    return ButtonPo.under({ element: this.root, testId: "confirm-yes" });
+    return this.getButton("confirm-yes");
   }
 
   getConfirmNoButtonPo(): ButtonPo {
-    return ButtonPo.under({ element: this.root, testId: "confirm-no" });
+    return this.getButton("confirm-no");
   }
 
   waitForVotingComplete(): Promise<void> {


### PR DESCRIPTION
# Motivation

There is a convenience method `getButton(testId: string)` in `BasePageObject` but it's not used in many places where it could be used.

# Changes

Replace `return ButtonPo.under({ element: this.root, testId});` with `return this.getButton(testId)`.

# Tests

test-only

# Todos

- [ ] Add entry to changelog (if necessary).

not worth mentioning?