### PR TITLE
Chore: Test util to set SNS projects

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -55,6 +55,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Screenshot e2e tests.
 * Allow specifying a test_filter to the e2e CI action.
 * Make it easy to skip the CI build step for quick testing
+* New test util to set SNS projects for testing.
 
 #### Changed
 

--- a/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
@@ -5,18 +5,16 @@
 import SnsAccountsFooter from "$lib/components/accounts/SnsAccountsFooter.svelte";
 import * as accountsServices from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   modalToolbarSelector,
   waitModalIntroEnd,
 } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { testAccountsModal } from "$tests/utils/accounts.test-utils";
-import { Principal } from "@dfinity/principal";
+import { resetSnsProjects, setSnsProject } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { page } from "../../../../../__mocks__/$app/stores";
@@ -28,19 +26,17 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 });
 
 describe("SnsAccountsFooter", () => {
-  const responses = snsResponseFor({
-    principal: mockPrincipal,
-    lifecycle: SnsSwapLifecycle.Committed,
-  });
-
-  const rootCanisterIdText = responses[0][0].rootCanisterId;
-  const rootCanisterId = Principal.fromText(rootCanisterIdText);
+  const rootCanisterId = rootCanisterIdMock;
+  const rootCanisterIdText = rootCanisterId.toText();
 
   beforeEach(() => {
-    snsQueryStore.reset();
+    resetSnsProjects();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
-    snsQueryStore.setData(responses);
+    setSnsProject({
+      rootCanisterId,
+      lifecycle: SnsSwapLifecycle.Committed,
+    });
     transactionsFeesStore.setFee({
       rootCanisterId,
       fee: BigInt(10_000),

--- a/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
@@ -14,7 +14,7 @@ import {
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { testAccountsModal } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { page } from "../../../../../__mocks__/$app/stores";
@@ -30,7 +30,6 @@ describe("SnsAccountsFooter", () => {
   const rootCanisterIdText = rootCanisterId.toText();
 
   beforeEach(() => {
-    resetSnsProjects();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
     setSnsProjects([

--- a/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
@@ -14,7 +14,7 @@ import {
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { testAccountsModal } from "$tests/utils/accounts.test-utils";
-import { resetSnsProjects, setSnsProject } from "$tests/utils/sns.test-utils";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { page } from "../../../../../__mocks__/$app/stores";
@@ -33,10 +33,12 @@ describe("SnsAccountsFooter", () => {
     resetSnsProjects();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
-    setSnsProject({
-      rootCanisterId,
-      lifecycle: SnsSwapLifecycle.Committed,
-    });
+    setSnsProjects([
+      {
+        rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
     transactionsFeesStore.setFee({
       rootCanisterId,
       fee: BigInt(10_000),

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -4,7 +4,6 @@
 
 import SnsNeuronInfoStake from "$lib/components/sns-neuron-detail/SnsNeuronInfoStake.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import { page } from "$mocks/$app/stores";
 import {
@@ -17,9 +16,10 @@ import {
   mockSnsNeuron,
   mockSnsNeuronWithPermissions,
 } from "$tests/mocks/sns-neurons.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import {
   SnsNeuronPermissionType,
@@ -29,16 +29,14 @@ import {
 import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
 
 describe("SnsNeuronInfoStake", () => {
-  const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Committed],
-  });
   beforeEach(() => {
-    const universe = data[0][0].rootCanisterId;
+    const rootCanisterId = rootCanisterIdMock;
     page.mock({
-      data: { universe },
+      data: { universe: rootCanisterId.toText() },
     });
 
-    snsQueryStore.setData(data);
+    resetSnsProjects();
+    setSnsProjects([{ rootCanisterId, lifecycle: SnsSwapLifecycle.Committed }]);
 
     jest
       .spyOn(authStore, "subscribe")

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronInfoStake.spec.ts
@@ -19,7 +19,7 @@ import {
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsNeuronInfoStakePo } from "$tests/page-objects/SnsNeuronInfoStake.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import {
   SnsNeuronPermissionType,
@@ -35,7 +35,6 @@ describe("SnsNeuronInfoStake", () => {
       data: { universe: rootCanisterId.toText() },
     });
 
-    resetSnsProjects();
     setSnsProjects([{ rootCanisterId, lifecycle: SnsSwapLifecycle.Committed }]);
 
     jest

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeader.spec.ts
@@ -4,7 +4,6 @@
 
 import SnsNeuronPageHeader from "$lib/components/sns-neuron-detail/SnsNeuronPageHeader.svelte";
 import { layoutTitleStore } from "$lib/stores/layout.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { dispatchIntersecting } from "$lib/utils/events.utils";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -12,9 +11,9 @@ import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.moc
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import { SnsNeuronPageHeaderPo } from "$tests/page-objects/SnsNeuronPageHeader.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -32,15 +31,20 @@ describe("SnsNeuronPageHeader", () => {
     return SnsNeuronPageHeaderPo.under(new JestPageObjectElement(container));
   };
 
+  beforeEach(() => {
+    resetSnsProjects();
+  });
+
   it("should render the Sns universe name", async () => {
     const projectName = "Tetris";
     const rootCanisterId = mockPrincipal;
-    const responses = snsResponseFor({
-      principal: rootCanisterId,
-      lifecycle: SnsSwapLifecycle.Committed,
-      projectName,
-    });
-    snsQueryStore.setData(responses);
+    setSnsProjects([
+      {
+        rootCanisterId: rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        projectName,
+      },
+    ]);
     page.mock({ data: { universe: rootCanisterId.toText() } });
 
     const po = renderSnsNeuronCmp(mockSnsNeuron);

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -11,7 +11,7 @@ import {
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -21,6 +21,7 @@ describe("selected-project-new-transaction-data derived store", () => {
 
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      resetSnsProjects();
       snsSwapCommitmentsStore.reset();
       transactionsFeesStore.reset();
     });

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -3,48 +3,56 @@
  */
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
-import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import { page } from "$mocks/$app/stores";
 import {
+  createQueryMetadataResponse,
   mockSnsSwapCommitment,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import { Principal } from "@dfinity/principal";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("selected-project-new-transaction-data derived store", () => {
   describe("snsSelectedProjectNewTxData", () => {
+    const rootCanisterId = rootCanisterIdMock;
+
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-      snsQueryStore.reset();
+      resetSnsProjects();
       snsSwapCommitmentsStore.reset();
       transactionsFeesStore.reset();
     });
+
     it("returns undefined when nns", () => {
       const $store = get(snsSelectedProjectNewTxData);
       expect($store).toBeUndefined();
     });
-    it("returns the data for the a new Tx from the current universe", () => {
-      const projectData = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Committed],
-      });
 
-      const rootCanisterIdText = projectData[0][0].rootCanisterId;
-      const tokenData = projectData[0][0].token;
-      const rootCanisterId = Principal.fromText(rootCanisterIdText);
+    it("returns the data for the a new Tx from the current universe", () => {
+      const token = {
+        name: "name",
+        symbol: "symbol",
+      };
+      const tokenData = createQueryMetadataResponse(token);
 
       snsSwapCommitmentsStore.setSwapCommitment({
         swapCommitment: mockSnsSwapCommitment(rootCanisterId),
         certified: true,
       });
 
-      snsQueryStore.setData(projectData);
+      setSnsProjects([
+        {
+          rootCanisterId,
+          lifecycle: SnsSwapLifecycle.Committed,
+          tokenMetadata: tokenData,
+        },
+      ]);
 
-      page.mock({ data: { universe: rootCanisterIdText } });
+      page.mock({ data: { universe: rootCanisterId.toText() } });
 
       const fee = mockSnsToken.fee;
       transactionsFeesStore.setFee({
@@ -53,32 +61,28 @@ describe("selected-project-new-transaction-data derived store", () => {
         certified: true,
       });
 
-      const token = mapOptionalToken(tokenData);
-
       const storeData = get(snsSelectedProjectNewTxData);
-      expect(storeData.rootCanisterId.toText()).toEqual(rootCanisterIdText);
-      expect(storeData.token).toEqual({
-        name: token.name,
-        symbol: token.symbol,
-      });
+      expect(storeData.rootCanisterId.toText()).toEqual(
+        rootCanisterId.toText()
+      );
+      expect(storeData.token).toEqual(token);
       expect(storeData.transactionFee.toE8s()).toEqual(fee);
     });
 
     it("returns undefined if no transaction fee", () => {
-      const projectData = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Committed],
-      });
-      const rootCanisterIdText = projectData[0][0].rootCanisterId;
-      const rootCanisterId = Principal.fromText(rootCanisterIdText);
-
       snsSwapCommitmentsStore.setSwapCommitment({
         swapCommitment: mockSnsSwapCommitment(rootCanisterId),
         certified: true,
       });
 
-      snsQueryStore.setData(projectData);
+      setSnsProjects([
+        {
+          rootCanisterId,
+          lifecycle: SnsSwapLifecycle.Committed,
+        },
+      ]);
 
-      page.mock({ data: { universe: rootCanisterIdText } });
+      page.mock({ data: { universe: rootCanisterId.toText() } });
 
       expect(get(snsSelectedProjectNewTxData)).toBeUndefined();
     });

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -7,7 +7,6 @@ import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { page } from "$mocks/$app/stores";
 import {
-  createQueryMetadataResponse,
   mockSnsSwapCommitment,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
@@ -36,18 +35,15 @@ describe("selected-project-new-transaction-data derived store", () => {
         name: "name",
         symbol: "symbol",
       };
-      const tokenData = createQueryMetadataResponse(token);
-
       snsSwapCommitmentsStore.setSwapCommitment({
         swapCommitment: mockSnsSwapCommitment(rootCanisterId),
         certified: true,
       });
-
       setSnsProjects([
         {
           rootCanisterId,
           lifecycle: SnsSwapLifecycle.Committed,
-          tokenMetadata: tokenData,
+          tokenMetadata: token,
         },
       ]);
 

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -12,7 +12,7 @@ import {
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -22,7 +22,6 @@ describe("selected-project-new-transaction-data derived store", () => {
 
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-      resetSnsProjects();
       snsSwapCommitmentsStore.reset();
       transactionsFeesStore.reset();
     });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -349,6 +349,22 @@ export const mockQueryTokenResponse: IcrcTokenMetadataResponse = [
   [IcrcMetadataResponseEntries.FEE, { Nat: mockSnsToken.fee }],
 ];
 
+export const createQueryMetadataResponse = ({
+  name,
+  symbol,
+}: Partial<
+  Pick<IcrcTokenMetadata, "name" | "symbol">
+>): IcrcTokenMetadataResponse =>
+  mockQueryTokenResponse.map(([key, value]) => {
+    if (key === IcrcMetadataResponseEntries.NAME) {
+      return [key, { Text: name }];
+    }
+    if (key === IcrcMetadataResponseEntries.SYMBOL) {
+      return [key, { Text: symbol }];
+    }
+    return [key, value];
+  });
+
 export const mockQueryMetadata: QuerySnsMetadata = {
   rootCanisterId: principal(0).toText(),
   certified: true,

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -94,7 +94,7 @@ export const snsResponseFor = ({
   ],
 ];
 
-const mergeSnsResponses = (
+export const mergeSnsResponses = (
   responses: [QuerySnsMetadata[], QuerySnsSwapState[]][]
 ): [QuerySnsMetadata[], QuerySnsSwapState[]] => {
   const metadata = responses.flatMap(([meta, _]) => meta);

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -1,5 +1,6 @@
 import type { SnsSummarySwap } from "$lib/types/sns";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
+import type { IcrcTokenMetadataResponse } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 import type {
   SnsSwap,
@@ -43,6 +44,7 @@ export const snsResponseFor = ({
   restrictedCountries,
   directParticipantCount,
   projectName,
+  tokenMetadata,
 }: {
   principal: Principal;
   lifecycle: SnsSwapLifecycle;
@@ -50,6 +52,7 @@ export const snsResponseFor = ({
   restrictedCountries?: string[];
   directParticipantCount?: [] | [bigint];
   projectName?: string;
+  tokenMetadata?: IcrcTokenMetadataResponse;
 }): [QuerySnsMetadata[], QuerySnsSwapState[]] => [
   [
     {
@@ -59,7 +62,7 @@ export const snsResponseFor = ({
           ? [projectName]
           : mockQueryMetadataResponse.name,
       },
-      token: mockQueryTokenResponse,
+      token: tokenMetadata ?? mockQueryTokenResponse,
       rootCanisterId: principal.toText(),
       certified,
     },

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -36,7 +36,8 @@ export const setSnsProjects = (
         restrictedCountries,
         directParticipantCount,
         projectName,
-        tokenMetadata: createQueryMetadataResponse(tokenMetadata),
+        tokenMetadata:
+          tokenMetadata && createQueryMetadataResponse(tokenMetadata),
       })
   );
   snsQueryStore.setData(mergeSnsResponses(responses));

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -1,32 +1,40 @@
 import { snsQueryStore } from "$lib/stores/sns.store";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import {
+  mergeSnsResponses,
+  snsResponseFor,
+} from "$tests/mocks/sns-response.mock";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
 
-export const setSnsProject = ({
-  rootCanisterId,
-  lifecycle,
-  certified = false,
-  restrictedCountries,
-  directParticipantCount,
-  projectName,
-}: {
-  rootCanisterId: Principal;
-  lifecycle: SnsSwapLifecycle;
-  certified?: boolean;
-  restrictedCountries?: string[];
-  directParticipantCount?: [] | [bigint];
-  projectName?: string;
-}) => {
-  const response = snsResponseFor({
-    principal: rootCanisterId,
-    lifecycle,
-    certified,
-    restrictedCountries,
-    directParticipantCount,
-    projectName,
-  });
-  snsQueryStore.setData(response);
+export const setSnsProjects = (
+  params: {
+    rootCanisterId: Principal;
+    lifecycle: SnsSwapLifecycle;
+    certified?: boolean;
+    restrictedCountries?: string[];
+    directParticipantCount?: [] | [bigint];
+    projectName?: string;
+  }[]
+) => {
+  const responses = params.map(
+    ({
+      rootCanisterId,
+      lifecycle,
+      certified,
+      restrictedCountries,
+      directParticipantCount,
+      projectName,
+    }) =>
+      snsResponseFor({
+        principal: rootCanisterId,
+        lifecycle,
+        certified,
+        restrictedCountries,
+        directParticipantCount,
+        projectName,
+      })
+  );
+  snsQueryStore.setData(mergeSnsResponses(responses));
 };
 
 export const resetSnsProjects = () => {

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -1,9 +1,10 @@
 import { snsQueryStore } from "$lib/stores/sns.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { createQueryMetadataResponse } from "$tests/mocks/sns-projects.mock";
 import {
   mergeSnsResponses,
   snsResponseFor,
 } from "$tests/mocks/sns-response.mock";
-import type { IcrcTokenMetadataResponse } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
 
@@ -15,7 +16,7 @@ export const setSnsProjects = (
     restrictedCountries?: string[];
     directParticipantCount?: [] | [bigint];
     projectName?: string;
-    tokenMetadata?: IcrcTokenMetadataResponse;
+    tokenMetadata?: Partial<Pick<IcrcTokenMetadata, "name" | "symbol">>;
   }[]
 ) => {
   const responses = params.map(
@@ -35,7 +36,7 @@ export const setSnsProjects = (
         restrictedCountries,
         directParticipantCount,
         projectName,
-        tokenMetadata,
+        tokenMetadata: createQueryMetadataResponse(tokenMetadata),
       })
   );
   snsQueryStore.setData(mergeSnsResponses(responses));

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -1,0 +1,34 @@
+import { snsQueryStore } from "$lib/stores/sns.store";
+import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import type { Principal } from "@dfinity/principal";
+import type { SnsSwapLifecycle } from "@dfinity/sns";
+
+export const setSnsProject = ({
+  rootCanisterId,
+  lifecycle,
+  certified = false,
+  restrictedCountries,
+  directParticipantCount,
+  projectName,
+}: {
+  rootCanisterId: Principal;
+  lifecycle: SnsSwapLifecycle;
+  certified?: boolean;
+  restrictedCountries?: string[];
+  directParticipantCount?: [] | [bigint];
+  projectName?: string;
+}) => {
+  const response = snsResponseFor({
+    principal: rootCanisterId,
+    lifecycle,
+    certified,
+    restrictedCountries,
+    directParticipantCount,
+    projectName,
+  });
+  snsQueryStore.setData(response);
+};
+
+export const resetSnsProjects = () => {
+  snsQueryStore.reset();
+};

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -3,6 +3,7 @@ import {
   mergeSnsResponses,
   snsResponseFor,
 } from "$tests/mocks/sns-response.mock";
+import type { IcrcTokenMetadataResponse } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
 
@@ -14,6 +15,7 @@ export const setSnsProjects = (
     restrictedCountries?: string[];
     directParticipantCount?: [] | [bigint];
     projectName?: string;
+    tokenMetadata?: IcrcTokenMetadataResponse;
   }[]
 ) => {
   const responses = params.map(
@@ -24,6 +26,7 @@ export const setSnsProjects = (
       restrictedCountries,
       directParticipantCount,
       projectName,
+      tokenMetadata,
     }) =>
       snsResponseFor({
         principal: rootCanisterId,
@@ -32,6 +35,7 @@ export const setSnsProjects = (
         restrictedCountries,
         directParticipantCount,
         projectName,
+        tokenMetadata,
       })
   );
   snsQueryStore.setData(mergeSnsResponses(responses));


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of `snsQueryStore`.

In this PR: Create a test util that abstracts the filling and resetting of snsQueryStore in tests.

# Changes

* New test utils: resetSnsProjects, setSnsProject.
* Use new test utils in SnsAccountsFooter.spec.ts

# Tests

Only test changes.

# Todos

- [x] Add entry to changelog (if necessary).
