### PR TITLE
Refactor: SNS Aggregator API doesn't convert data

### DIFF
--- a/frontend/src/lib/api/sns-aggregator.api.ts
+++ b/frontend/src/lib/api/sns-aggregator.api.ts
@@ -3,9 +3,8 @@ import {
   AGGREGATOR_CANISTER_VERSION,
   AGGREGATOR_PAGE_SIZE,
 } from "$lib/constants/sns.constants";
-import type { CachedSns, CachedSnsDto } from "$lib/types/sns-aggregator";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
 
 const aggergatorPageUrl = (page: number) => `/sns/list/page/${page}/slow.json`;
 
@@ -42,13 +41,12 @@ const querySnsAggregator = async (page = 0): Promise<CachedSnsDto[]> => {
   return data;
 };
 
-export const querySnsProjects = async (): Promise<CachedSns[]> => {
+export const querySnsProjects = async (): Promise<CachedSnsDto[]> => {
   logWithTimestamp("Loading SNS projects from aggregator canister...");
   try {
     const data: CachedSnsDto[] = await querySnsAggregator();
-    const convertedData = convertDtoData(data);
     logWithTimestamp("Loading SNS projects from aggregator canister completed");
-    return convertedData;
+    return data;
   } catch (err) {
     console.error("Error converting data", err);
     throw new Error("Error converting data from aggregator canister");

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -16,6 +16,7 @@ import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
 import { isForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
+import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
 import { Topic, type ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
@@ -25,7 +26,9 @@ import { getCurrentIdentity } from "../auth.services";
 
 export const loadSnsProjects = async (): Promise<void> => {
   try {
-    const cachedSnses = await querySnsProjects();
+    const aggregatorData = await querySnsProjects();
+    // TODO: Store this in a svelte store.
+    const cachedSnses = convertDtoData(aggregatorData);
     const identity = getCurrentIdentity();
     // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
     // The SNS Aggregator gives us the canister ids of the SNS projects.

--- a/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-aggregator-api.fake.ts
@@ -1,4 +1,4 @@
-import type { CachedSns } from "$lib/types/sns-aggregator";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
 import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
@@ -12,13 +12,13 @@ const implementedFunctions = {
 // State and helpers for fake implementations:
 //////////////////////////////////////////////
 
-const projects: CachedSns[] = [];
+const projects: CachedSnsDto[] = [];
 
 ////////////////////////
 // Fake implementations:
 ////////////////////////
 
-async function querySnsProjects(): Promise<CachedSns[]> {
+async function querySnsProjects(): Promise<CachedSnsDto[]> {
   return projects;
 }
 
@@ -36,7 +36,7 @@ export const addProjectWith = ({
 }: {
   rootCanisterId: string;
   lifecycle: SnsSwapLifecycle;
-}): CachedSns => {
+}): CachedSnsDto => {
   const project = aggregatorSnsMockWith({ rootCanisterId, lifecycle });
   projects.push(project);
   return project;

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -1,5 +1,5 @@
 import { querySnsProjects } from "$lib/api/sns-aggregator.api";
-import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 
 describe("sns-aggregator api", () => {
@@ -100,19 +100,17 @@ describe("sns-aggregator api", () => {
       expect(projects).toHaveLength(10);
     });
 
-    it("should convert response", async () => {
+    it("should not convert response", async () => {
       const mockFetch = jest.fn();
       mockFetch.mockReturnValue(
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve([tenAggregatedSnses[7]]),
+          json: () => Promise.resolve([aggregatorSnsMockDto]),
         })
       );
       global.fetch = mockFetch;
       const snses = await querySnsProjects();
-      const sns = snses.find(({ index }) => index === aggregatorSnsMock.index);
-      // TODO: Make clear that aggregatorSnsMock is the first in the list of aggregated SNSes
-      expect(sns).toEqual(aggregatorSnsMock);
+      expect(snses).toEqual([aggregatorSnsMockDto]);
     });
   });
 });

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -20,7 +20,7 @@ import {
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import {
-  aggregatorSnsMock,
+  aggregatorSnsMockDto,
   aggregatorSnsMockWith,
   aggregatorTokenMock,
 } from "$tests/mocks/sns-aggregator.mock";
@@ -113,12 +113,12 @@ describe("SNS public services", () => {
       const spyQuerySnsProjects = jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
+          Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
         );
 
       await loadSnsProjects();
 
-      const rootCanisterId = aggregatorSnsMock.canister_ids.root_canister_id;
+      const rootCanisterId = aggregatorSnsMockDto.canister_ids.root_canister_id;
       expect(spyQuerySnsProjects).toBeCalled();
 
       const queryStore = get(snsQueryStore);
@@ -134,12 +134,12 @@ describe("SNS public services", () => {
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() =>
-          Promise.resolve([aggregatorSnsMock, aggregatorSnsMock])
+          Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
         );
 
       await loadSnsProjects();
 
-      const rootCanisterId = aggregatorSnsMock.canister_ids.root_canister_id;
+      const rootCanisterId = aggregatorSnsMockDto.canister_ids.root_canister_id;
 
       const tokens = get(tokensStore);
       const token = tokens[rootCanisterId];
@@ -150,7 +150,7 @@ describe("SNS public services", () => {
 
     it("should load and map total token supply", async () => {
       const rootCanisterId = principal(0);
-      const totalSupply = BigInt(2_000_000_000);
+      const totalSupply = 2_000_000_000;
       const response = [
         {
           ...aggregatorSnsMockWith({
@@ -159,7 +159,7 @@ describe("SNS public services", () => {
           }),
           icrc1_total_supply: totalSupply,
         },
-        aggregatorSnsMock,
+        aggregatorSnsMockDto,
       ];
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
@@ -171,33 +171,33 @@ describe("SNS public services", () => {
       const data = supplies[rootCanisterId.toText()];
       expect(data).not.toBeUndefined();
       expect(data?.certified).toBeTruthy();
-      expect(data?.totalSupply).toEqual(totalSupply);
+      expect(data?.totalSupply).toEqual(BigInt(totalSupply));
     });
 
     it("loads derived state from property derived state", async () => {
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
-        .mockImplementation(() => Promise.resolve([aggregatorSnsMock]));
+        .mockImplementation(() => Promise.resolve([aggregatorSnsMockDto]));
 
       await loadSnsProjects();
 
       const queryStore = get(snsQueryStore);
       const derivedState = queryStore.swaps[0]?.derived[0];
-      const expectedDerivedState = aggregatorSnsMock.derived_state;
+      const expectedDerivedState = aggregatorSnsMockDto.derived_state;
       expect(derivedState.buyer_total_icp_e8s).toBe(
-        expectedDerivedState.buyer_total_icp_e8s[0]
+        BigInt(expectedDerivedState.buyer_total_icp_e8s)
       );
       expect(derivedState.sns_tokens_per_icp).toBe(
-        expectedDerivedState.sns_tokens_per_icp[0]
+        expectedDerivedState.sns_tokens_per_icp
       );
       expect(derivedState.cf_neuron_count[0]).toBe(
-        expectedDerivedState.cf_neuron_count[0]
+        BigInt(expectedDerivedState.cf_neuron_count)
       );
       expect(derivedState.cf_participant_count[0]).toBe(
-        expectedDerivedState.cf_participant_count[0]
+        BigInt(expectedDerivedState.cf_participant_count)
       );
       expect(derivedState.direct_participant_count[0]).toBe(
-        expectedDerivedState.direct_participant_count[0]
+        BigInt(expectedDerivedState.direct_participant_count)
       );
     });
   });

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -5,7 +5,7 @@ import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
-import { aggregatorSnsMock } from "$tests/mocks/sns-aggregator.mock";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
@@ -32,7 +32,7 @@ describe("app-services", () => {
 
     jest
       .spyOn(aggregatorApi, "querySnsProjects")
-      .mockResolvedValue([aggregatorSnsMock, aggregatorSnsMock]);
+      .mockResolvedValue([aggregatorSnsMockDto, aggregatorSnsMockDto]);
   });
 
   it("should init Nns", async () => {

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -302,16 +302,16 @@ export const aggregatorSnsMockWith = ({
 }: {
   rootCanisterId: string;
   lifecycle: SnsSwapLifecycle;
-}): CachedSns => ({
-  ...aggregatorSnsMock,
+}): CachedSnsDto => ({
+  ...aggregatorSnsMockDto,
   canister_ids: {
-    ...aggregatorSnsMock.canister_ids,
+    ...aggregatorSnsMockDto.canister_ids,
     root_canister_id: rootCanisterId,
   },
   swap_state: {
-    ...aggregatorSnsMock.swap_state,
+    ...aggregatorSnsMockDto.swap_state,
     swap: {
-      ...aggregatorSnsMock.swap_state.swap,
+      ...aggregatorSnsMockDto.swap_state.swap,
       lifecycle,
     },
   },


### PR DESCRIPTION
# Motivation

Add aggregator data in a Svelte store.

In this PR: Move the conversion of the aggregator data to the sns service `loadSnsProjects` before loading the stores.

# Changes

* Remove conversion of data in sns aggregator api.
* Use `convertDtoData` in `loadSnsProjects` before loading the data in the Svelte stores.

# Tests

* Fix tests after refactor.
* Change the test in sns aggregator api that checked the conversion.

# Todos

This is a refactor. Not worth an entry.
