### PR TITLE
Refactor: getNeuronTags helper

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -4,10 +4,9 @@
   import { TokenAmount, ICPToken } from "@dfinity/utils";
   import {
     formatVotingPower,
-    hasJoinedCommunityFund,
-    isHotkeyTag,
-    isNeuronControlledByHardwareWallet,
+    getNeuronTags,
     neuronStake,
+    type NeuronTag,
   } from "$lib/utils/neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
@@ -30,20 +29,12 @@
   $: canVote =
     neuron.dissolveDelaySeconds > BigInt(NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE);
 
-  let isCommunityFund: boolean;
-  $: isCommunityFund = hasJoinedCommunityFund(neuron);
-
-  let hotkeyTag: boolean;
-  $: hotkeyTag = isHotkeyTag({
+  let neuronTags: NeuronTag[];
+  $: neuronTags = getNeuronTags({
     neuron,
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
-  });
-
-  let isHWControlled: boolean;
-  $: isHWControlled = isNeuronControlledByHardwareWallet({
-    neuron,
-    accounts: $icpAccountsStore,
+    i18n: $i18n,
   });
 </script>
 
@@ -59,20 +50,8 @@
     {/if}
   </span>
   <svelte:fragment slot="tags">
-    {#if isCommunityFund}
-      <HeadingTag testId="neurons-fund-tag">
-        {$i18n.neurons.community_fund}
-      </HeadingTag>
-    {/if}
-    {#if hotkeyTag}
-      <HeadingTag testId="hotkey-tag">
-        {$i18n.neurons.hotkey_control}
-      </HeadingTag>
-    {/if}
-    {#if isHWControlled}
-      <HeadingTag testId="hardware-wallet-tag">
-        {$i18n.neurons.hardware_wallet_control}
-      </HeadingTag>
-    {/if}
+    {#each neuronTags as tag}
+      <HeadingTag testId="neuron-tag">{tag.text}</HeadingTag>
+    {/each}
   </svelte:fragment>
 </PageHeading>

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -1,31 +1,19 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    hasJoinedCommunityFund,
-    isHotkeyTag,
-    isNeuronControlledByHardwareWallet,
-  } from "$lib/utils/neuron.utils";
+  import { getNeuronTags, type NeuronTag } from "$lib/utils/neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 
   export let neuron: NeuronInfo;
   export let tagName: "p" | "h3" = "p";
 
-  let isCommunityFund: boolean;
-  $: isCommunityFund = hasJoinedCommunityFund(neuron);
-
-  let hotkeyFlag: boolean;
-  $: hotkeyFlag = isHotkeyTag({
+  let neuronTags: NeuronTag[];
+  $: neuronTags = getNeuronTags({
     neuron,
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
-  });
-
-  let isHWControlled: boolean;
-  $: isHWControlled = isNeuronControlledByHardwareWallet({
-    neuron,
-    accounts: $icpAccountsStore,
+    i18n: $i18n,
   });
 </script>
 
@@ -34,19 +22,9 @@
     >{neuron.neuronId}</svelte:element
   >
 
-  {#if isCommunityFund}
-    <small class="label">{$i18n.neurons.community_fund}</small>
-  {/if}
-  {#if hotkeyFlag}
-    <small class="label" data-tid="hotkey-tag"
-      >{$i18n.neurons.hotkey_control}</small
-    >
-  {/if}
-  {#if isHWControlled}
-    <small class="label" data-tid="hardware-wallet-tag"
-      >{$i18n.neurons.hardware_wallet_control}</small
-    >
-  {/if}
+  {#each neuronTags as tag}
+    <small class="label" data-tid="neuron-tag">{tag.text}</small>
+  {/each}
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -389,7 +389,7 @@ export const getNeuronTags = ({
   });
   if (isHWControlled) {
     tags.push({ text: i18n.neurons.hardware_wallet_control });
-    // All HW controlled are hotkeys, but we don't want to show two tags to the user.
+    // All HW controlled are hotkeys, but we don't want to show both tags to the user.
   } else if (isHotKeyControllable({ neuron, identity })) {
     tags.push({ text: i18n.neurons.hotkey_control });
   }

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -364,18 +364,37 @@ export const isHotKeyControllable = ({
   ) !== undefined &&
   fullNeuron.controller !== identity?.getPrincipal().toText();
 
-// All HW controlled are hotkeys, but we don't want to show two tags to the user.
-export const isHotkeyTag = ({
+export type NeuronTag = {
+  text: string;
+};
+
+export const getNeuronTags = ({
   neuron,
   identity,
   accounts,
+  i18n,
 }: {
   neuron: NeuronInfo;
   identity?: Identity | null;
   accounts: IcpAccountsStoreData;
-}): boolean =>
-  isHotKeyControllable({ neuron, identity }) &&
-  !isNeuronControlledByHardwareWallet({ neuron, accounts });
+  i18n: I18n;
+}): NeuronTag[] => {
+  const tags: NeuronTag[] = [];
+  if (hasJoinedCommunityFund(neuron)) {
+    tags.push({ text: i18n.neurons.community_fund });
+  }
+  const isHWControlled = isNeuronControlledByHardwareWallet({
+    neuron,
+    accounts,
+  });
+  if (isHWControlled) {
+    tags.push({ text: i18n.neurons.hardware_wallet_control });
+    // All HW controlled are hotkeys, but we don't want to show two tags to the user.
+  } else if (isHotKeyControllable({ neuron, identity })) {
+    tags.push({ text: i18n.neurons.hotkey_control });
+  }
+  return tags;
+};
 
 /**
  * An identity can manage the neurons' fund participation when one of the below is true:

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -51,7 +51,10 @@ describe("TransactionCard", () => {
         ...mockTransactionReceiveDataFromMain,
         type: AccountTransactionType.Burn,
       },
-      descriptions: en.ckbtc_transaction_names,
+      descriptions: en.ckbtc_transaction_names as unknown as Record<
+        string,
+        string
+      >,
     });
 
     const expectedText = replacePlaceholders(en.transaction_names.burn, {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -76,7 +76,7 @@ describe("NnsNeuronPageHeading", () => {
       joinedCommunityFundTimestampSeconds: BigInt(12333444),
     });
 
-    expect(await po.hasNeuronsFundTag()).toBe(true);
+    expect(await po.getNeuronTags()).toEqual(["Neurons' fund"]);
   });
 
   it("should render hotkey tag if user is a hotkey and not controlled by a hardware wallet", async () => {
@@ -94,7 +94,7 @@ describe("NnsNeuronPageHeading", () => {
       },
     });
 
-    expect(await po.hasHotkeyTag()).toBe(true);
+    expect(await po.getNeuronTags()).toEqual(["Hotkey control"]);
   });
 
   it("should render hardware wallet tag and not hotkey if neuron is controlled by a hardware wallet", async () => {
@@ -112,7 +112,6 @@ describe("NnsNeuronPageHeading", () => {
       },
     });
 
-    expect(await po.hasHotkeyTag()).toBe(false);
-    expect(await po.hasHardwareWalletTag()).toBe(true);
+    expect(await po.getNeuronTags()).toEqual(["Hardware Wallet"]);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -97,6 +97,28 @@ describe("NnsNeuronPageHeading", () => {
     expect(await po.getNeuronTags()).toEqual(["Hotkey control"]);
   });
 
+  it("should render hotkey and Neurons' Fund tag", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [],
+      hardwareWallets: [],
+    });
+    const po = renderComponent({
+      ...mockNeuron,
+      joinedCommunityFundTimestampSeconds: BigInt(12333444),
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        controller: "not-current-principal",
+        hotKeys: [mockIdentity.getPrincipal().toText()],
+      },
+    });
+
+    expect(await po.getNeuronTags()).toEqual([
+      "Neurons' fund",
+      "Hotkey control",
+    ]);
+  });
+
   it("should render hardware wallet tag and not hotkey if neuron is controlled by a hardware wallet", async () => {
     icpAccountsStore.setForTesting({
       main: mockMainAccount,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -161,8 +161,7 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.hasHardwareWalletTag()).toBe(true);
-    expect(await po.hasHotkeyTag()).toBe(false);
+    expect(await po.getNeuronTags()).toEqual(["Hardware Wallet"]);
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1283,7 +1283,7 @@ describe("neuron-utils", () => {
           accounts: accountsWithHW,
           i18n: en,
         })
-      ).toEqual([nfTag, { text: "Hardware Wallet" }]);
+      ).toEqual([nfTag, hwTag]);
     });
   });
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -38,6 +38,7 @@ import {
   getDissolvingTimeInSeconds,
   getDissolvingTimestampSeconds,
   getNeuronById,
+  getNeuronTags,
   getSpawningTimeInSeconds,
   hasEnoughMaturityToStake,
   hasJoinedCommunityFund,
@@ -45,7 +46,6 @@ import {
   isEnoughMaturityToSpawn,
   isEnoughToStakeNeuron,
   isHotKeyControllable,
-  isHotkeyTag,
   isIdentityController,
   isNeuronControllable,
   isNeuronControllableByUser,
@@ -69,6 +69,7 @@ import {
   type InvalidState,
 } from "$lib/utils/neuron.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -1118,7 +1119,7 @@ describe("neuron-utils", () => {
       ).toBe(false));
   });
 
-  describe("isHotkeyTag", () => {
+  describe("getNeuronHotkeys", () => {
     const accountsWithHW = {
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
@@ -1128,7 +1129,11 @@ describe("neuron-utils", () => {
       main: mockMainAccount,
       hardwareWallets: [],
     };
-    it("returns true if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
+
+    const hotkeyTag = { text: "Hotkey control" };
+    const hwTag = { text: "Hardware Wallet" };
+    const nfTag = { text: "Neurons' fund" };
+    it("returns 'hotkey' if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1138,15 +1143,16 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyTag({
+        getNeuronTags({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
+          i18n: en,
         })
-      ).toBe(true);
+      ).toEqual([hotkeyTag]);
     });
 
-    it("returns true if neuron is controllable by hotkey and no hardware wallet is attached", () => {
+    it("returns 'hotkey' if neuron is controllable by hotkey and no hardware wallet is attached", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1156,15 +1162,16 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyTag({
+        getNeuronTags({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithoutHw,
+          i18n: en,
         })
-      ).toBe(true);
+      ).toEqual([hotkeyTag]);
     });
 
-    it("returns false if neuron is controllable by hotkey and hardware wallet is the controller", () => {
+    it("returns 'Hardware Wallet' if neuron is controllable by hotkey and hardware wallet is the controller", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1174,15 +1181,16 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyTag({
+        getNeuronTags({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
+          i18n: en,
         })
-      ).toBe(false);
+      ).toEqual([hwTag]);
     });
 
-    it("returns false if neuron is the controller and a hotkey", () => {
+    it("returns empty array if neuron is the controller and a hotkey", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1192,15 +1200,16 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyTag({
+        getNeuronTags({
           neuron: neuron,
           identity: mockIdentity,
           accounts: accountsWithHW,
+          i18n: en,
         })
-      ).toBe(false);
+      ).toEqual([]);
     });
 
-    it("returns false if no identity", () => {
+    it("returns empty array if no identity", () => {
       const neuron = {
         ...mockNeuron,
         fullNeuron: {
@@ -1210,12 +1219,71 @@ describe("neuron-utils", () => {
         },
       };
       expect(
-        isHotkeyTag({
+        getNeuronTags({
           neuron: neuron,
           identity: null,
           accounts: accountsWithHW,
+          i18n: en,
         })
-      ).toBe(false);
+      ).toEqual([]);
+    });
+
+    it("returns 'Neurons' Fund' if neuron is part of Neurons' Fund", () => {
+      const neuron: NeuronInfo = {
+        ...mockNeuron,
+        joinedCommunityFundTimestampSeconds: 123445n,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+        },
+      };
+      expect(
+        getNeuronTags({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+          i18n: en,
+        })
+      ).toEqual([nfTag]);
+    });
+
+    it("returns 'Neurons' Fund' and 'Hotkey Control'", () => {
+      const neuron: NeuronInfo = {
+        ...mockNeuron,
+        joinedCommunityFundTimestampSeconds: 123445n,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+          controller: "not-user-nor-hw",
+        },
+      };
+      expect(
+        getNeuronTags({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+          i18n: en,
+        })
+      ).toEqual([nfTag, hotkeyTag]);
+    });
+
+    it("returns 'Neurons' Fund' and 'Hardware Wallet'", () => {
+      const neuron: NeuronInfo = {
+        ...mockNeuron,
+        joinedCommunityFundTimestampSeconds: 123445n,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          hotKeys: [mockIdentity.getPrincipal().toText()],
+          controller: mockHardwareWalletAccount.principal?.toText(),
+        },
+      };
+      expect(
+        getNeuronTags({
+          neuron: neuron,
+          identity: mockIdentity,
+          accounts: accountsWithHW,
+          i18n: en,
+        })
+      ).toEqual([nfTag, { text: "Hardware Wallet" }]);
     });
   });
 

--- a/frontend/src/tests/mocks/i18n.mock.ts
+++ b/frontend/src/tests/mocks/i18n.mock.ts
@@ -8,6 +8,6 @@ import * as enCore from "$lib/i18n/en.json";
 const en = {
   ...enCore,
   ...enGovernance,
-};
+} as I18n;
 
 export default en;

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -46,11 +46,7 @@ export class NnsNeuronCardPo extends BasePageObject {
     return Number(await this.getText("token-value"));
   }
 
-  hasHotkeyTag(): Promise<boolean> {
-    return this.root.byTestId("hotkey-tag").isPresent();
-  }
-
-  hasHardwareWalletTag(): Promise<boolean> {
-    return this.root.byTestId("hardware-wallet-tag").isPresent();
+  getNeuronTags(): Promise<string[]> {
+    return this.getCardTitlePo().getNeuronTags();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -11,4 +11,9 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
   getNeuronId(): Promise<string> {
     return this.root.querySelector("[data-tid=neuron-id]").getText();
   }
+
+  async getNeuronTags(): Promise<string[]> {
+    const elements = await this.root.allByTestId("neuron-tag");
+    return Promise.all(elements.map((tag) => tag.getText()));
+  }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronPageHeading.page-object.ts
@@ -23,15 +23,8 @@ export class NnsNeuronPageHeadingPo extends BasePageObject {
     return this.getText("voting-power");
   }
 
-  hasNeuronsFundTag(): Promise<boolean> {
-    return this.root.byTestId("neurons-fund-tag").isPresent();
-  }
-
-  hasHotkeyTag(): Promise<boolean> {
-    return this.root.byTestId("hotkey-tag").isPresent();
-  }
-
-  hasHardwareWalletTag(): Promise<boolean> {
-    return this.root.byTestId("hardware-wallet-tag").isPresent();
+  async getNeuronTags(): Promise<string[]> {
+    const elements = await this.root.allByTestId("neuron-tag");
+    return Promise.all(elements.map((tag) => tag.getText()));
   }
 }


### PR DESCRIPTION
# Motivation

Couple the logic of the neuron tags in one helper. Tags are related to each other, therefore, it makes sense to use one helper to get them all.

# Changes

* New neuron util `getNeuronTags`
* Remove neuron util `isHotkeyTag`.
* Use new util in NnsNeuronPageHeading.
* Use new util in NnsNeuronCardTitle.

# Tests

* Change methods to get presence of a tag, to get the list of tags.
* Change test in NnsNeuronPageHeading
* Change test in NnsNeuronCardTitle.
* Test new util `getNeuronTags`

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth an entry. Only refactor.
