### PR TITLE
Rename NnsNeuronMetaInfoCardPageObjectPo to NnsNeuronMetaInfoCardPo

### DIFF
--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -75,9 +75,7 @@ describe("NeuronDetail", () => {
 
       // Old components
       expect(await po.getMaturityCardPo().isPresent()).toBe(false);
-      expect(await po.getNnsNeuronMetaInfoCardPageObjectPo().isPresent()).toBe(
-        false
-      );
+      expect(await po.getNnsNeuronMetaInfoCardPo().isPresent()).toBe(false);
       expect(await po.getNnsNeuronInfoStakePo().isPresent()).toBe(false);
       expect(await po.hasJoinFundCard()).toBe(false);
 
@@ -162,9 +160,7 @@ describe("NeuronDetail", () => {
 
       // Old components
       expect(await po.getMaturityCardPo().isPresent()).toBe(true);
-      expect(await po.getNnsNeuronMetaInfoCardPageObjectPo().isPresent()).toBe(
-        true
-      );
+      expect(await po.getNnsNeuronMetaInfoCardPo().isPresent()).toBe(true);
       expect(await po.getNnsNeuronInfoStakePo().isPresent()).toBe(true);
       expect(await po.hasJoinFundCard()).toBe(true);
 

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -2,7 +2,7 @@ import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvance
 import { NnsNeuronInfoStakePo } from "$tests/page-objects/NnsNeuronInfoStake.page-object";
 import { NnsNeuronMaturityCardPo } from "$tests/page-objects/NnsNeuronMaturityCard.page-object";
 import { NnsNeuronMaturitySectionPo } from "$tests/page-objects/NnsNeuronMaturitySection.page-object";
-import { NnsNeuronMetaInfoCardPageObjectPo } from "$tests/page-objects/NnsNeuronMetaInfoCard.page-object";
+import { NnsNeuronMetaInfoCardPo } from "$tests/page-objects/NnsNeuronMetaInfoCard.page-object";
 import { NnsNeuronModalsPo } from "$tests/page-objects/NnsNeuronModals.page-object";
 import { NnsNeuronVotingPowerSectionPo } from "$tests/page-objects/NnsNeuronVotingPowerSection.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
@@ -25,8 +25,8 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return SkeletonCardPo.under(this.root);
   }
 
-  getNnsNeuronMetaInfoCardPageObjectPo(): NnsNeuronMetaInfoCardPageObjectPo {
-    return NnsNeuronMetaInfoCardPageObjectPo.under(this.root);
+  getNnsNeuronMetaInfoCardPo(): NnsNeuronMetaInfoCardPo {
+    return NnsNeuronMetaInfoCardPo.under(this.root);
   }
 
   async createDummyProposals(): Promise<void> {
@@ -74,7 +74,7 @@ export class NnsNeuronDetailPo extends BasePageObject {
   // TODO: Remove when ENABLE_NEURON_SETTINGS is cleaned up.
   //       See https://dfinity.atlassian.net/browse/GIX-1688
   getNeuronIdOldUi(): Promise<string | null> {
-    return this.getNnsNeuronMetaInfoCardPageObjectPo().getNeuronId();
+    return this.getNnsNeuronMetaInfoCardPo().getNeuronId();
   }
 
   getNeuronIdNewUi(): Promise<string | null> {
@@ -85,7 +85,7 @@ export class NnsNeuronDetailPo extends BasePageObject {
   //       See https://dfinity.atlassian.net/browse/GIX-1688
   async isNewUi(): Promise<boolean> {
     await Promise.race([
-      this.getNnsNeuronMetaInfoCardPageObjectPo().waitFor(),
+      this.getNnsNeuronMetaInfoCardPo().waitFor(),
       this.getPageHeaderPo().waitFor(),
     ]);
 

--- a/frontend/src/tests/page-objects/NnsNeuronMetaInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMetaInfoCard.page-object.ts
@@ -2,12 +2,12 @@ import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.pag
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsNeuronMetaInfoCardPageObjectPo extends BasePageObject {
+export class NnsNeuronMetaInfoCardPo extends BasePageObject {
   private static readonly TID = "nns-neuron-meta-info-card-component";
 
-  static under(element: PageObjectElement): NnsNeuronMetaInfoCardPageObjectPo {
-    return new NnsNeuronMetaInfoCardPageObjectPo(
-      element.byTestId(NnsNeuronMetaInfoCardPageObjectPo.TID)
+  static under(element: PageObjectElement): NnsNeuronMetaInfoCardPo {
+    return new NnsNeuronMetaInfoCardPo(
+      element.byTestId(NnsNeuronMetaInfoCardPo.TID)
     );
   }
 


### PR DESCRIPTION
# Motivation

"Po" already stands for "page object".
"PageObjectPo" is redundant.

# Changes

Rename `NnsNeuronMetaInfoCardPageObjectPo` to `NnsNeuronMetaInfoCardPo`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).

not worth it