### PR TITLE
Feat: SNS Aggregator Store

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -5,6 +5,7 @@ import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
 import { snsProposalsStore, snsQueryStore } from "$lib/stores/sns.store";
@@ -27,6 +28,7 @@ import { getCurrentIdentity } from "../auth.services";
 export const loadSnsProjects = async (): Promise<void> => {
   try {
     const aggregatorData = await querySnsProjects();
+    snsAggregatorStore.setData(aggregatorData);
     // TODO: Store this in a svelte store.
     const cachedSnses = convertDtoData(aggregatorData);
     const identity = getCurrentIdentity();

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,0 +1,26 @@
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import { writable, type Readable } from "svelte/store";
+
+/**
+ * `undefined` means that the data is not loaded yet.
+ */
+export interface SnsAggregatorData {
+  data: CachedSnsDto[] | undefined;
+}
+
+export interface SnsAggregatorStore extends Readable<SnsAggregatorData> {
+  setData: (data: CachedSnsDto[]) => void;
+  reset: () => void;
+}
+
+const initSnsAggreagatorStore = (): SnsAggregatorStore => {
+  const { subscribe, set } = writable<SnsAggregatorData>({ data: undefined });
+
+  return {
+    subscribe,
+    setData: (data) => set({ data }),
+    reset: () => set({ data: undefined }),
+  };
+};
+
+export const snsAggregatorStore = initSnsAggreagatorStore();

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -105,6 +105,7 @@ describe("SNS public services", () => {
       snsQueryStore.reset();
       snsFunctionsStore.reset();
       transactionsFeesStore.reset();
+      snsAggregatorStore.reset();
       jest.clearAllMocks();
       jest
         .spyOn(authStore, "subscribe")
@@ -136,6 +137,8 @@ describe("SNS public services", () => {
       jest
         .spyOn(aggregatorApi, "querySnsProjects")
         .mockImplementation(() => Promise.resolve(aggregatorMockSnsesDataDto));
+
+      expect(get(snsAggregatorStore).data).toBeUndefined();
 
       await loadSnsProjects();
 

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -9,6 +9,7 @@ import {
   loadSnsProjects,
 } from "$lib/services/$public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
 import { snsQueryStore } from "$lib/stores/sns.store";
@@ -20,6 +21,7 @@ import {
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import {
+  aggregatorMockSnsesDataDto,
   aggregatorSnsMockDto,
   aggregatorSnsMockWith,
   aggregatorTokenMock,
@@ -128,6 +130,16 @@ describe("SNS public services", () => {
       expect(functionsStore[rootCanisterId]).not.toBeUndefined();
       const feesStore = get(transactionsFeesStore);
       expect(feesStore.projects[rootCanisterId]).not.toBeUndefined();
+    });
+
+    it("should load sns aggregator store", async () => {
+      jest
+        .spyOn(aggregatorApi, "querySnsProjects")
+        .mockImplementation(() => Promise.resolve(aggregatorMockSnsesDataDto));
+
+      await loadSnsProjects();
+
+      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
     });
 
     it("should load and map tokens", async () => {

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -1,0 +1,37 @@
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { aggregatorMockSnsesDataDto } from "$tests/mocks/sns-aggregator.mock";
+import { get } from "svelte/store";
+
+describe("sns-aggregator store", () => {
+  describe("snsAggregatorStore", () => {
+    beforeEach(() => {
+      snsAggregatorStore.reset();
+    });
+
+    it("should set aggregator data", () => {
+      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+
+      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+    });
+
+    it("should reset data", () => {
+      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+
+      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+
+      snsAggregatorStore.reset();
+      expect(get(snsAggregatorStore).data).toBeUndefined();
+    });
+
+    it("should set data even when data is populated", () => {
+      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+
+      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+
+      snsAggregatorStore.setData([aggregatorMockSnsesDataDto[0]]);
+      expect(get(snsAggregatorStore).data).toEqual([
+        aggregatorMockSnsesDataDto[0],
+      ]);
+    });
+  });
+});

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -1,11 +1,11 @@
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type {
-  CachedSns,
-  CachedSnsDto,
-  CachedSnsTokenMetadataDto,
-} from "$lib/types/sns-aggregator";
+import type { CachedSns, CachedSnsDto } from "$lib/types/sns-aggregator";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+
+// TS is not smart enough to infer the type from the JSON file.
+export const aggregatorMockSnsesDataDto: CachedSnsDto[] =
+  tenAggregatedSnses.map((sns: unknown) => sns as CachedSnsDto);
 
 // It should match the token below
 export const aggregatorTokenMock: IcrcTokenMetadata = {
@@ -15,12 +15,7 @@ export const aggregatorTokenMock: IcrcTokenMetadata = {
 };
 
 export const aggregatorSnsMockDto: CachedSnsDto = {
-  ...tenAggregatedSnses[7],
-  // We need this to tell TS that it's an array of tuples, not an array of arrays.
-  icrc1_metadata: tenAggregatedSnses[7]
-    .icrc1_metadata as CachedSnsTokenMetadataDto,
-  // We need this to tell TS that not an array of numbers, but an array of one number.
-  icrc1_fee: tenAggregatedSnses[7].icrc1_fee as [number],
+  ...aggregatorMockSnsesDataDto[7],
 };
 
 // It should match the converted response from sns-aggregator.mock.json with the same `index` value

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -5,7 +5,7 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 
 // TS is not smart enough to infer the type from the JSON file.
 export const aggregatorMockSnsesDataDto: CachedSnsDto[] =
-  tenAggregatedSnses.map((sns: unknown) => sns as CachedSnsDto);
+  tenAggregatedSnses as unknown as CachedSnsDto[];
 
 // It should match the token below
 export const aggregatorTokenMock: IcrcTokenMetadata = {


### PR DESCRIPTION
# Motivation

Stop using deprecated get_state data.

In this PR: Store the aggregator data in its own store.

Then this data will be used in derived store `snsSummariesStore` so that we can use the new endpoints that the aggregator already collects.

# Changes

* New store: snsAggregatorStore.
* Load store in sns service `loadSnsProjects`.

# Tests

* Test new store.
* Test that service loads data in the store.

# Todos

Not worth an entry yet.
