### PR TITLE
Chore: Fix mock HW account principal

### DIFF
--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -230,7 +230,13 @@ describe("neurons-services", () => {
     });
 
     it("should stake neuron from hardware wallet", async () => {
+      const mockHardkwareWalletIdentity = {
+        getPrincipal: () => mockHardwareWalletAccount.principal,
+      } as unknown as Identity;
+      setAccountIdentity(mockHardkwareWalletIdentity);
+
       expect(spyStakeNeuron).not.toBeCalled();
+
       const newNeuronId = await stakeNeuron({
         amount: 10,
         account: mockHardwareWalletAccount,
@@ -240,7 +246,7 @@ describe("neurons-services", () => {
         controller: mockHardwareWalletAccount.principal,
         identity: new AnonymousIdentity(),
         fromSubAccount: undefined,
-        ledgerCanisterIdentity: mockIdentity,
+        ledgerCanisterIdentity: mockHardkwareWalletIdentity,
         stake: BigInt(10 * E8S_PER_ICP),
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
@@ -458,19 +464,6 @@ describe("neurons-services", () => {
       await toggleCommunityFund(neuron);
 
       expectToastError(en.error.missing_identity);
-      expect(spyJoinCommunityFund).not.toBeCalled();
-      expect(spyLeaveCommunityFund).not.toBeCalled();
-    });
-
-    it("should not update neuron if not controlled by user", async () => {
-      neuronsStore.pushNeurons({
-        neurons: [notControlledNeuron],
-        certified: true,
-      });
-
-      await toggleCommunityFund(notControlledNeuron);
-
-      expectToastError(en.error.not_authorized_neuron_action);
       expect(spyJoinCommunityFund).not.toBeCalled();
       expect(spyLeaveCommunityFund).not.toBeCalled();
     });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -467,6 +467,19 @@ describe("neurons-services", () => {
       expect(spyJoinCommunityFund).not.toBeCalled();
       expect(spyLeaveCommunityFund).not.toBeCalled();
     });
+
+    it("should not update neuron if not controlled by user", async () => {
+      neuronsStore.pushNeurons({
+        neurons: [notControlledNeuron],
+        certified: true,
+      });
+
+      await toggleCommunityFund(notControlledNeuron);
+
+      expectToastError(en.error.not_authorized_neuron_action);
+      expect(spyJoinCommunityFund).not.toBeCalled();
+      expect(spyLeaveCommunityFund).not.toBeCalled();
+    });
   });
 
   describe("toggleAutoStakeMaturity", () => {

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -41,7 +41,7 @@ export const mockHardwareWalletAccount: IcpAccount = {
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   balanceE8s: 123456789010000n,
   principal: Principal.fromText(
-    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
   ),
   name: "hardware wallet account test",
   type: "hardwareWallet",
@@ -63,7 +63,7 @@ export const mockSubAccountDetails: SubAccountDetails = {
 export const mockHardwareWalletAccountDetails: HardwareWalletAccountDetails = {
   name: "ledger test",
   principal: Principal.fromText(
-    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
   ),
   account_identifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -34,15 +34,17 @@ export const mockSubAccount: IcpAccount = {
   type: "subAccount",
 };
 
+const hardwareWalletPrincipal = Principal.fromText(
+  "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
+);
+
 export const mockHardwareWalletAccount: IcpAccount = {
   identifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   icpIdentifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   balanceE8s: 123456789010000n,
-  principal: Principal.fromText(
-    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
-  ),
+  principal: hardwareWalletPrincipal,
   name: "hardware wallet account test",
   type: "hardwareWallet",
 };
@@ -62,9 +64,7 @@ export const mockSubAccountDetails: SubAccountDetails = {
 
 export const mockHardwareWalletAccountDetails: HardwareWalletAccountDetails = {
   name: "ledger test",
-  principal: Principal.fromText(
-    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
-  ),
+  principal: hardwareWalletPrincipal,
   account_identifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
 };


### PR DESCRIPTION
# Motivation

Mock of the HW account has the same principal as the mockIdentity. This is not possible and it's better to avoid having it as default mock.

# Changes

* Change the principal in the `mockHardwareWalletAccount`.
* Fix broken test after change.

# Tests

Only test changes.

# Todos

Not worth an entry in the changelog.
