### PR TITLE
Populate the change log in scripts/nns-dapp/release-template

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -56,6 +56,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * A test that state is preserved in downgrade-upgrade tests.
 * Support SNS neuron permission in fake SNS governance API.
 * Support selective pausing and resuming in API fakes.
+* Automatically populate the change log section in the release proposal.
 
 #### Changed
 

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -24,15 +24,44 @@ else
   echo "Please populate ${WASM} and run this again."
   exit 0
 fi
+
+get_unreleased_changelog() {
+  # The command below does:
+  # 1. Take the CHANGELOG-Nns-Dapp.md file from (including) the first occurrence
+  #    of "### Application" until the end.
+  # 2. Of that, take the lines until (excluding) the first occurrence of
+  #    "### Operations"
+  # 3. Remove the first line (containing "### Application").
+  # 4. Remove blank lines.
+  # 5. Add a line with "####" at the end. (To correctly recognize an empty
+  #    section at the end.)
+  # 6. Remove empty sections. (Only output lines that don't start with # or that
+  #    are followed by a line that doesn't start with #.)
+  # 7. Add a blank line before and after each section heading.
+  # 8. Remove 2 leading blank lines which were added by the previous 2 steps.
+  # 8. Replace "###" with "##" to make the heading depth correct for the context
+  #    of the proposal text..
+  sed -nE '/^### Application/,//p' CHANGELOG-Nns-Dapp.md |
+    sed -nE '/^### Operations/q;p' |
+    sed '1d' |
+    grep -v "^$" |
+    (
+      cat -
+      echo '####'
+    ) |
+    awk '{if ($0 !~ /^#/ || prev !~ /^#/) print prev} {prev=$0}' |
+    awk '{ if ($0 ~ /^#/) print "\n"$0"\n"; else print $0 }' |
+    sed '1,2d' |
+    sed -E 's/###/##/'
+}
+
 cat <<EOF >release/PROPOSAL.md
 # Upgrade frontend NNS Dapp canister to commit \`$(git rev-parse tags/release-candidate)\`
 Wasm sha256 hash: \`${SHA}\` (\`${CI}\`)
 
 ## Change Log:
 
-* Write about...
-* ... what has changed
-* ... in simple bullet points
+$(get_unreleased_changelog)
 
 ## Commit Log:
 
@@ -91,3 +120,8 @@ EOF
 
 ./config.sh
 cp "nns-dapp-arg-${DFX_NETWORK}.did" "./release/nns-dapp-arg-${DFX_NETWORK}.did"
+
+echo
+echo "Output files:"
+echo "  release/PROPOSAL.md"
+echo "  release/ROLLBACK.md"

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -40,7 +40,7 @@ get_unreleased_changelog() {
   # 7. Add a blank line before and after each section heading.
   # 8. Remove 2 leading blank lines which were added by the previous 2 steps.
   # 8. Replace "###" with "##" to make the heading depth correct for the context
-  #    of the proposal text..
+  #    of the proposal text.
   sed -nE '/^### Application/,//p' CHANGELOG-Nns-Dapp.md |
     sed -nE '/^### Operations/q;p' |
     sed '1d' |


### PR DESCRIPTION
# Motivation

When we create a proposal, we need to do some manual copy/paste/editing to add in the change log section.
This is mechanical so can be automated.

# Changes

1. In `scripts/nns-dapp/release-template` populate the change log section from the "Application" part of the unreleased changes in `CHANGELOG-Nns-Dapp.md`.
2. Output at the end which files were created, for convenience.

# Tests

Ran the script manually. It created this output:

````
# Upgrade frontend NNS Dapp canister to commit `cbdf82cbc8fa28787e7faa70082b46ab98013967`
Wasm sha256 hash: `25d0749441efd9c03baee2a52cf491f0ec73d3c671f0de0dae5a09653d6836fb` (`https://github.com/dfinity/nns-dapp/actions/runs/5739002244`)

## Change Log:

### Added

* Enable merge neurons preview.
* Display page title in browser's tab.

### Changed

* Refactor storage to prepare for schema migration.
* Enhance user experience by rendering hyperlinks for the cards displayed on the Accounts, Neurons, Proposals, Launchpad, and Canister pages instead of buttons
* Bump agent-js `v0.18.1`.
* Clarify Ledger app version error message.
* Increase the displayed size of the projects logo on the "Launchpad".
* Do not display the "Vote on Proposals" title in the page's header on wide screens to align the behavior with pages that support multiple projects.
* New icon for dissolving neuron state.
* Keep menu open and visible on large screen (not only on extra large screen).
* Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
* Update SNS Aggregator response type and related converters.

### Removed

* Remove fallback to load SNSes directly from SNS canisters.

### Fixed

* Show the current dissolve Delay in the modal to increase a dissolving SNS neuron.
* Avoid repeating queries to canister status if the principal is not a controller, and avoid long-lasting display of skeletons.
* Correctly set the referrer on the detail page to go back to the effective previous page. Useful for the proposal detail page that can be opened from either from the "Proposals" or "Launchpage" pages. 
* Fix incorrect error message when the user tries to set a lower sns dissolve delay than current.
* Fix some type discrepancies with SNS aggregator data.
* Do not show unnecessary scrollbar in notifications.
* Fix error when getting an SNS Aggregator page fails.

### Not Published

* New NNS and SNS neuron details page layout.

## Commit Log:

```
+ bash -xc "git log --format='%C(auto) %h %s' 7f8855682..cbdf82cbc"
 cbdf82cbc Rename: XxActionItem -> XxItemAction (#3011)
 2526aaff9 CHANGELOG change meant for PR 3022 (#3023)
 1e8daf607 Use tar format gnu instead of ustar for frontend assets (#3022)
 fbd3a09ec NNS Dapp capital first letter (#3014)
 751416b47 refactor: Move the stable memory parsing code. (#2993)
 0ef9d548c npm audit fix (#3018)
 f483cb461 Fix proposals filters style alignment (#3021)
 0d5c19b47 Rename NnsNeuronMetaInfoCardPageObjectPo to NnsNeuronMetaInfoCardPo (#3013)
 2334b1064 Improve ux by using hyperlinks for the cards (#3005)
 c9edbd4df Invert tab title (#3019)
 32936671f Display page title in browser's tab / window title (#3006)
 92ce1f4bf Keep menu open and visible on large screen (#3004)
 7e875b4c7 Don't run reproducible assets against Mac OS 13 (#3017)
 567d67f18 Get development ICP with Icrc accounts (#3007)
 fa3096640 GIX-1777: Hotkey and NF's tags (#3003)
 e9130eb1f GIX-1777: Voting power section expansion (#2998)
 989cb3b00 GIX-1777: Format age bonus as percentage (#2991)
 bfaa74fe6 Remove ICP from few texts (#3002)
 84b92fd67 Fix back to accounts after transaction in wallet page (#2999)
 6e981f24c GIX-1777: Communicate when No Voting Power (#2996)
 adc45baa9 Chore: Clean getStateInfo (#2995)
 4ebc6d743 E2e/filter proposals by topic (#2988)
 13ebe7b86 Noassets feature flag (#2986)
 b01e29b2f Update cycle count estimates (#2992)
 7d772ea7a GIX-1777: New dissolving icon (#2990)
 c09e5946f Large user data (#2979)
 f4c57eb56 GIX-1687: Set ENABLE_NEURON_SETTINGS true except prod (#2989)
 04758e882 GIX-1777: UI Improvements (#2987)
 185f44fc0 Dedicated downgrade upgrade job (#2984)
 9c3e0defd GIX-1745: Enable new neuron UI for unit tests (#2982)
 b5d1804b7 GIX-1745: Neurons e2e test uses new neurons UI (#2983)
 eebbfea0a feat: dissolve_delay_below_current error message (#2980)
 e487fa820 Fix: SNS Governance E2E flakyness (#2978)
 9941622c3 GIX-1745: E2E SNS Governance test with new UI (#2977)
 6fda48616 Dev build (#2936)
 7a36d1c25 Faster formatting (#2972)
 b4e2ed1f3 Fix: deploy script (#2963)
 d840c6919 Update didc release (#2975)
 048097646 GIX-1745: SnsNeuronDetail page test new UI (#2969)
 b14020db7 GIX-1766: Add permissions SNS neuron buttons (#2966)
 c5796f6ac feat: Check that the number of accounts etc is preserved across upgrades (#2973)
 8f4222c53 fix: Use docker-build --network flag (#2974)
 bd62a87e1 chore: Install file in the builder image (#2971)
 e620eb228 Launch Merge neurons preview (#2968)
 42912c8ac fix: Pass the target (#2934)
 c64cfc09c Increase the displayed size of the projects logo on the "Launchpad" (#2970)
 8367adf79 Do not display proposals title on wide screens (#2965)
 8f4659e1a E2E flakiness: Don't vote on proposal created by a different test (#2954)
 5b4d1edb6 Remove ENABLE_SNS_VOTING flag (#2967)
 c4bdf820f GIX-1745: Disburse E2e test with new neuron detail page (#2961)
 61519a5e7 Proposal detail page back referrer (#2962)
 ebcc9af46 Use short paths (#2916)
 fbe6f49af Improve Ledger app version error message (#2960)
 266527c39 GIX-1765: Manage permissions in NNS neuron buttons (#2959)
 d01b3944a GIX-1764: Set neuron id in header title on scroll (#2957)
 3f9463d40 fix: Always update the index.html (#2955)
 4721ea033 GIX-1745: Test NnsNeuronDetail with new UI (#2951)
 fd2bef9b4 tweak: Show app subnet deployment ref (#2956)
 5cec6fcd0 Split aggregator changelog for proposal 123719 (#2944)
 3e55376a7 Canister status "endless loop" (#2950)
 6564e329a Chore: Refactor SnsNeuronMaturitySection to have neuron prop (#2952)
 552efc37b Chore: Rename ageSinceSeconds parameter (#2949)
 b3c838f3b GIX-1745: Neuron Settings Feature Flags flips between old and new UI (#2947)
 9d26fb662 Release: Version and Changelog (#2948)
 3bcea5e64 GIX-1684: SnsNeuronDissolveDelayActionItem (#2945)
 b10bf6847 GIX-1686: SnsNeuronAdvancedSection actions (#2946)
 8b5796dbb Fix race condition in removing SNS neuron hotkey (#2938)
 bc8734cf0 Migrate multi-tab-auth e2e test from wdio to playwright (#2940)
 ee35bc391 Fix Sns aggregator root url to fetch projects (#2942)
 1bd1d69b0 Use Readable type when Writable is not needed (#2939)
 a58d123ea update gix-components (#2937)
 1572c0d68 Cleanup: Use this.getButton() in page objects (#2935)
 24ce2b2d7 Upgrade Playwright (#2933)
 599c8c4a3 Test SNS hotkey management (#2932)
 9495a483a GIX-1684: SnsNeuronStateItemAction (#2931)
 2c10e0815 GIX-1686: SnsNeuronAdvancedSection Part 1 (#2929)
 778b848c7 GIX-1684: SnsNeuronVotingPowerSection (#2928)
 b4e9d6f0b Fix: Dissolve Delay Modal current Delay in Dissolving SNS neuron (#2930)
 aee163ac0 Fix SnsNeuronDetail.spec.ts (#2927)
```

## Wasm Verification

To build the wasm module yourself and verify its hash, run the following commands from the root of the [nns-dapp repo](https://github.com/dfinity/nns-dapp):

```
git fetch  # to ensure you have the latest changes.
git checkout "cbdf82cbc8fa28787e7faa70082b46ab98013967"
./scripts/docker-build
sha256sum nns-dapp.wasm.gz
```

You may also want to verify the canister arguments.  In the proposal they are
binary, which is not very readable. Docker provides both binary and text formats
and you can verify that the text format corresponds to the binary `arg_hex`
field in the proposal.

```
cat nns-dapp-arg-mainnet.did
didc encode "$(cat nns-dapp-arg-mainnet.did)"
```
````

# Todos

- [x] Add entry to changelog (if necessary).
