### PR TITLE
Fix: Remove unnecessary code ProjectDetail

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -32,6 +32,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Remove fallback to load SNSes directly from SNS canisters.
 * Remove ENABLE_SNS_AGGREGATOR flag.
+* Remove relying on the swap raw metrics to get the number of buyers of a Swap.
 
 #### Fixed
 

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -25,10 +25,7 @@
   import { debugSelectedProjectStore } from "$lib/derived/debug.derived";
   import { goto } from "$app/navigation";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import {
-    loadSnsSwapMetrics,
-    watchSnsMetrics,
-  } from "$lib/services/sns-swap-metrics.services";
+  import { loadSnsSwapMetrics } from "$lib/services/sns-swap-metrics.services";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
   import SaleInProgressModal from "$lib/modals/sns/sale/SaleInProgressModal.svelte";

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -79,11 +79,6 @@
         },
         forceFetch: true,
       }),
-      loadSnsSwapMetrics({
-        forceFetch: true,
-        rootCanisterId: Principal.fromText(rootCanisterId),
-        swapCanisterId,
-      }),
     ]);
   };
 
@@ -189,21 +184,13 @@
     nonNullish(derivedStateHasBuyersCount) &&
     !areWatchersSet
   ) {
-    // TODO: Remove once all SNS support the buyers count in derived state
     if (!derivedStateHasBuyersCount) {
-      // We load the metrics to have them initially available before setInterval starts
+      // TODO: Remove once Dragginz, OC and SONIC support new fields in in SnsGetDerivedStateResponse
       loadSnsSwapMetrics({
         rootCanisterId: Principal.fromText(rootCanisterId),
         swapCanisterId,
         forceFetch: false,
       });
-      if (enableOpenProjectWatchers) {
-        unsubscribeWatchMetrics?.();
-        unsubscribeWatchMetrics = watchSnsMetrics({
-          rootCanisterId: Principal.fromText(rootCanisterId),
-          swapCanisterId: swapCanisterId,
-        });
-      }
     }
 
     if (enableOpenProjectWatchers) {

--- a/frontend/src/lib/services/sns-swap-metrics.services.ts
+++ b/frontend/src/lib/services/sns-swap-metrics.services.ts
@@ -1,5 +1,4 @@
 import { querySnsSwapMetrics } from "$lib/api/sns-swap-metrics.api";
-import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import { parseSnsSwapSaleBuyerCount } from "$lib/utils/sns.utils";
 import type { Principal } from "@dfinity/principal";
@@ -47,20 +46,4 @@ export const loadSnsSwapMetrics = async ({
     rootCanisterId,
     metrics: { saleBuyerCount },
   });
-};
-
-export const watchSnsMetrics = ({
-  rootCanisterId,
-  swapCanisterId,
-}: {
-  rootCanisterId: Principal;
-  swapCanisterId: Principal;
-}): (() => void) => {
-  const interval = setInterval(() => {
-    loadSnsSwapMetrics({ rootCanisterId, swapCanisterId, forceFetch: true });
-  }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
-
-  return () => {
-    clearInterval(interval);
-  };
 };

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -134,37 +134,11 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         snsQueryStore.setData(response);
       });
 
-      it("should start watching swap metrics and stop on unmounting", async () => {
-        const { unmount } = render(ProjectDetail, props);
+      it("should fetch swap metrics on load", async () => {
+        render(ProjectDetail, props);
 
         await runResolvedPromises();
-        let expectedCalls = 1;
-        expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(
-          expectedCalls
-        );
-
-        const retryDelay = WATCH_SALE_STATE_EVERY_MILLISECONDS;
-        const callsBeforeStopPolling = 4;
-
-        while (expectedCalls < callsBeforeStopPolling) {
-          await advanceTime(retryDelay);
-          expectedCalls += 1;
-          expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(
-            expectedCalls
-          );
-        }
-        unmount();
-
-        await runResolvedPromises();
-        expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(
-          expectedCalls
-        );
-
-        // Even after waiting a long time there shouldn't be more calls.
-        await advanceTime(99 * retryDelay);
-        expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(
-          expectedCalls
-        );
+        expect(snsMetricsApi.querySnsSwapMetrics).toBeCalledTimes(1);
       });
     });
 


### PR DESCRIPTION
# Motivation

Remove unnecessary code in Project Detail page.

All new SNSes will have the field of number of buyers in the derived state. There is no need to rely on the swap raw metrics.

# Changes

* Do not call `loadSnsSwapMetrics` after participation.
* Remove `watchSnsMetrics` because all new SNSes support the count in derived state.

# Tests

* Fix tests after changes.

# Todos

- [x] Add entry to changelog (if necessary).
