### PR TITLE
fix: Use docker-build --network flag

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -43,6 +43,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Updated the calls to `docker-build` to use the `--network` flag.
 * Upgraded to Playwright 1.36.
 
 #### Deprecated

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -26,7 +26,7 @@ verify_healthy() {
 }
 
 get_current_wasm() {
-  DFX_NETWORK=local ./scripts/docker-build
+  ./scripts/docker-build --network local
 }
 
 get_prod_wasm() {
@@ -43,7 +43,7 @@ echo "Getting or building the wasm..."
 test -n "${CURRENT_WASM:-}" || {
   CURRENT_WASM="nns-dapp.wasm.gz"
   echo "Building $CURRENT_WASM..."
-  DFX_NETWORK=local ./scripts/docker-build
+  ./scripts/docker-build --network local
 }
 test -e "$CURRENT_WASM" || {
   echo "ERROR: Wasm file not found at '$CURRENT_WASM'."

--- a/scripts/propose-to/propose-to-upgrade-nns-dapp
+++ b/scripts/propose-to/propose-to-upgrade-nns-dapp
@@ -14,7 +14,7 @@ get_canister_id >/dev/null || {
 }
 
 WASM_FILE=nns-dapp.wasm.gz
-test -e "$WASM_FILE" || DFX_NETWORK="$DFX_NETWORK" ./scripts/docker-build
+test -e "$WASM_FILE" || ./scripts/docker-build --network "$DFX_NETWORK"
 SHA="$(sha256sum "$WASM_FILE" | awk '{print $1}')"
 CANISTER_ID="$(get_canister_id)"
 

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -32,7 +32,7 @@ echo "Getting or building the local wasm..."
 test -n "${CURRENT_WASM:-}" || {
   CURRENT_WASM="sns_aggregator.wasm.gz"
   echo "Building $CURRENT_WASM..."
-  DFX_NETWORK=local ./scripts/docker-build
+  ./scripts/docker-build --network local
 }
 test -e "$CURRENT_WASM" || {
   echo "ERROR: Wasm file not found at '$CURRENT_WASM'."


### PR DESCRIPTION
# Motivation
`docker-build` now specifies the network by means of a flag.  Some code still passes it as a command line argument, which happens to work if the relevant arguments have already been computed before but not otherwise.  This should be fixed.

# Changes
- Use the `--network` flag instead of an environment variable, whenever `docker-build` is called.

# Tests
- See CI

# Todos

- [x] Add entry to changelog (if necessary).
