### PR TITLE
E2E flakiness: Don't vote on proposal created by a different test

### DIFF
--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { Card, KeyValuePair, Value } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import type { ProposalStatusColor } from "$lib/constants/proposals.constants";
+  import {
+    type ProposalStatusColor,
+    PROPOSER_ID_DISPLAY_SPLIT_LENGTH,
+  } from "$lib/constants/proposals.constants";
   import Countdown from "./Countdown.svelte";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 
@@ -47,7 +50,10 @@
         <KeyValuePair testId="shortened-proposer">
           <span slot="key">{$i18n.proposal_detail.proposer_prefix}</span>
           <span slot="value" class="meta-data-value"
-            >{shortenWithMiddleEllipsis(proposer, 5)}</span
+            >{shortenWithMiddleEllipsis(
+              proposer,
+              PROPOSER_ID_DISPLAY_SPLIT_LENGTH
+            )}</span
           >
         </KeyValuePair>
       {/if}

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -44,7 +44,7 @@
       {/if}
 
       {#if proposer !== undefined}
-        <KeyValuePair>
+        <KeyValuePair testId="shortened-proposer">
           <span slot="key">{$i18n.proposal_detail.proposer_prefix}</span>
           <span slot="value" class="meta-data-value"
             >{shortenWithMiddleEllipsis(proposer, 5)}</span

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -43,3 +43,5 @@ export const PROPOSAL_COLOR: Record<
 };
 
 export const DEPRECATED_TOPICS = [Topic.SnsDecentralizationSale];
+
+export const PROPOSER_ID_DISPLAY_SPLIT_LENGTH = 5;

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -30,7 +30,7 @@ test("Test neuron voting", async ({ page, context }) => {
   const neuronId = neuronIds[0];
 
   step("Create dummy proposals");
-  await createDummyProposal(appPo);
+  const proposer = await createDummyProposal(appPo);
 
   step("Go to the neurons tab");
   await appPo.goToNeurons();
@@ -63,9 +63,11 @@ test("Test neuron voting", async ({ page, context }) => {
   expect(proposalIds.length).toBeGreaterThan(0);
 
   step("Open first proposal");
-  await (
-    await appPo.getProposalsPo().getNnsProposalListPo().getProposalCardPos()
-  )[0].click();
+  const proposalCard = await appPo
+    .getProposalsPo()
+    .getNnsProposalListPo()
+    .getFirstProposalCardPoForProposer(proposer);
+  await proposalCard.click();
   const proposalDetails = appPo.getProposalDetailPo().getNnsProposalPo();
   await proposalDetails.waitForContentLoaded();
   const initialAdoptVotingPower = await proposalDetails

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -72,6 +72,7 @@ export class NnsNeuronDetailPo extends BasePageObject {
   }
 
   // TODO: Remove when ENABLE_NEURON_SETTINGS is cleaned up.
+  //       See https://dfinity.atlassian.net/browse/GIX-1688
   getNeuronIdOldUi(): Promise<string | null> {
     return this.getNnsNeuronMetaInfoCardPageObjectPo().getNeuronId();
   }
@@ -81,6 +82,7 @@ export class NnsNeuronDetailPo extends BasePageObject {
   }
 
   // TODO: Remove when ENABLE_NEURON_SETTINGS is cleaned up.
+  //       See https://dfinity.atlassian.net/browse/GIX-1688
   async isNewUi(): Promise<boolean> {
     await Promise.race([
       this.getNnsNeuronMetaInfoCardPageObjectPo().waitFor(),

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -46,6 +46,10 @@ export class NnsNeuronDetailPo extends BasePageObject {
     );
   }
 
+  getNeuronId(): Promise<string> {
+    return this.getNnsNeuronMetaInfoCardPageObjectPo().getNeuronId();
+  }
+
   getMaturityCardPo(): NnsNeuronMaturityCardPo {
     return NnsNeuronMaturityCardPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -51,10 +51,6 @@ export class NnsNeuronDetailPo extends BasePageObject {
     );
   }
 
-  getNeuronId(): Promise<string> {
-    return this.getNnsNeuronMetaInfoCardPageObjectPo().getNeuronId();
-  }
-
   getMaturityCardPo(): NnsNeuronMaturityCardPo {
     return NnsNeuronMaturityCardPo.under(this.root);
   }
@@ -75,8 +71,30 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return NnsNeuronPageHeaderPo.under(this.root);
   }
 
-  getNeuronId(): Promise<string> {
+  // TODO: Remove when ENABLE_NEURON_SETTINGS is cleaned up.
+  getNeuronIdOldUi(): Promise<string | null> {
+    return this.getNnsNeuronMetaInfoCardPageObjectPo().getNeuronId();
+  }
+
+  getNeuronIdNewUi(): Promise<string | null> {
     return this.getPageHeaderPo().getNeuronId();
+  }
+
+  // TODO: Remove when ENABLE_NEURON_SETTINGS is cleaned up.
+  async isNewUi(): Promise<boolean> {
+    await Promise.race([
+      this.getNnsNeuronMetaInfoCardPageObjectPo().waitFor(),
+      this.getPageHeaderPo().waitFor(),
+    ]);
+
+    return this.getPageHeaderPo().isPresent();
+  }
+
+  async getNeuronId(): Promise<string> {
+    if (await this.isNewUi()) {
+      return this.getNeuronIdNewUi();
+    }
+    return this.getNeuronIdOldUi();
   }
 
   getUniverse(): Promise<string> {

--- a/frontend/src/tests/page-objects/NnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMetaInfoCard.page-object.ts
@@ -1,3 +1,4 @@
+import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,6 +9,14 @@ export class NnsNeuronMetaInfoCardPageObjectPo extends BasePageObject {
     return new NnsNeuronMetaInfoCardPageObjectPo(
       element.byTestId(NnsNeuronMetaInfoCardPageObjectPo.TID)
     );
+  }
+
+  getNnsNeuronCardTitlePo(): NnsNeuronCardTitlePo {
+    return NnsNeuronCardTitlePo.under(this.root);
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getNnsNeuronCardTitlePo().getNeuronId();
   }
 
   async getVotingPower(): Promise<number> {

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -1,3 +1,4 @@
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -16,6 +17,21 @@ export class NnsProposalListPo extends BasePageObject {
 
   getProposalCardPos(): Promise<ProposalCardPo[]> {
     return ProposalCardPo.allUnder(this.root);
+  }
+
+  async getFirstProposalCardPoForProposer(
+    proposer: string
+  ): Promise<ProposalCardPo> {
+    const shortProposer = shortenWithMiddleEllipsis(proposer, 5);
+    const allCards = await this.getProposalCardPos();
+
+    for (const card of allCards) {
+      if ((await card.getShortenedProposer()) === shortProposer) {
+        return card;
+      }
+    }
+
+    throw new Error(`No proposal card found for proposer ${proposer}`);
   }
 
   async getProposalIds(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -1,3 +1,4 @@
+import { PROPOSER_ID_DISPLAY_SPLIT_LENGTH } from "$lib/constants/proposals.constants";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
@@ -22,7 +23,10 @@ export class NnsProposalListPo extends BasePageObject {
   async getFirstProposalCardPoForProposer(
     proposer: string
   ): Promise<ProposalCardPo> {
-    const shortProposer = shortenWithMiddleEllipsis(proposer, 5);
+    const shortProposer = shortenWithMiddleEllipsis(
+      proposer,
+      PROPOSER_ID_DISPLAY_SPLIT_LENGTH
+    );
     const allCards = await this.getProposalCardPos();
 
     for (const card of allCards) {

--- a/frontend/src/tests/page-objects/ProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalCard.page-object.ts
@@ -1,3 +1,4 @@
+import { KeyValuePairPo } from "$tests/page-objects/KeyValuePair.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -16,5 +17,12 @@ export class ProposalCardPo extends BasePageObject {
 
   getProposalId(): Promise<string> {
     return this.getText("proposal-id");
+  }
+
+  getShortenedProposer(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "shortened-proposer",
+    }).getValueText();
   }
 }

--- a/frontend/src/tests/utils/e2e.nns-proposals.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.nns-proposals.test-utils.ts
@@ -8,8 +8,10 @@ import { expect } from "@playwright/test";
  * 1. stake a neuron
  * 2. use the neuron to create dummy proposals
  * 3. disburse the neuron
+ *
+ * Returns the id of the neuron used to create the proposals.
  */
-export const createDummyProposal = async (appPo: AppPo) => {
+export const createDummyProposal = async (appPo: AppPo): Promise<string> => {
   const localStep = (message: string) =>
     step(`Create a dummy proposal > ${message}`);
 
@@ -38,5 +40,12 @@ export const createDummyProposal = async (appPo: AppPo) => {
   await localStep("Create dummy proposals");
   await appPo.getNeuronDetailPo().getNnsNeuronDetailPo().createDummyProposals();
 
+  const proposer = appPo
+    .getNeuronDetailPo()
+    .getNnsNeuronDetailPo()
+    .getNeuronId();
+
   await appPo.goBack();
+
+  return proposer;
 };


### PR DESCRIPTION
# Motivation

End-to-end tests run in parallel against the same environment.
Proposals or global objects and so proposals created in one test can be seen by proposals created in another test.
This causes flakiness when a proposal gets more votes than expected because another test is voting for it at the same time.
This is likely to happen because we run the same test with Chrome and Firefox, potentially at the same time.

# Changes

1. In `frontend/src/tests/e2e/neurons.spec.ts` record the proposer ID and then choose a proposal with that proposer to vote on. This makes sure that different tests vote on different proposals.
2. In `createDummyProposal` return the neuron ID used to create the dummy proposals.
3. Page object changes.

# Tests

I was able to reliably reproduce the issue by adding a delay after creating the proposals.
Then I made sure the issue no longer reproduced with the same delay in play, before removing the delay again.

# Todos

- [ ] Add entry to changelog (if necessary).

not necessary