### PR TITLE
Fix disabled review cycles submit button

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -34,6 +34,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Fix error when getting an SNS Aggregator page fails.
 * Maintain text color in hyperlinks card when hovered.
 * Prevent default behavior of copy button to avoid unintentional navigation when used in hyperlinks cards.
+* Prevent the submission of cycles for top-up review unless an amount has been entered first.
 
 #### Security
 

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -6,7 +6,6 @@
     convertTCyclesToIcpNumber,
   } from "$lib/utils/token.utils";
   import Input from "$lib/components/ui/Input.svelte";
-  import { isNullish, nonNullish } from "@dfinity/utils";
   import { areEnoughCyclesSelected } from "$lib/utils/canisters.utils";
 
   export let amount: number | undefined = undefined;

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -6,7 +6,7 @@
     convertTCyclesToIcpNumber,
   } from "$lib/utils/token.utils";
   import Input from "$lib/components/ui/Input.svelte";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
 
   export let amount: number | undefined = undefined;
   export let icpToCyclesExchangeRate: bigint | undefined = undefined;
@@ -61,10 +61,9 @@
   };
 
   let enoughCycles: boolean;
-  $: enoughCycles =
-    minimumCycles === undefined
-      ? nonNullish(amountCycles)
-      : (amountCycles ?? 0) >= minimumCycles;
+  $: enoughCycles = isNullish(minimumCycles)
+    ? nonNullish(amountCycles)
+    : (amountCycles ?? 0) >= minimumCycles;
 </script>
 
 <form on:submit|preventDefault={selectAmount} data-tid="select-cycles-screen">

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -61,9 +61,8 @@
   };
 
   let enoughCycles: boolean;
-  $: enoughCycles = isNullish(minimumCycles)
-    ? nonNullish(amountCycles)
-    : (amountCycles ?? 0) >= minimumCycles;
+  $: enoughCycles =
+    (amountCycles ?? 0) >= (minimumCycles ?? 0) && amountCycles > 0;
 </script>
 
 <form on:submit|preventDefault={selectAmount} data-tid="select-cycles-screen">

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -6,6 +6,7 @@
     convertTCyclesToIcpNumber,
   } from "$lib/utils/token.utils";
   import Input from "$lib/components/ui/Input.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let amount: number | undefined = undefined;
   export let icpToCyclesExchangeRate: bigint | undefined = undefined;
@@ -61,7 +62,9 @@
 
   let enoughCycles: boolean;
   $: enoughCycles =
-    minimumCycles === undefined ? true : (amountCycles ?? 0) >= minimumCycles;
+    minimumCycles === undefined
+      ? nonNullish(amountCycles)
+      : (amountCycles ?? 0) >= minimumCycles;
 </script>
 
 <form on:submit|preventDefault={selectAmount} data-tid="select-cycles-screen">

--- a/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
+++ b/frontend/src/lib/components/canisters/SelectCyclesCanister.svelte
@@ -7,6 +7,7 @@
   } from "$lib/utils/token.utils";
   import Input from "$lib/components/ui/Input.svelte";
   import { isNullish, nonNullish } from "@dfinity/utils";
+  import { areEnoughCyclesSelected } from "$lib/utils/canisters.utils";
 
   export let amount: number | undefined = undefined;
   export let icpToCyclesExchangeRate: bigint | undefined = undefined;
@@ -61,8 +62,7 @@
   };
 
   let enoughCycles: boolean;
-  $: enoughCycles =
-    (amountCycles ?? 0) >= (minimumCycles ?? 0) && amountCycles > 0;
+  $: enoughCycles = areEnoughCyclesSelected({ amountCycles, minimumCycles });
 </script>
 
 <form on:submit|preventDefault={selectAmount} data-tid="select-cycles-screen">

--- a/frontend/src/lib/utils/canisters.utils.ts
+++ b/frontend/src/lib/utils/canisters.utils.ts
@@ -89,3 +89,12 @@ export const errorCanisterNameMessage = (name: string | undefined) => {
   }
   return undefined;
 };
+
+export const areEnoughCyclesSelected = ({
+  amountCycles,
+  minimumCycles,
+}: {
+  minimumCycles: number | undefined;
+  amountCycles: number | undefined;
+}): boolean =>
+  (amountCycles ?? 0) >= (minimumCycles ?? 0) && (amountCycles ?? 0) > 0;

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -25,6 +25,14 @@ describe("SelectCyclesCanister", () => {
     ).toBeInTheDocument();
   });
 
+  it("should have a submit button disabled per default", () => {
+    const { getByTestId } = render(SelectCyclesCanisterTest, { props });
+
+    expect(
+      getByTestId("select-cycles-button").getAttribute("disabled")
+    ).not.toBeNull();
+  });
+
   it("renders two inputs", () => {
     const { container } = render(SelectCyclesCanister, { props });
 

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -1,6 +1,7 @@
 import { CanisterStatus } from "$lib/canisters/ic-management/ic-management.canister.types";
 import { MAX_CANISTER_NAME_LENGTH } from "$lib/constants/canisters.constants";
 import {
+  areEnoughCyclesSelected,
   canisterStatusToText,
   errorCanisterNameMessage,
   formatCyclesToTCycles,
@@ -199,6 +200,71 @@ describe("canister-utils", () => {
       expect(
         errorCanisterNameMessage("a".repeat(MAX_CANISTER_NAME_LENGTH + 1))
       ).toBe("Canister name too long. Maximum of 24 characters allowed.");
+    });
+  });
+
+  describe("areEnoughCyclesSelected", () => {
+    it("undefined is not a valid amount of cycles", () => {
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: undefined,
+          minimumCycles: undefined,
+        })
+      ).toBeFalsy();
+      expect(
+        areEnoughCyclesSelected({ amountCycles: undefined, minimumCycles: 2 })
+      ).toBeFalsy();
+      expect(
+        areEnoughCyclesSelected({ amountCycles: undefined, minimumCycles: 0 })
+      ).toBeFalsy();
+    });
+
+    it("user entering zero is not a valid amount of cycles", () => {
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: 0,
+          minimumCycles: undefined,
+        })
+      ).toBeFalsy();
+      expect(
+        areEnoughCyclesSelected({ amountCycles: 0, minimumCycles: 2 })
+      ).toBeFalsy();
+      expect(
+        areEnoughCyclesSelected({ amountCycles: 0, minimumCycles: 0 })
+      ).toBeFalsy();
+    });
+
+    it("user entering less cycles than minimum is not a valid amount", () => {
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: 0,
+          minimumCycles: 1,
+        })
+      ).toBeFalsy();
+      expect(
+        areEnoughCyclesSelected({ amountCycles: 0.9999, minimumCycles: 1 })
+      ).toBeFalsy();
+    });
+
+    it("user entering expected cycles amount is valid", () => {
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: 1,
+          minimumCycles: undefined,
+        })
+      ).toBeTruthy();
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: 1,
+          minimumCycles: 0,
+        })
+      ).toBeTruthy();
+      expect(
+        areEnoughCyclesSelected({
+          amountCycles: 1,
+          minimumCycles: 0.5,
+        })
+      ).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
# Motivation

When topping up a canister, on mainnet and locally, the "Review Cycles Purchase" is not disabled per default, therefore user can submit it without entering any amount which lead the wizard to an empty step.

# Changes

- if no minimal amount, request at least an amount to be entered

# Screenshots

![tmp](https://github.com/dfinity/nns-dapp/assets/16886711/0ed133b7-ff49-4cfe-9368-747e8185004c)
