### PR TITLE
Chore: Remove SNS aggregator fallback

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -25,10 +25,12 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New icon for dissolving neuron state.
 * Keep menu open and visible on large screen (not only on extra large screen).
 * Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
-* Remove fallback to load SNSes directly from SNS canisters.
 
 #### Deprecated
 #### Removed
+
+* Remove fallback to load SNSes directly from SNS canisters.
+
 #### Fixed
 
 * Show the current dissolve Delay in the modal to increase a dissolving SNS neuron.

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -25,6 +25,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New icon for dissolving neuron state.
 * Keep menu open and visible on large screen (not only on extra large screen).
 * Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
+* Remove fallback to load SNSes directly from SNS canisters.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -1,15 +1,9 @@
 import { browser } from "$app/environment";
-import { SNS_AGGREGATOR_CANISTER_URL } from "$lib/constants/environment.constants";
-import {
-  loadSnsProjects,
-  loadSnsSummaries,
-} from "$lib/services/$public/sns.services";
+import { loadSnsProjects } from "$lib/services/$public/sns.services";
 import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
 import { authStore } from "$lib/stores/auth.store";
-import { ENABLE_SNS_AGGREGATOR } from "$lib/stores/feature-flags.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { get } from "svelte/store";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -19,12 +13,7 @@ export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
   const initNns: Promise<void>[] = [];
-
-  const initSns: Promise<void>[] = [
-    get(ENABLE_SNS_AGGREGATOR) && SNS_AGGREGATOR_CANISTER_URL !== undefined
-      ? loadSnsProjects()
-      : loadSnsSummaries(),
-  ];
+  const initSns: Promise<void>[] = [loadSnsProjects()];
 
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -132,7 +132,7 @@ export const loadSnsProjects = async (): Promise<void> => {
     toastsError(
       toToastError({
         err,
-        fallbackErrorLabelKey: "error.proposal_not_found",
+        fallbackErrorLabelKey: "error__sns.list_summaries",
       })
     );
   }

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -1,7 +1,6 @@
 import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
-import { queryAllSnsMetadata, querySnsSwapStates } from "$lib/api/sns.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
@@ -130,46 +129,13 @@ export const loadSnsProjects = async (): Promise<void> => {
     );
     // TODO: PENDING to be implemented, load SNS parameters.
   } catch (err) {
-    // If aggregator canister fails, fallback to the old way
-    // TODO: Agree on whether we want to fallback or not.
-    // If the error is due to overload of the system, we might not want the fallback.
-    // This is useful if the error comes from the aggregator canister only.
-    await loadSnsSummaries();
+    toastsError(
+      toToastError({
+        err,
+        fallbackErrorLabelKey: "error.proposal_not_found",
+      })
+    );
   }
-};
-
-export const loadSnsSummaries = (): Promise<void> => {
-  snsQueryStore.reset();
-
-  return queryAndUpdate<[QuerySnsMetadata[], QuerySnsSwapState[]], unknown>({
-    identityType: "anonymous",
-    strategy: FORCE_CALL_STRATEGY,
-    request: ({ certified, identity }) =>
-      Promise.all([
-        queryAllSnsMetadata({ certified, identity }),
-        querySnsSwapStates({ certified, identity }),
-      ]),
-    onLoad: ({ response }) => snsQueryStore.setData(response),
-    onError: ({ error: err, certified, identity }) => {
-      console.error(err);
-
-      if (
-        certified ||
-        identity.getPrincipal().isAnonymous() ||
-        isForceCallStrategy()
-      ) {
-        snsQueryStore.reset();
-
-        toastsError(
-          toToastError({
-            err,
-            fallbackErrorLabelKey: "error__sns.list_summaries",
-          })
-        );
-      }
-    },
-    logMessage: "Syncing Sns summaries",
-  });
 };
 
 export const loadProposalsSnsCF = async (): Promise<void> => {

--- a/frontend/src/tests/lib/services/_public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/app.services.spec.ts
@@ -3,7 +3,6 @@ import { loadSnsProjects } from "$lib/services/$public/sns.services";
 
 jest.mock("$lib/services/$public/sns.services", () => {
   return {
-    loadSnsSummaries: jest.fn().mockResolvedValue(Promise.resolve()),
     loadSnsProjects: jest.fn().mockResolvedValue(Promise.resolve()),
   };
 });

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -4,7 +4,6 @@
 
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import * as governanceApi from "$lib/api/sns-governance.api";
-import * as snsApi from "$lib/api/sns.api";
 import {
   loadSnsNervousSystemFunctions,
   loadSnsProjects,
@@ -108,8 +107,6 @@ describe("SNS public services", () => {
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
-      jest.spyOn(snsApi, "queryAllSnsMetadata").mockResolvedValue([]);
-      jest.spyOn(snsApi, "querySnsSwapStates").mockResolvedValue([]);
     });
 
     it("loads sns stores with data", async () => {


### PR DESCRIPTION
# Motivation

Clean up unused code and fail early.

# Changes

* Remove `loadSnsSummaries` service.
* `loadSnsProjects` does not fallback to `loadSnsSummaries`. Instead, it shows a toast error. Which was the error management of the fallback `loadSnsSummaries`.

# Tests

* Clean up some unnecessary code in the related services.

# Todos

- [x] Add entry to changelog (if necessary).
