### PR TITLE
GIX-1745: Test NnsNeuronDetail with new UI

### DIFF
--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -31,6 +31,8 @@ const neurons: Map<string, NeuronInfo[]> = new Map();
 
 const mapKey = (identity: Identity) => identity.getPrincipal().toText();
 
+let latestRewardEvent: RewardEvent = mockRewardEvent;
+
 const getNeurons = (identity: Identity) => {
   const key = mapKey(identity);
   let neuronList = neurons.get(key);
@@ -74,7 +76,7 @@ async function queryLastestRewardEvent({
   identity: _,
   certified: __,
 }: ApiQueryParams): Promise<RewardEvent> {
-  return mockRewardEvent;
+  return latestRewardEvent;
 }
 
 async function mergeNeurons({
@@ -169,6 +171,12 @@ export const addNeurons = ({
   for (const neuron of neurons) {
     addNeuronWith({ identity, ...neuron });
   }
+};
+
+export const setLatestRewardEvent = (
+  latestRewardEventParams: Partial<RewardEvent>
+) => {
+  latestRewardEvent = { ...latestRewardEvent, ...latestRewardEventParams };
 };
 
 // Call this inside a describe() block outside beforeEach() because it defines

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -137,9 +137,9 @@ describe("NeuronDetail", () => {
         canisterId: OWN_CANISTER_ID,
       });
 
-      await waitFor(async () =>
-        expect((await po.getSkeletonCardPos()).length).toBeGreaterThan(0)
-      );
+      await po.getSkeletonCardPo().waitFor();
+
+      expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
     });
 
     it("should render last maturity distribution", async () => {

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -115,8 +115,6 @@ describe("NeuronDetail", () => {
       fakeGovernanceApi.resume();
 
       await po.getSkeletonCardPo().waitForAbsent();
-
-      expect((await po.getSkeletonCardPos()).length).toBe(0);
     });
 
     it("should show the proper neuron id", async () => {
@@ -143,8 +141,6 @@ describe("NeuronDetail", () => {
       });
 
       await po.getSkeletonCardPo().waitFor();
-
-      expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
     });
 
     it("should render last maturity distribution", async () => {

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -85,6 +85,70 @@ describe("NeuronDetail", () => {
       expect(await po.getMaturitySectionPo().isPresent()).toBe(true);
       expect(await po.getAdvancedSectionPo().isPresent()).toBe(true);
     });
+
+    it("should display skeletons", async () => {
+      const { container } = render(NnsNeuronDetail, {
+        props: {
+          neuronIdText: `${neuronId}`,
+        },
+      });
+
+      const po = NnsNeuronDetailPo.under(new JestPageObjectElement(container));
+
+      expect((await po.getSkeletonCardPos()).length).toBeGreaterThan(0);
+    });
+
+    it("should hide skeletons after neuron data are available", async () => {
+      const { container } = render(NnsNeuronDetail, {
+        props: {
+          neuronIdText: `${neuronId}`,
+        },
+      });
+
+      const po = NnsNeuronDetailPo.under(new JestPageObjectElement(container));
+
+      expect((await po.getSkeletonCardPos()).length).toBeGreaterThan(0);
+
+      await runResolvedPromises();
+
+      expect((await po.getSkeletonCardPos()).length).toBe(0);
+    });
+
+    it("should show the proper neuron id", async () => {
+      const po = await renderComponent(`${neuronId}`);
+
+      expect(await po.getNeuronId()).toEqual(`${neuronId}`);
+    });
+
+    it("should render nns project name", async () => {
+      const po = await renderComponent(`${neuronId}`);
+
+      expect(await po.getUniverse()).toBe("Internet Computer");
+    });
+
+    it("should show skeletons when neuron is in voting process", async () => {
+      const po = await renderComponent(`${neuronId}`);
+
+      expect((await po.getSkeletonCardPos()).length).toBe(0);
+
+      voteRegistrationStore.add({
+        ...mockVoteRegistration,
+        neuronIdStrings: [`${neuronId}`],
+        canisterId: OWN_CANISTER_ID,
+      });
+
+      await waitFor(async () =>
+        expect((await po.getSkeletonCardPos()).length).toBeGreaterThan(0)
+      );
+    });
+
+    it("should render last maturity distribution", async () => {
+      const po = await renderComponent(`${neuronId}`);
+
+      expect(await po.getAdvancedSectionPo().lastRewardsDistribution()).toEqual(
+        "May 19, 1992"
+      );
+    });
   });
 
   describe("when old neuron details page", () => {

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -21,6 +21,10 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return SkeletonCardPo.allUnder(this.root);
   }
 
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
   getNnsNeuronMetaInfoCardPageObjectPo(): NnsNeuronMetaInfoCardPageObjectPo {
     return NnsNeuronMetaInfoCardPageObjectPo.under(this.root);
   }
@@ -49,10 +53,6 @@ export class NnsNeuronDetailPo extends BasePageObject {
 
   getMaturityCardPo(): NnsNeuronMaturityCardPo {
     return NnsNeuronMaturityCardPo.under(this.root);
-  }
-
-  getStakeInfoCardPo() {
-    return NnsNeuronInfoStakePo;
   }
 
   // TODO: To be removed https://dfinity.atlassian.net/browse/GIX-1688

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -8,6 +8,7 @@ import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVoti
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { NnsNeuronPageHeaderPo } from "./NnsNeuronPageHeader.page-object";
 
 export class NnsNeuronDetailPo extends BasePageObject {
   private static readonly TID = "nns-neuron-detail-component";
@@ -64,6 +65,18 @@ export class NnsNeuronDetailPo extends BasePageObject {
     await this.getNnsNeuronModalsPo()
       .getDisburseNnsNeuronModalPo()
       .disburseNeuron();
+  }
+
+  getPageHeaderPo(): NnsNeuronPageHeaderPo {
+    return NnsNeuronPageHeaderPo.under(this.root);
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getPageHeaderPo().getNeuronId();
+  }
+
+  getUniverse(): Promise<string> {
+    return this.getPageHeaderPo().getUniverse();
   }
 
   getVotingPowerSectionPo(): NnsNeuronVotingPowerSectionPo {

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeader.page-object.ts
@@ -18,4 +18,8 @@ export class NnsNeuronPageHeaderPo extends BasePageObject {
   getUniverse(): Promise<string> {
     return this.getUniversePageSummaryPo().getTitle();
   }
+
+  getNeuronId(): Promise<string> {
+    return this.root.byTestId("identifier").getText();
+  }
 }


### PR DESCRIPTION
# Motivation

We are shuffling data in the neuron details page to make it more user friendly.

In this PR: Add same tests for neuron detail when new UI is enabled.

In another PR: There are two pending tests that need logic in the component and will be done in another task: https://dfinity.atlassian.net/browse/GIX-1764

# Changes

* Add the same test cases in NnsNeuronDetail for old UI in the new UI.
* Add some methods in NnsNeuronDetailPo and NnsNeuronPageHeaderPo.

# Tests

Only test changes.

# Todos

Not worth a specific changelog entry.
