### PR TITLE
Ignore SIGPIPE in past-changelog-test

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -56,6 +56,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * past-changelog-test compares lines numbers correctly.
+* Ignore SIGPIPE in scripts/past-changelog-test which caused flakiness.
 
 #### Security
 

--- a/scripts/past-changelog-test
+++ b/scripts/past-changelog-test
@@ -6,13 +6,25 @@ set -xeuo pipefail
 CHANGELOG="CHANGELOG-Nns-Dapp.md"
 MAIN_ANCESTOR="$(git merge-base HEAD origin/main)"
 
+ignoreSigPipe() {
+  error="$?"
+  if [ "$error" = 141 ]; then
+    return 0
+  else
+    return "$error"
+  fi
+}
+
 if ! LAST_ADDED_ENTRY_CONTENT="$(git diff "$MAIN_ANCESTOR" "$CHANGELOG" | grep '^+[*-]' | tail -1 | sed -e 's/^+//')"; then
   echo "PASSED: No new entries were added to $CHANGELOG"
   exit 0
 fi
 
 LAST_ADDED_ENTRY_LINE_NUMBER="$(grep --fixed-string -n -m 1 -- "$LAST_ADDED_ENTRY_CONTENT" "$CHANGELOG" | cut -d: -f1)"
-LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$')"
+# Sometimes `git show` exits with SIGPIPE (141). This is probably because the
+# `grep` exits early, and `git show` is trying to write to a pipe that's no
+# longer there. We ignore this error.
+LAST_RELEASE_HEADING="$(git show origin/main:CHANGELOG-Nns-Dapp.md | grep -m 1 '^## Proposal [0-9]\+$' || ignoreSigPipe)"
 LAST_RELEASE_LINE_NUMBER="$(grep -n -m 1 "$LAST_RELEASE_HEADING" "$CHANGELOG" | cut -d: -f1)"
 
 if (("$LAST_ADDED_ENTRY_LINE_NUMBER" > "$LAST_RELEASE_LINE_NUMBER")); then


### PR DESCRIPTION
# Motivation

`scripts/past-changelog-test` has been flaky recently, occasionally failing with exit code 141.
I believe the issue is that `grep -m 1` stops reading input as soon as it finds a match and then the process before the pipe fails because it can no longer write to the pipe.
I'm not sure why this happens only sometimes.

Some references:
https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q
https://unix.stackexchange.com/questions/582844/how-to-suppress-sigpipe-in-bash

# Changes

When the line with `grep -m 1` fails, ignore it if it failed with exit code 141.

# Tests

Difficult to test because I couldn't reproduce the issue (well, only once) in this script.
But it reproduces quite well with `yes | head -1` so I did some manual tests with that.

# Todos

- [x] Add entry to changelog (if necessary).
