### PR TITLE
Display page title in browser's tab / window title

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,6 +12,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 * Enable merge neurons preview.
+* Display page title in browser's tab.
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/WalletSummary.svelte
+++ b/frontend/src/lib/components/accounts/WalletSummary.svelte
@@ -55,13 +55,14 @@
       detail: { intersecting },
     } = $event as unknown as CustomEvent<IntersectingDetail>;
 
-    layoutTitleStore.set(
-      intersecting
+    layoutTitleStore.set({
+      title: $i18n.wallet.title,
+      header: intersecting
         ? $i18n.wallet.title
         : `${accountName} – ${formatToken({
             value: accountBalance,
-          })} ${tokenSymbol}`
-    );
+          })} ${tokenSymbol}`,
+    });
   };
 </script>
 

--- a/frontend/src/lib/components/header/Title.svelte
+++ b/frontend/src/lib/components/header/Title.svelte
@@ -2,10 +2,21 @@
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { HeaderTitle } from "@dfinity/gix-components";
   import { triggerDebugReport } from "$lib/directives/debug.directives";
+
+  let pageTitle = "NNS Dapp";
+  $: pageTitle = `NNS Dapp${
+    $layoutTitleStore.title !== "" ? ` / ${$layoutTitleStore.title}` : ""
+  }`;
 </script>
 
+<svelte:head>
+  <title>{pageTitle}</title>
+</svelte:head>
+
 <div use:triggerDebugReport>
-  <HeaderTitle>{$layoutTitleStore}</HeaderTitle>
+  <HeaderTitle
+    >{$layoutTitleStore.header ?? $layoutTitleStore.title}</HeaderTitle
+  >
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/components/layout/LayoutList.svelte
+++ b/frontend/src/lib/components/layout/LayoutList.svelte
@@ -9,7 +9,11 @@
   let list = false;
   $: list = innerWidth > BREAKPOINT_LARGE;
 
-  $: (() => layoutTitleStore.set(list ? "" : title))();
+  $: (() =>
+    layoutTitleStore.set({
+      title: title,
+      header: list ? "" : title,
+    }))();
 </script>
 
 <svelte:window bind:innerWidth />

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronMetaInfoCard.svelte
@@ -32,11 +32,12 @@
       detail: { intersecting },
     } = $event as unknown as CustomEvent<IntersectingDetail>;
 
-    layoutTitleStore.set(
-      intersecting
+    layoutTitleStore.set({
+      title: $i18n.neuron_detail.title,
+      header: intersecting
         ? $i18n.neuron_detail.title
-        : `${$i18n.core.icp} – ${neuron.neuronId}`
-    );
+        : `${$i18n.core.icp} – ${neuron.neuronId}`,
+    });
   };
 
   // Note about replacePlaceholders and $st4kedMaturity

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeader.svelte
@@ -17,11 +17,12 @@
       detail: { intersecting },
     } = $event as unknown as CustomEvent<IntersectingDetail>;
 
-    layoutTitleStore.set(
-      intersecting
+    layoutTitleStore.set({
+      title: $i18n.neuron_detail.title,
+      header: intersecting
         ? $i18n.neuron_detail.title
-        : `${$i18n.core.icp} – ${neuron.neuronId}`
-    );
+        : `${$i18n.core.icp} – ${neuron.neuronId}`,
+    });
   };
 </script>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.svelte
@@ -60,11 +60,13 @@
       ? getSnsNeuronIdAsHexString(neuron)
       : undefined;
 
-    layoutTitleStore.set(
-      intersecting || isNullish(neuronId)
-        ? $i18n.neuron_detail.title
-        : shortenWithMiddleEllipsis(neuronId)
-    );
+    layoutTitleStore.set({
+      title: $i18n.neuron_detail.title,
+      header:
+        intersecting || isNullish(neuronId)
+          ? $i18n.neuron_detail.title
+          : shortenWithMiddleEllipsis(neuronId),
+    });
   };
 </script>
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte
@@ -34,11 +34,13 @@
       ? getSnsNeuronIdAsHexString(neuron)
       : undefined;
 
-    layoutTitleStore.set(
-      intersecting || isNullish(neuronId)
-        ? $i18n.neuron_detail.title
-        : `${token.symbol} - ${shortenWithMiddleEllipsis(neuronId)}`
-    );
+    layoutTitleStore.set({
+      title: $i18n.neuron_detail.title,
+      header:
+        intersecting || isNullish(neuronId)
+          ? $i18n.neuron_detail.title
+          : `${token.symbol} - ${shortenWithMiddleEllipsis(neuronId)}`,
+    });
   };
 </script>
 

--- a/frontend/src/lib/pages/NnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/NnsProposalDetail.svelte
@@ -116,13 +116,17 @@
 
   // END: loading and navigation
 
-  $: layoutTitleStore.set(
-    `${$i18n.proposal_detail.title}${
-      $selectedProposalStore.proposalId !== undefined
-        ? ` ${$selectedProposalStore.proposalId}`
-        : ""
-    }`
-  );
+  let title = $i18n.proposal_detail.title;
+  $: title = `${$i18n.proposal_detail.title}${
+    $selectedProposalStore.proposalId !== undefined
+      ? ` ${$selectedProposalStore.proposalId}`
+      : ""
+  }`;
+
+  $: layoutTitleStore.set({
+    title,
+    header: title,
+  });
 </script>
 
 <NnsProposal />

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -144,7 +144,9 @@
   // Set up watchers and load the data in stores
   /////////////////////////////////
 
-  $: layoutTitleStore.set($projectDetailStore?.summary?.metadata.name ?? "");
+  $: layoutTitleStore.set({
+    title: $projectDetailStore?.summary?.metadata.name ?? "",
+  });
 
   let enableOpenProjectWatchers = false;
   $: enableOpenProjectWatchers =

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+
+  layoutTitleStore.set({
+    title: $i18n.wallet.title,
+    header: "",
+  });
 
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>

--- a/frontend/src/lib/pages/SignInNeurons.svelte
+++ b/frontend/src/lib/pages/SignInNeurons.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+
+  layoutTitleStore.set({
+    title: $i18n.neuron_detail.title,
+    header: "",
+  });
 
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -160,11 +160,15 @@
   };
 
   // Update layout title
-  $: layoutTitleStore.set(
-    `${$i18n.proposal_detail.title}${
-      nonNullish(proposalIdText) ? ` ${proposalIdText}` : ""
-    }`
-  );
+  let title = $i18n.proposal_detail.title;
+  $: title = `${$i18n.proposal_detail.title}${
+    nonNullish(proposalIdText) ? ` ${proposalIdText}` : ""
+  }`;
+
+  $: layoutTitleStore.set({
+    title,
+    header: title,
+  });
 
   let proposalIds: bigint[];
   $: proposalIds = nonNullish(universeIdText)

--- a/frontend/src/lib/routes/NeuronDetail.svelte
+++ b/frontend/src/lib/routes/NeuronDetail.svelte
@@ -10,7 +10,9 @@
 
   export let neuronId: string | null | undefined;
 
-  layoutTitleStore.set($i18n.neuron_detail.title);
+  layoutTitleStore.set({
+    title: $i18n.neuron_detail.title,
+  });
 </script>
 
 <TestIdWrapper testId="neuron-detail-component">

--- a/frontend/src/lib/routes/Settings.svelte
+++ b/frontend/src/lib/routes/Settings.svelte
@@ -19,7 +19,15 @@
   $: remainingTimeMilliseconds = $authRemainingTimeStore;
 
   // Defer the title to avoid a visual glitch where the title moves from left to center in the header if navigation happens from Accounts page
-  onMount(debounce(() => layoutTitleStore.set($i18n.navigation.settings), 500));
+  onMount(
+    debounce(
+      () =>
+        layoutTitleStore.set({
+          title: $i18n.navigation.settings,
+        }),
+      500
+    )
+  );
 </script>
 
 <Island>

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -16,7 +16,9 @@
 
   export let accountIdentifier: string | undefined | null = undefined;
 
-  layoutTitleStore.set($i18n.wallet.title);
+  layoutTitleStore.set({
+    title: $i18n.wallet.title,
+  });
 </script>
 
 <TestIdWrapper testId="wallet-component">

--- a/frontend/src/lib/stores/layout.store.ts
+++ b/frontend/src/lib/stores/layout.store.ts
@@ -1,6 +1,7 @@
+import type { LayoutTitle } from "$lib/types/layout";
 import { writable } from "svelte/store";
 
-export const layoutTitleStore = writable<string>("");
+export const layoutTitleStore = writable<LayoutTitle>({ title: "" });
 
 // A store used to enable all sign-in buttons displayed on pages as enabled only once the app has been loaded
 // Once JS is loaded, auth has been synced and message listener are ready

--- a/frontend/src/lib/types/layout.ts
+++ b/frontend/src/lib/types/layout.ts
@@ -1,0 +1,4 @@
+export interface LayoutTitle {
+  title: string;
+  header?: string;
+}

--- a/frontend/src/routes/(app)/(nns)/canister/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/canister/+page.svelte
@@ -2,12 +2,22 @@
   import SignInCanisters from "$lib/pages/SignInCanisters.svelte";
   import CanisterDetail from "$lib/pages/CanisterDetail.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { onMount } from "svelte";
+  import { layoutTitleStore } from "$lib/stores/layout.store";
+  import { i18n } from "$lib/stores/i18n";
 
   // Preloaded by +page.ts
   export let data: { canister: string | null | undefined };
 
   let canisterId: string | null | undefined;
   $: ({ canister: canisterId } = data);
+
+  onMount(() =>
+    layoutTitleStore.set({
+      title: $i18n.canister_detail.title,
+      header: "",
+    })
+  );
 </script>
 
 {#if $authSignedInStore}

--- a/frontend/src/routes/(app)/(nns)/canisters/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/canisters/+layout.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import Layout from "$lib/components/layout/Layout.svelte";
   import Content from "$lib/components/layout/Content.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { i18n } from "$lib/stores/i18n";
 </script>
 
-<Layout>
-  <Content>
-    <slot />
-  </Content>
-</Layout>
+<LayoutList title={$i18n.navigation.canisters}>
+  <Layout>
+    <Content>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/routes/(app)/(nns)/canisters/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/canisters/+page.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import SignInCanisters from "$lib/pages/SignInCanisters.svelte";
-  import { onMount } from "svelte";
-  import { layoutTitleStore } from "$lib/stores/layout.store";
-  import { i18n } from "$lib/stores/i18n";
   import type { AppPath } from "$lib/constants/routes.constants";
   import { afterNavigate } from "$app/navigation";
   import type { Navigation } from "@sveltejs/kit";
@@ -12,8 +9,6 @@
 
   let referrerPath: AppPath | undefined = undefined;
   afterNavigate((nav: Navigation) => (referrerPath = referrerPathForNav(nav)));
-
-  onMount(() => layoutTitleStore.set($i18n.navigation.canisters));
 </script>
 
 {#if $authSignedInStore}

--- a/frontend/src/routes/(app)/(nns)/launchpad/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/launchpad/+layout.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import Layout from "$lib/components/layout/Layout.svelte";
   import Content from "$lib/components/layout/Content.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { i18n } from "$lib/stores/i18n";
 </script>
 
-<Layout>
-  <Content>
-    <slot />
-  </Content>
-</Layout>
+<LayoutList title={$i18n.sns_launchpad.header}>
+  <Layout>
+    <Content>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/routes/(app)/(nns)/launchpad/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/launchpad/+page.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { layoutTitleStore } from "$lib/stores/layout.store";
-  import { i18n } from "$lib/stores/i18n";
   import Launchpad from "$lib/pages/Launchpad.svelte";
-
-  onMount(async () => {
-    layoutTitleStore.set($i18n.sns_launchpad.header);
-  });
 </script>
 
 <Launchpad />

--- a/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletSummary.spec.ts
@@ -113,10 +113,10 @@ describe("WalletSummary", () => {
 
   const testTitle = async ({
     intersecting,
-    text,
+    header,
   }: {
     intersecting: boolean;
-    text: string;
+    header: string;
   }) => {
     const { getByTestId } = renderWalletSummary(props);
 
@@ -124,19 +124,21 @@ describe("WalletSummary", () => {
     dispatchIntersecting({ element, intersecting });
 
     const title = get(layoutTitleStore);
-    await waitFor(() => expect(title).toEqual(text));
+    await waitFor(() =>
+      expect(title).toEqual({ title: en.wallet.title, header })
+    );
   };
 
   it("should render account name and balance if title not intersecting viewport", async () =>
     await testTitle({
       intersecting: false,
-      text: `${en.accounts.main} – ${formatToken({
+      header: `${en.accounts.main} – ${formatToken({
         value: mockMainAccount.balanceE8s,
       })} ${ICPToken.symbol}`,
     }));
 
   it("should render a static title if title is intersecting viewport", async () =>
-    await testTitle({ intersecting: true, text: en.wallet.title }));
+    await testTitle({ intersecting: true, header: en.wallet.title }));
 
   it("should not render a balance if token is unlikely undefined", () => {
     const { container } = renderWalletSummary({

--- a/frontend/src/tests/lib/components/header/Title.spec.ts
+++ b/frontend/src/tests/lib/components/header/Title.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Title from "$lib/components/header/Title.svelte";
+import { layoutTitleStore } from "$lib/stores/layout.store";
+import { render, within } from "@testing-library/svelte";
+
+describe("Title", () => {
+  beforeEach(() => layoutTitleStore.set({ title: "" }));
+
+  it("should render a title in the DOM header", () => {
+    const testTitle = "test test test";
+
+    layoutTitleStore.set({ title: testTitle });
+
+    render(Title);
+
+    const title = within(document.head).getByText(`NNS Dapp / ${testTitle}`);
+
+    expect(title).not.toBeNull();
+  });
+
+  it("should render a header", () => {
+    const testTitle = "test test test";
+    const testHeader = "header my header";
+
+    layoutTitleStore.set({ title: testTitle, header: testHeader });
+
+    const { getByText } = render(Title);
+    expect(getByText(testHeader)).toBeInTheDocument();
+  });
+
+  it("should fallback to title for header", () => {
+    const testTitle = "test test test";
+
+    layoutTitleStore.set({ title: testTitle });
+
+    const { container } = render(Title);
+    expect(container.querySelector("h4")?.textContent).toEqual(testTitle);
+  });
+
+  it("should render empty header", () => {
+    const testTitle = "test test test";
+    const testHeader = "";
+
+    layoutTitleStore.set({ title: testTitle, header: testHeader });
+
+    const { container } = render(Title);
+    expect(container.querySelector("h4")?.textContent.trim()).toEqual(
+      testHeader.trim()
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/layout/Layout.spec.ts
+++ b/frontend/src/tests/lib/components/layout/Layout.spec.ts
@@ -22,9 +22,13 @@ jest.mock("$lib/services/$public/worker-metrics.services", () => ({
 
 describe("Layout", () => {
   describe("Main layout", () => {
-    beforeAll(() => layoutTitleStore.set("the header"));
+    beforeAll(() =>
+      layoutTitleStore.set({
+        title: "the header",
+      })
+    );
 
-    afterAll(() => layoutTitleStore.set(""));
+    afterAll(() => layoutTitleStore.set({ title: "" }));
 
     it("should render a menu button", () => {
       const { getByTestId } = render(LayoutTest, { props: { spy: undefined } });

--- a/frontend/src/tests/lib/components/layout/UniverseSplitContent.spec.ts
+++ b/frontend/src/tests/lib/components/layout/UniverseSplitContent.spec.ts
@@ -17,7 +17,11 @@ describe("UniverseSplitContent", () => {
     .spyOn(authStore, "subscribe")
     .mockImplementation(mutableMockAuthStoreSubscribe);
 
-  beforeAll(() => layoutTitleStore.set("the header"));
+  beforeAll(() =>
+    layoutTitleStore.set({
+      title: "the header",
+    })
+  );
 
   it("should render the universe nav", () => {
     const { getByTestId } = render(UniverseSplitContent);

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeader.spec.ts
@@ -41,7 +41,7 @@ describe("NnsNeuronPageHeader", () => {
     dispatchIntersecting({ element, intersecting });
 
     const title = get(layoutTitleStore);
-    expect(title).toEqual(text);
+    expect(title).toEqual({ title: "Neuron", header: text });
   };
 
   it("should render a title with neuron ID if title is not intersecting viewport", () =>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMetaInfoCard.spec.ts
@@ -217,7 +217,9 @@ describe("SnsNeuronMetaInfoCard", () => {
     dispatchIntersecting({ element, intersecting });
 
     const title = get(layoutTitleStore);
-    await waitFor(() => expect(title).toEqual(text));
+    await waitFor(() =>
+      expect(title).toEqual({ title: en.neuron_detail.title, header: text })
+    );
   };
 
   it("should render a title with neuron ID if title is not intersecting viewport", () =>

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -9,6 +9,7 @@ import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { snsResponseFor } from "$tests/mocks/sns-response.mock";
@@ -68,7 +69,7 @@ describe("SnsNeuronPageHeader", () => {
     dispatchIntersecting({ element, intersecting });
 
     const title = get(layoutTitleStore);
-    expect(title).toEqual(text);
+    expect(title).toEqual({ title: en.neuron_detail.title, header: text });
   };
 
   it("should render a title with neuron ID if title is not intersecting viewport", () =>

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -214,7 +214,9 @@ describe("NeuronDetail", () => {
       dispatchIntersecting({ element, intersecting });
 
       const title = get(layoutTitleStore);
-      await waitFor(() => expect(title).toEqual(text));
+      await waitFor(() =>
+        expect(title).toEqual({ title: en.neuron_detail.title, header: text })
+      );
     };
 
     it("should render a title with neuron ID if title is not intersecting viewport", async () =>

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -122,7 +122,10 @@ describe("SnsProposalDetail", () => {
       });
 
       expect(spyOnSetTitle).toHaveBeenCalledTimes(1);
-      expect(spyOnSetTitle).toHaveBeenCalledWith(`Proposal ${proposalIdText}`);
+      expect(spyOnSetTitle).toHaveBeenCalledWith({
+        title: `Proposal ${proposalIdText}`,
+        header: `Proposal ${proposalIdText}`,
+      });
     });
 
     it("should render the name of the nervous function as title", async () => {

--- a/frontend/src/tests/lib/routes/Settings.spec.ts
+++ b/frontend/src/tests/lib/routes/Settings.spec.ts
@@ -22,11 +22,12 @@ describe("Settings", () => {
 
   it("should set title", async () => {
     const titleBefore = get(layoutTitleStore);
-    expect(titleBefore).toEqual("");
+    expect(titleBefore).toEqual({ title: "" });
 
     render(Settings);
 
-    await (() => expect(get(layoutTitleStore)).toEqual(en.navigation.settings));
+    await (() =>
+      expect(get(layoutTitleStore)).toEqual({ title: en.navigation.settings }));
   });
 
   it("should render principal", () => {


### PR DESCRIPTION
# Motivation

Displaying a page title within the browser's tab / window title can be particularly useful if multiple tabs are open and generally speaking a bit more user friendly.

# Note

Discussed with Artem, for this first iteration we only want to display static or public information within the tab's title. For example we do not display neuron id or account identitifer.

# Changes

- extend `layoutTitleStore` to support a title for the browser's tab and the page header
- implement new store object instead of string in existing pages
- in `Title` component render a title header tag if corrresponding information is set
- in `Title` component if no header is provided fallback on the title (which is mandatory and can be empty as currently)
- use `LayoutList` in Launch Pad and Proposals for consistency reason
- implement few titles setter that were missing

# Screenshots

Few examples:

<img width="1534" alt="Capture d’écran 2023-08-01 à 13 13 12" src="https://github.com/dfinity/nns-dapp/assets/16886711/eb7fe288-038f-4d0c-89d2-65dd0d146986">
<img width="1534" alt="Capture d’écran 2023-08-01 à 13 13 08" src="https://github.com/dfinity/nns-dapp/assets/16886711/ec0d24df-c418-46fe-9338-77154b0797da">
<img width="1534" alt="Capture d’écran 2023-08-01 à 13 13 06" src="https://github.com/dfinity/nns-dapp/assets/16886711/48634ad8-72d0-4d49-9ced-069013e5bd27">
<img width="1534" alt="Capture d’écran 2023-08-01 à 13 13 02" src="https://github.com/dfinity/nns-dapp/assets/16886711/6899b033-97ea-4e22-8328-c82c86284be2">
