### PR TITLE
tweak: Show app subnet deployment ref

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -116,7 +116,8 @@ jobs:
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary
           set -x
           {
-                  printf "## Deployed %s\n\nCommit: %s\nRef: %s\n\n" "${{ inputs.canisters }}" "$(git rev-parse HEAD)" "${{ github.ref }}"
+            commit="$(git rev-parse HEAD)"
+            printf "## Deployed %s\n\nCommit: %s\nRef: %s\n\n" "${{ inputs.canisters }}" "[$commit](https://github.com/dfinity/nns-dapp/commit/$commit)" "${{ github.ref }}"
             for canister in nns-dapp sns_aggregator ; do
               printf "## %s\n\n" "$canister"
               printf "URL:    "

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -115,8 +115,9 @@ jobs:
         run: |
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary
           set -x
-          for canister in nns-dapp sns_aggregator ; do
-            {
+          {
+            printf "# Deployed ${{ github.ref }}"
+            for canister in nns-dapp sns_aggregator ; do
               printf "## %s\n\n" "$canister"
               printf "URL:    "
               dfx-canister-url --network "$DFX_NETWORK" "$canister"
@@ -125,5 +126,5 @@ jobs:
               echo
               dfx canister info --network "$DFX_NETWORK" "$canister"
               echo
-            } >> $GITHUB_STEP_SUMMARY || true
-          done
+            done
+          } >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -40,77 +40,77 @@ jobs:
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
-#        # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
-#      - name: Get versions
-#        id: tool_versions
-#        run: echo "dfx=$(jq -r .dfx dfx.json)" >> "$GITHUB_OUTPUT"
-#      - name: Set credentials
-#        #        uses: aviate-labs/setup-dfx@v0.2.3
-#        #with:
-#        #  dfx-version: ${{ steps.tool_versions.outputs.dfx }}
-#        #  dfx-disable-encryption: true
-#        run: |
-#          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-#          printf "%s" "${{ secrets.DFX_IDENTITY_PEM }}" | dfx identity import --storage-mode=plaintext ci /dev/stdin
-#          dfx identity use ci
-#        env:
-#          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
-#      - name: Get SNS scripts
-#        uses: actions/checkout@v3
-#        with:
-#          repository: 'dfinity/snsdemo'
-#          path: 'snsdemo'
-#          # Version from 2023-06-06 with dfx v0.14.1
-#          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
-#      - name: Set up SNS scripts
-#        run: |
-#          : Install more
-#          sudo apt-get update -yy && sudo apt-get install -yy moreutils
-#          : Add scripts to the path
-#          echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
-#      - name: Verify identity
-#        run: |
-#          dfx identity whoami
-#          dfx identity get-principal
-#      - name: Set nns-dapp canister ID
-#        run: |
-#          set -x
-#          CANISTER_NAME="nns-dapp"
-#          export DFX_NETWORK CANISTER_NAME
-#          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-#          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$NNS_DAPP_APP_SUBNET_CANISTER_ID"
-#      - name: Set sns_aggregator canister ID
-#        run: |
-#          set -x
-#          CANISTER_NAME="sns_aggregator"
-#          export DFX_NETWORK CANISTER_NAME
-#          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-#          DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-#          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
-#      - name: Build wasms and config
-#        uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          network: ${{ env.DFX_NETWORK }}
-#      - name: Deploy nns-dapp
-#        if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
-#        run: |
-#          set -x
-#          CANISTER_NAME="nns-dapp"
-#          scripts/nns-dapp/split-assets
-#          # Note: inputs.mode is set if this workflow is run manually, using workflow_dispatch defined above.
-#          #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
-#          ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
-#          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
-#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
-#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
-#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
-#      - name: Deploy sns_aggregator
-#        if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
-#        run: |
-#          set -x
-#          CANISTER_NAME="sns_aggregator"
-#          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --wasm out/sns_aggregator.wasm.gz
+        # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
+      - name: Get versions
+        id: tool_versions
+        run: echo "dfx=$(jq -r .dfx dfx.json)" >> "$GITHUB_OUTPUT"
+      - name: Set credentials
+        #        uses: aviate-labs/setup-dfx@v0.2.3
+        #with:
+        #  dfx-version: ${{ steps.tool_versions.outputs.dfx }}
+        #  dfx-disable-encryption: true
+        run: |
+          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+          printf "%s" "${{ secrets.DFX_IDENTITY_PEM }}" | dfx identity import --storage-mode=plaintext ci /dev/stdin
+          dfx identity use ci
+        env:
+          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      - name: Get SNS scripts
+        uses: actions/checkout@v3
+        with:
+          repository: 'dfinity/snsdemo'
+          path: 'snsdemo'
+          # Version from 2023-06-06 with dfx v0.14.1
+          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
+      - name: Set up SNS scripts
+        run: |
+          : Install more
+          sudo apt-get update -yy && sudo apt-get install -yy moreutils
+          : Add scripts to the path
+          echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+      - name: Verify identity
+        run: |
+          dfx identity whoami
+          dfx identity get-principal
+      - name: Set nns-dapp canister ID
+        run: |
+          set -x
+          CANISTER_NAME="nns-dapp"
+          export DFX_NETWORK CANISTER_NAME
+          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$NNS_DAPP_APP_SUBNET_CANISTER_ID"
+      - name: Set sns_aggregator canister ID
+        run: |
+          set -x
+          CANISTER_NAME="sns_aggregator"
+          export DFX_NETWORK CANISTER_NAME
+          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+          DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
+      - name: Build wasms and config
+        uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          network: ${{ env.DFX_NETWORK }}
+      - name: Deploy nns-dapp
+        if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
+        run: |
+          set -x
+          CANISTER_NAME="nns-dapp"
+          scripts/nns-dapp/split-assets
+          # Note: inputs.mode is set if this workflow is run manually, using workflow_dispatch defined above.
+          #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
+          ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
+          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
+          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
+          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
+          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
+      - name: Deploy sns_aggregator
+        if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
+        run: |
+          set -x
+          CANISTER_NAME="sns_aggregator"
+          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --wasm out/sns_aggregator.wasm.gz
       - name: Canister info
         run: |
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -38,8 +38,8 @@ jobs:
       SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID: "otgyv-wyaaa-aaaak-qcgba-cai"
       DFX_NETWORK: app
     steps:
-#      - name: Checkout nns-dapp
-#        uses: actions/checkout@v3
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v3
 #        # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
 #      - name: Get versions
 #        id: tool_versions
@@ -116,7 +116,7 @@ jobs:
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary
           set -x
           {
-            printf "# Deployed %s from %s\n" "${{ inputs.canisters }}" "${{ github.ref }}"
+                  printf "## Deployed %s\n\nCommit: %s\nRef: %s\n\n" "${{ inputs.canisters }}" "$(git rev-parse HEAD)" "${{ github.ref }}"
             for canister in nns-dapp sns_aggregator ; do
               printf "## %s\n\n" "$canister"
               printf "URL:    "

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -38,85 +38,85 @@ jobs:
       SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID: "otgyv-wyaaa-aaaak-qcgba-cai"
       DFX_NETWORK: app
     steps:
-      - name: Checkout nns-dapp
-        uses: actions/checkout@v3
-        # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
-      - name: Get versions
-        id: tool_versions
-        run: echo "dfx=$(jq -r .dfx dfx.json)" >> "$GITHUB_OUTPUT"
-      - name: Set credentials
-        #        uses: aviate-labs/setup-dfx@v0.2.3
-        #with:
-        #  dfx-version: ${{ steps.tool_versions.outputs.dfx }}
-        #  dfx-disable-encryption: true
-        run: |
-          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-          printf "%s" "${{ secrets.DFX_IDENTITY_PEM }}" | dfx identity import --storage-mode=plaintext ci /dev/stdin
-          dfx identity use ci
-        env:
-          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
-      - name: Get SNS scripts
-        uses: actions/checkout@v3
-        with:
-          repository: 'dfinity/snsdemo'
-          path: 'snsdemo'
-          # Version from 2023-06-06 with dfx v0.14.1
-          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
-      - name: Set up SNS scripts
-        run: |
-          : Install more
-          sudo apt-get update -yy && sudo apt-get install -yy moreutils
-          : Add scripts to the path
-          echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
-      - name: Verify identity
-        run: |
-          dfx identity whoami
-          dfx identity get-principal
-      - name: Set nns-dapp canister ID
-        run: |
-          set -x
-          CANISTER_NAME="nns-dapp"
-          export DFX_NETWORK CANISTER_NAME
-          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$NNS_DAPP_APP_SUBNET_CANISTER_ID"
-      - name: Set sns_aggregator canister ID
-        run: |
-          set -x
-          CANISTER_NAME="sns_aggregator"
-          export DFX_NETWORK CANISTER_NAME
-          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-          DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
-          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
-      - name: Build wasms and config
-        uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          network: ${{ env.DFX_NETWORK }}
-      - name: Deploy nns-dapp
-        if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
-        run: |
-          set -x
-          CANISTER_NAME="nns-dapp"
-          scripts/nns-dapp/split-assets
-          # Note: inputs.mode is set if this workflow is run manually, using workflow_dispatch defined above.
-          #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
-          ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
-          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
-      - name: Deploy sns_aggregator
-        if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
-        run: |
-          set -x
-          CANISTER_NAME="sns_aggregator"
-          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --wasm out/sns_aggregator.wasm.gz
+#      - name: Checkout nns-dapp
+#        uses: actions/checkout@v3
+#        # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
+#      - name: Get versions
+#        id: tool_versions
+#        run: echo "dfx=$(jq -r .dfx dfx.json)" >> "$GITHUB_OUTPUT"
+#      - name: Set credentials
+#        #        uses: aviate-labs/setup-dfx@v0.2.3
+#        #with:
+#        #  dfx-version: ${{ steps.tool_versions.outputs.dfx }}
+#        #  dfx-disable-encryption: true
+#        run: |
+#          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+#          printf "%s" "${{ secrets.DFX_IDENTITY_PEM }}" | dfx identity import --storage-mode=plaintext ci /dev/stdin
+#          dfx identity use ci
+#        env:
+#          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+#      - name: Get SNS scripts
+#        uses: actions/checkout@v3
+#        with:
+#          repository: 'dfinity/snsdemo'
+#          path: 'snsdemo'
+#          # Version from 2023-06-06 with dfx v0.14.1
+#          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
+#      - name: Set up SNS scripts
+#        run: |
+#          : Install more
+#          sudo apt-get update -yy && sudo apt-get install -yy moreutils
+#          : Add scripts to the path
+#          echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+#      - name: Verify identity
+#        run: |
+#          dfx identity whoami
+#          dfx identity get-principal
+#      - name: Set nns-dapp canister ID
+#        run: |
+#          set -x
+#          CANISTER_NAME="nns-dapp"
+#          export DFX_NETWORK CANISTER_NAME
+#          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+#          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$NNS_DAPP_APP_SUBNET_CANISTER_ID"
+#      - name: Set sns_aggregator canister ID
+#        run: |
+#          set -x
+#          CANISTER_NAME="sns_aggregator"
+#          export DFX_NETWORK CANISTER_NAME
+#          jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+#          DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
+#          dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
+#      - name: Build wasms and config
+#        uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          network: ${{ env.DFX_NETWORK }}
+#      - name: Deploy nns-dapp
+#        if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
+#        run: |
+#          set -x
+#          CANISTER_NAME="nns-dapp"
+#          scripts/nns-dapp/split-assets
+#          # Note: inputs.mode is set if this workflow is run manually, using workflow_dispatch defined above.
+#          #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
+#          ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
+#          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
+#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
+#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
+#          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
+#      - name: Deploy sns_aggregator
+#        if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
+#        run: |
+#          set -x
+#          CANISTER_NAME="sns_aggregator"
+#          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --wasm out/sns_aggregator.wasm.gz
       - name: Canister info
         run: |
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary
           set -x
           {
-            printf "# Deployed ${{ github.ref }}"
+            printf "# Deployed %s from %s\n" "${{ inputs.canisters }}" "${{ github.ref }}"
             for canister in nns-dapp sns_aggregator ; do
               printf "## %s\n\n" "$canister"
               printf "URL:    "

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -116,8 +116,11 @@ jobs:
           # How to add a github summary: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-adding-a-job-summary
           set -x
           {
-            commit="$(git rev-parse HEAD)"
-            printf "## Deployed %s\n\nCommit: %s\nRef: %s\n\n" "${{ inputs.canisters }}" "[$commit](https://github.com/dfinity/nns-dapp/commit/$commit)" "${{ github.ref }}"
+            MODE="${{ inputs.mode || 'upgrade' }}"
+            printf "## %s %s\n\nCommit: %s\nRef: %s\n\n" \
+              "${MODE^}" "${{ inputs.canisters }}" \
+              "[${GITHUB_SHA}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})" \
+              "[${GITHUB_REF_NAME}](https://github.com/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME})"
             for canister in nns-dapp sns_aggregator ; do
               printf "## %s\n\n" "$canister"
               printf "URL:    "

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -9,6 +9,7 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ## Unreleased
 
 ### Added
+- Display commit, branch name and similar data when deploying to a test canister.
 ### Changed
 ### Fixed
 ### Security


### PR DESCRIPTION
# Motivation
When deploying to the app subnet often, it is easy to forget what version was last deployed.

# Changes
* Prominently display which canisters were deployed with which mode with which branch or tag and commit.

# Tests
* See a workflow run; note the body of the workflow was disabled, so the canister commits are "none".  This is expected.  https://github.com/dfinity/nns-dapp/actions/runs/5647370743

# Todos

- [x] Add entry to changelog (if necessary).
