### PR TITLE
Use Agent instead of HttpAgent when possible

### DIFF
--- a/frontend/src/lib/api/agent.api.ts
+++ b/frontend/src/lib/api/agent.api.ts
@@ -1,9 +1,9 @@
 import { FETCH_ROOT_KEY } from "$lib/constants/environment.constants";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import { createAgent as createAgentUtil, nonNullish } from "@dfinity/utils";
 
 type PrincipalAsText = string;
-let agents: Record<PrincipalAsText, HttpAgent> | undefined | null = undefined;
+let agents: Record<PrincipalAsText, Agent> | undefined | null = undefined;
 
 export const createAgent = async ({
   identity,
@@ -11,7 +11,7 @@ export const createAgent = async ({
 }: {
   identity: Identity;
   host?: string;
-}): Promise<HttpAgent> => {
+}): Promise<Agent> => {
   const principalAsText: string = identity.getPrincipal().toText();
 
   // e.g. a particular agent for anonymous call and another for signed-in identity

--- a/frontend/src/lib/api/ckbtc-index.api.ts
+++ b/frontend/src/lib/api/ckbtc-index.api.ts
@@ -6,7 +6,7 @@ import type {
 import { getTransactions as getIcrcTransactions } from "$lib/api/icrc-index.api";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import { IcrcIndexCanister } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 
@@ -42,7 +42,7 @@ const ckBTCIndexCanister = async ({
   canisterId: Principal;
 }): Promise<{
   canister: IcrcIndexCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   const agent = await createAgent({
     identity,

--- a/frontend/src/lib/api/ckbtc-minter.api.ts
+++ b/frontend/src/lib/api/ckbtc-minter.api.ts
@@ -1,7 +1,7 @@
 import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import {
   CkBTCMinterCanister,
   type EstimateWithdrawalFee,
@@ -151,7 +151,7 @@ const ckBTCMinterCanister = async ({
   canisterId: Principal;
 }): Promise<{
   canister: CkBTCMinterCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   const agent = await createAgent({
     identity,

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -5,7 +5,7 @@ import { invalidIcrcAddress } from "$lib/utils/accounts.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
 import type { Identity } from "@dfinity/agent";
-import { HttpAgent } from "@dfinity/agent";
+import { HttpAgent, type Agent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import { IcrcLedgerCanister, decodeIcrcAccount } from "@dfinity/ledger";
 import type { BlockHeight, E8s, NeuronId } from "@dfinity/nns";
@@ -22,7 +22,7 @@ export const testAccountPrincipal =
 export const testAccountAddress =
   "5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087";
 
-const getTestAccountAgent = async (): Promise<HttpAgent> => {
+const getTestAccountAgent = async (): Promise<Agent> => {
   // Create an identity who's default ledger account is initialised with 10k ICP on the testnet, then use that
   // identity to send the current user some ICP to test things with.
   // The identity's principal is ${testAccountPrincipal}
@@ -35,7 +35,7 @@ const getTestAccountAgent = async (): Promise<HttpAgent> => {
     base64ToUInt8Array(privateKey)
   );
 
-  const agent: HttpAgent = new HttpAgent({
+  const agent: Agent = new HttpAgent({
     host: HOST,
     identity,
   });

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -6,7 +6,7 @@ import { HOST } from "$lib/constants/environment.constants";
 import { isLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { hashCode, logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import type {
   E8s,
   KnownNeuron,
@@ -524,7 +524,7 @@ export const governanceCanister = async ({
   identity: Identity;
 }): Promise<{
   canister: GovernanceCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   const agent = await createAgent({
     identity,

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -6,7 +6,7 @@ import { isLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import type { IcpAccountIdentifierText } from "$lib/types/account";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import type { BlockHeight } from "@dfinity/nns";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import type { TokenAmount } from "@dfinity/utils";
@@ -101,7 +101,7 @@ export const ledgerCanister = async ({
   identity: Identity;
 }): Promise<{
   canister: LedgerCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   logWithTimestamp(`LC call...`);
   const agent = await createAgent({

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -7,7 +7,7 @@ import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import type {
   BalanceParams,
   IcrcTokenMetadataResponse,
@@ -143,7 +143,7 @@ export const icrcLedgerCanister = async ({
   canisterId: Principal;
 }): Promise<{
   canister: IcrcLedgerCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   const agent = await createAgent({
     identity,

--- a/frontend/src/lib/api/nns-dapp.api.ts
+++ b/frontend/src/lib/api/nns-dapp.api.ts
@@ -4,7 +4,7 @@ import type { AccountDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { HOST } from "$lib/constants/environment.constants";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 
 export const addAccount = async (identity: Identity): Promise<void> => {
   logWithTimestamp("Adding account call...");
@@ -33,7 +33,7 @@ export const nnsDappCanister = async ({
   identity: Identity;
 }): Promise<{
   canister: NNSDappCanister;
-  agent: HttpAgent;
+  agent: Agent;
 }> => {
   const agent = await createAgent({ identity, host: HOST });
 

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -9,7 +9,7 @@ import {
 import { ApiErrorKey } from "$lib/types/api.errors";
 import type { QueryRootCanisterId } from "$lib/types/sns.query";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import { IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger";
 import type { DeployedSns, SnsWasmCanister } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -99,7 +99,7 @@ const listSnses = async ({
   agent,
   certified,
 }: {
-  agent: HttpAgent;
+  agent: Agent;
   certified: boolean;
 }): Promise<Principal[]> => {
   logWithTimestamp(`Loading list of Snses certified:${certified} call...`);
@@ -129,7 +129,7 @@ export const initSns = async ({
   rootCanisterId,
   certified,
 }: {
-  agent: HttpAgent;
+  agent: Agent;
   rootCanisterId: Principal;
   certified: boolean;
 }): Promise<SnsWrapper> => {

--- a/frontend/src/lib/worker-utils/canister.worker-utils.ts
+++ b/frontend/src/lib/worker-utils/canister.worker-utils.ts
@@ -1,10 +1,10 @@
 import type { CanisterId } from "$lib/types/canister";
 import type { CanisterActorParams } from "$lib/types/worker";
-import { HttpAgent } from "@dfinity/agent";
+import { HttpAgent, type Agent } from "@dfinity/agent";
 
 export interface CreateCanisterWorkerParams {
   canisterId: CanisterId;
-  agent: HttpAgent;
+  agent: Agent;
 }
 
 export const createCanisterWorker = async <T>({

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -25,14 +25,14 @@ import {
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import type { HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import { GovernanceCanister, LedgerCanister, Topic, Vote } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/api/agent.api", () => {
   return {
-    createAgent: () => Promise.resolve(mock<HttpAgent>()),
+    createAgent: () => Promise.resolve(mock<Agent>()),
   };
 });
 

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -47,7 +47,7 @@ import {
   rootCanisterIdMock,
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
-import type { HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import { LedgerCanister, type SnsWasmCanisterOptions } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import {
@@ -63,7 +63,7 @@ import mock from "jest-mock-extended/lib/Mock";
 jest.mock("$lib/proxy/api.import.proxy");
 jest.mock("$lib/api/agent.api", () => {
   return {
-    createAgent: () => Promise.resolve(mock<HttpAgent>()),
+    createAgent: () => Promise.resolve(mock<Agent>()),
   };
 });
 

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -13,7 +13,7 @@ import {
   rootCanisterIdMock,
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
-import type { HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import mock from "jest-mock-extended/lib/Mock";
 
 const listSnsesSpy = jest.fn().mockResolvedValue(deployedSnsMock);
@@ -63,7 +63,7 @@ describe("sns-wrapper api", () => {
 
   describe("initSns", () => {
     it("inits sns wrapper", async () => {
-      const mockAgent = mock<HttpAgent>();
+      const mockAgent = mock<Agent>();
       await initSns({
         agent: mockAgent,
         rootCanisterId: rootCanisterIdMock,

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -33,7 +33,7 @@ import {
   rootCanisterIdMock,
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
-import type { HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import { LedgerCanister, type SnsWasmCanisterOptions } from "@dfinity/nns";
 import {
   SnsSwapLifecycle,
@@ -45,7 +45,7 @@ import mock from "jest-mock-extended/lib/Mock";
 jest.mock("$lib/proxy/api.import.proxy");
 jest.mock("$lib/api/agent.api", () => {
   return {
-    createAgent: () => Promise.resolve(mock<HttpAgent>()),
+    createAgent: () => Promise.resolve(mock<Agent>()),
   };
 });
 

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "$tests/mocks/ledger.identity.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { MockNNSDappCanister } from "$tests/mocks/nns-dapp.canister.mock";
-import type { HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import { principalToAccountIdentifier } from "@dfinity/nns";
 import { LedgerError, type ResponseVersion } from "@zondax/ledger-icp";
 import { mock } from "jest-mock-extended";
@@ -137,7 +137,7 @@ describe("icp-ledger.services", () => {
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
 
-      const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
+      const mockCreateAgent = () => Promise.resolve(mock<Agent>());
       jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
 
       jest

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -55,7 +55,7 @@ import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import {
   InsufficientFundsError,
   TransferError,
@@ -84,7 +84,7 @@ import { get } from "svelte/store";
 jest.mock("$lib/proxy/api.import.proxy");
 jest.mock("$lib/api/agent.api", () => {
   return {
-    createAgent: () => Promise.resolve(mock<HttpAgent>()),
+    createAgent: () => Promise.resolve(mock<Agent>()),
   };
 });
 


### PR DESCRIPTION
# Motivation

`HttpAgent` is an implementation of `Agent`.
I plan to add another implementation which wraps another agent.
So when we don't care what the implementation is, we should refer to the type `Agent` instead of `HttpAgent`.

# Changes

When referring to the type `HttpAgent`, refer to type `Agent` instead unless we're actually constructing an instance.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).

not worth an entry