### PR TITLE
Chore: Use SNS Aggregator for nervous system functions

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -22,7 +22,7 @@
   import SnsFollowee from "./SnsFollowee.svelte";
   import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
   import {
-    getOrCreateSnsParametersProjectStore,
+    createSnsParametersProjectStore,
     type SnsNervousSystemFunctionsProjectStore,
   } from "$lib/derived/sns-ns-functions-project.derived";
 
@@ -52,7 +52,7 @@
 
   let nsFunctions: SnsNervousSystemFunctionsProjectStore | undefined;
   $: nsFunctions = nonNullish(rootCanisterId)
-    ? getOrCreateSnsParametersProjectStore(rootCanisterId)
+    ? createSnsParametersProjectStore(rootCanisterId)
     : undefined;
 
   let followees: SnsFolloweesByNeuron[] = [];

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -22,7 +22,7 @@
   import SnsFollowee from "./SnsFollowee.svelte";
   import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
   import {
-    createSnsParametersProjectStore,
+    createSnsNsFunctionsProjectStore,
     type SnsNervousSystemFunctionsProjectStore,
   } from "$lib/derived/sns-ns-functions-project.derived";
 
@@ -52,7 +52,7 @@
 
   let nsFunctions: SnsNervousSystemFunctionsProjectStore | undefined;
   $: nsFunctions = nonNullish(rootCanisterId)
-    ? createSnsParametersProjectStore(rootCanisterId)
+    ? createSnsNsFunctionsProjectStore(rootCanisterId)
     : undefined;
 
   let followees: SnsFolloweesByNeuron[] = [];
@@ -66,7 +66,9 @@
 
   let showLoading: boolean;
   $: showLoading =
-    nonNullish(neuron) && neuron.followees.length > 0 && isNullish(nsFunctions);
+    nonNullish(neuron) &&
+    neuron.followees.length > 0 &&
+    isNullish($nsFunctions);
 </script>
 
 <CardInfo testId="sns-neuron-following-card-component">

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -14,14 +14,17 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { KeyValuePairInfo } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNervousSystemFunction, SnsNeuron } from "@dfinity/sns";
+  import type { SnsNeuron } from "@dfinity/sns";
   import { getContext } from "svelte";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import FollowSnsNeuronsButton from "./actions/FollowSnsNeuronsButton.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
-  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import SnsFollowee from "./SnsFollowee.svelte";
   import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
+  import {
+    getOrCreateSnsParametersProjectStore,
+    type SnsNervousSystemFunctionsProjectStore,
+  } from "$lib/derived/sns-ns-functions-project.derived";
 
   $: {
     if (rootCanisterId !== undefined) {
@@ -47,25 +50,23 @@
         identity: $authStore.identity,
       });
 
-  let nsFunctions: SnsNervousSystemFunction[];
+  let nsFunctions: SnsNervousSystemFunctionsProjectStore | undefined;
   $: nsFunctions = nonNullish(rootCanisterId)
-    ? $snsFunctionsStore[rootCanisterId.toText()]?.nsFunctions ?? []
-    : [];
+    ? getOrCreateSnsParametersProjectStore(rootCanisterId)
+    : undefined;
 
   let followees: SnsFolloweesByNeuron[] = [];
   $: followees =
-    isNullish(neuron) || nsFunctions.length === 0
+    isNullish(neuron) || isNullish(nsFunctions)
       ? []
       : followeesByNeuronId({
           neuron,
-          nsFunctions,
+          nsFunctions: $nsFunctions ?? [],
         });
 
   let showLoading: boolean;
   $: showLoading =
-    nonNullish(neuron) &&
-    neuron.followees.length > 0 &&
-    nsFunctions.length === 0;
+    nonNullish(neuron) && neuron.followees.length > 0 && isNullish(nsFunctions);
 </script>
 
 <CardInfo testId="sns-neuron-following-card-component">

--- a/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
+++ b/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
@@ -1,0 +1,57 @@
+import {
+  snsAggregatorStore,
+  type SnsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
+import {
+  snsFunctionsStore,
+  type SnsNervousSystemFunctionsStore,
+} from "$lib/stores/sns-functions.store";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import { convertNervousFuncttion } from "$lib/utils/sns-aggregator-converters.utils";
+import type { Principal } from "@dfinity/principal";
+import type { SnsNervousSystemFunction } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+
+export type SnsNervousSystemFunctionsProjectStore = Readable<
+  SnsNervousSystemFunction[] | undefined
+>;
+
+const stores: Record<string, SnsNervousSystemFunctionsProjectStore> = {};
+
+const initSnsParametersProjectStore = (
+  rootCanisterId: Principal
+): SnsNervousSystemFunctionsProjectStore =>
+  derived<
+    [SnsNervousSystemFunctionsStore, SnsAggregatorStore],
+    SnsNervousSystemFunction[] | undefined
+  >(
+    [snsFunctionsStore, snsAggregatorStore],
+    ([snsFunctions, aggregatorData]) => {
+      const rootCanisterIdText = rootCanisterId.toText();
+      if (nonNullish(snsFunctions[rootCanisterIdText])) {
+        return snsFunctions[rootCanisterIdText].nsFunctions;
+      }
+      const aggregatorProject: CachedSnsDto | undefined =
+        aggregatorData.data?.find(
+          ({ canister_ids: { root_canister_id } }) =>
+            rootCanisterIdText === root_canister_id
+        );
+      if (nonNullish(aggregatorProject)) {
+        return aggregatorProject.parameters.functions.map(
+          convertNervousFuncttion
+        );
+      }
+      return undefined;
+    }
+  );
+
+export const getOrCreateSnsParametersProjectStore = (
+  rootCanisterId: Principal
+): SnsNervousSystemFunctionsProjectStore => {
+  const key = rootCanisterId.toText();
+  if (!stores[key]) {
+    stores[key] = initSnsParametersProjectStore(rootCanisterId);
+  }
+  return stores[key];
+};

--- a/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
+++ b/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
@@ -17,7 +17,7 @@ export type SnsNervousSystemFunctionsProjectStore = Readable<
   SnsNervousSystemFunction[] | undefined
 >;
 
-export const createSnsParametersProjectStore = (
+export const createSnsNsFunctionsProjectStore = (
   rootCanisterId: Principal
 ): SnsNervousSystemFunctionsProjectStore =>
   derived<

--- a/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
+++ b/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
@@ -17,9 +17,7 @@ export type SnsNervousSystemFunctionsProjectStore = Readable<
   SnsNervousSystemFunction[] | undefined
 >;
 
-const stores: Record<string, SnsNervousSystemFunctionsProjectStore> = {};
-
-const initSnsParametersProjectStore = (
+export const createSnsParametersProjectStore = (
   rootCanisterId: Principal
 ): SnsNervousSystemFunctionsProjectStore =>
   derived<
@@ -45,13 +43,3 @@ const initSnsParametersProjectStore = (
       return undefined;
     }
   );
-
-export const getOrCreateSnsParametersProjectStore = (
-  rootCanisterId: Principal
-): SnsNervousSystemFunctionsProjectStore => {
-  const key = rootCanisterId.toText();
-  if (!stores[key]) {
-    stores[key] = initSnsParametersProjectStore(rootCanisterId);
-  }
-  return stores[key];
-};

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -2,7 +2,7 @@ import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { getOrCreateSnsParametersProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+import { createSnsParametersProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
@@ -186,7 +186,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
 export const loadSnsNervousSystemFunctions = async (
   rootCanisterId: Principal
 ) => {
-  const store = getOrCreateSnsParametersProjectStore(rootCanisterId);
+  const store = createSnsParametersProjectStore(rootCanisterId);
   const storeData = get(store);
   // Avoid loading the same data multiple times if the data is loaded
   if (nonNullish(storeData)) {

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -2,6 +2,7 @@ import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { getOrCreateSnsParametersProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
@@ -185,9 +186,10 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
 export const loadSnsNervousSystemFunctions = async (
   rootCanisterId: Principal
 ) => {
-  const store = get(snsFunctionsStore);
-  // Avoid loading the same data multiple times if the data loaded is certified
-  if (store[rootCanisterId.toText()]?.certified) {
+  const store = getOrCreateSnsParametersProjectStore(rootCanisterId);
+  const storeData = get(store);
+  // Avoid loading the same data multiple times if the data is loaded
+  if (nonNullish(storeData)) {
     return;
   }
 

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -2,7 +2,7 @@ import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { createSnsParametersProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
@@ -186,7 +186,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
 export const loadSnsNervousSystemFunctions = async (
   rootCanisterId: Principal
 ) => {
-  const store = createSnsParametersProjectStore(rootCanisterId);
+  const store = createSnsNsFunctionsProjectStore(rootCanisterId);
   const storeData = get(store);
   // Avoid loading the same data multiple times if the data is loaded
   if (nonNullish(storeData)) {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -78,7 +78,7 @@ const convertFunctionType = (
   };
 };
 
-const convertNervousFuncttion = ({
+export const convertNervousFuncttion = ({
   id,
   name,
   description,

--- a/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
@@ -36,6 +36,7 @@ describe("nsFunctionsProjectStore", () => {
 
   it("returns the functions from snsFunctionsStore when snsAggregatorStore has data", () => {
     snsAggregatorStore.setData([aggregatorProject]);
+    const functions = aggregatorSnsMockDto.parameters.functions;
     snsFunctionsStore.setProjectFunctions({
       rootCanisterId,
       nsFunctions: [nervousSystemFunctionMock],
@@ -44,6 +45,7 @@ describe("nsFunctionsProjectStore", () => {
 
     const store = createSnsNsFunctionsProjectStore(rootCanisterId);
     expect(get(store)).toEqual([nervousSystemFunctionMock]);
+    expect(get(store)).not.toEqual(functions.map(convertNervousFuncttion));
   });
 
   it("returns the functions from snsAggregator if no functions in snsFunctionsStore", () => {

--- a/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
@@ -1,0 +1,76 @@
+import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
+import { convertNervousFuncttion } from "$lib/utils/sns-aggregator-converters.utils";
+import { mockCanisterId } from "$tests/mocks/canisters.mock";
+import {
+  aggregatorSnsMockDto,
+  aggregatorSnsMockWith,
+} from "$tests/mocks/sns-aggregator.mock";
+import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { get } from "svelte/store";
+
+describe("nsFunctionsProjectStore", () => {
+  const rootCanisterId = rootCanisterIdMock;
+  const aggregatorProject = aggregatorSnsMockWith({
+    rootCanisterId: rootCanisterId.toText(),
+  });
+
+  beforeEach(() => {
+    snsAggregatorStore.reset();
+    snsFunctionsStore.reset();
+  });
+
+  it("returns the functions from snsFunctionsStore", () => {
+    const rootCanisterId = rootCanisterIdMock;
+    snsFunctionsStore.setProjectFunctions({
+      rootCanisterId,
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
+    });
+
+    const store = createSnsNsFunctionsProjectStore(rootCanisterId);
+    expect(get(store)).toEqual([nervousSystemFunctionMock]);
+  });
+
+  it("returns the functions from snsFunctionsStore when snsAggregatorStore has data", () => {
+    snsAggregatorStore.setData([aggregatorProject]);
+    snsFunctionsStore.setProjectFunctions({
+      rootCanisterId,
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
+    });
+
+    const store = createSnsNsFunctionsProjectStore(rootCanisterId);
+    expect(get(store)).toEqual([nervousSystemFunctionMock]);
+  });
+
+  it("returns the functions from snsAggregator if no functions in snsFunctionsStore", () => {
+    snsAggregatorStore.setData([aggregatorProject]);
+    const functions = aggregatorSnsMockDto.parameters.functions;
+
+    const store = createSnsNsFunctionsProjectStore(rootCanisterId);
+    expect(get(store)).toEqual(functions.map(convertNervousFuncttion));
+  });
+
+  it("returns undefined if project is not set in no store", () => {
+    const store = createSnsNsFunctionsProjectStore(rootCanisterId);
+    expect(get(store)).toBeUndefined();
+  });
+
+  it("returns undefined if another project has ns functions but not this one", () => {
+    snsFunctionsStore.setProjectFunctions({
+      rootCanisterId,
+      nsFunctions: [nervousSystemFunctionMock],
+      certified: true,
+    });
+    const storeWithNsFunctions =
+      createSnsNsFunctionsProjectStore(rootCanisterId);
+    expect(get(storeWithNsFunctions)).not.toBeUndefined();
+
+    const storeWithoutNsFunctions =
+      createSnsNsFunctionsProjectStore(mockCanisterId);
+    expect(get(storeWithoutNsFunctions)).toBeUndefined();
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -9,6 +9,7 @@ import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposa
 import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
+import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
@@ -56,6 +57,7 @@ describe("SnsProposalDetail", () => {
       jest.clearAllMocks();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
       authStore.setForTesting(undefined);
+      snsFunctionsStore.reset();
       page.mock({ data: { universe: rootCanisterId.toText() } });
     });
 

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -28,6 +28,7 @@ import {
 } from "$tests/mocks/sns-aggregator.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -74,7 +75,7 @@ describe("SNS public services", () => {
       expect(spyGetFunctions).toBeCalled();
     });
 
-    it("should not call api if nervous functions are in the store and certified", async () => {
+    it("should not call api if nervous functions are in the snsFunctionsStore store and certified", async () => {
       snsFunctionsStore.setProjectFunctions({
         rootCanisterId: mockPrincipal,
         nsFunctions: [nervousSystemFunctionMock],
@@ -85,6 +86,22 @@ describe("SNS public services", () => {
         .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
 
       await loadSnsNervousSystemFunctions(mockPrincipal);
+
+      expect(spyGetFunctions).not.toBeCalled();
+    });
+
+    it("should not call api if nervous functions are in the snsAggregator store", async () => {
+      const rootCanisterId = rootCanisterIdMock;
+      const aggregatorProject = aggregatorSnsMockWith({
+        rootCanisterId: rootCanisterId.toText(),
+      });
+      snsAggregatorStore.setData([aggregatorProject]);
+      const spyGetFunctions = jest.spyOn(
+        governanceApi,
+        "getNervousSystemFunctions"
+      );
+
+      await loadSnsNervousSystemFunctions(rootCanisterId);
 
       expect(spyGetFunctions).not.toBeCalled();
     });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -297,8 +297,8 @@ export const aggregatorSnsMockWith = ({
   rootCanisterId = "4nwps-saaaa-aaaaa-aabjq-cai",
   lifecycle = SnsSwapLifecycle.Committed,
 }: {
-  rootCanisterId: string;
-  lifecycle: SnsSwapLifecycle;
+  rootCanisterId?: string;
+  lifecycle?: SnsSwapLifecycle;
 }): CachedSnsDto => ({
   ...aggregatorSnsMockDto,
   canister_ids: {


### PR DESCRIPTION
# Motivation

No need to request the nervous functions of an SNS. The aggregator already provides the data.

# Changes

* New derived store factory `createSnsFunctionsProjectStore`. It checks first the functions store and then aggregator to return the nervous functions.
* Use the new derived store factory in `SnsNeuronFollowingCard`.
* Check the new derived store in `loadSnsNervousSystemFunctions`.

# Tests

* Test `createSnsFunctionsProjectStore`.
* The changes in `loadSnsNervousSystemFunctions` exposed a missing store reset in the SnsProposalDetail test.
* Add test case in `loadSnsNervousSystemFunctions`.

# Todos

Not worth an entry, only refactor.
