### PR TITLE
GIX-1797: Add HW controller tag

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,6 +12,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
+* New tag for NNS neurons: "Hardware Wallet".
+
 #### Changed
 
 * Don't display proposal navigation on launch-pad page.

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -5,7 +5,7 @@
   import {
     formatVotingPower,
     hasJoinedCommunityFund,
-    isHotkeyFlag,
+    isHotkeyTag,
     isNeuronControlledByHardwareWallet,
     neuronStake,
   } from "$lib/utils/neuron.utils";
@@ -33,8 +33,8 @@
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
 
-  let hotkeyFlag: boolean;
-  $: hotkeyFlag = isHotkeyFlag({
+  let hotkeyTag: boolean;
+  $: hotkeyTag = isHotkeyTag({
     neuron,
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
@@ -64,7 +64,7 @@
         {$i18n.neurons.community_fund}
       </HeadingTag>
     {/if}
-    {#if hotkeyFlag}
+    {#if hotkeyTag}
       <HeadingTag testId="hotkey-tag">
         {$i18n.neurons.hotkey_control}
       </HeadingTag>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -5,7 +5,6 @@
   import {
     formatVotingPower,
     hasJoinedCommunityFund,
-    isHotKeyControllable,
     isHotkeyFlag,
     isNeuronControlledByHardwareWallet,
     neuronStake,

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -6,6 +6,8 @@
     formatVotingPower,
     hasJoinedCommunityFund,
     isHotKeyControllable,
+    isHotkeyFlag,
+    isNeuronControlledByHardwareWallet,
     neuronStake,
   } from "$lib/utils/neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -14,6 +16,7 @@
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authStore } from "$lib/stores/auth.store";
   import HeadingTag from "../common/HeadingTag.svelte";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
 
@@ -31,10 +34,17 @@
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
 
-  let isHotKeyControl: boolean;
-  $: isHotKeyControl = isHotKeyControllable({
+  let hotkeyFlag: boolean;
+  $: hotkeyFlag = isHotkeyFlag({
     neuron,
     identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
+
+  let isHWControlled: boolean;
+  $: isHWControlled = isNeuronControlledByHardwareWallet({
+    neuron,
+    accounts: $icpAccountsStore,
   });
 </script>
 
@@ -55,9 +65,14 @@
         {$i18n.neurons.community_fund}
       </HeadingTag>
     {/if}
-    {#if isHotKeyControl}
+    {#if hotkeyFlag}
       <HeadingTag testId="hotkey-tag">
         {$i18n.neurons.hotkey_control}
+      </HeadingTag>
+    {/if}
+    {#if isHWControlled}
+      <HeadingTag testId="hardware-wallet-tag">
+        {$i18n.neurons.hardware_wallet_control}
       </HeadingTag>
     {/if}
   </svelte:fragment>

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -3,9 +3,11 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     hasJoinedCommunityFund,
-    isHotKeyControllable,
+    isHotkeyFlag,
+    isNeuronControlledByHardwareWallet,
   } from "$lib/utils/neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
   export let tagName: "p" | "h3" = "p";
@@ -13,10 +15,17 @@
   let isCommunityFund: boolean;
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
 
-  let isHotKeyControl: boolean;
-  $: isHotKeyControl = isHotKeyControllable({
+  let hotkeyFlag: boolean;
+  $: hotkeyFlag = isHotkeyFlag({
     neuron,
     identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+  });
+
+  let isHWControlled: boolean;
+  $: isHWControlled = isNeuronControlledByHardwareWallet({
+    neuron,
+    accounts: $icpAccountsStore,
   });
 </script>
 
@@ -28,8 +37,15 @@
   {#if isCommunityFund}
     <small class="label">{$i18n.neurons.community_fund}</small>
   {/if}
-  {#if isHotKeyControl}
-    <small class="label">{$i18n.neurons.hotkey_control}</small>
+  {#if hotkeyFlag}
+    <small class="label" data-tid="hotkey-tag"
+      >{$i18n.neurons.hotkey_control}</small
+    >
+  {/if}
+  {#if isHWControlled}
+    <small class="label" data-tid="hardware-wallet-tag"
+      >{$i18n.neurons.hardware_wallet_control}</small
+    >
   {/if}
 </div>
 

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     hasJoinedCommunityFund,
-    isHotkeyFlag,
+    isHotkeyTag,
     isNeuronControlledByHardwareWallet,
   } from "$lib/utils/neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
@@ -16,7 +16,7 @@
   $: isCommunityFund = hasJoinedCommunityFund(neuron);
 
   let hotkeyFlag: boolean;
-  $: hotkeyFlag = isHotkeyFlag({
+  $: hotkeyFlag = isHotkeyTag({
     neuron,
     identity: $authStore.identity,
     accounts: $icpAccountsStore,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -280,6 +280,7 @@
     "create": "Create",
     "community_fund": "Neurons' fund",
     "hotkey_control": "Hotkey control",
+    "hardware_wallet_control": "Hardware Wallet",
     "stake": "Stake",
     "amount_icp_stake": "$amount ICP Stake",
     "ic_stake": "ICP Stake",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -290,6 +290,7 @@ interface I18nNeurons {
   create: string;
   community_fund: string;
   hotkey_control: string;
+  hardware_wallet_control: string;
   stake: string;
   amount_icp_stake: string;
   ic_stake: string;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -364,6 +364,19 @@ export const isHotKeyControllable = ({
   ) !== undefined &&
   fullNeuron.controller !== identity?.getPrincipal().toText();
 
+// All HW controlled are hotkeys, but we don't want to show two tags to the user.
+export const isHotkeyFlag = ({
+  neuron,
+  identity,
+  accounts,
+}: {
+  neuron: NeuronInfo;
+  identity?: Identity | null;
+  accounts: IcpAccountsStoreData;
+}): boolean =>
+  isHotKeyControllable({ neuron, identity }) &&
+  !isNeuronControlledByHardwareWallet({ neuron, accounts });
+
 /**
  * An identity can manage the neurons' fund participation when one of the below is true:
  * - User is the controller.

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -365,7 +365,7 @@ export const isHotKeyControllable = ({
   fullNeuron.controller !== identity?.getPrincipal().toText();
 
 // All HW controlled are hotkeys, but we don't want to show two tags to the user.
-export const isHotkeyFlag = ({
+export const isHotkeyTag = ({
   neuron,
   identity,
   accounts,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -45,7 +45,7 @@ import {
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
   isHotKeyControllable,
-  isHotkeyFlag,
+  isHotkeyTag,
   isIdentityController,
   isNeuronControllable,
   isNeuronControllableByUser,
@@ -1118,7 +1118,7 @@ describe("neuron-utils", () => {
       ).toBe(false));
   });
 
-  describe("isHotkeyFlag", () => {
+  describe("isHotkeyTag", () => {
     const accountsWithHW = {
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
@@ -1138,7 +1138,7 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyFlag({
+        isHotkeyTag({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
@@ -1156,7 +1156,7 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyFlag({
+        isHotkeyTag({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithoutHw,
@@ -1174,7 +1174,7 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyFlag({
+        isHotkeyTag({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
@@ -1192,7 +1192,7 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyFlag({
+        isHotkeyTag({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
@@ -1210,7 +1210,7 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyFlag({
+        isHotkeyTag({
           neuron: neuron,
           identity: null,
           accounts: accountsWithHW,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -45,6 +45,7 @@ import {
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
   isHotKeyControllable,
+  isHotkeyFlag,
   isIdentityController,
   isNeuronControllable,
   isNeuronControllableByUser,
@@ -1115,6 +1116,107 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
         })
       ).toBe(false));
+  });
+
+  describe("isHotkeyFlag", () => {
+    const accountsWithHW = {
+      main: mockMainAccount,
+      hardwareWallets: [mockHardwareWalletAccount],
+    };
+
+    const accountsWithoutHw = {
+      main: mockMainAccount,
+      hardwareWallets: [],
+    };
+    it("returns true if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: "not-hardware-wallet",
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      expect(
+        isHotkeyFlag({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+        })
+      ).toBe(true);
+    });
+
+    it("returns true if neuron is controllable by hotkey and no hardware wallet is attached", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockHardwareWalletAccount.principal?.toText(),
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      expect(
+        isHotkeyFlag({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithoutHw,
+        })
+      ).toBe(true);
+    });
+
+    it("returns false if neuron is controllable by hotkey and hardware wallet is the controller", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockHardwareWalletAccount.principal?.toText(),
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      expect(
+        isHotkeyFlag({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+        })
+      ).toBe(false);
+    });
+
+    it("returns false if neuron is the controller and a hotkey", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: mockIdentity.getPrincipal().toText(),
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      expect(
+        isHotkeyFlag({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+        })
+      ).toBe(false);
+    });
+
+    it("returns false if no identity", () => {
+      const neuron = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          controller: "not-user",
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+        },
+      };
+      expect(
+        isHotkeyFlag({
+          neuron: neuron,
+          identity: null,
+          accounts: accountsWithHW,
+        })
+      ).toBe(false);
+    });
   });
 
   describe("isIdentityController", () => {

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -6,6 +6,10 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class NnsNeuronCardPo extends BasePageObject {
   private static readonly TID = "nns-neuron-card-component";
 
+  static under(element: PageObjectElement): NnsNeuronCardPo {
+    return new NnsNeuronCardPo(element.byTestId(NnsNeuronCardPo.TID));
+  }
+
   static async allUnder(
     element: PageObjectElement
   ): Promise<NnsNeuronCardPo[]> {
@@ -40,5 +44,13 @@ export class NnsNeuronCardPo extends BasePageObject {
 
   async getBalance(): Promise<number> {
     return Number(await this.getText("token-value"));
+  }
+
+  hasHotkeyTag(): Promise<boolean> {
+    return this.root.byTestId("hotkey-tag").isPresent();
+  }
+
+  hasHardwareWalletTag(): Promise<boolean> {
+    return this.root.byTestId("hardware-wallet-tag").isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -30,4 +30,8 @@ export class NnsNeuronPageHeadingPo extends BasePageObject {
   hasHotkeyTag(): Promise<boolean> {
     return this.root.byTestId("hotkey-tag").isPresent();
   }
+
+  hasHardwareWalletTag(): Promise<boolean> {
+    return this.root.byTestId("hardware-wallet-tag").isPresent();
+  }
 }


### PR DESCRIPTION
# Motivation

Users can identify which neurons are controlled by an attached hardware wallet.

In this PR, I introduce a new neuron tag: "Hardware Wallet".

# Changes

* New util `isHotkeyFlag`.
* Use `isNeuronControlledByHardwareWallet` and `isHotkeyFlag` in NnsNeuronPageHeading to render the tags. 
* Use `isNeuronControlledByHardwareWallet` and `isHotkeyFlag` in NnsNeuronCardTitle to render the tags.

# Tests

* Add a test case for `NnsNeuronPageHeading`.
* Add a test case for `NnsNeuronCard` where `NnsNeuronCardTitle` is tested.
* Add method to POs `NnsNeuronPageHeading` and `NnsNeuronCardPo`.
* Test new util `isHotkeyFlag`.

# Todos

- [x] Add entry to changelog (if necessary).
