### PR TITLE
Refactor: Fix type issues sns aggregator

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -35,6 +35,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Avoid repeating queries to canister status if the principal is not a controller, and avoid long-lasting display of skeletons.
 * Correctly set the referrer on the detail page to go back to the effective previous page. Useful for the proposal detail page that can be opened from either from the "Proposals" or "Launchpage" pages. 
 * Fix incorrect error message when the user tries to set a lower sns dissolve delay than current.
+* Fix some type discrepancies with SNS aggregator data.
 
 #### Security
 

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -8,6 +8,7 @@ import type {
   IcrcMetadataResponseEntries,
   IcrcTokenMetadataResponse,
 } from "@dfinity/ledger";
+import { Principal } from "@dfinity/principal";
 import type {
   SnsFunctionType,
   SnsGetDerivedStateResponse,
@@ -42,7 +43,7 @@ type ListSnsCanisterIds = {
   ledger: string;
   swap: string;
   dapps: string[];
-  archives: [];
+  archives: string[];
   index: string;
 };
 
@@ -79,11 +80,22 @@ type CachedSnsMetadataDto = {
   description: string;
 };
 
+export interface GenericNervousSystemFunctionDto {
+  validator_canister_id: string | null;
+  target_canister_id: string | null;
+  validator_method_name: string | null;
+  target_method_name: string | null;
+}
+
+export type CachedFunctionTypeDto =
+  | { NativeNervousSystemFunction: Record<never, never> }
+  | { GenericNervousSystemFunction: GenericNervousSystemFunctionDto };
+
 type CachedNervousFunctionDto = {
   id: number;
   name: string;
   description: string;
-  function_type: SnsFunctionType;
+  function_type: CachedFunctionTypeDto;
 };
 
 type CachedCountriesDto = {
@@ -131,9 +143,9 @@ type CachedSnsSwapDto = {
 type CachedSnsSwapDerivedDto = {
   buyer_total_icp_e8s: number;
   sns_tokens_per_icp: number;
-  cf_participant_count: number | undefined | null;
-  direct_participant_count: number | undefined | null;
-  cf_neuron_count: number | undefined | null;
+  cf_participant_count?: number | undefined | null;
+  direct_participant_count?: number | undefined | null;
+  cf_neuron_count?: number | undefined | null;
 };
 
 type CachedSwapParamsResponseDto = {
@@ -149,7 +161,7 @@ type CachedLifecycleResponseDto = {
   lifecycle: number | null;
 };
 
-type CachedSnsTokenMetadataDto = [
+export type CachedSnsTokenMetadataDto = [
   string | IcrcMetadataResponseEntries,
   (
     | { Int: [number] }
@@ -159,14 +171,14 @@ type CachedSnsTokenMetadataDto = [
   )
 ][];
 
-type CachedSnsDto = {
+export type CachedSnsDto = {
   index: number;
   canister_ids: CanisterIds;
   list_sns_canisters: ListSnsCanisterIds;
   meta: CachedSnsMetadataDto;
   parameters: {
     functions: CachedNervousFunctionDto[];
-    reserved_ids: bigint[];
+    reserved_ids: number[];
   };
   // @deprecated
   swap_state: {
@@ -188,6 +200,14 @@ const convertOptionalNumToBigInt = (
   return num === undefined || num === null ? undefined : BigInt(num);
 };
 
+const convertOptionalStringToOptionalPrincipal = (
+  principalText: string | null | undefined
+): [] | [Principal] => {
+  return principalText === undefined || principalText === null
+    ? []
+    : [Principal.fromText(principalText)];
+};
+
 const convertMeta = (
   { url, name, description }: CachedSnsMetadataDto,
   rootCanisterId: string
@@ -198,6 +218,31 @@ const convertMeta = (
   logo: toNullable(aggregatorCanisterLogoPath(rootCanisterId)),
 });
 
+const convertFunctionType = (
+  functionType: CachedFunctionTypeDto
+): SnsFunctionType => {
+  if ("NativeNervousSystemFunction" in functionType) {
+    return { NativeNervousSystemFunction: {} };
+  }
+  const { GenericNervousSystemFunction } = functionType;
+  return {
+    GenericNervousSystemFunction: {
+      validator_canister_id: convertOptionalStringToOptionalPrincipal(
+        GenericNervousSystemFunction.validator_canister_id
+      ),
+      target_canister_id: convertOptionalStringToOptionalPrincipal(
+        GenericNervousSystemFunction.target_canister_id
+      ),
+      validator_method_name: toNullable(
+        GenericNervousSystemFunction.validator_method_name
+      ),
+      target_method_name: toNullable(
+        GenericNervousSystemFunction.target_method_name
+      ),
+    },
+  };
+};
+
 const convertNervousFuncttion = ({
   id,
   name,
@@ -207,7 +252,7 @@ const convertNervousFuncttion = ({
   id: BigInt(id),
   name: name,
   description: toNullable(description),
-  function_type: toNullable(function_type),
+  function_type: toNullable(convertFunctionType(function_type)),
 });
 
 const convertSwapInitParams = (
@@ -397,7 +442,7 @@ const convertSnsData = ({
   lifecycle: convertLifecycleResponse(lifecycle),
 });
 
-const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>
+export const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>
   data.map(convertSnsData);
 
 const querySnsAggregator = async (page = 0): Promise<CachedSnsDto[]> => {

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -22,7 +22,7 @@ import type {
   SnsSwapInit,
 } from "@dfinity/sns";
 import type { GetInitResponse } from "@dfinity/sns/dist/candid/sns_swap";
-import { nonNullish, toNullable } from "@dfinity/utils";
+import { isNullish, nonNullish, toNullable } from "@dfinity/utils";
 
 const aggregatorCanisterLogoPath = (rootCanisterId: string) =>
   `${SNS_AGGREGATOR_CANISTER_URL}/${AGGREGATOR_CANISTER_VERSION}/sns/root/${rootCanisterId}/logo.png`;
@@ -80,14 +80,14 @@ type CachedSnsMetadataDto = {
   description: string;
 };
 
-export interface GenericNervousSystemFunctionDto {
+interface GenericNervousSystemFunctionDto {
   validator_canister_id: string | null;
   target_canister_id: string | null;
   validator_method_name: string | null;
   target_method_name: string | null;
 }
 
-export type CachedFunctionTypeDto =
+type CachedFunctionTypeDto =
   | { NativeNervousSystemFunction: Record<never, never> }
   | { GenericNervousSystemFunction: GenericNervousSystemFunctionDto };
 
@@ -161,6 +161,7 @@ type CachedLifecycleResponseDto = {
   lifecycle: number | null;
 };
 
+// Export for testing purposes
 export type CachedSnsTokenMetadataDto = [
   string | IcrcMetadataResponseEntries,
   (
@@ -171,6 +172,7 @@ export type CachedSnsTokenMetadataDto = [
   )
 ][];
 
+// Export for testing purposes
 export type CachedSnsDto = {
   index: number;
   canister_ids: CanisterIds;
@@ -203,9 +205,7 @@ const convertOptionalNumToBigInt = (
 const convertOptionalStringToOptionalPrincipal = (
   principalText: string | null | undefined
 ): [] | [Principal] => {
-  return principalText === undefined || principalText === null
-    ? []
-    : [Principal.fromText(principalText)];
+  return isNullish(principalText) ? [] : [Principal.fromText(principalText)];
 };
 
 const convertMeta = (
@@ -442,6 +442,7 @@ const convertSnsData = ({
   lifecycle: convertLifecycleResponse(lifecycle),
 });
 
+// Export for testing purposes.
 export const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>
   data.map(convertSnsData);
 

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -1,8 +1,18 @@
-import { querySnsProjects } from "$lib/api/sns-aggregator.api";
-import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
+import { convertDtoData, querySnsProjects } from "$lib/api/sns-aggregator.api";
+import {
+  aggregatorSnsMock,
+  aggregatorSnsMockDto,
+} from "$tests/mocks/sns-aggregator.mock";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 
 describe("sns-aggregator api", () => {
+  describe("convertDtoData", () => {
+    it("should convert data", () => {
+      const convertedData = convertDtoData([aggregatorSnsMockDto]);
+      expect(convertedData).toEqual([aggregatorSnsMock]);
+    });
+  });
+
   describe("querySnsProjects", () => {
     afterEach(() => {
       jest.resetAllMocks();

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -1,5 +1,10 @@
-import type { CachedSns } from "$lib/api/sns-aggregator.api";
+import type {
+  CachedSns,
+  CachedSnsDto,
+  CachedSnsTokenMetadataDto,
+} from "$lib/api/sns-aggregator.api";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 
 // It should match the token below
@@ -7,6 +12,15 @@ export const aggregatorTokenMock: IcrcTokenMetadata = {
   name: "CatalyzeDAO",
   symbol: "CAT",
   fee: 100000n,
+};
+
+export const aggregatorSnsMockDto: CachedSnsDto = {
+  ...tenAggregatedSnses[7],
+  // We need this to tell TS that it's an array of tuples, not an array of arrays.
+  icrc1_metadata: tenAggregatedSnses[7]
+    .icrc1_metadata as CachedSnsTokenMetadataDto,
+  // We need this to tell TS that not an array of numbers, but an array of one number.
+  icrc1_fee: tenAggregatedSnses[7].icrc1_fee as [number],
 };
 
 // It should match the converted response from sns-aggregator.mock.json with the same `index` value


### PR DESCRIPTION
# Motivation

There were some inconsistencies in the types of SNS Aggregator. These were discovered when adding a test that checked the converter.

# Changes

* New types from aggregator: `CachedFunctionTypeDto` and `GenericNervousSystemFunctionDto`.
* Fix some type errors.
* Expose the converter and some type to be able to use them outside.

# Tests

* Add a test that converter transforms the JSON data into the expected type.

# Todos

- [x] Add entry to changelog (if necessary).
