### PR TITLE
Allow new releases in scripts/past-changelog-test.test

### DIFF
--- a/scripts/past-changelog-test.test
+++ b/scripts/past-changelog-test.test
@@ -19,16 +19,25 @@ sponge() {
   mv "$tmp_file" "$1"
 }
 
-awk '/## Proposal/ {if (!done) {print "* change above"; done=1}} 1' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
+
+awk "/$LAST_RELEASE_HEADING/ {if (!done) {print \"* change above\"; done=1}} 1" CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
 if ! "$SCRIPT"; then
   echo "Should have passed with change above most recent release." >&2
   exit 1
 fi
 git checkout CHANGELOG-Nns-Dapp.md
 
-awk '/## Proposal/ {if (!done) {print; print "* change below"; done=1; next}} 1' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+awk "/$LAST_RELEASE_HEADING/ {if (!done) {print; print \"* change below\"; done=1; next}} 1" CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
 if "$SCRIPT"; then
   echo "Should have failed with change below most recent release." >&2
+  exit 1
+fi
+git checkout CHANGELOG-Nns-Dapp.md
+
+awk "/$LAST_RELEASE_HEADING/ {if (!done) {print \"## Proposal 999999\"; print \"* change in new release\"; done=1}} 1" CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+if ! "$SCRIPT"; then
+  echo "Should have passed with change adding a new release." >&2
   exit 1
 fi
 git checkout CHANGELOG-Nns-Dapp.md


### PR DESCRIPTION
# Motivation

I recently added a test for `past-changelog-test` in https://github.com/dfinity/nns-dapp/pull/3046
but it fails when a PR adds a new release because in that case adding new changes in the newly created release is allowed.
`past-changelog-test` handles this correctly but `past-changelog-test.test` doesn't.

# Changes

1. In `past-changelog-test.test` when making a change below the first `## Proposal` heading in order to expect it to fail, make sure the change happens below the first `## Proposal` heading that exists in `origin/main` and not the first heading in the current commit if it adds a new `## Proposal` heading.
2. Add one more test to make sure that a new `## Proposal` heading with changes below it is allowed.

# Tests

test only

# Todos

- [ ] Add entry to changelog (if necessary).

Covered because it should have been done correctly in the previous PR.