### PR TITLE
Fix past-changelog-test line number comparison

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -285,6 +285,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: scripts/past-changelog-test
+      - run: scripts/past-changelog-test.test
   checks-pass:
     needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog"]
     if: ${{ always() }}

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -75,6 +75,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Deploy.sh script
 * Improve sns governance e2e test.
+* past-changelog-test compares lines numbers correctly.
 
 #### Security
 

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -15,7 +15,7 @@ LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTR
 LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
 LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "$LAST_RELEASE_HEADING" "$CHANGELOG" | cut -d: -f1)"
 
-if (( "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" )); then
+if (("$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER")); then
   echo "ERROR: $CHANGELOG entries should not be added to existing releases." >&2
   exit 1
 fi

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -15,7 +15,7 @@ LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTR
 LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
 LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "$LAST_RELEASE_HEADING" "$CHANGELOG" | cut -d: -f1)"
 
-if [[ "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" ]]; then
+if (( "$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER" )); then
   echo "ERROR: $CHANGELOG entries should not be added to existing releases." >&2
   exit 1
 fi

--- a/scripts/past-changelog-test.test
+++ b/scripts/past-changelog-test.test
@@ -10,6 +10,15 @@ if ! "$SCRIPT"; then
   exit 1
 fi
 
+# Writes stdin to the given file, but only after reading all of stdin.
+# Polyfill because `sponge` is not available everywhere.
+sponge() {
+  local tmp_file
+  tmp_file="$(mktemp)"
+  cat >"$tmp_file"
+  mv "$tmp_file" "$1"
+}
+
 awk '/## Proposal/ {if (!done) {print "* change above"; done=1}} 1' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
 if ! "$SCRIPT"; then
   echo "Should have passed with change above most recent release." >&2

--- a/scripts/past-changelog-test.test
+++ b/scripts/past-changelog-test.test
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT="$SOURCE_DIR/past-changelog-test"
+CHANGELOG="CHANGELOG-Nns-Dapp.md"
+
+if ! "$SCRIPT"; then
+  echo "Should have passed without additional changes." >&2
+  exit 1
+fi
+
+awk '/## Proposal/ {if (!done) {print "* change above"; done=1}} 1' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+if ! "$SCRIPT"; then
+  echo "Should have passed with change above most recent release." >&2
+  exit 1
+fi
+git checkout CHANGELOG-Nns-Dapp.md
+
+awk '/## Proposal/ {if (!done) {print; print "* change below"; done=1; next}} 1' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+if "$SCRIPT"; then
+  echo "Should have failed with change below most recent release." >&2
+  exit 1
+fi
+git checkout CHANGELOG-Nns-Dapp.md
+
+sed '199i\
+* changed on line 199
+' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+if "$SCRIPT"; then
+  echo "Should have failed with change on line 199." >&2
+  exit 1
+fi
+git checkout CHANGELOG-Nns-Dapp.md


### PR DESCRIPTION
# Motivation

We have a test `past-changelog-test` to make sure no change log entries are added in existing releases.
But the way it compared line numbers, using `[[ "$x" > "$y" ]]` seems to be doing string comparison instead of number comparison.
Using `(( ))` instead o `[[ ]]` does number comparison instead.

# Changes

1. Fix `past-changelog-test` to do proper number comparison.
2. Add a test for the test.
3. Add the test to the GitHub workflow.

# Tests

Added

# Todos

- [x] Add entry to changelog (if necessary).
