### PR TITLE
Use tar format gnu instead of ustar for frontend assets

### DIFF
--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13]
         time: [now, future]
     steps:
       - name: Unbork mac

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -68,7 +68,7 @@ find . -type f | xargs -I{} gzip -fn "{}"
   --owner=0 \
   --group=0 \
   --numeric-owner \
-  --format=ustar \
+  --format=gnu \
   --exclude .last_build_id \
   -f "$TOPLEVEL/assets.tar.xz" \
   .


### PR DESCRIPTION
# Motivation

Our reproducible assets test started failing recently because we got different hashes on MacOS 13.
It turns out that gnu-tar 1.35 creates different binary files than 1.34 (confirmed with [this run](https://github.com/dfinity/nns-dapp/actions/runs/5738350606/job/15551756916)).
Looking at the binary, there are some 0x30 bytes (character '0') that became 0x00 bytes, so my guess that this is caused by the change
> Leave the devmajor and devminor fields empty (rather than zero) for non-special files, as this is more compatible with traditional tar.

listed [here](https://www.gnu.org/software/tar/).

We are currently using `--format=ustar`. The only reason I used `ustar` in [this PR](https://github.com/dfinity/nns-dapp/pull/1766) is that it is listed [here](https://reproducible-builds.org/docs/archives/) as being helpful for reproducibility.
So I tried using `--format=gnu` instead, which is also mentioned there as a possibility, and the problem went away.

# Changes

1. Use `--format=gnu` instead of `--format=ustar` for archiving the frontend assets.
2. Enable MacOS 13 once again in the reproducible assets test (was disabled in [this PR](https://github.com/dfinity/nns-dapp/pull/3017)).

# Tests

CI

# Todos

- [ ] Add entry to changelog (if necessary).
