### PR TITLE
Feat: Collapse proposal summary in ballots summary

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,7 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 * New NNS and SNS neuron details page layout.
 * Update SNS Swap types to match the latest canister interface. 
-* Hide proposal summary in ballots by default.
+* Hide by default the proposal summary in ballots.
 
 #### Deprecated
 #### Removed

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Hardware Wallet users need to sign transactions only once. Except for staking a neuron.
 * New NNS and SNS neuron details page layout.
 * Update SNS Swap types to match the latest canister interface. 
+* Hide proposal summary in ballots by default.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
+++ b/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
@@ -5,8 +5,9 @@
   import { Vote } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
   import ProposalSummary from "$lib/components/proposal-detail/ProposalSummary.svelte";
-  import { SkeletonText } from "@dfinity/gix-components";
+  import { KeyValuePairInfo, SkeletonText } from "@dfinity/gix-components";
   import { keyOf } from "$lib/utils/utils";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let ballot: Required<BallotInfo>;
 
@@ -23,27 +24,29 @@
   );
 </script>
 
-{#if proposal?.proposal !== undefined}
-  <p class="value">{proposal.id}</p>
-
-  <p class="vote value">
-    {keyOf({ obj: $i18n.core, key: Vote[ballot.vote].toLowerCase() })}
-  </p>
-
-  <div class="summary">
-    <ProposalSummary summary={proposal.proposal.summary} />
-  </div>
-{:else}
-  <SkeletonText />
-
-  <SkeletonText />
-
-  <div class="summary">
+<TestIdWrapper testId="ballot-summary-component">
+  {#if proposal?.proposal !== undefined}
+    <KeyValuePairInfo testId="ballot-summary">
+      <p slot="key" class="value">{proposal.id}</p>
+      <p slot="value" class="vote value">
+        {keyOf({ obj: $i18n.core, key: Vote[ballot.vote].toLowerCase() })}
+      </p>
+      <div slot="info" class="summary">
+        <ProposalSummary summary={proposal.proposal.summary} />
+      </div>
+    </KeyValuePairInfo>
+  {:else}
     <SkeletonText />
+
     <SkeletonText />
-    <SkeletonText />
-  </div>
-{/if}
+
+    <div class="summary">
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+    </div>
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   .vote {
@@ -55,8 +58,6 @@
   }
 
   .summary {
-    grid-column-start: 1;
-    grid-column-end: 3;
     // fix broken layout with too long urls in summary
     word-break: break-word;
     // Fix too wide <pre> with code-blocks

--- a/frontend/src/lib/components/neuron-detail/Ballots/Ballots.svelte
+++ b/frontend/src/lib/components/neuron-detail/Ballots/Ballots.svelte
@@ -68,10 +68,6 @@
   li {
     padding: var(--padding-2x) 0;
 
-    display: grid;
-    grid-template-columns: 80% auto;
-    grid-column-gap: var(--padding);
-
     border-top: 1px solid currentColor;
     &:first-child {
       border-top: none;

--- a/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
@@ -8,6 +8,9 @@ import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
+import { BallotSummaryPo } from "$tests/page-objects/BallotSummary.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
 import type { BallotInfo, Proposal } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
@@ -83,4 +86,26 @@ describe("BallotSummary", () => {
 
   it("should render ballot vote unspecified", async () =>
     await testVote(Vote.Unspecified));
+
+  it("should show ballot summary on info click", async () => {
+    const { container } = render(BallotSummary, {
+      props: { ballot: mockBallot },
+    });
+
+    const po = BallotSummaryPo.under(new JestPageObjectElement(container));
+
+    await runResolvedPromises();
+
+    expect(await po.isBallotSummaryVisible()).toBe(false);
+
+    po.clickInfoIcon();
+
+    // We need to wait, without waiting the test will fail
+    await waitFor(async () =>
+      expect(await po.isBallotSummaryVisible()).toBe(true)
+    );
+    expect(await po.getBallotSummary()).toBe(
+      "Initialize datacenter records. For more info about this proposal, read the forum announcement: https://forum.dfinity.org/t/improvements-to-node-provider-remuneration/10553"
+    );
+  });
 });

--- a/frontend/src/tests/page-objects/BallotSummary.page-object.ts
+++ b/frontend/src/tests/page-objects/BallotSummary.page-object.ts
@@ -1,0 +1,30 @@
+import { KeyValuePairInfoPo } from "$tests/page-objects/KeyValuePairInfo.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class BallotSummaryPo extends BasePageObject {
+  static readonly TID = "ballot-summary-component";
+
+  static under(element: PageObjectElement): BallotSummaryPo {
+    return new BallotSummaryPo(element.byTestId(BallotSummaryPo.TID));
+  }
+
+  getKeyValuePairPo(): KeyValuePairInfoPo {
+    return KeyValuePairInfoPo.under({
+      element: this.root,
+      testId: "ballot-summary",
+    });
+  }
+
+  clickInfoIcon(): Promise<void> {
+    return this.getKeyValuePairPo().clickInfoIcon();
+  }
+
+  isBallotSummaryVisible(): Promise<boolean> {
+    return this.getKeyValuePairPo().isDescriptionVisible();
+  }
+
+  async getBallotSummary(): Promise<string> {
+    return (await this.getKeyValuePairPo().getDescriptionText()).trim();
+  }
+}

--- a/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePairInfo.page-object.ts
@@ -39,4 +39,8 @@ export class KeyValuePairInfoPo extends BasePageObject {
   getDescriptionText(): Promise<string> {
     return this.getText(`${this.testId}-description`);
   }
+
+  async isDescriptionVisible(): Promise<boolean> {
+    return this.root.byTestId("collapsible-content").isVisible();
+  }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -151,4 +151,13 @@ export class JestPageObjectElement implements PageObjectElement {
     // Not tested:
     // userEvent.selectOption(this.element, text);
   }
+
+  async isVisible(): Promise<boolean> {
+    try {
+      expect(this.element).toBeVisible();
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -107,4 +107,8 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   async selectOption(text: string): Promise<void> {
     await this.locator.selectOption(text);
   }
+
+  async isVisible(): Promise<boolean> {
+    throw new Error("Not implement");
+  }
 }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -32,4 +32,5 @@ export interface PageObjectElement {
   typeText(text: string): Promise<void>;
   selectOption(option: string): Promise<void>;
   getValue(): Promise<string>;
+  isVisible(): Promise<boolean>;
 }


### PR DESCRIPTION
# Motivation

Improve the UX of the voting ballots by hiding the proposal summary by default.

Proposal summaries can be very long and it's hard to navigate the ballots with so much text.

# Changes

* Use the KeyValuePairInfo in the BallotSummary.

# Tests

* Add a test to check that BallotSummary shows description on info click.
* BallotSummary PO.

# Todos

- [x] Add entry to changelog (if necessary).
