### PR TITLE
Fix back to accounts after transaction in wallet page

### DIFF
--- a/frontend/src/lib/components/layout/LayoutNavGuard.svelte
+++ b/frontend/src/lib/components/layout/LayoutNavGuard.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
   import { isNullish } from "@dfinity/utils";
   import { navigating } from "$app/stores";
-  import { Spinner } from "@dfinity/gix-components";
-
-  // To be used only when the transition between pages lasts long; otherwise, it can appear as being glitchy.
-  export let spinnerWhileNavigating = false;
 </script>
 
 <!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
 {#if isNullish($navigating)}
   <slot />
-{:else if spinnerWhileNavigating}
-  <Spinner />
 {/if}

--- a/frontend/src/routes/(login)/+layout.svelte
+++ b/frontend/src/routes/(login)/+layout.svelte
@@ -2,18 +2,22 @@
   import Banner from "$lib/components/header/Banner.svelte";
   import { onMount } from "svelte";
   import { initAppAuth } from "$lib/services/$public/app.services";
-  import { Layout, ContentBackdrop } from "@dfinity/gix-components";
+  import { Layout, ContentBackdrop, Spinner } from "@dfinity/gix-components";
   import LoginMenuItems from "$lib/components/login/LoginMenuItems.svelte";
   import LoginFooter from "$lib/components/login/LoginFooter.svelte";
   import LoginHeader from "$lib/components/login/LoginHeader.svelte";
   import LoginBackground from "$lib/components/login/LoginBackground.svelte";
+  import { navigating } from "$app/stores";
+  import { isNullish } from "@dfinity/utils";
   import Warnings from "$lib/components/warnings/Warnings.svelte";
-  import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
 
   onMount(async () => await initAppAuth());
 </script>
 
-<LayoutNavGuard spinnerWhileNavigating>
+<!-- Workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/5434 -->
+<!-- We do not use the <LayoutNavGuard /> here because the Spinner has to find place in this +layout.svelte -->
+<!-- If we would move the spinner to that <LayoutNavGuard /> component, then we would face the issue too -->
+{#if isNullish($navigating)}
   <Layout layout="stretch">
     <Banner />
 
@@ -39,7 +43,9 @@
   </Layout>
 
   <Warnings bringToastsForward />
-</LayoutNavGuard>
+{:else}
+  <Spinner />
+{/if}
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";


### PR DESCRIPTION
# Motivation

Refactoring the navigation spinner in #2962 within the component that prevents SvelteKit issue [#5434](https://github.com/sveltejs/kit/issues/5434) actually also lead to the same issue of duplicating the `split-pane` in the DOM. Therefore we have to undo the refactor and keep the spinner within the `+layout` of the sign-in page.

# Reproduce

- Open the wallet (e.g. of the main account)
- Make a transaction
- Click the back button
- Where the menu button should now reappear, there is only a non-functional back button

# Changes

- revert moving spinner from login layout to navigation guard
   - remove spinner from nav component
   - redo spinner in +layout of login (same code as on mainnet)
