### PR TITLE
Chore: Use new sns project test util

### DIFF
--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -3,7 +3,6 @@
  */
 
 import IncreaseSnsDissolveDelayButton from "$lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -12,9 +11,9 @@ import {
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockToken } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { SnsSwapLifecycle, type SnsNeuron } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -25,15 +24,15 @@ jest.mock("$lib/services/sns-parameters.services");
 
 describe("IncreaseSnsDissolveDelayButton", () => {
   const rootCanisterId = mockPrincipal;
-  const response = snsResponseFor({
-    principal: rootCanisterId,
-    lifecycle: SnsSwapLifecycle.Committed,
-    certified: true,
-  });
   beforeEach(() => {
     jest.clearAllMocks();
-    snsQueryStore.reset();
-    snsQueryStore.setData(response);
+    setSnsProjects([
+      {
+        rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        certified: true,
+      },
+    ]);
     tokensStore.reset();
     tokensStore.setToken({
       canisterId: rootCanisterId,

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -7,7 +7,6 @@ import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { authStore } from "$lib/stores/auth.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { formatToken } from "$lib/utils/token.utils";
@@ -18,7 +17,8 @@ import {
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   SnsNeuronPermissionType,
   SnsSwapLifecycle,
@@ -49,16 +49,17 @@ describe("SnsNeuronCard", () => {
   const defaultProps = {
     ariaLabel: "test label",
   };
-  const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Open],
-    certified: true,
-  });
+
   beforeEach(() => {
-    snsQueryStore.setData(data);
+    setSnsProjects([
+      {
+        rootCanisterId: rootCanisterIdMock,
+        lifecycle: SnsSwapLifecycle.Open,
+        certified: true,
+      },
+    ]);
   });
-  afterEach(() => {
-    snsQueryStore.reset();
-  });
+
   it("renders a Card", () => {
     const { getByTestId } = render(SnsNeuronCard, {
       props: { neuron: mockSnsNeuron, ...defaultProps },

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -17,30 +17,28 @@ import {
 } from "$lib/derived/selected-universe.derived";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import {
   mockSnsCanisterId,
   mockSnsCanisterIdText,
 } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("selected universe derived stores", () => {
   beforeEach(() => {
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockSnsCanisterId,
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
   });
 
   describe("isNnsUniverseStore", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-project-accounts.derived.spec.ts
@@ -7,26 +7,24 @@ import {
   snsProjectMainAccountStore,
 } from "$lib/derived/sns/sns-project-accounts.derived";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-project-accounts store", () => {
   beforeEach(() => {
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockPrincipal,
+    setSnsProjects([
+      {
+        rootCanisterId: mockPrincipal,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -2,44 +2,37 @@
  * @jest-environment jsdom
  */
 
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
-import { Principal } from "@dfinity/principal";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("snsSelectedTransactionFeeStore", () => {
-  const data = snsResponsesForLifecycle({
-    lifecycles: [SnsSwapLifecycle.Committed],
+  const rootCanisterId = mockPrincipal;
+  const universe = rootCanisterId.toText();
+  const projectParams = {
+    rootCanisterId: mockPrincipal,
+    lifecycle: SnsSwapLifecycle.Committed,
     certified: true,
-  });
-
+    tokenMetadata: mockToken,
+  };
   beforeEach(() => {
-    snsQueryStore.reset();
+    resetSnsProjects();
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 
   it("returns transaction fee of current selected sns project", () => {
-    snsQueryStore.setData(data);
-    const [metadatas] = data;
-    page.mock({ data: { universe: metadatas[0].rootCanisterId } });
-    const ledgerMetadata = metadatas[0].token;
-    const symbolResponse = ledgerMetadata.find(
-      (metadata) => metadata[0] === IcrcMetadataResponseEntries.SYMBOL
-    );
-    const symbol =
-      symbolResponse !== undefined && "Text" in symbolResponse[1]
-        ? symbolResponse[1].Text
-        : undefined;
+    setSnsProjects([projectParams]);
+    page.mock({ data: { universe } });
 
     const fee = BigInt(10_000);
     transactionsFeesStore.setFee({
-      rootCanisterId: Principal.fromText(metadatas[0].rootCanisterId),
+      rootCanisterId,
       fee,
       certified: true,
     });
@@ -47,20 +40,21 @@ describe("snsSelectedTransactionFeeStore", () => {
     const actualFeeTokens = get(snsSelectedTransactionFeeStore);
 
     expect(actualFeeTokens?.toE8s()).toBe(fee);
-    expect(actualFeeTokens?.token.symbol).toBe(symbol);
+    expect(actualFeeTokens?.token.symbol).toBe(mockToken.symbol);
   });
 
   it("returns undefined if selected project is NNS", () => {
-    snsQueryStore.setData(data);
-    page.mock({ data: { universe: mockPrincipal.toText() } });
+    setSnsProjects([projectParams]);
+    page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+
     const actualFeeTokens = get(snsSelectedTransactionFeeStore);
 
     expect(actualFeeTokens).toBeUndefined();
   });
 
   it("returns undefined if current selected project has no data", () => {
-    const [metadatas] = data;
-    page.mock({ data: { universe: metadatas[0].rootCanisterId } });
+    page.mock({ data: { universe } });
+
     const actualFeeTokens = get(snsSelectedTransactionFeeStore);
 
     expect(actualFeeTokens).toBeUndefined();

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -7,11 +7,10 @@ import {
   sortedSnsUserNeuronsStore,
 } from "$lib/derived/sns/sns-sorted-neurons.derived";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { snsResponsesFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -23,14 +22,16 @@ describe("sortedSnsNeuronStore", () => {
 
   beforeEach(() => {
     snsNeuronsStore.reset();
-    snsQueryStore.reset();
-
-    snsQueryStore.setData(
-      snsResponsesFor([
-        { principal: mockPrincipal, lifecycle: SnsSwapLifecycle.Committed },
-        { principal: principal2, lifecycle: SnsSwapLifecycle.Committed },
-      ])
-    );
+    setSnsProjects([
+      {
+        rootCanisterId: mockPrincipal,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+      {
+        rootCanisterId: principal2,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
   });
 
   it("returns an empty array if no neurons", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
@@ -1,30 +1,25 @@
 import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
-import { Principal } from "@dfinity/principal";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("snsTotalSupplyTokenAmountStore", () => {
   beforeEach(() => {
-    snsQueryStore.reset();
     snsTotalTokenSupplyStore.reset();
   });
   it("should return the total supply of tokens for each SNS in TokenAmount", () => {
-    const responses = snsResponsesForLifecycle({
-      certified: true,
-      lifecycles: [
-        SnsSwapLifecycle.Committed,
-        SnsSwapLifecycle.Open,
-        SnsSwapLifecycle.Open,
-      ],
-    });
-    const rootCanisterIds = responses[0].map(({ rootCanisterId }) =>
-      Principal.fromText(rootCanisterId)
+    const projectsParams = [
+      { rootCanisterId: principal(0), lifecycle: SnsSwapLifecycle.Committed },
+      { rootCanisterId: principal(1), lifecycle: SnsSwapLifecycle.Open },
+      { rootCanisterId: principal(2), lifecycle: SnsSwapLifecycle.Open },
+    ];
+    const rootCanisterIds = projectsParams.map(
+      ({ rootCanisterId }) => rootCanisterId
     );
-    snsQueryStore.setData(responses);
+    setSnsProjects(projectsParams);
     const totalSupplyBase = BigInt(10_000_000_000);
     const totalSupplies = rootCanisterIds.map((rootCanisterId, index) => ({
       rootCanisterId,

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -10,6 +10,7 @@ import {
 } from "$tests/mocks/sns-response.mock";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
+import { isNullish } from "@dfinity/utils";
 
 export const setSnsProjects = (
   params: {
@@ -22,18 +23,26 @@ export const setSnsProjects = (
     tokenMetadata?: Partial<IcrcTokenMetadata>;
   }[]
 ) => {
+  if (
+    params.filter(({ rootCanisterId }) => isNullish(rootCanisterId)).length > 5
+  ) {
+    throw new Error("Too many projects without canister id.");
+  }
   const responses = params.map(
-    ({
-      rootCanisterId,
-      lifecycle,
-      certified,
-      restrictedCountries,
-      directParticipantCount,
-      projectName,
-      tokenMetadata,
-    }) =>
+    (
+      {
+        rootCanisterId,
+        lifecycle,
+        certified,
+        restrictedCountries,
+        directParticipantCount,
+        projectName,
+        tokenMetadata,
+      },
+      index
+    ) =>
       snsResponseFor({
-        principal: rootCanisterId ?? principal(0),
+        principal: rootCanisterId ?? principal(index),
         lifecycle,
         certified,
         restrictedCountries,

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -1,6 +1,9 @@
 import { snsQueryStore } from "$lib/stores/sns.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import { createQueryMetadataResponse } from "$tests/mocks/sns-projects.mock";
+import {
+  createQueryMetadataResponse,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
 import {
   mergeSnsResponses,
   snsResponseFor,
@@ -10,13 +13,13 @@ import type { SnsSwapLifecycle } from "@dfinity/sns";
 
 export const setSnsProjects = (
   params: {
-    rootCanisterId: Principal;
+    rootCanisterId?: Principal;
     lifecycle: SnsSwapLifecycle;
     certified?: boolean;
     restrictedCountries?: string[];
     directParticipantCount?: [] | [bigint];
     projectName?: string;
-    tokenMetadata?: Partial<Pick<IcrcTokenMetadata, "name" | "symbol">>;
+    tokenMetadata?: Partial<IcrcTokenMetadata>;
   }[]
 ) => {
   const responses = params.map(
@@ -30,7 +33,7 @@ export const setSnsProjects = (
       tokenMetadata,
     }) =>
       snsResponseFor({
-        principal: rootCanisterId,
+        principal: rootCanisterId ?? principal(0),
         lifecycle,
         certified,
         restrictedCountries,


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of snsQueryStore.

In this PR: Use the new test util `setSnsProjects` in more tests.

# Changes

* Move from `snsQueryStore.setData` to `setSnsProjects` in some test files.

# Tests

Only test changes.

# Todos

Already covered by a changelog entry.
