### PR TITLE
Chore: Clean getStateInfo

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -18,7 +18,7 @@
 
   export let neuron: NeuronInfo;
 
-  let stateInfo: StateInfo | undefined;
+  let stateInfo: StateInfo;
   $: stateInfo = getStateInfo(neuron.state);
 
   let ageBonus: number;
@@ -39,7 +39,7 @@
     {/if}
   </svelte:fragment>
   <span slot="title" data-tid="state-text">
-    {keyOf({ obj: $i18n.neuron_state, key: NeuronState[neuron.state] })}
+    {keyOf({ obj: $i18n.neuron_state, key: stateInfo.textKey })}
   </span>
   <svelte:fragment slot="subtitle">
     {#if neuron.state === NeuronState.Locked}

--- a/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
+++ b/frontend/src/lib/components/neurons/NeuronStateInfo.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-
   import type { StateInfo } from "$lib/utils/neuron.utils";
-  import { NeuronState } from "@dfinity/nns";
+  import type { NeuronState } from "@dfinity/nns";
   import { getStateInfo } from "$lib/utils/neuron.utils";
   import { keyOf } from "$lib/utils/utils";
   import { ICON_SIZE_SMALL_PIXELS } from "$lib/constants/layout.constants";
@@ -16,7 +15,7 @@
 {#if stateInfo !== undefined}
   <div class="status" data-tid="neuron-state-info">
     <svelte:component this={stateInfo.Icon} size={ICON_SIZE_SMALL_PIXELS} />
-    {keyOf({ obj: $i18n.neuron_state, key: NeuronState[state] })}
+    {keyOf({ obj: $i18n.neuron_state, key: stateInfo.textKey })}
   </div>
 {/if}
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -23,7 +23,7 @@
   let state: NeuronState;
   $: state = getSnsNeuronState(neuron);
 
-  let stateInfo: StateInfo | undefined;
+  let stateInfo: StateInfo;
   $: stateInfo = getStateInfo(state);
 
   let ageBonus: number;
@@ -53,7 +53,7 @@
     {/if}
   </svelte:fragment>
   <span slot="title" data-tid="state-text">
-    {keyOf({ obj: $i18n.neuron_state, key: NeuronState[state] })}
+    {keyOf({ obj: $i18n.neuron_state, key: stateInfo.textKey })}
   </span>
   <svelte:fragment slot="subtitle">
     {#if state === NeuronState.Locked}

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -60,43 +60,37 @@ import { formatToken } from "./token.utils";
 import { isDefined } from "./utils";
 
 export type StateInfo = {
-  textKey: string;
   Icon?: typeof SvelteComponent;
-  status: "ok" | "warn" | "spawning";
+  textKey: keyof I18n["neuron_state"];
 };
 
-type StateMapper = {
-  [key: number]: StateInfo;
-};
-export const stateTextMapper: StateMapper = {
+type StateMapper = Record<NeuronState, StateInfo>;
+
+const stateInfoMapper: StateMapper = {
   [NeuronState.Locked]: {
-    textKey: "locked",
     Icon: IconLockClosed,
-    status: "ok",
+    textKey: "Locked",
   },
   [NeuronState.Unspecified]: {
-    textKey: "unspecified",
-    status: "ok",
+    Icon: undefined,
+    textKey: "Unspecified",
   },
   [NeuronState.Dissolved]: {
-    textKey: "dissolved",
     Icon: IconLockOpen,
-    status: "ok",
+    textKey: "Dissolved",
   },
   [NeuronState.Dissolving]: {
-    textKey: "dissolving",
     Icon: IconDissolving,
-    status: "warn",
+    textKey: "Dissolving",
   },
   [NeuronState.Spawning]: {
-    textKey: "spawning",
     Icon: IconHistoryToggleOff,
-    status: "spawning",
+    textKey: "Spawning",
   },
 };
 
-export const getStateInfo = (neuronState: NeuronState): StateInfo | undefined =>
-  stateTextMapper[neuronState];
+export const getStateInfo = (neuronState: NeuronState): StateInfo =>
+  stateInfoMapper[neuronState];
 
 /**
  * Calculation of the voting power of a neuron.


### PR DESCRIPTION
# Motivation

Clean and improve the neuron util `getStateInfo`

# Changes

* Remove the "status" field.
* Use the "textKey" instead of relying in the key of the enum for the transation key.
* Change the type of the state info to ensure text keys match an i18n key.
* Remove unnecessary `undefined` type.

# Tests

No tests. Changes are statically checked.

# Todos

No changes for the user. Same functionality.
