### PR TITLE
fix: Always update the index.html

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -11,6 +11,7 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Added
 ### Changed
 ### Fixed
+* Update the index.html when it has changed.
 ### Security
 ### Not Published
 ### Removed

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -286,12 +286,10 @@ pub fn insert_favicon() {
 pub fn insert_home_page() {
     STATE.with(|state| {
         let path = "/index.html";
-        if state.stable.borrow().assets.borrow().get(path).is_none() {
-            let asset = Asset {
-                headers: Vec::new(),
-                bytes: include_bytes!("index.html").to_vec(),
-            };
-            insert_asset(path, asset);
-        }
+        let asset = Asset {
+            headers: Vec::new(),
+            bytes: include_bytes!("index.html").to_vec(),
+        };
+        insert_asset(path, asset);
     });
 }

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -267,29 +267,21 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 ///       issue in production, they may be misleading at best and may hide real
 ///       errors when developers examine the canister.
 pub fn insert_favicon() {
-    STATE.with(|state| {
-        // Ensure that there is a favicon, or else we get log spam about bad requests.
-        {
-            let favicon_path = "/favicon.ico";
-            if state.stable.borrow().assets.borrow().get(favicon_path).is_none() {
-                let asset = Asset {
-                    headers: Vec::new(),
-                    bytes: include_bytes!("favicon.ico").to_vec(),
-                };
-                insert_asset(favicon_path, asset);
-            }
-        }
-    });
+    // Ensure that there is a favicon, or else we get log spam about bad requests.
+    let favicon_path = "/favicon.ico";
+    let asset = Asset {
+        headers: Vec::new(),
+        bytes: include_bytes!("favicon.ico").to_vec(),
+    };
+    insert_asset(favicon_path, asset);
 }
 
 /// Insert a home page into the certified assets.
 pub fn insert_home_page() {
-    STATE.with(|state| {
-        let path = "/index.html";
-        let asset = Asset {
-            headers: Vec::new(),
-            bytes: include_bytes!("index.html").to_vec(),
-        };
-        insert_asset(path, asset);
-    });
+    let path = "/index.html";
+    let asset = Asset {
+        headers: Vec::new(),
+        bytes: include_bytes!("index.html").to_vec(),
+    };
+    insert_asset(path, asset);
 }

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -296,7 +296,7 @@
   <body>
     <main>
       <section>
-        <h1>SNS aggregator HAS CHANGED</h1>
+        <h1>SNS aggregator</h1>
         <p>
           The aggregator collects information on all deployed SNS and
           re-publishes aggegate values as certified query calls. This data is

--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -296,7 +296,7 @@
   <body>
     <main>
       <section>
-        <h1>SNS aggregator</h1>
+        <h1>SNS aggregator HAS CHANGED</h1>
         <p>
           The aggregator collects information on all deployed SNS and
           re-publishes aggegate values as certified query calls. This data is


### PR DESCRIPTION
# Motivation
The sns aggregator index.html is not updating.  This is because the index.html is saved with stable memory and not replaced if present.

# Changes
* Always replace the index.html when requested to install the index.html, rather than checking whether it is already there.
* Ditto for the favicon.

# Tests
* Deployed this PR to the app subnet, then again with a different HTML content, then again with the original HTML content.  In every case the displayed HTML after deployment was correct.

# Todos

- [x] Add entry to changelog (if necessary).
