### PR TITLE
GIX-1751: Hide neurons fund in advanced section

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -98,7 +98,9 @@
       </div>
     {/if}
     <NnsAutoStakeMaturity {neuron} />
-    <JoinCommunityFundCheckbox {neuron} disabled={!isControlledByUser} />
+    {#if isControlledByUser}
+      <JoinCommunityFundCheckbox {neuron} />
+    {/if}
     {#if isControllable}
       <SplitNnsNeuronButton {neuron} variant="secondary" />
     {/if}

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -27,6 +27,10 @@ import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronAdvancedSection", () => {
+  const identityMainAccount = {
+    ...mockMainAccount,
+    principal: mockIdentity.getPrincipal(),
+  };
   const renderComponent = (neuron: NeuronInfo) => {
     const { container } = render(NeuronContextActionsTest, {
       props: {
@@ -88,7 +92,12 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.lastRewardsDistribution()).toBe("May 19, 1992");
   });
 
-  it("should render actions", async () => {
+  it("should render actions if user is the controller", async () => {
+    icpAccountsStore.setForTesting({
+      main: identityMainAccount,
+      subAccounts: [],
+      hardwareWallets: [],
+    });
     const po = renderComponent({
       ...mockNeuron,
       fullNeuron: {
@@ -114,25 +123,6 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.hasSplitNeuronButton()).toBe(false);
   });
 
-  it("should render enabled join neurons' fund if user is the controller", async () => {
-    icpAccountsStore.setForTesting({
-      main: mockMainAccount,
-      subAccounts: [],
-      hardwareWallets: [],
-    });
-    const po = renderComponent({
-      ...mockNeuron,
-      fullNeuron: {
-        ...mockNeuron.fullNeuron,
-        controller: mockMainAccount.principal.toText(),
-      },
-    });
-
-    expect(
-      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
-    ).toBeNull();
-  });
-
   it("should not render join neurons' fund if user is not the controller", async () => {
     const po = renderComponent({
       ...mockNeuron,
@@ -145,7 +135,7 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.getJoinNeuronsFundCheckbox().isPresent()).toBe(false);
   });
 
-  it("should render split button and disabled join neurons' fund if user is controlled by hardware wallet", async () => {
+  it("should render split button but not join neurons' fund if user is controlled by hardware wallet", async () => {
     icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [],
@@ -159,9 +149,7 @@ describe("NnsNeuronAdvancedSection", () => {
       },
     });
 
-    expect(
-      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
-    ).not.toBeNull();
+    expect(await po.getJoinNeuronsFundCheckbox().isPresent()).toBe(false);
     expect(await po.hasSplitNeuronButton()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -135,7 +135,7 @@ describe("NnsNeuronAdvancedSection", () => {
     expect(await po.getJoinNeuronsFundCheckbox().isPresent()).toBe(false);
   });
 
-  it("should render split button but not join neurons' fund if user is controlled by hardware wallet", async () => {
+  it("should render split button but not join neurons' fund if neuron is controlled by hardware wallet", async () => {
     icpAccountsStore.setForTesting({
       main: mockMainAccount,
       subAccounts: [],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -133,7 +133,7 @@ describe("NnsNeuronAdvancedSection", () => {
     ).toBeNull();
   });
 
-  it("should render disabled join neurons' fund if user is not the controller", async () => {
+  it("should not render join neurons' fund if user is not the controller", async () => {
     const po = renderComponent({
       ...mockNeuron,
       fullNeuron: {
@@ -142,9 +142,7 @@ describe("NnsNeuronAdvancedSection", () => {
       },
     });
 
-    expect(
-      await po.getJoinNeuronsFundCheckbox().getAttribute("disabled")
-    ).not.toBeNull();
+    expect(await po.getJoinNeuronsFundCheckbox().isPresent()).toBe(false);
   });
 
   it("should render split button and disabled join neurons' fund if user is controlled by hardware wallet", async () => {


### PR DESCRIPTION
# Motivation

Bug: Current functionality doesn't show the Neurons' Fund checkbox if user can't control it. There is already the tag to show that the user is part of the Neurons' Fund for informational purposes.

# Changes

* Do not render the Neurons' Fund in NnsNeuronAdvancedSection instead of disabled if user is not the controller.

# Tests

* Edit tests after change in functionality.

# Todos

Not worth an entry. This is part of the unpublished new neuron details.
