### PR TITLE
Expose component props setter and getter

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -1,3 +1,6 @@
+<!-- Expose getters and setters to access properties in a testing context -->
+<svelte:options accessors />
+
 <script lang="ts">
   import type { Account } from "$lib/types/account";
   import {


### PR DESCRIPTION
# Motivation

Vitest (PR #2475) requires component's properties exposed as setter and getter if props are read within the test which is the case of `<CkBTCTransactionsList />`.
