### PR TITLE
Proposal detail page back referrer

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,7 +13,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
-- bump agent-js `v0.18.1`
+* Bump agent-js `v0.18.1`.
 * Clarify Ledger app version error message.
 
 #### Deprecated
@@ -21,6 +21,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Show the current dissolve Delay in the modal to increase a dissolving SNS neuron.
+* Avoid repeating queries to canister status if the principal is not a controller, and avoid long-lasting display of skeletons.
+* Correctly set the referrer on the detail page to go back to the effective previous page. Useful for the proposal detail page that can be opened from either from the "Proposals" or "Launchpage" pages. 
 
 #### Security
 

--- a/frontend/src/lib/components/layout/LayoutNavGuard.svelte
+++ b/frontend/src/lib/components/layout/LayoutNavGuard.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import { isNullish } from "@dfinity/utils";
   import { navigating } from "$app/stores";
+  import { Spinner } from "@dfinity/gix-components";
+
+  // To be used only when the transition between pages lasts long; otherwise, it can appear as being glitchy.
+  export let spinner = false;
 </script>
 
 <!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
 {#if isNullish($navigating)}
   <slot />
+{:else if spinner}
+  <Spinner />
 {/if}

--- a/frontend/src/lib/components/layout/LayoutNavGuard.svelte
+++ b/frontend/src/lib/components/layout/LayoutNavGuard.svelte
@@ -4,12 +4,12 @@
   import { Spinner } from "@dfinity/gix-components";
 
   // To be used only when the transition between pages lasts long; otherwise, it can appear as being glitchy.
-  export let spinner = false;
+  export let spinnerWhileNavigating = false;
 </script>
 
 <!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
 {#if isNullish($navigating)}
   <slot />
-{:else if spinner}
+{:else if spinnerWhileNavigating}
   <Spinner />
 {/if}

--- a/frontend/src/routes/(app)/(u)/(detail)/neuron/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/neuron/+layout.svelte
@@ -3,12 +3,15 @@
   import Content from "$lib/components/layout/Content.svelte";
   import { goto } from "$app/navigation";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
+  import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
 
   const back = (): Promise<void> => goto($neuronsPathStore);
 </script>
 
-<Layout>
-  <Content {back}>
-    <slot />
-  </Content>
-</Layout>
+<LayoutNavGuard>
+  <Layout>
+    <Content {back}>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutNavGuard>

--- a/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/proposal/+layout.svelte
@@ -6,6 +6,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import type { Navigation } from "@sveltejs/kit";
   import { referrerPathForNav } from "$lib/utils/page.utils";
+  import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
 
   let referrerPath: AppPath | undefined = undefined;
   afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
@@ -16,8 +17,10 @@
     );
 </script>
 
-<Layout>
-  <Content {back}>
-    <slot />
-  </Content>
-</Layout>
+<LayoutNavGuard>
+  <Layout>
+    <Content {back}>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutNavGuard>

--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
@@ -3,12 +3,15 @@
   import Content from "$lib/components/layout/Content.svelte";
   import { goto } from "$app/navigation";
   import { accountsPathStore } from "$lib/derived/paths.derived";
+  import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
 
   const back = (): Promise<void> => goto($accountsPathStore);
 </script>
 
-<Layout>
-  <Content {back}>
-    <slot />
-  </Content>
-</Layout>
+<LayoutNavGuard>
+  <Layout>
+    <Content {back}>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutNavGuard>

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -2,20 +2,18 @@
   import Banner from "$lib/components/header/Banner.svelte";
   import { onMount } from "svelte";
   import { initAppAuth } from "$lib/services/$public/app.services";
-  import { Layout, ContentBackdrop, Spinner } from "@dfinity/gix-components";
+  import { Layout, ContentBackdrop } from "@dfinity/gix-components";
   import LoginMenuItems from "$lib/components/login/LoginMenuItems.svelte";
   import LoginFooter from "$lib/components/login/LoginFooter.svelte";
   import LoginHeader from "$lib/components/login/LoginHeader.svelte";
   import LoginBackground from "$lib/components/login/LoginBackground.svelte";
-  import { navigating } from "$app/stores";
-  import { isNullish } from "@dfinity/utils";
   import Warnings from "$lib/components/warnings/Warnings.svelte";
+  import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
 
   onMount(async () => await initAppAuth());
 </script>
 
-<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
-{#if isNullish($navigating)}
+<LayoutNavGuard spinner>
   <Layout layout="stretch">
     <Banner />
 
@@ -41,9 +39,7 @@
   </Layout>
 
   <Warnings bringToastsForward />
-{:else}
-  <Spinner />
-{/if}
+</LayoutNavGuard>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -13,7 +13,7 @@
   onMount(async () => await initAppAuth());
 </script>
 
-<LayoutNavGuard spinner>
+<LayoutNavGuard spinnerWhileNavigating>
   <Layout layout="stretch">
     <Banner />
 


### PR DESCRIPTION
# Motivation

Implementing the workaround for `onDestroy` at the top level of the `+layout` of the detail pages (PR #2880) had for side effect to make the navigation callbacks of its pages/layouts to not being called. As those are not called, the dapp is not able to determine which was the `referrer` of these pages and per extension, to effectivelly use the referrer in back action.

Long story short, on mainnet, navigation from the "Launchpad" to a "Proposal" and clicking back lead the users to "Proposals" page instead of going back to "Launchpad".

# Changes

- refactor workaround in a dedicated component `LayoutNavGuard`
- use component within the layouts
- remove top layout as unused

# Notes

I noticed a type in the CHANGELOG and since I was already there, I also improved the communication of the fix #2950 which is not related to this PR.