### PR TITLE
Package json license

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "@dfinity/nns-dapp",
   "version": "2.0.44",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "build:csp": "node scripts/build.csp.mjs",
     "build:preload": "node scripts/build.preload.mjs",


### PR DESCRIPTION
# Motivation

Add flags to package.json for better definition.

# Changes

`"license": "SEE LICENSE IN LICENSE.md",`

source: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license

> If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one...
