### PR TITLE
Chore: Refactor SnsNeuronMaturitySection to have neuron prop

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.svelte
@@ -5,18 +5,8 @@
   import SnsAvailableMaturityActionItem from "./SnsAvailableMaturityActionItem.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { formattedTotalMaturity } from "$lib/utils/sns-neuron.utils";
-  import {
-    SELECTED_SNS_NEURON_CONTEXT_KEY,
-    type SelectedSnsNeuronContext,
-  } from "$lib/types/sns-neuron-detail.context";
-  import { getContext } from "svelte";
-  import { nonNullish } from "@dfinity/utils";
 
-  const { store }: SelectedSnsNeuronContext =
-    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-
-  let neuron: SnsNeuron | undefined | null;
-  $: neuron = $store.neuron;
+  export let neuron: SnsNeuron;
 </script>
 
 <Section testId="sns-neuron-maturity-section-component">
@@ -27,12 +17,10 @@
   <p slot="description">
     {$i18n.neuron_detail.maturity_section_description}
   </p>
-  {#if nonNullish(neuron)}
-    <ul class="content">
-      <SnsStakedMaturityActionItem {neuron} />
-      <SnsAvailableMaturityActionItem {neuron} />
-    </ul>
-  {/if}
+  <ul class="content">
+    <SnsStakedMaturityActionItem {neuron} />
+    <SnsAvailableMaturityActionItem {neuron} />
+  </ul>
 </Section>
 
 <style lang="scss">

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -181,7 +181,9 @@
                 {token}
               />
               <Separator spacing="none" />
-              <SnsNeuronMaturitySection />
+              <SnsNeuronMaturitySection
+                neuron={$selectedSnsNeuronStore.neuron}
+              />
               <Separator spacing="none" />
               <SnsNeuronAdvancedSection
                 neuron={$selectedSnsNeuronStore.neuron}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
@@ -21,6 +21,7 @@ describe("SnsNeuronMaturitySection", () => {
     const { container } = render(NeuronContextActionsTest, {
       props: {
         neuron,
+        passPropNeuron: true,
         rootCanisterId: mockCanisterId,
         testComponent: SnsNeuronMaturitySection,
       },


### PR DESCRIPTION
# Motivation

Refactor the SnsNeuronMaturitySection to expect the neuron as prop instead of reading the context.

# Changes

* Add prop `neuron` in SnsNeuronMaturitySection.

# Tests

* Pass the neuron as prop.

# Todos

Not worth a changelog entry.
