### PR TITLE
Fix: SNS Governance E2E flakyness

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -54,6 +54,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Deploy.sh script
+* Improve sns governance e2e test.
 
 #### Security
 

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -93,7 +93,7 @@
   {#if $authSignedInStore}
     <button
       role="menuitem"
-      data-tid="get-icp-button"
+      data-tid={`get-${token.symbol}-button`}
       on:click|preventDefault|stopPropagation={() => (visible = true)}
       class="open"
     >

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -27,6 +27,9 @@
   let selectedProjectId = OWN_CANISTER_ID;
   $: selectedProjectId = $selectedUniverseIdStore;
 
+  let isNns: boolean;
+  $: isNns = selectedProjectId.toText() === OWN_CANISTER_ID.toText();
+
   const onSubmit = async () => {
     if (invalidForm || inputValue === undefined) {
       toastsError({
@@ -39,10 +42,7 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (
-        selectedProjectId.toText() === OWN_CANISTER_ID.toText() ||
-        tokenBalanceE8s === 0n
-      ) {
+      if (isNns || tokenBalanceE8s === 0n) {
         await getICPs(inputValue);
       } else {
         await getTokens({
@@ -93,7 +93,7 @@
   {#if $authSignedInStore}
     <button
       role="menuitem"
-      data-tid={`get-${token.symbol}-button`}
+      data-tid={`get-${isNns || tokenBalanceE8s === 0n ? "icp" : "sns"}-button`}
       on:click|preventDefault|stopPropagation={() => (visible = true)}
       class="open"
     >

--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -33,7 +33,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
 
   // Get some ICP to be able to transfer
-  await appPo.getTokens(20);
+  await appPo.getIcpTokens(20);
 
   step("AU004: The user MUST be able to transfer funds");
   expect(await nnsAccountsPo.getAccountBalance(mainAccountName)).toEqual(

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -12,7 +12,7 @@ test("Test disburse neuron", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  await appPo.getTokens(10);
+  await appPo.getIcpTokens(10);
   // TODO: Remove once we set feature flag to true https://dfinity.atlassian.net/browse/GIX-1687
   await page.evaluate(() =>
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -12,7 +12,7 @@ test("Test merge neurons", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  await appPo.getTokens(10);
+  await appPo.getIcpTokens(10);
 
   step("Go to the neurons tab");
   await appPo.goToNeurons();

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -14,7 +14,7 @@ test("Test neuron voting", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  await appPo.getTokens(41);
+  await appPo.getIcpTokens(41);
 
   // should be created before dummy proposals
   step("Stake neuron (for voting)");

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -23,8 +23,12 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(snsProjectName).toMatch(/[A-Z]{5}/);
 
   await snsUniverseCard.click();
+
   step("Acquire tokens");
-  await appPo.getTokens(20);
+  await appPo.openMenu();
+  await appPo.getTokensButton(snsProjectName).waitFor();
+  await appPo.getMenuItemsPo().getGetTokensPo().getTokens(20, snsProjectName);
+  await appPo.closeMenu();
 
   expect(
     await appPo

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -25,7 +25,7 @@ test("Test SNS governance", async ({ page, context }) => {
   await snsUniverseCard.click();
 
   step("Acquire tokens");
-  await appPo.getSnsTokens(1);
+  await appPo.getSnsTokens(20);
 
   expect(
     await appPo

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -25,10 +25,7 @@ test("Test SNS governance", async ({ page, context }) => {
   await snsUniverseCard.click();
 
   step("Acquire tokens");
-  await appPo.openMenu();
-  await appPo.getTokensButton(snsProjectName).waitFor();
-  await appPo.getMenuItemsPo().getGetTokensPo().getTokens(20, snsProjectName);
-  await appPo.closeMenu();
+  await appPo.getSnsTokens(1);
 
   expect(
     await appPo

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -43,7 +43,7 @@ test("Test SNS participation", async ({ page, context }) => {
 
   step("Get some ICP to participate in the sale");
   await appPo.goBack();
-  await appPo.getTokens(20);
+  await appPo.getIcpTokens(20);
   await openProjects[0].click();
 
   step("D004: User can participate in a sale");

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -136,7 +136,6 @@ export class AppPo extends BasePageObject {
 
   async getSnsTokens(amount: number): Promise<void> {
     await this.openMenu();
-    await this.getMenuItemsPo().getGetTokensPo().getSnsTokensButton().waitFor();
     await this.getMenuItemsPo().getGetTokensPo().getSnsTokens(amount);
     await this.closeMenu();
   }

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -134,13 +134,16 @@ export class AppPo extends BasePageObject {
     await this.getBackdropPo().waitForAbsent();
   }
 
-  getTokensButton(token: string): ButtonPo {
-    return this.getMenuItemsPo().getGetTokensPo().getTokensButtonPo(token);
+  async getSnsTokens(amount: number): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().getGetTokensPo().getSnsTokensButton().waitFor();
+    await this.getMenuItemsPo().getGetTokensPo().getSnsTokens(amount);
+    await this.closeMenu();
   }
 
-  async getTokens(amount: number, token = "icp"): Promise<void> {
+  async getIcpTokens(amount: number): Promise<void> {
     await this.openMenu();
-    await this.getMenuItemsPo().getGetTokensPo().getTokens(amount, token);
+    await this.getMenuItemsPo().getGetTokensPo().getIcpTokens(amount);
     await this.closeMenu();
   }
 

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -134,9 +134,13 @@ export class AppPo extends BasePageObject {
     await this.getBackdropPo().waitForAbsent();
   }
 
-  async getTokens(amount: number): Promise<void> {
+  getTokensButton(token: string): ButtonPo {
+    return this.getMenuItemsPo().getGetTokensPo().getTokensButtonPo(token);
+  }
+
+  async getTokens(amount: number, token = "icp"): Promise<void> {
     await this.openMenu();
-    await this.getMenuItemsPo().getGetTokensPo().getTokens(amount);
+    await this.getMenuItemsPo().getGetTokensPo().getTokens(amount, token);
     await this.closeMenu();
   }
 

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -39,6 +39,7 @@ export class GetTokensPo extends BasePageObject {
   }
 
   async getSnsTokens(amount: number): Promise<void> {
+    await this.getSnsTokensButton().waitFor();
     await this.clickGetSnsTokens();
     await this.getTokens(amount);
   }

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { ButtonPo } from "./Button.page-object";
 
 export class GetTokensPo extends BasePageObject {
   static readonly TID = "get-tokens-component";
@@ -8,8 +9,12 @@ export class GetTokensPo extends BasePageObject {
     return new GetTokensPo(element.byTestId(GetTokensPo.TID));
   }
 
-  clickGetTokens(): Promise<void> {
-    return this.getButton("get-icp-button").click();
+  getTokensButtonPo(token: string): ButtonPo {
+    return this.getButton(`get-${token}-button`);
+  }
+
+  clickGetTokens(token: string): Promise<void> {
+    return this.getTokensButtonPo(token).click();
   }
 
   enterAmount(amount: number): Promise<void> {
@@ -24,8 +29,8 @@ export class GetTokensPo extends BasePageObject {
     return this.root.byTestId("get-icp-form").waitForAbsent();
   }
 
-  async getTokens(amount: number): Promise<void> {
-    await this.clickGetTokens();
+  async getTokens(amount: number, token: string): Promise<void> {
+    await this.clickGetTokens(token);
     await this.enterAmount(amount);
     await this.clickSubmit();
     await this.waitForModalClosed();

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -9,12 +9,16 @@ export class GetTokensPo extends BasePageObject {
     return new GetTokensPo(element.byTestId(GetTokensPo.TID));
   }
 
-  getTokensButtonPo(token: string): ButtonPo {
-    return this.getButton(`get-${token}-button`);
+  clickGetIcpTokens(): Promise<void> {
+    return this.getButton("get-icp-button").click();
   }
 
-  clickGetTokens(token: string): Promise<void> {
-    return this.getTokensButtonPo(token).click();
+  getSnsTokensButton(): ButtonPo {
+    return this.getButton("get-sns-button");
+  }
+
+  clickGetSnsTokens(): Promise<void> {
+    return this.getSnsTokensButton().click();
   }
 
   enterAmount(amount: number): Promise<void> {
@@ -29,8 +33,17 @@ export class GetTokensPo extends BasePageObject {
     return this.root.byTestId("get-icp-form").waitForAbsent();
   }
 
-  async getTokens(amount: number, token: string): Promise<void> {
-    await this.clickGetTokens(token);
+  async getIcpTokens(amount: number): Promise<void> {
+    await this.clickGetIcpTokens();
+    await this.getTokens(amount);
+  }
+
+  async getSnsTokens(amount: number): Promise<void> {
+    await this.clickGetSnsTokens();
+    await this.getTokens(amount);
+  }
+
+  private async getTokens(amount: number): Promise<void> {
     await this.enterAmount(amount);
     await this.clickSubmit();
     await this.waitForModalClosed();


### PR DESCRIPTION
# Motivation

We want trustworthy e2e tests.

In this PR: Fix a flakyness in the E2E test sns-governance when getting the SNS tokens.

# Changes

* Change test id for the get tokens button. It relies now on the token symbol. This way we can wait for it in playwright.
* Getting tokens methods expect a new argument "token" to get the button.
* Use the new parameter in the sns-governance e2e test.

# Tests

Only test changes.

# Todos

- [x] Add entry to changelog (if necessary).
