### PR TITLE
Remove wdio e2e test related steps from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,28 +211,6 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate .env configuration for e2e-tests
-        run: |
-          DFX_NETWORK=local ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh
-      - name: Prepare for e2e tests
-        working-directory: e2e-tests
-        run: |
-          npm ci
-          # wipe the screenshots, they will be re-committed
-          rm -rf screenshots
-      - name: Run chrome e2e tests
-        working-directory: e2e-tests
-        run: |
-          set -o pipefail
-          export WDIO_BROWSER=chrome
-          SCREENSHOT=1 npm run test |& tee -a chrome-wdio.log
-      - name: Run firefox e2e tests
-        working-directory: e2e-tests
-        # Allow Firefox to fail until the source of flakiness is found and fixed.
-        continue-on-error: true
-        run: |
-          export WDIO_BROWSER=firefox
-          SCREENSHOT=1 npm run test |& tee -a firefox-wdio.log
       - name: Get the postinstall instruction count
         run: |
           dfx canister install --upgrade-unchanged nns-dapp --wasm nns-dapp.wasm.gz --mode upgrade --argument "$(cat nns-dapp-arg-local.did)"
@@ -241,36 +219,6 @@ jobs:
           echo "Cycles consumed are instructions * some factor that depends on subnet.  There is no guarantee that that formula will not change."
       - name: Stop replica
         run: dfx stop
-      - name: Archive wdio logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: wdio-logs
-          path: e2e-tests/*-wdio.log
-          # Disable screenshot saving until screenshots are stable.
-          #      - name: Commit screenshots
-          #        if: ${{ github.ref != 'refs/heads/main' }}
-          #        uses: EndBug/add-and-commit@v9.1.1
-          #        with:
-          #          add: e2e-tests/screenshots
-          #          author_name: Screenshot Committer
-          #          author_email: "<nobody@example.com>"
-          #          message: "Update screenshots"
-          #          # do not pull: if this branch is behind, then we might as well let
-          #          # the pushing fail
-          #          pull: "NO-PULL"
-          #
-      - name: Archive screenshots
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: e2e-screenshots
-          path: e2e-tests/screenshots/**/*.png
-          retention-days: 7
-      - name: Remove screenshots until they are stable
-        working-directory: e2e-tests
-        run: |
-          rm -rf screenshots
   network_independent_wasm:
     name: "Same wasms for mainnet and local"
     # Note: The dockerfile structure SHOULD guarantee that the network is not used in any wasm build commands.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,31 +97,6 @@ jobs:
       - name: Run linter
         run: npm run check
         working-directory: ./frontend
-  e2e-lint:
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-    env:
-      DFX_NETWORK: mainnet
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Install dfx
-        run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-      - name: Provide a config
-        run: ./config.sh
-      - name: Install dependencies
-        run: npm ci
-        working-directory: ./e2e-tests
-      - name: Run e2e linter
-        run: npm run lint
-        working-directory: ./e2e-tests
   shell-checks:
     name: ShellCheck
     runs-on: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -262,7 +262,7 @@ jobs:
       - run: scripts/past-changelog-test
       - run: scripts/past-changelog-test.test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "e2e-lint", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,13 +76,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Update chromedriver
-        run: |
-          node --version
-          npm --version
-          npm update chromedriver
-          git diff package-lock.json
-        working-directory: e2e-tests
       - name: Commit updated chromedriver
         uses: EndBug/add-and-commit@v9.1.1
         with:


### PR DESCRIPTION
# Motivation

All wdio e2e tests have been replaced with playwright e2e tests.

# Changes

Remove everything related to the old wdio e2e tests from GitHub workflow files.

# Tests

none

# Todos

- [ ] Add entry to changelog (if necessary).

Will add when everything related to wdio e2e tests has been removed.