### PR TITLE
GIX-1795: Add Dissolve Date in Advanced Section

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -13,6 +13,7 @@
   import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
   import {
     canUserManageNeuronFundParticipation,
+    getDissolvingTimestampSeconds,
     isNeuronControllable,
     maturityLastDistribution,
   } from "$lib/utils/neuron.utils";
@@ -38,6 +39,9 @@
     accounts: $icpAccountsStore,
     identity: $authStore.identity,
   });
+
+  let dissolvingTimestamp: bigint | undefined;
+  $: dissolvingTimestamp = getDissolvingTimestampSeconds(neuron);
 </script>
 
 <Section testId="nns-neuron-advanced-section-component">
@@ -59,6 +63,15 @@
       >
     </KeyValuePair>
     <NnsNeuronAge {neuron} />
+    {#if nonNullish(dissolvingTimestamp)}
+      <KeyValuePair>
+        <span slot="key" class="label">{$i18n.neuron_detail.dissolve_date}</span
+        >
+        <span slot="value" class="value" data-tid="neuron-dissolve-date"
+          >{secondsToDateTime(dissolvingTimestamp)}</span
+        >
+      </KeyValuePair>
+    {/if}
     {#if nonNullish(neuron.fullNeuron)}
       <KeyValuePair>
         <span slot="key" class="label"

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -34,10 +34,12 @@
     : undefined;
 
   let allowedToSplit: boolean;
-  $: allowedToSplit = hasPermissionToSplit({
-    neuron,
-    identity: $authStore.identity,
-  });
+  $: allowedToSplit =
+    nonNullish(neuron) &&
+    hasPermissionToSplit({
+      neuron,
+      identity: $authStore.identity,
+    });
 
   let dissolvingTimestamp: bigint | undefined;
   $: dissolvingTimestamp = getSnsDissolvingTimestampSeconds(neuron);
@@ -49,53 +51,56 @@
     {$i18n.neuron_detail.advanced_settings_description}
   </p>
   <div class="content">
-    <KeyValuePair>
-      <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
-      <Hash
-        slot="value"
-        className="value"
-        tagName="span"
-        testId="neuron-id"
-        text={getSnsNeuronIdAsHexString(neuron)}
-        showCopy
-        flowLessCopy
-        id="neuron-id"
-      />
-    </KeyValuePair>
-    <KeyValuePair>
-      <span slot="key" class="label">{$i18n.neuron_detail.created}</span>
-      <span slot="value" class="value" data-tid="neuron-created"
-        >{secondsToDateTime(neuron.created_timestamp_seconds)}</span
-      >
-    </KeyValuePair>
-    <SnsNeuronAge {neuron} />
-    {#if nonNullish(dissolvingTimestamp)}
+    {#if nonNullish(neuron)}
       <KeyValuePair>
-        <span slot="key" class="label">{$i18n.neuron_detail.dissolve_date}</span
-        >
-        <span slot="value" class="value" data-tid="neuron-dissolve-date"
-          >{secondsToDateTime(dissolvingTimestamp)}</span
-        >
-      </KeyValuePair>
-    {/if}
-    {#if nonNullish(neuronAccount)}
-      <KeyValuePair>
-        <span slot="key" class="label"
-          >{$i18n.neuron_detail.neuron_account}</span
-        >
+        <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
         <Hash
           slot="value"
           className="value"
           tagName="span"
-          testId="neuron-account"
-          text={encodeIcrcAccount(neuronAccount)}
-          id="neuron-account"
+          testId="neuron-id"
+          text={getSnsNeuronIdAsHexString(neuron)}
           showCopy
           flowLessCopy
+          id="neuron-id"
         />
       </KeyValuePair>
+      <KeyValuePair>
+        <span slot="key" class="label">{$i18n.neuron_detail.created}</span>
+        <span slot="value" class="value" data-tid="neuron-created"
+          >{secondsToDateTime(neuron.created_timestamp_seconds)}</span
+        >
+      </KeyValuePair>
+      <SnsNeuronAge {neuron} />
+      {#if nonNullish(dissolvingTimestamp)}
+        <KeyValuePair>
+          <span slot="key" class="label"
+            >{$i18n.neuron_detail.dissolve_date}</span
+          >
+          <span slot="value" class="value" data-tid="neuron-dissolve-date"
+            >{secondsToDateTime(dissolvingTimestamp)}</span
+          >
+        </KeyValuePair>
+      {/if}
+      {#if nonNullish(neuronAccount)}
+        <KeyValuePair>
+          <span slot="key" class="label"
+            >{$i18n.neuron_detail.neuron_account}</span
+          >
+          <Hash
+            slot="value"
+            className="value"
+            tagName="span"
+            testId="neuron-account"
+            text={encodeIcrcAccount(neuronAccount)}
+            id="neuron-account"
+            showCopy
+            flowLessCopy
+          />
+        </KeyValuePair>
+      {/if}
+      <SnsNeuronVestingPeriodRemaining {neuron} />
     {/if}
-    <SnsNeuronVestingPeriodRemaining {neuron} />
     <SnsAutoStakeMaturity />
 
     {#if allowedToSplit}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte
@@ -5,6 +5,7 @@
   import Hash from "../ui/Hash.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
+    getSnsDissolvingTimestampSeconds,
     getSnsNeuronIdAsHexString,
     hasPermissionToSplit,
   } from "$lib/utils/sns-neuron.utils";
@@ -33,12 +34,13 @@
     : undefined;
 
   let allowedToSplit: boolean;
-  $: allowedToSplit =
-    nonNullish(neuron) &&
-    hasPermissionToSplit({
-      neuron,
-      identity: $authStore.identity,
-    });
+  $: allowedToSplit = hasPermissionToSplit({
+    neuron,
+    identity: $authStore.identity,
+  });
+
+  let dissolvingTimestamp: bigint | undefined;
+  $: dissolvingTimestamp = getSnsDissolvingTimestampSeconds(neuron);
 </script>
 
 <Section testId="sns-neuron-advanced-section-component">
@@ -47,46 +49,53 @@
     {$i18n.neuron_detail.advanced_settings_description}
   </p>
   <div class="content">
-    {#if nonNullish(neuron)}
+    <KeyValuePair>
+      <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
+      <Hash
+        slot="value"
+        className="value"
+        tagName="span"
+        testId="neuron-id"
+        text={getSnsNeuronIdAsHexString(neuron)}
+        showCopy
+        flowLessCopy
+        id="neuron-id"
+      />
+    </KeyValuePair>
+    <KeyValuePair>
+      <span slot="key" class="label">{$i18n.neuron_detail.created}</span>
+      <span slot="value" class="value" data-tid="neuron-created"
+        >{secondsToDateTime(neuron.created_timestamp_seconds)}</span
+      >
+    </KeyValuePair>
+    <SnsNeuronAge {neuron} />
+    {#if nonNullish(dissolvingTimestamp)}
       <KeyValuePair>
-        <span slot="key" class="label">{$i18n.neurons.neuron_id}</span>
+        <span slot="key" class="label">{$i18n.neuron_detail.dissolve_date}</span
+        >
+        <span slot="value" class="value" data-tid="neuron-dissolve-date"
+          >{secondsToDateTime(dissolvingTimestamp)}</span
+        >
+      </KeyValuePair>
+    {/if}
+    {#if nonNullish(neuronAccount)}
+      <KeyValuePair>
+        <span slot="key" class="label"
+          >{$i18n.neuron_detail.neuron_account}</span
+        >
         <Hash
           slot="value"
           className="value"
           tagName="span"
-          testId="neuron-id"
-          text={getSnsNeuronIdAsHexString(neuron)}
+          testId="neuron-account"
+          text={encodeIcrcAccount(neuronAccount)}
+          id="neuron-account"
           showCopy
           flowLessCopy
-          id="neuron-id"
         />
       </KeyValuePair>
-      <KeyValuePair>
-        <span slot="key" class="label">{$i18n.neuron_detail.created}</span>
-        <span slot="value" class="value" data-tid="neuron-created"
-          >{secondsToDateTime(neuron.created_timestamp_seconds)}</span
-        >
-      </KeyValuePair>
-      <SnsNeuronAge {neuron} />
-      {#if nonNullish(neuronAccount)}
-        <KeyValuePair>
-          <span slot="key" class="label"
-            >{$i18n.neuron_detail.neuron_account}</span
-          >
-          <Hash
-            slot="value"
-            className="value"
-            tagName="span"
-            testId="neuron-account"
-            text={encodeIcrcAccount(neuronAccount)}
-            id="neuron-account"
-            showCopy
-            flowLessCopy
-          />
-        </KeyValuePair>
-      {/if}
-      <SnsNeuronVestingPeriodRemaining {neuron} />
     {/if}
+    <SnsNeuronVestingPeriodRemaining {neuron} />
     <SnsAutoStakeMaturity />
 
     {#if allowedToSplit}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -646,6 +646,7 @@
     "advanced_settings_title": "Advanced details & settings",
     "advanced_settings_description": "Advanced preferences for managing your neuron",
     "neuron_account": "Neuron Account",
+    "dissolve_date": "Dissolve Date",
     "created": "Date created"
   },
   "sns_launchpad": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -669,6 +669,7 @@ interface I18nNeuron_detail {
   advanced_settings_title: string;
   advanced_settings_description: string;
   neuron_account: string;
+  dissolve_date: string;
   created: string;
 }
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -223,15 +223,23 @@ export const hasValidStake = (neuron: NeuronInfo): boolean =>
       BigInt(DEFAULT_TRANSACTION_FEE_E8S)
     : false;
 
-export const getDissolvingTimeInSeconds = (
+export const getDissolvingTimestampSeconds = (
   neuron: NeuronInfo
 ): bigint | undefined =>
   neuron.state === NeuronState.Dissolving &&
   neuron.fullNeuron?.dissolveState !== undefined &&
   "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState
-    ? neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds -
-      BigInt(nowInSeconds())
+    ? neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
     : undefined;
+
+export const getDissolvingTimeInSeconds = (
+  neuron: NeuronInfo
+): bigint | undefined => {
+  const dissolvingTimestamp = getDissolvingTimestampSeconds(neuron);
+  return nonNullish(dissolvingTimestamp)
+    ? dissolvingTimestamp - BigInt(nowInSeconds())
+    : undefined;
+};
 
 export const getSpawningTimeInSeconds = (
   neuron: NeuronInfo

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -70,7 +70,7 @@ export const getSnsNeuronState = ({
   return NeuronState.Unspecified;
 };
 
-export const getSnsDissolvingTimeInSeconds = (
+export const getSnsDissolvingTimestampSeconds = (
   neuron: SnsNeuron
 ): bigint | undefined => {
   const neuronState = getSnsNeuronState(neuron);
@@ -80,8 +80,17 @@ export const getSnsDissolvingTimeInSeconds = (
     dissolveState !== undefined &&
     "WhenDissolvedTimestampSeconds" in dissolveState
   ) {
-    return dissolveState.WhenDissolvedTimestampSeconds - BigInt(nowInSeconds());
+    return dissolveState.WhenDissolvedTimestampSeconds;
   }
+};
+
+export const getSnsDissolvingTimeInSeconds = (
+  neuron: SnsNeuron
+): bigint | undefined => {
+  const dissolvingTimestamp = getSnsDissolvingTimestampSeconds(neuron);
+  return nonNullish(dissolvingTimestamp)
+    ? dissolvingTimestamp - BigInt(nowInSeconds())
+    : undefined;
 };
 
 export const getSnsLockedTimeInSeconds = (

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -30,7 +30,7 @@ import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 
 describe("NnsNeuronAdvancedSection", () => {
-  const nowInSeconds = 1689843195;
+  const nowInSeconds = new Date("Jul 20, 2023 8:53 AM").getTime() / 1000;
   const identityMainAccount = {
     ...mockMainAccount,
     principal: mockIdentity.getPrincipal(),
@@ -233,7 +233,9 @@ describe("NnsNeuronAdvancedSection", () => {
 
     const po = renderComponent(neuron);
 
-    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+    expect(normalizeWhitespace(await po.dissolveDate())).toBe(
+      "Jul 20, 2027 8:53 AM"
+    );
   });
 
   it("should not render dissolve date if neuron is not dissolving", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -233,6 +233,17 @@ describe("NnsNeuronAdvancedSection", () => {
 
     const po = renderComponent(neuron);
 
-    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+  });
+
+  it("should not render dissolve date if neuron is not dissolving", async () => {
+    const neuron: NeuronInfo = {
+      ...mockNeuron,
+      state: NeuronState.Locked,
+    };
+
+    const po = renderComponent(neuron);
+
+    expect(await po.dissolveDate()).toBeNull();
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -123,6 +123,17 @@ describe("SnsNeuronAdvancedSection", () => {
 
     const po = renderComponent(neuron);
 
-    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+  });
+
+  it("should not render dissolve date if neuron is not dissolving", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+    });
+
+    const po = renderComponent(neuron);
+
+    expect(await po.dissolveDate()).toBeNull();
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -29,7 +29,7 @@ import type { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 
 describe("SnsNeuronAdvancedSection", () => {
-  const nowInSeconds = 1689843195;
+  const nowInSeconds = new Date("Jul 20, 2023 8:53 AM").getTime() / 1000;
   const renderComponent = (neuron: SnsNeuron) => {
     const { container } = renderSelectedSnsNeuronContext({
       Component: SnsNeuronAdvancedSection,
@@ -123,7 +123,9 @@ describe("SnsNeuronAdvancedSection", () => {
 
     const po = renderComponent(neuron);
 
-    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
+    expect(normalizeWhitespace(await po.dissolveDate())).toBe(
+      "Jul 20, 2027 8:53 AM"
+    );
   });
 
   it("should not render dissolve date if neuron is not dissolving", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -3,7 +3,11 @@
  */
 
 import SnsNeuronAdvancedSection from "$lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.svelte";
-import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_FOUR_YEARS,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import {
   mockAuthStoreSubscribe,
@@ -20,6 +24,7 @@ import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronAdvancedSectionPo } from "$tests/page-objects/SnsNeuronAdvancedSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
+import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 
@@ -105,5 +110,19 @@ describe("SnsNeuronAdvancedSection", () => {
     const po = renderComponent(neuron);
 
     expect(await po.hasSplitNeuronButton()).toBe(false);
+  });
+
+  it("should render dissolve date if neuron is dissolving", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      whenDissolvedTimestampSeconds: BigInt(
+        nowInSeconds + SECONDS_IN_FOUR_YEARS
+      ),
+    });
+
+    const po = renderComponent(neuron);
+
+    expect(await po.dissolveDate()).toBe("Jul 20, 2027 8:53 AM");
   });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -36,6 +36,7 @@ import {
   formattedStakedMaturity,
   formattedTotalMaturity,
   getDissolvingTimeInSeconds,
+  getDissolvingTimestampSeconds,
   getNeuronById,
   getSpawningTimeInSeconds,
   hasEnoughMaturityToStake,
@@ -352,6 +353,48 @@ describe("neuron-utils", () => {
         joinedCommunityFundTimestampSeconds: undefined,
       };
       expect(hasJoinedCommunityFund(joinedNeuron)).toBe(false);
+    });
+  });
+
+  describe("getDissolvingTimestampSeconds", () => {
+    it("returns undefined if neuron not dissolving", () => {
+      const dissolveNeuron = {
+        ...mockNeuron,
+        state: NeuronState.Dissolved,
+      };
+      expect(getDissolvingTimestampSeconds(dissolveNeuron)).toBeUndefined();
+      const lockedNeuron = {
+        ...mockNeuron,
+        state: NeuronState.Locked,
+      };
+      expect(getDissolvingTimestampSeconds(lockedNeuron)).toBeUndefined();
+    });
+
+    it("returns undefined if dissolve state has no timestamp", () => {
+      const neuron = {
+        ...mockNeuron,
+        state: NeuronState.Dissolving,
+        fullNeuron: {
+          ...mockFullNeuron,
+          dissolveState: undefined,
+        },
+      };
+      expect(getDissolvingTimestampSeconds(neuron)).toBeUndefined();
+    });
+
+    it("returns dissolve date", () => {
+      const dissolveDate = BigInt(nowInSeconds() + SECONDS_IN_FOUR_YEARS);
+      const neuron = {
+        ...mockNeuron,
+        state: NeuronState.Dissolving,
+        fullNeuron: {
+          ...mockFullNeuron,
+          dissolveState: {
+            WhenDissolvedTimestampSeconds: dissolveDate,
+          },
+        },
+      };
+      expect(getDissolvingTimestampSeconds(neuron)).toBe(dissolveDate);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -20,6 +20,7 @@ import {
   formattedStakedMaturity,
   formattedTotalMaturity,
   getSnsDissolvingTimeInSeconds,
+  getSnsDissolvingTimestampSeconds,
   getSnsLockedTimeInSeconds,
   getSnsNeuronByHexId,
   getSnsNeuronHotkeys,
@@ -241,6 +242,31 @@ describe("sns-neuron utils", () => {
         },
       ];
       expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
+    });
+  });
+
+  describe("getSnsDissolvingTimestampSeconds", () => {
+    it("returns undefined if not dissolving", () => {
+      const lockedNeuron = createMockSnsNeuron({
+        id: [1, 2, 3, 4],
+        state: NeuronState.Locked,
+      });
+      expect(getSnsDissolvingTimestampSeconds(lockedNeuron)).toBeUndefined();
+      const dissolvedNeuron = createMockSnsNeuron({
+        id: [1, 2, 3, 4],
+        state: NeuronState.Dissolved,
+      });
+      expect(getSnsDissolvingTimestampSeconds(dissolvedNeuron)).toBeUndefined();
+    });
+
+    it("returns dissolve date", () => {
+      const todayInSeconds = BigInt(Math.round(Date.now() / 1000));
+      const dissolveDate = todayInSeconds + BigInt(SECONDS_IN_YEAR);
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        dissolve_state: [{ WhenDissolvedTimestampSeconds: dissolveDate }],
+      };
+      expect(getSnsDissolvingTimestampSeconds(neuron)).toBe(dissolveDate);
     });
   });
 

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -19,7 +19,7 @@ export class NnsNeuronAdvancedSectionPo extends BasePageObject {
     return this.getText("neuron-created");
   }
 
-  dissolveDate(): Promise<string> {
+  dissolveDate(): Promise<string | null> {
     return this.getText("neuron-dissolve-date");
   }
 

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -19,6 +19,10 @@ export class NnsNeuronAdvancedSectionPo extends BasePageObject {
     return this.getText("neuron-created");
   }
 
+  dissolveDate(): Promise<string> {
+    return this.getText("neuron-dissolve-date");
+  }
+
   getNnsNeuronAgePo(): NnsNeuronAgePo {
     return NnsNeuronAgePo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -20,7 +20,7 @@ export class SnsNeuronAdvancedSectionPo extends BasePageObject {
     return this.getText("neuron-created");
   }
 
-  dissolveDate(): Promise<string> {
+  dissolveDate(): Promise<string | null> {
     return this.getText("neuron-dissolve-date");
   }
 

--- a/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronAdvancedSection.page-object.ts
@@ -20,6 +20,10 @@ export class SnsNeuronAdvancedSectionPo extends BasePageObject {
     return this.getText("neuron-created");
   }
 
+  dissolveDate(): Promise<string> {
+    return this.getText("neuron-dissolve-date");
+  }
+
   getNnsNeuronAgePo(): SnsNeuronAgePo {
     return SnsNeuronAgePo.under(this.root);
   }


### PR DESCRIPTION
# Motivation

Add the dissolve date for dissolving neurons in the Advanced Section.

# Changes

* New utils to get the dissolve date from SNS and NNS neurons.
* New utils are used in another related util.
* New utils are used to get the dissolve date (if any) and render it in the SNS and SNS NeuronAdvancedSection.

# Tests

* Test new utils.
* Test new functionality in SNS and SNS NeuronAdvancedSection.

# Todos

Not yet necessary, it's covered by the entry of the new neuron details UI.
