### PR TITLE
Chore: Use new sns project test util

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -7,7 +7,6 @@ import DisburseSnsNeuronModal from "$lib/modals/neurons/DisburseSnsNeuronModal.s
 import * as authServices from "$lib/services/auth.services";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import {
   createMockIdentity,
@@ -19,7 +18,7 @@ import {
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsNeuron, mockSnsNeuronId } from "$tests/mocks/sns-neurons.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -58,12 +57,12 @@ describe("DisburseSnsNeuronModal", () => {
       certified: true,
     });
 
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockSnsMainAccount.principal,
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsMainAccount.principal,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
   });
 
   it("should display modal", async () => {

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -8,7 +8,6 @@ import IncreaseSnsDissolveDelayModal from "$lib/modals/sns/neurons/IncreaseSnsDi
 import * as authServices from "$lib/services/auth.services";
 import { loadSnsParameters } from "$lib/services/sns-parameters.services";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
 import { page } from "$mocks/$app/stores";
 import {
@@ -21,7 +20,7 @@ import {
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -80,13 +79,12 @@ describe("IncreaseSnsDissolveDelayModal", () => {
       parameters: snsNervousSystemParametersMock,
     });
 
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockPrincipal,
+    setSnsProjects([
+      {
+        rootCanisterId: mockPrincipal,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
 
     page.mock({ data: { universe: mockPrincipal.toText() } });
   });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -8,7 +8,6 @@ import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import * as workerBalances from "$lib/services/worker-balances.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
@@ -19,11 +18,11 @@ import {
   mockSnsFullProject,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import {
   mockTokensSubscribe,
   mockUniversesTokens,
 } from "$tests/mocks/tokens.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
 import { render, waitFor, type RenderResult } from "@testing-library/svelte";
@@ -72,13 +71,12 @@ describe("SnsAccounts", () => {
       .spyOn(tokensStore, "subscribe")
       .mockImplementation(mockTokensSubscribe(mockUniversesTokens));
 
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockSnsFullProject.rootCanisterId,
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
   });
 
   describe("when there are accounts in the store", () => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -17,7 +17,6 @@ import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import {
@@ -37,10 +36,10 @@ import {
   createMockSnsNeuron,
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsNeuronId } from "@dfinity/sns";
@@ -58,21 +57,12 @@ describe("SnsNeuronDetail", () => {
   fakeSnsApi.install();
 
   const rootCanisterId = rootCanisterIdMock;
-  const responses = snsResponseFor({
-    principal: rootCanisterId,
-    lifecycle: SnsSwapLifecycle.Committed,
-  });
   const projectName = "Test SNS";
 
   const nonExistingNeuron = createMockSnsNeuron({
     id: [1, 1, 1, 1, 1],
   });
   const nonExistingNeuronId = getSnsNeuronIdAsHexString(nonExistingNeuron);
-
-  // Clone the summary to avoid mutating the mock
-  const summary = { ...responses[0][0] };
-  summary.metadata.name = [projectName];
-  responses[0][0] = summary;
 
   const mainAccount = {
     owner: mockIdentity.getPrincipal(),
@@ -87,8 +77,13 @@ describe("SnsNeuronDetail", () => {
     snsParametersStore.reset();
     snsNeuronsStore.reset();
     snsAccountsStore.reset();
-    snsQueryStore.reset();
-    snsQueryStore.setData(responses);
+    setSnsProjects([
+      {
+        projectName,
+        rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
 
     fakeSnsLedgerApi.addAccountWith({
       rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -12,7 +12,6 @@ import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -24,8 +23,8 @@ import {
   createMockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -58,12 +57,12 @@ describe("SnsNeurons", () => {
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
 
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: rootCanisterIdMock,
+    setSnsProjects([
+      {
+        rootCanisterId: rootCanisterIdMock,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -6,7 +6,6 @@ import SnsProposals from "$lib/pages/SnsProposals.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import {
@@ -16,7 +15,7 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import {
   SnsProposalDecisionStatus,
@@ -44,13 +43,12 @@ describe("SnsProposals", () => {
     jest.clearAllMocks();
     snsProposalsStore.reset();
     snsFunctionsStore.reset();
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: rootCanisterId,
+    setSnsProjects([
+      {
+        rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
     // Reset to default value
     page.mock({ data: { universe: rootCanisterId.toText() } });
   });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -15,14 +15,14 @@ import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { waitModalIntroEnd } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { mockTokensSubscribe } from "$tests/mocks/tokens.mock";
 import { testAccountsModal } from "$tests/utils/accounts.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -73,19 +73,19 @@ describe("SnsWallet", () => {
     accountIdentifier: mockSnsMainAccount.identifier,
   };
 
-  const responses = snsResponseFor({
-    principal: mockPrincipal,
-    lifecycle: SnsSwapLifecycle.Committed,
-  });
-
-  const rootCanisterIdText = responses[0][0].rootCanisterId;
-  const rootCanisterId = Principal.fromText(rootCanisterIdText);
+  const rootCanisterId = rootCanisterIdMock;
+  const rootCanisterIdText = rootCanisterId.toText();
 
   beforeEach(() => {
     snsQueryStore.reset();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
-    snsQueryStore.setData(responses);
+    setSnsProjects([
+      {
+        rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
     transactionsFeesStore.setFee({
       rootCanisterId,
       fee: BigInt(10_000),

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -6,11 +6,10 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import ProposalDetail from "$lib/routes/ProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
@@ -34,13 +33,12 @@ describe("ProposalDetail", () => {
   afterAll(jest.clearAllMocks);
 
   beforeEach(() => {
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockSnsFullProject.rootCanisterId,
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
   });
 
   it("should render NnsProposalDetail by default", () => {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -7,12 +7,11 @@ import { AppPath } from "$lib/constants/routes.constants";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
-import { snsResponseFor } from "$tests/mocks/sns-response.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
@@ -43,13 +42,12 @@ jest.mock("$lib/services/ckbtc-info.services", () => {
 
 describe("Wallet", () => {
   beforeEach(() => {
-    snsQueryStore.reset();
-    snsQueryStore.setData(
-      snsResponseFor({
-        principal: mockSnsFullProject.rootCanisterId,
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
-      })
-    );
+      },
+    ]);
     icpAccountsStore.setForTesting(mockAccountsStoreData);
   });
 


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of snsQueryStore.

In this PR: Use the new test util setSnsProjects in more tests.

# Changes

* Move from snsQueryStore.setData to setSnsProjects in some test files.

# Tests

Only test changes.

# Todos

Already covered by a changelog entry.
