### PR TITLE
Update cycle count estimates

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -46,6 +46,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Updated the downgrade-upgrade test summary.
 * Increased the size of the persistent state in downgrade-upgrade tests.
 * Moved the downgrade-upgrade test into a dedicated job.
 * Faster formatting of shell and yaml files, by operating only on named or changed files.

--- a/scripts/nns-dapp/estimate-upgrade-cycles
+++ b/scripts/nns-dapp/estimate-upgrade-cycles
@@ -29,7 +29,7 @@ post_upgrade_instruction_count="$(jq -r '.["post_upgrade stop"].cumulative' ,pos
 mainnet_state_recovery_instruction_count="$(jq -r '.["post_upgrade after state_recovery"].increase' ,postupgrade-mainnet.json)"
 max_instructions=1000000000000
 
-humreadable() { numfmt --to=si --format="%.3f" "${!1}"; }
+humreadable() { numfmt --to=si --format="%.1f" "${!1}"; }
 body_columns() { printf "| %-60s | %20s | %12s |\n" "**$1**" "$(humreadable "$2")" "$(percent "$2")"; }
 percent() { echo "$(((${!1} * 100) / max_instructions))%"; }
 
@@ -54,9 +54,9 @@ export post_upgrade_instruction_count mainnet_state_recovery_instruction_count
   echo "|---------------------------------------|-------------------|-------------|-------------------|"
   for metric in accounts_count sub_accounts_count hardware_wallet_accounts_count neurons_created_count transactions_count; do
     mainnet_metric="$(jq -r ".$metric // 0" ,counts-mainnet.json)"
-    mainnet_metric_str="$(numfmt --to=si --format="%.3f" "$mainnet_metric")"
+    mainnet_metric_str="$(humreadable mainnet_metric)"
     local_metric="$(jq -r ".$metric // 0" ,counts-local.json)"
-    local_metric_str="$(numfmt --to=si --format="%.3f" "$local_metric")"
+    local_metric_str="$(humreadable local_metric)"
     if ((mainnet_metric == 0)); then
       percent_str="-"
     else

--- a/scripts/nns-dapp/estimate-upgrade-cycles
+++ b/scripts/nns-dapp/estimate-upgrade-cycles
@@ -27,10 +27,6 @@ done
 
 post_upgrade_instruction_count="$(jq -r '.["post_upgrade stop"].cumulative' ,postupgrade-local.json)"
 mainnet_state_recovery_instruction_count="$(jq -r '.["post_upgrade after state_recovery"].increase' ,postupgrade-mainnet.json)"
-# Assuming mainnet state recovery is as now, simply adding the mainnet state upgrade cycle count makes a reasonable estimate of cycles consumed.
-state_recovery_safety_factor=2
-likely_instruction_count="$((post_upgrade_instruction_count + mainnet_state_recovery_instruction_count))"
-maximum_likely_instruction_count="$((post_upgrade_instruction_count + state_recovery_safety_factor * mainnet_state_recovery_instruction_count))"
 max_instructions=1000000000000
 
 humreadable() { numfmt --to=si --format="%.3f" "${!1}"; }
@@ -38,15 +34,37 @@ body_columns() { printf "| %-60s | %20s | %12s |\n" "**$1**" "$(humreadable "$2"
 percent() { echo "$(((${!1} * 100) / max_instructions))%"; }
 
 # Declare the variables as exported to satisfy shellcheck; it is not needed for the code.
-export likely_instruction_count maximum_likely_instruction_count
+export post_upgrade_instruction_count mainnet_state_recovery_instruction_count
 (
+  echo
   echo "## Upgrade cycle counts"
   echo "| Name                                                         | Cycles               | % max cycles | "
   echo "|--------------------------------------------------------------|----------------------|--------------|"
   body_columns "Mainnet state recovery instruction count" mainnet_state_recovery_instruction_count
+  # TODO: Show the downgrade cycle count; this should be similar to production, most of the time.
   body_columns "PR post upgrade instruction count" post_upgrade_instruction_count
-  body_columns "Likely PR count in prod" likely_instruction_count
-  body_columns "Instruction count with ${state_recovery_safety_factor}x increase in user data" maximum_likely_instruction_count
+  echo
+)
+
+(
+  echo
+  echo "## State size"
+  echo "The test state size should be similar to production."
+  echo "| Data type                             | Num in Production | Num in test | % test/production |"
+  echo "|---------------------------------------|-------------------|-------------|-------------------|"
+  for metric in accounts_count sub_accounts_count hardware_wallet_accounts_count neurons_created_count transactions_count; do
+    mainnet_metric="$(jq -r ".$metric // 0" ,counts-mainnet.json)"
+    mainnet_metric_str="$(numfmt --to=si --format="%.3f" "$mainnet_metric")"
+    local_metric="$(jq -r ".$metric // 0" ,counts-local.json)"
+    local_metric_str="$(numfmt --to=si --format="%.3f" "$local_metric")"
+    if ((mainnet_metric == 0)); then
+      percent_str="-"
+    else
+      percent_str="$(((local_metric * 100) / mainnet_metric))%"
+    fi
+    printf '| %-37s | %17s | %11s | %17s |\n' "**$metric**" "$mainnet_metric_str" "$local_metric_str" "$percent_str"
+  done
+  echo
 )
 
 {


### PR DESCRIPTION
# Motivation
Now that the state is large and _should_ be prod-like, the upgrade cycle count estimate is now very wrong.

Instead we give just the upgrade cycle count and compare the size of the mainnet and test states.  This way a reader has access to the key data and can see how realistic the cycle estimate is.

# Changes
* Remove projected cycle counts, leaving just the actual counts.
* Add a state size table, comparing the local testnet with mainnet.
* Truncate floats; three decimal places can make the decimal separator look like a thousands separator.  One decimal place is probably enough.

# Tests
* Run in CI: https://github.com/dfinity/nns-dapp/actions/runs/5680844725#summary-15395895036
* Run locally:
```
$ scripts/nns-dapp/estimate-upgrade-cycles 2>/dev/null

## Upgrade cycle counts
| Name                                                         | Cycles               | % max cycles | 
|--------------------------------------------------------------|----------------------|--------------|
| **Mainnet state recovery instruction count**                 |               693,6G |          69% |
| **PR post upgrade instruction count**                        |               322,4G |          32% |


## State size
The test state size should be similar to production.
| Data type                             | Num in Production | Num in test | % test/production |
|---------------------------------------|-------------------|-------------|-------------------|
| **accounts_count**                    |            195,1K |      200,0K |              102% |
| **sub_accounts_count**                |             34,4K |      300,0K |              873% |
| **hardware_wallet_accounts_count**    |             11,1K |      100,0K |              903% |
| **neurons_created_count**             |             44,6K |         0,0 |                0% |
| **transactions_count**                |            630,1K |         0,0 |                0% |

$
```

# Todos

- [x] Add entry to changelog (if necessary).
- Future: The test state does need neurons and transactions to make it realistic and a few more statistics, such as upgrade time, would be nice.