### PR TITLE
GIX-1777: Communicate when No Voting Power

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -6,6 +6,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import PageHeading from "../common/PageHeading.svelte";
+  import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 
   export let neuron: NeuronInfo;
 
@@ -14,13 +15,22 @@
     amount: neuronStake(neuron),
     token: ICPToken,
   });
+
+  // NNS neurons come with voting power but that doesn't mean they can vote.
+  let canVote: boolean;
+  $: canVote =
+    neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
 </script>
 
 <PageHeading testId="nns-neuron-page-heading-component">
   <AmountDisplay slot="title" {amount} size="huge" singleLine />
-  <svelte:fragment slot="subtitle">
-    {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-      $votingPower: formatVotingPower(neuron.votingPower),
-    })}
-  </svelte:fragment>
+  <span slot="subtitle" data-tid="voting-power">
+    {#if canVote}
+      {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
+        $votingPower: formatVotingPower(neuron.votingPower),
+      })}
+    {:else}
+      {$i18n.neuron_detail.voting_power_zero_subtitle}
+    {/if}
+  </span>
 </PageHeading>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -16,7 +16,7 @@
     token: ICPToken,
   });
 
-  // NNS neurons come with voting power but that doesn't mean they can vote.
+  // The API might return a non-zero voting power even if the neuron can't vote.
   let canVote: boolean;
   $: canVote =
     neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -8,6 +8,7 @@
   import NnsStakeItemAction from "./NnsStakeItemAction.svelte";
   import NnsNeuronStateItemAction from "./NnsNeuronStateItemAction.svelte";
   import NnsNeuronDissolveDelayActionItem from "./NnsNeuronDissolveDelayActionItem.svelte";
+  import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 
   export let neuron: NeuronInfo;
 
@@ -16,12 +17,21 @@
     amount: neuronStake(neuron),
     token: ICPToken,
   });
+
+  // NNS neurons come with voting power but that doesn't mean they can vote.
+  let canVote: boolean;
+  $: canVote =
+    neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
 </script>
 
 <Section testId="nns-neuron-voting-power-section-component">
   <h3 slot="title">{$i18n.neurons.voting_power}</h3>
   <p slot="end" class="title-value" data-tid="voting-power">
-    {formatVotingPower(neuron.votingPower)}
+    {#if canVote}
+      {formatVotingPower(neuron.votingPower)}
+    {:else}
+      {$i18n.neuron_detail.voting_power_zero}
+    {/if}
   </p>
   <p slot="description">
     {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -18,7 +18,7 @@
     token: ICPToken,
   });
 
-  // NNS neurons come with voting power but that doesn't mean they can vote.
+  // The API might return a non-zero voting power even if the neuron can't vote.
   let canVote: boolean;
   $: canVote =
     neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -1,9 +1,4 @@
 <script lang="ts">
-  import {
-    SELECTED_SNS_NEURON_CONTEXT_KEY,
-    type SelectedSnsNeuronContext,
-  } from "$lib/types/sns-neuron-detail.context";
-  import { getContext } from "svelte";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { TokenAmount, type Token, nonNullish } from "@dfinity/utils";
@@ -18,13 +13,8 @@
   import PageHeading from "../common/PageHeading.svelte";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
 
+  export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
-
-  const { store }: SelectedSnsNeuronContext =
-    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-
-  let neuron: SnsNeuron | undefined | null;
-  $: neuron = $store.neuron;
 
   let token: Token | undefined;
   $: token = $tokensStore[$selectedUniverseIdStore.toText()].token;
@@ -37,6 +27,9 @@
           token: token,
         })
       : undefined;
+
+  let votingPower: number;
+  $: votingPower = snsNeuronVotingPower({ neuron, snsParameters: parameters });
 </script>
 
 <PageHeading testId="sns-neuron-page-heading-component">
@@ -46,12 +39,12 @@
     {/if}
   </svelte:fragment>
   <span slot="subtitle" data-tid="voting-power">
-    {#if nonNullish(neuron)}
+    {#if votingPower > 0}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
-        $votingPower: formatVotingPower(
-          snsNeuronVotingPower({ neuron, snsParameters: parameters })
-        ),
+        $votingPower: formatVotingPower(votingPower),
       })}
+    {:else}
+      {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
   </span>
 </PageHeading>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -18,14 +18,21 @@
 
   let universe: Universe;
   $: universe = $selectedUniverseStore;
+
+  let votingPower: number;
+  $: votingPower = snsNeuronVotingPower({ neuron, snsParameters: parameters });
 </script>
 
 <Section testId="sns-neuron-voting-power-section-component">
   <h3 slot="title">{$i18n.neurons.voting_power}</h3>
   <p slot="end" class="title-value" data-tid="voting-power">
-    {formatVotingPower(
-      snsNeuronVotingPower({ neuron, snsParameters: parameters })
-    )}
+    {#if votingPower > 0}
+      {formatVotingPower(
+        snsNeuronVotingPower({ neuron, snsParameters: parameters })
+      )}
+    {:else}
+      {$i18n.neuron_detail.voting_power_zero}
+    {/if}
   </p>
   <p slot="description">
     {replacePlaceholders($i18n.neuron_detail.voting_power_section_description, {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -561,6 +561,8 @@
     "increase_stake": "Increase Stake",
     "split_neuron": "Split Neuron",
     "voting_power_subtitle": "Voting Power: $votingPower",
+    "voting_power_zero_subtitle": "No Voting Power",
+    "voting_power_zero": "None",
     "voting_power_tooltip_with_stake": "Calculated as: <br/>($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus<br/>($stake + $st4kedMaturity) x $delayMultiplier x $ageMultiplier",
     "voting_power_section_description": "Voting Power = ($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus",
     "maturity_section_description": "Earn rewards by voting on proposals and/or following active neurons.",

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -173,7 +173,10 @@
           {#if $ENABLE_NEURON_SETTINGS && nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron) && nonNullish(transactionFee)}
             <div class="section-wrapper">
               <SnsNeuronPageHeader {token} />
-              <SnsNeuronPageHeading {parameters} />
+              <SnsNeuronPageHeading
+                {parameters}
+                neuron={$selectedSnsNeuronStore.neuron}
+              />
               <Separator spacing="none" />
               <SnsNeuronVotingPowerSection
                 neuron={$selectedSnsNeuronStore.neuron}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -584,6 +584,8 @@ interface I18nNeuron_detail {
   increase_stake: string;
   split_neuron: string;
   voting_power_subtitle: string;
+  voting_power_zero_subtitle: string;
+  voting_power_zero: string;
   voting_power_tooltip_with_stake: string;
   voting_power_section_description: string;
   maturity_section_description: string;

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -623,6 +623,8 @@ export const neuronAge = ({
  * voting_power = neuron's_stake * dissolve_delay_bonus * age_bonus * voting_power_multiplier
  * The backend logic: https://gitlab.com/dfinity-lab/public/ic/-/blob/07ce9cef07535bab14d88f3f4602e1717be6387a/rs/sns/governance/src/neuron.rs#L158
  *
+ * Returns 0 if the neuron is not eligible to vote.
+ *
  * @param {SnsNeuron} neuron
  * @param {SnsNervousSystemParameters} neuron.snsParameters
  * @param {number} neuron.newDissolveDelayInSeconds

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
+import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeadingPo } from "$tests/page-objects/NnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -28,5 +29,27 @@ describe("NnsNeuronPageHeading", () => {
     });
 
     expect(await po.getStake()).toEqual("3.14");
+  });
+
+  it("should render neuron's voting power", async () => {
+    const votingPower = 314_000_000n;
+    const po = renderComponent({
+      ...mockNeuron,
+      votingPower,
+      dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE * 2),
+    });
+
+    expect(await po.getVotingPower()).toEqual("Voting Power: 3.14");
+  });
+
+  it("should render no voting power if neuron can't vote", async () => {
+    const votingPower = 314_000_000n;
+    const po = renderComponent({
+      ...mockNeuron,
+      votingPower,
+      dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE - 100),
+    });
+
+    expect(await po.getVotingPower()).toEqual("No Voting Power");
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import NnsNeuronVotingPowerSection from "$lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte";
+import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -28,10 +29,22 @@ describe("NnsStakeItemAction", () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
       votingPower: 614000000n,
+      dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE + 100),
     };
     const po = renderComponent(neuron);
 
     expect(await po.getVotingPower()).toBe("6.14");
+  });
+
+  it("should render no voting power if neuron can't vote", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      votingPower: 614000000n,
+      dissolveDelaySeconds: BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE - 100),
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getVotingPower()).toBe("None");
   });
 
   it("should render item actions", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -4,7 +4,6 @@
 
 import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
 import { SECONDS_IN_EIGHT_YEARS } from "$lib/constants/constants";
-import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -14,14 +13,13 @@ import { SnsNeuronPageHeadingPo } from "$tests/page-objects/SnsNeuronPageHeading
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronPageHeading", () => {
   const renderSnsNeuronCmp = (neuron: SnsNeuron) => {
-    const { container } = renderSelectedSnsNeuronContext({
-      Component: SnsNeuronPageHeading,
-      neuron,
-      reload: jest.fn(),
+    const { container } = render(SnsNeuronPageHeading, {
       props: {
+        neuron,
         parameters: snsNervousSystemParametersMock,
       },
     });
@@ -51,5 +49,20 @@ describe("SnsNeuronPageHeading", () => {
     const po = renderSnsNeuronCmp(neuron);
 
     expect(await po.getVotingPower()).toEqual("Voting Power: 5.59");
+  });
+
+  it("should render no votig power if neuron can't vote", async () => {
+    const stake = 314_000_000n;
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      dissolveDelaySeconds:
+        snsNervousSystemParametersMock
+          .neuron_minimum_dissolve_delay_to_vote_seconds[0] - 100n,
+      stake,
+    });
+    const po = renderSnsNeuronCmp(neuron);
+
+    expect(await po.getVotingPower()).toEqual("No Voting Power");
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -51,6 +51,20 @@ describe("NnsStakeItemAction", () => {
     expect(await po.getVotingPower()).toBe("5.23");
   });
 
+  it("should render no voting power if neuron can't vote", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      stake: 314000000n,
+      state: NeuronState.Locked,
+      dissolveDelaySeconds:
+        snsNervousSystemParametersMock
+          .neuron_minimum_dissolve_delay_to_vote_seconds[0] - 100n,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getVotingPower()).toBe("None");
+  });
+
   it("should render item actions", async () => {
     const po = renderComponent(mockSnsNeuron);
 

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -18,4 +18,8 @@ export class NnsNeuronPageHeadingPo extends BasePageObject {
   getStake(): Promise<string> {
     return this.getAmountDisplayPo().getAmount();
   }
+
+  getVotingPower(): Promise<string> {
+    return this.getText("voting-power");
+  }
 }


### PR DESCRIPTION
# Motivation

Communicate better when a neuron can't vote.

In this PR: Improve the subtitle of the new neuron details page when neuron has no voting right and also the value in the voting power section.

# Changes

* Check whether neuron can vote and show a related message in NnsNeuronPageHeader and SnsNeuronPageHeading.
* Check whether neuron can vote and show a related text in NnsNeuronVotingPowerSection and SnsNeuronVotingPowerSection.

# Tests

* Test new cases in the page heading subtitle.
* Test new cases in the voting power section.

# Todos

Covered by changelog entry related to new neuron details UI.
