### PR TITLE
GIX-1712: One confirmation with Ledger device

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -19,6 +19,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Implement the standard accounts dropdown selector in canisters' features.
 * Review and optimize the number of steps and the UI of the canisters' related modals.
 * Hotkeys can now manage Neurons' Fund participation as long as the neuron is not controlled by a hardware wallet.
+* Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 
 #### Deprecated
 #### Removed
@@ -53,7 +54,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Update candid interface for NNS governance to improve 1-proposal support.
 * Rename deleted workflows to start with "ZZZ".
-* Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 
 #### Deprecated
 #### Removed

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -83,6 +83,13 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New icon for dissolving neuron state.
 * Keep menu open and visible on large screen (not only on extra large screen).
 * Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
+* Update SNS Aggregator response type and related converters.
+* Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
+
+#### Deprecated
+#### Removed
+
+* Remove fallback to load SNSes directly from SNS canisters.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -53,6 +53,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Update candid interface for NNS governance to improve 1-proposal support.
 * Rename deleted workflows to start with "ZZZ".
+* Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 
 #### Deprecated
 #### Removed
@@ -83,8 +84,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New icon for dissolving neuron state.
 * Keep menu open and visible on large screen (not only on extra large screen).
 * Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
-* Update SNS Aggregator response type and related converters.
-* Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 
 #### Deprecated
 #### Removed

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -85,11 +85,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Keep menu open and visible on large screen (not only on extra large screen).
 * Use tar format `gnu` instead of `ustar` to archive the frontend assets, to keep reproducibility between GNU tar versions 1.34 and 1.35.
 
-#### Deprecated
-#### Removed
-
-* Remove fallback to load SNSes directly from SNS canisters.
-
 #### Fixed
 
 * Show the current dissolve Delay in the modal to increase a dissolving SNS neuron.

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -75,7 +75,6 @@ export class LedgerIdentity extends SignIdentity {
     return this.publicKey;
   }
 
-  // We still keep this even though it's not used directly here, because it's required by the interface.
   public override async sign(blob: ArrayBuffer): Promise<Signature> {
     const callback = async (app: LedgerApp): Promise<Signature> => {
       const responseSign: ResponseSign = await app.sign(

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -265,11 +265,11 @@ export class LedgerIdentity extends SignIdentity {
     // If cached data doesn't match, ignore and move on to sign the request.
     // The `ingress_expiry` is different in the cached in the new request because the new one is created after the first call.
     // But the signature was done with the cached body. That's why we use the cached body.
-    const newRequest = {
+    const newBody = {
       ...body,
       ingress_expiry: cachedBody.ingress_expiry,
     };
-    if (this.requestsMatch(cachedBody, newRequest)) {
+    if (this.requestsMatch(cachedBody, newBody)) {
       return {
         ...fields,
         body: {

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -273,7 +273,8 @@ export class LedgerIdentity extends SignIdentity {
     if (nonNullish(requestData)) {
       const { signature, body: cachedBody } = requestData;
       // If cached data doesn't match, ignore and move on to sign the request.
-      // `ingress_expiry` doesn't need to match. TODO: Ask why.
+      // The `ingress_expiry` is different in the cached in the new request because the new one is created after the first call.
+      // But the signature was done with the cached body. That's why we use the cached body.
       if (sendersMatch(cachedBody.sender, body.sender)) {
         return {
           ...fields,

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -115,6 +115,7 @@ export const resetIdentitiesCachedForTesting = () => (identities = {});
 export const getLedgerIdentity = async (
   identifier: string
 ): Promise<LedgerIdentity> => {
+  // TODO: remove caching of the identities to avoid issues with the LedgerIdentity instance being reused.
   if (identities[identifier]) {
     return identities[identifier];
   }

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -115,7 +115,6 @@ export const resetIdentitiesCachedForTesting = () => (identities = {});
 export const getLedgerIdentity = async (
   identifier: string
 ): Promise<LedgerIdentity> => {
-  // TODO: remove caching of the identities to avoid issues with the LedgerIdentity instance being reused.
   if (identities[identifier]) {
     return identities[identifier];
   }

--- a/frontend/src/lib/utils/ledger.utils.ts
+++ b/frontend/src/lib/utils/ledger.utils.ts
@@ -8,7 +8,13 @@ import { i18n } from "$lib/stores/i18n";
 import { LedgerErrorKey, LedgerErrorMessage } from "$lib/types/ledger.errors";
 import type { Signature } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import type { ResponseAddress, ResponseSign } from "@zondax/ledger-icp";
+import { isNullish } from "@dfinity/utils";
+import type {
+  LedgerError,
+  ResponseAddress,
+  ResponseSign,
+  ResponseSignUpdateCall,
+} from "@zondax/ledger-icp";
 import { get } from "svelte/store";
 import { replacePlaceholders } from "./i18n.utils";
 
@@ -48,18 +54,25 @@ export const decodePublicKey = async ({
   return publicKey;
 };
 
-export const decodeSignature = async ({
-  signatureRS,
-  returnCode,
-  errorMessage,
-}: ResponseSign): Promise<Signature> => {
-  const labels = get(i18n);
-
+const checkResponseCode = async (returnCode: LedgerError): Promise<void> => {
   const { LedgerError } = await import("@zondax/ledger-icp");
   if (returnCode === LedgerError.TransactionRejected) {
     throw new LedgerErrorKey("error__ledger.user_rejected_transaction");
   }
-  if (signatureRS === null || signatureRS === undefined) {
+};
+
+const checkSignature = ({
+  signature,
+  returnCode,
+  errorMessage,
+}: {
+  signature?: Buffer;
+  returnCode: LedgerError;
+  errorMessage?: string;
+}) => {
+  const labels = get(i18n);
+
+  if (isNullish(signature)) {
     throw new LedgerErrorMessage(
       replacePlaceholders(labels.error__ledger.signature_unexpected, {
         $code: `${returnCode}`,
@@ -68,7 +81,7 @@ export const decodeSignature = async ({
     );
   }
 
-  const { byteLength, length } = signatureRS;
+  const { byteLength, length } = signature;
 
   if (byteLength !== LEDGER_SIGNATURE_LENGTH) {
     throw new LedgerErrorMessage(
@@ -77,8 +90,42 @@ export const decodeSignature = async ({
       })
     );
   }
+};
+
+export const decodeSignature = async ({
+  signatureRS,
+  returnCode,
+  errorMessage,
+}: ResponseSign): Promise<Signature> => {
+  await checkResponseCode(returnCode);
+  checkSignature({ signature: signatureRS, returnCode, errorMessage });
 
   return bufferToArrayBuffer(signatureRS) as Signature;
+};
+
+export type RequestSignatures = {
+  callSignature: Signature;
+  readStateSignature: Signature;
+};
+
+export const decodeSignatures = async ({
+  RequestSignatureRS,
+  StatusReadSignatureRS,
+  returnCode,
+  errorMessage,
+}: ResponseSignUpdateCall): Promise<RequestSignatures> => {
+  await checkResponseCode(returnCode);
+  checkSignature({ signature: RequestSignatureRS, returnCode, errorMessage });
+  checkSignature({
+    signature: StatusReadSignatureRS,
+    returnCode,
+    errorMessage,
+  });
+
+  return {
+    callSignature: bufferToArrayBuffer(RequestSignatureRS) as Signature,
+    readStateSignature: bufferToArrayBuffer(StatusReadSignatureRS) as Signature,
+  };
 };
 
 const bufferToArrayBuffer = (buffer: Buffer): ArrayBuffer =>

--- a/frontend/src/lib/utils/ledger.utils.ts
+++ b/frontend/src/lib/utils/ledger.utils.ts
@@ -115,6 +115,7 @@ export const decodeUpdateSignatures = async ({
   errorMessage,
 }: ResponseSignUpdateCall): Promise<RequestSignatures> => {
   await checkResponseCode(returnCode);
+  // TODO: Could we get different returnCode per signature?
   checkSignature({ signature: RequestSignatureRS, returnCode, errorMessage });
   checkSignature({
     signature: StatusReadSignatureRS,
@@ -134,3 +135,6 @@ const bufferToArrayBuffer = (buffer: Buffer): ArrayBuffer =>
 // Check docs for more detais: https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-read-state
 // Quote: "Moreover, all paths with prefix /request_status/<request_id> must refer to the same request ID <request_id>."
 export const getRequestId = (body: ReadRequest): RequestId => body.paths[0][1];
+export const createReadStatePaths = (requestId: RequestId) => [
+  [new TextEncoder().encode("request_status"), requestId],
+];

--- a/frontend/src/lib/utils/ledger.utils.ts
+++ b/frontend/src/lib/utils/ledger.utils.ts
@@ -6,7 +6,7 @@ import {
 import { Secp256k1PublicKey } from "$lib/keys/secp256k1";
 import { i18n } from "$lib/stores/i18n";
 import { LedgerErrorKey, LedgerErrorMessage } from "$lib/types/ledger.errors";
-import type { Signature } from "@dfinity/agent";
+import type { ReadRequest, RequestId, Signature } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { isNullish } from "@dfinity/utils";
 import type {
@@ -108,7 +108,7 @@ export type RequestSignatures = {
   readStateSignature: Signature;
 };
 
-export const decodeSignatures = async ({
+export const decodeUpdateSignatures = async ({
   RequestSignatureRS,
   StatusReadSignatureRS,
   returnCode,
@@ -130,3 +130,7 @@ export const decodeSignatures = async ({
 
 const bufferToArrayBuffer = (buffer: Buffer): ArrayBuffer =>
   buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
+// Check docs for more detais: https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-read-state
+// Quote: "Moreover, all paths with prefix /request_status/<request_id> must refer to the same request ID <request_id>."
+export const getRequestId = (body: ReadRequest): RequestId => body.paths[0][1];

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -390,3 +390,20 @@ export const expandObject = (
     }
     return acc;
   }, {} as Record<string, unknown>);
+
+export const sameBufferData = (
+  buffer1: ArrayBuffer,
+  buffer2: ArrayBuffer
+): boolean => {
+  if (buffer1.byteLength !== buffer2.byteLength) {
+    return false;
+  }
+  const dv1 = new Int8Array(buffer1);
+  const dv2 = new Int8Array(buffer2);
+  for (let i = 0; i < buffer1.byteLength; i++) {
+    if (dv1[i] !== dv2[i]) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -77,6 +77,14 @@ describe("LedgerIdentity", () => {
       StatusReadHash: Buffer.from(""),
       StatusReadSignatureRS: readStateSignature,
     });
+
+    mockLedgerApp.sign.mockResolvedValue({
+      errorMessage: undefined,
+      returnCode: LedgerError.NoErrors,
+      signatureRS: callSignature,
+      preSignHash: Buffer.from(""),
+      signatureDER: Buffer.from(""),
+    });
   });
 
   it("should not call to sign read state request after signing call request", async () => {
@@ -89,19 +97,23 @@ describe("LedgerIdentity", () => {
     const readRequest = await identity.transformRequest(mockReadStateRequest);
     expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
     expect(readRequest.endpoint).toBe("read_state");
+    identity.clearInstanceVariablesForTesting();
   });
 
   it("should call to sign read state request after signing call request if neuron flag is set", async () => {
     const identity = await LedgerIdentity.create();
-    identity.flagUpcomingStakeNeuron();
 
+    identity.flagUpcomingStakeNeuron();
     const request = await identity.transformRequest(mockHttpRequest);
-    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(0);
+    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(1);
     expect(request.endpoint).toBe("call");
 
     const readRequest = await identity.transformRequest(mockReadStateRequest);
-    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(2);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(0);
+    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(2);
     expect(readRequest.endpoint).toBe("read_state");
+    identity.clearInstanceVariablesForTesting();
   });
 
   it("should sign new call requests", async () => {
@@ -114,5 +126,6 @@ describe("LedgerIdentity", () => {
     const request2 = await identity.transformRequest(mockHttpRequest);
     expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(2);
     expect(request2.endpoint).toBe("call");
+    identity.clearInstanceVariablesForTesting();
   });
 });

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -1,0 +1,105 @@
+import { LedgerIdentity } from "$lib/identities/ledger.identity";
+import { Secp256k1PublicKey } from "$lib/keys/secp256k1";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import {
+  fromHexString,
+  rawPublicKeyHex,
+} from "$tests/mocks/ledger.identity.mock";
+import {
+  Expiry,
+  SubmitRequestType,
+  type Endpoint,
+  type HttpAgentRequest,
+  type ReadRequestType,
+} from "@dfinity/agent";
+import type TransportWebHID from "@ledgerhq/hw-transport-webhid";
+import type InternetComputerApp from "@zondax/ledger-icp";
+import { LedgerError } from "@zondax/ledger-icp";
+import { mock } from "jest-mock-extended";
+
+describe("LedgerIdentity", () => {
+  const mockLedgerApp = mock<InternetComputerApp>();
+  const mockTransport = mock<TransportWebHID>();
+
+  const publicKey = Secp256k1PublicKey.fromRaw(fromHexString(rawPublicKeyHex));
+  const mockHttpRequest: HttpAgentRequest = {
+    endpoint: "call" as Endpoint.Call,
+    request: {},
+    body: {
+      request_type: "call" as SubmitRequestType.Call,
+      paths: [],
+      canister_id: mockCanisterId,
+      method_name: "get_balance",
+      arg: new TextEncoder().encode(""),
+      sender: mockPrincipal,
+      ingress_expiry: new Expiry(100000),
+    },
+  };
+  const mockReadStateRequest: HttpAgentRequest = {
+    endpoint: "read_state" as Endpoint.ReadState,
+    request: {},
+    body: {
+      request_type: "read_state" as ReadRequestType.ReadState,
+      paths: [],
+      method_name: "get_balance",
+      arg: new TextEncoder().encode(""),
+      sender: mockPrincipal,
+      ingress_expiry: new Expiry(100000),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLedgerApp.getAddressAndPubKey.mockResolvedValue({
+      errorMessage: undefined,
+      returnCode: LedgerError.NoErrors,
+      publicKey: Buffer.from(publicKey.toRaw()),
+      principal: Buffer.from(mockPrincipal.toUint8Array()),
+      address: Buffer.from(""),
+      principalText: mockPrincipal.toText(),
+    });
+    jest.spyOn(LedgerIdentity, "connect").mockResolvedValue({
+      app: mockLedgerApp,
+      transport: mockTransport,
+    });
+    jest
+      .spyOn(LedgerIdentity, "fetchPublicKeyFromDevice")
+      .mockResolvedValue(publicKey);
+    const callSignature = Buffer.alloc(64);
+    const readStateSignature = Buffer.alloc(64);
+
+    mockLedgerApp.signUpdateCall.mockResolvedValue({
+      errorMessage: undefined,
+      returnCode: LedgerError.NoErrors,
+      RequestHash: Buffer.from(""),
+      RequestSignatureRS: callSignature,
+      StatusReadHash: Buffer.from(""),
+      StatusReadSignatureRS: readStateSignature,
+    });
+  });
+
+  it("should not call to sign read state request after signing call request", async () => {
+    const identity = await LedgerIdentity.create();
+
+    const request = await identity.transformRequest(mockHttpRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(request.endpoint).toBe("call");
+
+    const readRequest = await identity.transformRequest(mockReadStateRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(readRequest.endpoint).toBe("read_state");
+  });
+
+  it("should sign new call requests", async () => {
+    const identity = await LedgerIdentity.create();
+
+    const request = await identity.transformRequest(mockHttpRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(request.endpoint).toBe("call");
+
+    const request2 = await identity.transformRequest(mockHttpRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(2);
+    expect(request2.endpoint).toBe("call");
+  });
+});

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -44,8 +44,6 @@ describe("LedgerIdentity", () => {
   const readStateBody1 = {
     request_type: "read_state" as ReadRequestType.ReadState,
     paths: [[new TextEncoder().encode("request_status"), requestId1]],
-    method_name: "get_balance",
-    arg: new TextEncoder().encode(""),
     sender: mockPrincipal,
     ingress_expiry: new Expiry(100000),
   };
@@ -161,7 +159,6 @@ describe("LedgerIdentity", () => {
       body: {
         ...readStateBody1,
         paths: [[new TextEncoder().encode("request_status"), requestId2]],
-        method_name: "get_balance2",
       },
     };
     const identity = await LedgerIdentity.create();

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -91,6 +91,19 @@ describe("LedgerIdentity", () => {
     expect(readRequest.endpoint).toBe("read_state");
   });
 
+  it("should call to sign read state request after signing call request if neuron flag is set", async () => {
+    const identity = await LedgerIdentity.create();
+    identity.flagUpcomingStakeNeuron();
+
+    const request = await identity.transformRequest(mockHttpRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(request.endpoint).toBe("call");
+
+    const readRequest = await identity.transformRequest(mockReadStateRequest);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(2);
+    expect(readRequest.endpoint).toBe("read_state");
+  });
+
   it("should sign new call requests", async () => {
     const identity = await LedgerIdentity.create();
 

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   PollingCancelledError,
   PollingLimitExceededError,
   removeKeys,
+  sameBufferData,
   smallerVersion,
   stringifyJson,
   uniqueObjects,
@@ -833,6 +834,24 @@ describe("utils", () => {
     it("should parse JSON strings", () => {
       const obj = { a: JSON.stringify({ b: "c" }) };
       expect(expandObject(obj)).toEqual({ a: { b: "c" } });
+    });
+  });
+
+  describe("sameBufferData", () => {
+    it("returns true if same data", () => {
+      const a = new Uint16Array([1, 2, 3]).buffer;
+      const b = new Uint16Array([1, 2, 3]).buffer;
+      expect(sameBufferData(a, b)).toBe(true);
+    });
+
+    it("returns false if not same data", () => {
+      const a = new Uint16Array([1, 2, 3]).buffer;
+      const b1 = new Uint16Array([1, 2, 4]).buffer;
+      expect(sameBufferData(a, b1)).toBe(false);
+      const b2 = new Uint16Array([1, 2]).buffer;
+      expect(sameBufferData(a, b2)).toBe(false);
+      const b3 = new Uint16Array([1, 2, 3, 4]).buffer;
+      expect(sameBufferData(a, b3)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Improve the UX of HW users.

In this PR: Users are required to confirm the transactions only ONCE with the device. Not twice as until now.

In a nutshell, the read_state call is signed at the same time than the other request. This is possible because the request id is deterministic of the request and can be calculated before hand. We cache the read_state signature so that we can reused it in the following request call which is the read_state one.

# Changes

* LedgerIdentity uses app method "signUpdateCall" instead of "sign" that requires the blob of the read_state call also.
* Store the read_state body and signature in the LedgerIdentity to be reused in the following call.
* Do not use the new method if the transaction is to stake a neuron because there is an issue in the Ledger App. This will be solved in the next release.

# Tests

* Add a test for the LedgerIdentity to check the `transformRequest` functionality.

# Todos

- [x] Add entry to changelog (if necessary).
