### PR TITLE
Make it easy to skip the CI build step for quick testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent run_id below to reuse an existing build
         # instead of building.
-        if: true
+        if: false
         id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,25 @@ jobs:
   build:
     runs-on: ubuntu-latest-m
     timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout nns-dapp
         uses: actions/checkout@v3
+      - name: Skip build for testing
+        # Set to true and set a recent run_id below to reuse an existing build
+        # instead of building.
+        if: false
+        id: skip_build
+        run: |
+          echo "skip_build=true" >> "$GITHUB_OUTPUT"
+          mkdir out
+          # The run ID is the number at the end of a URL like this:
+          # https://github.com/dfinity/nns-dapp/actions/runs/5801187848
+          run_id=5801187848
+          gh run download "$run_id" --dir ./out -n out
       - name: Build nns-dapp repo
+        if: steps.skip_build.outputs.skip_build != 'true'
         uses: ./.github/actions/build_nns_dapp
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent run_id below to reuse an existing build
         # instead of building.
-        if: false
+        if: true
         id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -49,6 +49,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Proposal details e2e test.
 * Automatically populate the change log section in the release proposal.
 * Remove empty section headings in scripts/nns-dapp/split-changelog.
+* Make it easy to skip the CI build step for quick testing
 
 #### Changed
 


### PR DESCRIPTION
# Motivation

Iterative testing on CI can be quite slow if every time you have to wait for the build step before your actual test runs.
If you're only changing your test and not your code under test it can be useful to skip the build step and reuse the artifacts from the previous build.

# Changes

In `.github/workflows/build.yml`, add a step to skip the build and reuse a previous build.
By default it's disabled, but with the code in place it's easy to enable.

When the build is skipped, the "Check that metadata is present" test will fail but everything else should pass as normal.

# Tests

With skipping disabled: https://github.com/dfinity/nns-dapp/actions/runs/5806927625
With skipping enabled: https://github.com/dfinity/nns-dapp/actions/runs/5807123115

# Todos

- [x] Add entry to changelog (if necessary).
