### PR TITLE
Improve Ledger app version error message

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -14,6 +14,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 - bump agent-js `v0.18.1`
+* Clarify Ledger app version error message.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -749,7 +749,7 @@
     "unexpected_wallet": "Found unexpected public key. Are you sure you're using the right hardware wallet?",
     "access_denied": "Access denied to use the ledger device.",
     "user_rejected_transaction": "The transaction was rejected on the ledger device.",
-    "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Ledger App to at least version $minVersion.",
+    "version_not_supported": "Sorry, transaction not supported with version $currentVersion. Please upgrade the Internet Computer app on your Ledger device to at least version $minVersion.",
     "browser_not_supported": "Sorry, the browser does not support the WebHID API needed to connect the hardware wallet. Check support in https://caniuse.com/?search=WebHID",
     "incorrect_identifier": "Wallet account identifier doesn't match. Are you sure you connected the right hardware wallet? Expected identifier: $identifier. Wallet identifier: $ledgerIdentifier."
   },


### PR DESCRIPTION
# Motivation

With the pervious error message I was confused because I thought I had to upgrade the Ledger firmware but the version didn't match. So I thought the error message could be clearer.

# Changes

Change the error message to mention "Internet Computer app on your Ledger device".

# Tests

Temporarily increase the required version to manually test the error message:
<img width="793" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/15ff6db3-e534-4d11-a828-d75557796897">


# Todos

- [x] Add entry to changelog (if necessary).
