### PR TITLE
Chore: Rename ageSinceSeconds parameter

### DIFF
--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -51,7 +51,7 @@ describe("SnsNeuronAdvancedSection", () => {
     const neuron = createMockSnsNeuron({
       id,
       createdTimestampSeconds: created,
-      ageSinceSeconds: created + BigInt(SECONDS_IN_DAY * 10),
+      ageSinceTimestampSeconds: created + BigInt(SECONDS_IN_DAY * 10),
     });
     const po = renderComponent(neuron);
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -151,7 +151,7 @@ describe("SnsNeuronMetaInfoCard", () => {
       id: [1],
       state: NeuronState.Locked,
       votingPowerMultiplier: 100n,
-      ageSinceSeconds: BigInt(nowSeconds) - 200n,
+      ageSinceTimestampSeconds: BigInt(nowSeconds) - 200n,
       dissolveDelaySeconds: maxDissolveDelay - 200n,
     });
     const snsParameters: SnsNervousSystemParameters = {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -71,7 +71,7 @@ describe("SnsNeuronStateItemAction", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
-      ageSinceSeconds: BigInt(nowInSeconds - SECONDS_IN_FOUR_YEARS),
+      ageSinceTimestampSeconds: BigInt(nowInSeconds - SECONDS_IN_FOUR_YEARS),
     });
     const po = renderComponent(neuron);
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPower.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPower.spec.ts
@@ -24,7 +24,7 @@ describe("SnsNeuronVotingPower", () => {
     id: [1],
     state: NeuronState.Locked,
     votingPowerMultiplier: 100n,
-    ageSinceSeconds: BigInt(nowSeconds) - 200n,
+    ageSinceTimestampSeconds: BigInt(nowSeconds) - 200n,
     dissolveDelaySeconds: maxDissolveDelay - 200n,
   });
   const parameters: SnsNervousSystemParameters = {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerExplanation.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerExplanation.spec.ts
@@ -51,7 +51,7 @@ describe("SnsNeuronVotingPowerExplanation", () => {
       stakedMaturity: 800_000_000n,
       id: [1],
       state: NeuronState.Locked,
-      ageSinceSeconds: BigInt(nowSeconds) - 200n,
+      ageSinceTimestampSeconds: BigInt(nowSeconds) - 200n,
       dissolveDelaySeconds: maxDissolveDelay - 200n,
       votingPowerMultiplier: 100n,
     });
@@ -68,7 +68,7 @@ describe("SnsNeuronVotingPowerExplanation", () => {
       stakedMaturity: 800_000_000n,
       id: [1],
       state: NeuronState.Locked,
-      ageSinceSeconds: BigInt(nowSeconds) - 200n,
+      ageSinceTimestampSeconds: BigInt(nowSeconds) - 200n,
       dissolveDelaySeconds: maxDissolveDelay - 200n,
       votingPowerMultiplier: 50n,
     });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -44,7 +44,7 @@ describe("NnsStakeItemAction", () => {
       stakedMaturity: 100000000n,
       state: NeuronState.Locked,
       dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
-      ageSinceSeconds: BigInt(nowInSeconds - SECONDS_IN_YEAR),
+      ageSinceTimestampSeconds: BigInt(nowInSeconds - SECONDS_IN_YEAR),
     });
     const po = renderComponent(neuron);
 

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -33,7 +33,7 @@ export const createMockSnsNeuron = ({
   whenDissolvedTimestampSeconds = BigInt(
     Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
   ),
-  ageSinceSeconds = BigInt(1000),
+  ageSinceTimestampSeconds = BigInt(1000),
   stakedMaturity = BigInt(100_000_000),
   maturity = BigInt(100_000_000),
   createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
@@ -49,7 +49,7 @@ export const createMockSnsNeuron = ({
   votingPowerMultiplier?: bigint;
   dissolveDelaySeconds?: bigint;
   whenDissolvedTimestampSeconds?: bigint;
-  ageSinceSeconds?: bigint;
+  ageSinceTimestampSeconds?: bigint;
   stakedMaturity?: bigint;
   maturity?: bigint;
   createdTimestampSeconds?: bigint;
@@ -63,7 +63,7 @@ export const createMockSnsNeuron = ({
     created_timestamp_seconds: createdTimestampSeconds,
     staked_maturity_e8s_equivalent: [stakedMaturity],
     auto_stake_maturity: [],
-    aging_since_timestamp_seconds: ageSinceSeconds,
+    aging_since_timestamp_seconds: ageSinceTimestampSeconds,
     voting_power_percentage_multiplier: votingPowerMultiplier,
     dissolve_state:
       state === undefined || state === NeuronState.Dissolved


### PR DESCRIPTION
# Motivation

Rename the parameter `ageSinceSeconds` of `createMockSnsNeuron` due to misunderstanding that it's a timestamp, not a duration.

# Changes

* Rename parameter `ageSinceSeconds` to `ageSinceTimestampSeconds` in `createMockSnsNeuron`.

# Tests

Only rename, no new tests.

# Todos

Not worth a changelog entry.