### PR TITLE
Invert tab title

### DIFF
--- a/frontend/src/lib/components/header/Title.svelte
+++ b/frontend/src/lib/components/header/Title.svelte
@@ -4,9 +4,9 @@
   import { triggerDebugReport } from "$lib/directives/debug.directives";
 
   let pageTitle = "NNS Dapp";
-  $: pageTitle = `NNS Dapp${
-    $layoutTitleStore.title !== "" ? ` / ${$layoutTitleStore.title}` : ""
-  }`;
+  $: pageTitle = `${$layoutTitleStore.title ?? ""}${
+    $layoutTitleStore.title !== "" ? ` / ` : ""
+  }NNS Dapp`;
 </script>
 
 <svelte:head>

--- a/frontend/src/tests/lib/components/header/Title.spec.ts
+++ b/frontend/src/tests/lib/components/header/Title.spec.ts
@@ -16,7 +16,7 @@ describe("Title", () => {
 
     render(Title);
 
-    const title = within(document.head).getByText(`NNS Dapp / ${testTitle}`);
+    const title = within(document.head).getByText(`${testTitle} / NNS Dapp`);
 
     expect(title).not.toBeNull();
   });


### PR DESCRIPTION
# Motivation

Follow best practice and invert tab titles. e.g. instead of `NNS Dapp / My Tokens` render `My Tokens / NNS Dapp`.
