### PR TITLE
GIX-1766: Add permissions SNS neuron buttons

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte
@@ -3,10 +3,20 @@
   import { IconExpandCircleDown } from "@dfinity/gix-components";
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { formattedMaturity } from "$lib/utils/sns-neuron.utils";
+  import {
+    formattedMaturity,
+    hasPermissionToStakeMaturity,
+  } from "$lib/utils/sns-neuron.utils";
   import SnsStakeMaturityButton from "./actions/SnsStakeMaturityButton.svelte";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let neuron: SnsNeuron;
+
+  let allowedToStakeMaturity: boolean;
+  $: allowedToStakeMaturity = hasPermissionToStakeMaturity({
+    neuron,
+    identity: $authStore.identity,
+  });
 </script>
 
 <CommonItemAction testId="sns-available-maturity-item-action-component">
@@ -17,5 +27,7 @@
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >
-  <SnsStakeMaturityButton variant="secondary" />
+  {#if allowedToStakeMaturity}
+    <SnsStakeMaturityButton variant="secondary" />
+  {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -4,7 +4,10 @@
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import Hash from "../ui/Hash.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+  import {
+    getSnsNeuronIdAsHexString,
+    hasPermissionToSplit,
+  } from "$lib/utils/sns-neuron.utils";
   import SnsNeuronAge from "../sns-neurons/SnsNeuronAge.svelte";
   import { encodeIcrcAccount, type IcrcAccount } from "@dfinity/ledger";
   import type { Principal } from "@dfinity/principal";
@@ -13,6 +16,7 @@
   import SnsAutoStakeMaturity from "./actions/SnsAutoStakeMaturity.svelte";
   import SplitSnsNeuronButton from "./actions/SplitSnsNeuronButton.svelte";
   import type { E8s } from "@dfinity/nns";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let governanceCanisterId: Principal | undefined;
   export let neuron: SnsNeuron;
@@ -27,6 +31,14 @@
         subaccount: neuron?.id[0]?.id,
       }
     : undefined;
+
+  let allowedToSplit: boolean;
+  $: allowedToSplit =
+    nonNullish(neuron) &&
+    hasPermissionToSplit({
+      neuron,
+      identity: $authStore.identity,
+    });
 </script>
 
 <Section testId="sns-neuron-advanced-section-component">
@@ -76,7 +88,10 @@
       <SnsNeuronVestingPeriodRemaining {neuron} />
     {/if}
     <SnsAutoStakeMaturity />
-    <SplitSnsNeuronButton {neuron} {parameters} {transactionFee} {token} />
+
+    {#if allowedToSplit}
+      <SplitSnsNeuronButton {neuron} {parameters} {transactionFee} {token} />
+    {/if}
   </div>
 </Section>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.svelte
@@ -12,9 +12,11 @@
     dissolveDelayMultiplier,
     getSnsDissolveDelaySeconds,
     getSnsNeuronState,
+    hasPermissionToDissolve,
   } from "$lib/utils/sns-neuron.utils";
   import { fromNullable } from "@dfinity/utils";
   import IncreaseSnsDissolveDelayButton from "./actions/IncreaseSnsDissolveDelayButton.svelte";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
@@ -43,6 +45,12 @@
   $: minimumDelayToVoteInSeconds =
     fromNullable(parameters.neuron_minimum_dissolve_delay_to_vote_seconds) ??
     0n;
+
+  let allowedToDissolve = false;
+  $: allowedToDissolve = hasPermissionToDissolve({
+    neuron,
+    identity: $authStore.identity,
+  });
 </script>
 
 <CommonItemAction testId="sns-neuron-dissolve-delay-item-action-component">
@@ -68,5 +76,7 @@
       </span>
     {/if}</svelte:fragment
   >
-  <IncreaseSnsDissolveDelayButton {neuron} variant="secondary" />
+  {#if allowedToDissolve}
+    <IncreaseSnsDissolveDelayButton {neuron} variant="secondary" />
+  {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -30,10 +30,12 @@
   $: ageBonus = ageMultiplier({ neuron, snsParameters });
 
   let allowedToDisburse: boolean;
-  $: allowedToDisburse = hasPermissionToDisburse({
-    neuron,
-    identity: $authStore.identity,
-  });
+  $: allowedToDisburse =
+    state === NeuronState.Dissolved &&
+    hasPermissionToDisburse({
+      neuron,
+      identity: $authStore.identity,
+    });
 
   let allowedToDissolve = false;
   $: allowedToDissolve =
@@ -68,7 +70,7 @@
       </span>
     {/if}
   </svelte:fragment>
-  {#if state === NeuronState.Dissolved && allowedToDisburse}
+  {#if allowedToDisburse}
     <DisburseSnsButton {neuron} />
   {:else if allowedToDissolve}
     <DissolveSnsNeuronButton {neuron} />

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -10,9 +10,12 @@
   import {
     ageMultiplier,
     getSnsNeuronState,
+    hasPermissionToDisburse,
+    hasPermissionToDissolve,
   } from "$lib/utils/sns-neuron.utils";
   import DisburseSnsButton from "./actions/DisburseSnsButton.svelte";
   import DissolveSnsNeuronButton from "./actions/DissolveSnsNeuronButton.svelte";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let neuron: SnsNeuron;
   export let snsParameters: SnsNervousSystemParameters;
@@ -25,6 +28,20 @@
 
   let ageBonus: number;
   $: ageBonus = ageMultiplier({ neuron, snsParameters });
+
+  let allowedToDisburse: boolean;
+  $: allowedToDisburse = hasPermissionToDisburse({
+    neuron,
+    identity: $authStore.identity,
+  });
+
+  let allowedToDissolve = false;
+  $: allowedToDissolve =
+    [NeuronState.Dissolving, NeuronState.Locked].includes(state) &&
+    hasPermissionToDissolve({
+      neuron,
+      identity: $authStore.identity,
+    });
 </script>
 
 <CommonItemAction testId="sns-neuron-state-item-action-component">
@@ -51,9 +68,9 @@
       </span>
     {/if}
   </svelte:fragment>
-  {#if state === NeuronState.Dissolved}
+  {#if state === NeuronState.Dissolved && allowedToDisburse}
     <DisburseSnsButton {neuron} />
-  {:else}
+  {:else if allowedToDissolve}
     <DissolveSnsNeuronButton {neuron} />
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakeItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakeItemAction.svelte
@@ -5,13 +5,19 @@
   import { i18n } from "$lib/stores/i18n";
   import { formatToken } from "$lib/utils/token.utils";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
+  import {
+    getSnsNeuronStake,
+    isCommunityFund,
+  } from "$lib/utils/sns-neuron.utils";
   import SnsIncreaseStakeButton from "./actions/SnsIncreaseStakeButton.svelte";
   import type { Universe } from "$lib/types/universe";
 
   export let neuron: SnsNeuron;
   export let token: Token;
   export let universe: Universe;
+
+  let isIncreaseStakeAllowed = false;
+  $: isIncreaseStakeAllowed = !isCommunityFund(neuron);
 </script>
 
 <ItemAction testId="sns-stake-item-action-component">
@@ -30,7 +36,11 @@
     </h4>
     <p class="description">{$i18n.neurons.ic_stake}</p>
   </div>
-  <SnsIncreaseStakeButton slot="actions" variant="secondary" />
+  <svelte:fragment slot="actions">
+    {#if isIncreaseStakeAllowed}
+      <SnsIncreaseStakeButton variant="secondary" />
+    {/if}
+  </svelte:fragment>
 </ItemAction>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.spec.ts
@@ -3,18 +3,32 @@
  */
 
 import SnsAvailableMaturityActionItem from "$lib/components/sns-neuron-detail/SnsAvailableMaturityActionItem.svelte";
+import { authStore } from "$lib/stores/auth.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
-import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import {
+  allSnsNeuronPermissions,
+  createMockSnsNeuron,
+} from "$tests/mocks/sns-neurons.mock";
 import { SnsAvailableMaturityActionItemPo } from "$tests/page-objects/SnsAvailableMaturityActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import type { SnsNeuron } from "@dfinity/sns";
+import type { Principal } from "@dfinity/principal";
+import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
 
 describe("SnsAvailableMaturityActionItem", () => {
-  const mockNeuron = createMockSnsNeuron({
+  const controllerPermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions,
+  };
+  const controlledNeuron = createMockSnsNeuron({
     id: [1],
     maturity: 314000000n,
+    permissions: [controllerPermissions],
   });
   const renderComponent = (neuron: SnsNeuron) => {
     const { container } = render(NeuronContextActionsTest, {
@@ -31,15 +45,38 @@ describe("SnsAvailableMaturityActionItem", () => {
     );
   };
 
+  const noStakeMaturityPermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions.filter(
+      (p) => p !== SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_STAKE_MATURITY
+    ),
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
+
   it("should render available maturity", async () => {
-    const po = renderComponent(mockNeuron);
+    const po = renderComponent(controlledNeuron);
 
     expect(await po.getMaturity()).toBe("3.14");
   });
 
   it("should render stake maturity button", async () => {
-    const po = renderComponent(mockNeuron);
+    const po = renderComponent(controlledNeuron);
 
     expect(await po.hasStakeButton()).toBe(true);
+  });
+
+  it("should not render stake maturity button if user has no stake maturity permission", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      permissions: [noStakeMaturityPermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.hasStakeButton()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayActionItem.spec.ts
@@ -9,14 +9,25 @@ import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
+import { authStore } from "$lib/stores/auth.store";
 import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import {
+  allSnsNeuronPermissions,
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { SnsNeuronDissolveDelayActionItemPo } from "$tests/page-objects/SnsNeuronDissolveDelayActionItem.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
-import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
+import type { Principal } from "@dfinity/principal";
+import {
+  SnsNeuronPermissionType,
+  type SnsNervousSystemParameters,
+  type SnsNeuron,
+} from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronDissolveDelayActionItem", () => {
@@ -45,15 +56,32 @@ describe("SnsNeuronDissolveDelayActionItem", () => {
     );
   };
 
+  const controllerPermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions,
+  };
+  const noDissolvePermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions.filter(
+      (p) =>
+        p !==
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE
+    ),
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(nowInSeconds * 1000);
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
   });
 
   it("should render dissolve delay text and bonus if neuron is locked", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
+      permissions: [controllerPermissions],
       dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
     });
     const po = renderComponent(neuron);
@@ -67,6 +95,7 @@ describe("SnsNeuronDissolveDelayActionItem", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolving,
+      permissions: [controllerPermissions],
       whenDissolvedTimestampSeconds: BigInt(
         nowInSeconds + SECONDS_IN_FOUR_YEARS
       ),
@@ -82,6 +111,7 @@ describe("SnsNeuronDissolveDelayActionItem", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolving,
+      permissions: [controllerPermissions],
       whenDissolvedTimestampSeconds: BigInt(nowInSeconds + SECONDS_IN_YEAR - 1),
     });
     const parameters: SnsNervousSystemParameters = {
@@ -97,11 +127,23 @@ describe("SnsNeuronDissolveDelayActionItem", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolved,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 
     expect(await po.getDissolveState()).toBe("Dissolve Delay: 0");
     expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
+  });
+
+  it("should not render increase dissolve delay button if user doesn't have dissolve permissions", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+      permissions: [noDissolvePermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -4,14 +4,21 @@
 
 import SnsNeuronStateItemAction from "$lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
+import { authStore } from "$lib/stores/auth.store";
 import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import {
+  allSnsNeuronPermissions,
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
-import type { SnsNeuron } from "@dfinity/sns";
+import type { Principal } from "@dfinity/principal";
+import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronStateItemAction", () => {
@@ -29,15 +36,38 @@ describe("SnsNeuronStateItemAction", () => {
     );
   };
 
+  const controllerPermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions,
+  };
+  const noDissolvePermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions.filter(
+      (p) =>
+        p !==
+        SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_CONFIGURE_DISSOLVE_STATE
+    ),
+  };
+  const noDisbursePermissions = {
+    principal: [mockIdentity.getPrincipal()] as [Principal],
+    permission_type: allSnsNeuronPermissions.filter(
+      (p) => p !== SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_DISBURSE
+    ),
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(nowInSeconds * 1000);
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
   });
 
   it("should render locked text and Start dissolving button if neuron is locked", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 
@@ -45,10 +75,22 @@ describe("SnsNeuronStateItemAction", () => {
     expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
   });
 
+  it("should not render Start dissolving button if user has no dissolve permissions", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      permissions: [noDissolvePermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+  });
+
   it("should render dissolving text and Stop dissolving button if neuron is dissolving", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolving,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 
@@ -56,10 +98,22 @@ describe("SnsNeuronStateItemAction", () => {
     expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
   });
 
+  it("should not render Stop dissolving button if user has no dissolve permissions", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      permissions: [noDissolvePermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+  });
+
   it("should render unlocked text and disburse button if neuron is unlocked", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolved,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 
@@ -67,10 +121,22 @@ describe("SnsNeuronStateItemAction", () => {
     expect(await po.hasDisburseButton()).toBe(true);
   });
 
+  it("should not render disburse button if user has no disburse permissions", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+      permissions: [noDisbursePermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.hasDisburseButton()).toBe(false);
+  });
+
   it("should render age bonus for Locked neurons", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
+      permissions: [controllerPermissions],
       ageSinceTimestampSeconds: BigInt(nowInSeconds - SECONDS_IN_FOUR_YEARS),
     });
     const po = renderComponent(neuron);
@@ -82,6 +148,7 @@ describe("SnsNeuronStateItemAction", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolving,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 
@@ -92,6 +159,7 @@ describe("SnsNeuronStateItemAction", () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolved,
+      permissions: [controllerPermissions],
     });
     const po = renderComponent(neuron);
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -84,6 +84,7 @@ describe("SnsNeuronStateItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+    expect(await po.hasDisburseButton()).toBe(false);
   });
 
   it("should render dissolving text and Stop dissolving button if neuron is dissolving", async () => {
@@ -107,6 +108,7 @@ describe("SnsNeuronStateItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
+    expect(await po.hasDisburseButton()).toBe(false);
   });
 
   it("should render unlocked text and disburse button if neuron is unlocked", async () => {
@@ -130,6 +132,7 @@ describe("SnsNeuronStateItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.hasDisburseButton()).toBe(false);
+    expect(await po.getDissolveButtonPo().isPresent()).toBe(false);
   });
 
   it("should render age bonus for Locked neurons", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
@@ -46,6 +46,7 @@ describe("SnsStakeItemAction", () => {
   it("should not render increase stake button if neuron belongs to CF", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
+      // Having a sourceNnsNeuronId makes the neuron a CF neuron.
       sourceNnsNeuronId: 123455n,
     });
     const po = renderComponent(neuron);

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
@@ -46,7 +46,7 @@ describe("SnsStakeItemAction", () => {
   it("should not render increase stake button if neuron belongs to CF", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
-      sourceNeuronId: 123455n,
+      sourceNnsNeuronId: 123455n,
     });
     const po = renderComponent(neuron);
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
@@ -42,4 +42,14 @@ describe("SnsStakeItemAction", () => {
 
     expect(await po.hasIncreaseStakeButton()).toBe(true);
   });
+
+  it("should not render increase stake button if neuron belongs to CF", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      sourceNeuronId: 123455n,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.hasIncreaseStakeButton()).toBe(false);
+  });
 });

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -54,6 +54,7 @@ export const createMockSnsNeuron = ({
   stakedMaturity?: bigint;
   maturity?: bigint;
   createdTimestampSeconds?: bigint;
+  // Having a sourceNnsNeuronId makes the neuron a CF neuron.
   sourceNnsNeuronId?: NeuronId;
 }): SnsNeuron => {
   return {

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -7,7 +7,7 @@ import type { ProjectNeuronStore } from "$lib/stores/sns-neurons.store";
 import type { SnsParameters } from "$lib/stores/sns-parameters.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";
-import { NeuronState } from "@dfinity/nns";
+import { NeuronState, type NeuronId } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import {
   SnsNeuronPermissionType,
@@ -15,7 +15,7 @@ import {
   type SnsNeuron,
 } from "@dfinity/sns";
 import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
-import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+import { arrayOfNumberToUint8Array, isNullish } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 import { mockIdentity } from "./auth.store.mock";
 import { rootCanisterIdMock } from "./sns.api.mock";
@@ -37,6 +37,7 @@ export const createMockSnsNeuron = ({
   stakedMaturity = BigInt(100_000_000),
   maturity = BigInt(100_000_000),
   createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
+  sourceNeuronId,
 }: {
   stake?: bigint;
   id: number[];
@@ -53,11 +54,12 @@ export const createMockSnsNeuron = ({
   stakedMaturity?: bigint;
   maturity?: bigint;
   createdTimestampSeconds?: bigint;
+  sourceNeuronId?: NeuronId;
 }): SnsNeuron => {
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
     permissions,
-    source_nns_neuron_id: [],
+    source_nns_neuron_id: isNullish(sourceNeuronId) ? [] : [sourceNeuronId],
     maturity_e8s_equivalent: maturity,
     cached_neuron_stake_e8s: stake,
     created_timestamp_seconds: createdTimestampSeconds,
@@ -199,3 +201,7 @@ export const buildMockSnsParametersStore =
     );
     return () => undefined;
   };
+
+export const allSnsNeuronPermissions = Int32Array.from(
+  enumValues(SnsNeuronPermissionType)
+);

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -37,7 +37,7 @@ export const createMockSnsNeuron = ({
   stakedMaturity = BigInt(100_000_000),
   maturity = BigInt(100_000_000),
   createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
-  sourceNeuronId,
+  sourceNnsNeuronId,
 }: {
   stake?: bigint;
   id: number[];
@@ -54,12 +54,14 @@ export const createMockSnsNeuron = ({
   stakedMaturity?: bigint;
   maturity?: bigint;
   createdTimestampSeconds?: bigint;
-  sourceNeuronId?: NeuronId;
+  sourceNnsNeuronId?: NeuronId;
 }): SnsNeuron => {
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
     permissions,
-    source_nns_neuron_id: isNullish(sourceNeuronId) ? [] : [sourceNeuronId],
+    source_nns_neuron_id: isNullish(sourceNnsNeuronId)
+      ? []
+      : [sourceNnsNeuronId],
     maturity_e8s_equivalent: maturity,
     cached_neuron_stake_e8s: stake,
     created_timestamp_seconds: createdTimestampSeconds,

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { ButtonPo } from "./Button.page-object";
 
 export class SnsNeuronStateItemActionPo extends BasePageObject {
   private static readonly TID = "sns-neuron-state-item-action-component";
@@ -22,7 +23,11 @@ export class SnsNeuronStateItemActionPo extends BasePageObject {
     return this.getButton("disburse-button").isPresent();
   }
 
+  getDissolveButtonPo(): ButtonPo {
+    return this.getButton("sns-dissolve-button");
+  }
+
   getDissolveButtonText(): Promise<string> {
-    return this.getButton("sns-dissolve-button").getText();
+    return this.getDissolveButtonPo().getText();
   }
 }


### PR DESCRIPTION
# Motivation

Use SNS neuron permissions to hide buttons for users without permission for the action.

# Changes

* Hide / show stake neuron button in SnsAvailableMaturityActionItem.
* Hide / show split neuron button in SnsNeuronAdvancedSection.
* Hide / show increase dissolve delay button in SnsNeuronDissolveDelayActionItem.
* Hide / show disburse or start/stop dissolve button in SnsNeuronStateItemAction.
* Hide / show increase stake button in SnsStakeItemAction. This is not related to permissions, but to avoid the users from doing something unexpected.

# Tests

* Check stake neuron button in SnsAvailableMaturityActionItem.
* Check split neuron button in SnsNeuronAdvancedSection.
* Check increase dissolve delay button in SnsNeuronDissolveDelayActionItem.
* Check disburse or start/stop dissolve button in SnsNeuronStateItemAction.
* Check increase stake button in SnsStakeItemAction.

# Todos

Not worth an entry, this applies the same functionality until now.
