### PR TITLE
GIX-1686: SnsNeuronAdvancedSection actions

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -3,16 +3,22 @@
   import { KeyValuePair, Section } from "@dfinity/gix-components";
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import Hash from "../ui/Hash.svelte";
-  import type { SnsNeuron } from "@dfinity/sns";
+  import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
   import SnsNeuronAge from "../sns-neurons/SnsNeuronAge.svelte";
   import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger";
   import type { Principal } from "@dfinity/principal";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, type Token } from "@dfinity/utils";
   import SnsNeuronVestingPeriodRemaining from "./SnsNeuronVestingPeriodRemaining.svelte";
+  import SnsAutoStakeMaturity from "./actions/SnsAutoStakeMaturity.svelte";
+  import SplitSnsNeuronButton from "./actions/SplitSnsNeuronButton.svelte";
+  import type { E8s } from "@dfinity/nns";
 
   export let governanceCanisterId: Principal | undefined;
   export let neuron: SnsNeuron;
+  export let parameters: SnsNervousSystemParameters;
+  export let transactionFee: E8s;
+  export let token: Token;
 
   let neuronAccount: IcrcAccount | undefined;
   $: neuronAccount = nonNullish(governanceCanisterId)
@@ -69,6 +75,8 @@
       {/if}
       <SnsNeuronVestingPeriodRemaining {neuron} />
     {/if}
+    <SnsAutoStakeMaturity />
+    <SplitSnsNeuronButton {neuron} {parameters} {transactionFee} {token} />
   </div>
 </Section>
 
@@ -83,5 +91,8 @@
     flex-direction: column;
     align-items: flex-start;
     gap: var(--padding-2x);
+
+    --checkbox-padding: 0;
+    --checkbox-label-order: 1;
   }
 </style>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -156,7 +156,7 @@
           <SkeletonCard cardType="info" separator />
           <SkeletonCard cardType="info" separator />
         {:else}
-          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron)}
+          {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron) && nonNullish(transactionFee)}
             <div class="section-wrapper">
               <SnsNeuronPageHeader />
               <SnsNeuronPageHeading {parameters} />
@@ -172,6 +172,9 @@
               <SnsNeuronAdvancedSection
                 neuron={$selectedSnsNeuronStore.neuron}
                 {governanceCanisterId}
+                {parameters}
+                {token}
+                {transactionFee}
               />
             </div>
           {/if}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -5,20 +5,30 @@
 import SnsNeuronAdvancedSection from "$lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte";
 import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import {
+  createMockSnsNeuron,
+  snsNervousSystemParametersMock,
+} from "$tests/mocks/sns-neurons.mock";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronAdvancedSectionPo } from "$tests/page-objects/SnsNeuronAdvancedSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
-import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronAdvancedSection", () => {
   const nowInSeconds = 1689843195;
   const renderComponent = (neuron: SnsNeuron) => {
-    const { container } = render(SnsNeuronAdvancedSection, {
+    const { container } = renderSelectedSnsNeuronContext({
+      Component: SnsNeuronAdvancedSection,
+      neuron,
+      reload: () => undefined,
       props: {
         neuron,
         governanceCanisterId: mockPrincipal,
+        parameters: snsNervousSystemParametersMock,
+        token: mockToken,
+        transactionFee: 10_000n,
       },
     });
 
@@ -51,5 +61,17 @@ describe("SnsNeuronAdvancedSection", () => {
     );
     expect(await po.neuronAge()).toBe("20 days, 10 hours");
     expect(await po.neuronAccount()).toBe("xlmdg-v...813ee24");
+  });
+
+  it("should render actions", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      stake: 314_000_000n,
+      maturity: 100_000_000n,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.hasSplitNeuronButton()).toBe(true);
+    expect(await po.hasStakeMaturityCheckbox()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -39,4 +39,14 @@ export class SnsNeuronAdvancedSectionPo extends BasePageObject {
   vestingPeriodIsPresent(): Promise<boolean> {
     return this.getVestingPeriodPo().vestingPeriodIsPresent();
   }
+
+  hasStakeMaturityCheckbox(): Promise<boolean> {
+    return this.root
+      .byTestId("auto-stake-maturity-checkbox-component")
+      .isPresent();
+  }
+
+  hasSplitNeuronButton(): Promise<boolean> {
+    return this.getButton("split-neuron-button").isPresent();
+  }
 }


### PR DESCRIPTION
# Motivation

We are shuffling the data in the neuron detail to make it more user friendly.

In this PR: Add the action items in the sns neuron advanced section.

# Changes

* Render the auto stake maturity and split button in the SnsNeuronAdvancedSection.

# Tests

* Add test to check that actions are present.

# Todos

Not yet worth an entry in the changelog.
