### PR TITLE
Fix: "Send ICP" instead of "Stake Neuron" in HW

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -39,6 +39,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Maintain text color in hyperlinks card when hovered.
 * Prevent default behavior of copy button to avoid unintentional navigation when used in hyperlinks cards.
 * Prevent the submission of cycles for top-up review unless an amount has been entered first.
+* Fix user story where message in HW screen was saying "Send ICP" when it should be "Stake Neuron".
 
 #### Security
 

--- a/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletListNeuronsButton.svelte
@@ -10,6 +10,8 @@
   import { mapHardwareWalletNeuronInfo } from "$lib/utils/hardware-wallet-neurons.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { openWalletModal } from "$lib/utils/modals.utils";
+  import { isNullish } from "@dfinity/utils";
+  import { toastsError } from "$lib/stores/toasts.store";
 
   // Get the store for the neurons of the hardware wallet from the dedicated context
   const context: WalletContext = getContext<WalletContext>(WALLET_CONTEXT_KEY);
@@ -21,7 +23,18 @@
       labelKey: "busy_screen.pending_approval_hw",
     });
 
-    const { neurons, err } = await listNeuronsHardwareWalletProxy();
+    const account = $store.account;
+
+    // Edge case, if this button is displayed, the account should be defined
+    if (isNullish(account)) {
+      stopBusy("accounts");
+      toastsError({ labelKey: "error__account.not_found" });
+      return;
+    }
+
+    const { neurons, err } = await listNeuronsHardwareWalletProxy(
+      account.identifier
+    );
 
     store.update((data) => ({
       ...data,

--- a/frontend/src/lib/proxy/icp-ledger.services.proxy.ts
+++ b/frontend/src/lib/proxy/icp-ledger.services.proxy.ts
@@ -37,12 +37,14 @@ export const showAddressAndPubKeyOnHardwareWalletProxy = async () => {
   return showAddressAndPubKeyOnHardwareWallet();
 };
 
-export const listNeuronsHardwareWalletProxy = async (): Promise<{
+export const listNeuronsHardwareWalletProxy = async (
+  accountIdentifier: string
+): Promise<{
   neurons: NeuronInfo[];
   err?: string;
 }> => {
   const { listNeuronsHardwareWallet } = await importLedgerServices();
-  return listNeuronsHardwareWallet();
+  return listNeuronsHardwareWallet(accountIdentifier);
 };
 
 export const isLedgerIdentityProxy = async (

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -34,7 +34,7 @@ export const connectToHardwareWallet = async (
   try {
     callback({ connectionState: LedgerConnectionState.CONNECTING });
 
-    const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
+    const ledgerIdentity: LedgerIdentity = await LedgerIdentity.create();
 
     callback({
       connectionState: LedgerConnectionState.CONNECTED,
@@ -95,9 +95,6 @@ export const registerHardwareWallet = async ({
   }
 };
 
-const createLedgerIdentity = (): Promise<LedgerIdentity> =>
-  LedgerIdentity.create();
-
 // Used to cache the identities.
 // The identity is an instance of the class LedgerIdentity.
 // This identity is used in other layers and then cached. If this returns a new one it's not necessarily used.
@@ -118,7 +115,7 @@ export const getLedgerIdentity = async (
   if (identities[identifier]) {
     return identities[identifier];
   }
-  const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
+  const ledgerIdentity: LedgerIdentity = await LedgerIdentity.create();
 
   identities[identifier] = ledgerIdentity;
 
@@ -142,7 +139,7 @@ export const getLedgerIdentity = async (
 
 export const showAddressAndPubKeyOnHardwareWallet = async () => {
   try {
-    const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
+    const ledgerIdentity: LedgerIdentity = await LedgerIdentity.create();
     await ledgerIdentity.showAddressAndPubKeyOnDevice();
   } catch (err: unknown) {
     toastUnexpectedError({
@@ -166,12 +163,16 @@ const toastUnexpectedError = ({
     })
   );
 
-export const listNeuronsHardwareWallet = async (): Promise<{
+export const listNeuronsHardwareWallet = async (
+  accountIdentifier: string
+): Promise<{
   neurons: NeuronInfo[];
   err?: string;
 }> => {
   try {
-    const ledgerIdentity: LedgerIdentity = await createLedgerIdentity();
+    const ledgerIdentity: LedgerIdentity = await getLedgerIdentity(
+      accountIdentifier
+    );
     const neurons: NeuronInfo[] = await queryNeurons({
       identity: ledgerIdentity,
       certified: true,

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -314,7 +314,7 @@ describe("icp-ledger.services", () => {
   describe("query neurons", () => {
     const mockNeurons = [mockNeuron];
 
-    beforeAll(() => {
+    beforeEach(() => {
       jest
         .spyOn(api, "queryNeurons")
         .mockImplementation(() => Promise.resolve(mockNeurons));
@@ -330,9 +330,31 @@ describe("icp-ledger.services", () => {
       );
 
       it("should list neurons on hardware wallet", async () => {
-        const { neurons } = await listNeuronsHardwareWallet();
+        const { neurons } = await listNeuronsHardwareWallet(
+          mockLedgerIdentifier
+        );
 
         expect(neurons).toEqual(mockNeurons);
+      });
+
+      it("should create and cache the identity", async () => {
+        await listNeuronsHardwareWallet(mockLedgerIdentifier);
+
+        expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+
+        await getLedgerIdentity(mockLedgerIdentifier);
+
+        expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+      });
+
+      it("should not create a new identity if cached ", async () => {
+        await getLedgerIdentity(mockLedgerIdentifier);
+
+        expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
+
+        await listNeuronsHardwareWallet(mockLedgerIdentifier);
+
+        expect(LedgerIdentity.create).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -348,7 +370,7 @@ describe("icp-ledger.services", () => {
       it("should not list neurons if ledger throw an error", async () => {
         const spyToastError = jest.spyOn(toastsStore, "toastsError");
 
-        const { err } = await listNeuronsHardwareWallet();
+        const { err } = await listNeuronsHardwareWallet(mockLedgerIdentifier);
 
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({


### PR DESCRIPTION
# Motivation

Bug:

* Visit HW wallet page.
* Click on "Show Neurons". Finish process.
* Go to "Neurons".
* Stake a neuron from the HW account.

Expected: "Stake Neuron" appears in the ledger device.
Instead: "Send ICP" appeared in the ledger device.

Reason:

`createAgent` caches the agents per identity. On "Show Neuron" a new agent was created and cached.

Yet, when staking a neuron, a new identity was created. The neurons flag was set in the new identity, but the api layer was using the cached agent with the previous identity. And the neurons flag was not set in it.

# Changes

* Add an accountIdentifier to the `listNeuronsHardwareWallet` service.
* Ledger service `listNeuronsHardwareWallet` uses `getLedgerIdentity` which uses the cache to create and return the identity.

# Tests

* Add tests to `listNeuronsHardwareWallet` to check that identity is cached and reused if previously cached.

# Todos

- [x] Add entry to changelog (if necessary).
