### PR TITLE
Don't run reproducible assets against Mac OS 13

### DIFF
--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12]
         time: [now, future]
     steps:
       - name: Unbork mac

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -58,6 +58,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Deprecated
 #### Removed
 
+* Don't run reproducible assets test against Mac OS 13
+
 #### Fixed
 
 * Deploy.sh script

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -31,9 +31,6 @@ else
   exit 1
 fi
 
-echo "$tar --version"
-"$tar" --version
-
 if ! command -v xz >/dev/null; then
   echo "did not find xz, please install"
   echo "  brew install xz"

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -31,6 +31,9 @@ else
   exit 1
 fi
 
+echo "$tar --version"
+"$tar" --version
+
 if ! command -v xz >/dev/null; then
   echo "did not find xz, please install"
   echo "  brew install xz"


### PR DESCRIPTION
# Motivation

The reproducible assets test is getting a different hash on Mac OS 13.
The full WASM build is already only reproducible on Linux, which is why we run it in Docker.

# Changes

Don't run reproducible assets against Mac OS 13

# Tests

CI

# Todos

- [x] Add entry to changelog (if necessary).
