### PR TITLE
Format changelogs

### DIFF
--- a/scripts/fmt
+++ b/scripts/fmt
@@ -10,4 +10,5 @@ time xargs -P8 -I{} bash -c "{}" <<EOF
 ./scripts/fmt-rs
 ./scripts/fmt-sh
 ./scripts/fmt-yaml
+./scripts/fmt-changelogs
 EOF

--- a/scripts/fmt-changelogs
+++ b/scripts/fmt-changelogs
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+cd "$(dirname "$(realpath "$0")")/.."
+
+npx prettier CHANGELOG-Nns-Dapp.md CHANGELOG-Sns_Aggregator.md --write


### PR DESCRIPTION
# Motivation

Since we migrated to the CHANGELOGS I often personally produce and notice inconsistency in the format of these files. 
This PR aims to add a dedicated formatter (`prettier`) to solve the issue.

# Notes

Unlike traditional repo on the IC, we do not have the JS tooling at the root of the repo. That's why the formatter use an npm cli command.

# Changes

- new script `fmt-changelogs` that uses prettier to format the CHANGELOGs markdown file
- add script to global `fmt` script