### PR TITLE
E2e/filter proposals by status

### DIFF
--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -63,7 +63,7 @@
       <p class="description">{title}</p>
     </blockquote>
 
-    <KeyValuePair>
+    <KeyValuePair testId="proposal-status">
       <p slot="key" class={`${color ?? ""} status`}>
         {statusString}
       </p>

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,7 +2,7 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
 import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
-import { Topic } from "@dfinity/nns";
+import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
@@ -45,4 +45,31 @@ test("Test neuron voting", async ({ page, context }) => {
   await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
 
   expect((await getVisibleCardTopics()).includes("Exchange Rate")).toBe(false);
+
+  step("Filter proposals by Status");
+  const getVisibleCardStatuses = () =>
+    appPo.getProposalsPo().getNnsProposalListPo().getCardStatuses();
+
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect(await getVisibleCardStatuses()).toEqual(["Open"]);
+  // Invert topic filter
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+  // Open status cards are visible
+  expect(await getVisibleCardStatuses()).toContain("Open");
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectAllStatuses([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect(await getVisibleCardStatuses()).not.toContain("Open");
 });

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -12,6 +12,10 @@ export class KeyValuePairPo extends BasePageObject {
     return new KeyValuePairPo(element.querySelector(`[data-tid=${testId}]`));
   }
 
+  async getKeyText(): Promise<string> {
+    return this.root.querySelector("dt").getText();
+  }
+
   async getValueText(): Promise<string> {
     return this.root.querySelector("dd").getText();
   }

--- a/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
@@ -1,7 +1,7 @@
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import type { Topic } from "@dfinity/nns";
+import type { ProposalStatus, Topic } from "@dfinity/nns";
 
 export class NnsProposalFiltersPo extends BasePageObject {
   private static readonly TID = "nns-proposals-filters-component";
@@ -53,10 +53,33 @@ export class NnsProposalFiltersPo extends BasePageObject {
     await this.getFilterModalPo().waitForAbsent();
   }
 
+  async selectAllStatuses(exceptions: ProposalStatus[]): Promise<void> {
+    await this.clickFiltersByStatusButton();
+    await this.getFilterModalPo().clickSelectAllButton();
+
+    for (const testId of exceptions.map(
+      (value) => `filter-modal-option-${value}`
+    )) {
+      const filterEntry = this.getFilterModalPo().getFilterEntryByIdPo(testId);
+      await filterEntry.click();
+    }
+
+    // confirm and close modal
+    await this.getFilterModalPo().clickConfirmButton();
+    await this.getFilterModalPo().waitForAbsent();
+  }
+
   async selectTopicFilter(topics: Topic[]): Promise<void> {
     await this.clickFiltersByTopicsButton();
     return this.selectEntriesInFilterModal(
       topics.map((value) => `filter-modal-option-${value}`)
+    );
+  }
+
+  async selectStatusFilter(statuses: ProposalStatus[]): Promise<void> {
+    await this.clickFiltersByStatusButton();
+    return this.selectEntriesInFilterModal(
+      statuses.map((value) => `filter-modal-option-${value}`)
     );
   }
 }

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -31,6 +31,17 @@ export class NnsProposalListPo extends BasePageObject {
     return Array.from(new Set(topics));
   }
 
+  async getCardStatuses(): Promise<string[]> {
+    const statuses = await Promise.all(
+      (
+        await this.getProposalCardPos()
+      ).map((card) => card.getProposalStatusText())
+    );
+
+    // return unique values only
+    return Array.from(new Set(statuses));
+  }
+
   async getFirstProposalCardPoForProposer(
     proposer: string
   ): Promise<ProposalCardPo> {

--- a/frontend/src/tests/page-objects/ProposalCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalCard.page-object.ts
@@ -26,6 +26,15 @@ export class ProposalCardPo extends BasePageObject {
     }).getValueText();
   }
 
+  async getProposalStatusText(): Promise<string> {
+    return (
+      await KeyValuePairPo.under({
+        element: this.root,
+        testId: "proposal-status",
+      }).getKeyText()
+    ).trim();
+  }
+
   getShortenedProposer(): Promise<string> {
     return KeyValuePairPo.under({
       element: this.root,


### PR DESCRIPTION
# Motivation

Filter proposals by status playwright test (part of `user-V02-proposal-filters-work.e2e`).

# Changes

- Status filter/getter in POs
- proposals.spec / filter by Status

# Tests

Yes

# Todos

Will be added when the whole spec is done.
- [ ] Add entry to changelog (if necessary).
