### PR TITLE
Hide proposal navigation when on launchpad

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -190,6 +190,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 - Set a custom URL for `internet_identity` on `ic` rather than using the default.
 - Improve Canister Detail tests by mocking the api layer instead of services.
 - Copied the newest version of clap.bash from snsdemo.
+- Don't display proposal navigation on launch-pad page.
 
 #### Fixed
 

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -14,6 +14,8 @@
   import { filteredProposals } from "$lib/derived/proposals.derived";
   import { navigateToProposal } from "$lib/utils/proposals.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { referrerPathStore } from "$lib/stores/routes.store";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
@@ -25,11 +27,13 @@
 
 <TestIdWrapper testId="nns-proposal-component">
   {#if $store?.proposal?.id !== undefined}
-    <ProposalNavigation
-      currentProposalId={$store.proposal.id}
-      {proposalIds}
-      selectProposal={navigateToProposal}
-    />
+    {#if $referrerPathStore !== AppPath.Launchpad}
+      <ProposalNavigation
+        currentProposalId={$store.proposal.id}
+        {proposalIds}
+        selectProposal={navigateToProposal}
+      />
+    {/if}
 
     <div class="content-grid" data-tid="proposal-details-grid">
       <div class="content-a content-cell-island">

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -3,7 +3,9 @@
  */
 
 import * as proposalsApi from "$lib/api/proposals.api";
+import { AppPath } from "$lib/constants/routes.constants";
 import { filteredProposals } from "$lib/derived/proposals.derived";
+import { referrerPathStore } from "$lib/stores/routes.store";
 import {
   generateMockProposals,
   mockProposalInfo,
@@ -94,5 +96,19 @@ describe("Proposal", () => {
 
     expect(await po.getOlderButtonPo().isPresent()).toBe(true);
     expect(await po.getNewerButtonPo().isPresent()).toBe(true);
+  });
+
+  it("should not render proposal navigation when on launchpad", async () => {
+    jest
+      .spyOn(filteredProposals, "subscribe")
+      .mockImplementation(
+        createMockProposalsStoreSubscribe(generateMockProposals(10))
+      );
+    referrerPathStore.set(AppPath.Launchpad);
+
+    const { container } = renderProposalModern(5n);
+    const po = ProposalNavigationPo.under(new JestPageObjectElement(container));
+
+    expect(await po.isPresent()).toBe(false);
   });
 });


### PR DESCRIPTION
# Motivation

Currently the proposal navigation uses all type proposals (based on selected filters), so even not related to the launchpad proposals are in the list. The quick workaround is to not display proposal navigation block in this case.

# Changes

- remove navigation when navigated from the /launchpad

# Tests

- "should not render proposal navigation when on launchpad"

# Todos

- [x] Add entry to changelog (if necessary).
