### PR TITLE
Fix Sns aggregator root url to fetch projects

### DIFF
--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -345,7 +345,7 @@
     </main>
 
     <script>
-      // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io/v1/sns
+      // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io
       // Use the above for local development of this HTML page
       const aggregatorUrl = "";
 
@@ -411,7 +411,7 @@
       };
 
       const loadSnses = () =>
-        fetch(`${aggregatorUrl}/list/latest/slow.json`)
+        fetch(`${aggregatorUrl}/v1/sns/list/latest/slow.json`)
           .then((response) => response.json())
           .then((latest) => renderSnses(latest));
 

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -345,9 +345,9 @@
     </main>
 
     <script>
-      // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io
+      // Mainnet: https://3r4gx-wqaaa-aaaaq-aaaia-cai.raw.icp0.io/v1/sns
       // Use the above for local development of this HTML page
-      const aggregatorUrl = "";
+      const aggregatorUrl = "/v1/sns";
 
       const lifecycleText = (lifeCycle) => {
         switch (lifeCycle) {
@@ -411,7 +411,7 @@
       };
 
       const loadSnses = () =>
-        fetch(`${aggregatorUrl}/v1/sns/list/latest/slow.json`)
+        fetch(`${aggregatorUrl}/list/latest/slow.json`)
           .then((response) => response.json())
           .then((latest) => renderSnses(latest));
 


### PR DESCRIPTION
# Motivation

When we deploy the Sns aggregator its landing page is not able to fetch the list of projects anynmore.

This is an issue of the refactoring of the root URL developed in PR #2896.

# Changes

- shorten root url and move prefix `/v1/sns/` to effective fetch
