### PR TITLE
Refactor: CommonItemActionPo

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -24,9 +24,7 @@
 
 <CommonItemAction testId="nns-available-maturity-item-action-component">
   <IconExpandCircleDown slot="icon" />
-  <span slot="title" data-tid="available-maturity"
-    >{formattedMaturity(neuron)}</span
-  >
+  <svelte:fragment slot="title">{formattedMaturity(neuron)}</svelte:fragment>
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -50,13 +50,13 @@
 
 <CommonItemAction testId="nns-neuron-dissolve-delay-item-action-component">
   <IconClockNoFill slot="icon" />
-  <span slot="title" data-tid="dissolve-delay-text"
+  <svelte:fragment slot="title"
     >{`${keyOf({
       obj: $i18n.neuron_detail,
       key: stateTextMapper[neuron.state],
     })} ${
       remainingTimeSeconds > 0n ? secondsToDuration(remainingTimeSeconds) : "0"
-    }`}</span
+    }`}</svelte:fragment
   >
   <svelte:fragment slot="subtitle">
     {#if Number(remainingTimeSeconds) >= NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE}

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -34,9 +34,9 @@
       <svelte:component this={stateInfo.Icon} />
     {/if}
   </svelte:fragment>
-  <span slot="title" data-tid="state-text">
+  <svelte:fragment slot="title">
     {keyOf({ obj: $i18n.neuron_state, key: stateInfo.textKey })}
-  </span>
+  </svelte:fragment>
   <svelte:fragment slot="subtitle">
     {#if neuron.state === NeuronState.Locked}
       <AgeBonusText ageMultiplier={ageMultiplier(neuron.ageSeconds)} />

--- a/frontend/src/lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte
@@ -10,8 +10,8 @@
 
 <CommonItemAction testId="nns-staked-maturity-item-action-component">
   <IconStakedMaturity slot="icon" />
-  <span slot="title" data-tid="staked-maturity"
-    >{formattedStakedMaturity(neuron)}</span
+  <svelte:fragment slot="title"
+    >{formattedStakedMaturity(neuron)}</svelte:fragment
   >
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.staked_description}</svelte:fragment

--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
@@ -21,9 +21,7 @@
 
 <CommonItemAction testId="sns-available-maturity-item-action-component">
   <IconExpandCircleDown slot="icon" />
-  <span slot="title" data-tid="available-maturity"
-    >{formattedMaturity(neuron)}</span
-  >
+  <svelte:fragment slot="title">{formattedMaturity(neuron)}</svelte:fragment>
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -51,9 +51,9 @@
       <svelte:component this={stateInfo.Icon} />
     {/if}
   </svelte:fragment>
-  <span slot="title" data-tid="state-text">
+  <svelte:fragment slot="title">
     {keyOf({ obj: $i18n.neuron_state, key: stateInfo.textKey })}
-  </span>
+  </svelte:fragment>
   <svelte:fragment slot="subtitle">
     {#if state === NeuronState.Locked}
       <AgeBonusText ageMultiplier={ageBonus} />

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.svelte
@@ -10,8 +10,8 @@
 
 <CommonItemAction testId="sns-staked-maturity-item-action-component">
   <IconStakedMaturity slot="icon" />
-  <span slot="title" data-tid="staked-maturity"
-    >{formattedStakedMaturity(neuron)}</span
+  <svelte:fragment slot="title"
+    >{formattedStakedMaturity(neuron)}</svelte:fragment
   >
   <svelte:fragment slot="subtitle"
     >{$i18n.neuron_detail.staked_description}</svelte:fragment

--- a/frontend/src/lib/components/ui/CommonItemAction.svelte
+++ b/frontend/src/lib/components/ui/CommonItemAction.svelte
@@ -9,8 +9,8 @@
     <slot name="icon" />
   </div>
   <div class="content">
-    <h4 data-tid="staked-maturity"><slot name="title" /></h4>
-    <p class="description"><slot name="subtitle" /></p>
+    <h4 data-tid="title"><slot name="title" /></h4>
+    <p data-tid="subtitle" class="description"><slot name="subtitle" /></p>
   </div>
   <div slot="actions" class="actions">
     <slot />

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -30,9 +30,9 @@ describe("NnsAvailableMaturityItemAction", () => {
       },
     });
 
-    return NnsAvailableMaturityItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return NnsAvailableMaturityItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ describe("NnsAvailableMaturityItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getMaturity()).toBe("3.14");
+    expect(await po.getTitle()).toBe("3.14");
   });
 
   it("should render buttons", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -30,9 +30,9 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
       },
     });
 
-    return NnsNeuronDissolveDelayItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return NnsNeuronDissolveDelayItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   const controlledNeuron = {
@@ -58,9 +58,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe(
-      "Dissolve Delay: 2 years, 12 hours"
-    );
+    expect(await po.getTitle()).toBe("Dissolve Delay: 2 years, 12 hours");
     expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: +25%");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
@@ -79,7 +77,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe("Remaining: 2 years, 12 hours");
+    expect(await po.getTitle()).toBe("Remaining: 2 years, 12 hours");
     expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: +25%");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
@@ -103,7 +101,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe("Dissolve Delay: 0");
+    expect(await po.getTitle()).toBe("Dissolve Delay: 0");
     expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -30,9 +30,9 @@ describe("NnsNeuronStateItemAction", () => {
       },
     });
 
-    return NnsNeuronStateItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return NnsNeuronStateItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   const controlledNeuron = {
@@ -64,7 +64,7 @@ describe("NnsNeuronStateItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Locked");
+    expect(await po.getTitle()).toBe("Locked");
     expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
   });
 
@@ -85,7 +85,7 @@ describe("NnsNeuronStateItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Dissolving");
+    expect(await po.getTitle()).toBe("Dissolving");
     expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
   });
 
@@ -125,7 +125,7 @@ describe("NnsNeuronStateItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Unlocked");
+    expect(await po.getTitle()).toBe("Unlocked");
     expect(await po.hasDisburseButton()).toBe(true);
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakedMaturityItemAction.spec.ts
@@ -19,9 +19,9 @@ describe("NnsStakedMaturityItemAction", () => {
       },
     });
 
-    return NnsStakedMaturityItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return NnsStakedMaturityItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   it("should render staked maturity", async () => {
@@ -34,6 +34,6 @@ describe("NnsStakedMaturityItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getStakedMaturity()).toBe("3.14");
+    expect(await po.getTitle()).toBe("3.14");
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
@@ -40,9 +40,9 @@ describe("SnsAvailableMaturityItemAction", () => {
       },
     });
 
-    return SnsAvailableMaturityItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return SnsAvailableMaturityItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   const noStakeMaturityPermissions = {
@@ -61,7 +61,7 @@ describe("SnsAvailableMaturityItemAction", () => {
   it("should render available maturity", async () => {
     const po = renderComponent(controlledNeuron);
 
-    expect(await po.getMaturity()).toBe("3.14");
+    expect(await po.getTitle()).toBe("3.14");
   });
 
   it("should render stake maturity button", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -51,9 +51,9 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
       },
     });
 
-    return SnsNeuronDissolveDelayItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return SnsNeuronDissolveDelayItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   const controllerPermissions = {
@@ -86,7 +86,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe("Dissolve Delay: 4 years");
+    expect(await po.getTitle()).toBe("Dissolve Delay: 4 years");
     expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: +13%");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
@@ -102,7 +102,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe("Remaining: 4 years");
+    expect(await po.getTitle()).toBe("Remaining: 4 years");
     expect(await po.getDissolveBonus()).toBe("Dissolve delay bonus: +13%");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
@@ -131,7 +131,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getDissolveState()).toBe("Dissolve Delay: 0");
+    expect(await po.getTitle()).toBe("Dissolve Delay: 0");
     expect(await po.getDissolveBonus()).toBe("No dissolve delay bonus");
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -31,9 +31,9 @@ describe("SnsNeuronStateItemAction", () => {
       },
     });
 
-    return SnsNeuronStateItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return SnsNeuronStateItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   const controllerPermissions = {
@@ -71,7 +71,7 @@ describe("SnsNeuronStateItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Locked");
+    expect(await po.getTitle()).toBe("Locked");
     expect(await po.getDissolveButtonText()).toBe("Start Dissolving");
   });
 
@@ -95,7 +95,7 @@ describe("SnsNeuronStateItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Dissolving");
+    expect(await po.getTitle()).toBe("Dissolving");
     expect(await po.getDissolveButtonText()).toBe("Stop Dissolving");
   });
 
@@ -119,7 +119,7 @@ describe("SnsNeuronStateItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getState()).toBe("Unlocked");
+    expect(await po.getTitle()).toBe("Unlocked");
     expect(await po.hasDisburseButton()).toBe(true);
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
@@ -22,9 +22,9 @@ describe("SnsStakedMaturityItemAction", () => {
       },
     });
 
-    return SnsStakedMaturityItemActionPo.under(
-      new JestPageObjectElement(container)
-    );
+    return SnsStakedMaturityItemActionPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   it("should render staked maturity", async () => {
@@ -34,6 +34,6 @@ describe("SnsStakedMaturityItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getStakedMaturity()).toBe("3.14");
+    expect(await po.getTitle()).toBe("3.14");
   });
 });

--- a/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { CommonItemActionPo } from "$tests/page-objects/CommonItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+import CommonItemActionTest from "./CommonItemActionTest.svelte";
+
+describe("CommonItemAction", () => {
+  const testId = "common-item-action-component";
+  const renderComonent = ({ title, subtitle }) => {
+    const { container } = render(CommonItemActionTest, {
+      props: { title, subtitle, testId },
+    });
+    return CommonItemActionPo.under({
+      element: new JestPageObjectElement(container),
+      testId,
+    });
+  };
+
+  it("should render title and subtitle", async () => {
+    const title = "title";
+    const subtitle = "subtitle";
+    const po = renderComonent({ title, subtitle });
+    expect(await po.getTitle()).toBe(title);
+    expect(await po.getSubtitle()).toBe(subtitle);
+  });
+});

--- a/frontend/src/tests/lib/components/ui/CommonItemActionTest.svelte
+++ b/frontend/src/tests/lib/components/ui/CommonItemActionTest.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
+  import { IconStakedMaturity } from "@dfinity/gix-components";
+
+  export let testId: string;
+  export let title: string;
+  export let subtitle: string;
+</script>
+
+<CommonItemAction {testId}>
+  <IconStakedMaturity slot="icon" />
+  <svelte:fragment slot="title">{title}</svelte:fragment>
+  <svelte:fragment slot="subtitle">{subtitle}</svelte:fragment>
+</CommonItemAction>

--- a/frontend/src/tests/page-objects/CommonItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/CommonItemAction.page-object.ts
@@ -1,0 +1,22 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+
+export class CommonItemActionPo extends BasePageObject {
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
+  }): CommonItemActionPo {
+    return new CommonItemActionPo(element.byTestId(testId));
+  }
+
+  async getTitle(): Promise<string> {
+    return this.root.byTestId("title").getText();
+  }
+
+  async getSubtitle(): Promise<string> {
+    return this.root.byTestId("subtitle").getText();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
@@ -1,17 +1,17 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class NnsAvailableMaturityItemActionPo extends BasePageObject {
+export class NnsAvailableMaturityItemActionPo extends CommonItemActionPo {
   private static readonly TID = "nns-available-maturity-item-action-component";
 
-  static under(element: PageObjectElement): NnsAvailableMaturityItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): NnsAvailableMaturityItemActionPo {
     return new NnsAvailableMaturityItemActionPo(
       element.byTestId(NnsAvailableMaturityItemActionPo.TID)
     );
-  }
-
-  getMaturity(): Promise<string> {
-    return this.getText("available-maturity");
   }
 
   hasStakeButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,19 +1,19 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 import { DissolveDelayBonusTextPo } from "./DissolveDelayBonusText.page-object";
 
-export class NnsNeuronDissolveDelayItemActionPo extends BasePageObject {
+export class NnsNeuronDissolveDelayItemActionPo extends CommonItemActionPo {
   private static readonly TID =
     "nns-neuron-dissolve-delay-item-action-component";
 
-  static under(element: PageObjectElement): NnsNeuronDissolveDelayItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): NnsNeuronDissolveDelayItemActionPo {
     return new NnsNeuronDissolveDelayItemActionPo(
       element.byTestId(NnsNeuronDissolveDelayItemActionPo.TID)
     );
-  }
-
-  getDissolveState(): Promise<string> {
-    return this.getText("dissolve-delay-text");
   }
 
   getDissolveDelayBonusTextPo(): DissolveDelayBonusTextPo {

--- a/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronMaturitySection.page-object.ts
@@ -17,7 +17,7 @@ export class NnsNeuronMaturitySectionPo extends BasePageObject {
   }
 
   getStakedMaturityItemActionPo(): NnsStakedMaturityItemActionPo {
-    return NnsStakedMaturityItemActionPo.under(this.root);
+    return NnsStakedMaturityItemActionPo.under({ element: this.root });
   }
 
   hasStakedMaturityItemAction(): Promise<boolean> {
@@ -25,7 +25,7 @@ export class NnsNeuronMaturitySectionPo extends BasePageObject {
   }
 
   getAvailableMaturityItemActionPo(): NnsAvailableMaturityItemActionPo {
-    return NnsAvailableMaturityItemActionPo.under(this.root);
+    return NnsAvailableMaturityItemActionPo.under({ element: this.root });
   }
 
   hasAvailableMaturityItemAction(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronStateItemAction.page-object.ts
@@ -1,12 +1,16 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AgeBonusTextPo } from "./AgeBonusText.page-object";
 import type { ButtonPo } from "./Button.page-object";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class NnsNeuronStateItemActionPo extends BasePageObject {
+export class NnsNeuronStateItemActionPo extends CommonItemActionPo {
   private static readonly TID = "nns-neuron-state-item-action-component";
 
-  static under(element: PageObjectElement): NnsNeuronStateItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): NnsNeuronStateItemActionPo {
     return new NnsNeuronStateItemActionPo(
       element.byTestId(NnsNeuronStateItemActionPo.TID)
     );

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -30,7 +30,7 @@ export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
   }
 
   getNeuronStateItemActionPo(): NnsNeuronStateItemActionPo {
-    return NnsNeuronStateItemActionPo.under(this.root);
+    return NnsNeuronStateItemActionPo.under({ element: this.root });
   }
 
   hasNeuronStateItemAction(): Promise<boolean> {
@@ -38,7 +38,7 @@ export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
   }
 
   getNeuronDissolveDelayItemActionPo(): NnsNeuronDissolveDelayItemActionPo {
-    return NnsNeuronDissolveDelayItemActionPo.under(this.root);
+    return NnsNeuronDissolveDelayItemActionPo.under({ element: this.root });
   }
 
   hasNeuronDissolveDelayItemAction(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NnsStakedMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakedMaturityItemAction.page-object.ts
@@ -1,16 +1,16 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class NnsStakedMaturityItemActionPo extends BasePageObject {
+export class NnsStakedMaturityItemActionPo extends CommonItemActionPo {
   private static readonly TID = "nns-staked-maturity-item-action-component";
 
-  static under(element: PageObjectElement): NnsStakedMaturityItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): NnsStakedMaturityItemActionPo {
     return new NnsStakedMaturityItemActionPo(
       element.byTestId(NnsStakedMaturityItemActionPo.TID)
     );
-  }
-
-  getStakedMaturity(): Promise<string> {
-    return this.getText("staked-maturity");
   }
 }

--- a/frontend/src/tests/page-objects/SnsAvailableMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsAvailableMaturityItemAction.page-object.ts
@@ -1,17 +1,17 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class SnsAvailableMaturityItemActionPo extends BasePageObject {
+export class SnsAvailableMaturityItemActionPo extends CommonItemActionPo {
   private static readonly TID = "sns-available-maturity-item-action-component";
 
-  static under(element: PageObjectElement): SnsAvailableMaturityItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): SnsAvailableMaturityItemActionPo {
     return new SnsAvailableMaturityItemActionPo(
       element.byTestId(SnsAvailableMaturityItemActionPo.TID)
     );
-  }
-
-  getMaturity(): Promise<string> {
-    return this.getText("available-maturity");
   }
 
   hasStakeButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,19 +1,19 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 import { DissolveDelayBonusTextPo } from "./DissolveDelayBonusText.page-object";
 
-export class SnsNeuronDissolveDelayItemActionPo extends BasePageObject {
+export class SnsNeuronDissolveDelayItemActionPo extends CommonItemActionPo {
   private static readonly TID =
     "sns-neuron-dissolve-delay-item-action-component";
 
-  static under(element: PageObjectElement): SnsNeuronDissolveDelayItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): SnsNeuronDissolveDelayItemActionPo {
     return new SnsNeuronDissolveDelayItemActionPo(
       element.byTestId(SnsNeuronDissolveDelayItemActionPo.TID)
     );
-  }
-
-  getDissolveState(): Promise<string> {
-    return this.getText("dissolve-delay-text");
   }
 
   getDissolveDelayBonusTextPo(): DissolveDelayBonusTextPo {

--- a/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronMaturitySection.page-object.ts
@@ -17,7 +17,7 @@ export class SnsNeuronMaturitySectionPo extends BasePageObject {
   }
 
   getStakedMaturityItemActionPo(): SnsStakedMaturityItemActionPo {
-    return SnsStakedMaturityItemActionPo.under(this.root);
+    return SnsStakedMaturityItemActionPo.under({ element: this.root });
   }
 
   hasStakedMaturityItemAction(): Promise<boolean> {
@@ -25,7 +25,7 @@ export class SnsNeuronMaturitySectionPo extends BasePageObject {
   }
 
   getAvailableMaturityItemActionPo(): SnsAvailableMaturityItemActionPo {
-    return SnsAvailableMaturityItemActionPo.under(this.root);
+    return SnsAvailableMaturityItemActionPo.under({ element: this.root });
   }
 
   hasAvailableMaturityItemAction(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,19 +1,19 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AgeBonusTextPo } from "./AgeBonusText.page-object";
 import type { ButtonPo } from "./Button.page-object";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class SnsNeuronStateItemActionPo extends BasePageObject {
+export class SnsNeuronStateItemActionPo extends CommonItemActionPo {
   private static readonly TID = "sns-neuron-state-item-action-component";
 
-  static under(element: PageObjectElement): SnsNeuronStateItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): SnsNeuronStateItemActionPo {
     return new SnsNeuronStateItemActionPo(
       element.byTestId(SnsNeuronStateItemActionPo.TID)
     );
-  }
-
-  getState(): Promise<string> {
-    return this.getText("state-text");
   }
 
   getAgeBonusTextPo(): AgeBonusTextPo {

--- a/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronVotingPowerSection.page-object.ts
@@ -30,7 +30,7 @@ export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
   }
 
   getStateItemActionPo(): SnsNeuronStateItemActionPo {
-    return SnsNeuronStateItemActionPo.under(this.root);
+    return SnsNeuronStateItemActionPo.under({ element: this.root });
   }
 
   hasStateItemAction(): Promise<boolean> {
@@ -38,7 +38,7 @@ export class SnsNeuronVotingPowerSectionPo extends BasePageObject {
   }
 
   getDisslveDelayItemActionPo(): SnsNeuronDissolveDelayItemActionPo {
-    return SnsNeuronDissolveDelayItemActionPo.under(this.root);
+    return SnsNeuronDissolveDelayItemActionPo.under({ element: this.root });
   }
 
   hasDissolveDelayItemActionPo(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/SnsStakedMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsStakedMaturityItemAction.page-object.ts
@@ -1,16 +1,16 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommonItemActionPo } from "./CommonItemAction.page-object";
 
-export class SnsStakedMaturityItemActionPo extends BasePageObject {
+export class SnsStakedMaturityItemActionPo extends CommonItemActionPo {
   private static readonly TID = "sns-staked-maturity-item-action-component";
 
-  static under(element: PageObjectElement): SnsStakedMaturityItemActionPo {
+  static under({
+    element,
+  }: {
+    element: PageObjectElement;
+  }): SnsStakedMaturityItemActionPo {
     return new SnsStakedMaturityItemActionPo(
       element.byTestId(SnsStakedMaturityItemActionPo.TID)
     );
-  }
-
-  getStakedMaturity(): Promise<string> {
-    return this.getText("staked-maturity");
   }
 }


### PR DESCRIPTION
# Motivation

Share the PO among all the ItemAction components that use the CommonItemAction.

# Changes

* New PO CommonItemActionPo.
* All the others extend this one.
* Remove unnecessary `span` to access title with data-tid in all CommonItemAction implementations.
* Adapt all tests and instance creations to the new interface.
* New test for CommonItemAction.

# Tests

Only test changes.

# Todos

Covered by a changelog entry.
