### PR TITLE
GIX-1684: SnsNeuronDissolveDelayActionItem

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconClockNoFill } from "@dfinity/gix-components";
+  import { NeuronState } from "@dfinity/nns";
+  import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import Tooltip from "../ui/Tooltip.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { keyOf } from "$lib/utils/utils";
+  import { secondsToDuration } from "$lib/utils/date.utils";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+  import {
+    dissolveDelayMultiplier,
+    getSnsDissolveDelaySeconds,
+    getSnsNeuronState,
+  } from "$lib/utils/sns-neuron.utils";
+  import { fromNullable } from "@dfinity/utils";
+  import IncreaseSnsDissolveDelayButton from "./actions/IncreaseSnsDissolveDelayButton.svelte";
+
+  export let neuron: SnsNeuron;
+  export let parameters: SnsNervousSystemParameters;
+
+  let state: NeuronState;
+  $: state = getSnsNeuronState(neuron);
+
+  let dissolveBonus: number;
+  $: dissolveBonus = dissolveDelayMultiplier({
+    neuron,
+    snsParameters: parameters,
+  });
+
+  let dissolvingTime: bigint;
+  $: dissolvingTime = getSnsDissolveDelaySeconds(neuron) ?? 0n;
+
+  const stateTextMapper = {
+    [NeuronState.Dissolved]: "dissolve_delay_row_title",
+    [NeuronState.Dissolving]: "remaining_title",
+    [NeuronState.Spawning]: "remaining_title",
+    [NeuronState.Locked]: "dissolve_delay_row_title",
+    [NeuronState.Unspecified]: "unspecified",
+  };
+
+  let minimumDelayToVoteInSeconds: bigint;
+  $: minimumDelayToVoteInSeconds =
+    fromNullable(parameters.neuron_minimum_dissolve_delay_to_vote_seconds) ??
+    0n;
+</script>
+
+<CommonItemAction testId="sns-neuron-dissolve-delay-item-action-component">
+  <IconClockNoFill slot="icon" />
+  <span slot="title" data-tid="dissolve-delay-text"
+    >{`${keyOf({
+      obj: $i18n.neuron_detail,
+      key: stateTextMapper[state],
+    })} ${dissolvingTime > 0n ? secondsToDuration(dissolvingTime) : "0"}`}</span
+  >
+  <svelte:fragment slot="subtitle">
+    {#if dissolvingTime >= minimumDelayToVoteInSeconds}
+      <Tooltip id="neuron-dissolve-delay-bonus" text={dissolveBonus.toFixed(8)}>
+        <span data-tid="dissolve-bonus-text">
+          {replacePlaceholders($i18n.neuron_detail.dissolve_bonus_label, {
+            $dissolveBonus: dissolveBonus.toFixed(2),
+          })}
+        </span>
+      </Tooltip>
+    {:else}
+      <span data-tid="dissolve-bonus-text">
+        {$i18n.neuron_detail.no_dissolve_bonus}
+      </span>
+    {/if}</svelte:fragment
+  >
+  <IncreaseSnsDissolveDelayButton {neuron} variant="secondary" />
+</CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -10,6 +10,7 @@
   import type { Universe } from "$lib/types/universe";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import SnsNeuronStateItemAction from "./SnsNeuronStateItemAction.svelte";
+  import SnsNeuronDissolveDelayActionItem from "./SnsNeuronDissolveDelayActionItem.svelte";
 
   export let parameters: SnsNervousSystemParameters;
   export let neuron: SnsNeuron;
@@ -34,6 +35,7 @@
   <ul class="content">
     <SnsStakeItemAction {neuron} {token} {universe} />
     <SnsNeuronStateItemAction {neuron} snsParameters={parameters} />
+    <SnsNeuronDissolveDelayActionItem {neuron} {parameters} />
   </ul>
 </Section>
 

--- a/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
@@ -7,6 +7,7 @@
   import { NeuronState } from "@dfinity/nns";
 
   export let neuron: SnsNeuron;
+  export let variant: "primary" | "secondary" = "primary";
 
   let isUnlocked: boolean;
   $: isUnlocked = getSnsNeuronState(neuron) === NeuronState.Dissolved;
@@ -14,7 +15,7 @@
 
 <VestingTooltipWrapper {neuron}>
   <button
-    class="primary"
+    class={variant}
     disabled={isVesting(neuron)}
     data-tid="sns-increase-dissolve-delay"
     on:click={() => openSnsNeuronModal({ type: "increase-dissolve-delay" })}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import SnsNeuronDissolveDelayActionItem from "$lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.svelte";
+import {
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_FOUR_YEARS,
+  SECONDS_IN_HALF_YEAR,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
+import {
+  createMockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { SnsNeuronDissolveDelayActionItemPo } from "$tests/page-objects/SnsNeuronDissolveDelayActionItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
+import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SnsNeuronDissolveDelayActionItem", () => {
+  const nowInSeconds = 1689843195;
+  const maxDissolveDelay = BigInt(SECONDS_IN_EIGHT_YEARS);
+  const dissolveDelayToVote = BigInt(SECONDS_IN_HALF_YEAR);
+  const snsParameters: SnsNervousSystemParameters = {
+    ...snsNervousSystemParametersMock,
+    neuron_minimum_dissolve_delay_to_vote_seconds: [dissolveDelayToVote],
+    max_dissolve_delay_seconds: [maxDissolveDelay],
+    max_dissolve_delay_bonus_percentage: [25n],
+  };
+  const renderComponent = (
+    neuron: SnsNeuron,
+    parameters: SnsNervousSystemParameters = snsParameters
+  ) => {
+    const { container } = render(SnsNeuronDissolveDelayActionItem, {
+      props: {
+        neuron,
+        parameters,
+      },
+    });
+
+    return SnsNeuronDissolveDelayActionItemPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(nowInSeconds * 1000);
+  });
+
+  it("should render dissolve delay text and bonus if neuron is locked", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveState()).toBe("Dissolve Delay: 4 years");
+    expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: 1.13");
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
+  });
+
+  it("should render remaining text and bonus if neuron is dissolving", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      whenDissolvedTimestampSeconds: BigInt(
+        nowInSeconds + SECONDS_IN_FOUR_YEARS
+      ),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveState()).toBe("Remaining: 4 years");
+    expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: 1.13");
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
+  });
+
+  it("should render no bonus text if neuron is dissolving less than minimum to vote", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      whenDissolvedTimestampSeconds: BigInt(nowInSeconds + SECONDS_IN_YEAR - 1),
+    });
+    const parameters: SnsNervousSystemParameters = {
+      ...snsParameters,
+      neuron_minimum_dissolve_delay_to_vote_seconds: [BigInt(SECONDS_IN_YEAR)],
+    };
+    const po = renderComponent(neuron, parameters);
+
+    expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
+  });
+
+  it("should render dissolve delay text with 0 and no bonus text if neuron is unlocked", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveState()).toBe("Dissolve Delay: 0");
+    expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -56,6 +56,6 @@ describe("NnsStakeItemAction", () => {
 
     expect(await po.hasStakeItemAction()).toBe(true);
     expect(await po.hasStateItemAction()).toBe(true);
-    expect(await po.hasDisslveDelayItemActionPo()).toBe(true);
+    expect(await po.hasDissolveDelayItemActionPo()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -56,5 +56,6 @@ describe("NnsStakeItemAction", () => {
 
     expect(await po.hasStakeItemAction()).toBe(true);
     expect(await po.hasStateItemAction()).toBe(true);
+    expect(await po.hasDisslveDelayItemActionPo()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -43,13 +43,14 @@ describe("IncreaseSnsDissolveDelayButton", () => {
     page.mock({ data: { universe: rootCanisterId.toText() } });
   });
 
-  const renderComponent = (neuron: SnsNeuron) => {
-    const { container } = render(SnsNeuronContextTest, {
+  const renderComponent = (
+    neuron: SnsNeuron,
+    variant: "primary" | "secondary" = "primary"
+  ) => {
+    const { container } = render(IncreaseSnsDissolveDelayButton, {
       props: {
         neuron,
-        passPropNeuron: true,
-        rootCanisterId,
-        testComponent: IncreaseSnsDissolveDelayButton,
+        variant,
       },
     });
 
@@ -74,6 +75,16 @@ describe("IncreaseSnsDissolveDelayButton", () => {
     });
     const po = renderComponent(unlockedNeuron);
     expect(await po.getText()).toEqual("Set Dissolve Delay");
+  });
+
+  it("should set variant", async () => {
+    const unlockedNeuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+    });
+    const variant = "secondary";
+    const po = renderComponent(unlockedNeuron, variant);
+    expect(await po.getClasses()).toContain(variant);
   });
 
   it("should open increase increase dissolve delay modal", async () => {

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -23,4 +23,8 @@ export class ButtonPo extends SimpleBasePageObject {
   async isDisabled(): Promise<boolean> {
     return (await this.root.getAttribute("disabled")) !== null;
   }
+
+  getClasses(): Promise<string[]> {
+    return this.root.getClasses();
+  }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronDissolveDelayActionItem.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDissolveDelayActionItem.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsNeuronDissolveDelayActionItemPo extends BasePageObject {
+  private static readonly TID =
+    "sns-neuron-dissolve-delay-item-action-component";
+
+  static under(element: PageObjectElement): SnsNeuronDissolveDelayActionItemPo {
+    return new SnsNeuronDissolveDelayActionItemPo(
+      element.byTestId(SnsNeuronDissolveDelayActionItemPo.TID)
+    );
+  }
+
+  getDissolveState(): Promise<string> {
+    return this.getText("dissolve-delay-text");
+  }
+
+  getDissolveBonus(): Promise<string> {
+    return this.getText("dissolve-bonus-text");
+  }
+
+  hasIncreaseDissolveDelayButton(): Promise<boolean> {
+    return this.getButton("sns-increase-dissolve-delay").isPresent();
+  }
+}

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -37,7 +37,7 @@ export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
     return SnsNeuronDissolveDelayActionItemPo.under(this.root);
   }
 
-  hasDisslveDelayItemActionPo(): Promise<boolean> {
+  hasDissolveDelayItemActionPo(): Promise<boolean> {
     return this.getDisslveDelayItemActionPo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -1,7 +1,8 @@
+import { SnsNeuronDissolveDelayActionItemPo } from "$tests/page-objects/SnsNeuronDissolveDelayActionItem.page-object";
+import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
+import { SnsStakeItemActionPo } from "$tests/page-objects/SnsStakeItemAction.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SnsNeuronStateItemActionPo } from "./SnsNeuronStateItemAction.page-object";
-import { SnsStakeItemActionPo } from "./SnsStakeItemAction.page-object";
 
 export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-voting-power-section-component";
@@ -30,5 +31,13 @@ export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
 
   hasStateItemAction(): Promise<boolean> {
     return this.getStateItemActionPo().isPresent();
+  }
+
+  getDisslveDelayItemActionPo(): SnsNeuronDissolveDelayActionItemPo {
+    return SnsNeuronDissolveDelayActionItemPo.under(this.root);
+  }
+
+  hasDisslveDelayItemActionPo(): Promise<boolean> {
+    return this.getDisslveDelayItemActionPo().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

We are shuffling data in the neuron details to make it more user friendly.

In this PR: Render the information about the dissolve delay in the sns neuron detail.

# Changes

* New component SnsNeuronDissolveDelayActionItem.
* Use new component in SnsNeuronVotingPowerSection.
* Add new prop "variant" to IncreaseSnsDissolveDelayButton.

# Tests

* New test file and PO for new component SnsNeuronDissolveDelayActionItem.
* Test that new action is rendered in SnsNeuronVotingPowerSection.

# Todos

Not yet worth an entry in the changelog.
