### PR TITLE
GIX-1765: Manage permissions in NNS neuron buttons

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { formattedMaturity } from "$lib/utils/neuron.utils";
+  import {
+    formattedMaturity,
+    isNeuronControllable,
+  } from "$lib/utils/neuron.utils";
   import { IconExpandCircleDown } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import NnsStakeMaturityButton from "./actions/NnsStakeMaturityButton.svelte";
   import SpawnNeuronButton from "./actions/SpawnNeuronButton.svelte";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
+
+  let isControllable: boolean;
+  $: isControllable = isNeuronControllable({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
 </script>
 
 <CommonItemAction testId="nns-available-maturity-item-action-component">
@@ -18,6 +30,8 @@
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >
-  <NnsStakeMaturityButton {neuron} variant="secondary" />
-  <SpawnNeuronButton {neuron} />
+  {#if isControllable}
+    <NnsStakeMaturityButton {neuron} variant="secondary" />
+    <SpawnNeuronButton {neuron} />
+  {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -11,13 +11,32 @@
   import { secondsToDate, secondsToDateTime } from "$lib/utils/date.utils";
   import { nonNullish } from "@dfinity/utils";
   import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
-  import { maturityLastDistribution } from "$lib/utils/neuron.utils";
+  import {
+    isNeuronControllable,
+    isNeuronControllableByUser,
+    maturityLastDistribution,
+  } from "$lib/utils/neuron.utils";
   import Hash from "../ui/Hash.svelte";
   import NnsAutoStakeMaturity from "./actions/NnsAutoStakeMaturity.svelte";
   import JoinCommunityFundCheckbox from "./actions/JoinCommunityFundCheckbox.svelte";
   import SplitNnsNeuronButton from "./actions/SplitNnsNeuronButton.svelte";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
+
+  let isControllable: boolean;
+  $: isControllable = isNeuronControllable({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
+
+  let isControlledByUser: boolean;
+  $: isControlledByUser = isNeuronControllableByUser({
+    neuron,
+    mainAccount: $icpAccountsStore.main,
+  });
 </script>
 
 <Section testId="nns-neuron-advanced-section-component">
@@ -79,8 +98,10 @@
       </div>
     {/if}
     <NnsAutoStakeMaturity {neuron} />
-    <JoinCommunityFundCheckbox {neuron} />
-    <SplitNnsNeuronButton {neuron} variant="secondary" />
+    <JoinCommunityFundCheckbox {neuron} disabled={!isControlledByUser} />
+    {#if isControllable}
+      <SplitNnsNeuronButton {neuron} variant="secondary" />
+    {/if}
   </div>
 </Section>
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.svelte
@@ -4,6 +4,7 @@
     dissolveDelayMultiplier,
     getDissolvingTimeInSeconds,
     getSpawningTimeInSeconds,
+    isNeuronControllable,
   } from "$lib/utils/neuron.utils";
   import { IconClockNoFill } from "@dfinity/gix-components";
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
@@ -14,6 +15,8 @@
   import { keyOf } from "$lib/utils/utils";
   import { secondsToDuration } from "$lib/utils/date.utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
 
@@ -37,6 +40,13 @@
   let remainingTimeSeconds: bigint;
   $: remainingTimeSeconds =
     dissolvingTime ?? spawningTime ?? neuron.dissolveDelaySeconds;
+
+  let isControllable: boolean;
+  $: isControllable = isNeuronControllable({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
 </script>
 
 <CommonItemAction testId="nns-neuron-dissolve-delay-item-action-component">
@@ -64,5 +74,7 @@
       </span>
     {/if}</svelte:fragment
   >
-  <IncreaseDissolveDelayButton variant="secondary" />
+  {#if isControllable}
+    <IncreaseDissolveDelayButton variant="secondary" />
+  {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -3,6 +3,7 @@
   import {
     ageMultiplier,
     getStateInfo,
+    isNeuronControllable,
     type StateInfo,
   } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
@@ -12,6 +13,8 @@
   import Tooltip from "../ui/Tooltip.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
 
@@ -20,6 +23,13 @@
 
   let ageBonus: number;
   $: ageBonus = ageMultiplier(neuron.ageSeconds);
+
+  let isControllable: boolean;
+  $: isControllable = isNeuronControllable({
+    neuron,
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
 </script>
 
 <CommonItemAction testId="nns-neuron-state-item-action-component">
@@ -46,9 +56,11 @@
       </span>
     {/if}
   </svelte:fragment>
-  {#if neuron.state === NeuronState.Dissolved}
-    <DisburseButton />
-  {:else}
-    <DissolveActionButton neuronState={neuron.state} />
+  {#if isControllable}
+    {#if neuron.state === NeuronState.Dissolved}
+      <DisburseButton />
+    {:else}
+      <DissolveActionButton neuronState={neuron.state} />
+    {/if}
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.svelte
@@ -11,6 +11,7 @@
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
 
   export let neuron: NeuronInfo;
+  export let disabled = false;
 
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
@@ -21,6 +22,7 @@
 </script>
 
 <Checkbox
+  {disabled}
   preventDefault
   inputId="join-community-fund-checkbox"
   checked={isCommunityFund}

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronContextActionsTest.svelte
@@ -11,6 +11,7 @@
 
   export let testComponent: typeof SvelteComponent;
   export let neuron: NeuronInfo | undefined;
+  export let moreProps: Record<string, unknown> = {};
 
   export const neuronStore = writable<NnsNeuronStore>({
     neuron,
@@ -21,6 +22,6 @@
   });
 </script>
 
-<svelte:component this={testComponent} {neuron} />
+<svelte:component this={testComponent} {neuron} {...moreProps} />
 
 <NnsNeuronModals />

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
@@ -3,6 +3,12 @@
  */
 
 import NnsAvailableMaturityActionItem from "$lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte";
+import { authStore } from "$lib/stores/auth.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsAvailableMaturityActionItemPo } from "$tests/page-objects/NnsAvailableMaturityActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -24,6 +30,12 @@ describe("NnsAvailableMaturityActionItem", () => {
     );
   };
 
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
   it("should render available maturity", async () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
@@ -38,9 +50,28 @@ describe("NnsAvailableMaturityActionItem", () => {
   });
 
   it("should render buttons", async () => {
-    const po = renderComponent(mockNeuron);
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockIdentity.getPrincipal().toText(),
+      },
+    });
 
     expect(await po.hasSpawnButton()).toBe(true);
     expect(await po.hasStakeButton()).toBe(true);
+  });
+
+  it("should not render buttons if user is not the controller", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockCanisterId.toText(),
+      },
+    });
+
+    expect(await po.hasSpawnButton()).toBe(false);
+    expect(await po.hasStakeButton()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityActionItem.spec.ts
@@ -4,11 +4,16 @@
 
 import NnsAvailableMaturityActionItem from "$lib/components/neuron-detail/NnsAvailableMaturityActionItem.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsAvailableMaturityActionItemPo } from "$tests/page-objects/NnsAvailableMaturityActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -34,6 +39,7 @@ describe("NnsAvailableMaturityActionItem", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    icpAccountsStore.resetForTesting();
   });
 
   it("should render available maturity", async () => {
@@ -55,6 +61,25 @@ describe("NnsAvailableMaturityActionItem", () => {
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         controller: mockIdentity.getPrincipal().toText(),
+      },
+    });
+
+    expect(await po.hasSpawnButton()).toBe(true);
+    expect(await po.hasStakeButton()).toBe(true);
+  });
+
+  it("should render buttons if controlled by attached hardware wallet", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [mockHardwareWalletAccount],
+    });
+
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockHardwareWalletAccount.principal.toText(),
       },
     });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -147,7 +147,7 @@ describe("NnsNeuronAdvancedSection", () => {
     ).not.toBeNull();
   });
 
-  it("should render disabled join neurons' fund if user is controlled by hardware wallet", async () => {
+  it("should render split button and disabled join neurons' fund if user is controlled by hardware wallet", async () => {
     icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [],
@@ -164,5 +164,6 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(
       await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
     ).not.toBeNull();
+    expect(await po.hasSplitNeuronButton()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -4,8 +4,19 @@
 
 import NnsNeuronAdvancedSection from "$lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte";
 import { SECONDS_IN_MONTH } from "$lib/constants/constants";
+import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
-import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvancedSection.page-object";
@@ -31,6 +42,10 @@ describe("NnsNeuronAdvancedSection", () => {
 
   beforeEach(() => {
     nnsLatestRewardEventStore.reset();
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+    icpAccountsStore.resetForTesting();
   });
 
   it("should render neuron data", async () => {
@@ -74,10 +89,80 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render actions", async () => {
-    const po = renderComponent(mockNeuron);
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockIdentity.getPrincipal().toText(),
+      },
+    });
 
     expect(await po.hasStakeMaturityCheckbox()).toBe(true);
     expect(await po.hasJoinNeuronsFundCheckbox()).toBe(true);
     expect(await po.hasSplitNeuronButton()).toBe(true);
+  });
+
+  it("should not render split neuron action if user is not the controller", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockCanisterId.toText(),
+      },
+    });
+
+    expect(await po.hasSplitNeuronButton()).toBe(false);
+  });
+
+  it("should render enabled join neurons' fund if user is the controller", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [],
+    });
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockMainAccount.principal.toText(),
+      },
+    });
+
+    expect(
+      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
+    ).toBeNull();
+  });
+
+  it("should render disabled join neurons' fund if user is not the controller", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockCanisterId.toText(),
+      },
+    });
+
+    expect(
+      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
+    ).not.toBeNull();
+  });
+
+  it("should render disabled join neurons' fund if user is controlled by hardware wallet", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [mockHardwareWalletAccount],
+    });
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockHardwareWalletAccount.principal.toText(),
+      },
+    });
+
+    expect(
+      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
+    ).not.toBeNull();
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.spec.ts
@@ -4,6 +4,11 @@
 
 import NnsNeuronDissolveDelayActionItem from "$lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.svelte";
 import { SECONDS_IN_MONTH, SECONDS_IN_YEAR } from "$lib/constants/constants";
+import { authStore } from "$lib/stores/auth.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronDissolveDelayActionItemPo } from "$tests/page-objects/NnsNeuronDissolveDelayActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -25,9 +30,23 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
     );
   };
 
+  const controlledNeuron = {
+    ...mockNeuron,
+    fullNeuron: {
+      ...mockNeuron.fullNeuron,
+      controller: mockIdentity.getPrincipal().toText(),
+    },
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
   it("should render dissolve delay text and bonus if neuron is locked", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Locked,
       dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 2),
     };
@@ -42,11 +61,11 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
 
   it("should render remaining text and bonus if neuron is dissolving", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolving,
       dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 2),
       fullNeuron: {
-        ...mockNeuron.fullNeuron,
+        ...controlledNeuron.fullNeuron,
         dissolveState: {
           DissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 2),
         },
@@ -61,7 +80,7 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
 
   it("should render no bonus text if neuron is dissolving less than 6 months", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolving,
       dissolveDelaySeconds: BigInt(SECONDS_IN_MONTH * 4),
     };
@@ -72,7 +91,7 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
 
   it("should render dissolve delay text with 0 and no bonus text if neuron is unlocked", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolved,
       dissolveDelaySeconds: BigInt(0),
     };
@@ -81,5 +100,20 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
     expect(await po.getDissolveState()).toBe("Dissolve Delay: 0");
     expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
+  });
+
+  it("should not render increase dissolve delay button if user is not the controller", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolved,
+      dissolveDelaySeconds: BigInt(0),
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: "not-controller",
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.spec.ts
@@ -5,10 +5,15 @@
 import NnsNeuronDissolveDelayActionItem from "$lib/components/neuron-detail/NnsNeuronDissolveDelayActionItem.svelte";
 import { SECONDS_IN_MONTH, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronDissolveDelayActionItemPo } from "$tests/page-objects/NnsNeuronDissolveDelayActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -39,6 +44,7 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
   };
 
   beforeEach(() => {
+    icpAccountsStore.resetForTesting();
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -115,5 +121,25 @@ describe("NnsNeuronDissolveDelayActionItem", () => {
     const po = renderComponent(neuron);
 
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
+  });
+
+  it("should render increase dissolve delay button if controlled by hardware wallet", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [mockHardwareWalletAccount],
+    });
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Dissolved,
+      dissolveDelaySeconds: BigInt(0),
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: mockHardwareWalletAccount.principal.toText(),
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -4,6 +4,11 @@
 
 import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
+import { authStore } from "$lib/stores/auth.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -25,9 +30,31 @@ describe("NnsNeuronStateItemAction", () => {
     );
   };
 
+  const controlledNeuron = {
+    ...mockNeuron,
+    fullNeuron: {
+      ...mockNeuron.fullNeuron,
+      controller: mockIdentity.getPrincipal().toText(),
+    },
+  };
+
+  const notControlledNeuron = {
+    ...mockNeuron,
+    fullNeuron: {
+      ...mockNeuron.fullNeuron,
+      controller: "some-other-principal",
+    },
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
   it("should render locked text and Start dissolving button if neuron is locked", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Locked,
     };
     const po = renderComponent(neuron);
@@ -36,9 +63,19 @@ describe("NnsNeuronStateItemAction", () => {
     expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
   });
 
+  it("should not render dissolving button if neuron is locked but user is not the controller", async () => {
+    const neuron: NeuronInfo = {
+      ...notControlledNeuron,
+      state: NeuronState.Locked,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+  });
+
   it("should render dissolving text and Stop dissolving button if neuron is dissolving", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolving,
     };
     const po = renderComponent(neuron);
@@ -47,9 +84,19 @@ describe("NnsNeuronStateItemAction", () => {
     expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
   });
 
+  it("should not render dissolve button if neuron is dissolving but user is not the controller", async () => {
+    const neuron: NeuronInfo = {
+      ...notControlledNeuron,
+      state: NeuronState.Dissolving,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+  });
+
   it("should render unlocked text and disburse button if neuron is unlocked", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolved,
     };
     const po = renderComponent(neuron);
@@ -58,9 +105,19 @@ describe("NnsNeuronStateItemAction", () => {
     expect(await po.hasDisburseButton()).toBe(true);
   });
 
+  it("should not render disburse button if neuron is unlocked but user is not the controller", async () => {
+    const neuron: NeuronInfo = {
+      ...notControlledNeuron,
+      state: NeuronState.Dissolved,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.hasDisburseButton()).toBe(false);
+  });
+
   it("should render age bonus for Locked neurons", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Locked,
       ageSeconds: BigInt(SECONDS_IN_FOUR_YEARS),
     };
@@ -71,7 +128,7 @@ describe("NnsNeuronStateItemAction", () => {
 
   it("should render no age bonus for dissolving neurons", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolving,
     };
     const po = renderComponent(neuron);
@@ -81,7 +138,7 @@ describe("NnsNeuronStateItemAction", () => {
 
   it("should render no age bonus for unlocked neurons", async () => {
     const neuron: NeuronInfo = {
-      ...mockNeuron,
+      ...controlledNeuron,
       state: NeuronState.Dissolving,
     };
     const po = renderComponent(neuron);

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -5,10 +5,15 @@
 import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -92,6 +97,25 @@ describe("NnsNeuronStateItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+  });
+
+  it("should render dissolve button if hardware wallet is the controller", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [mockHardwareWalletAccount],
+    });
+    const neuron: NeuronInfo = {
+      ...notControlledNeuron,
+      state: NeuronState.Dissolving,
+      fullNeuron: {
+        ...notControlledNeuron.fullNeuron,
+        controller: mockHardwareWalletAccount.principal.toText(),
+      },
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(true);
   });
 
   it("should render unlocked text and disburse button if neuron is unlocked", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -19,7 +19,7 @@ describe("JoinCommunityFundCheckbox", () => {
     jest.clearAllMocks();
   });
 
-  it("renders checkbox", () => {
+  it("renders enabled checkbox", () => {
     const neuron = {
       ...mockNeuron,
       joinedCommunityFundTimestampSeconds: undefined,
@@ -33,6 +33,26 @@ describe("JoinCommunityFundCheckbox", () => {
     });
 
     expect(queryByTestId("checkbox")).toBeInTheDocument();
+    expect(queryByTestId("checkbox").getAttribute("disabled")).toBeNull();
+  });
+
+  it("renders disabled checkbox", () => {
+    const neuron = {
+      ...mockNeuron,
+      joinedCommunityFundTimestampSeconds: undefined,
+    };
+
+    const { queryByTestId } = render(NeuronContextActionsTest, {
+      props: {
+        neuron,
+        testComponent: JoinCommunityFundCheckbox,
+        moreProps: {
+          disabled: true,
+        },
+      },
+    });
+
+    expect(queryByTestId("checkbox").getAttribute("disabled")).not.toBeNull();
   });
 
   it("renders checked if neuron is part of the fund", () => {

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -41,8 +41,12 @@ export class NnsNeuronAdvancedSectionPo extends BasePageObject {
       .isPresent();
   }
 
+  getJoinNeuronsFundCheckbox(): PageObjectElement {
+    return this.root.querySelector("#join-community-fund-checkbox");
+  }
+
   hasJoinNeuronsFundCheckbox(): Promise<boolean> {
-    return this.root.querySelector("#join-community-fund-checkbox").isPresent();
+    return this.getJoinNeuronsFundCheckbox().isPresent();
   }
 
   hasSplitNeuronButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { ButtonPo } from "./Button.page-object";
 
 export class NnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "nns-neuron-state-item-action-component";
@@ -20,6 +21,10 @@ export class NnsNeuronStateItemActionPo extends BasePageObject {
 
   hasDisburseButton(): Promise<boolean> {
     return this.getButton("disburse-button").isPresent();
+  }
+
+  getDissolveButtonPo(): ButtonPo {
+    return this.getButton("nns-dissolve-action-button");
   }
 
   getDissolveButtonText(): Promise<string> {


### PR DESCRIPTION
# Motivation

Some neuron actions are available only for controllers.

In this PR: Apply same rules to show/hide neuron buttons in new NNS neuron detail.

Except one difference. The Join Neuron's fund is rendered but disabled if neuron is not controlled by user. This is similar to what we do for the auto stake checkbox. Currently, the whole card of Neurons' Fund doesn't appear if neuron is not controlled by the user.

# Changes

* Hide actions if user not controller in NnsAvailableMaturityActionItem.
* Hide split button and disable join neurons' fund checkbox if user not controller in NnsNeuronAdvancedSection.
* Hide actions if user not controller in NnsNeuronDissolveDelayActionItem.
* Hide actions if user not controller in NnsNeuronStateItemAction.
* Add `disabled` prop to JoinCommunityFundCheckbox

# Tests

* Test that buttons are hidden when user not controller in NnsAvailableMaturityActionItem.
* Test that split button is hidden and join neurons' fund checkbox is disabled when user not controller in NnsNeuronAdvancedSection.
* Test that buttons are hidden when user not controller in NnsNeuronDissolveDelayActionItem.
* Test that buttons are hidden when user not controller in NnsNeuronStateItemAction.
* Test new `disabled` prop in JoinCommunityFundCheckbox

# Todos

This is the current functionality, applied to the new UI. It doesn't deserver an entry in the changelog.
