### PR TITLE
Add disburseMaturity service

### DIFF
--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -466,6 +466,33 @@ export const stakeMaturity = async ({
   logWithTimestamp(`Stake maturity: complete`);
 };
 
+export const disburseMaturity = async ({
+  neuronId,
+  rootCanisterId,
+  identity,
+  percentageToDisburse,
+}: {
+  neuronId: SnsNeuronId;
+  rootCanisterId: Principal;
+  identity: Identity;
+  percentageToDisburse: number;
+}): Promise<void> => {
+  logWithTimestamp(`Disburse maturity: call...`);
+
+  const { disburseMaturity: percentageToDisburseApi } = await wrapper({
+    identity,
+    rootCanisterId: rootCanisterId.toText(),
+    certified: true,
+  });
+
+  await percentageToDisburseApi({
+    neuronId,
+    percentageToDisburse,
+  });
+
+  logWithTimestamp(`Disburse maturity: complete`);
+};
+
 export const registerVote = async ({
   neuronId,
   rootCanisterId,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -841,6 +841,7 @@
     "sns_load_functions": "There was an error while loading the project topics.",
     "sns_add_hotkey": "There was an error adding the hotkey.",
     "sns_stake_maturity": "There was an error while staking the maturity of the neuron.",
+    "sns_disburse_maturity": "There was an error while disbursing the maturity of the neuron.",
     "sns_amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need a minimum of $minimum $token to stake a neuron.",
     "sns_reload_no_universe": "A project should be provided to execute this feature"
   },

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -3,6 +3,7 @@ import {
   addNeuronPermissions,
   autoStakeMaturity as autoStakeMaturityApi,
   disburse as disburseApi,
+  disburseMaturity as disburseMaturityApi,
   getSnsNeuron as getSnsNeuronApi,
   querySnsNeuron,
   querySnsNeurons,
@@ -764,6 +765,36 @@ export const stakeMaturity = async ({
   } catch (err: unknown) {
     toastsError({
       labelKey: "error__sns.sns_stake_maturity",
+      err,
+    });
+
+    return { success: false };
+  }
+};
+
+export const disburseMaturity = async ({
+  neuronId,
+  rootCanisterId,
+  percentageToDisburse,
+}: {
+  neuronId: SnsNeuronId;
+  rootCanisterId: Principal;
+  percentageToDisburse: number;
+}): Promise<{ success: boolean }> => {
+  try {
+    const identity = await getSnsNeuronIdentity();
+
+    await disburseMaturityApi({
+      neuronId,
+      rootCanisterId,
+      percentageToDisburse,
+      identity,
+    });
+
+    return { success: true };
+  } catch (err: unknown) {
+    toastsError({
+      labelKey: "error__sns.sns_disburse_maturity",
       err,
     });
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -877,6 +877,7 @@ interface I18nError__sns {
   sns_load_functions: string;
   sns_add_hotkey: string;
   sns_stake_maturity: string;
+  sns_disburse_maturity: string;
   sns_amount_not_enough_stake_neuron: string;
   sns_reload_no_universe: string;
 }

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -11,6 +11,7 @@ import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
 import * as services from "$lib/services/sns-neurons.services";
 import {
   disburse,
+  disburseMaturity,
   increaseStakeNeuron,
   stakeMaturity,
   startDissolving,
@@ -750,6 +751,34 @@ describe("sns-neurons-services", () => {
         neuronId,
         rootCanisterId,
         percentageToStake,
+        identity,
+      });
+    });
+  });
+
+  describe("disburseMaturity", () => {
+    it("should call api.disburseMaturity", async () => {
+      const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;
+      const identity = mockIdentity;
+      const rootCanisterId = mockPrincipal;
+      const percentageToDisburse = 75;
+
+      const spyOnDisburseMaturity = jest
+        .spyOn(governanceApi, "disburseMaturity")
+        .mockImplementation(() => Promise.resolve());
+
+      const { success } = await disburseMaturity({
+        neuronId,
+        rootCanisterId,
+        percentageToDisburse,
+      });
+
+      expect(success).toBeTruthy();
+
+      expect(spyOnDisburseMaturity).toBeCalledWith({
+        neuronId,
+        rootCanisterId,
+        percentageToDisburse,
         identity,
       });
     });


### PR DESCRIPTION
# Motivation

Add `disburseMaturity` service. Needs for the upcoming sns disburse maturity feature.

# Changes

- disburseMaturity sns api
- disburseMaturity sns service

# Tests

- "Should call api.disburseMaturity"

# Todos

- [ ] Add entry to changelog (if necessary).
