### PR TITLE
GIX-1745: Neurons e2e test uses new neurons UI

### DIFF
--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -2,7 +2,11 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
@@ -15,6 +19,13 @@ test("Test neuron voting", async ({ page, context }) => {
 
   step("Get some ICP");
   await appPo.getIcpTokens(41);
+
+  // TODO: Remove once we set feature flag to true https://dfinity.atlassian.net/browse/GIX-1687
+  await setFeatureFlag({
+    page,
+    featureFlag: "ENABLE_NEURON_SETTINGS",
+    value: true,
+  });
 
   // should be created before dummy proposals
   step("Stake neuron (for voting)");
@@ -41,11 +52,13 @@ test("Test neuron voting", async ({ page, context }) => {
   await appPo.goToNeuronDetails(neuronId);
 
   step("Get neuron voting power");
-  const neuronAVotingPower = await appPo
-    .getNeuronDetailPo()
-    .getNnsNeuronDetailPo()
-    .getNnsNeuronMetaInfoCardPageObjectPo()
-    .getVotingPower();
+  const neuronAVotingPower = Number(
+    await appPo
+      .getNeuronDetailPo()
+      .getNnsNeuronDetailPo()
+      .getVotingPowerSectionPo()
+      .getVotingPower()
+  );
 
   // vp=stake*2 when max dissolve delay (https://support.dfinity.org/hc/en-us/articles/4404284534420-What-is-voting-power-)
   expect(neuronAVotingPower).toBe(stake * 2);


### PR DESCRIPTION
# Motivation

Move e2e tests to the new neuron details UI.

In this PR: Move the neurons.spec.ts e2e test to new neuron details UI.

# Changes

* Set feature flag `ENABLE_NEURON_SETTINGS` to true in e2e test neurons.spec and make it pass.

# Tests

Only test changes.

# Todos

Already covered by a changelog entry.
