### PR TITLE
Increase the displayed size of the projects logo on the "Launchpad"

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -15,6 +15,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Bump agent-js `v0.18.1`.
 * Clarify Ledger app version error message.
+* Increase the displayed size of the projects logo on the "Launchpad".
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -48,7 +48,7 @@
   theme={userHasParticipated ? "highlighted" : undefined}
 >
   <div class="title" slot="start">
-    <Logo src={logo} alt={$i18n.sns_launchpad.project_logo} />
+    <Logo src={logo} alt={$i18n.sns_launchpad.project_logo} size="big" />
     <h3 data-tid="project-name">{title}</h3>
   </div>
 
@@ -72,7 +72,7 @@
   .title {
     display: flex;
     gap: var(--padding-1_5x);
-    align-items: flex-start;
+    align-items: center;
     margin-bottom: var(--padding);
 
     h3 {


### PR DESCRIPTION
# Motivation

It looks cooler. Reviewed with Artem.

# Changes

- bump logo size to "big" in project card and align title center

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2023-07-25 à 15 19 48" src="https://github.com/dfinity/nns-dapp/assets/16886711/2229c497-2b02-4dde-8ea3-4e0210070f8d">

<img width="612" alt="Capture d’écran 2023-07-25 à 15 21 28" src="https://github.com/dfinity/nns-dapp/assets/16886711/23421d44-5888-4ef2-bdf9-efa2aea8b1cb">

After:

<img width="1536" alt="Capture d’écran 2023-07-25 à 15 19 42" src="https://github.com/dfinity/nns-dapp/assets/16886711/fcf16662-cf62-4ee2-aa76-cc541df79861">

<img width="612" alt="Capture d’écran 2023-07-25 à 15 21 55" src="https://github.com/dfinity/nns-dapp/assets/16886711/e8b3a673-1987-4725-9449-623678fa1143">

