### PR TITLE
Get development ICP with Icrc accounts

### DIFF
--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -1,10 +1,13 @@
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST, IS_TESTNET } from "$lib/constants/environment.constants";
 import type { Account } from "$lib/types/account";
+import { invalidIcrcAddress } from "$lib/utils/accounts.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
 import type { Identity } from "@dfinity/agent";
 import { HttpAgent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
+import { IcrcLedgerCanister, decodeIcrcAccount } from "@dfinity/ledger";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -82,6 +85,27 @@ export const acquireICPTs = async ({
 
   const agent = await getTestAccountAgent();
 
+  const validIcrcAddress = !invalidIcrcAddress(accountIdentifier);
+
+  // Icrc
+  if (validIcrcAddress) {
+    const canister = IcrcLedgerCanister.create({
+      agent,
+      canisterId: LEDGER_CANISTER_ID,
+    });
+
+    const { owner, subaccount } = decodeIcrcAccount(accountIdentifier);
+
+    return canister.transfer({
+      amount: e8s,
+      to: {
+        owner,
+        subaccount: toNullable(subaccount),
+      },
+    });
+  }
+
+  // Old school ICP
   const ledgerCanister: LedgerCanister = LedgerCanister.create({ agent });
 
   return ledgerCanister.transfer({


### PR DESCRIPTION
# Motivation

We have a "Get ICP" feature we used for development purpose which does not transfer ICP anymore if the `ENABLE_ICP_ICRC` flag is activated.

This PR checks if the transfer destination address is an Icrc address and if so, uses the Icrc ledger definition to proceed.
