### PR TITLE
Fix proposals filters style alignment

### DIFF
--- a/frontend/src/lib/components/proposals/FiltersWrapper.svelte
+++ b/frontend/src/lib/components/proposals/FiltersWrapper.svelte
@@ -7,13 +7,10 @@
     display: flex;
     flex-wrap: wrap;
     padding: 0 0 var(--padding-3x);
+    gap: var(--padding);
 
     --checkbox-flex-direction: row-reverse;
     --checkbox-font-size: var(--font-size-small);
-
-    :global(button) {
-      margin: var(--padding) var(--padding) 0 0;
-    }
 
     > :global(div.checkbox) {
       width: fit-content;


### PR DESCRIPTION
# Motivation

I guess the filters used to be aligned but, following the introduction of the Sns universes those aren't aligned gracefuly with the overall content.

# Changes

- align filters with top of the universe

# Screenshots

Is:

<img width="660" alt="before2" src="https://github.com/dfinity/nns-dapp/assets/16886711/8e316908-c143-48b4-886a-d09c8df631b7">
<img width="1534" alt="before1" src="https://github.com/dfinity/nns-dapp/assets/16886711/4e1bec95-f895-4ebf-9687-9d817ece36c8">

Afterwards:

<img width="660" alt="Capture d’écran 2023-08-02 à 13 03 49" src="https://github.com/dfinity/nns-dapp/assets/16886711/1a1e8096-402e-4b03-8cc6-3e6d447ee66f">
<img width="1536" alt="Capture d’écran 2023-08-02 à 13 03 53" src="https://github.com/dfinity/nns-dapp/assets/16886711/be4a38f9-4d5a-4645-a03d-0a7d230cd8fd">

