### PR TITLE
Fix: deploy script

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -44,6 +44,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Fixed
 
+* Deploy.sh script
+
 #### Security
 
 ## Proposal 123718

--- a/build-backend.sh
+++ b/build-backend.sh
@@ -10,5 +10,4 @@ echo Compiling rust package
 "$TOPLEVEL/build-rs.sh" nns-dapp
 
 echo Sanity check
-# NOT WORKING IN MACOS
-# scripts/nns-dapp/test-exports
+scripts/nns-dapp/test-exports

--- a/build-backend.sh
+++ b/build-backend.sh
@@ -10,4 +10,5 @@ echo Compiling rust package
 "$TOPLEVEL/build-rs.sh" nns-dapp
 
 echo Sanity check
-scripts/nns-dapp/test-exports
+# NOT WORKING IN MACOS
+# scripts/nns-dapp/test-exports

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,9 +105,8 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
   # Note:  NNS dapp is the only canister provided by this repo, however dfx.json
   #        includes other canisters for testing purposes.  If testing you MAY wish
   #        to deploy these other canisters as well, but you probably don't.
-  ./build.sh
   DFX_NETWORK="$DFX_NETWORK" ./config.sh
   dfx canister --network "$DFX_NETWORK" create nns-dapp --no-wallet || echo "canister for NNS Dapp may have been created already"
-  dfx canister install nns-dapp --argument "$(cat "nns-dapp-arg-${DFX_NETWORK}.did")" --wasm ./nns-dapp.wasm.gz --mode reinstall --network "$DFX_NETWORK"
+  dfx deploy nns-dapp --argument "$(cat "nns-dapp-arg-${DFX_NETWORK}.did")" --upgrade-unchanged --network "$DFX_NETWORK" --no-wallet
   echo "NNS Dapp deployed to: $(dfx-canister-url --network "$DFX_NETWORK" nns-dapp)"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+export PATH="$PWD/scripts:$PATH"
+
 cd "$(dirname "$(realpath "$0")")" || exit
 
 help_text() {
@@ -102,8 +105,9 @@ if [[ "$DEPLOY_NNS_DAPP" == "true" ]]; then
   # Note:  NNS dapp is the only canister provided by this repo, however dfx.json
   #        includes other canisters for testing purposes.  If testing you MAY wish
   #        to deploy these other canisters as well, but you probably don't.
+  ./build.sh
   DFX_NETWORK="$DFX_NETWORK" ./config.sh
   dfx canister --network "$DFX_NETWORK" create nns-dapp --no-wallet || echo "canister for NNS Dapp may have been created already"
-  dfx deploy nns-dapp --argument "$(cat "nns-dapp-arg-${DFX_NETWORK}.did")" --upgrade-unchanged --network "$DFX_NETWORK" --no-wallet
+  dfx canister install nns-dapp --argument "$(cat "nns-dapp-arg-${DFX_NETWORK}.did")" --wasm ./nns-dapp.wasm.gz --mode reinstall --network "$DFX_NETWORK"
   echo "NNS Dapp deployed to: $(dfx-canister-url --network "$DFX_NETWORK" nns-dapp)"
 fi

--- a/scripts/nns-dapp/test-exports
+++ b/scripts/nns-dapp/test-exports
@@ -21,7 +21,7 @@ source "$(clap.build)"
 GOLDEN_FILE="rs/backend/nns-dapp-exports.txt"
 
 wasm_exports() {
-  ic-wasm <(gunzip <"$1") info | sed -nE '/^Exported methods:/,/^]/{s/^ *"(.*)".*/\1/g;ta;b;:a;s/ *[(].*//g;p}'
+  ic-wasm <(gunzip <"$1") info | sed -nE '/^Exported methods:/,/^]/p' | sed '1d;$d' | sed -E 's/.*"(.*)",/\1/'
 }
 
 if [ "$UPDATE_GOLDEN" = "true" ]; then


### PR DESCRIPTION
# Motivation

Fix the convenient script to deploy current nns dapp branch to a testnet `./deploy.sh`.

PENDING: Fix `scripts/nns-dapp/test-exports` for Mac.

# Changes

* Do not use `dfx deploy` which isn't working and instead, build the wasm and then install it.

# Tests

I deployed to nnsdapp testnet https://vh6yy-miaaa-aaaaa-aaaya-cai.nnsdapp.testnet.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
