### PR TITLE
Rename deleted workflows

### DIFF
--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -1,1 +1,3 @@
 name: ZZZ old workflow aggregator.yaml
+on:
+  workflow_dispatch:

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -1,3 +1,8 @@
 name: ZZZ old workflow aggregator.yaml
 on:
   workflow_dispatch:
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Hello world!

--- a/.github/workflows/aggregator.yaml
+++ b/.github/workflows/aggregator.yaml
@@ -1,0 +1,1 @@
+name: ZZZ old workflow aggregator.yaml

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,5 +1,5 @@
 # TODO: Remove once the workflow is renamed on GitHub
-name: ZZZ old workflow aggregator.yaml
+name: ZZZ old workflow docker-build.yaml
 on:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -1,5 +1,5 @@
 # TODO: Remove once the workflow is renamed on GitHub
-name: ZZZ old workflow aggregator.yaml
+name: ZZZ old workflow e2e-testnet.yml
 on:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,5 +1,5 @@
 # TODO: Remove once the workflow is renamed on GitHub
-name: ZZZ old workflow aggregator.yaml
+name: ZZZ old workflow security-audit.yaml
 on:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -1,5 +1,5 @@
 # TODO: Remove once the workflow is renamed on GitHub
-name: ZZZ old workflow aggregator.yaml
+name: ZZZ old workflow selenium.yml
 on:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -1,5 +1,5 @@
 # TODO: Remove once the workflow is renamed on GitHub
-name: ZZZ old workflow aggregator.yaml
+name: ZZZ old workflow testnet.yml
 on:
   workflow_dispatch:
 jobs:

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -60,6 +60,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Updated the calls to `docker-build` to use the `--network` flag.
 * Upgraded to Playwright 1.36.
 * Update candid interface for NNS governance to improve 1-proposal support.
+* Rename deleted workflows to start with "ZZZ".
 
 #### Deprecated
 #### Removed


### PR DESCRIPTION
# Motivation

The GitHub Actions tab still lists workflows that we've already deleted:

<img width="442" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/bccd1010-be70-47c6-98bc-662d40462c55">

This makes it harder than necessary to find a workflow you're looking for.
Since the workflows are listed alphabetically I want to rename the deleted workflows to something starting with "ZZZ" so that the ones we still use appear at the top and don't require clicking "Show more workflows..."

# Changes

Recreate the deleted workflow files and give the workflows a name starting with "ZZZ".

I plan to delete these files again as soon as the workflows have been renamed on GitHub.

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
