### PR TITLE
Fix: SNS Aggregator page 2 doesn't exist

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -40,6 +40,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Fix incorrect error message when the user tries to set a lower sns dissolve delay than current.
 * Fix some type discrepancies with SNS aggregator data.
 * Do not show unnecessary scrollbar in notifications.
+* Fix error when getting an SNS Aggregator page fails.
 
 #### Security
 

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -10,20 +10,31 @@ import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
 const aggergatorPageUrl = (page: number) => `/sns/list/page/${page}/slow.json`;
 
 const querySnsAggregator = async (page = 0): Promise<CachedSnsDto[]> => {
-  const response = await fetch(
-    `${SNS_AGGREGATOR_CANISTER_URL}/${AGGREGATOR_CANISTER_VERSION}${aggergatorPageUrl(
-      page
-    )}`
-  );
-  if (!response.ok) {
-    throw new Error("Error loading SNS projects from aggregator canister");
+  try {
+    const response = await fetch(
+      `${SNS_AGGREGATOR_CANISTER_URL}/${AGGREGATOR_CANISTER_VERSION}${aggergatorPageUrl(
+        page
+      )}`
+    );
+    if (!response.ok) {
+      throw new Error("Error loading SNS projects from aggregator canister");
+    }
+    const data: CachedSnsDto[] = await response.json();
+    if (data.length === AGGREGATOR_PAGE_SIZE) {
+      const nextPageData = await querySnsAggregator(page + 1);
+      return [...data, ...nextPageData];
+    }
+    return data;
+  } catch (e) {
+    // If the error is after the first page, is because there are no more pages it fails
+    if (page > 0) {
+      console.error(
+        `Error loading SNS project page ${page} from aggregator canister`
+      );
+      return [];
+    }
+    throw e;
   }
-  const data: CachedSnsDto[] = await response.json();
-  if (data.length === AGGREGATOR_PAGE_SIZE) {
-    const nextPageData = await querySnsAggregator(page + 1);
-    return [...data, ...nextPageData];
-  }
-  return data;
 };
 
 export const querySnsProjects = async (): Promise<CachedSns[]> => {

--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -17,6 +17,10 @@ const querySnsAggregator = async (page = 0): Promise<CachedSnsDto[]> => {
       )}`
     );
     if (!response.ok) {
+      // If the error is after the first page, is because there are no more pages it fails
+      if (page > 0) {
+        return [];
+      }
       throw new Error("Error loading SNS projects from aggregator canister");
     }
     const data: CachedSnsDto[] = await response.json();

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -50,6 +50,29 @@ describe("sns-aggregator api", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it("should fetch not fail if second page failes", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      const mockFetch = jest.fn();
+      mockFetch
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(tenAggregatedSnses),
+          })
+        )
+        .mockReturnValueOnce(new Error("Second page doesn't exist"));
+      global.fetch = mockFetch;
+      const projects = await querySnsProjects();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/1/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(projects).toHaveLength(10);
+    });
+
     it("should convert response", async () => {
       const mockFetch = jest.fn();
       mockFetch.mockReturnValue(

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -50,7 +50,34 @@ describe("sns-aggregator api", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it("should fetch not fail if second page failes", async () => {
+    it("should not fail if second page response is not ok", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      const mockFetch = jest.fn();
+      mockFetch
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(tenAggregatedSnses),
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: false,
+          })
+        );
+      global.fetch = mockFetch;
+      const projects = await querySnsProjects();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/1/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(projects).toHaveLength(10);
+    });
+
+    it("should not fail if second page failes", async () => {
       jest.spyOn(console, "error").mockImplementation(() => undefined);
       const mockFetch = jest.fn();
       mockFetch


### PR DESCRIPTION
# Motivation

Bug in current mainnet. The NNS Dapp sees that the first SNS aggregator page is full; therefore, it tries to get the second page. Yet, the second page fails, and the whole process of getting the info from the aggregator fails and uses the fallback.

In this PR: Ignore errors for pages higher than 0.

# Changes

* Ignore errors for pages higher than 0 in `querySnsAggregator` helper.

# Tests

* I added first a test, it failed, and then I implemented the solution.

# Todos

- [x] Add entry to changelog (if necessary).
