### PR TITLE
GIX-1745: Neuron Settings Feature Flags flips between old and new UI

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -28,6 +28,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Not Published
 
+* New NNS and SNS neuron details page layout.
+
 ### Operations
 
 #### Added

--- a/frontend/src/lib/components/neuron-detail/NeuronJoinFundCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronJoinFundCard.svelte
@@ -7,6 +7,7 @@
   import JoinCommunityFundCheckbox from "./actions/JoinCommunityFundCheckbox.svelte";
   import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -17,23 +18,25 @@
   });
 </script>
 
-{#if isControlledByUser}
-  <CardInfo>
-    <KeyValuePairInfo testId="join-community-fund">
-      <h3 slot="key">{$i18n.neurons.community_fund_title}</h3>
+<TestIdWrapper testId="neuron-join-fund-card-component">
+  {#if isControlledByUser}
+    <CardInfo>
+      <KeyValuePairInfo testId="join-community-fund">
+        <h3 slot="key">{$i18n.neurons.community_fund_title}</h3>
 
-      <div class="info" slot="info">
-        <Html text={$i18n.neuron_detail.community_fund_more_info} />
+        <div class="info" slot="info">
+          <Html text={$i18n.neuron_detail.community_fund_more_info} />
+        </div>
+      </KeyValuePairInfo>
+
+      <div class="join">
+        <JoinCommunityFundCheckbox {neuron} />
       </div>
-    </KeyValuePairInfo>
+    </CardInfo>
 
-    <div class="join">
-      <JoinCommunityFundCheckbox {neuron} />
-    </div>
-  </CardInfo>
-
-  <Separator />
-{/if}
+    <Separator />
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   h3 {

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -159,14 +159,16 @@
               <NnsNeuronMaturitySection {neuron} />
               <Separator spacing="none" />
               <NnsNeuronAdvancedSection {neuron} />
+              <Separator spacing="none" />
             </div>
-          {/if}
-          <Summary displayUniverse={false} />
+          {:else}
+            <Summary displayUniverse={false} />
 
-          <NnsNeuronMetaInfoCard {neuron} />
-          <NnsNeuronInfoStake {neuron} />
-          <NnsNeuronMaturityCard {neuron} />
-          <NeuronJoinFundCard {neuron} />
+            <NnsNeuronMetaInfoCard {neuron} />
+            <NnsNeuronInfoStake {neuron} />
+            <NnsNeuronMaturityCard {neuron} />
+            <NeuronJoinFundCard {neuron} />
+          {/if}
           <NeuronFollowingCard {neuron} />
 
           {#if IS_TESTNET}
@@ -192,6 +194,6 @@
   .section-wrapper {
     display: flex;
     flex-direction: column;
-    gap: var(--padding-3x);
+    gap: var(--padding-4x);
   }
 </style>

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -190,17 +190,19 @@
                 {token}
                 {transactionFee}
               />
+              <Separator spacing="none" />
             </div>
-          {/if}
-          <Summary />
-
-          {#if nonNullish(transactionFee) && nonNullish(parameters) && nonNullish(token)}
-            <SnsNeuronMetaInfoCard {parameters} {transactionFee} {token} />
           {:else}
-            <SkeletonCard size="large" cardType="info" separator />
+            <Summary />
+
+            {#if nonNullish(transactionFee) && nonNullish(parameters) && nonNullish(token)}
+              <SnsNeuronMetaInfoCard {parameters} {transactionFee} {token} />
+            {:else}
+              <SkeletonCard size="large" cardType="info" separator />
+            {/if}
+            <SnsNeuronInfoStake />
+            <SnsNeuronMaturityCard />
           {/if}
-          <SnsNeuronInfoStake />
-          <SnsNeuronMaturityCard />
           <SnsNeuronFollowingCard />
           {#if nonNullish(parameters)}
             <SnsNeuronHotkeysCard {parameters} />
@@ -221,6 +223,6 @@
   .section-wrapper {
     display: flex;
     flex-direction: column;
-    gap: var(--padding-3x);
+    gap: var(--padding-4x);
   }
 </style>

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -42,6 +42,17 @@ describe("NeuronDetail", () => {
       new Date("1992-05-22T21:00:00").getTime() / 1000
     ),
   };
+  const renderComponent = async (neuronId: string) => {
+    const { container } = render(NnsNeuronDetail, {
+      props: {
+        neuronIdText: neuronId,
+      },
+    });
+
+    await runResolvedPromises();
+
+    return NnsNeuronDetailPo.under(new JestPageObjectElement(container));
+  };
 
   const querySkeleton = (container: HTMLElement): HTMLElement | null =>
     container.querySelector('[data-tid="skeleton-card"]');
@@ -54,18 +65,6 @@ describe("NeuronDetail", () => {
   });
 
   describe("when new neuron details page", () => {
-    const renderComponent = async (neuronId: string) => {
-      const { container } = render(NnsNeuronDetail, {
-        props: {
-          neuronIdText: neuronId,
-        },
-      });
-
-      await runResolvedPromises();
-
-      return NnsNeuronDetailPo.under(new JestPageObjectElement(container));
-    };
-
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_SETTINGS", true);
     });
@@ -73,6 +72,15 @@ describe("NeuronDetail", () => {
     it("renders new sections", async () => {
       const po = await renderComponent(`${neuronId}`);
 
+      // Old components
+      expect(await po.getMaturityCardPo().isPresent()).toBe(false);
+      expect(await po.getNnsNeuronMetaInfoCardPageObjectPo().isPresent()).toBe(
+        false
+      );
+      expect(await po.getNnsNeuronInfoStakePo().isPresent()).toBe(false);
+      expect(await po.hasJoinFundCard()).toBe(false);
+
+      // New components
       expect(await po.getVotingPowerSectionPo().isPresent()).toBe(true);
       expect(await po.getMaturitySectionPo().isPresent()).toBe(true);
       expect(await po.getAdvancedSectionPo().isPresent()).toBe(true);
@@ -82,6 +90,23 @@ describe("NeuronDetail", () => {
   describe("when old neuron details page", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_SETTINGS", false);
+    });
+
+    it("renders old sections", async () => {
+      const po = await renderComponent(`${neuronId}`);
+
+      // Old components
+      expect(await po.getMaturityCardPo().isPresent()).toBe(true);
+      expect(await po.getNnsNeuronMetaInfoCardPageObjectPo().isPresent()).toBe(
+        true
+      );
+      expect(await po.getNnsNeuronInfoStakePo().isPresent()).toBe(true);
+      expect(await po.hasJoinFundCard()).toBe(true);
+
+      // New components
+      expect(await po.getVotingPowerSectionPo().isPresent()).toBe(false);
+      expect(await po.getMaturitySectionPo().isPresent()).toBe(false);
+      expect(await po.getAdvancedSectionPo().isPresent()).toBe(false);
     });
 
     it("should query neurons", async () => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -12,6 +12,7 @@ import {
 import { pageStore } from "$lib/derived/page.derived";
 import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
@@ -117,6 +118,40 @@ describe("SnsNeuronDetail", () => {
   const validNeuronIdAsHexString = subaccountToHexString(validNeuronId.id);
   const neuronStake = 1;
 
+  describe("with new settings", () => {
+    beforeEach(() => {
+      page.mock({
+        data: { universe: rootCanisterIdMock.toText() },
+        routeId: AppPath.Neuron,
+      });
+
+      fakeSnsGovernanceApi.addNeuronWith({
+        rootCanisterId,
+        id: [validNeuronId],
+        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+      });
+
+      overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_SETTINGS", true);
+    });
+
+    it("should render new sections", async () => {
+      const po = await renderComponent({
+        neuronId: validNeuronIdAsHexString,
+      });
+
+      // Old cards should not be present
+      expect(await po.getMetaInfoCardPo().isPresent()).toBe(false);
+      expect(await po.getMaturityCardPo().isPresent()).toBe(false);
+      expect(await po.getStakeCardPo().isPresent()).toBe(false);
+
+      expect(await po.getVotingPowerSectionPo().isPresent()).toBe(true);
+      expect(await po.getMaturitySectionPo().isPresent()).toBe(true);
+      expect(await po.getAdvancedSectionPo().isPresent()).toBe(true);
+      expect(await po.getFollowingCardPo().isPresent()).toBe(true);
+      expect(await po.getHotkeysCardPo().isPresent()).toBe(true);
+    });
+  });
+
   describe("when neuron and projects are valid and present", () => {
     const props = {
       neuronId: validNeuronIdAsHexString,
@@ -132,6 +167,8 @@ describe("SnsNeuronDetail", () => {
         id: [validNeuronId],
         cached_neuron_stake_e8s: numberToE8s(neuronStake),
       });
+
+      overrideFeatureFlagsStore.setFlag("ENABLE_NEURON_SETTINGS", false);
     });
 
     it("should load neuron details", async () => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -186,6 +186,11 @@ describe("SnsNeuronDetail", () => {
     it("should render cards", async () => {
       const po = await renderComponent(props);
 
+      // New sections
+      expect(await po.getVotingPowerSectionPo().isPresent()).toBe(false);
+      expect(await po.getMaturitySectionPo().isPresent()).toBe(false);
+      expect(await po.getAdvancedSectionPo().isPresent()).toBe(false);
+
       expect(await po.getMetaInfoCardPo().isPresent()).toBe(true);
       expect(await po.getHotkeysCardPo().isPresent()).toBe(true);
       expect(await po.getMetaInfoCardPo().isPresent()).toBe(true);

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -1,7 +1,10 @@
+import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvancedSection.page-object";
 import { NnsNeuronInfoStakePo } from "$tests/page-objects/NnsNeuronInfoStake.page-object";
 import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
+import { NnsNeuronMaturitySectionPo } from "$tests/page-objects/NnsNeuronMaturitySection.page-object";
 import { NnsNeuronMetaInfoCardPageObjectPo } from "$tests/page-objects/NnsNeuronMetaInfoCard.page-object";
 import { NnsNeuronModalsPo } from "$tests/page-objects/NnsNeuronModals.page-object";
+import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -52,5 +55,17 @@ export class NnsNeuronDetailPo extends BasePageObject {
     await this.getNnsNeuronModalsPo()
       .getDisburseNnsNeuronModalPo()
       .disburseNeuron();
+  }
+
+  getVotingPowerSectionPo(): NnsNeuronVotingPowerSectionPo {
+    return NnsNeuronVotingPowerSectionPo.under(this.root);
+  }
+
+  getMaturitySectionPo(): NnsNeuronMaturitySectionPo {
+    return NnsNeuronMaturitySectionPo.under(this.root);
+  }
+
+  getAdvancedSectionPo(): NnsNeuronAdvancedSectionPo {
+    return NnsNeuronAdvancedSectionPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -50,6 +50,15 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return NnsNeuronMaturityCardPo.under(this.root);
   }
 
+  getStakeInfoCardPo() {
+    return NnsNeuronInfoStakePo;
+  }
+
+  // TODO: To be removed https://dfinity.atlassian.net/browse/GIX-1688
+  hasJoinFundCard(): Promise<boolean> {
+    return this.root.byTestId("neuron-join-fund-card-component").isPresent();
+  }
+
   async disburseNeuron(): Promise<void> {
     await this.getNnsNeuronInfoStakePo().clickDisburse();
     await this.getNnsNeuronModalsPo()

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -1,11 +1,14 @@
 import { AddSnsHotkeyModalPo } from "$tests/page-objects/AddSnsHotkeyModal.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsIncreaseStakeNeuronModalPo } from "$tests/page-objects/SnsIncreaseStakeNeuronModal.page-object";
+import { SnsNeuronAdvancedSectionPo } from "$tests/page-objects/SnsNeuronAdvancedSection.page-object";
 import { SnsNeuronFollowingCardPo } from "$tests/page-objects/SnsNeuronFollowingCard.page-object";
 import { SnsNeuronHotkeysCardPo } from "$tests/page-objects/SnsNeuronHotkeysCard.page-object";
 import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
 import { SnsNeuronMaturityCardPo } from "$tests/page-objects/SnsNeuronMaturityCard.page-object";
+import { SnsNeuronMaturitySectionPo } from "$tests/page-objects/SnsNeuronMaturitySection.page-object";
 import { SnsNeuronMetaInfoCardPo } from "$tests/page-objects/SnsNeuronMetaInfoCard.page-object";
+import { SnsNeuronVotingPowerSectionPo } from "$tests/page-objects/SnsNeuronVotingPowerSection.page-object";
 import { SummaryPo } from "$tests/page-objects/Summary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -86,5 +89,17 @@ export class SnsNeuronDetailPo extends BasePageObject {
 
   getHotkeyPrincipals(): Promise<string[]> {
     return this.getHotkeysCardPo().getHotkeyPrincipals();
+  }
+
+  getVotingPowerSectionPo(): SnsNeuronVotingPowerSectionPo {
+    return SnsNeuronVotingPowerSectionPo.under(this.root);
+  }
+
+  getMaturitySectionPo(): SnsNeuronMaturitySectionPo {
+    return SnsNeuronMaturitySectionPo.under(this.root);
+  }
+
+  getAdvancedSectionPo(): SnsNeuronAdvancedSectionPo {
+    return SnsNeuronAdvancedSectionPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

We are shuffling data in the neuron details page.

In this PR: The feature flag flips between the old and new UI.

# Changes

* Add the old cards of NnsNeuronDetails inside the "else" statement of the ENABLE_NEURON_SETTINGS
* Add the old cards of SnsNeuronDetails inside the "else" statement of the ENABLE_NEURON_SETTINGS
* Increase spacing between sections to adapt to old design. There is a task to fix that onece we are fully in the new design.

# Tests

* Test new sections are rendered in NnsNeuronDetails and SnsNeuronDetails. Add getters to the POs.

# Todos

- [x] Add entry to changelog (if necessary).
