### PR TITLE
GIX-1777: Hotkey and NF's tags

### DIFF
--- a/frontend/src/lib/components/common/HeadingTag.svelte
+++ b/frontend/src/lib/components/common/HeadingTag.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<span class="description" data-tid={testId}>
+  <slot />
+</span>
+
+<style lang="scss">
+  span {
+    background-color: var(--focus-background-tint);
+    padding: var(--padding);
+    border-radius: var(--border-radius-0_5x);
+  }
+</style>

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -2,7 +2,7 @@
   export let testId: string | undefined = undefined;
 
   let hasTags: boolean;
-  $: hasTags = !!$$slots.tag;
+  $: hasTags = $$slots.tags !== undefined;
 </script>
 
 <div class="container" data-tid={testId}>
@@ -12,7 +12,7 @@
   </h4>
   {#if hasTags}
     <div class="tags">
-      <slot name="tag" />
+      <slot name="tags" />
     </div>
   {/if}
 </div>

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -7,6 +7,7 @@
   <h4 class="description">
     <slot name="subtitle" />
   </h4>
+  <slot name="tag" />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   export let testId: string | undefined = undefined;
+
+  let hasTags: boolean;
+  $: hasTags = !!$$slots.tag;
 </script>
 
 <div class="container" data-tid={testId}>
@@ -7,7 +10,11 @@
   <h4 class="description">
     <slot name="subtitle" />
   </h4>
-  <slot name="tag" />
+  {#if hasTags}
+    <div class="tags">
+      <slot name="tag" />
+    </div>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -23,6 +30,12 @@
     h4 {
       margin: 0;
       font-weight: normal;
+    }
+
+    .tags {
+      display: flex;
+      align-items: center;
+      gap: var(--padding);
     }
   }
 </style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -50,27 +50,15 @@
     {/if}
   </span>
   <svelte:fragment slot="tag">
-    {#if isCommunityFund || isHotKeyControl}
-      <div class="tags">
-        {#if isCommunityFund}
-          <HeadingTag testId="neurons-fund-tag">
-            {$i18n.neurons.community_fund}
-          </HeadingTag>
-        {/if}
-        {#if isHotKeyControl}
-          <HeadingTag testId="hotkey-tag">
-            {$i18n.neurons.hotkey_control}
-          </HeadingTag>
-        {/if}
-      </div>
+    {#if isCommunityFund}
+      <HeadingTag testId="neurons-fund-tag">
+        {$i18n.neurons.community_fund}
+      </HeadingTag>
+    {/if}
+    {#if isHotKeyControl}
+      <HeadingTag testId="hotkey-tag">
+        {$i18n.neurons.hotkey_control}
+      </HeadingTag>
     {/if}
   </svelte:fragment>
 </PageHeading>
-
-<style lang="scss">
-  .tags {
-    display: flex;
-    align-items: center;
-    gap: var(--padding);
-  }
-</style>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -49,7 +49,7 @@
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
   </span>
-  <svelte:fragment slot="tag">
+  <svelte:fragment slot="tags">
     {#if isCommunityFund}
       <HeadingTag testId="neurons-fund-tag">
         {$i18n.neurons.community_fund}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -2,11 +2,18 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { TokenAmount, ICPToken } from "@dfinity/utils";
-  import { formatVotingPower, neuronStake } from "$lib/utils/neuron.utils";
+  import {
+    formatVotingPower,
+    hasJoinedCommunityFund,
+    isHotKeyControllable,
+    neuronStake,
+  } from "$lib/utils/neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import PageHeading from "../common/PageHeading.svelte";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
+  import { authStore } from "$lib/stores/auth.store";
+  import HeadingTag from "../common/HeadingTag.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -20,6 +27,15 @@
   let canVote: boolean;
   $: canVote =
     neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
+
+  let isCommunityFund: boolean;
+  $: isCommunityFund = hasJoinedCommunityFund(neuron);
+
+  let isHotKeyControl: boolean;
+  $: isHotKeyControl = isHotKeyControllable({
+    neuron,
+    identity: $authStore.identity,
+  });
 </script>
 
 <PageHeading testId="nns-neuron-page-heading-component">
@@ -33,4 +49,28 @@
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
   </span>
+  <svelte:fragment slot="tag">
+    {#if isCommunityFund || isHotKeyControl}
+      <div class="tags">
+        {#if isCommunityFund}
+          <HeadingTag testId="neurons-fund-tag">
+            {$i18n.neurons.community_fund}
+          </HeadingTag>
+        {/if}
+        {#if isHotKeyControl}
+          <HeadingTag testId="hotkey-tag">
+            {$i18n.neurons.hotkey_control}
+          </HeadingTag>
+        {/if}
+      </div>
+    {/if}
+  </svelte:fragment>
 </PageHeading>
+
+<style lang="scss">
+  .tags {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -6,12 +6,15 @@
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import {
     getSnsNeuronStake,
+    isUserHotkey,
     snsNeuronVotingPower,
   } from "$lib/utils/sns-neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import PageHeading from "../common/PageHeading.svelte";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import { authStore } from "$lib/stores/auth.store";
+  import HeadingTag from "../common/HeadingTag.svelte";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
@@ -30,6 +33,12 @@
 
   let votingPower: number;
   $: votingPower = snsNeuronVotingPower({ neuron, snsParameters: parameters });
+
+  let isHotkey: boolean;
+  $: isHotkey = isUserHotkey({
+    neuron,
+    identity: $authStore.identity,
+  });
 </script>
 
 <PageHeading testId="sns-neuron-page-heading-component">
@@ -47,4 +56,10 @@
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
   </span>
+  <svelte:fragment slot="tag">
+    {#if isHotkey}
+      <HeadingTag testId="hotkey-tag">{$i18n.neurons.hotkey_control}</HeadingTag
+      >
+    {/if}
+  </svelte:fragment>
 </PageHeading>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -56,7 +56,7 @@
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
   </span>
-  <svelte:fragment slot="tag">
+  <svelte:fragment slot="tags">
     {#if isHotkey}
       <HeadingTag testId="hotkey-tag">{$i18n.neurons.hotkey_control}</HeadingTag
       >

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -4,6 +4,11 @@
 
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
+import { authStore } from "$lib/stores/auth.store";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeadingPo } from "$tests/page-objects/NnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -16,6 +21,12 @@ describe("NnsNeuronPageHeading", () => {
 
     return NnsNeuronPageHeadingPo.under(new JestPageObjectElement(container));
   };
+
+  beforeEach(() => {
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
+  });
 
   it("should render the neuron's stake", async () => {
     const stake = 314_000_000n;
@@ -51,5 +62,27 @@ describe("NnsNeuronPageHeading", () => {
     });
 
     expect(await po.getVotingPower()).toEqual("No Voting Power");
+  });
+
+  it("should render neuron's fund tag if belongs part of neurons fund", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      joinedCommunityFundTimestampSeconds: BigInt(12333444),
+    });
+
+    expect(await po.hasNeuronsFundTag()).toBe(true);
+  });
+
+  it("should hotkey tag is user is a hotkey", async () => {
+    const po = renderComponent({
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: "not-current-principal",
+        hotKeys: [mockIdentity.getPrincipal().toText()],
+      },
+    });
+
+    expect(await po.hasHotkeyTag()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -22,4 +22,12 @@ export class NnsNeuronPageHeadingPo extends BasePageObject {
   getVotingPower(): Promise<string> {
     return this.getText("voting-power");
   }
+
+  hasNeuronsFundTag(): Promise<boolean> {
+    return this.root.byTestId("neurons-fund-tag").isPresent();
+  }
+
+  hasHotkeyTag(): Promise<boolean> {
+    return this.root.byTestId("hotkey-tag").isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronPageHeading.page-object.ts
@@ -22,4 +22,8 @@ export class SnsNeuronPageHeadingPo extends BasePageObject {
   getVotingPower(): Promise<string> {
     return this.getText("voting-power");
   }
+
+  hasHotkeyTag(): Promise<boolean> {
+    return this.root.byTestId("hotkey-tag").isPresent();
+  }
 }


### PR DESCRIPTION
# Motivation

Identify hotkey neurons and those belonging to Neurons' Fund.

This is already a feature in the current neuron details page. In this PR, it adds the same functionality in the new neuron details page.

# Changes

* New UI component HeadingTag.
* Use new HeadingTag in NnsNeuronPageHeading to render a tag when neuron is part of Neurons' Fund or the user is a hotkey.
* Use new HeadingTag in SnsNeuronPageHeading to render a tag when the user is a hotkey of the neuron.

# Tests

* Test new functionality in NnsNeuronPageHeading and SnsNeuronPageHeading.

# Todos

Covered already by an entry in the changelog.
