### PR TITLE
GIX-1764: Set neuron id in header title on scroll

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
@@ -5,13 +5,35 @@
   import { MAX_NEURON_ID_DIGITS } from "$lib/constants/neurons.constants";
   import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
   import PageHeader from "../common/PageHeader.svelte";
+  import { onIntersection } from "$lib/directives/intersection.directives";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { i18n } from "$lib/stores/i18n";
+  import type { IntersectingDetail } from "$lib/types/intersection.types";
 
   export let neuron: NeuronInfo;
+
+  const updateLayoutTitle = ($event: Event) => {
+    const {
+      detail: { intersecting },
+    } = $event as unknown as CustomEvent<IntersectingDetail>;
+
+    layoutTitleStore.set(
+      intersecting
+        ? $i18n.neuron_detail.title
+        : `${$i18n.core.icp} – ${neuron.neuronId}`
+    );
+  };
 </script>
 
 <PageHeader testId="nns-neuron-page-header-component">
   <UniversePageSummary slot="start" universe={NNS_UNIVERSE} />
-  <span slot="end" class="description header-end">
+  <span
+    slot="end"
+    class="description header-end"
+    data-tid="neuron-id-element"
+    use:onIntersection
+    on:nnsIntersecting={updateLayoutTitle}
+  >
     <IdentifierHash
       identifier={neuron.neuronId.toString()}
       splitLength={MAX_NEURON_ID_DIGITS / 2}

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -172,7 +172,7 @@
         {:else}
           {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron) && nonNullish(transactionFee)}
             <div class="section-wrapper">
-              <SnsNeuronPageHeader />
+              <SnsNeuronPageHeader {token} />
               <SnsNeuronPageHeading {parameters} />
               <Separator spacing="none" />
               <SnsNeuronVotingPowerSection

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
@@ -3,11 +3,14 @@
  */
 
 import NnsNeuronPageHeader from "$lib/components/neuron-detail/NnsNeuronPageHeader.svelte";
+import { dispatchIntersecting } from "$lib/directives/intersection.directives";
+import { layoutTitleStore } from "$lib/stores/layout.store";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeaderPo } from "$tests/page-objects/NnsNeuronPageHeader.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
 
 describe("NnsNeuronPageHeader", () => {
   const renderComponent = (neuron: NeuronInfo) => {
@@ -21,4 +24,29 @@ describe("NnsNeuronPageHeader", () => {
 
     expect(await po.getUniverse()).toEqual("Internet Computer");
   });
+
+  const testTitle = async ({
+    intersecting,
+    text,
+  }: {
+    intersecting: boolean;
+    text: string;
+  }) => {
+    const { getByTestId } = render(NnsNeuronPageHeader, {
+      props: { neuron: mockNeuron },
+    });
+
+    const element = getByTestId("neuron-id-element") as HTMLElement;
+
+    dispatchIntersecting({ element, intersecting });
+
+    const title = get(layoutTitleStore);
+    expect(title).toEqual(text);
+  };
+
+  it("should render a title with neuron ID if title is not intersecting viewport", () =>
+    testTitle({ intersecting: false, text: "ICP – 1" }));
+
+  it("should render a static title if title is intersecting viewport", () =>
+    testTitle({ intersecting: true, text: "Neuron" }));
 });


### PR DESCRIPTION
# Motivation

Current neuron details sets the neuron id in the header when the user scrolls down.

We want to keep the same behavior in the new neuron page.

# Changes

* Update the layout title on intersecting the NnsPageHeader component.
* Update the layout title on intersecting the SnsPageHeader component.

# Tests

* Test that intersection updates layout title in both components.

# Todos

Not worth an entry. This maintains the same functionality as we have now.
